### PR TITLE
docs(gateway): update relay auto-select docs and tooltips to mention failover

### DIFF
--- a/docs/cli/commands/gateway.mdx
+++ b/docs/cli/commands/gateway.mdx
@@ -43,7 +43,7 @@ Once started, the gateway component will:
 - Automatically connect to a healthy relay with the lowest latency (unless the `--target-relay-name` flag is specified)
 - Establish outbound SSH reverse tunnel to relay server (no inbound firewall rules needed)
 - Authenticate using SSH certificates issued by Infisical
-- Automatically reconnect if the connection is lost
+- Automatically reconnect if the connection is lost, and fail over to a different healthy relay if the current one becomes unreachable
 - Provide access to private resources within your network
 
 ### Flags
@@ -229,6 +229,8 @@ The gateway name is provided as a positional argument.
   </Accordion>
   <Accordion title="How are relays auto-selected?">
       If the `--target-relay-name` flag is omitted, the gateway automatically selects the optimal relay. It first checks for healthy organization relays and connects to the one with the lowest latency. If no organization relays are available, it then performs the same latency-based selection among the available managed relays.
+
+      If the selected relay becomes unreachable while the gateway is running, the gateway will automatically switch to a different healthy one. Gateways started with an explicit `--target-relay-name` do not switch and will keep retrying the specified relay.
   </Accordion>
   <Accordion title="When restarting the gateway without a relay flag, does it select a new relay every time?">
       No. The first time the gateway starts, it selects the optimal relay (based on latency) and caches that selection. On subsequent restarts, it will prioritize connecting to the cached relay. If it's unable to connect, it will then re-evaluate and connect to the next most optimal relay available.

--- a/docs/documentation/platform/gateways/gateway-deployment.mdx
+++ b/docs/documentation/platform/gateways/gateway-deployment.mdx
@@ -256,10 +256,13 @@ Yes. Each gateway stores its credentials in a separate config file scoped by nam
 <Accordion title="What happens if there is a network interruption?">
 The gateway is designed to handle network interruptions gracefully:
 
-- **Automatic reconnection**: The gateway will automatically attempt to reconnect if the SSH connection is lost
+- **Automatic reconnection**: The gateway will automatically attempt to reconnect to relay servers if the SSH connection is lost
+- **Connection retry logic**: Built-in retry mechanisms handle temporary network outages without manual intervention
 - **Automatic failover**: Gateways configured with automatic relay selection will switch to a different healthy relay if the current one becomes unreachable
 - **Gateway Pools**: If the gateway itself becomes unavailable, a [Gateway Pool](/documentation/platform/gateways/gateway-pools) will automatically route through a healthy member
+- **Persistent SSH tunnels**: SSH connections are automatically re-established when connectivity is restored
 - **Certificate rotation**: The gateway handles certificate renewal automatically during reconnection
+- **Graceful degradation**: The gateway logs connection issues and continues attempting to restore connectivity
 
 No manual intervention is typically required during network interruptions.
 

--- a/docs/documentation/platform/gateways/gateway-deployment.mdx
+++ b/docs/documentation/platform/gateways/gateway-deployment.mdx
@@ -256,11 +256,10 @@ Yes. Each gateway stores its credentials in a separate config file scoped by nam
 <Accordion title="What happens if there is a network interruption?">
 The gateway is designed to handle network interruptions gracefully:
 
-- **Automatic reconnection**: The gateway will automatically attempt to reconnect to relay servers if the SSH connection is lost
-- **Connection retry logic**: Built-in retry mechanisms handle temporary network outages without manual intervention
-- **Persistent SSH tunnels**: SSH connections are automatically re-established when connectivity is restored
+- **Automatic reconnection**: The gateway will automatically attempt to reconnect if the SSH connection is lost
+- **Automatic failover**: Gateways configured with automatic relay selection will switch to a different healthy relay if the current one becomes unreachable
+- **Gateway Pools**: If the gateway itself becomes unavailable, a [Gateway Pool](/documentation/platform/gateways/gateway-pools) will automatically route through a healthy member
 - **Certificate rotation**: The gateway handles certificate renewal automatically during reconnection
-- **Graceful degradation**: The gateway logs connection issues and continues attempting to restore connectivity
 
 No manual intervention is typically required during network interruptions.
 

