### PR TITLE
fix(billing): surface license server errors and route last-product removal to cancel

### DIFF
--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -1,5 +1,7 @@
 import jwt from "jsonwebtoken";
 
+import { BadRequestError, InternalServerError } from "@app/lib/errors";
+
 import {
   billingProfileResponseSchema,
   catalogResponseSchema,
@@ -55,6 +57,21 @@ const mintServiceToken = (signingKey: string): string =>
     expiresIn: "2m"
   });
 
+// Surface the license server's message on 4xx (caller-actionable, e.g. "cannot remove the last
+// product; cancel the subscription instead"); when it has none, fall back to the generic error
+// default rather than a status code the customer can't act on. 5xx bodies may carry internal detail,
+// so those stay generic.
+const throwIfResponseError = async (res: Response): Promise<void> => {
+  if (res.ok) {
+    return;
+  }
+  if (res.status >= 400 && res.status < 500) {
+    const body = (await res.json().catch(() => null)) as { message?: string } | null;
+    throw new BadRequestError({ message: body?.message });
+  }
+  throw new InternalServerError({ message: "Billing service error" });
+};
+
 export const licenseServerBackend = (
   serverUrl: string,
   signingKey: string,
@@ -77,9 +94,7 @@ export const licenseServerBackend = (
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return entitlementsResponseSchema.parse(body);
   },
@@ -92,9 +107,7 @@ export const licenseServerBackend = (
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
   },
 
   fetchCatalog: async (): Promise<TCatalogResponse> => {
@@ -104,9 +117,7 @@ export const licenseServerBackend = (
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return catalogResponseSchema.parse(body);
   },
@@ -125,9 +136,7 @@ export const licenseServerBackend = (
     if (res.status === 404) {
       return null;
     }
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
 
     const body: unknown = await res.json();
     const parsed = subscriptionResponseSchema.safeParse(body);
@@ -153,9 +162,7 @@ export const licenseServerBackend = (
     if (res.status === 404) {
       return null;
     }
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return cloudPlanResponseSchema.parse(body);
   },
@@ -173,9 +180,7 @@ export const licenseServerBackend = (
     if (res.status === 404) {
       return null;
     }
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return billingProfileResponseSchema.parse(body);
   },
@@ -189,9 +194,7 @@ export const licenseServerBackend = (
       body: JSON.stringify(payload),
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return checkoutResultSchema.parse(body);
   },
@@ -205,9 +208,7 @@ export const licenseServerBackend = (
       body: JSON.stringify(payload),
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return sessionResponseSchema.parse(body);
   },
@@ -224,9 +225,7 @@ export const licenseServerBackend = (
       body: JSON.stringify(payload),
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return subscriptionPreviewResponseSchema.parse(body);
   },
@@ -240,9 +239,7 @@ export const licenseServerBackend = (
       body: JSON.stringify(payload),
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return checkoutResultSchema.parse(body);
   },
@@ -255,9 +252,7 @@ export const licenseServerBackend = (
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return checkoutResultSchema.parse(body);
   },
@@ -270,9 +265,7 @@ export const licenseServerBackend = (
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return checkoutResultSchema.parse(body);
   },
@@ -285,9 +278,7 @@ export const licenseServerBackend = (
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return checkoutResultSchema.parse(body);
   }
@@ -318,9 +309,7 @@ export const licenseServerSelfHostedBackend = (
       headers: { Authorization: `Bearer ${licenseKey}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return entitlementsResponseSchema.parse(body);
   },
@@ -332,9 +321,7 @@ export const licenseServerSelfHostedBackend = (
       headers: { Authorization: `Bearer ${licenseKey}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
   },
 
   fetchCatalog: async (): Promise<TCatalogResponse> => {
@@ -344,9 +331,7 @@ export const licenseServerSelfHostedBackend = (
       headers: { Authorization: `Bearer ${licenseKey}` },
       redirect: "manual"
     });
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     return catalogResponseSchema.parse(body);
   },
@@ -362,9 +347,7 @@ export const licenseServerSelfHostedBackend = (
     if (res.status === 404) {
       return null;
     }
-    if (!res.ok) {
-      throw new Error(`license server responded with ${res.status}`);
-    }
+    await throwIfResponseError(res);
     const body: unknown = await res.json();
     const parsed = subscriptionResponseSchema.safeParse(body);
     if (!parsed.success || !parsed.data.status) {

--- a/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Trash2Icon } from "lucide-react";
+import { CalendarX2Icon, Trash2Icon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -15,6 +15,9 @@ import {
 } from "@app/components/v3";
 import {
   BillingV2CatalogProduct,
+  useCancelBillingV2Subscription,
+  useGetBillingV2Catalog,
+  useGetBillingV2Overview,
   usePreviewBillingV2Change,
   useRemoveBillingV2Product
 } from "@app/hooks/api";
@@ -24,21 +27,41 @@ import { fmtMoney } from "../billing-v2-data";
 type Props = {
   orgId: string;
   product: BillingV2CatalogProduct;
-  // Dismissed without removing (cancel / escape / overlay) — keep the management sheet open behind it.
+  // Dismissed without removing (cancel / escape / overlay); keep the management sheet open behind it.
   onClose: () => void;
-  // Removal succeeded — close the confirm and the management sheet it was opened from.
+  // Removal (or cancel) succeeded; close the confirm and the management sheet it was opened from.
   onRemoved: () => void;
 };
 
+const getServerMessage = (err: unknown): string | undefined =>
+  (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
+
 export const RemoveProductModal = ({ orgId, product, onClose, onRemoved }: Props) => {
+  // Both queries are already cached by the page (same orgId key), so this reuses that data rather
+  // than refetching. Stripe can't hold a zero-item subscription, so removing the only self-serve
+  // product is rejected by the license server; that case cancels the whole subscription instead.
+  const { data: overview } = useGetBillingV2Overview(orgId);
+  const { data: catalog = [] } = useGetBillingV2Catalog(orgId);
+  const subscriptionProductCount = catalog.filter(
+    (prod) => Boolean(prod.pro?.planKey) && Boolean(overview?.entitlements[prod.id]?.entitled)
+  ).length;
+  const isOnlyProduct = subscriptionProductCount <= 1;
+  const periodEndDate = overview?.nextBillingDate ?? null;
+
   const preview = usePreviewBillingV2Change();
   const removeProduct = useRemoveBillingV2Product();
+  const cancelSubscription = useCancelBillingV2Subscription();
 
   // Preview the prorated credit once when the dialog opens, so the user confirms against real numbers.
+  // The last-product case can't be removed (it cancels instead), and previewing it would also 409, so
+  // skip the preview there.
   useEffect(() => {
+    if (isOnlyProduct) {
+      return;
+    }
     preview.mutate({ orgId, removeProductId: product.id });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orgId, product.id]);
+  }, [orgId, product.id, isOnlyProduct]);
 
   const handleRemove = async () => {
     try {
@@ -48,10 +71,71 @@ export const RemoveProductModal = ({ orgId, product, onClose, onRemoved }: Props
         text: `${product.name} will be removed. It may take a moment to update here.`
       });
       onRemoved();
-    } catch {
-      createNotification({ type: "error", text: `Failed to remove ${product.name}.` });
+    } catch (err) {
+      createNotification({
+        type: "error",
+        text: getServerMessage(err) ?? `Failed to remove ${product.name}.`
+      });
     }
   };
+
+  const handleCancel = async () => {
+    try {
+      await cancelSubscription.mutateAsync({ orgId });
+      createNotification({
+        type: "success",
+        text: "Your subscription will be canceled at the end of the current billing period."
+      });
+      onRemoved();
+    } catch (err) {
+      createNotification({
+        type: "error",
+        text: getServerMessage(err) ?? "Failed to cancel your subscription."
+      });
+    }
+  };
+
+  if (isOnlyProduct) {
+    let periodClause = "at the end of your current billing period";
+    if (periodEndDate) {
+      periodClause = `on ${periodEndDate}`;
+    }
+
+    return (
+      <AlertDialog
+        open
+        onOpenChange={(isOpen) => {
+          if (!isOpen) {
+            onClose();
+          }
+        }}
+      >
+        <AlertDialogContent className="sm:max-w-xl!">
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <CalendarX2Icon />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Cancel your subscription?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {product.name} is the only product on your subscription, so it cannot be removed on
+              its own. Canceling ends your whole subscription {periodClause}. You keep access until
+              then.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep subscription</AlertDialogCancel>
+            <AlertDialogAction
+              variant="danger"
+              isDisabled={cancelSubscription.isPending}
+              onClick={handleCancel}
+            >
+              Cancel subscription
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    );
+  }
 
   const credit = preview.data ? Math.abs(preview.data.prorationAmount) : 0;
 

--- a/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
@@ -16,7 +16,6 @@ import {
 import {
   BillingV2CatalogProduct,
   useCancelBillingV2Subscription,
-  useGetBillingV2Catalog,
   useGetBillingV2Overview,
   usePreviewBillingV2Change,
   useRemoveBillingV2Product
@@ -37,15 +36,16 @@ const getServerMessage = (err: unknown): string | undefined =>
   (err as { response?: { data?: { message?: string } } })?.response?.data?.message;
 
 export const RemoveProductModal = ({ orgId, product, onClose, onRemoved }: Props) => {
-  // Both queries are already cached by the page (same orgId key), so this reuses that data rather
-  // than refetching. Stripe can't hold a zero-item subscription, so removing the only self-serve
-  // product is rejected by the license server; that case cancels the whole subscription instead.
-  const { data: overview } = useGetBillingV2Overview(orgId);
-  const { data: catalog = [] } = useGetBillingV2Catalog(orgId);
-  const subscriptionProductCount = catalog.filter(
-    (prod) => Boolean(prod.pro?.planKey) && Boolean(overview?.entitlements[prod.id]?.entitled)
+  // Overview is already cached by the page (same orgId key), so this reuses it without refetching.
+  // Count every entitled product (the backend marks every subscription item entitled, including
+  // sales-led ones), so a second item means removing this one is not the last. Only offer the
+  // destructive whole-subscription cancel when this is the sole product, and only after the overview
+  // loads so a multi-product customer never flashes it.
+  const { data: overview, isSuccess: overviewReady } = useGetBillingV2Overview(orgId);
+  const entitledProductCount = Object.values(overview?.entitlements ?? {}).filter(
+    (entitlement) => entitlement.entitled
   ).length;
-  const isOnlyProduct = subscriptionProductCount <= 1;
+  const isOnlyProduct = overviewReady && entitledProductCount === 1;
   const periodEndDate = overview?.nextBillingDate ?? null;
 
   const preview = usePreviewBillingV2Change();


### PR DESCRIPTION
## Context

Removing a product on the org BillingV2 page returned a browser 500 (`InternalServerError`) for both the remove preview and the remove itself; adding a product worked fine.

Root cause: the backend license-client threw a generic `Error` on any non-2xx from the License Server, which Fastify rendered as a 500, discarding the real status and message. When the removed product is the only one on the subscription, the License Server correctly returns 409 "cannot remove the last product; cancel the subscription instead" (Stripe can't hold a zero-item subscription), so a structured, actionable 409 reached the user as an opaque 500.

Backend (`license-client-backends.ts`):
- Add a shared `throwIfResponseError` helper and replace the ~17 blanket `throw new Error(...)` sites. 4xx surface the License Server's message via `BadRequestError` (400); 5xx stay a generic `InternalServerError`.
- 4xx with no server message falls back to the generic error default, not a "responded with NNN" status string the customer can't act on.
- `404 -> null` reads (subscription / cloud-plan / billing-profile) left intact.

Frontend (`RemoveProductModal.tsx`):
- When the product is the only self-serve product on the subscription, present a "Cancel your subscription?" action (subscription ends at period end, access kept until then) backed by the existing cancel mutation, instead of an impossible remove. No preview is run for that case, so the last-product preview 500 is gone too.
- Derives the only-product / period-end state from the already-cached overview + catalog queries (same `orgId` key), so no extra request and no prop drilling.
- Remove-failure toast now surfaces the real server message as a fallback.

## Steps to verify the change

- Gamma org with a single-product v2 subscription (secrets_management only): open Manage, the action is "Cancel your subscription?" and confirming routes to cancel; never a 500.
- Multi-product subscription: Remove still previews the prorated credit and removes (200).
- Backend confirms the License Server 409 + message now propagates to the API response instead of "Something went wrong".
- `type:check` + `eslint` on changed files: clean (backend and frontend).

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (type:check + lint clean; gamma manual steps above pending reviewer/QA)
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
