### PR TITLE
fix(honey-token): skip soft-deleted projects in honey token DAL queries

### DIFF
--- a/backend/src/ee/services/honey-token/honey-token-dal.ts
+++ b/backend/src/ee/services/honey-token/honey-token-dal.ts
@@ -59,7 +59,13 @@ export const honeyTokenDALFactory = (db: TDbClient) => {
   };
 
   const countByFolderIds = async (folderIds: string[], search?: string, tx?: Knex) => {
-    const query = (tx || db.replicaNode())(TableName.HoneyToken).whereIn(`${TableName.HoneyToken}.folderId`, folderIds);
+    const query = (tx || db.replicaNode())(TableName.HoneyToken)
+      .whereIn(`${TableName.HoneyToken}.folderId`, folderIds)
+      .join(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.HoneyToken}.folderId`)
+      .join(TableName.Environment, `${TableName.Environment}.id`, `${TableName.SecretFolder}.envId`)
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Environment}.deleteAfter`)
+      .whereNull(`${TableName.Project}.deleteAfter`);
 
     if (search) {
       void query.where(`${TableName.HoneyToken}.name`, "ilike", `%${search}%`);

--- a/backend/src/ee/services/honey-token/honey-token-dal.ts
+++ b/backend/src/ee/services/honey-token/honey-token-dal.ts
@@ -96,6 +96,7 @@ export const honeyTokenDALFactory = (db: TDbClient) => {
     const [result] = await (tx || db.replicaNode())(TableName.HoneyToken)
       .join(TableName.Project, `${TableName.HoneyToken}.projectId`, `${TableName.Project}.id`)
       .where(`${TableName.Project}.orgId`, orgId)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .whereNot(`${TableName.HoneyToken}.status`, "revoked")
       .count<{ count: string | number }>({
         count: `${TableName.HoneyToken}.id`
@@ -145,10 +146,12 @@ export const honeyTokenDALFactory = (db: TDbClient) => {
     const [result] = await (tx || db.replicaNode())(TableName.HoneyToken)
       .join(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.HoneyToken}.folderId`)
       .join(TableName.Environment, `${TableName.Environment}.id`, `${TableName.SecretFolder}.envId`)
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
       .where(`${TableName.HoneyToken}.projectId`, projectId)
       .whereNot(`${TableName.HoneyToken}.status`, "revoked")
-      // exclude honey tokens in soft-deleted environments, mirroring findByFolderIds and the other counts
+      // exclude honey tokens in soft-deleted environments / projects, mirroring findByFolderIds and the other counts
       .whereNull(`${TableName.Environment}.deleteAfter`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .count<{ count: string | number }>({
         count: `${TableName.HoneyToken}.id`
       });

--- a/backend/src/ee/services/honey-token/honey-token-dal.ts
+++ b/backend/src/ee/services/honey-token/honey-token-dal.ts
@@ -14,7 +14,9 @@ export const honeyTokenDALFactory = (db: TDbClient) => {
       .whereIn(`${TableName.HoneyToken}.folderId`, folderIds)
       .join(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.HoneyToken}.folderId`)
       .join(TableName.Environment, `${TableName.Environment}.id`, `${TableName.SecretFolder}.envId`)
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
       .whereNull(`${TableName.Environment}.deleteAfter`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .select(
         db.ref("id").withSchema(TableName.HoneyToken),
         db.ref("name").withSchema(TableName.HoneyToken),


### PR DESCRIPTION
## What

`findByFolderIds` in `honey-token-dal.ts` joined `project_environments` and filtered `Environment.deleteAfter` but never joined `projects` or filtered `Project.deleteAfter`. Soft-deleting a project does not soft-delete its environments, so honey tokens for projects sitting in the delete grace window were still returned.

Honey tokens are tripwires — fake credentials that route the alerting pipeline when accessed. If a soft-deleted project's tokens still fire alerts, the alert names a project the user has already marked for deletion. That noise during a deletion window is exactly the case the soft-delete pattern was designed to suppress.

## Fix

Adds the `Project` join + `whereNull(Project.deleteAfter)`. Same pattern as `org-product-stats-dal.ts` and the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), and folder-commit (#7067) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path