### PR TITLE
fix(insights): scope duplicated-secrets groups to caller-readable secrets

### DIFF
--- a/backend/src/ee/services/insights/insights-fns.test.ts
+++ b/backend/src/ee/services/insights/insights-fns.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../permission/project-permission";
 import { filterVisibleDuplicationGroups, TInsightsDuplicationGroup } from "./insights-fns";
 
+// Describe grant per environment (no tag condition).
 const buildPermission = (environments: string[]) =>
   createMongoAbility<MongoAbility<ProjectPermissionSet>>(
     environments.map(
@@ -23,39 +24,44 @@ const buildPermission = (environments: string[]) =>
     { conditionsMatcher }
   );
 
-const secret = (key: string, slug: string, secretPath = "/") => ({
+// Describe grant scoped to a tag within an environment.
+const buildTagScopedPermission = (environment: string, tagSlug: string) =>
+  createMongoAbility<MongoAbility<ProjectPermissionSet>>(
+    [
+      {
+        action: [ProjectPermissionSecretActions.DescribeSecret],
+        subject: ProjectPermissionSub.Secrets,
+        conditions: { environment, secretTags: { $in: [tagSlug] } }
+      } as RawRuleOf<MongoAbility<ProjectPermissionSet>>
+    ],
+    { conditionsMatcher }
+  );
+
+const secret = (key: string, slug: string, secretPath = "/", secretTags: string[] = []) => ({
   key,
   environment: { name: slug, slug },
-  secretPath
+  secretPath,
+  secretTags
 });
 
 describe("filterVisibleDuplicationGroups", () => {
   it("drops a secret in an environment the caller cannot describe, dropping the now-single group", () => {
     const groups: TInsightsDuplicationGroup[] = [{ secrets: [secret("DB_PASS", "dev"), secret("DB_PASS", "prod")] }];
-
-    const result = filterVisibleDuplicationGroups(groups, buildPermission(["dev"]));
-
-    // dev secret was readable, prod was not -> group reduced to one -> removed entirely
-    expect(result).toHaveLength(0);
+    expect(filterVisibleDuplicationGroups(groups, buildPermission(["dev"]))).toHaveLength(0);
   });
 
   it("keeps a group when more than one secret remains visible to the caller", () => {
     const groups: TInsightsDuplicationGroup[] = [
       { secrets: [secret("API_KEY", "dev", "/"), secret("API_KEY", "dev", "/svc")] }
     ];
-
     const result = filterVisibleDuplicationGroups(groups, buildPermission(["dev"]));
-
     expect(result).toHaveLength(1);
     expect(result[0].secrets).toHaveLength(2);
-    expect(result[0].secrets.every((s) => s.environment.slug === "dev")).toBe(true);
   });
 
   it("returns full groups when the caller can describe every environment", () => {
     const groups: TInsightsDuplicationGroup[] = [{ secrets: [secret("DB_PASS", "dev"), secret("DB_PASS", "prod")] }];
-
     const result = filterVisibleDuplicationGroups(groups, buildPermission(["dev", "prod"]));
-
     expect(result).toHaveLength(1);
     expect(result[0].secrets).toHaveLength(2);
   });
@@ -64,10 +70,29 @@ describe("filterVisibleDuplicationGroups", () => {
     const groups: TInsightsDuplicationGroup[] = [
       { secrets: [secret("TOKEN", "dev"), secret("TOKEN", "staging"), secret("TOKEN", "prod")] }
     ];
-
     const result = filterVisibleDuplicationGroups(groups, buildPermission(["dev", "staging"]));
-
     expect(result).toHaveLength(1);
     expect(result[0].secrets.map((s) => s.environment.slug).sort()).toEqual(["dev", "staging"]);
+  });
+
+  it("honors a tag-conditioned describe grant (group of matching-tag secrets stays visible)", () => {
+    const groups: TInsightsDuplicationGroup[] = [
+      {
+        secrets: [secret("A", "dev", "/", ["shared"]), secret("B", "dev", "/", ["shared"])]
+      }
+    ];
+    const result = filterVisibleDuplicationGroups(groups, buildTagScopedPermission("dev", "shared"));
+    expect(result).toHaveLength(1);
+    expect(result[0].secrets).toHaveLength(2);
+  });
+
+  it("filters out secrets whose tags do not match a tag-conditioned grant", () => {
+    const groups: TInsightsDuplicationGroup[] = [
+      {
+        secrets: [secret("A", "dev", "/", ["shared"]), secret("B", "dev", "/", ["other"])]
+      }
+    ];
+    // only the "shared"-tagged secret is visible -> group reduced to one -> removed
+    expect(filterVisibleDuplicationGroups(groups, buildTagScopedPermission("dev", "shared"))).toHaveLength(0);
   });
 });

--- a/backend/src/ee/services/insights/insights-fns.test.ts
+++ b/backend/src/ee/services/insights/insights-fns.test.ts
@@ -1,0 +1,73 @@
+import { createMongoAbility, MongoAbility, RawRuleOf } from "@casl/ability";
+import { describe, expect, it } from "vitest";
+
+import { conditionsMatcher } from "@app/lib/casl";
+
+import {
+  ProjectPermissionSecretActions,
+  ProjectPermissionSet,
+  ProjectPermissionSub
+} from "../permission/project-permission";
+import { filterVisibleDuplicationGroups, TInsightsDuplicationGroup } from "./insights-fns";
+
+const buildPermission = (environments: string[]) =>
+  createMongoAbility<MongoAbility<ProjectPermissionSet>>(
+    environments.map(
+      (environment) =>
+        ({
+          action: [ProjectPermissionSecretActions.DescribeSecret],
+          subject: ProjectPermissionSub.Secrets,
+          conditions: { environment }
+        }) as RawRuleOf<MongoAbility<ProjectPermissionSet>>
+    ),
+    { conditionsMatcher }
+  );
+
+const secret = (key: string, slug: string, secretPath = "/") => ({
+  key,
+  environment: { name: slug, slug },
+  secretPath
+});
+
+describe("filterVisibleDuplicationGroups", () => {
+  it("drops a secret in an environment the caller cannot describe, dropping the now-single group", () => {
+    const groups: TInsightsDuplicationGroup[] = [{ secrets: [secret("DB_PASS", "dev"), secret("DB_PASS", "prod")] }];
+
+    const result = filterVisibleDuplicationGroups(groups, buildPermission(["dev"]));
+
+    // dev secret was readable, prod was not -> group reduced to one -> removed entirely
+    expect(result).toHaveLength(0);
+  });
+
+  it("keeps a group when more than one secret remains visible to the caller", () => {
+    const groups: TInsightsDuplicationGroup[] = [
+      { secrets: [secret("API_KEY", "dev", "/"), secret("API_KEY", "dev", "/svc")] }
+    ];
+
+    const result = filterVisibleDuplicationGroups(groups, buildPermission(["dev"]));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].secrets).toHaveLength(2);
+    expect(result[0].secrets.every((s) => s.environment.slug === "dev")).toBe(true);
+  });
+
+  it("returns full groups when the caller can describe every environment", () => {
+    const groups: TInsightsDuplicationGroup[] = [{ secrets: [secret("DB_PASS", "dev"), secret("DB_PASS", "prod")] }];
+
+    const result = filterVisibleDuplicationGroups(groups, buildPermission(["dev", "prod"]));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].secrets).toHaveLength(2);
+  });
+
+  it("filters only the unreadable members of a mixed group", () => {
+    const groups: TInsightsDuplicationGroup[] = [
+      { secrets: [secret("TOKEN", "dev"), secret("TOKEN", "staging"), secret("TOKEN", "prod")] }
+    ];
+
+    const result = filterVisibleDuplicationGroups(groups, buildPermission(["dev", "staging"]));
+
+    expect(result).toHaveLength(1);
+    expect(result[0].secrets.map((s) => s.environment.slug).sort()).toEqual(["dev", "staging"]);
+  });
+});

