### PR TITLE
fix(audit-logs): misattribution on change secret

### DIFF
--- a/backend/src/ee/routes/v1/secret-approval-request-router.ts
+++ b/backend/src/ee/routes/v1/secret-approval-request-router.ts
@@ -143,7 +143,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
-      const { approval, projectId, secretMutationEvents } =
+      const { approval, projectId, secretMutationEvents, requestedByActor } =
         await server.services.secretApprovalRequest.mergeSecretApprovalRequest({
           actorId: req.permission.id,
           actor: req.permission.type,
@@ -170,6 +170,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
       for await (const event of secretMutationEvents) {
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
+          actor: requestedByActor ?? req.auditLogInfo.actor,
           orgId: req.permission.orgId,
           projectId,
           event

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -12,7 +12,7 @@ import {
   TSecretApprovalRequestsSecretsInsert,
   TSecretApprovalRequestsSecretsV2Insert
 } from "@app/db/schemas";
-import { Event, EventType } from "@app/ee/services/audit-log/audit-log-types";
+import { Actor, Event, EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { AUDIT_LOG_SENSITIVE_VALUE } from "@app/lib/config/const";
 import { getConfig } from "@app/lib/config/env";
 import { crypto, SymmetricKeySize } from "@app/lib/crypto/cryptography";
@@ -1264,6 +1264,17 @@ export const secretApprovalRequestServiceFactory = ({
 
     const { created, updated, deleted } = mergeStatus.secrets;
 
+    const requestedByActor: Actor | undefined = secretApprovalRequest.committerUserId
+      ? {
+          type: ActorType.USER,
+          metadata: {
+            userId: secretApprovalRequest.committerUserId,
+            email: secretApprovalRequest.committerUser?.email,
+            username: secretApprovalRequest.committerUser?.username ?? ""
+          }
+        }
+      : undefined;
+
     const secretMutationEvents: Event[] = [];
 
     if (created.length) {
@@ -1399,7 +1410,7 @@ export const secretApprovalRequestServiceFactory = ({
       }
     }
 
-    return { ...mergeStatus, projectId, secretMutationEvents };
+    return { ...mergeStatus, projectId, secretMutationEvents, requestedByActor };
   };
 
   // function to save secret change to secret approval

--- a/frontend/src/components/secrets/SecretReferenceDetails/SecretReferenceDetails.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/SecretReferenceDetails.tsx
@@ -307,15 +307,15 @@ export const SecretReferenceTree = ({
     (env: string, path: string, key: string) => {
       onClose?.();
       navigate({
-        to: ROUTE_PATHS.SecretManager.SecretDashboardPage.path,
+        to: ROUTE_PATHS.SecretManager.OverviewPage.path,
         params: {
           orgId: routeParams.orgId as string,
-          projectId: currentProject?.id || "",
-          envSlug: env
+          projectId: currentProject?.id || ""
         },
         search: {
           secretPath: path || "/",
-          search: key || ""
+          search: key || "",
+          environments: [env]
         }
       });
     },

--- a/frontend/src/components/secrets/SecretReferenceDetails/nodes/SecretNode.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/nodes/SecretNode.tsx
@@ -48,15 +48,15 @@ export const SecretNode = ({ data }: NodeProps & { data: SecretNodeData }) => {
     if (isRoot) return;
     onClose?.();
     navigate({
-      to: ROUTE_PATHS.SecretManager.SecretDashboardPage.path,
+      to: ROUTE_PATHS.SecretManager.OverviewPage.path,
       params: {
         orgId: routeParams.orgId as string,
-        projectId: currentProject?.id || "",
-        envSlug: environment
+        projectId: currentProject?.id || ""
       },
       search: {
         secretPath,
-        search: secretKey
+        search: secretKey,
+        environments: [environment]
       }
     });
   }, [

--- a/frontend/src/components/secrets/SecretReferenceDetails/nodes/SecretNode.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/nodes/SecretNode.tsx
@@ -59,7 +59,16 @@ export const SecretNode = ({ data }: NodeProps & { data: SecretNodeData }) => {
         environments: [environment]
       }
     });
-  }, [navigate, routeParams.orgId, currentProject, secretPath, secretKey, isRoot, onClose]);
+  }, [
+    navigate,
+    routeParams.orgId,
+    currentProject,
+    environment,
+    secretPath,
+    secretKey,
+    isRoot,
+    onClose
+  ]);
 
   const envBadge = (
     <Badge

--- a/frontend/src/components/secrets/SecretReferenceDetails/nodes/SecretNode.tsx
+++ b/frontend/src/components/secrets/SecretReferenceDetails/nodes/SecretNode.tsx
@@ -59,16 +59,7 @@ export const SecretNode = ({ data }: NodeProps & { data: SecretNodeData }) => {
         environments: [environment]
       }
     });
-  }, [
-    navigate,
-    routeParams.orgId,
-    currentProject,
-    environment,
-    secretPath,
-    secretKey,
-    isRoot,
-    onClose
-  ]);
+  }, [navigate, routeParams.orgId, currentProject, secretPath, secretKey, isRoot, onClose]);
 
   const envBadge = (
     <Badge

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -443,24 +443,53 @@ const OverviewPageContent = () => {
     userAvailableEnvs?.[0]?.id ? [userAvailableEnvs[0].id] : []
   );
 
-  // Apply the environment filter when linked via the `environments` search param (e.g. from the
-  // secret reference tree). This runs reactively rather than on mount only, because the tree is
-  // rendered inside this page, so navigating from a node updates the param without remounting.
+  // Apply one-shot deep-link inputs to local filters, then strip them from the URL in a SINGLE
+  // navigate. These arrive either from a notification/email link (`search`, `filterBy`) or from
+  // the secret reference tree (`environments` + `search`). Handling them in one effect/navigate
+  // (rather than two racing effects) guarantees every param is cleared after it's applied. That
+  // matters most for `environments`: re-selecting the same environment from the reference tree
+  // changes the param again and re-fires this effect instead of being a no-op. Runs reactively
+  // (not mount-only) because the tree is rendered inside this page, so navigating from a node
+  // updates the params without remounting.
   useEffect(() => {
-    const envSlugs = routerSearch.environments;
-    if (!envSlugs || envSlugs.length === 0 || userAvailableEnvs.length === 0) return;
+    const { search, filterBy, environments: envSlugs, ...query } = routerSearch;
+    const hasEnvLink = Boolean(envSlugs?.length);
 
-    const envIds = userAvailableEnvs
-      .filter((env) => envSlugs.includes(env.slug))
-      .map((env) => env.id);
-    if (envIds.length > 0) {
-      setStoredEnvIds(envIds);
+    if (!search && !filterBy && !hasEnvLink) return;
+    // Env link present but envs not loaded yet → wait so we don't strip it before applying.
+    if (hasEnvLink && userAvailableEnvs.length === 0) return;
+
+    if (envSlugs && envSlugs.length > 0) {
+      const envIds = userAvailableEnvs
+        .filter((env) => envSlugs.includes(env.slug))
+        .map((env) => env.id);
+      if (envIds.length > 0) {
+        setStoredEnvIds(envIds);
+      }
     }
 
-    // Treat the param as a one-shot deep-link input (mirrors the `search` handling below) so it
-    // doesn't override the user's stored env filter on subsequent renders.
-    navigate({ search: (prev) => ({ ...prev, environments: [] }), replace: true });
-  }, [routerSearch.environments?.join(","), userAvailableEnvs.length]);
+    if (search || filterBy) {
+      const initialFilter = { ...DEFAULT_FILTER_STATE };
+      if (filterBy) {
+        const rowType = Object.values(RowType).find((rt) => rt === filterBy);
+        if (rowType) {
+          initialFilter[rowType] = true;
+        }
+      }
+      setFilter(initialFilter);
+
+      if (search) {
+        setSearchFilter(search as string);
+      }
+    }
+
+    navigate({ search: query, replace: true });
+  }, [
+    routerSearch.search,
+    routerSearch.filterBy,
+    routerSearch.environments?.join(","),
+    userAvailableEnvs.length
+  ]);
 
   const filteredEnvs = useMemo(() => {
     if (!storedEnvIds.length) return [];
@@ -874,28 +903,6 @@ const OverviewPageContent = () => {
       }
     }
   }, [routerSearch.dynamicSecretId, dynamicSecrets?.map((ds) => ds.id).join(",")]);
