### PR TITLE
fix(access-approval-request): skip soft-deleted projects in DAL queries

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-dal.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-dal.ts
@@ -357,6 +357,8 @@ export const accessApprovalRequestDALFactory = (db: TDbClient): TAccessApprovalR
               `${TableName.Environment}.deleteAfter`
             );
           })
+          .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+          .whereNull(`${TableName.Project}.deleteAfter`)
 
           .select(selectAllTableCols(TableName.AccessApprovalRequest))
           .select(
@@ -653,6 +655,8 @@ export const accessApprovalRequestDALFactory = (db: TDbClient): TAccessApprovalR
           `${TableName.Environment}.deleteAfter`
         );
       })
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .select(selectAllTableCols(TableName.AccessApprovalRequest))
       .select(
         tx.ref("approverUserId").withSchema(TableName.AccessApprovalPolicyApprover),
@@ -890,6 +894,8 @@ export const accessApprovalRequestDALFactory = (db: TDbClient): TAccessApprovalR
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .leftJoin(
           TableName.AdditionalPrivilege,
           `${TableName.AccessApprovalRequest}.privilegeId`,


### PR DESCRIPTION
## What

Three queries in \`access-approval-request-dal.ts\` join \`project_environments\` with \`andOnNull(Environment.deleteAfter)\` on a leftJoin but never enforce \`Project.deleteAfter\`. Soft-deleting a project does not soft-delete its environments, so approval requests for projects sitting in the delete grace window were still returned by the request-list, approval-window, and dashboard queries.

## Fix

Adds an \`inner join\` on \`projects\` with \`whereNull(Project.deleteAfter)\` after each existing env join. Because it is an inner join, it also plugs the pre-existing leftJoin-with-\`andOnNull\` leak that Greptile flagged in #7067: when the env leftJoin fails (env soft-deleted), \`env.projectId\` is null so the Project inner join fails and the row is dropped.

Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), and secret-approval-request (#7090, merged) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path