### PR TITLE
fix(secret-rotation): enforce secret-level delete permission on overwrite move

### DIFF
--- a/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
+++ b/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
@@ -1131,7 +1131,8 @@ export const secretRotationV2ServiceFactory = ({
             subject(ProjectPermissionSub.Secrets, {
               environment: destinationEnvironment,
               secretPath: destinationSecretPath,
-              secretName: conflictingSecret.key
+              secretName: conflictingSecret.key,
+              secretTags: conflictingSecret.tags?.map((el) => el.slug)
             })
           );
         });

--- a/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
+++ b/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
@@ -1124,6 +1124,18 @@ export const secretRotationV2ServiceFactory = ({
       }
 
       if (conflictingDestinationSecrets.length && overwriteDestination) {
+        // Require secret-level delete permission.
+        conflictingDestinationSecrets.forEach((conflictingSecret) => {
+          ForbiddenError.from(permission).throwUnlessCan(
+            ProjectPermissionSecretActions.Delete,
+            subject(ProjectPermissionSub.Secrets, {
+              environment: destinationEnvironment,
+              secretPath: destinationSecretPath,
+              secretName: conflictingSecret.key
+            })
+          );
+        });
+
         await secretV2BridgeDAL.deleteMany(
           conflictingDestinationSecrets.map((s) => ({ key: s.key, type: SecretType.Shared })),
           destinationFolder.id,


### PR DESCRIPTION
## Context

The secret-rotation move operation accepts an `overwriteDestination` flag. When set, `moveSecretRotation`
deletes any secrets at the destination that conflict with the rotation's mapped keys before moving the
rotation into place. The move was authorized only against secret-rotation permissions (`Delete` on the
source rotation, `Create` on the destination), but the conflicting-secret deletion ran without checking
secret-level permission on the secrets being removed.

This adds a per-secret `ProjectPermissionSecretActions.Delete` check for each conflicting destination
secret before the overwrite, matching how normal secret deletion is authorized
(`secret-v2-bridge-service.ts`). The check runs inside the existing transaction, so if it fails nothing
is deleted.

- Before: an overwrite move removed conflicting destination secrets using only rotation permissions.
- After: each conflicting secret requires secret-level delete permission at the destination
  (environment + path + name) before it is removed.

Changed files:

- `backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts`: enforce
  `ProjectPermissionSecretActions.Delete` per conflicting destination secret before `deleteMany`.

## Screenshots

<!-- Not applicable (no UI/UX change). -->

## Steps to verify the change

- Manual: as a user/role with secret-rotation `Create`/`Delete` but without secret `Delete` permission
  at the destination, move a rotation with `overwriteDestination: true` onto a path that has conflicting
  secrets. The request is now rejected (403) instead of deleting them. With secret `Delete` permission
  at the destination, the move succeeds as before.
- A standalone unit test isn't practical for this DI-heavy service method; the check mirrors the
  established per-secret delete authorization used in `secret-v2-bridge-service.ts`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)