### PR TITLE
fix(hsm): support strict-template HSMs

### DIFF
--- a/backend/src/ee/services/hsm/hsm-service.ts
+++ b/backend/src/ee/services/hsm/hsm-service.ts
@@ -136,8 +136,10 @@ export const hsmServiceFactory = ({ hsmModule: { isInitialized, pkcs11 }, envCon
   const $findKey = (sessionHandle: pkcs11js.Handle, type: HsmKeyType) => {
     const label = type === HsmKeyType.HMAC ? `${envConfig.HSM_KEY_LABEL}_HMAC` : envConfig.HSM_KEY_LABEL;
 
-    // AES is pinned to CKK_AES. HMAC matches on class + label only so vendor-specific generic-secret subtypes are also accepted.
-    // CKM_SHA256_HMAC works against any of them.
+    // AES is pinned to CKK_AES. HMAC matches on class + label + CKA_SIGN/CKA_VERIFY so
+    // vendor-specific generic-secret subtypes (e.g. nShield's CKK_SHA256_HMAC) are accepted,
+    // while any unrelated secret with the same label suffix that cannot perform CKM_SHA256_HMAC
+    // is filtered out at the search layer rather than failing later in C_SignInit / C_VerifyInit.
     const template: pkcs11js.Template = [
       { type: pkcs11js.CKA_CLASS, value: pkcs11js.CKO_SECRET_KEY },
       { type: pkcs11js.CKA_LABEL, value: label }
@@ -145,6 +147,8 @@ export const hsmServiceFactory = ({ hsmModule: { isInitialized, pkcs11 }, envCon
 
     if (type === HsmKeyType.AES) {
       template.push({ type: pkcs11js.CKA_KEY_TYPE, value: pkcs11js.CKK_AES });
+    } else {
+      template.push({ type: pkcs11js.CKA_SIGN, value: true }, { type: pkcs11js.CKA_VERIFY, value: true });
     }
 
     try {

--- a/backend/src/ee/services/hsm/hsm-service.ts
+++ b/backend/src/ee/services/hsm/hsm-service.ts
@@ -135,13 +135,17 @@ export const hsmServiceFactory = ({ hsmModule: { isInitialized, pkcs11 }, envCon
 
   const $findKey = (sessionHandle: pkcs11js.Handle, type: HsmKeyType) => {
     const label = type === HsmKeyType.HMAC ? `${envConfig.HSM_KEY_LABEL}_HMAC` : envConfig.HSM_KEY_LABEL;
-    const keyType = type === HsmKeyType.HMAC ? pkcs11js.CKK_GENERIC_SECRET : pkcs11js.CKK_AES;
 
-    const template = [
+    // AES is pinned to CKK_AES. HMAC matches on class + label only so vendor-specific generic-secret subtypes are also accepted.
+    // CKM_SHA256_HMAC works against any of them.
+    const template: pkcs11js.Template = [
       { type: pkcs11js.CKA_CLASS, value: pkcs11js.CKO_SECRET_KEY },
-      { type: pkcs11js.CKA_KEY_TYPE, value: keyType },
       { type: pkcs11js.CKA_LABEL, value: label }
     ];
+
+    if (type === HsmKeyType.AES) {
+      template.push({ type: pkcs11js.CKA_KEY_TYPE, value: pkcs11js.CKK_AES });
+    }
 
     try {
       // Initialize search
@@ -393,7 +397,9 @@ export const hsmServiceFactory = ({ hsmModule: { isInitialized, pkcs11 }, envCon
         ];
 
         if (!$keyExists(sessionHandle, HsmKeyType.AES)) {
-          // Template for generating 256-bit AES master key
+          // Template for generating 256-bit AES master key.
+          // Negative usage attributes are set explicitly so HSMs with strict template validation works.
+          // On permissive HSMs these are already the implicit defaults.
           const keyTemplate = [
             { type: pkcs11js.CKA_CLASS, value: pkcs11js.CKO_SECRET_KEY },
             { type: pkcs11js.CKA_KEY_TYPE, value: pkcs11js.CKK_AES },
@@ -401,6 +407,11 @@ export const hsmServiceFactory = ({ hsmModule: { isInitialized, pkcs11 }, envCon
             { type: pkcs11js.CKA_LABEL, value: envConfig.HSM_KEY_LABEL! },
             { type: pkcs11js.CKA_ENCRYPT, value: true }, // Allow encryption
             { type: pkcs11js.CKA_DECRYPT, value: true }, // Allow decryption
+            { type: pkcs11js.CKA_SIGN, value: false },
+            { type: pkcs11js.CKA_VERIFY, value: false },
+            { type: pkcs11js.CKA_WRAP, value: false },
+            { type: pkcs11js.CKA_UNWRAP, value: false },
+            { type: pkcs11js.CKA_DERIVE, value: false },
             ...genericAttributes
           ];
 
@@ -421,10 +432,15 @@ export const hsmServiceFactory = ({ hsmModule: { isInitialized, pkcs11 }, envCon
           const hmacKeyTemplate = [
             { type: pkcs11js.CKA_CLASS, value: pkcs11js.CKO_SECRET_KEY },
             { type: pkcs11js.CKA_KEY_TYPE, value: pkcs11js.CKK_GENERIC_SECRET },
-            { type: pkcs11js.CKA_VALUE_LEN, value: HMAC_KEY_SIZE / 8 }, // 256-bit key
+            { type: pkcs11js.CKA_VALUE_LEN, value: HMAC_KEY_SIZE / 8 },
             { type: pkcs11js.CKA_LABEL, value: `${envConfig.HSM_KEY_LABEL!}_HMAC` },
             { type: pkcs11js.CKA_SIGN, value: true }, // Allow signing
             { type: pkcs11js.CKA_VERIFY, value: true }, // Allow verification
+            { type: pkcs11js.CKA_ENCRYPT, value: false },
+            { type: pkcs11js.CKA_DECRYPT, value: false },
+            { type: pkcs11js.CKA_WRAP, value: false },
+            { type: pkcs11js.CKA_UNWRAP, value: false },
+            { type: pkcs11js.CKA_DERIVE, value: false },
             ...genericAttributes
           ];
 


### PR DESCRIPTION
## Context

Adds explicit-false usage attributes (`CKA_WRAP/UNWRAP/DERIVE`, and `CKA_SIGN/VERIFY` on AES and `CKA_ENCRYPT/DECRYPT` on HMAC) to both generate templates so HSMs with strict template validation no longer reject key creation with `CKR_TEMPLATE_INCONSISTENT`. Also relaxes the HMAC find to match on class + label only so vendor-specific generic-secret subtypes (e.g. nShield's CKK_SHA256_HMAC) are accepted. AES stays pinned to CKK_AES.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)