### PR TITLE
fix(secret-approval-request): skip soft-deleted projects in approval request DAL queries

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-dal.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-dal.ts
@@ -84,6 +84,7 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
         );
       })
       .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .join(
         TableName.SecretApprovalPolicy,
         `${TableName.SecretApprovalRequest}.policyId`,
@@ -399,6 +400,8 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
                 `${TableName.Environment}.deleteAfter`
               );
             })
+            .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+            .whereNull(`${TableName.Project}.deleteAfter`)
             .join(
               TableName.SecretApprovalPolicy,
               `${TableName.SecretApprovalRequest}.policyId`,
@@ -456,6 +459,8 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .join(
           TableName.SecretApprovalPolicy,
           `${TableName.SecretApprovalRequest}.policyId`,
@@ -669,6 +674,8 @@ export const secretApprovalRequestDALFactory = (db: TDbClient) => {
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .join(
           TableName.SecretApprovalPolicy,
           `${TableName.SecretApprovalRequest}.policyId`,


### PR DESCRIPTION
## What

Four queries in `secret-approval-request-dal.ts` join `project_environments` and filter `Environment.deleteAfter` but never filter `Project.deleteAfter`. Soft-deleting a project does not soft-delete its environments, so approval requests for projects sitting in the delete grace window were still returned by every find / list / pagination path.

The shared `findQuery` helper already joins `TableName.Project` but never enforces `whereNull(Project.deleteAfter)`; the three other ad-hoc subqueries that build the same shape (in `findById`, the paginated `find`, and the SAR window query) also missed the Project join entirely.

## Fix

Adds the `Project` join + `whereNull(Project.deleteAfter)` to every place that already filters `Environment.deleteAfter`. Mirrors the pattern in `org-product-stats-dal.ts` and the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), and secret-import (#7089) fixes.

## Not changed

`deleteByProjectId` — that path is the project-cleanup worker, which intentionally targets soft-deleted projects for cleanup.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path