-
-  // Apply search and/or resource type filter when linked via notification/email
-  useEffect(() => {
-    if (routerSearch.search || routerSearch.filterBy) {
-      const { search, filterBy, ...query } = routerSearch;
-      // temp workaround until we transition state to query params
-      navigate({ search: query, replace: true });
-
-      const initialFilter = { ...DEFAULT_FILTER_STATE };
-      if (filterBy) {
-        const rowType = Object.values(RowType).find((rt) => rt === filterBy);
-        if (rowType) {
-          initialFilter[rowType] = true;
-        }
-      }
-      setFilter(initialFilter);
-
-      if (search) {
-        setSearchFilter(search as string);
-      }
-    }
-  }, [routerSearch.search, routerSearch.filterBy]);
 
   const handleViewCommitHistory = async (envSlug: string, preloadedFolderId?: string) => {
     if (!subscription?.pitRecovery) {

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -443,17 +443,24 @@ const OverviewPageContent = () => {
     userAvailableEnvs?.[0]?.id ? [userAvailableEnvs[0].id] : []
   );
 
+  // Apply the environment filter when linked via the `environments` search param (e.g. from the
+  // secret reference tree). This runs reactively rather than on mount only, because the tree is
+  // rendered inside this page, so navigating from a node updates the param without remounting.
   useEffect(() => {
     const envSlugs = routerSearch.environments;
-    if (envSlugs && envSlugs.length > 0) {
-      const envIds = userAvailableEnvs
-        .filter((env) => envSlugs.includes(env.slug))
-        .map((env) => env.id);
-      if (envIds.length > 0) {
-        setStoredEnvIds(envIds);
-      }
+    if (!envSlugs || envSlugs.length === 0 || userAvailableEnvs.length === 0) return;
+
+    const envIds = userAvailableEnvs
+      .filter((env) => envSlugs.includes(env.slug))
+      .map((env) => env.id);
+    if (envIds.length > 0) {
+      setStoredEnvIds(envIds);
     }
-  }, []);
+
+    // Treat the param as a one-shot deep-link input (mirrors the `search` handling below) so it
+    // doesn't override the user's stored env filter on subsequent renders.
+    navigate({ search: (prev) => ({ ...prev, environments: [] }), replace: true });
+  }, [routerSearch.environments?.join(","), userAvailableEnvs.length]);
 
   const filteredEnvs = useMemo(() => {
     if (!storedEnvIds.length) return [];


### PR DESCRIPTION
## Context

When a secret was changed, the actor being saved on audit logs was the approver instead of the commiter (the user that requested the change). This was causing confusion.

This PR also fixes the redirect to the right overview page when a click on a node at the dependency graph happens. 

## Screenshots



https://github.com/user-attachments/assets/4362dbb5-be29-4a70-af14-735bba111f1b




## Steps to verify the change

### audit logs saving wrong actor 
- create a secret change policy 
- perform a secret change using an account 
- With another account, accept this change
- check the audit logs and validate that on the secret change the actor that is saved is the commiter, not the approver 


### redirect on dependency graph 
- create a secret reference between a "source secret" and a "destination secret"
- check the "source secret" dependency graph by clicking on `Secret References`
- Check the `Dependency Graph` and click on a referenced secret
- Make sure that you are being redirected to the new overview page. 

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)