--- a/docs/documentation/platform/gateways/overview.mdx
+++ b/docs/documentation/platform/gateways/overview.mdx
@@ -65,9 +65,10 @@ To monitor their operational status, gateways transmit heartbeats every 3 minute
 
 Infisical automatically notifies all organization admins of unhealthy gateway or relay statuses through email and in-app notifications.
 
-## High Availability with Gateway Pools
+## High Availability
 
-For production workloads, you can group multiple gateways into a **Gateway Pool** to provide automatic failover. When a gateway in a pool goes down, the platform routes through a healthy member automatically. See [Gateway Pools](/documentation/platform/gateways/gateway-pools) for details.
+1. **Relay failover**: Gateways configured with automatic relay selection will switch to a different healthy relay if the current one becomes unreachable, providing built-in resilience without additional configuration.
+2. **Gateway Pools**: For production workloads, you can group multiple gateways into a Gateway Pool to provide automatic failover at the gateway level. When a gateway in a pool goes down, the platform routes through a healthy member automatically. See [Gateway Pools](/documentation/platform/gateways/gateway-pools) for details.
 
 ## Getting Started
 

--- a/docs/documentation/platform/gateways/relay-deployment/overview.mdx
+++ b/docs/documentation/platform/gateways/relay-deployment/overview.mdx
@@ -191,7 +191,8 @@ openssl s_client -connect <relay-ip>:8443
 <Accordion title="What happens if my relay server goes down?">
 Relay server outages affect gateway connectivity:
 
-- **Gateway reconnection**: Gateways will automatically attempt to reconnect when the relay comes back online
+- **Automatic failover**: Gateways configured with automatic relay selection will switch to a different healthy relay if the current one becomes unreachable
+- **Gateway reconnection**: Gateways connected to a specific relay will automatically attempt to reconnect when the relay comes back online
 - **Service interruption**: While the relay is down, the Infisical platform cannot reach gateways through that relay. As a result, any secrets or resources accessed via those gateways will be temporarily unavailable until connectivity is restored.
 - **Multiple relays**: Deploy multiple relay servers for redundancy and high availability
 - **Automatic restart**: Use systemd or container orchestration to automatically restart failed relay services

--- a/frontend/src/pages/organization/NetworkingPage/GatewayDetailsByIDPage/components/GatewayAuthMethod/AwsStartCommandDialog.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/GatewayDetailsByIDPage/components/GatewayAuthMethod/AwsStartCommandDialog.tsx
@@ -78,7 +78,8 @@ export const AwsStartCommandDialog = ({ isOpen, onOpenChange, gatewayId, gateway
         </div>
         <FormControl
           label="Relay"
-          tooltipText="The relay this gateway should connect through. Auto Select picks one server-side at connect time."
+          tooltipText="The relay this gateway should connect through. Auto Select picks a healthy relay and switches to another if it becomes unreachable."
+          tooltipClassName="max-w-md"
         >
           <FilterableSelect
             value={relay}

--- a/frontend/src/pages/organization/NetworkingPage/GatewayDetailsByIDPage/components/GatewayAuthMethod/EnrollmentTokenDialog.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/GatewayDetailsByIDPage/components/GatewayAuthMethod/EnrollmentTokenDialog.tsx
@@ -83,7 +83,8 @@ export const EnrollmentTokenDialog = ({
         </div>
         <FormControl
           label="Relay"
-          tooltipText="The relay this gateway should connect through. Auto Select picks one server-side at connect time."
+          tooltipText="The relay this gateway should connect through. Auto Select picks a healthy relay and switches to another if it becomes unreachable."
+          tooltipClassName="max-w-md"
         >
           <FilterableSelect
             value={relay}


### PR DESCRIPTION
## Context

Updated gateway docs and frontend tooltips to mention that auto-selected relays will automatically fail over to a different healthy relay if the current one becomes unreachable. Previously the docs and UI copy only described the initial selection behavior without mentioning failover.

- Gateway CLI docs: added failover mention to the reconnect bullet and expanded the "How are relays auto-selected?" FAQ with failover details
- Frontend: updated relay `tooltipText` in `AwsStartCommandDialog` and `EnrollmentTokenDialog` to describe failover behavior

## Screenshots

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)