### PR TITLE
improvement: give more visibility to auth link and actions

### DIFF
--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -156,13 +156,6 @@ export default function InitialSignupStep({
               </div>
             </>
           )}
-          <div className="mt-6 flex flex-row justify-center text-xs text-label">
-            <Link to="/login">
-              <span className="cursor-pointer duration-200 hover:text-foreground hover:underline hover:decoration-project/45 hover:underline-offset-2">
-                Already have an account? Log in
-              </span>
-            </Link>
-          </div>
           <p className="mt-4 text-center text-xs text-pretty text-label">
             By signing up, you agree to our{" "}
             <a
@@ -201,6 +194,14 @@ export default function InitialSignupStep({
           </span>
           <CircleChevronRightIcon className="size-4.5 opacity-75" />
         </a>
+      </div>
+      <div className="mt-4 flex flex-row items-center justify-center gap-1.5 text-sm">
+        <span className="text-label">Already have an account?</span>
+        <Link to="/login">
+          <span className="cursor-pointer text-foreground/95 underline decoration-project/60 underline-offset-2 transition-colors duration-200 hover:decoration-project">
+            Log in
+          </span>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage/LoginPage.tsx
@@ -39,7 +39,7 @@ export const LoginPage = ({ isAdmin }: { isAdmin?: boolean }) => {
         <meta name="og:description" content={t("login.og-description") ?? ""} />
       </Helmet>
       <AuthPageHeader>
-        <Button asChild>
+        <Button asChild variant="project">
           <Link to="/signup">Sign Up</Link>
         </Button>
       </AuthPageHeader>

--- a/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
@@ -381,32 +381,33 @@ export const InitialStep = ({ setSection, isAdmin }: Props) => {
           )}
 
           {!isLoading && loginError && <Error text={t("login.error-login") ?? ""} />}
-          {config.allowSignUp &&
+        </CardContent>
+      </Card>
+      <div className="mt-6 flex flex-col items-center gap-3">
+        {config.allowSignUp &&
           (shouldDisplayLoginMethod(LoginMethod.EMAIL) ||
             shouldDisplayLoginMethod(LoginMethod.GOOGLE) ||
             shouldDisplayLoginMethod(LoginMethod.GITHUB) ||
-            shouldDisplayLoginMethod(LoginMethod.GITLAB)) ? (
-            <div className="mt-6 flex flex-row justify-center text-xs text-label">
+            shouldDisplayLoginMethod(LoginMethod.GITLAB)) && (
+            <div className="flex flex-row items-center justify-center gap-1.5 text-sm">
+              <span className="text-label">Don&apos;t have an account?</span>
               <Link to="/signup">
-                <span className="cursor-pointer duration-200 hover:text-foreground hover:underline hover:decoration-project/45 hover:underline-offset-2">
-                  Don&apos;t have an account yet? {t("login.create-account")}
-                </span>
-              </Link>
-            </div>
-          ) : (
-            <div className="mt-4" />
-          )}
-          {shouldDisplayLoginMethod(LoginMethod.EMAIL) && (
-            <div className="mt-2 flex flex-row justify-center text-xs text-label">
-              <Link to="/account-recovery">
-                <span className="cursor-pointer duration-200 hover:text-foreground hover:underline hover:decoration-project/45 hover:underline-offset-2">
-                  Recover your account
+                <span className="cursor-pointer text-foreground/95 underline decoration-project/60 underline-offset-2 transition-colors duration-200 hover:decoration-project">
+                  Sign up
                 </span>
               </Link>
             </div>
           )}
-        </CardContent>
-      </Card>
+        {shouldDisplayLoginMethod(LoginMethod.EMAIL) && (
+          <div className="flex flex-row justify-center text-xs text-label">
+            <Link to="/account-recovery">
+              <span className="cursor-pointer duration-200 hover:text-foreground hover:underline hover:decoration-project/45 hover:underline-offset-2">
+                Recover your account
+              </span>
+            </Link>
+          </div>
+        )}
+      </div>
     </form>
   );
 };

--- a/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
@@ -126,7 +126,7 @@ export const SignUpPage = ({ invite }: SignUpPageProps) => {
         <meta name="og:description" content={t("signup.og-description") as string} />
       </Helmet>
       <AuthPageHeader>
-        <Button asChild>
+        <Button asChild variant="project">
           <Link to="/login">Log In</Link>
         </Button>
       </AuthPageHeader>


### PR DESCRIPTION
## Context

This PR improves the visibility of the sign up action on the login page and the log in action on the sign up page

## Screenshots

<img width="3456" height="2234" alt="CleanShot 2026-06-30 at 11 25 04@2x" src="https://github.com/user-attachments/assets/2e608865-d997-488d-a514-d5a9a349ee4a" />

<img width="3456" height="2234" alt="CleanShot 2026-06-30 at 11 24 59@2x" src="https://github.com/user-attachments/assets/cbac6eb1-37ce-4fa8-83ef-5917cc667df6" />


## Steps to verify the change

- look / click

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)