### PR TITLE
fix(template): reject unescaped expressions in permission templates

### DIFF
--- a/backend/src/ee/services/project-template/project-template-service.ts
+++ b/backend/src/ee/services/project-template/project-template-service.ts
@@ -18,6 +18,7 @@ import {
   TUnpackedPermission
 } from "@app/ee/services/project-template/project-template-types";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
 import { unpackPermissions } from "@app/server/routes/sanitizedSchema/permission";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
 import { TOrgMembershipDALFactory } from "@app/services/org-membership/org-membership-dal";
@@ -265,6 +266,16 @@ export const projectTemplateServiceFactory = ({
 
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Create, OrgPermissionSubjects.ProjectTemplates);
 
+    // Template roles are materialized into project custom roles (rendered by the same permission
+    // templating), so validate them the same way role creation does.
+    roles.forEach((role) => {
+      validateHandlebarTemplate("Project Template Role", JSON.stringify(role.permissions || []), {
+        allowedExpressions: (val) => val.includes("identity."),
+        allowedHelpers: ["stripPrefix"],
+        rejectUnescaped: true
+      });
+    });
+
     if (type === ProjectType.AI) {
       throw new BadRequestError({ message: "Agent Sentinel project templates are not supported" });
     }
@@ -509,6 +520,19 @@ export const projectTemplateServiceFactory = ({
     });
 
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Edit, OrgPermissionSubjects.ProjectTemplates);
+
+    if (roles) {
+      // Template roles are materialized into project custom roles, so validate them the same way
+      // role update does.
+      roles.forEach((role) => {
+        validateHandlebarTemplate("Project Template Role", JSON.stringify(role.permissions || []), {
+          allowedExpressions: (val) => val.includes("identity."),
+          allowedHelpers: ["stripPrefix"],
+          rejectUnescaped: true
+        });
+      });
+    }
+
     if (projectTemplate.type !== ProjectType.SecretManager && environments)
       throw new BadRequestError({ message: "Cannot configure environments for non-SecretManager project templates" });
 

