### PR TITLE
fix: allow clearing certificate policy max duration input field

### DIFF
--- a/frontend/src/pages/cert-manager/CodeSigningPage/components/CreateSignerWizard/CertificateStep.tsx
+++ b/frontend/src/pages/cert-manager/CodeSigningPage/components/CreateSignerWizard/CertificateStep.tsx
@@ -261,7 +261,10 @@ export const CertificateStep = ({
                 min={1}
                 max={3650}
                 value={field.value ?? ""}
-                onChange={(e) => field.onChange(Number(e.target.value))}
+                onChange={(e) => {
+                  const val = e.target.value;
+                  field.onChange(val === "" ? "" : Number(val));
+                }}
                 placeholder="365"
                 isError={Boolean(error)}
               />

--- a/frontend/src/pages/cert-manager/PkiSubscribersPage/components/PkiSubscriberModal.tsx
+++ b/frontend/src/pages/cert-manager/PkiSubscribersPage/components/PkiSubscriberModal.tsx
@@ -77,7 +77,7 @@ const schema = z
       [CertExtendedKeyUsage.TIMESTAMPING]: z.boolean().optional()
     }),
     enableAutoRenewal: z.boolean().optional().default(false),
-    renewalBefore: z.number().min(1).optional(),
+    renewalBefore: z.coerce.number().min(1).optional(),
     renewalUnit: z.nativeEnum(TimeUnit).optional(),
     // Properties for Azure ADCS only
     azureTemplateType: z.string().optional(),
@@ -753,7 +753,11 @@ export const PkiSubscriberModal = ({ popUp, handlePopUpToggle }: Props) => {
                           placeholder="5"
                           type="number"
                           min={1}
-                          onChange={(e) => onChange(Number(e.target.value))}
+                          value={field.value ?? ""}
+                          onChange={(e) => {
+                            const val = e.target.value;
+                            onChange(val === "" ? "" : Number(val));
+                          }}
                         />
                       </FormControl>
                     )}

--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificatePoliciesTab/CreatePolicyModal.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificatePoliciesTab/CreatePolicyModal.tsx
@@ -1096,7 +1096,11 @@ export const CreatePolicyModal = ({
                             type="number"
                             placeholder="365"
                             className="w-full"
-                            onChange={(e) => field.onChange(Number(e.target.value))}
+                            value={field.value ?? ""}
+                            onChange={(e) => {
+                              const val = e.target.value;
+                              field.onChange(val === "" ? "" : Number(val));
+                            }}
                           />
                         </FormControl>
                       )}

--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificatePoliciesTab/shared/schemas.ts
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificatePoliciesTab/shared/schemas.ts
@@ -36,7 +36,7 @@ export const uiExtendedKeyUsagesSchema = z.object({
 
 export const uiValiditySchema = z.object({
   maxDuration: z.object({
-    value: z.number().min(1, "Duration must be at least 1"),
+    value: z.coerce.number().min(1, "Duration must be at least 1"),
     unit: z.nativeEnum(CertDurationUnit)
   })
 });

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/EditSignerModal/CertificateStep.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/EditSignerModal/CertificateStep.tsx
@@ -160,7 +160,10 @@ export const CertificateStep = ({
                   min={1}
                   max={3650}
                   value={field.value ?? ""}
-                  onChange={(e) => field.onChange(Number(e.target.value))}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    field.onChange(val === "" ? "" : Number(val));
+                  }}
                   placeholder="365"
                   isError={Boolean(error)}
                 />


### PR DESCRIPTION
## Description

Fix the certificate policy max duration input so users can clear the field and type a new value instead of being stuck on 0.

## Type of change

- [x] Bug fix

## Testing

1. Go to Cert Manager > Policies > Create Policy
2. Expand the Certificate Validity section
3. Click into the Max Duration field and clear the value
4. Verify the field empties (shows placeholder) and you can type a new number