### PR TITLE
fix(dynamic-secret): skip soft-deleted projects in DAL queries

### DIFF
--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-dal.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-dal.ts
@@ -223,6 +223,7 @@ export const dynamicSecretDALFactory = (db: TDbClient): TDynamicSecretDALFactory
       .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
       .whereNull(`${TableName.Environment}.deleteAfter`)
       .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .where(`${TableName.DynamicSecret}.gatewayV2Id`, gatewayId)
       .select(
         db.ref("id").withSchema(TableName.DynamicSecret),
@@ -251,6 +252,7 @@ export const dynamicSecretDALFactory = (db: TDbClient): TDynamicSecretDALFactory
       .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
       .whereNull(`${TableName.Environment}.deleteAfter`)
       .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .where(`${TableName.DynamicSecret}.gatewayPoolId`, gatewayPoolId)
       .select(
         db.ref("id").withSchema(TableName.DynamicSecret),
@@ -279,8 +281,10 @@ export const dynamicSecretDALFactory = (db: TDbClient): TDynamicSecretDALFactory
       const result = await (tx || db.replicaNode())(TableName.DynamicSecret)
         .join(TableName.SecretFolder, `${TableName.DynamicSecret}.folderId`, `${TableName.SecretFolder}.id`)
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
         .where(`${TableName.Environment}.projectId`, projectId)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .count("* as count")
         .first();
 

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-dal.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-dal.ts
@@ -239,8 +239,13 @@ export const dynamicSecretDALFactory = (db: TDbClient): TDynamicSecretDALFactory
 
   const countByGatewayId = async (gatewayId: string, tx?: Knex) => {
     const result = await (tx || db.replicaNode())(TableName.DynamicSecret)
+      .join(TableName.SecretFolder, `${TableName.DynamicSecret}.folderId`, `${TableName.SecretFolder}.id`)
+      .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+      .whereNull(`${TableName.Environment}.deleteAfter`)
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .where(`${TableName.DynamicSecret}.gatewayV2Id`, gatewayId)
-      .count("id")
+      .count(`${TableName.DynamicSecret}.id`)
       .first();
 
     return parseInt(String(result?.count || "0"), 10);
@@ -269,8 +274,13 @@ export const dynamicSecretDALFactory = (db: TDbClient): TDynamicSecretDALFactory
 
   const countByGatewayPoolId = async (gatewayPoolId: string, tx?: Knex) => {
     const result = await (tx || db.replicaNode())(TableName.DynamicSecret)
+      .join(TableName.SecretFolder, `${TableName.DynamicSecret}.folderId`, `${TableName.SecretFolder}.id`)
+      .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+      .whereNull(`${TableName.Environment}.deleteAfter`)
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .where(`${TableName.DynamicSecret}.gatewayPoolId`, gatewayPoolId)
-      .count("id")
+      .count(`${TableName.DynamicSecret}.id`)
       .first();
 
     return parseInt(String(result?.count || "0"), 10);


### PR DESCRIPTION
## What

Three queries in `dynamic-secret-dal.ts` joined `project_environments` and `projects` but only filtered `Environment.deleteAfter` — never `Project.deleteAfter`:

- `findByGatewayId` (used when listing dynamic secrets tied to a gateway)
- `findByGatewayPoolId` (same, but for gateway pools)
- `countByProject` (insights / org stats)

Soft-deleting a project does not soft-delete its environments, so these queries kept returning dynamic-secret rows for projects sitting in the delete grace window. The gateway-detail and insights pages would still surface a soft-deleted project's dynamic secrets, and gateway/pool delete flows would seq-scan over them.

## Fix

Adds `whereNull(Project.deleteAfter)` to all three, matching the pattern already used in `org-product-stats-dal.ts` and the recently shipped webhook (#6970), integration (#6983), and secret-rotation-v2 (#7002) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as the existing org-product-stats-dal)
- [x] The change is limited to the affected code path