--- a/backend/src/ee/services/insights/insights-fns.ts
+++ b/backend/src/ee/services/insights/insights-fns.ts
@@ -4,7 +4,7 @@ import { hasSecretReadValueOrDescribePermission } from "@app/ee/services/permiss
 import { ProjectPermissionSecretActions, ProjectPermissionSet } from "@app/ee/services/permission/project-permission";
 
 export type TInsightsDuplicationGroup = {
-  secrets: { key: string; environment: { name: string; slug: string }; secretPath: string }[];
+  secrets: { key: string; environment: { name: string; slug: string }; secretPath: string; secretTags?: string[] }[];
 };
 
 // Keep only the secrets in each duplication group that the actor can describe, and only groups that
@@ -20,7 +20,8 @@ export const filterVisibleDuplicationGroups = (
         hasSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret, {
           environment: s.environment.slug,
           secretPath: s.secretPath,
-          secretName: s.key
+          secretName: s.key,
+          secretTags: s.secretTags
         })
       )
     }))

--- a/backend/src/ee/services/insights/insights-fns.ts
+++ b/backend/src/ee/services/insights/insights-fns.ts
@@ -1,0 +1,27 @@
+import { MongoAbility } from "@casl/ability";
+
+import { hasSecretReadValueOrDescribePermission } from "@app/ee/services/permission/permission-fns";
+import { ProjectPermissionSecretActions, ProjectPermissionSet } from "@app/ee/services/permission/project-permission";
+
+export type TInsightsDuplicationGroup = {
+  secrets: { key: string; environment: { name: string; slug: string }; secretPath: string }[];
+};
+
+// Keep only the secrets in each duplication group that the actor can describe, and only groups that
+// still contain more than one. A group reduced to a single visible secret is no longer a duplication
+// from the actor's perspective, so it cannot reveal a secret in an environment/path they cannot access.
+export const filterVisibleDuplicationGroups = (
+  groups: TInsightsDuplicationGroup[],
+  permission: MongoAbility<ProjectPermissionSet>
+): TInsightsDuplicationGroup[] =>
+  groups
+    .map((group) => ({
+      secrets: group.secrets.filter((s) =>
+        hasSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret, {
+          environment: s.environment.slug,
+          secretPath: s.secretPath,
+          secretName: s.key
+        })
+      )
+    }))
+    .filter((group) => group.secrets.length > 1);

