### PR TITLE
feat: corrected the reporting token error

### DIFF
--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -521,7 +521,7 @@ const envSchema = z
       ? databaseReadReplicaSchema.parse(JSON.parse(data.DB_READ_REPLICAS))
       : undefined,
     // Inferred from the legacy license server key; needs a new signal once License Server v2 fully replaces it.
-    isCloud: Boolean(data.LICENSE_SERVER_KEY),
+    isCloud: Boolean(data.LICENSE_SERVER_KEY || data.LICENSE_SERVER_V2_SERVICE_KEY),
     isLicenseDualReadEnabled: data.LICENSE_SERVER_V2_MODE === "read-compare",
     isSmtpConfigured: Boolean(data.SMTP_HOST),
     isRedisConfigured: Boolean(data.REDIS_URL || data.REDIS_SENTINEL_HOSTS || data.REDIS_CLUSTER_HOSTS),

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -48,7 +48,8 @@ const SERVICE_TOKEN_SUBJECT = "infisical-cloud";
 
 // The license server validates a short-lived RS256 service JWT (iss/aud/exp/sub) that we sign with
 // our private key and it verifies with the matching public key. Mint a fresh token per request.
-const mintServiceToken = (signingKey: string): string =>
+// Exported so the usage reporter authenticates cloud requests the same way (never sending the raw key).
+export const mintServiceToken = (signingKey: string): string =>
   jwt.sign({}, signingKey, {
     algorithm: "RS256",
     issuer: SERVICE_TOKEN_ISSUER,

--- a/backend/src/services/license-client/usage/usage-reporter.ts
+++ b/backend/src/services/license-client/usage/usage-reporter.ts
@@ -1,6 +1,8 @@
 import { TEnvConfig } from "@app/lib/config/env";
 import { logger } from "@app/lib/logger";
 
+import { mintServiceToken } from "../license-client-backends";
+
 const SNAPSHOTS_PATH = "/v1/usage/snapshots";
 
 export type TUsageSnapshot = {
@@ -16,7 +18,9 @@ export type TUsageReporter = {
   reportSnapshots: (snapshots: TUsageSnapshot[]) => Promise<void>;
 };
 
-export const usageReporterFactory = (serverUrl: string, serviceKey: string): TUsageReporter => ({
+// getBearerToken is called per request so a cloud reporter can mint a fresh short-lived JWT each time
+// (a self-hosted reporter just returns its static license key).
+export const usageReporterFactory = (serverUrl: string, getBearerToken: () => string): TUsageReporter => ({
   reportSnapshots: async (snapshots: TUsageSnapshot[]) => {
     if (!snapshots.length) {
       return;
@@ -25,7 +29,7 @@ export const usageReporterFactory = (serverUrl: string, serviceKey: string): TUs
     const url = new URL(SNAPSHOTS_PATH, serverUrl);
     const res = await fetch(url, {
       method: "POST",
-      headers: { Authorization: `Bearer ${serviceKey}`, "Content-Type": "application/json" },
+      headers: { Authorization: `Bearer ${getBearerToken()}`, "Content-Type": "application/json" },
       body: JSON.stringify({ snapshots }),
       redirect: "manual"
     });
@@ -40,7 +44,9 @@ export const usageReporterFactory = (serverUrl: string, serviceKey: string): TUs
 const SELF_HOSTED_V2_LICENSE_KEY_PREFIX = "infisical_lk_";
 
 // Returns null when the v2 license server is disabled or unconfigured, which keeps usage reporting
-// inert. A self-hosted v2 license reports with its own key as the bearer; cloud uses the service key.
+// inert. A self-hosted v2 license reports with its own license key as the bearer; cloud mints a
+// short-lived RS256 service JWT signed with the service key (the same scheme the rest of the v2
+// client uses), so the raw signing key is never sent over the wire.
 export const buildUsageReporter = (
   envConfig: Pick<
     TEnvConfig,
@@ -57,18 +63,6 @@ export const buildUsageReporter = (
     return null;
   }
 
-  // A self-hosted v2 license authenticates with its own key; otherwise fall back to the cloud service key.
-  const licenseKey = envConfig.LICENSE_KEY;
-  const bearerKey = licenseKey?.startsWith(SELF_HOSTED_V2_LICENSE_KEY_PREFIX)
-    ? licenseKey
-    : envConfig.LICENSE_SERVER_V2_SERVICE_KEY;
-  if (!bearerKey) {
-    logger.warn(
-      "usage-reporter: enabled but no LICENSE_KEY (self-hosted) / LICENSE_SERVER_V2_SERVICE_KEY (cloud) is set; usage reporting disabled"
-    );
-    return null;
-  }
-
   // Don't forward the bearer to a non-HTTPS or malformed destination.
   let parsedUrl: URL;
   try {
@@ -77,10 +71,24 @@ export const buildUsageReporter = (
     logger.warn("usage-reporter: LICENSE_SERVER_V2_URL is not a valid URL; usage reporting disabled");
     return null;
   }
-  if (parsedUrl.protocol !== "https:") {
+  if (parsedUrl.protocol !== "https:" && process.env.NODE_ENV !== "development") {
     logger.warn("usage-reporter: LICENSE_SERVER_V2_URL must use https; usage reporting disabled");
     return null;
   }
 
-  return usageReporterFactory(serverUrl, bearerKey);
+  // Self-hosted: authenticate with the raw license key as the bearer.
+  const licenseKey = envConfig.LICENSE_KEY;
+  if (licenseKey?.startsWith(SELF_HOSTED_V2_LICENSE_KEY_PREFIX)) {
+    return usageReporterFactory(serverUrl, () => licenseKey);
+  }
+
+  // Cloud: mint a fresh service JWT per request signed with the service key (an RSA private key).
+  const serviceKey = envConfig.LICENSE_SERVER_V2_SERVICE_KEY;
+  if (!serviceKey) {
+    logger.warn(
+      "usage-reporter: enabled but LICENSE_SERVER_V2_SERVICE_KEY (cloud) is not set; usage reporting disabled"
+    );
+    return null;
+  }
+  return usageReporterFactory(serverUrl, () => mintServiceToken(serviceKey));
 };


### PR DESCRIPTION
## Context
This PR fixes the usage reporting token error as the key was directly passed and not minting jwt in cloud connection

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)