### PR TITLE
feat: resolved errorsf for self hosted license v2

### DIFF
--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/services/license-client/license-client-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 
+import { isV2SelfHostedLicenseKey } from "../license/license-fns";
 import { OrgPermissionBillingActions, OrgPermissionSubjects } from "../permission/org-permission";
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
 import {
@@ -38,7 +39,7 @@ import {
 } from "./license-v2-types";
 
 type TLicenseV2ServiceFactoryDep = {
-  envConfig: Pick<TEnvConfig, "LICENSE_SERVER_V2_MODE">;
+  envConfig: Pick<TEnvConfig, "LICENSE_SERVER_V2_MODE" | "LICENSE_KEY">;
   orgDAL: Pick<TOrgDALFactory, "findById" | "countAllOrgMembers">;
   identityOrgMembershipDAL: Pick<TIdentityOrgDALFactory, "countAllOrgIdentities">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
@@ -66,6 +67,11 @@ export type TLicenseV2ServiceFactory = ReturnType<typeof licenseV2ServiceFactory
 // glyph on the client.
 const FALLBACK_ICON = "box";
 const FALLBACK_COLOR = "#6b7280";
+
+// Self-hosted has no cloud-plan endpoint, so the org seat caps ride on the license entitlements
+// instead. These keys mirror the v2 keys in dual-read feature-mapping (MaxIdentities.key, member_limit).
+const IDENTITY_LIMIT_FEATURE_KEY = "max_identities";
+const MEMBER_LIMIT_FEATURE_KEY = "member_limit";
 
 const CATALOG_MODELS: BillingV2Model[] = ["seat", "usage", "limit", "flat"];
 
@@ -263,6 +269,10 @@ export const licenseV2ServiceFactory = ({
   permissionService,
   licenseClient
 }: TLicenseV2ServiceFactoryDep) => {
+  // A self-hosted v2 license is managed out-of-band: the billing surface is read-only. Self-serve
+  // mutations don't need an explicit guard here, the self-hosted license client rejects them itself.
+  const isSelfHostedLicense = isV2SelfHostedLicenseKey(envConfig.LICENSE_KEY ?? "");
+
   const ensureBillingRead = async (orgId: string, actor: TGetBillingV2OverviewDTO["actor"]) => {
     const { permission } = await permissionService.getOrgPermission({
       actorId: actor.id,
@@ -406,15 +416,32 @@ export const licenseV2ServiceFactory = ({
     });
 
     // Plan caps come from the license server (a null limit means genuinely unlimited). Used counts
-    // are overlaid here; a missing plan leaves limits unknown.
+    // are overlaid here; a missing plan leaves limits unknown. Self-hosted has no cloud-plan endpoint,
+    // so the caps are read off the license entitlements instead.
     let memberLimit: number | null = null;
     let identityLimit: number | null = null;
-    try {
-      const cloudPlan = await licenseClient.getCloudPlan(orgId);
-      memberLimit = cloudPlan?.currentPlan.memberLimit ?? null;
-      identityLimit = cloudPlan?.currentPlan.identityLimit ?? null;
-    } catch (error) {
-      logger.error(error, `billing-v2: failed to read cloud plan [orgId=${orgId}]`);
+    if (isSelfHostedLicense) {
+      try {
+        const entitlements = await licenseClient.getEntitlements({
+          id: orgId,
+          name: organization.name,
+          slug: organization.slug
+        });
+        const memberCap = entitlements?.features[MEMBER_LIMIT_FEATURE_KEY]?.value;
+        const identityCap = entitlements?.features[IDENTITY_LIMIT_FEATURE_KEY]?.value;
+        memberLimit = typeof memberCap === "number" ? memberCap : null;
+        identityLimit = typeof identityCap === "number" ? identityCap : null;
+      } catch (error) {
+        logger.error(error, `billing-v2: failed to read entitlement caps [orgId=${orgId}]`);
+      }
+    } else {
+      try {
+        const cloudPlan = await licenseClient.getCloudPlan(orgId);
+        memberLimit = cloudPlan?.currentPlan.memberLimit ?? null;
+        identityLimit = cloudPlan?.currentPlan.identityLimit ?? null;
+      } catch (error) {
+        logger.error(error, `billing-v2: failed to read cloud plan [orgId=${orgId}]`);
+      }
     }
 
     // Name the plan from the subscription's tier so enterprise/trial orgs aren't all labelled "Pro".
@@ -433,8 +460,9 @@ export const licenseV2ServiceFactory = ({
     let payment: BillingV2Overview["payment"] = null;
     let billingDetails: BillingV2Overview["billingDetails"] = null;
     let invoices: BillingV2Overview["invoices"] = [];
+    // Self-hosted has no Stripe customer (no billing profile endpoint); leave payment/invoices empty.
     try {
-      const profile = await licenseClient.getBillingProfile(orgId);
+      const profile = isSelfHostedLicense ? null : await licenseClient.getBillingProfile(orgId);
       if (profile) {
         payment = profile.payment;
         // name/email/address/taxIds pass straight through (address keeps its nullable sub-fields;
@@ -457,8 +485,10 @@ export const licenseV2ServiceFactory = ({
     }
 
     const overview: BillingV2Overview = {
-      isCloud: true,
-      mode: "self-serve",
+      // Self-hosted is a read-only, managed view: the UI hides payment/invoices/details and shows the
+      // "managed by your account team" banner off these two fields.
+      isCloud: !isSelfHostedLicense,
+      mode: isSelfHostedLicense ? "managed" : "self-serve",
       subState,
       planName,
       nextBillingDate,

--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -19,6 +19,12 @@ export const isOfflineLicenseKey = (licenseKey: string): boolean => {
   }
 };
 
+// Self-hosted License Server v2 keys carry this prefix; legacy online keys look like "QVHK-HIGYH".
+export const SELF_HOSTED_V2_LICENSE_KEY_PREFIX = "infisical_lk_";
+
+export const isV2SelfHostedLicenseKey = (licenseKey: string): boolean =>
+  licenseKey.startsWith(SELF_HOSTED_V2_LICENSE_KEY_PREFIX);
+
 export const getLicenseKeyConfig = (
   config?: Pick<TEnvConfig, "LICENSE_KEY" | "LICENSE_KEY_OFFLINE">
 ): TLicenseKeyConfig => {
@@ -31,6 +37,10 @@ export const getLicenseKeyConfig = (
   const licenseKey = cfg.LICENSE_KEY;
 
   if (licenseKey) {
+    if (isV2SelfHostedLicenseKey(licenseKey)) {
+      return { isValid: true, licenseKey, type: LicenseType.OnlineV2 };
+    }
+
     if (isOfflineLicenseKey(licenseKey)) {
       return { isValid: true, licenseKey, type: LicenseType.Offline };
     }

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -68,7 +68,7 @@ type TLicenseServiceFactoryDep = {
   licenseDAL: TLicenseDALFactory;
   keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "deleteItem">;
   projectDAL: TProjectDALFactory;
-  licenseClient?: Pick<TLicenseClientFactory, "getEntitlements" | "getSubscription">;
+  licenseClient?: Pick<TLicenseClientFactory, "getEntitlements" | "getSubscription" | "refreshEntitlements">;
   licenseDualRead?: Pick<TDualReadServiceFactory, "compareInBackground">;
 };
 
@@ -76,6 +76,10 @@ export type TLicenseServiceFactory = ReturnType<typeof licenseServiceFactory>;
 
 const LICENSE_SERVER_CLOUD_LOGIN = "/api/auth/v1/license-server-login";
 const LICENSE_SERVER_ON_PREM_LOGIN = "/api/auth/v1/license-login";
+
+// A self-hosted v2 license is single-tenant: the license key identifies the tenant, so entitlement
+// reads carry no real org id. This fixed id only keys the local entitlement cache for the instance.
+const SELF_HOSTED_LICENSE_ORG_ID = "self-hosted";
 
 export const licenseServiceFactory = ({
   orgDAL,
@@ -139,6 +143,50 @@ export const licenseServiceFactory = ({
     }
   };
 
+  // Self-hosted equivalent of syncLicenseKeyOnPremFeatures, but sourced from License Server v2: project
+  // the license's entitlements into the v1 feature shape and refresh the instance-wide onPremFeatures.
+  const syncSelfHostedV2Features = async (shouldThrow: boolean = false) => {
+    logger.info("Start syncing self-hosted license features from License Server v2");
+    try {
+      if (!licenseClient) {
+        throw new BadRequestError({ message: "License Server v2 client is not configured" });
+      }
+
+      const entitlements = await licenseClient.getEntitlements({ id: SELF_HOSTED_LICENSE_ORG_ID });
+      if (!entitlements) {
+        throw new BadRequestError({ message: "License Server v2 entitlements are unavailable" });
+      }
+      const currentPlan = projectV2ToFeatureSet(getDefaultOnPremFeatures(), entitlements);
+
+      // The entitlement projection only carries feature flags; derive the plan tier from the
+      // subscription/contract view. Non-fatal so a subscription read failure keeps the features.
+      try {
+        const subscription = await licenseClient.getSubscription(SELF_HOSTED_LICENSE_ORG_ID);
+        const paidTiers = (subscription?.items ?? [])
+          .map((item) => item.plan.toLowerCase())
+          .filter((tier) => tier !== "free");
+        if (paidTiers.some((tier) => tier.includes("enterprise"))) {
+          currentPlan.slug = "enterprise";
+        } else if (paidTiers.length > 0) {
+          currentPlan.slug = "pro";
+        }
+      } catch (error) {
+        logger.error(error, "syncSelfHostedV2Features: failed to resolve plan tier from subscription");
+      }
+
+      // Usage is instance-wide for self-hosted (null orgId aggregates the whole instance), as in the v1 sync.
+      currentPlan.workspacesUsed = await projectDAL.countOfBillableOrgProjects(null);
+      currentPlan.membersUsed = await licenseDAL.countOfOrgMembers(null);
+      currentPlan.identitiesUsed = await licenseDAL.countOrgUsersAndIdentities(null);
+
+      onPremFeatures = currentPlan;
+      logger.info("Successfully synced self-hosted license features from License Server v2");
+    } catch (error) {
+      logger.error(error, "Failed to sync self-hosted license features from License Server v2");
+      if (shouldThrow) throw error;
+    }
+  };
+
   const init = async () => {
     try {
       if (envConfig.LICENSE_SERVER_V2_SERVICE_KEY) {
@@ -152,6 +200,16 @@ export const licenseServiceFactory = ({
         const token = await licenseServerCloudApi.refreshLicense();
         if (token) instanceType = InstanceType.Cloud;
         logger.info(`Instance type: ${InstanceType.Cloud}`);
+        isValidLicense = true;
+        return;
+      }
+
+      // New self-hosted key (prefix "infisical_lk_") resolves features from License Server v2. The key
+      // authenticates directly (no on-prem login handshake); a successful entitlements sync validates it.
+      if (licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.OnlineV2) {
+        await syncSelfHostedV2Features(true);
+        instanceType = InstanceType.EnterpriseOnPremV2;
+        logger.info(`Instance type: ${InstanceType.EnterpriseOnPremV2}`);
         isValidLicense = true;
         return;
       }
@@ -212,6 +270,12 @@ export const licenseServiceFactory = ({
     if (licenseKeyConfig?.isValid && licenseKeyConfig?.type === LicenseType.Online) {
       logger.info("Setting up background sync process for refresh onPremFeatures");
       const job = new CronJob("*/10 * * * *", syncLicenseKeyOnPremFeatures);
+      job.start();
+      return job;
+    }
+    if (licenseKeyConfig?.isValid && licenseKeyConfig?.type === LicenseType.OnlineV2) {
+      logger.info("Setting up background sync process for refresh onPremFeatures from License Server v2");
+      const job = new CronJob("*/10 * * * *", () => syncSelfHostedV2Features());
       job.start();
       return job;
     }
@@ -332,10 +396,15 @@ export const licenseServiceFactory = ({
     if (instanceType === InstanceType.EnterpriseOnPrem) {
       await syncLicenseKeyOnPremFeatures(true);
     }
+    if (instanceType === InstanceType.EnterpriseOnPremV2) {
+      // Bust the license server's cached entitlements (e.g. after a license change), then re-sync.
+      await licenseClient?.refreshEntitlements({ id: SELF_HOSTED_LICENSE_ORG_ID });
+      await syncSelfHostedV2Features(true);
+    }
   };
 
   const generateOrgCustomerId = async (orgName: string, email?: string | null) => {
-    if (instanceType === InstanceType.Cloud) {
+    if (instanceType === InstanceType.Cloud && envConfig.LICENSE_SERVER_KEY) {
       const {
         data: { customerId }
       } = await licenseServerCloudApi.request.post<{ customerId: string }>(
@@ -359,7 +428,7 @@ export const licenseServiceFactory = ({
     if (!org) throw new NotFoundError({ message: `Organization with ID '${orgId}' not found` });
 
     const rootOrgId = org.id;
-    if (instanceType === InstanceType.Cloud) {
+    if (instanceType === InstanceType.Cloud && envConfig.LICENSE_SERVER_KEY) {
       const quantity = await licenseDAL.countOfOrgMembers(rootOrgId, tx);
       const quantityIdentities = await licenseDAL.countOrgUsersAndIdentities(rootOrgId, tx);
       if (org?.customerId) {
@@ -378,6 +447,11 @@ export const licenseServiceFactory = ({
         usedSeats,
         usedIdentitySeats
       });
+    } else if (instanceType === InstanceType.EnterpriseOnPremV2) {
+      // v2 self-hosted reports usage asynchronously via the usage-snapshot queue, not a synchronous seat
+      // patch; keep the in-memory counts current so limit checks are accurate until the next sync.
+      onPremFeatures.membersUsed = await licenseDAL.countOfOrgMembers(null, tx);
+      onPremFeatures.identitiesUsed = await licenseDAL.countOrgUsersAndIdentities(null, tx);
     }
     await refreshPlan(rootOrgId);
   };

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -4,6 +4,8 @@ export enum InstanceType {
   OnPrem = "self-hosted",
   EnterpriseOnPrem = "enterprise-self-hosted",
   EnterpriseOnPremOffline = "enterprise-self-hosted-offline",
+  // Self-hosted instance whose license is resolved from License Server v2 (new "infisical_lk_" key).
+  EnterpriseOnPremV2 = "enterprise-self-hosted-v2",
   Cloud = "cloud"
 }
 
@@ -147,7 +149,9 @@ export type TOrgLicensesDTO = TOrgPermission;
 
 export enum LicenseType {
   Offline = "offline",
-  Online = "online"
+  Online = "online",
+  // New self-hosted key (prefix "infisical_lk_") that resolves entitlements from License Server v2.
+  OnlineV2 = "online-v2"
 }
 
 export type TLicenseKeyConfig =

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -26,6 +26,7 @@ import {
 } from "./license-client-types";
 
 const ENTITLEMENTS_PATH = "/v1/entitlements";
+const ENTITLEMENTS_REFRESH_PATH = "/v1/entitlements/refresh";
 const PRODUCTS_PATH = "/v1/products";
 const SUBSCRIPTION_PATH = "/v1/subscription";
 const CLOUD_PLAN_PATH = "/v1/cloud-plan";
@@ -81,6 +82,19 @@ export const licenseServerBackend = (
     }
     const body: unknown = await res.json();
     return entitlementsResponseSchema.parse(body);
+  },
+
+  refreshEntitlements: async (org: TEntitlementOrg): Promise<void> => {
+    const url = new URL(ENTITLEMENTS_REFRESH_PATH, serverUrl);
+    url.searchParams.set("org_id", org.id);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
+      redirect: "manual"
+    });
+    if (!res.ok) {
+      throw new Error(`license server responded with ${res.status}`);
+    }
   },
 
   fetchCatalog: async (): Promise<TCatalogResponse> => {
@@ -277,4 +291,95 @@ export const licenseServerBackend = (
     const body: unknown = await res.json();
     return checkoutResultSchema.parse(body);
   }
+});
+
+// Stripe-backed billing (checkout, portal, subscription mutations, cloud plan, billing profile) does
+// not exist for self-hosted licenses; the license is managed out-of-band. These reject so a caller
+// never silently no-ops.
+const notSupportedOnSelfHosted = (operation: string) => (): Promise<never> =>
+  Promise.reject(new Error(`license operation "${operation}" is not supported for self-hosted licenses`));
+
+// Backend for a self-hosted License Server v2 license. Unlike the cloud backend it authenticates with
+// the raw license key as a bearer token (not a minted RS256 service JWT) and is single-tenant: the key
+// identifies the license, so entitlement/subscription reads carry no org_id. Only the read + usage +
+// refresh endpoints the self-hosted contract exposes are implemented; everything billing-related throws.
+export const licenseServerSelfHostedBackend = (
+  serverUrl: string,
+  licenseKey: string,
+  region?: string
+): TLicenseClientBackend => ({
+  fetchEntitlements: async (): Promise<TEntitlementsResponse> => {
+    const url = new URL(ENTITLEMENTS_PATH, serverUrl);
+    if (region) {
+      url.searchParams.set("region", region);
+    }
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${licenseKey}` },
+      redirect: "manual"
+    });
+    if (!res.ok) {
+      throw new Error(`license server responded with ${res.status}`);
+    }
+    const body: unknown = await res.json();
+    return entitlementsResponseSchema.parse(body);
+  },
+
+  refreshEntitlements: async (): Promise<void> => {
+    const url = new URL(ENTITLEMENTS_REFRESH_PATH, serverUrl);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${licenseKey}` },
+      redirect: "manual"
+    });
+    if (!res.ok) {
+      throw new Error(`license server responded with ${res.status}`);
+    }
+  },
+
+  fetchCatalog: async (): Promise<TCatalogResponse> => {
+    const url = new URL(PRODUCTS_PATH, serverUrl);
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${licenseKey}` },
+      redirect: "manual"
+    });
+    if (!res.ok) {
+      throw new Error(`license server responded with ${res.status}`);
+    }
+    const body: unknown = await res.json();
+    return catalogResponseSchema.parse(body);
+  },
+
+  // The license's subscription/contract view. A 404 (no contract yet) degrades to "no subscription".
+  fetchSubscription: async (): Promise<TSubscriptionResponse | null> => {
+    const url = new URL(SUBSCRIPTION_PATH, serverUrl);
+    const res = await fetch(url, {
+      method: "GET",
+      headers: { Authorization: `Bearer ${licenseKey}` },
+      redirect: "manual"
+    });
+    if (res.status === 404) {
+      return null;
+    }
+    if (!res.ok) {
+      throw new Error(`license server responded with ${res.status}`);
+    }
+    const body: unknown = await res.json();
+    const parsed = subscriptionResponseSchema.safeParse(body);
+    if (!parsed.success || !parsed.data.status) {
+      return null;
+    }
+    return parsed.data;
+  },
+
+  fetchCloudPlan: notSupportedOnSelfHosted("fetchCloudPlan"),
+  fetchBillingProfile: notSupportedOnSelfHosted("fetchBillingProfile"),
+  createCheckoutSession: notSupportedOnSelfHosted("createCheckoutSession"),
+  createPortalSession: notSupportedOnSelfHosted("createPortalSession"),
+  previewSubscriptionChange: notSupportedOnSelfHosted("previewSubscriptionChange"),
+  addSubscriptionItems: notSupportedOnSelfHosted("addSubscriptionItems"),
+  removeSubscriptionItem: notSupportedOnSelfHosted("removeSubscriptionItem"),
+  cancelSubscription: notSupportedOnSelfHosted("cancelSubscription"),
+  resumeSubscription: notSupportedOnSelfHosted("resumeSubscription")
 });

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -255,6 +255,8 @@ export type TCreatePortalPayload = {
 
 export type TLicenseClientBackend = {
   fetchEntitlements: (org: TEntitlementOrg) => Promise<TEntitlementsResponse>;
+  // Ask the license server to recompute/bust its cached entitlements after a license change.
+  refreshEntitlements: (org: TEntitlementOrg) => Promise<void>;
   fetchCatalog: () => Promise<TCatalogResponse>;
   fetchSubscription: (orgId: string) => Promise<TSubscriptionResponse | null>;
   fetchCloudPlan: (orgId: string) => Promise<TCloudPlanResponse | null>;

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -3,7 +3,7 @@ import { TEnvConfig } from "@app/lib/config/env";
 import { logger } from "@app/lib/logger";
 
 import { featureReaderFactory } from "./feature-reader";
-import { licenseServerBackend } from "./license-client-backends";
+import { licenseServerBackend, licenseServerSelfHostedBackend } from "./license-client-backends";
 import { entitlementResolverFactory } from "./license-client-cache";
 import {
   TAddSubscriptionItemsPayload,
@@ -17,26 +17,31 @@ import {
 type TLicenseClientFactoryDep = {
   envConfig: Pick<
     TEnvConfig,
-    "LICENSE_SERVER_V2_MODE" | "LICENSE_SERVER_V2_URL" | "LICENSE_SERVER_V2_SERVICE_KEY" | "INTERNAL_REGION"
+    | "LICENSE_SERVER_V2_MODE"
+    | "LICENSE_SERVER_V2_URL"
+    | "LICENSE_SERVER_V2_SERVICE_KEY"
+    | "LICENSE_KEY"
+    | "INTERNAL_REGION"
   >;
   keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry" | "deleteItem">;
 };
 
 export type TLicenseClientFactory = ReturnType<typeof licenseClientFactory>;
 
-// Returns null (SDK dormant -> getFeature serves fallbacks) unless the kill switch is on and the
-// server URL + service key are configured.
+// Mirrors SELF_HOSTED_V2_LICENSE_KEY_PREFIX in ee/license-fns; inlined to avoid a services -> ee
+// runtime import cycle (license-client <- license-service <- license-fns).
+const SELF_HOSTED_V2_LICENSE_KEY_PREFIX = "infisical_lk_";
+
+// Returns null (SDK dormant -> getFeature serves fallbacks) unless the kill switch is on and either a
+// self-hosted v2 license key or the cloud service key (plus server URL) is configured.
 const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicenseClientBackend | null => {
   if (envConfig.LICENSE_SERVER_V2_MODE === "off") {
     return null;
   }
 
   const serverUrl = envConfig.LICENSE_SERVER_V2_URL;
-  const signingKey = envConfig.LICENSE_SERVER_V2_SERVICE_KEY;
-  if (!serverUrl || !signingKey) {
-    logger.warn(
-      "license-client: enabled but LICENSE_SERVER_V2_URL / _SERVICE_KEY is missing; serving feature fallbacks"
-    );
+  if (!serverUrl) {
+    logger.warn("license-client: enabled but LICENSE_SERVER_V2_URL is missing; serving feature fallbacks");
     return null;
   }
 
@@ -50,6 +55,19 @@ const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicens
   }
   if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
     logger.warn("license-client: LICENSE_SERVER_V2_URL must use http(s); serving feature fallbacks");
+    return null;
+  }
+
+  // A self-hosted v2 license authenticates with its own key as a bearer token; the cloud path mints an
+  // RS256 service JWT from the service key instead.
+  const licenseKey = envConfig.LICENSE_KEY;
+  if (licenseKey?.startsWith(SELF_HOSTED_V2_LICENSE_KEY_PREFIX)) {
+    return licenseServerSelfHostedBackend(serverUrl, licenseKey, envConfig.INTERNAL_REGION);
+  }
+
+  const signingKey = envConfig.LICENSE_SERVER_V2_SERVICE_KEY;
+  if (!signingKey) {
+    logger.warn("license-client: enabled but LICENSE_SERVER_V2_SERVICE_KEY is missing; serving feature fallbacks");
     return null;
   }
 
@@ -73,6 +91,16 @@ export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFact
       return;
     }
     await resolver.invalidateEntitlements(orgId);
+  };
+
+  // Ask the license server to recompute its cached entitlements (used after a license change), then
+  // drop the local cache so the next read reflects them. No-op when the backend is dormant.
+  const refreshEntitlements = async (org: TEntitlementOrg) => {
+    if (!backend) {
+      return;
+    }
+    await backend.refreshEntitlements(org);
+    await invalidateEntitlements(org.id);
   };
 
   const getCatalog = async () => {
@@ -156,6 +184,7 @@ export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFact
     ...featureReaderFactory({ getEntitlements }),
     getEntitlements,
     invalidateEntitlements,
+    refreshEntitlements,
     getCatalog,
     getSubscription,
     getCloudPlan,

--- a/backend/src/services/license-client/usage/usage-reporter.ts
+++ b/backend/src/services/license-client/usage/usage-reporter.ts
@@ -36,24 +36,40 @@ export const usageReporterFactory = (serverUrl: string, serviceKey: string): TUs
   }
 });
 
+// Mirrors SELF_HOSTED_V2_LICENSE_KEY_PREFIX in ee/license-fns; inlined to avoid a services -> ee import.
+const SELF_HOSTED_V2_LICENSE_KEY_PREFIX = "infisical_lk_";
+
 // Returns null when the v2 license server is disabled or unconfigured, which keeps usage reporting
-// inert until Phase 2 flips LICENSE_SERVER_V2_MODE on.
+// inert. A self-hosted v2 license reports with its own key as the bearer; cloud uses the service key.
 export const buildUsageReporter = (
-  envConfig: Pick<TEnvConfig, "LICENSE_SERVER_V2_MODE" | "LICENSE_SERVER_V2_URL" | "LICENSE_SERVER_V2_SERVICE_KEY">
+  envConfig: Pick<
+    TEnvConfig,
+    "LICENSE_SERVER_V2_MODE" | "LICENSE_SERVER_V2_URL" | "LICENSE_SERVER_V2_SERVICE_KEY" | "LICENSE_KEY"
+  >
 ): TUsageReporter | null => {
   if (envConfig.LICENSE_SERVER_V2_MODE === "off") {
     return null;
   }
 
   const serverUrl = envConfig.LICENSE_SERVER_V2_URL;
-  if (!serverUrl || !envConfig.LICENSE_SERVER_V2_SERVICE_KEY) {
+  if (!serverUrl) {
+    logger.warn("usage-reporter: enabled but LICENSE_SERVER_V2_URL is missing; usage reporting disabled");
+    return null;
+  }
+
+  // A self-hosted v2 license authenticates with its own key; otherwise fall back to the cloud service key.
+  const licenseKey = envConfig.LICENSE_KEY;
+  const bearerKey = licenseKey?.startsWith(SELF_HOSTED_V2_LICENSE_KEY_PREFIX)
+    ? licenseKey
+    : envConfig.LICENSE_SERVER_V2_SERVICE_KEY;
+  if (!bearerKey) {
     logger.warn(
-      "usage-reporter: enabled but LICENSE_SERVER_V2_URL / LICENSE_SERVER_V2_SERVICE_KEY is missing; usage reporting disabled"
+      "usage-reporter: enabled but no LICENSE_KEY (self-hosted) / LICENSE_SERVER_V2_SERVICE_KEY (cloud) is set; usage reporting disabled"
     );
     return null;
   }
 
-  // Don't forward the service-key bearer to a non-HTTPS or malformed destination.
+  // Don't forward the bearer to a non-HTTPS or malformed destination.
   let parsedUrl: URL;
   try {
     parsedUrl = new URL(serverUrl);
@@ -66,5 +82,5 @@ export const buildUsageReporter = (
     return null;
   }
 
-  return usageReporterFactory(serverUrl, envConfig.LICENSE_SERVER_V2_SERVICE_KEY);
+  return usageReporterFactory(serverUrl, bearerKey);
 };

--- a/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
@@ -182,6 +182,12 @@ export const BillingV2Page = () => {
 
   const sheetRedirecting = createPortalSession.isPending || createCheckoutSession.isPending;
 
+  // A managed (self-hosted licensed) org can't self-serve through Stripe; its plan is set by the license.
+  const isManaged = overview?.mode === "managed";
+  const pageDescription = isManaged
+    ? "View your subscription, products, and usage. Your plan is managed through your license."
+    : "Manage your subscription, products, and payment. Payment is handled securely through Stripe.";
+
   return (
     <div className="h-full bg-bunker-800">
       <Helmet>
@@ -191,11 +197,7 @@ export const BillingV2Page = () => {
       </Helmet>
       <div className="flex h-full w-full justify-center bg-bunker-800 text-white">
         <div className="w-full max-w-8xl">
-          <PageHeader
-            scope="org"
-            title={t("billing.title")}
-            description="Manage your subscription, products, and payment. Payment is handled securely through Stripe."
-          />
+          <PageHeader scope="org" title={t("billing.title")} description={pageDescription} />
           <OrgPermissionCan
             passThrough={false}
             I={OrgPermissionBillingActions.Read}


### PR DESCRIPTION
## Context

- Recognize new `infisical_lk_` license keys (legacy `QVHK-HIGYH` keys still work) and run the instance in a new `EnterpriseOnPremV2` mode.
- Resolve features/usage from License Server v2, authenticating with the license key as a bearer token (single-tenant, no org id).
- Sync entitlements + subscription on boot and via background refresh; report usage via snapshots (recorded, not charged).
- Only read/refresh/usage endpoints are wired for self-hosted; Stripe billing (checkout/portal/subscription changes) is rejected.
- Billing page shows a read-only "managed by your license" view (plan, products, shared members + machine-identity usage; payment/invoices/checkout hidden).
- Tested old license key working

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)