### PR TITLE
fix(secret-approval-policy): skip soft-deleted projects in DAL queries

### DIFF
--- a/backend/src/ee/services/secret-approval-policy/secret-approval-policy-dal.ts
+++ b/backend/src/ee/services/secret-approval-policy/secret-approval-policy-dal.ts
@@ -40,7 +40,9 @@ export const secretApprovalPolicyDALFactory = (db: TDbClient) => {
         `${TableName.SecretApprovalPolicy}.id`
       )
       .join(TableName.Environment, `${TableName.SecretApprovalPolicyEnvironment}.envId`, `${TableName.Environment}.id`)
+      .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
       .whereNull(`${TableName.Environment}.deleteAfter`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .where((qb) => {
         if (customFilter?.envId) {
           void qb.where(`${TableName.SecretApprovalPolicyEnvironment}.envId`, "=", customFilter.envId);
@@ -282,6 +284,8 @@ export const secretApprovalPolicyDALFactory = (db: TDbClient) => {
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where(
           // eslint-disable-next-line @typescript-eslint/no-misused-promises
           buildFindFilter(


### PR DESCRIPTION
## What

Sibling fix to #7106 for the secret-approval-policy DAL. Two queries filter \`Environment.deleteAfter\` but never \`Project.deleteAfter\`:

- The main policy find helper (used by \`getSecretApprovalPolicies\` / \`findPolicyByEnvIdAndSecretPath\` conflict check).
- The by-envId+secretPath conflict-check subquery.

Soft-deleting a project does not soft-delete its environments, so secret-approval policies for projects sitting in the delete grace window were still returned. The conflict-check is user-visible: a policy in a soft-deleted project could still register as a conflict against a policy the user is creating in a live project sharing the same env id.

## Fix

Adds \`Project\` join + \`whereNull(Project.deleteAfter)\` to both queries. Mirrors the pattern in \`org-product-stats-dal.ts\` and the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), and secret-approval-request (#7090, merged) fixes.

Related: my earlier PR (#6968) refactored this same file for the batched conflict-check; this closes the soft-delete gap in the underlying DAL that #6968 assumed.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path