### PR TITLE
feature(machine-identity): assign project roles when creating identities

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -1426,7 +1426,16 @@ interface CreateIdentityEvent {
     name: string;
     hasDeleteProtection: boolean;
     metadata?: { key: string; value: string }[];
-    roles?: { role: string; isTemporary: boolean }[];
+    roles?: (
+      | { role: string; isTemporary: false }
+      | {
+          role: string;
+          isTemporary: true;
+          temporaryMode: string;
+          temporaryRange: string;
+          temporaryAccessStartTime: string;
+        }
+    )[];
   };
 }
 

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -1420,13 +1420,13 @@ interface DeleteServiceTokenEvent {
 }
 
 interface CreateIdentityEvent {
-  // note: currently not logging org-role
   type: EventType.CREATE_IDENTITY;
   metadata: {
     identityId: string;
     name: string;
     hasDeleteProtection: boolean;
     metadata?: { key: string; value: string }[];
+    roles?: { role: string; isTemporary: boolean }[];
   };
 }
 

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2235,7 +2235,9 @@ export const registerRoutes = async (
     identityMembershipV2DAL,
     identityAccessTokenService,
     keyStore,
-    projectDAL
+    projectDAL,
+    orgDAL,
+    roleDAL
   });
 
   const identityProjectService = identityProjectServiceFactory({

--- a/backend/src/server/routes/v1/project-identity-router.ts
+++ b/backend/src/server/routes/v1/project-identity-router.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 
-import { AccessScope, IdentitiesSchema } from "@app/db/schemas";
+import { AccessScope, IdentitiesSchema, TemporaryPermissionMode } from "@app/db/schemas";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, IDENTITIES } from "@app/lib/api-docs";
+import { ms } from "@app/lib/ms";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
@@ -57,7 +58,24 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
       body: z.object({
         name: z.string().trim().min(1).describe(IDENTITIES.CREATE.name),
         hasDeleteProtection: z.boolean().default(false).describe(IDENTITIES.CREATE.hasDeleteProtection),
-        metadata: z.array(metadataSchema).optional().describe(IDENTITIES.CREATE.metadata)
+        metadata: z.array(metadataSchema).optional().describe(IDENTITIES.CREATE.metadata),
+        roles: z
+          .array(
+            z.union([
+              z.object({
+                role: z.string(),
+                isTemporary: z.literal(false).default(false)
+              }),
+              z.object({
+                role: z.string(),
+                isTemporary: z.literal(true),
+                temporaryMode: z.nativeEnum(TemporaryPermissionMode),
+                temporaryRange: z.string().refine((val) => ms(val) > 0, "Temporary range must be a positive number"),
+                temporaryAccessStartTime: z.string().datetime()
+              })
+            ])
+          )
+          .optional()
       }),
       response: {
         200: z.object({
@@ -76,7 +94,8 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
         data: {
           name: req.body.name,
           hasDeleteProtection: req.body.hasDeleteProtection,
-          metadata: req.body.metadata
+          metadata: req.body.metadata,
+          roles: req.body.roles
         }
       });
 

--- a/backend/src/server/routes/v1/project-identity-router.ts
+++ b/backend/src/server/routes/v1/project-identity-router.ts
@@ -63,11 +63,11 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
           .array(
             z.union([
               z.object({
-                role: z.string(),
+                role: z.string().min(1),
                 isTemporary: z.literal(false).default(false)
               }),
               z.object({
-                role: z.string(),
+                role: z.string().min(1),
                 isTemporary: z.literal(true),
                 temporaryMode: z.nativeEnum(TemporaryPermissionMode),
                 temporaryRange: z.string().refine((val) => ms(val) > 0, "Temporary range must be a positive number"),
@@ -109,7 +109,17 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
             name: req.body.name,
             hasDeleteProtection: req.body.hasDeleteProtection,
             metadata: req.body.metadata,
-            roles: req.body.roles?.map(({ role, isTemporary }) => ({ role, isTemporary }))
+            roles: req.body.roles?.map((r) =>
+              r.isTemporary
+                ? {
+                    role: r.role,
+                    isTemporary: r.isTemporary,
+                    temporaryMode: r.temporaryMode,
+                    temporaryRange: r.temporaryRange,
+                    temporaryAccessStartTime: r.temporaryAccessStartTime
+                  }
+                : { role: r.role, isTemporary: r.isTemporary }
+            )
           }
         }
       });

--- a/backend/src/server/routes/v1/project-identity-router.ts
+++ b/backend/src/server/routes/v1/project-identity-router.ts
@@ -108,7 +108,8 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
             identityId: identity.id,
             name: req.body.name,
             hasDeleteProtection: req.body.hasDeleteProtection,
-            metadata: req.body.metadata
+            metadata: req.body.metadata,
+            roles: req.body.roles?.map(({ role, isTemporary }) => ({ role, isTemporary }))
           }
         }
       });

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -199,16 +199,19 @@ export const identityV2ServiceFactory = ({
       resolvedRoleDocs = data.roles.map((membershipRole) => {
         const isCustom = Boolean(customRolesGroupBySlug?.[membershipRole.role]?.[0]);
         if (membershipRole.isTemporary) {
-          const relativeTimeInMs = membershipRole.temporaryRange ? ms(membershipRole.temporaryRange) : null;
+          if (membershipRole.temporaryMode !== TemporaryPermissionMode.Relative) {
+            throw new BadRequestError({ message: "Only relative temporary permission mode is supported" });
+          }
+          const relativeTimeInMs = ms(membershipRole.temporaryRange);
           return {
             role: isCustom ? ProjectMembershipRole.Custom : membershipRole.role,
             customRoleId: isCustom ? customRolesGroupBySlug[membershipRole.role][0].id : null,
             isTemporary: true as const,
-            temporaryMode: TemporaryPermissionMode.Relative,
+            temporaryMode: membershipRole.temporaryMode,
             temporaryRange: membershipRole.temporaryRange,
             temporaryAccessStartTime: new Date(membershipRole.temporaryAccessStartTime),
             temporaryAccessEndTime: new Date(
-              new Date(membershipRole.temporaryAccessStartTime).getTime() + (relativeTimeInMs as number)
+              new Date(membershipRole.temporaryAccessStartTime).getTime() + relativeTimeInMs
             )
           };
         }

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -4,7 +4,9 @@ import {
   OrganizationActionScope,
   OrgMembershipRole,
   ProjectMembershipRole,
-  ProjectType
+  ProjectType,
+  TemporaryPermissionMode,
+  TMembershipRolesInsert
 } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import {
@@ -12,11 +14,25 @@ import {
   OrgPermissionIdentityActions,
   OrgPermissionSubjects
 } from "@app/ee/services/permission/org-permission";
+import {
+  constructPermissionErrorMessage,
+  validatePrivilegeChangeOperation
+} from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
-import { ProjectPermissionIdentityActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import {
+  isCustomProjectRole,
+  ProjectPermissionIdentityActions,
+  ProjectPermissionSub
+} from "@app/ee/services/permission/project-permission";
 import { TKeyStoreFactory } from "@app/keystore/keystore";
-import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, NotFoundError, PermissionBoundaryError } from "@app/lib/errors";
+import { groupBy } from "@app/lib/fn";
+import { ms } from "@app/lib/ms";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
+import { TRoleDALFactory } from "@app/services/role/role-dal";
 
 import { ActorType } from "../auth/auth-type";
 import { getIdentityActiveLockoutAuthMethods } from "../identity/identity-fns";
@@ -51,6 +67,8 @@ type TScopedIdentityV2ServiceFactoryDep = {
   identityAccessTokenService: Pick<TIdentityAccessTokenServiceFactory, "revokeAllTokensForIdentity">;
   keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
   projectDAL: Pick<TProjectDALFactory, "findActorAccessibleProjectIds" | "findOrgProjectIds" | "findById">;
+  orgDAL: Pick<TOrgDALFactory, "findById">;
+  roleDAL: Pick<TRoleDALFactory, "find">;
 };
 
 export type TScopedIdentityV2ServiceFactory = ReturnType<typeof identityV2ServiceFactory>;
@@ -65,7 +83,9 @@ export const identityV2ServiceFactory = ({
   identityMetadataDAL,
   identityAccessTokenService,
   keyStore,
-  projectDAL
+  projectDAL,
+  orgDAL,
+  roleDAL
 }: TScopedIdentityV2ServiceFactoryDep) => {
   const orgFactory = newOrgIdentityFactory({
     permissionService
@@ -95,8 +115,112 @@ export const identityV2ServiceFactory = ({
       });
     }
 
+    let resolvedRoleDocs: Omit<TMembershipRolesInsert, "membershipId">[] | null = null;
+
+    if (scopeData.scope === AccessScope.Project && data.roles && data.roles.length > 0) {
+      const hasNoPermanentRole = data.roles.every((el) => el.isTemporary);
+      if (hasNoPermanentRole) {
+        throw new BadRequestError({ message: "Identity must have at least one permanent role" });
+      }
+
+      const { permission: actorPermission } = await permissionService.getProjectPermission({
+        actor: dto.permission.type,
+        actorId: dto.permission.id,
+        actionProjectType: ActionProjectType.Any,
+        actorAuthMethod: dto.permission.authMethod,
+        projectId: scopeData.projectId,
+        actorOrgId: dto.permission.orgId
+      });
+
+      const project = await requestMemoize(requestMemoKeys.projectFindById(scopeData.projectId), () =>
+        projectDAL.findById(scopeData.projectId)
+      );
+      if (project?.type === ProjectType.CertificateManager) {
+        const invalidRoles = data.roles.filter(
+          (r) => r.role !== ProjectMembershipRole.Admin && r.role !== ProjectMembershipRole.Member
+        );
+        if (invalidRoles.length > 0) {
+          throw new BadRequestError({ message: "Certificate Manager only supports Admin and Member roles." });
+        }
+      }
+
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+        requestMemoKeys.orgFindById(dto.permission.orgId),
+        () => orgDAL.findById(dto.permission.orgId)
+      );
+
+      const permissionRoles = await permissionService.getProjectPermissionByRoles(
+        data.roles.map((el) => el.role),
+        scopeData.projectId
+      );
+      for (const permissionRole of permissionRoles) {
+        if (permissionRole?.role?.name !== ProjectMembershipRole.NoAccess) {
+          const permissionBoundary = validatePrivilegeChangeOperation(
+            shouldUseNewPrivilegeSystem,
+            [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
+            ProjectPermissionSub.Identity,
+            actorPermission,
+            permissionRole.permission,
+            { assignableRole: permissionRole.role?.slug }
+          );
+          if (!permissionBoundary.isValid) {
+            throw new PermissionBoundaryError({
+              message: constructPermissionErrorMessage(
+                "Failed to create identity project membership",
+                shouldUseNewPrivilegeSystem,
+                ProjectPermissionIdentityActions.AssignRole,
+                ProjectPermissionSub.Identity
+              ),
+              details: { missingPermissions: permissionBoundary.missingPermissions }
+            });
+          }
+        }
+      }
+
+      const customInputRoles = data.roles.filter((el) => isCustomProjectRole(el.role));
+      const hasCustomRole = customInputRoles.length > 0;
+      if (hasCustomRole && !plan?.rbac) {
+        throw new BadRequestError({
+          message:
+            "Failed to assign custom role to identity due to plan RBAC restriction. Upgrade to Infisical Enterprise to assign custom roles."
+        });
+      }
+      const customRoles = hasCustomRole
+        ? await roleDAL.find({
+            projectId: scopeData.projectId,
+            $in: { slug: customInputRoles.map(({ role }) => role) }
+          })
+        : [];
+      if (customRoles.length !== customInputRoles.length) {
+        throw new NotFoundError({ message: "One or more custom roles not found" });
+      }
+      const customRolesGroupBySlug = groupBy(customRoles, ({ slug }) => slug);
+
+      resolvedRoleDocs = data.roles.map((membershipRole) => {
+        const isCustom = Boolean(customRolesGroupBySlug?.[membershipRole.role]?.[0]);
+        if (membershipRole.isTemporary) {
+          const relativeTimeInMs = membershipRole.temporaryRange ? ms(membershipRole.temporaryRange) : null;
+          return {
+            role: isCustom ? ProjectMembershipRole.Custom : membershipRole.role,
+            customRoleId: isCustom ? customRolesGroupBySlug[membershipRole.role][0].id : null,
+            isTemporary: true as const,
+            temporaryMode: TemporaryPermissionMode.Relative,
+            temporaryRange: membershipRole.temporaryRange,
+            temporaryAccessStartTime: new Date(membershipRole.temporaryAccessStartTime),
+            temporaryAccessEndTime: new Date(
+              new Date(membershipRole.temporaryAccessStartTime).getTime() + (relativeTimeInMs as number)
+            )
+          };
+        }
+        return {
+          role: isCustom ? ProjectMembershipRole.Custom : membershipRole.role,
+          customRoleId: isCustom ? customRolesGroupBySlug[membershipRole.role][0].id : null
+        };
+      });
+    }
+
     let projectMemberRole = ProjectMembershipRole.NoAccess as string;
-    if (scopeData.scope === AccessScope.Project) {
+    if (scopeData.scope === AccessScope.Project && !resolvedRoleDocs) {
       const project = await projectDAL.findById(scopeData.projectId);
       if (project?.type === ProjectType.CertificateManager) {
         projectMemberRole = ProjectMembershipRole.Member;
@@ -134,7 +258,10 @@ export const identityV2ServiceFactory = ({
           },
           tx
         );
-        await membershipRoleDAL.insertMany([{ membershipId: projectMembership.id, role: projectMemberRole }], tx);
+        const roleEntries: TMembershipRolesInsert[] = resolvedRoleDocs
+          ? resolvedRoleDocs.map((doc) => ({ ...doc, membershipId: projectMembership.id }))
+          : [{ membershipId: projectMembership.id, role: projectMemberRole }];
+        await membershipRoleDAL.insertMany(roleEntries, tx);
       }
 
       let insertedMetadata: Array<{

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -154,7 +154,7 @@ export const identityV2ServiceFactory = ({
         scopeData.projectId
       );
       for (const permissionRole of permissionRoles) {
-        if (permissionRole?.role?.name !== ProjectMembershipRole.NoAccess) {
+        if (permissionRole?.role?.slug !== ProjectMembershipRole.NoAccess) {
           const permissionBoundary = validatePrivilegeChangeOperation(
             shouldUseNewPrivilegeSystem,
             [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],

--- a/backend/src/services/identity-v2/identity-types.ts
+++ b/backend/src/services/identity-v2/identity-types.ts
@@ -1,4 +1,4 @@
-import { AccessScope, AccessScopeData } from "@app/db/schemas";
+import { AccessScope, AccessScopeData, TemporaryPermissionMode } from "@app/db/schemas";
 import { TSearchResourceOperator } from "@app/lib/search-resource/search";
 import { OrderByDirection, OrgServiceActor, TOrgPermission } from "@app/lib/types";
 
@@ -16,6 +16,16 @@ export enum IdentityOrderBy {
   Role = "role"
 }
 
+export type TCreateIdentityV2RoleDTO =
+  | { role: string; isTemporary: false }
+  | {
+      role: string;
+      isTemporary: true;
+      temporaryMode: TemporaryPermissionMode;
+      temporaryRange: string;
+      temporaryAccessStartTime: string;
+    };
+
 export type TCreateIdentityV2DTO = {
   permission: OrgServiceActor;
   scopeData: AccessScopeData;
@@ -23,6 +33,7 @@ export type TCreateIdentityV2DTO = {
     name: string;
     hasDeleteProtection: boolean;
     metadata?: { key: string; value: string }[];
+    roles?: TCreateIdentityV2RoleDTO[];
   };
 };
 


### PR DESCRIPTION
## Context

Project identity creation (`POST /v1/projects/:projectId/identities`) previously always assigned a default role (`NoAccess`, or `Member` for Certificate Manager projects). Roles had to be set in a separate step.

This PR adds an optional `roles` array to the create payload so callers can assign permanent and temporary project roles at creation time. Validation mirrors existing membership flows: at least one permanent role, permission-boundary checks, RBAC/custom-role plan gating, Certificate Manager role restrictions, and relative temporary permissions only.

`CREATE_IDENTITY` audit events now include assigned roles (`role`, `isTemporary`).

## Steps to verify the change

1. Create a project identity **without** `roles` → should still get default role behavior.
2. Create with permanent roles (e.g. `admin`, `member`) → membership roles match input.
3. Create with temporary relative role → `temporaryAccessEndTime` computed from `temporaryAccessStartTime` + `temporaryRange`.
4. Verify failures:
   - Only temporary roles → 400
   - Actor lacks `AssignRole` / `GrantPrivileges` → 403
   - Custom role on non-RBAC plan → 400
   - Invalid custom role slug → 404
   - Certificate Manager with non Admin/Member role → 400
5. Confirm audit log `CREATE_IDENTITY` includes `roles`.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)