### PR TITLE
fix: project category card text jank on hover

### DIFF
--- a/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
@@ -372,7 +372,7 @@ export const ProjectCategoryOverview = () => {
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleTileClick(type);
               }}
-              className={`group h-auto cursor-pointer rounded-md transition-all duration-200 ease-out hover:scale-[1.01] ${cardClassName}`}
+              className={`group h-auto cursor-pointer rounded-md transition-all duration-200 ease-out will-change-transform hover:scale-[1.01] ${cardClassName}`}
             >
               {tileBody}
             </Card>


### PR DESCRIPTION
## Context

Noticed the category title and stats text's animation were janky (scale factor is 1.01 which is causing raster issues).
scale factor of 1.05 would solve it but the active card's visual presence was huge, so I moved the cards to each their own composite layer (we only have 5 in this page, so it shouldn't be a problem).

## Screenshots

### Before

https://github.com/user-attachments/assets/97238702-f55e-4b0b-8750-a22a7da9456a

### After

https://github.com/user-attachments/assets/36034a12-9d02-4b2a-9700-ed952c25ba55


