### PR TITLE
feat: license multi plan and ui fix

### DIFF
--- a/backend/src/ee/routes/v1/license-v2-router.ts
+++ b/backend/src/ee/routes/v1/license-v2-router.ts
@@ -29,8 +29,18 @@ const BillingV2DimSchema = z.object({
 
 const BillingV2CompareRowSchema = z.object({
   label: z.string(),
-  pro: z.union([z.string(), z.number(), z.boolean()]),
-  ent: z.union([z.string(), z.number(), z.boolean()])
+  // Cells keyed by plan tier so the UI renders one column per plan.
+  cells: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+});
+
+const BillingV2PlanSchema = z.object({
+  tier: z.string(),
+  name: z.string(),
+  selfServe: z.boolean(),
+  salesLed: z.boolean(),
+  feature: z.string().optional(),
+  base: z.object({ monthly: z.number(), annual: z.number() }).optional(),
+  dims: BillingV2DimSchema.array()
 });
 
 const BillingV2CatalogProductSchema = z.object({
@@ -42,15 +52,7 @@ const BillingV2CatalogProductSchema = z.object({
   addon: z.boolean().optional(),
   desc: z.string(),
   tagline: z.string().optional(),
-  fromPrice: z.string().optional(),
-  pro: z.object({
-    base: z.object({ monthly: z.number(), annual: z.number() }).optional(),
-    dims: BillingV2DimSchema.array().optional(),
-    proFeature: z.string(),
-    planKey: z.string().optional()
-  }),
-  enterprise: z.object({ sales: z.literal(true), feature: z.string() }).nullable(),
-  upgradeChanges: z.object({ add: z.string().array() }).optional(),
+  plans: BillingV2PlanSchema.array(),
   includes: z.string().array().optional(),
   compare: BillingV2CompareRowSchema.array().optional()
 });
@@ -66,6 +68,7 @@ const BillingV2InvoiceSchema = z.object({
 
 const BillingV2EntitlementSchema = z.object({
   entitled: z.boolean(),
+  planTier: z.string().optional(),
   limit: z.number().nullable().optional(),
   used: z.number().optional(),
   unit: z.string().nullable().optional()
@@ -219,6 +222,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
       params: z.object({ organizationId: z.string().trim() }),
       body: z.object({
         productId: z.string().trim(),
+        plan: z.string().trim().optional(),
         cadence: z.enum(["monthly", "annual"]).optional(),
         email: z.string().trim().email().optional(),
         returnPath: ReturnPathSchema
@@ -237,6 +241,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         orgId: req.params.organizationId,
         actor: buildActor(req.permission),
         productId: req.body.productId,
+        plan: req.body.plan,
         cadence: req.body.cadence,
         email: req.body.email,
         returnPath: req.body.returnPath
@@ -278,6 +283,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
       body: z
         .object({
           addProductId: z.string().trim().optional(),
+          plan: z.string().trim().optional(),
           cadence: z.enum(["monthly", "annual"]).optional(),
           removeProductId: z.string().trim().optional()
         })
@@ -294,6 +300,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         orgId: req.params.organizationId,
         actor: buildActor(req.permission),
         addProductId: req.body.addProductId,
+        plan: req.body.plan,
         cadence: req.body.cadence,
         removeProductId: req.body.removeProductId
       });
@@ -310,6 +317,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
       params: z.object({ organizationId: z.string().trim() }),
       body: z.object({
         productId: z.string().trim(),
+        plan: z.string().trim().optional(),
         cadence: z.enum(["monthly", "annual"]).optional()
       }),
       response: {
@@ -322,6 +330,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         orgId: req.params.organizationId,
         actor: buildActor(req.permission),
         productId: req.body.productId,
+        plan: req.body.plan,
         cadence: req.body.cadence
       });
     }

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -25,6 +25,7 @@ import {
   BillingV2Entitlement,
   BillingV2Model,
   BillingV2Overview,
+  BillingV2Plan,
   BillingV2Preview,
   BillingV2SubState,
   TAddBillingV2PaymentMethodDTO,
@@ -146,13 +147,12 @@ const planHasPricing = (plan: TCatalogProduct["plans"][number]): boolean =>
 const findPaidSelfServePlan = (product: TCatalogProduct) =>
   product.plans.find((plan) => plan.selfServe === true && plan.tier !== "free" && planHasPricing(plan));
 
-const toCatalogProduct = (product: TCatalogProduct): BillingV2CatalogProduct => {
-  const paidSelfServePlan = findPaidSelfServePlan(product);
-  const salesLedPlan = product.plans.find((plan) => plan.salesLed === true);
-
-  // Fold the plan's per-dimension/per-cadence prices into the dim view the UI renders.
+// Project a single catalog plan into the UI shape: fold its per-dimension/per-cadence prices into the
+// dim view, and surface its base fee when it has one. Each plan carries its own pricing, so a product
+// with several tiers (pro, advanced, pro+) maps each tier independently.
+const toPlan = (product: TCatalogProduct, plan: TCatalogProduct["plans"][number]): BillingV2Plan => {
   const priceByDim = new Map<string, { monthly: number; annual: number; included: number }>();
-  (paidSelfServePlan?.prices ?? []).forEach((price) => {
+  plan.prices.forEach((price) => {
     const entry = priceByDim.get(price.dimensionKey) ?? { monthly: 0, annual: 0, included: 0 };
     if (price.cadence === "annual") {
       entry.annual = centsToDollars(price.unitAmountCents);
@@ -181,38 +181,41 @@ const toCatalogProduct = (product: TCatalogProduct): BillingV2CatalogProduct => 
     });
   });
 
-  const pro: BillingV2CatalogProduct["pro"] = {
-    proFeature: paidSelfServePlan?.feature ?? "",
-    planKey: paidSelfServePlan?.tier,
+  const result: BillingV2Plan = {
+    tier: plan.tier,
+    name: plan.name,
+    selfServe: plan.selfServe,
+    salesLed: plan.salesLed,
+    feature: plan.feature,
     dims
   };
-  const baseMonthly = paidSelfServePlan?.basePriceMonthlyCents;
-  const baseAnnual = paidSelfServePlan?.basePriceAnnualCents;
+
+  const baseMonthly = plan.basePriceMonthlyCents;
+  const baseAnnual = plan.basePriceAnnualCents;
   if ((baseMonthly !== null && baseMonthly !== undefined) || (baseAnnual !== null && baseAnnual !== undefined)) {
-    pro.base = { monthly: centsToDollars(baseMonthly), annual: centsToDollars(baseAnnual) };
+    result.base = { monthly: centsToDollars(baseMonthly), annual: centsToDollars(baseAnnual) };
   }
 
-  let enterprise: BillingV2CatalogProduct["enterprise"] = null;
-  if (salesLedPlan) {
-    enterprise = { sales: true, feature: salesLedPlan.feature ?? "" };
-  }
+  return result;
+};
 
-  const cellValue = (
-    cells: { tier: string; value: string | number | boolean }[],
-    tier: string
-  ): string | boolean | number => {
-    const cell = cells.find((candidate) => candidate.tier === tier);
-    if (!cell) {
-      return false;
-    }
-    return cell.value;
-  };
+const toCatalogProduct = (product: TCatalogProduct): BillingV2CatalogProduct => {
+  // Surface every paid self-serve plan plus any sales-led plan, in catalog order; the free tier is
+  // implicit and never rendered as an upgrade option.
+  const plans = product.plans
+    .filter(
+      (plan) => plan.tier !== "free" && ((plan.selfServe === true && planHasPricing(plan)) || plan.salesLed === true)
+    )
+    .map((plan) => toPlan(product, plan));
 
-  const compare: BillingV2CompareRow[] = product.comparison.map((row) => ({
-    label: row.label,
-    pro: cellValue(row.cells, "pro"),
-    ent: cellValue(row.cells, "enterprise")
-  }));
+  // Keep every comparison cell keyed by its tier so the UI can render a column per plan.
+  const compare: BillingV2CompareRow[] = product.comparison.map((row) => {
+    const cells: Record<string, string | boolean | number> = {};
+    row.cells.forEach((cell) => {
+      cells[cell.tier] = cell.value;
+    });
+    return { label: row.label, cells };
+  });
 
   return {
     id: product.id,
@@ -223,8 +226,7 @@ const toCatalogProduct = (product: TCatalogProduct): BillingV2CatalogProduct => 
     addon: product.addon,
     desc: product.description ?? "",
     tagline: product.tagline,
-    pro,
-    enterprise,
+    plans,
     includes: product.includes,
     compare
   };
@@ -233,18 +235,23 @@ const toCatalogProduct = (product: TCatalogProduct): BillingV2CatalogProduct => 
 // Translates a catalog product into the line items the checkout endpoint expects: its paid
 // self-serve plan plus the primary priced dimension for the chosen cadence at quantity 1. A base-only
 // product (a base fee with no metered dimensions, e.g. the NHI add-on) checks out with no quantities.
-const buildCheckoutItems = (product: TCatalogProduct, cadence: "monthly" | "annual"): TCheckoutLineItem[] | null => {
-  const paidSelfServePlan = findPaidSelfServePlan(product);
-  if (!paidSelfServePlan) {
+const buildCheckoutItems = (
+  product: TCatalogProduct,
+  cadence: "monthly" | "annual",
+  planTier?: string
+): TCheckoutLineItem[] | null => {
+  // A requested tier must resolve to a self-serve plan; with none requested, fall back to the first
+  // paid self-serve plan (the legacy single-"pro" behaviour).
+  const plan = planTier
+    ? product.plans.find((candidate) => candidate.tier === planTier && candidate.selfServe === true)
+    : findPaidSelfServePlan(product);
+  if (!plan) {
     return null;
   }
 
-  const price = paidSelfServePlan.prices.find(
-    (candidate) => candidate.cadence === cadence && candidate.unitAmountCents > 0
-  );
+  const price = plan.prices.find((candidate) => candidate.cadence === cadence && candidate.unitAmountCents > 0);
 
-  const baseCents =
-    cadence === "annual" ? paidSelfServePlan.basePriceAnnualCents : paidSelfServePlan.basePriceMonthlyCents;
+  const baseCents = cadence === "annual" ? plan.basePriceAnnualCents : plan.basePriceMonthlyCents;
   const hasBasePrice = baseCents !== null && baseCents !== undefined;
 
   // Neither a metered price nor a base fee for this cadence means there's nothing to charge.
@@ -255,7 +262,7 @@ const buildCheckoutItems = (product: TCatalogProduct, cadence: "monthly" | "annu
   return [
     {
       productId: product.id,
-      plan: paidSelfServePlan.tier,
+      plan: plan.tier,
       cadence,
       quantities: price ? { [price.dimensionKey]: 1 } : {}
     }
@@ -352,7 +359,7 @@ export const licenseV2ServiceFactory = ({
 
         const unit = limitKey ? (nounByDimension.get(`${item.productId}:${limitKey}`) ?? null) : null;
 
-        entitlements[item.productId] = { entitled: true, used, limit, unit };
+        entitlements[item.productId] = { entitled: true, planTier: item.plan, used, limit, unit };
       });
     }
 
@@ -539,6 +546,7 @@ export const licenseV2ServiceFactory = ({
     orgId,
     actor,
     productId,
+    plan,
     cadence,
     email,
     returnPath
@@ -551,7 +559,7 @@ export const licenseV2ServiceFactory = ({
       throw new NotFoundError({ message: `Product with ID '${productId}' not found` });
     }
 
-    const items = buildCheckoutItems(product, normalizeCadence(cadence));
+    const items = buildCheckoutItems(product, normalizeCadence(cadence), plan);
     if (!items) {
       throw new BadRequestError({ message: "This product is not available for self-serve checkout" });
     }
@@ -575,13 +583,17 @@ export const licenseV2ServiceFactory = ({
 
   // Resolve a catalog product id + cadence into the license-server line items, shared by the
   // preview and add paths so both price the same way checkout does.
-  const resolveAddItems = async (productId: string, cadence?: "monthly" | "annual"): Promise<TCheckoutLineItem[]> => {
+  const resolveAddItems = async (
+    productId: string,
+    cadence?: "monthly" | "annual",
+    plan?: string
+  ): Promise<TCheckoutLineItem[]> => {
     const catalog = await licenseClient.getCatalog();
     const product = catalog?.products.find((candidate) => candidate.id === productId);
     if (!product) {
       throw new NotFoundError({ message: `Product with ID '${productId}' not found` });
     }
-    const items = buildCheckoutItems(product, normalizeCadence(cadence));
+    const items = buildCheckoutItems(product, normalizeCadence(cadence), plan);
     if (!items) {
       throw new BadRequestError({ message: "This product is not available for self-serve checkout" });
     }
@@ -594,6 +606,7 @@ export const licenseV2ServiceFactory = ({
     orgId,
     actor,
     addProductId,
+    plan,
     cadence,
     removeProductId
   }: TPreviewBillingV2ChangeDTO): Promise<{ preview: BillingV2Preview }> => {
@@ -604,7 +617,7 @@ export const licenseV2ServiceFactory = ({
 
     const payload: TSubscriptionPreviewPayload = {};
     if (addProductId) {
-      payload.add = await resolveAddItems(addProductId, cadence);
+      payload.add = await resolveAddItems(addProductId, cadence, plan);
     }
     if (removeProductId) {
       payload.remove = [removeProductId];
@@ -629,9 +642,9 @@ export const licenseV2ServiceFactory = ({
 
   // Add a product to an existing active subscription (clears any scheduled cancel server-side). The
   // first-purchase / no-subscription path stays on checkoutSession, which opens Stripe Checkout.
-  const addProduct = async ({ orgId, actor, productId, cadence }: TAddBillingV2ProductDTO) => {
+  const addProduct = async ({ orgId, actor, productId, plan, cadence }: TAddBillingV2ProductDTO) => {
     await ensureManageBilling(orgId, actor);
-    const items = await resolveAddItems(productId, cadence);
+    const items = await resolveAddItems(productId, cadence, plan);
     const result = await licenseClient.addSubscriptionItems(orgId, { items });
     await licenseClient.invalidateEntitlements(orgId);
     return { subscriptionId: result.subscriptionId };

--- a/backend/src/ee/services/license-v2/license-v2-types.ts
+++ b/backend/src/ee/services/license-v2/license-v2-types.ts
@@ -15,10 +15,23 @@ export type BillingV2Dim = {
   included: number;
 };
 
+// A comparison row's cells are keyed by plan tier ("pro" | "advanced" | "enterprise" | ...) so the UI
+// can render one column per plan instead of a fixed pro/enterprise pair.
 export type BillingV2CompareRow = {
   label: string;
-  pro: string | boolean | number;
-  ent: string | boolean | number;
+  cells: Record<string, string | boolean | number>;
+};
+
+// A single purchasable (or sales-led) plan within a product. A product exposes an ordered list of
+// these — the free tier is implicit and never listed.
+export type BillingV2Plan = {
+  tier: string;
+  name: string;
+  selfServe: boolean;
+  salesLed: boolean;
+  feature?: string;
+  base?: { monthly: number; annual: number };
+  dims: BillingV2Dim[];
 };
 
 export type BillingV2CatalogProduct = {
@@ -30,15 +43,7 @@ export type BillingV2CatalogProduct = {
   addon?: boolean;
   desc: string;
   tagline?: string;
-  fromPrice?: string;
-  pro: {
-    base?: { monthly: number; annual: number };
-    dims?: BillingV2Dim[];
-    proFeature: string;
-    planKey?: string;
-  };
-  enterprise: { sales: true; feature: string } | null;
-  upgradeChanges?: { add: string[] };
+  plans: BillingV2Plan[];
   includes?: string[];
   compare?: BillingV2CompareRow[];
 };
@@ -61,6 +66,9 @@ export type BillingV2Invoice = {
 
 export type BillingV2Entitlement = {
   entitled: boolean;
+  // Tier the org is currently subscribed to for this product (from the subscription item), so the UI
+  // can mark the matching plan card as the active one. Absent for feature-only entitlements.
+  planTier?: string;
   limit?: number | null;
   used?: number;
   // Singular noun for the limited dimension (e.g. "certificate"), resolved from the catalog so the
@@ -122,6 +130,8 @@ export type TCreateBillingV2CheckoutSessionDTO = {
   orgId: string;
   actor: OrgServiceActor;
   productId: string;
+  // Which plan tier of the product to purchase; defaults to the first paid self-serve plan.
+  plan?: string;
   cadence?: "monthly" | "annual";
   email?: string;
   returnPath?: string;
@@ -152,6 +162,8 @@ export type TPreviewBillingV2ChangeDTO = {
   orgId: string;
   actor: OrgServiceActor;
   addProductId?: string;
+  // Plan tier of the product being added; defaults to the first paid self-serve plan.
+  plan?: string;
   cadence?: "monthly" | "annual";
   removeProductId?: string;
 };
@@ -160,6 +172,8 @@ export type TAddBillingV2ProductDTO = {
   orgId: string;
   actor: OrgServiceActor;
   productId: string;
+  // Plan tier to add; defaults to the first paid self-serve plan.
+  plan?: string;
   cadence?: "monthly" | "annual";
 };
 

--- a/frontend/src/components/v3/generic/AlertDialog/AlertDialog.tsx
+++ b/frontend/src/components/v3/generic/AlertDialog/AlertDialog.tsx
@@ -136,17 +136,29 @@ function AlertDialogAction({
   size = "sm",
   isFullWidth = false,
   isDisabled = false,
+  isPending = false,
   ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Action> &
-  Pick<React.ComponentProps<typeof Button>, "variant" | "size" | "isFullWidth" | "isDisabled">) {
+}: Omit<React.ComponentProps<typeof AlertDialogPrimitive.Action>, "asChild"> &
+  Pick<
+    React.ComponentProps<typeof Button>,
+    "variant" | "size" | "isFullWidth" | "isDisabled" | "isPending"
+  >) {
+  // Invert the asChild composition: Radix's Action lends its close-on-click behaviour to the real
+  // Button, so Button renders a native <button> and its isPending spinner works (a Slot child would
+  // strip it). Button forbids isPending together with asChild for exactly that reason.
   return (
-    <Button variant={variant} size={size} isFullWidth={isFullWidth} isDisabled={isDisabled} asChild>
-      <AlertDialogPrimitive.Action
+    <AlertDialogPrimitive.Action asChild>
+      <Button
         data-slot="alert-dialog-action"
+        variant={variant}
+        size={size}
+        isPending={isPending}
+        isFullWidth={isFullWidth}
+        isDisabled={isDisabled}
         className={cn(className)}
         {...props}
       />
-    </Button>
+    </AlertDialogPrimitive.Action>
   );
 }
 

--- a/frontend/src/hooks/api/billingV2/index.tsx
+++ b/frontend/src/hooks/api/billingV2/index.tsx
@@ -19,6 +19,7 @@ export type {
   BillingV2Model,
   BillingV2Overview,
   BillingV2PaymentMethod,
+  BillingV2Plan,
   BillingV2Preview,
   BillingV2PreviewLine,
   BillingV2SubState

--- a/frontend/src/hooks/api/billingV2/mutations.tsx
+++ b/frontend/src/hooks/api/billingV2/mutations.tsx
@@ -36,13 +36,14 @@ export const useCreateBillingV2CheckoutSession = () => {
     mutationFn: async ({
       orgId,
       productId,
+      plan,
       cadence,
       email,
       returnPath
     }: TCreateBillingV2CheckoutSessionDTO) => {
       const { data } = await apiRequest.post<BillingV2CheckoutResult>(
         `/api/v1/organizations/${orgId}/billing/v2/checkout-session`,
-        { productId, cadence, email, returnPath }
+        { productId, plan, cadence, email, returnPath }
       );
 
       return data;
@@ -72,6 +73,7 @@ export const usePreviewBillingV2Change = () => {
     mutationFn: async ({
       orgId,
       addProductId,
+      plan,
       cadence,
       removeProductId
     }: TPreviewBillingV2ChangeDTO) => {
@@ -79,7 +81,7 @@ export const usePreviewBillingV2Change = () => {
         data: { preview }
       } = await apiRequest.post<{ preview: BillingV2Preview }>(
         `/api/v1/organizations/${orgId}/billing/v2/subscription/preview`,
-        { addProductId, cadence, removeProductId }
+        { addProductId, plan, cadence, removeProductId }
       );
 
       return preview;
@@ -90,10 +92,10 @@ export const usePreviewBillingV2Change = () => {
 export const useAddBillingV2Product = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ orgId, productId, cadence }: TAddBillingV2ProductDTO) => {
+    mutationFn: async ({ orgId, productId, plan, cadence }: TAddBillingV2ProductDTO) => {
       const { data } = await apiRequest.post<BillingV2MutationResult>(
         `/api/v1/organizations/${orgId}/billing/v2/subscription/items`,
-        { productId, cadence }
+        { productId, plan, cadence }
       );
 
       return data;

--- a/frontend/src/hooks/api/billingV2/types.ts
+++ b/frontend/src/hooks/api/billingV2/types.ts
@@ -11,10 +11,22 @@ export type BillingV2Dim = {
   included: number;
 };
 
+// A comparison row's cells are keyed by plan tier ("pro" | "advanced" | "enterprise" | ...) so the
+// table can render one column per plan.
 export type BillingV2CompareRow = {
   label: string;
-  pro: string | boolean;
-  ent: string | boolean;
+  cells: Record<string, string | boolean | number>;
+};
+
+// A single purchasable (or sales-led) plan of a product. The free tier is implicit and never listed.
+export type BillingV2Plan = {
+  tier: string;
+  name: string;
+  selfServe: boolean;
+  salesLed: boolean;
+  feature?: string;
+  base?: { monthly: number; annual: number };
+  dims: BillingV2Dim[];
 };
 
 export type BillingV2CatalogProduct = {
@@ -26,14 +38,7 @@ export type BillingV2CatalogProduct = {
   addon?: boolean;
   desc: string;
   tagline?: string;
-  pro: {
-    base?: { monthly: number; annual: number };
-    dims?: BillingV2Dim[];
-    proFeature: string;
-    planKey?: string;
-  };
-  enterprise: { sales: true; feature: string } | null;
-  upgradeChanges?: { add: string[] };
+  plans: BillingV2Plan[];
   includes?: string[];
   compare?: BillingV2CompareRow[];
 };
@@ -63,6 +68,8 @@ export type BillingV2Invoice = {
 
 export type BillingV2Entitlement = {
   entitled: boolean;
+  // Tier the org is currently subscribed to for this product; lets the UI mark the active plan card.
+  planTier?: string;
   limit?: number | null;
   used?: number;
   // Singular noun for the limited dimension (e.g. "certificate"); rendered, pluralized, beside the count.
@@ -115,6 +122,7 @@ export type TCreateBillingV2PortalSessionDTO = {
 export type TCreateBillingV2CheckoutSessionDTO = {
   orgId: string;
   productId: string;
+  plan?: string;
   cadence?: BillingV2Cadence;
   email?: string;
   returnPath?: string;
@@ -149,6 +157,7 @@ export type BillingV2MutationResult = {
 export type TPreviewBillingV2ChangeDTO = {
   orgId: string;
   addProductId?: string;
+  plan?: string;
   cadence?: BillingV2Cadence;
   removeProductId?: string;
 };
@@ -156,6 +165,7 @@ export type TPreviewBillingV2ChangeDTO = {
 export type TAddBillingV2ProductDTO = {
   orgId: string;
   productId: string;
+  plan?: string;
   cadence?: BillingV2Cadence;
 };
 

--- a/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/BillingV2Page.tsx
@@ -50,7 +50,8 @@ export const BillingV2Page = () => {
 
   const [flow, setFlow] = useState<BillingV2Flow | null>(null);
   const [removeProdId, setRemoveProdId] = useState<string | null>(null);
-  const [addProdId, setAddProdId] = useState<string | null>(null);
+  // The product to add in place plus the chosen plan tier (an existing-subscription upgrade path).
+  const [addProd, setAddProd] = useState<{ id: string; plan: string } | null>(null);
 
   // Stripe redirects back with ?checkout=success|canceled; surface the outcome and refresh state.
   useEffect(() => {
@@ -82,7 +83,7 @@ export const BillingV2Page = () => {
 
   const cadence = intervalToCadence(overview?.interval ?? null);
   const removeProd = removeProdId ? catalogById(catalog, removeProdId) : undefined;
-  const addProd = addProdId ? catalogById(catalog, addProdId) : undefined;
+  const addProdProduct = addProd ? catalogById(catalog, addProd.id) : undefined;
 
   const close = () => setFlow(null);
 
@@ -98,10 +99,11 @@ export const BillingV2Page = () => {
     }
   };
 
-  const redirectToCheckout = async (productId: string) => {
+  const redirectToCheckout = async (productId: string, plan: string) => {
     const result = await createCheckoutSession.mutateAsync({
       orgId,
       productId,
+      plan,
       cadence,
       email: billingEmail,
       returnPath: window.location.pathname
@@ -141,7 +143,7 @@ export const BillingV2Page = () => {
     overview?.subState === "trialing" ||
     overview?.subState === "past-due";
 
-  const onSheetManage = async (productId: string) => {
+  const onSheetManage = async (productId: string, plan: string) => {
     const isEntitled = Boolean(overview?.entitlements[productId]?.entitled);
     if (isEntitled) {
       await redirectToPortal();
@@ -149,10 +151,10 @@ export const BillingV2Page = () => {
     }
     if (hasActiveSubscription) {
       close();
-      setAddProdId(productId);
+      setAddProd({ id: productId, plan });
       return;
     }
-    await redirectToCheckout(productId);
+    await redirectToCheckout(productId, plan);
   };
 
   const onUpdatePayment = async () => {
@@ -248,12 +250,13 @@ export const BillingV2Page = () => {
         />
       )}
 
-      {addProd && (
+      {addProdProduct && addProd && (
         <AddProductModal
           orgId={orgId}
-          product={addProd}
+          product={addProdProduct}
+          plan={addProd.plan}
           cadence={cadence}
-          onClose={() => setAddProdId(null)}
+          onClose={() => setAddProd(null)}
         />
       )}
     </div>

--- a/frontend/src/pages/organization/BillingV2Page/components/AddProductModal.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/AddProductModal.tsx
@@ -25,23 +25,25 @@ import { fmtMoney } from "../billing-v2-data";
 type Props = {
   orgId: string;
   product: BillingV2CatalogProduct;
+  plan: string;
   cadence: BillingV2Cadence;
   onClose: () => void;
 };
 
-export const AddProductModal = ({ orgId, product, cadence, onClose }: Props) => {
+export const AddProductModal = ({ orgId, product, plan, cadence, onClose }: Props) => {
   const preview = usePreviewBillingV2Change();
   const addProduct = useAddBillingV2Product();
 
   // Preview the prorated charge once when the dialog opens, so the user confirms against real numbers.
   useEffect(() => {
-    preview.mutate({ orgId, addProductId: product.id, cadence });
+    preview.mutate({ orgId, addProductId: product.id, plan, cadence });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orgId, product.id, cadence]);
+  }, [orgId, product.id, plan, cadence]);
 
-  const handleAdd = async () => {
+  const handleAdd = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     try {
-      await addProduct.mutateAsync({ orgId, productId: product.id, cadence });
+      await addProduct.mutateAsync({ orgId, productId: product.id, plan, cadence });
       createNotification({
         type: "success",
         text: `${product.name} was added. It may take a moment to update here.`
@@ -62,7 +64,7 @@ export const AddProductModal = ({ orgId, product, cadence, onClose }: Props) => 
     <AlertDialog
       open
       onOpenChange={(isOpen) => {
-        if (!isOpen) {
+        if (!isOpen && !addProduct.isPending) {
           onClose();
         }
       }}
@@ -111,6 +113,7 @@ export const AddProductModal = ({ orgId, product, cadence, onClose }: Props) => 
             variant="org"
             isDisabled={addProduct.isPending || !canConfirm}
             onClick={handleAdd}
+            isPending={addProduct.isPending}
           >
             Add {product.name}
           </AlertDialogAction>

--- a/frontend/src/pages/organization/BillingV2Page/components/AddProductModal.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/AddProductModal.tsx
@@ -64,7 +64,7 @@ export const AddProductModal = ({ orgId, product, plan, cadence, onClose }: Prop
     <AlertDialog
       open
       onOpenChange={(isOpen) => {
-        if (!isOpen && !addProduct.isPending) {
+        if (!isOpen) {
           onClose();
         }
       }}

--- a/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
@@ -427,7 +427,8 @@ const ProductRow = ({ prod, entitlement, readOnly, onManage, onContact }: Produc
     limitNote = `${used.toLocaleString()} / ${entitlement.limit.toLocaleString()}${unit}`;
   }
 
-  const selfServe = Boolean(prod.pro?.planKey);
+  const selfServe = prod.plans.some((plan) => plan.selfServe);
+  const salesLed = prod.plans.some((plan) => plan.salesLed);
 
   let action = null;
   if (!readOnly) {
@@ -444,7 +445,7 @@ const ProductRow = ({ prod, entitlement, readOnly, onManage, onContact }: Produc
           Upgrade
         </Button>
       );
-    } else if (prod.enterprise) {
+    } else if (salesLed) {
       action = (
         <Button variant="org" size="sm" onClick={() => onContact(prod)}>
           Contact sales

--- a/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ArrowRight, Check, ExternalLink, ShoppingCart } from "lucide-react";
 
 import {
@@ -16,44 +17,34 @@ import {
   TableHeader,
   TableRow
 } from "@app/components/v3";
-import { BillingV2Cadence, BillingV2CatalogProduct, BillingV2Entitlement } from "@app/hooks/api";
+import {
+  BillingV2Cadence,
+  BillingV2CatalogProduct,
+  BillingV2CompareRow,
+  BillingV2Entitlement,
+  BillingV2Plan
+} from "@app/hooks/api";
 
 import { cadenceWord, cadenceWordShort, fmtMoney, unitPrice } from "../billing-v2-data";
 import { ActiveBadge, ProductIcon } from "./shared";
 
 type PriceLine = { amount: string; unit: string };
 
-// The plan's flat/base fee for the active cadence, when it has one (e.g. "$20 / month").
-const proBaseLine = (
-  prod: BillingV2CatalogProduct,
-  cadence: BillingV2Cadence
-): PriceLine | null => {
-  const base = prod.pro?.base;
-  if (!base) {
-    return null;
-  }
-  return { amount: fmtMoney(unitPrice(base, cadence)), unit: `/ ${cadenceWord(cadence)}` };
-};
-
 // A plan's price is a base fee plus any number of metered dimensions, and any combination is valid:
 // base only, meter only, or both. The base fee leads as the headline; every priced dimension is then
 // listed below (e.g. "$5 per MCP / mo", "$3 per Agent / mo"). When there's no base fee the first
 // dimension is promoted to the headline so the card always opens with a price.
-const ProPricing = ({
-  prod,
-  cadence
-}: {
-  prod: BillingV2CatalogProduct;
-  cadence: BillingV2Cadence;
-}) => {
-  const dims = prod.pro?.dims ?? [];
+const PlanPricing = ({ plan, cadence }: { plan: BillingV2Plan; cadence: BillingV2Cadence }) => {
+  const dims = plan.dims ?? [];
   const dimLines = dims.map((dim) => ({
     key: dim.key,
     amount: fmtMoney(unitPrice(dim, cadence), 2),
     unit: `per ${dim.noun} / ${cadenceWordShort(cadence)}`
   }));
 
-  let headline = proBaseLine(prod, cadence);
+  let headline: PriceLine | null = plan.base
+    ? { amount: fmtMoney(unitPrice(plan.base, cadence)), unit: `/ ${cadenceWord(cadence)}` }
+    : null;
   let usageLines = dimLines;
   if (!headline && dims.length > 0) {
     headline = {
@@ -90,14 +81,102 @@ const ProPricing = ({
   );
 };
 
-const renderCompareCell = (value: string | boolean) => {
+const renderCompareCell = (value: string | boolean | number | undefined) => {
   if (value === true) {
     return <Check className="mx-auto size-3.5 text-success" />;
   }
-  if (value === false) {
+  if (value === false || value === undefined) {
     return <span className="text-muted">—</span>;
   }
   return value;
+};
+
+type PlanBadgeProps = { plan: BillingV2Plan; isCurrent: boolean };
+
+const PlanBadge = ({ plan, isCurrent }: PlanBadgeProps) => {
+  if (isCurrent) {
+    return (
+      <Badge variant="success">
+        <Check className="text-success" />
+        Current Plan
+      </Badge>
+    );
+  }
+  if (plan.salesLed) {
+    return <Badge variant="neutral">Talk to Us</Badge>;
+  }
+  return <Badge variant="neutral">Self-Checkout</Badge>;
+};
+
+type PlanCardProps = {
+  prodId: string;
+  plan: BillingV2Plan;
+  cadence: BillingV2Cadence;
+  isCurrent: boolean;
+  entitled: boolean;
+  redirecting?: boolean;
+  onSelect: (prodId: string, planTier: string) => void;
+  onContact: () => void;
+};
+
+const PlanCard = ({
+  prodId,
+  plan,
+  cadence,
+  isCurrent,
+  entitled,
+  redirecting,
+  onSelect,
+  onContact
+}: PlanCardProps) => {
+  // A sales-led plan with no published price shows "Custom"; everything else renders its pricing.
+  const isCustom = plan.salesLed && !plan.base && plan.dims.length === 0;
+
+  let cta = null;
+  if (plan.salesLed && !isCurrent) {
+    cta = (
+      <Button variant="org" size="sm" className="mt-auto self-start" onClick={onContact}>
+        Contact sales
+        <ArrowRight />
+      </Button>
+    );
+  } else if (plan.selfServe && !entitled) {
+    // Picking a self-serve plan starts checkout (or an in-place add for an existing subscription).
+    cta = (
+      <Button
+        variant="org"
+        size="sm"
+        className="mt-auto self-start"
+        isPending={redirecting}
+        onClick={() => onSelect(prodId, plan.tier)}
+      >
+        <ShoppingCart />
+        Continue to checkout
+      </Button>
+    );
+  }
+
+  return (
+    <div
+      className={`flex flex-col gap-3.5 rounded-xl border p-[18px] ${
+        isCurrent ? "border-success/40 bg-success/5" : "border-border bg-card"
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[15px] font-medium text-foreground">{plan.name}</span>
+        <PlanBadge plan={plan} isCurrent={isCurrent} />
+      </div>
+      {isCustom ? (
+        <div className="flex items-baseline">
+          <span className="text-2xl font-medium text-foreground">Custom</span>
+        </div>
+      ) : (
+        <PlanPricing plan={plan} cadence={cadence} />
+      )}
+      {plan.feature && <div className="text-xs text-accent">{plan.feature}</div>}
+      {cta}
+    </div>
+  );
 };
 
 type EntitlementSummaryProps = {
@@ -125,106 +204,123 @@ const EntitlementSummary = ({ entitlement }: EntitlementSummaryProps) => {
   );
 };
 
+type CompareTableProps = {
+  plans: BillingV2Plan[];
+  compare: BillingV2CompareRow[];
+};
+
+const CompareTable = ({ plans, compare }: CompareTableProps) => (
+  <div>
+    <div className="mb-3 text-xs font-medium text-muted">Compare Plan</div>
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead aria-label="Feature" />
+          {plans.map((plan) => (
+            <TableHead key={plan.tier} className="text-center">
+              {plan.name}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {compare.map((row) => (
+          <TableRow key={row.label}>
+            <TableCell className="text-accent">{row.label}</TableCell>
+            {plans.map((plan) => (
+              <TableCell key={plan.tier} className="text-center">
+                {renderCompareCell(row.cells[plan.tier])}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </div>
+);
+
+const IncludesList = ({ includes }: { includes: string[] }) => (
+  <div>
+    <div className="mb-3 text-xs font-medium tracking-wide text-muted uppercase">
+      What&apos;s included
+    </div>
+    <div className="grid gap-x-5 gap-y-2.5 sm:grid-cols-2">
+      {includes.map((feature) => (
+        <div className="flex items-start gap-2 text-xs text-accent" key={feature}>
+          <Check className="mt-0.5 size-3 shrink-0 text-success" />
+          {feature}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// Static column classes (Tailwind can't see computed ones); cap at three before wrapping.
+const GRID_COLS: Record<number, string> = {
+  1: "grid-cols-1",
+  2: "sm:grid-cols-2",
+  3: "sm:grid-cols-2 lg:grid-cols-3"
+};
+
 type PlansViewProps = {
   prod: BillingV2CatalogProduct;
   entitlement?: BillingV2Entitlement;
   cadence: BillingV2Cadence;
+  redirecting?: boolean;
+  pendingTier: string | null;
+  onSelect: (prodId: string, planTier: string) => void;
   onContact: (prod: BillingV2CatalogProduct) => void;
 };
 
-const PlansView = ({ prod, entitlement, cadence, onContact }: PlansViewProps) => {
-  const hasEnterprise = !!prod.enterprise;
+const PlansView = ({
+  prod,
+  entitlement,
+  cadence,
+  redirecting,
+  pendingTier,
+  onSelect,
+  onContact
+}: PlansViewProps) => {
+  // Sales-led ("Contact sales") plans sort last; alphabetical by name within each group breaks ties.
+  const plans = [...(prod.plans ?? [])].sort((a, b) => {
+    if (a.salesLed !== b.salesLed) {
+      return a.salesLed ? 1 : -1;
+    }
+    return a.name.localeCompare(b.name);
+  });
   const entitled = Boolean(entitlement?.entitled);
-  const selfServe = Boolean(prod.pro?.planKey);
+  // When entitled but the server didn't say which tier, fall back to the first self-serve plan so a
+  // card is still marked active (mirrors the previous single-"pro" behaviour).
+  const currentTier =
+    entitlement?.planTier ?? (entitled ? plans.find((plan) => plan.selfServe)?.tier : undefined);
+
+  const gridCols = GRID_COLS[Math.min(plans.length, 3)] ?? GRID_COLS[3];
+  const showCompare = Boolean(prod.compare && prod.compare.length > 0 && plans.length > 1);
 
   return (
     <>
       <EntitlementSummary entitlement={entitlement} />
 
-      <div className={`grid gap-3.5 ${hasEnterprise ? "sm:grid-cols-2" : "grid-cols-1"}`}>
-        <div
-          className={`flex flex-col gap-3.5 rounded-xl border p-[18px] ${
-            entitled ? "border-success/40 bg-success/5" : "border-org/40 bg-org/5"
-          }`}
-        >
-          <div className="flex items-center justify-between gap-2">
-            <span className="text-[15px] font-medium text-foreground">Pro</span>
-            {entitled ? (
-              <Badge variant="success">
-                <Check className="text-success" />
-                Current Plan
-              </Badge>
-            ) : (
-              <Badge variant="neutral">Self-Checkout</Badge>
-            )}
-          </div>
-          <ProPricing prod={prod} cadence={cadence} />
-          {prod.pro?.proFeature && <div className="text-xs text-accent">{prod.pro.proFeature}</div>}
-        </div>
-
-        {hasEnterprise && prod.enterprise && (
-          <div className="flex flex-col gap-3.5 rounded-xl border border-border bg-card p-[18px]">
-            <div className="flex items-center justify-between gap-2">
-              <span className="font-medium text-foreground">Enterprise</span>
-              <Badge variant="neutral">Talk to Us</Badge>
-            </div>
-            <div className="flex items-baseline">
-              <span className="text-2xl font-medium text-foreground">Custom</span>
-            </div>
-            <div className="text-xs text-accent">{prod.enterprise.feature}</div>
-            {selfServe && (
-              <Button
-                variant="org"
-                size="sm"
-                className="mt-auto self-start"
-                onClick={() => onContact(prod)}
-              >
-                Contact sales
-                <ArrowRight />
-              </Button>
-            )}
-          </div>
-        )}
+      <div className={`grid gap-3.5 ${gridCols}`}>
+        {plans.map((plan) => (
+          <PlanCard
+            key={plan.tier}
+            prodId={prod.id}
+            plan={plan}
+            cadence={cadence}
+            entitled={entitled}
+            isCurrent={entitled && plan.tier === currentTier}
+            redirecting={Boolean(redirecting) && pendingTier === plan.tier}
+            onSelect={onSelect}
+            onContact={() => onContact(prod)}
+          />
+        ))}
       </div>
 
-      {hasEnterprise && prod.compare && (
-        <div>
-          <div className="mb-3 text-xs font-medium text-muted">Compare Plans</div>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead aria-label="Feature" />
-                <TableHead className="text-center">Pro</TableHead>
-                <TableHead className="text-center">Enterprise</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {prod.compare.map((row) => (
-                <TableRow key={row.label}>
-                  <TableCell className="text-accent">{row.label}</TableCell>
-                  <TableCell className="text-center">{renderCompareCell(row.pro)}</TableCell>
-                  <TableCell className="text-center">{renderCompareCell(row.ent)}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
-
-      {!(hasEnterprise && prod.compare) && prod.includes && (
-        <div>
-          <div className="mb-3 text-xs font-medium tracking-wide text-muted uppercase">
-            What&apos;s included
-          </div>
-          <div className="grid gap-x-5 gap-y-2.5 sm:grid-cols-2">
-            {prod.includes.map((f) => (
-              <div className="flex items-start gap-2 text-xs text-accent" key={f}>
-                <Check className="mt-0.5 size-3 shrink-0 text-success" />
-                {f}
-              </div>
-            ))}
-          </div>
-        </div>
+      {showCompare && prod.compare ? (
+        <CompareTable plans={plans} compare={prod.compare} />
+      ) : (
+        prod.includes && prod.includes.length > 0 && <IncludesList includes={prod.includes} />
       )}
     </>
   );
@@ -237,7 +333,7 @@ type ProductSheetProps = {
   cadence: BillingV2Cadence;
   redirecting?: boolean;
   onClose: () => void;
-  onManage: (prodId: string) => void;
+  onManage: (prodId: string, planTier: string) => void;
   onRemove: (prodId: string) => void;
   onContact: (prod: BillingV2CatalogProduct) => void;
 };
@@ -253,36 +349,33 @@ export const ProductSheet = ({
   onRemove,
   onContact
 }: ProductSheetProps) => {
+  // Track which plan's button was clicked so only that card spins while the request is in flight,
+  // rather than every card sharing the single `redirecting` flag.
+  const [pendingTier, setPendingTier] = useState<string | null>(null);
+
   if (!prod) {
     return null;
   }
 
   const entitled = Boolean(entitlement?.entitled);
-  const selfServe = Boolean(prod.pro?.planKey);
+  const selfServe = prod.plans.some((plan) => plan.selfServe);
 
-  let primaryCta = null;
-  if (entitled) {
-    primaryCta = (
-      <Button variant="org" onClick={() => onManage(prodId)} isPending={redirecting}>
-        Manage in Stripe
-        <ExternalLink />
-      </Button>
-    );
-  } else if (selfServe) {
-    primaryCta = (
-      <Button variant="org" onClick={() => onManage(prodId)} isPending={redirecting}>
-        <ShoppingCart />
-        Continue to Checkout
-      </Button>
-    );
-  } else if (prod.enterprise) {
-    primaryCta = (
-      <Button variant="org" onClick={() => onContact(prod)}>
-        Contact sales
-        <ArrowRight />
-      </Button>
-    );
-  }
+  const handleSelect = (id: string, planTier: string) => {
+    setPendingTier(planTier);
+    onManage(id, planTier);
+  };
+
+  // An entitled product is managed in the Stripe portal; selecting a plan is handled per-card.
+  const primaryCta = entitled ? (
+    <Button
+      variant="org"
+      onClick={() => onManage(prodId, entitlement?.planTier ?? "")}
+      isPending={redirecting}
+    >
+      Manage in Stripe
+      <ExternalLink />
+    </Button>
+  ) : null;
 
   return (
     <Sheet
@@ -323,6 +416,9 @@ export const ProductSheet = ({
             prod={prod}
             entitlement={entitlement}
             cadence={cadence}
+            redirecting={redirecting}
+            pendingTier={pendingTier}
+            onSelect={handleSelect}
             onContact={onContact}
           />
         </div>

--- a/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/ProductSheet.tsx
@@ -211,7 +211,7 @@ type CompareTableProps = {
 
 const CompareTable = ({ plans, compare }: CompareTableProps) => (
   <div>
-    <div className="mb-3 text-xs font-medium text-muted">Compare Plan</div>
+    <div className="mb-3 text-xs font-medium text-muted">Compare Plans</div>
     <Table>
       <TableHeader>
         <TableRow>

--- a/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
@@ -63,7 +63,8 @@ export const RemoveProductModal = ({ orgId, product, onClose, onRemoved }: Props
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orgId, product.id, isOnlyProduct]);
 
-  const handleRemove = async () => {
+  const handleRemove = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     try {
       await removeProduct.mutateAsync({ orgId, productId: product.id });
       createNotification({
@@ -195,6 +196,7 @@ export const RemoveProductModal = ({ orgId, product, onClose, onRemoved }: Props
             variant="danger"
             isDisabled={removeProduct.isPending || previewLoading}
             onClick={handleRemove}
+            isPending={removeProduct.isPending}
           >
             Remove {product.name}
           </AlertDialogAction>


### PR DESCRIPTION
## Context

This PR removes the hardcoded pro and enterprise from product plans and shows the full thing. Also some improvements in loading of product add and remove.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)