--- a/backend/src/lib/template/validate-handlebars.test.ts
+++ b/backend/src/lib/template/validate-handlebars.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+// logger is initialized at app boot and is undefined under unit tests; stub it so the reject path
+// surfaces the BadRequestError rather than a "logger is undefined" error.
+vi.mock("@app/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+// eslint-disable-next-line import/first
+import { isValidHandleBarTemplate, validateHandlebarTemplate } from "./validate-handlebars";
+
+const allow = (expression: string) => expression.includes("identity");
+const lenient = { allowedExpressions: allow }; // default: escaping not enforced (e.g. dynamic-secret callers)
+const strict = { allowedExpressions: allow, rejectUnescaped: true }; // permission callers (role / additional-privilege)
+
+describe("validateHandlebarTemplate", () => {
+  it("accepts an escaped, allowed expression (strict and lenient)", () => {
+    expect(() => validateHandlebarTemplate("test", "{{identity.id}}", strict)).not.toThrow();
+    expect(() => validateHandlebarTemplate("test", "{{identity.id}}", lenient)).not.toThrow();
+  });
+
+  it("strict: rejects an unescaped triple-mustache expression even when the path is allowed", () => {
+    expect(() => validateHandlebarTemplate("test", "{{{identity.id}}}", strict)).toThrow(
+      /Template sanitization failed/
+    );
+  });
+
+  it("strict: rejects the unescaped ampersand form ({{& }}) even when the path is allowed", () => {
+    expect(() => validateHandlebarTemplate("test", "{{&identity.id}}", strict)).toThrow(/Template sanitization failed/);
+  });
+
+  it("lenient (default): allows an unescaped expression, preserving behavior for non-permission callers", () => {
+    expect(() => validateHandlebarTemplate("test", "{{{identity.id}}}", lenient)).not.toThrow();
+  });
+
+  it("rejects a disallowed expression regardless of mode", () => {
+    expect(() => validateHandlebarTemplate("test", "{{secret.value}}", strict)).toThrow(/Template sanitization failed/);
+  });
+});
+
+describe("isValidHandleBarTemplate", () => {
+  it("returns true for an escaped, allowed expression", () => {
+    expect(isValidHandleBarTemplate("{{identity.id}}", strict)).toBe(true);
+  });
+
+  it("strict: returns false for an unescaped triple-mustache expression even when the path is allowed", () => {
+    expect(isValidHandleBarTemplate("{{{identity.id}}}", strict)).toBe(false);
+  });
+
+  it("lenient (default): returns true for an unescaped expression with an allowed path", () => {
+    expect(isValidHandleBarTemplate("{{{identity.id}}}", lenient)).toBe(true);
+  });
+});

--- a/backend/src/lib/template/validate-handlebars.ts
+++ b/backend/src/lib/template/validate-handlebars.ts
@@ -6,6 +6,9 @@ import { logger } from "../logger";
 type SanitizationArg = {
   allowedExpressions?: (arg: string) => boolean;
   allowedHelpers?: string[];
+  // When true, accept only escaped expressions ({{ }}) and reject unescaped ones ({{{ }}} / {{& }}).
+  // Opt-in so callers that render with noEscape (e.g. dynamic-secret statements) keep current behavior.
+  rejectUnescaped?: boolean;
 };
 
 const isValidExpression = (expression: string, dto: SanitizationArg): boolean => {
@@ -23,8 +26,15 @@ export const validateHandlebarTemplate = (templateName: string, template: string
   parsedAst.body.forEach((el) => {
     if (el.type === "ContentStatement") return;
     if (el.type === "MustacheStatement" && "path" in el) {
-      const { path } = el as { type: "MustacheStatement"; path: { type: "PathExpression"; original: string } };
-      if (path.type === "PathExpression" && isValidExpression(path.original, dto)) return;
+      const { path, escaped } = el as {
+        type: "MustacheStatement";
+        escaped?: boolean;
+        path: { type: "PathExpression"; original: string };
+      };
+      // When rejectUnescaped is set, accept only escaped expressions ({{ }}); otherwise escaping is not
+      // enforced (preserving existing behavior for callers that render with noEscape).
+      const escapedOk = !dto.rejectUnescaped || escaped === true;
+      if (escapedOk && path.type === "PathExpression" && isValidExpression(path.original, dto)) return;
     }
     logger.error(el, "Template sanitization failed");
     throw new BadRequestError({ message: `Template sanitization failed: ${templateName}` });
@@ -36,8 +46,15 @@ export const isValidHandleBarTemplate = (template: string, dto: SanitizationArg)
   return parsedAst.body.every((el) => {
     if (el.type === "ContentStatement") return true;
     if (el.type === "MustacheStatement" && "path" in el) {
-      const { path } = el as { type: "MustacheStatement"; path: { type: "PathExpression"; original: string } };
-      if (path.type === "PathExpression" && isValidExpression(path.original, dto)) return true;
+      const { path, escaped } = el as {
+        type: "MustacheStatement";
+        escaped?: boolean;
+        path: { type: "PathExpression"; original: string };
+      };
+      // When rejectUnescaped is set, only escaped expressions ({{ }}) are permitted; otherwise escaping
+      // is not enforced (preserving existing behavior for callers that render with noEscape).
+      const escapedOk = !dto.rejectUnescaped || escaped === true;
+      if (escapedOk && path.type === "PathExpression" && isValidExpression(path.original, dto)) return true;
     }
     return false;
   });

--- a/backend/src/services/additional-privilege/additional-privilege-service.ts
+++ b/backend/src/services/additional-privilege/additional-privilege-service.ts
@@ -70,7 +70,8 @@ export const additionalPrivilegeServiceFactory = ({
 
     validateHandlebarTemplate("Additional Privilege Create", JSON.stringify(data.permissions || []), {
       allowedExpressions: (val) => val.includes("identity."),
-      allowedHelpers: ["stripPrefix"]
+      allowedHelpers: ["stripPrefix"],
+      rejectUnescaped: true
     });
 
     if (!data.isTemporary) {
@@ -134,7 +135,8 @@ export const additionalPrivilegeServiceFactory = ({
 
     validateHandlebarTemplate("Additional Privilege Create", JSON.stringify(data.permissions || []), {
       allowedExpressions: (val) => val.includes("identity."),
-      allowedHelpers: ["stripPrefix"]
+      allowedHelpers: ["stripPrefix"],
+      rejectUnescaped: true
     });
 
     const updatedData = { ...existingPrivilege, ...data };

--- a/backend/src/services/role/role-service.ts
+++ b/backend/src/services/role/role-service.ts
@@ -105,7 +105,8 @@ export const roleServiceFactory = ({
 
     validateHandlebarTemplate("Role Creation", JSON.stringify(data.permissions || []), {
       allowedExpressions: (val) => val.includes("identity."),
-      allowedHelpers: ["stripPrefix"]
+      allowedHelpers: ["stripPrefix"],
+      rejectUnescaped: true
     });
 
     const role = await roleDAL.create({
@@ -151,7 +152,8 @@ export const roleServiceFactory = ({
 
     validateHandlebarTemplate("Role Update", JSON.stringify(data.permissions || []), {
       allowedExpressions: (val) => val.includes("identity."),
-      allowedHelpers: ["stripPrefix"]
+      allowedHelpers: ["stripPrefix"],
+      rejectUnescaped: true
     });
 
     const role = await roleDAL.updateById(existingRole.id, {


### PR DESCRIPTION
## Context

`validateHandlebarTemplate` / `isValidHandleBarTemplate` validate Handlebars templates by checking
that each mustache statement's path is an allowed expression. They did not check whether the
expression was escaped, so unescaped forms (`{{{ ... }}}` and the equivalent `{{& ... }}`) passed as
long as the path was allowed.

This adds an opt-in `rejectUnescaped` option to the validator: when set, only escaped expressions
(`{{ ... }}`) are accepted. It is enabled everywhere permission rules are authored: role and
additional-privilege creation/update, and project-template creation/update (template roles are
materialized into project custom roles and rendered by the same permission templating, so they need
the same validation). The option defaults off, so the other callers, the dynamic-secret providers,
which render their statements with `noEscape` (e.g. LDAP renders raw values into LDIF), keep their
current behavior and are unaffected.

- Before: the permission-template validator accepted unescaped expressions, and project templates
  did not run this validator at all.
- After: with `rejectUnescaped`, role, additional-privilege, and project-template validators accept
  only escaped expressions; dynamic-secret statement validation is unchanged.

Changed files:

- `backend/src/lib/template/validate-handlebars.ts`: add the opt-in `rejectUnescaped` option to
  `validateHandlebarTemplate` and `isValidHandleBarTemplate`.
- `backend/src/services/role/role-service.ts`: pass `rejectUnescaped: true` on role create and update.
- `backend/src/services/additional-privilege/additional-privilege-service.ts`: pass
  `rejectUnescaped: true` on additional-privilege create and update.
- `backend/src/ee/services/project-template/project-template-service.ts`: validate template role
  permissions with `rejectUnescaped: true` on template create and update.
- `backend/src/lib/template/validate-handlebars.test.ts`: unit tests for both modes (opt-in rejects
  unescaped forms; default accepts them, preserving non-permission caller behavior).

## Screenshots

<!-- Not applicable (no UI/UX change). -->

## Steps to verify the change

- Unit test (included): `npm run test:unit -- src/lib/template/validate-handlebars.test.ts`. It covers
  the opt-in mode (escaped accepted; `{{{ }}}` and `{{& }}` rejected) and the default mode (unescaped
  accepted), plus a disallowed expression.
- Manual: creating/updating a role or additional privilege with normal `{{ ... }}` expressions works;
  one containing `{{{ ... }}}` is rejected. Dynamic-secret statements (including LDAP) that use
  `{{{ ... }}}` continue to validate and work as before.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)