### PR TITLE
improvement(secret-v2-bridge): reuse buffers for secret cache ETag

### DIFF
--- a/backend/src/lib/crypto/cache.ts
+++ b/backend/src/lib/crypto/cache.ts
@@ -1,10 +1,13 @@
 import { crypto } from "@app/lib/crypto/cryptography";
 
-export const generateCacheKeyFromData = (data: unknown) =>
+export const generateCacheKeyFromBuffer = (data: Buffer) =>
   crypto.nativeCrypto
     .createHash("sha256")
-    .update(JSON.stringify(data))
+    .update(data)
     .digest("base64")
     .replace(/\+/g, "-")
     .replace(/\//g, "_")
     .replace(/=/g, "");
+
+export const generateCacheKeyFromData = (data: unknown) =>
+  generateCacheKeyFromBuffer(Buffer.from(JSON.stringify(data)));

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -29,7 +29,7 @@ import { TSecretApprovalRequestSecretDALFactory } from "@app/ee/services/secret-
 import { scanSecretPolicyViolations } from "@app/ee/services/secret-scanning-v2/secret-scanning-v2-fns";
 import { TSecretSnapshotServiceFactory } from "@app/ee/services/secret-snapshot/secret-snapshot-service";
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
-import { generateCacheKeyFromData } from "@app/lib/crypto/cache";
+import { generateCacheKeyFromBuffer, generateCacheKeyFromData } from "@app/lib/crypto/cache";
 import { utcDayStamp } from "@app/lib/dates";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
@@ -1273,19 +1273,19 @@ export const secretV2BridgeServiceFactory = ({
       try {
         await keyStore.setExpiry(cacheKey, SECRET_DAL_TTL());
         const cachedSecrets = secretManagerDecryptor({ cipherTextBlob: Buffer.from(encryptedCachedSecrets, "base64") });
+        // Decrypted bytes are the exact serialized payload the miss path hashed, so hashing them reproduces
+        // the same ETag without re-serializing the object.
+        const cachedEtag = `"${generateCacheKeyFromBuffer(cachedSecrets)}"`;
         const { secrets, imports = [] } = JSON.parse(cachedSecrets.toString("utf8")) as {
           secrets: typeof decryptedSecrets;
           imports: typeof importedSecrets;
         };
-        const payload = {
-          secrets: secrets.map((el) => ({
-            ...el,
-            createdAt: new Date(el.createdAt),
-            updatedAt: new Date(el.updatedAt)
-          })),
-          imports
-        };
-        const cachedEtag = `"${generateCacheKeyFromData(payload)}"`;
+        // Parsed array is owned here, so rehydrate dates in place instead of cloning every secret.
+        for (const secret of secrets) {
+          secret.createdAt = new Date(secret.createdAt);
+          secret.updatedAt = new Date(secret.updatedAt);
+        }
+        const payload = { secrets, imports };
         await keyStore.hashSet(etagRedisKey, etagField, cachedEtag);
         await keyStore.setExpiry(etagRedisKey, KeyStoreTtls.SecretEtagInSeconds);
         recordSecretCacheAccessMetric(SecretCacheAccessResult.HIT);
@@ -1531,9 +1531,9 @@ export const secretV2BridgeServiceFactory = ({
 
     if (!includeImports) {
       const payload = { secrets: decryptedSecrets, imports: [] };
-      const encryptedUpdatedCachedSecrets = secretManagerEncryptor({
-        plainText: Buffer.from(JSON.stringify(payload))
-      }).cipherTextBlob;
+      const serializedPayload = Buffer.from(JSON.stringify(payload));
+      const computedEtag = `"${generateCacheKeyFromBuffer(serializedPayload)}"`;
+      const encryptedUpdatedCachedSecrets = secretManagerEncryptor({ plainText: serializedPayload }).cipherTextBlob;
       const cacheBytes = encryptedUpdatedCachedSecrets.byteLength;
       const stored = cacheBytes < MAX_SECRET_CACHE_BYTES;
       if (stored) {
@@ -1541,7 +1541,6 @@ export const secretV2BridgeServiceFactory = ({
       }
       recordSecretCacheWriteMetric({ bytes: cacheBytes, stored });
       recordSecretCacheAccessMetric(SecretCacheAccessResult.MISS);
-      const computedEtag = `"${generateCacheKeyFromData(payload)}"`;
       await keyStore.hashSet(etagRedisKey, etagField, computedEtag);
       await keyStore.setExpiry(etagRedisKey, KeyStoreTtls.SecretEtagInSeconds);
       return { ...payload, etag: computedEtag };
@@ -1609,9 +1608,9 @@ export const secretV2BridgeServiceFactory = ({
     });
 
     const payload = { secrets: decryptedSecrets, imports: importedSecrets };
-    const encryptedUpdatedCachedSecrets = secretManagerEncryptor({
-      plainText: Buffer.from(JSON.stringify(payload))
-    }).cipherTextBlob;
+    const serializedPayload = Buffer.from(JSON.stringify(payload));
+    const computedEtag = `"${generateCacheKeyFromBuffer(serializedPayload)}"`;
+    const encryptedUpdatedCachedSecrets = secretManagerEncryptor({ plainText: serializedPayload }).cipherTextBlob;
     const cacheBytes = encryptedUpdatedCachedSecrets.byteLength;
     const stored = cacheBytes < MAX_SECRET_CACHE_BYTES;
     if (stored) {
@@ -1619,7 +1618,6 @@ export const secretV2BridgeServiceFactory = ({
     }
     recordSecretCacheWriteMetric({ bytes: cacheBytes, stored });
     recordSecretCacheAccessMetric(SecretCacheAccessResult.MISS);
-    const computedEtag = `"${generateCacheKeyFromData(payload)}"`;
     await keyStore.hashSet(etagRedisKey, etagField, computedEtag);
     await keyStore.setExpiry(etagRedisKey, KeyStoreTtls.SecretEtagInSeconds);
     return { ...payload, etag: computedEtag };


### PR DESCRIPTION
## Context

`getSecrets` recomputed the secret-read ETag by re-running `JSON.stringify` + SHA-256 over the entire decrypted payload on every server-side cache hit. That re-serialization was the dominant wall-time and allocation cost on the secret-read hot path (surfaced as `generateCacheKeyFromData` / `cache.ts` in profiling).

- Cache hits now hash the decrypted buffer directly (the exact bytes that were stored), so no re-serialization.
- Cache misses serialize the payload once and reuse that buffer for both encryption and the ETag hash, instead of two `JSON.stringify` passes.
- Hit path rehydrates `createdAt`/`updatedAt` in place instead of cloning every secret via `.map(spread)`.
- Add `generateCacheKeyFromBuffer`; `generateCacheKeyFromData` delegates to it. ETag value is byte-identical to before, so client 304s keep matching across deploy.

Hash the plaintext, not the ciphertext: AES-256-GCM uses a random IV per encryption, so ciphertext bytes differ for identical content. The serialized plaintext is the stable content fingerprint.

## Steps to verify the change

- Standalone check: refactored `generateCacheKeyFromData` is byte-identical to the prior implementation across samples (incl. unicode and ~1kb payloads), and hit-path hash equals miss-path hash.
- `make reviewable-api` is green (lint:fix + type:check, no errors).
- Unit suite: 893 passed / 22 skipped. The 5 failing suites are unrelated (missing `@infisical/quic` native binding on this arch, fail at module load).
- Behavioral path covered by `e2e-test/routes/v3/secrets-v2.spec.ts` (requires live DB/Redis).

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
