### PR TITLE
fix: add max length validation to environment name

### DIFF
--- a/backend/src/server/routes/v1/deprecated-project-env-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-env-router.ts
@@ -128,7 +128,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
         workspaceId: z.string().trim().describe(ENVIRONMENTS.CREATE.projectId)
       }),
       body: z.object({
-        name: z.string().trim().min(1).max(64).describe(ENVIRONMENTS.CREATE.name),
+        name: z.string().trim().min(1).max(255).describe(ENVIRONMENTS.CREATE.name),
         position: z.number().min(1).optional().describe(ENVIRONMENTS.CREATE.position),
         slug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.CREATE.slug)
       }),
@@ -191,7 +191,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
       }),
       body: z.object({
         slug: slugSchema({ max: 64 }).optional().describe(ENVIRONMENTS.UPDATE.slug),
-        name: z.string().trim().min(1).max(64).optional().describe(ENVIRONMENTS.UPDATE.name),
+        name: z.string().trim().min(1).max(255).optional().describe(ENVIRONMENTS.UPDATE.name),
         position: z.number().optional().describe(ENVIRONMENTS.UPDATE.position)
       }),
       response: {

--- a/backend/src/server/routes/v1/deprecated-project-env-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-env-router.ts
@@ -128,7 +128,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
         workspaceId: z.string().trim().describe(ENVIRONMENTS.CREATE.projectId)
       }),
       body: z.object({
-        name: z.string().trim().describe(ENVIRONMENTS.CREATE.name),
+        name: z.string().trim().min(1).max(64).describe(ENVIRONMENTS.CREATE.name),
         position: z.number().min(1).optional().describe(ENVIRONMENTS.CREATE.position),
         slug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.CREATE.slug)
       }),
@@ -191,7 +191,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
       }),
       body: z.object({
         slug: slugSchema({ max: 64 }).optional().describe(ENVIRONMENTS.UPDATE.slug),
-        name: z.string().trim().optional().describe(ENVIRONMENTS.UPDATE.name),
+        name: z.string().trim().min(1).max(64).optional().describe(ENVIRONMENTS.UPDATE.name),
         position: z.number().optional().describe(ENVIRONMENTS.UPDATE.position)
       }),
       response: {

--- a/backend/src/server/routes/v1/project-env-router.ts
+++ b/backend/src/server/routes/v1/project-env-router.ts
@@ -136,7 +136,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
         projectId: z.string().trim().describe(ENVIRONMENTS.CREATE.projectId)
       }),
       body: z.object({
-        name: z.string().trim().min(1).max(64).describe(ENVIRONMENTS.CREATE.name),
+        name: z.string().trim().min(1).max(255).describe(ENVIRONMENTS.CREATE.name),
         position: z.number().min(1).optional().describe(ENVIRONMENTS.CREATE.position),
         slug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.CREATE.slug)
       }),
@@ -212,7 +212,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
       }),
       body: z.object({
         slug: slugSchema({ max: 64 }).optional().describe(ENVIRONMENTS.UPDATE.slug),
-        name: z.string().trim().min(1).max(64).optional().describe(ENVIRONMENTS.UPDATE.name),
+        name: z.string().trim().min(1).max(255).optional().describe(ENVIRONMENTS.UPDATE.name),
         position: z.number().optional().describe(ENVIRONMENTS.UPDATE.position)
       }),
       response: {

--- a/backend/src/server/routes/v1/project-env-router.ts
+++ b/backend/src/server/routes/v1/project-env-router.ts
@@ -136,7 +136,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
         projectId: z.string().trim().describe(ENVIRONMENTS.CREATE.projectId)
       }),
       body: z.object({
-        name: z.string().trim().describe(ENVIRONMENTS.CREATE.name),
+        name: z.string().trim().min(1).max(64).describe(ENVIRONMENTS.CREATE.name),
         position: z.number().min(1).optional().describe(ENVIRONMENTS.CREATE.position),
         slug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.CREATE.slug)
       }),
@@ -212,7 +212,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
       }),
       body: z.object({
         slug: slugSchema({ max: 64 }).optional().describe(ENVIRONMENTS.UPDATE.slug),
-        name: z.string().trim().optional().describe(ENVIRONMENTS.UPDATE.name),
+        name: z.string().trim().min(1).max(64).optional().describe(ENVIRONMENTS.UPDATE.name),
         position: z.number().optional().describe(ENVIRONMENTS.UPDATE.position)
       }),
       response: {


### PR DESCRIPTION
## Context

Environment name field had no max length validation on the backend — only `z.string().trim()` with no upper bound. The slug field correctly enforced `max(64)` via `slugSchema`, but name was inconsistent.

Submitting a name longer than 64 characters via the API bypassed all validation and would either store an unreasonably long string or produce a raw PostgreSQL 500 error at 255+ chars, instead of a proper 400 response.

Closes #7086

## Screenshots

### Before 
<img width="761" height="510" alt="Screenshot 2026-06-30 at 12 33 23 PM" src="https://github.com/user-attachments/assets/b304d366-67f1-4885-90f8-5ae3e34bcfd7" />

### After
<img width="662" height="473" alt="image" src="https://github.com/user-attachments/assets/987cb844-7b3c-438b-942e-2515b0810dc1" />

<img width="742" height="403" alt="image" src="https://github.com/user-attachments/assets/5ccd1b0e-a0c5-4c11-9225-8fa46e0c1a6c" />

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)