### PR TITLE
fix(access-approval-policy): skip soft-deleted projects in DAL queries

### DIFF
--- a/backend/src/ee/services/access-approval-policy/access-approval-policy-dal.ts
+++ b/backend/src/ee/services/access-approval-policy/access-approval-policy-dal.ts
@@ -409,7 +409,9 @@ export const accessApprovalPolicyDALFactory = (db: TDbClient): TAccessApprovalPo
         `${TableName.AccessApprovalPolicyEnvironment}.policyId`
       )
       .join(TableName.Environment, `${TableName.AccessApprovalPolicyEnvironment}.envId`, `${TableName.Environment}.id`)
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
       .whereNull(`${TableName.Environment}.deleteAfter`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .where((qb) => {
         if (customFilter?.envId) {
           void qb.where(`${TableName.AccessApprovalPolicyEnvironment}.envId`, "=", customFilter.envId);
@@ -633,6 +635,8 @@ export const accessApprovalPolicyDALFactory = (db: TDbClient): TAccessApprovalPo
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where(
           // eslint-disable-next-line @typescript-eslint/no-misused-promises
           buildFindFilter(


### PR DESCRIPTION
## What

Two queries in \`access-approval-policy-dal.ts\` join \`project_environments\` and filter \`Environment.deleteAfter\` but never join \`projects\` or filter \`Project.deleteAfter\`.

- The main policy find helper (used by \`getAccessApprovalPolicies\` / \`findPolicyByEnvIdAndSecretPath\` conflict check).
- The by-envId+secretPath conflict-check query used when creating or updating a policy.

Soft-deleting a project does not soft-delete its environments, so access-approval policies for projects sitting in the delete grace window were still returned. The conflict check in particular is user-visible: a policy in a soft-deleted project could still register as a conflict against a policy the user is creating in a live project that happens to share the same env id.

## Fix

Adds \`Project\` join + \`whereNull(Project.deleteAfter)\` to both queries. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), and secret-approval-request (#7090, merged) fixes.

Related: my earlier PR (#6967) refactored this same file for the batched conflict-check; this closes the soft-delete gap in the underlying DAL that #6967 assumed.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path