### PR TITLE
fix(backend-go): parse CORS env arrays

### DIFF
--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -368,6 +368,8 @@ type Config struct {
 	ParsedRedisSentinelHosts     []RedisHostPort
 	ParsedRedisClusterHosts      []RedisHostPort
 	ParsedRedisReadReplicas      []RedisHostPort
+	ParsedCORSAllowedOrigins     []string
+	ParsedCORSAllowedHeaders     []string
 }
 
 func (c *Config) Addr() string {
@@ -809,6 +811,16 @@ func LoadConfig() (*Config, error) {
 		cfg.ParsedRedisReadReplicas, issues = parseHostPortList(cfg.RedisReadReplicas, "REDIS_READ_REPLICAS")
 		parseIssues = append(parseIssues, issues...)
 	}
+	if cfg.CORSAllowedOrigins != "" {
+		var issues []string
+		cfg.ParsedCORSAllowedOrigins, issues = parseStringListEnv(cfg.CORSAllowedOrigins, "CORS_ALLOWED_ORIGINS")
+		parseIssues = append(parseIssues, issues...)
+	}
+	if cfg.CORSAllowedHeaders != "" {
+		var issues []string
+		cfg.ParsedCORSAllowedHeaders, issues = parseStringListEnv(cfg.CORSAllowedHeaders, "CORS_ALLOWED_HEADERS")
+		parseIssues = append(parseIssues, issues...)
+	}
 	if len(parseIssues) > 0 {
 		return nil, &ValidationError{Issues: parseIssues}
 	}
@@ -845,6 +857,40 @@ func parseHostPortList(raw, envVar string) (result []RedisHostPort, issues []str
 		result = append(result, hp)
 	}
 	return
+}
+
+func parseStringListEnv(raw, envVar string) (result, issues []string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+
+	trimValues := func(values []string) []string {
+		trimmed := make([]string, 0, len(values))
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value != "" {
+				trimmed = append(trimmed, value)
+			}
+		}
+		return trimmed
+	}
+
+	if json.Valid([]byte(raw)) || strings.HasPrefix(raw, "[") || strings.HasPrefix(raw, "{") {
+		var values []string
+		if err := json.Unmarshal([]byte(raw), &values); err != nil {
+			return nil, []string{fmt.Sprintf("%s must be a JSON array of strings: %v", envVar, err)}
+		}
+		return trimValues(values), nil
+	}
+
+	for entry := range strings.SplitSeq(raw, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry != "" {
+			result = append(result, entry)
+		}
+	}
+	return result, nil
 }
 
 func (c *Config) validate() []string {

--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -876,7 +876,7 @@ func parseStringListEnv(raw, envVar string) (result, issues []string) {
 		return trimmed
 	}
 
-	if json.Valid([]byte(raw)) || strings.HasPrefix(raw, "[") || strings.HasPrefix(raw, "{") {
+	if strings.HasPrefix(raw, "[") || strings.HasPrefix(raw, "{") {
 		var values []string
 		if err := json.Unmarshal([]byte(raw), &values); err != nil {
 			return nil, []string{fmt.Sprintf("%s must be a JSON array of strings: %v", envVar, err)}

--- a/backend-go/internal/config/config_test.go
+++ b/backend-go/internal/config/config_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseStringListEnvJSONArray(t *testing.T) {
+	got, issues := parseStringListEnv(`["https://example.com"]`, "CORS_ALLOWED_ORIGINS")
+
+	if len(issues) > 0 {
+		t.Fatalf("expected no issues, got %v", issues)
+	}
+
+	want := []string{"https://example.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestParseStringListEnvJSONArrayMultipleValues(t *testing.T) {
+	got, issues := parseStringListEnv(`["https://a.com","https://b.com"]`, "CORS_ALLOWED_ORIGINS")
+
+	if len(issues) > 0 {
+		t.Fatalf("expected no issues, got %v", issues)
+	}
+
+	want := []string{"https://a.com", "https://b.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestParseStringListEnvCommaSeparated(t *testing.T) {
+	got, issues := parseStringListEnv("https://a.com, https://b.com", "CORS_ALLOWED_ORIGINS")
+
+	if len(issues) > 0 {
+		t.Fatalf("expected no issues, got %v", issues)
+	}
+
+	want := []string{"https://a.com", "https://b.com"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
+func TestParseStringListEnvRejectsMalformedJSONArray(t *testing.T) {
+	_, issues := parseStringListEnv(`["https://example.com"`, "CORS_ALLOWED_ORIGINS")
+
+	if len(issues) != 1 {
+		t.Fatalf("expected one issue, got %v", issues)
+	}
+	if !strings.Contains(issues[0], "CORS_ALLOWED_ORIGINS") {
+		t.Fatalf("expected issue to mention env var, got %q", issues[0])
+	}
+}
+
+func TestParseStringListEnvRejectsNonArrayJSON(t *testing.T) {
+	_, issues := parseStringListEnv(`{"origin":"https://example.com"}`, "CORS_ALLOWED_ORIGINS")
+
+	if len(issues) != 1 {
+		t.Fatalf("expected one issue, got %v", issues)
+	}
+	if !strings.Contains(issues[0], "CORS_ALLOWED_ORIGINS") {
+		t.Fatalf("expected issue to mention env var, got %q", issues[0])
+	}
+}
+
+func TestLoadConfigRejectsMalformedCORSAllowedOrigins(t *testing.T) {
+	t.Setenv("NODE_ENV", "production")
+	t.Setenv("AUTH_SECRET", "test-auth-secret")
+	t.Setenv("DB_CONNECTION_URI", "postgres://user:pass@localhost:5432/infisical")
+	t.Setenv("ENCRYPTION_KEY", "test-encryption-key")
+	t.Setenv("REDIS_URL", "redis://localhost:6379")
+	t.Setenv("CORS_ALLOWED_ORIGINS", `["https://example.com"`)
+	t.Setenv("CORS_ALLOWED_HEADERS", "")
+	t.Setenv("DB_READ_REPLICAS", "")
+
+	_, err := LoadConfig()
+
+	var validationErr *ValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+	if len(validationErr.Issues) != 1 {
+		t.Fatalf("expected one validation issue, got %v", validationErr.Issues)
+	}
+	if !strings.Contains(validationErr.Issues[0], "CORS_ALLOWED_ORIGINS") {
+		t.Fatalf("expected issue to mention env var, got %q", validationErr.Issues[0])
+	}
+}

--- a/backend-go/internal/config/config_test.go
+++ b/backend-go/internal/config/config_test.go
@@ -46,6 +46,19 @@ func TestParseStringListEnvCommaSeparated(t *testing.T) {
 	}
 }
 
+func TestParseStringListEnvTreatsJSONScalarAsPlainText(t *testing.T) {
+	got, issues := parseStringListEnv(`"https://example.com"`, "CORS_ALLOWED_ORIGINS")
+
+	if len(issues) > 0 {
+		t.Fatalf("expected no issues, got %v", issues)
+	}
+
+	want := []string{`"https://example.com"`}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("expected %v, got %v", want, got)
+	}
+}
+
 func TestParseStringListEnvRejectsMalformedJSONArray(t *testing.T) {
 	_, issues := parseStringListEnv(`["https://example.com"`, "CORS_ALLOWED_ORIGINS")
 

--- a/backend-go/internal/server/server.go
+++ b/backend-go/internal/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -112,22 +111,12 @@ func (s *Server) buildCORSConfig() *middlewares.CORSConfig {
 		AllowCredentials: true,
 	}
 
-	// Parse comma-separated allowed headers
-	if s.config.CORSAllowedHeaders != "" {
-		for h := range strings.SplitSeq(s.config.CORSAllowedHeaders, ",") {
-			if h = strings.TrimSpace(h); h != "" {
-				cfg.AllowedHeaders = append(cfg.AllowedHeaders, h)
-			}
-		}
+	if len(s.config.ParsedCORSAllowedHeaders) > 0 {
+		cfg.AllowedHeaders = append(cfg.AllowedHeaders, s.config.ParsedCORSAllowedHeaders...)
 	}
 
-	// Parse comma-separated allowed origins
-	if s.config.CORSAllowedOrigins != "" {
-		for o := range strings.SplitSeq(s.config.CORSAllowedOrigins, ",") {
-			if o = strings.TrimSpace(o); o != "" {
-				cfg.AllowedOrigins = append(cfg.AllowedOrigins, o)
-			}
-		}
+	if len(s.config.ParsedCORSAllowedOrigins) > 0 {
+		cfg.AllowedOrigins = append(cfg.AllowedOrigins, s.config.ParsedCORSAllowedOrigins...)
 	}
 
 	// Add site URL to allowed origins

--- a/backend-go/internal/server/server_test.go
+++ b/backend-go/internal/server/server_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/infisical/api/internal/config"
+	"github.com/infisical/api/internal/server/middlewares"
+)
+
+func TestBuildCORSConfigUsesParsedOriginsAndSiteURL(t *testing.T) {
+	s := &Server{
+		config: &config.Config{
+			ParsedCORSAllowedOrigins: []string{"https://example.com"},
+			SiteURL:                  "https://app.example.com",
+		},
+	}
+
+	cfg := s.buildCORSConfig()
+
+	want := []string{"https://example.com", "https://app.example.com"}
+	if !reflect.DeepEqual(cfg.AllowedOrigins, want) {
+		t.Fatalf("expected origins %v, got %v", want, cfg.AllowedOrigins)
+	}
+}
+
+func TestBuildCORSConfigUsesParsedHeaders(t *testing.T) {
+	s := &Server{
+		config: &config.Config{
+			ParsedCORSAllowedHeaders: []string{"Authorization", "X-Custom-Header"},
+		},
+	}
+
+	cfg := s.buildCORSConfig()
+
+	want := []string{"Authorization", "X-Custom-Header"}
+	if !reflect.DeepEqual(cfg.AllowedHeaders, want) {
+		t.Fatalf("expected headers %v, got %v", want, cfg.AllowedHeaders)
+	}
+}
+
+func TestCORSWithDocumentedJSONOriginAllowsBrowserOrigin(t *testing.T) {
+	t.Setenv("AUTH_SECRET", "test-auth-secret")
+	t.Setenv("DB_CONNECTION_URI", "postgres://user:pass@localhost:5432/infisical")
+	t.Setenv("ENCRYPTION_KEY", "test-encryption-key")
+	t.Setenv("REDIS_URL", "redis://localhost:6379")
+	t.Setenv("CORS_ALLOWED_ORIGINS", `["https://example.com"]`)
+
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		t.Fatalf("expected config to load, got %v", err)
+	}
+
+	s := &Server{config: cfg}
+	handler := middlewares.CORS(s.buildCORSConfig())(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("expected Access-Control-Allow-Origin %q, got %q", "https://example.com", got)
+	}
+}


### PR DESCRIPTION
## Context

The Go backend parsed `CORS_ALLOWED_ORIGINS` and `CORS_ALLOWED_HEADERS` as comma-separated strings, while the documented and Node backend format is a JSON string array. With the documented value `CORS_ALLOWED_ORIGINS=["https://example.com"]`, Go would treat the brackets and quotes as part of the origin, so browser requests from `https://example.com` would not match the configured CORS origin.

This updates Go config loading to parse JSON string arrays for CORS env vars, keeps comma-separated values working for compatibility, and returns a validation error for malformed JSON-shaped values.

## Screenshots

Not applicable.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
