### PR TITLE
fix(secret-snapshot): skip soft-deleted projects in snapshot DAL queries

### DIFF
--- a/backend/src/ee/services/secret-snapshot/snapshot-dal.ts
+++ b/backend/src/ee/services/secret-snapshot/snapshot-dal.ts
@@ -29,6 +29,7 @@ export const snapshotDALFactory = (db: TDbClient) => {
         .join(TableName.Environment, `${TableName.Snapshot}.envId`, `${TableName.Environment}.id`)
         .whereNull(`${TableName.Environment}.deleteAfter`)
         .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .select(selectAllTableCols(TableName.Snapshot))
         .select(
           db.ref("id").withSchema(TableName.Environment).as("envId"),
@@ -66,6 +67,8 @@ export const snapshotDALFactory = (db: TDbClient) => {
         .where(`${TableName.Snapshot}.id`, snapshotId)
         .join(TableName.Environment, `${TableName.Snapshot}.envId`, `${TableName.Environment}.id`)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .leftJoin(TableName.SnapshotSecret, `${TableName.Snapshot}.id`, `${TableName.SnapshotSecret}.snapshotId`)
         .leftJoin(
           TableName.SecretVersion,
@@ -161,6 +164,8 @@ export const snapshotDALFactory = (db: TDbClient) => {
         .where(`${TableName.Snapshot}.id`, snapshotId)
         .join(TableName.Environment, `${TableName.Snapshot}.envId`, `${TableName.Environment}.id`)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .leftJoin(TableName.SnapshotSecretV2, `${TableName.Snapshot}.id`, `${TableName.SnapshotSecretV2}.snapshotId`)
         .leftJoin(
           TableName.SecretVersionV2,


### PR DESCRIPTION
## What

Three snapshot DAL helpers joined `project_environments` and (in one case) `projects` but only filtered `Environment.deleteAfter`, never `Project.deleteAfter`:

- `findById` (used for snapshot listing / details)
- `findSecretSnapshotDataById` (legacy snapshot fetch by id)
- `findSecretSnapshotV2DataById` (current snapshot fetch by id)

Soft-deleting a project does not soft-delete its environments. So a snapshot inside a soft-deleted project's environment could still be fetched, viewed, and rolled back during the grace window. Rolling back to such a snapshot would un-delete secret rows and pre-stage data the user expected to be gone — exactly the case the soft-delete pattern was designed to prevent.

## Fix

Adds the `Project.deleteAfter` null filter (and the `Project` join where missing) to all three. Mirrors the pattern already used in `org-product-stats-dal.ts` and the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), and dynamic-secret (#7065) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path