### PR TITLE
fix: reset certificate request modal form on successful submission

### DIFF
--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
@@ -300,6 +300,7 @@ export const CertificateIssuanceModal = ({
       const handleIssuanceResponse = (response: Awaited<ReturnType<typeof issueCertificate>>) => {
         if ("certificate" in response && response.certificate) {
           createNotification({ text: "Successfully created certificate", type: "success" });
+          resetAllState();
           handlePopUpToggle("issueCertificate", false);
           if (currentOrg?.id && currentProject?.id && response.certificate.certificateId) {
             navigate({
@@ -320,12 +321,14 @@ export const CertificateIssuanceModal = ({
             text: "Certificate request submitted successfully. Approval is required before the certificate can be issued.",
             type: "success"
           });
+          resetAllState();
           handlePopUpToggle("issueCertificate", false);
         } else {
           createNotification({
             text: `Certificate request submitted successfully. This may take a few minutes to process. Certificate Request ID: ${response.certificateRequestId}`,
             type: "success"
           });
+          resetAllState();
           handlePopUpToggle("issueCertificate", false);
         }
       };
@@ -481,7 +484,8 @@ export const CertificateIssuanceModal = ({
       constraints.templateRequiresCA,
       actualSelectedProfile?.defaults,
       handlePopUpToggle,
-      navigate
+      navigate,
+      resetAllState
     ]
   );
 


### PR DESCRIPTION
## Description
Reset the certificate request modal form state after successful submission so inputs don't persist when the modal is reopened.

The form was only being reset via the Radix Dialog `onOpenChange` callback, which only fires on user-initiated closes (Escape, overlay click, X button). When a submission resulted in pending approval or async processing (no navigation away), `handlePopUpToggle` programmatically closed the modal without triggering `onOpenChange`, leaving stale form values for the next open.

## Type of change
- [x] Bug fix

## Testing
1. Set up a certificate profile with an approval policy
2. Open an Application, go to the Requests tab, click "+ Request Certificate"
3. Select a profile, type a CN (e.g. `api.example.com`), fill required fields, submit
4. Click "+ Request Certificate" again
5. Verify the form is clean (no stale CN or other values from the previous submission)