### PR TITLE
chore(telemetry): remove project ID from InfisicalCore meter labels

### DIFF
--- a/backend/src/lib/telemetry/instrumentation.ts
+++ b/backend/src/lib/telemetry/instrumentation.ts
@@ -32,9 +32,8 @@ const INFISICAL_CORE_METER_ATTRIBUTES = [
   "http.request.method",
   "http.route",
   "http.response.status_code",
-  // Tenant scope — bounded by org/project count
+  // Tenant scope — bounded by org count
   "infisical.organization.id",
-  "infisical.project.id",
   "infisical.environment",
   // Bounded enums
   "infisical.auth.method",

--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -234,17 +234,14 @@ const isTelemetryEnabled = () => getConfig().OTEL_TELEMETRY_COLLECTION_ENABLED;
 
 /**
  * Pull only the keys that survive the InfisicalCore View allowlist (see instrumentation.ts):
- * organization.id, project.id. Returns an empty object when no request context is available
- * (e.g. queue workers / cron handlers) — those call sites pass their own tenant labels.
+ * organization.id. Returns an empty object when no request context is
+ * available (e.g. queue workers / cron handlers) — those call sites pass their own tenant labels.
  */
 export const buildBaseAttributes = (): Record<string, string> => {
   const attributes: Record<string, string> = {};
 
   const orgId = requestContext.get(RequestContextKey.OrgId);
   if (orgId) attributes["infisical.organization.id"] = orgId;
-
-  const projectDetails = requestContext.get(RequestContextKey.ProjectDetails);
-  if (projectDetails?.id) attributes["infisical.project.id"] = projectDetails.id;
 
   return attributes;
 };

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -174,7 +174,6 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         "error.type": classifyError(error)
       };
       if (orgId) coreAttrs["infisical.organization.id"] = orgId;
-      if (projectDetails?.id) coreAttrs["infisical.project.id"] = projectDetails.id;
       coreHttpErrorCounter.add(1, coreAttrs);
     }
 

--- a/docs/self-hosting/guides/monitoring-telemetry.mdx
+++ b/docs/self-hosting/guides/monitoring-telemetry.mdx
@@ -343,13 +343,13 @@ Replace `otel-collector:8889` with the actual hostname and port where your OpenT
 Infisical emits metrics on two OpenTelemetry meters simultaneously. Choose which to scrape based on your deployment scale.
 
 - **High-cardinality, per-actor meters:** the `Infisical` and `API` meters' original metrics (`infisical.http.server.request.*`, `infisical.http.server.error.count`, `infisical.secret.read.count`, `infisical.auth.attempt.count`, `infisical.kmip.operation.count`) include per-actor labels such as `user.email`, `identity.name`, `client.address`, `user_agent.original`, `organization.name`, `project.name`, `secret.path`, and `secret.name`. The `SecretSyncs`, `PkiSyncs`, and `Integrations` meters likewise carry unbounded labels such as `syncId`. Useful for self-hosted deployments where you want per-user visibility directly in Grafana. May become expensive at large scale (many users, identities, or IPs) due to label cardinality.
-- **`InfisicalCore` meter (bounded-cardinality):** all newer metrics (queue, audit log, permission cache, secret cache, rate limit, build info, `infisical.core.http.error.count`, authentication latency, token renewal, SSO config changes, SCIM provisioning, and database connection pool) use only IDs and bounded enums as labels. No names, emails, IPs, or user agents. Designed for large or multi-tenant deployments. Per-actor detail is available in audit logs instead.
+- **`InfisicalCore` meter (bounded-cardinality):** all newer metrics (queue, audit log, permission cache, secret cache, rate limit, build info, `infisical.core.http.error.count`, authentication latency, token renewal, SSO config changes, SCIM provisioning, and database connection pool) use only `infisical.organization.id` and bounded enums as labels. No project IDs, names, emails, IPs, or user agents. Per-project and per-actor detail is available in audit logs instead.
 
 All meters emit at the same time. If you are a self-hosted instance and find the per-actor labels useful, keep using the high-cardinality metrics. For larger or multi-tenant deployments, scrape only the `InfisicalCore` metrics to keep cardinality under control.
 
 To eliminate the in-memory cost of the high-cardinality meters entirely, set `OTEL_DROP_HIGH_CARDINALITY_METERS=true`. When enabled, the SDK discards all data points from the `Infisical`, `API`, `SecretSyncs`, `PkiSyncs`, and `Integrations` meters before aggregation. The instruments still exist in code (no errors), but nothing is stored or exported. Only `InfisicalCore` metrics are emitted. Defaults to `false`.
 
-For per-user / per-identity / per-IP breakdowns, query the audit log table. It carries `actorId`, `actorType`, `ip`, `userAgent` and full event detail. Metrics give you the *rate* and *latency*; audit logs give you the *who*.
+For per-user / per-identity / per-IP / per-project breakdowns, query the audit log table. It carries `actorId`, `actorType`, `projectId`, `ip`, `userAgent` and full event detail. Metrics give you the *rate* and *latency*; audit logs give you the *who* and *where*.
 
 ### Resource attributes (every metric)
 


### PR DESCRIPTION
## Context

`infisical.project.id` was included in the `InfisicalCore` meter attribute allowlist and documented as a bounded, cloud-safe label. In multi-tenant deployments, project count is not bounded — a single org can have tens of thousands of projects — so this label can create a large cardinality explosion across `InfisicalCore` metrics (cache, queue, HTTP errors, etc.).

This PR removes `infisical.project.id` from the `InfisicalCore` meter only:

- Drop it from `INFISICAL_CORE_METER_ATTRIBUTES` in `instrumentation.ts` so the SDK View silently strips it from all core instruments
- Stop attaching it in `buildBaseAttributes()` and on `coreHttpErrorCounter` in `error-handler.ts`
- Update monitoring docs to clarify that `InfisicalCore` uses `infisical.organization.id` plus bounded enums, and that per-project breakdowns should come from audit logs

## Steps to verify the change

1. Start the backend with telemetry enabled:
   ```bash
   OTEL_TELEMETRY_COLLECTION_ENABLED=true
   OTEL_EXPORT_TYPE=prometheus
   ```
2. Hit a project-scoped API route (e.g. secret read) and confirm `/metrics` still exports `InfisicalCore` metrics.
3. Verify `InfisicalCore` series no longer include `infisical_project_id` (or equivalent label) — e.g. on `infisical_core_http_error_count`, `infisical_secret_cache_access_count`.
4. Confirm legacy `Infisical` metrics (e.g. `infisical_http_server_request_count`) still include `infisical.project.id` when `OTEL_DROP_HIGH_CARDINALITY_METERS` is not set.
5. Review `docs/self-hosting/guides/monitoring-telemetry.mdx` and confirm the `InfisicalCore` section no longer describes `project.id` as a bounded core label.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)