### PR TITLE
fix(folder-commit): skip soft-deleted projects in PIT history queries

### DIFF
--- a/backend/src/services/folder-commit-changes/folder-commit-changes-dal.ts
+++ b/backend/src/services/folder-commit-changes/folder-commit-changes-dal.ts
@@ -101,6 +101,11 @@ export const folderCommitChangesDALFactory = (db: TDbClient) => {
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .leftJoin(TableName.Project, function joinActiveProjectForFolderCommit() {
+          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
+            `${TableName.Project}.deleteAfter`
+          );
+        })
         .where((qb) => {
           if (projectId) {
             void qb.where(`${TableName.Environment}.projectId`, "=", projectId);

--- a/backend/src/services/folder-commit-changes/folder-commit-changes-dal.ts
+++ b/backend/src/services/folder-commit-changes/folder-commit-changes-dal.ts
@@ -96,16 +96,13 @@ export const folderCommitChangesDALFactory = (db: TDbClient) => {
           `${TableName.FolderCommitChanges}.folderVersionId`,
           `${TableName.SecretFolderVersion}.id`
         )
-        .leftJoin<TProjectEnvironments>(TableName.Environment, function joinActiveEnvForFolderCommit() {
+        .innerJoin<TProjectEnvironments>(TableName.Environment, function joinActiveEnvForFolderCommit() {
           this.on(`${TableName.FolderCommit}.envId`, `${TableName.Environment}.id`).andOnNull(
             `${TableName.Environment}.deleteAfter`
           );
         })
-        .leftJoin(TableName.Project, function joinActiveProjectForFolderCommit() {
-          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
-            `${TableName.Project}.deleteAfter`
-          );
-        })
+        .innerJoin(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where((qb) => {
           if (projectId) {
             void qb.where(`${TableName.Environment}.projectId`, "=", projectId);

--- a/backend/src/services/folder-commit/folder-commit-dal.ts
+++ b/backend/src/services/folder-commit/folder-commit-dal.ts
@@ -69,6 +69,11 @@ export const folderCommitDALFactory = (db: TDbClient) => {
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .leftJoin(TableName.Project, function joinActiveProjectForFolderCommit() {
+          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
+            `${TableName.Project}.deleteAfter`
+          );
+        })
         .where((qb) => {
           if (projectId) {
             void qb.where(`${TableName.Environment}.projectId`, "=", projectId);
@@ -386,6 +391,11 @@ export const folderCommitDALFactory = (db: TDbClient) => {
         .leftJoin<TProjectEnvironments>(TableName.Environment, function joinActiveEnvForFolderCommit() {
           this.on(`${TableName.FolderCommit}.envId`, `${TableName.Environment}.id`).andOnNull(
             `${TableName.Environment}.deleteAfter`
+          );
+        })
+        .leftJoin(TableName.Project, function joinActiveProjectForFolderCommit() {
+          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
+            `${TableName.Project}.deleteAfter`
           );
         })
         .where((qb) => {

--- a/backend/src/services/folder-commit/folder-commit-dal.ts
+++ b/backend/src/services/folder-commit/folder-commit-dal.ts
@@ -64,16 +64,13 @@ export const folderCommitDALFactory = (db: TDbClient) => {
     try {
       const doc = await (tx || db.replicaNode())(TableName.FolderCommit)
         .where({ folderId })
-        .leftJoin(TableName.Environment, function joinActiveEnvForFolderCommit() {
+        .innerJoin(TableName.Environment, function joinActiveEnvForFolderCommit() {
           this.on(`${TableName.FolderCommit}.envId`, `${TableName.Environment}.id`).andOnNull(
             `${TableName.Environment}.deleteAfter`
           );
         })
-        .leftJoin(TableName.Project, function joinActiveProjectForFolderCommit() {
-          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
-            `${TableName.Project}.deleteAfter`
-          );
-        })
+        .innerJoin(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where((qb) => {
           if (projectId) {
             void qb.where(`${TableName.Environment}.projectId`, "=", projectId);
@@ -385,19 +382,16 @@ export const folderCommitDALFactory = (db: TDbClient) => {
 
   const findById = async (id: string, tx?: Knex, projectId?: string): Promise<TFolderCommits> => {
     try {
-      const doc = await (tx || db.replicaNode())(TableName.FolderCommit)
+      const doc = (await (tx || db.replicaNode())(TableName.FolderCommit)
         // eslint-disable-next-line @typescript-eslint/no-misused-promises
         .where(buildFindFilter({ id }, TableName.FolderCommit))
-        .leftJoin<TProjectEnvironments>(TableName.Environment, function joinActiveEnvForFolderCommit() {
+        .innerJoin<TProjectEnvironments>(TableName.Environment, function joinActiveEnvForFolderCommit() {
           this.on(`${TableName.FolderCommit}.envId`, `${TableName.Environment}.id`).andOnNull(
             `${TableName.Environment}.deleteAfter`
           );
         })
-        .leftJoin(TableName.Project, function joinActiveProjectForFolderCommit() {
-          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
-            `${TableName.Project}.deleteAfter`
-          );
-        })
+        .innerJoin(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where((qb) => {
           if (projectId) {
             void qb.where(`${TableName.Environment}.projectId`, "=", projectId);
@@ -405,7 +399,7 @@ export const folderCommitDALFactory = (db: TDbClient) => {
         })
         .select(selectAllTableCols(TableName.FolderCommit))
         .orderBy("commitId", "desc")
-        .first();
+        .first()) as TFolderCommits | undefined;
       if (!doc) {
         throw new NotFoundError({
           message: `Folder commit not found for ID ${id}`


### PR DESCRIPTION
## What

Three queries in the folder-commit DALs join `project_environments` with `andOnNull(Environment.deleteAfter)` but never join `projects` or filter `Project.deleteAfter`:

- `folder-commit-dal.findLatestCommit`
- `folder-commit-dal.findById`
- `folder-commit-changes-dal.findByCommitId`

Soft-deleting a project does not soft-delete its environments. The point-in-time (PIT) commit history and rollback UI for a soft-deleted project would still surface its commits during the grace window.

## Fix

Adds a parallel `leftJoin(Project, ...).andOnNull(Project.deleteAfter)` to each query — same style this file already uses on environments. Mirrors the pattern from `org-product-stats-dal.ts` and the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), and snapshot (#7066) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path