--- a/backend/src/ee/services/insights/insights-service.ts
+++ b/backend/src/ee/services/insights/insights-service.ts
@@ -29,6 +29,7 @@ import { containsSecretReference } from "@app/services/secret-v2-bridge/secret-r
 import { TSecretV2BridgeDALFactory } from "@app/services/secret-v2-bridge/secret-v2-bridge-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
+import { filterVisibleDuplicationGroups } from "./insights-fns";
 import {
   // TGetAccessLocationsDTO,
   TGetAccessVolumeDTO,
@@ -517,7 +518,7 @@ export const insightsServiceFactory = ({
   };
 
   const getSecretsDuplication = async (dto: TGetSecretsDuplicationDTO, actorDto: OrgServiceActor) => {
-    await checkInsightsPermission(permissionService, licenseService, dto.projectId, actorDto);
+    const { permission } = await checkInsightsPermission(permissionService, licenseService, dto.projectId, actorDto);
 
     const cacheKey = KeyStorePrefixes.InsightsCache(dto.projectId, "secrets-duplication");
 
@@ -576,9 +577,17 @@ export const insightsServiceFactory = ({
       }
     });
 
+    // Only surface secrets the caller can describe (groups reduced below two are dropped), so a
+    // duplication group cannot reveal a secret in an environment/path the caller cannot access.
+    // Applied outside withCache so the project-scoped cache stays permission-independent.
+    const visibleResult = {
+      ...result,
+      groups: filterVisibleDuplicationGroups(result.groups, permission)
+    };
+
     const remainingTTL = await getCacheTtl(keyStore, cacheKey);
 
-    return { result, remainingTTL };
+    return { result: visibleResult, remainingTTL };
   };
 
   const getCounts = async (dto: TGetInsightsCountsDTO, actorDto: OrgServiceActor) => {

--- a/backend/src/ee/services/insights/insights-service.ts
+++ b/backend/src/ee/services/insights/insights-service.ts
@@ -1,7 +1,7 @@
 import { ForbiddenError } from "@casl/ability";
 
 // import geoip from "geoip-lite";
-import { ActionProjectType, IdentityAuthMethod } from "@app/db/schemas";
+import { ActionProjectType, IdentityAuthMethod, SecretType, TableName } from "@app/db/schemas";
 import { TAuditLogDALFactory } from "@app/ee/services/audit-log/audit-log-dal";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { TDynamicSecretDALFactory } from "@app/ee/services/dynamic-secret/dynamic-secret-dal";
@@ -52,7 +52,7 @@ type TInsightsServiceFactoryDep = {
   folderDAL: Pick<TSecretFolderDALFactory, "findSecretPathByFolderIds" | "countByProject">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
-    "findStaleByProject" | "countStaleByProject" | "findDuplicatedSecretValues" | "countByProject"
+    "findStaleByProject" | "countStaleByProject" | "findDuplicatedSecretValues" | "countByProject" | "find"
   >;
   dynamicSecretDAL: Pick<TDynamicSecretDALFactory, "countByProject">;
   honeyTokenDAL: Pick<THoneyTokenDALFactory, "countByProjectId">;
@@ -562,6 +562,22 @@ export const insightsServiceFactory = ({
           if (f) folderRecord[f.id] = f.path;
         });
 
+        // findDuplicatedSecretValues does not return tags; load them so tag-conditioned read
+        // permissions are honored when filtering visibility per caller.
+        const secretsWithTags = folderIds.length
+          ? await secretV2BridgeDAL.find({
+              $in: { [`${TableName.SecretV2}.folderId` as "folderId"]: folderIds },
+              [`${TableName.SecretV2}.type` as "type"]: SecretType.Shared
+            })
+          : [];
+        const tagSlugsByFolderKey = new Map<string, string[]>();
+        secretsWithTags.forEach((s) => {
+          tagSlugsByFolderKey.set(
+            `${s.folderId}:${s.key}`,
+            (s.tags ?? []).map((t) => t.slug)
+          );
+        });
+
         const groups = filteredGroups.map((g) => ({
           secrets: g.secrets.map((s) => ({
             key: s.key,
@@ -569,7 +585,8 @@ export const insightsServiceFactory = ({
               name: s.environmentName,
               slug: s.environment
             },
-            secretPath: folderRecord[s.folderId] ?? "/"
+            secretPath: folderRecord[s.folderId] ?? "/",
+            secretTags: tagSlugsByFolderKey.get(`${s.folderId}:${s.key}`) ?? []
           }))
         }));
 


### PR DESCRIPTION
## Context

The Secret Insights "duplicated secrets" endpoint groups secrets that share a value (by blind index)
across the whole project. It enforced only the project-wide `Insights: Read` permission, so a caller
could see groups containing secrets in environments/paths they cannot otherwise access, including
seeing that a readable secret shares a value with one they cannot read.

This filters the returned duplication groups by the caller's per-secret permission: each group now
keeps only the secrets the caller can describe (`DescribeSecret` on the secret's environment + path),
and only groups that still contain more than one secret are returned (a group reduced to a single
visible secret is no longer a "duplication" from the caller's perspective). The filtering is applied
outside `withCache` so the project-scoped cache stays permission-independent, mirroring the existing
honey-token handling in `getCounts`.

- Before: duplication groups were returned project-wide, regardless of per-secret access.
- After: a caller only sees duplications among secrets they can describe; secrets they cannot describe
  are excluded, and groups that drop below two visible secrets are omitted.

Changed files:

- `backend/src/ee/services/insights/insights-fns.ts`: new `filterVisibleDuplicationGroups` helper
  (keeps only secrets the caller can describe; drops groups left with fewer than two).
- `backend/src/ee/services/insights/insights-service.ts`: capture the caller permission from
  `checkInsightsPermission` and apply `filterVisibleDuplicationGroups` to the duplication result after
  the cache.
- `backend/src/ee/services/insights/insights-fns.test.ts`: unit tests for the helper.

## Screenshots

<!-- Not applicable (no UI/UX change). -->

## Steps to verify the change

- Unit test (included): `npm run test:unit -- src/ee/services/insights/insights-fns.test.ts`. It covers
  dropping secrets in environments the caller cannot describe, removing groups reduced below two, and
  returning full groups when the caller can describe every environment.
- Manual: with a role granted `Insights: Read` plus secret read on a lower environment but not on
  production, open the Insights duplicated-secrets view. Groups now only include secrets in
  environments/paths the role can describe; a duplication between a readable and a non-readable secret
  no longer appears.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
