### PR TITLE
improvement: migrate invite user to org to v3 components

### DIFF
--- a/frontend/src/components/roles/RoleOption.tsx
+++ b/frontend/src/components/roles/RoleOption.tsx
@@ -9,10 +9,10 @@ export const RoleOption = ({
   return (
     <components.Option isSelected={isSelected} {...props}>
       <div className="flex flex-row items-center justify-between">
-        <div>
+        <div className="min-w-0 flex-1">
           <p className="truncate">{children}</p>
           {props.data.description ? (
-            <p className="truncate text-xs leading-4 text-mineshaft-400">
+            <p className="text-xs leading-4 break-words whitespace-normal text-mineshaft-400">
               {props.data.description}
             </p>
           ) : (

--- a/frontend/src/helpers/project.ts
+++ b/frontend/src/helpers/project.ts
@@ -139,7 +139,8 @@ export const getProjectTitle = (type: ProjectType) => {
     [ProjectType.CertificateManager]: "Certificate Manager",
     [ProjectType.SSH]: "SSH",
     [ProjectType.SecretScanning]: "Secret Scanning",
-    [ProjectType.PAM]: "PAM"
+    [ProjectType.PAM]: "PAM",
+    [ProjectType.AI]: "AI"
   };
   return titleConvert[type] || type;
 };

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -1,19 +1,31 @@
 import { useEffect, useMemo } from "react";
 import { Controller, useForm } from "react-hook-form";
+import { components, OptionProps, SingleValueProps } from "react-select";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { CheckIcon, Info } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { RoleOption } from "@app/components/roles";
 import {
   Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
   FilterableSelect,
-  FormControl,
-  Modal,
-  ModalContent,
-  TextArea
-} from "@app/components/v2";
+  TextArea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
+import { getProjectLucideIcon, getProjectTitle } from "@app/helpers/project";
 import { findOrgMembershipRole } from "@app/helpers/roles";
 import {
   useAddUsersToOrg,
@@ -71,6 +83,40 @@ const PRODUCT_DEFINITIONS: ProductDefinition[] = [
   { type: ProjectType.PAM, name: "PAM", isSingleton: false },
   { type: ProjectType.AI, name: "AI", isSingleton: false }
 ];
+
+// Prefer the shared project title (matches the Projects pages, e.g. "Secrets Management"), falling
+// back to the definition name for types the util doesn't map (e.g. AI).
+const getProductLabel = (product: ProductDefinition) => {
+  const title = getProjectTitle(product.type);
+  return title === product.type ? product.name : title;
+};
+
+// Render each product with its shared project icon (getProjectLucideIcon) so the select matches the
+// Projects pages and the org sidebar.
+const ProductOption = ({ isSelected, children, ...props }: OptionProps<ProductDefinition>) => {
+  const Icon = getProjectLucideIcon(props.data.type);
+  return (
+    <components.Option isSelected={isSelected} {...props}>
+      <div className="flex flex-row items-center gap-2">
+        <Icon className="size-4 shrink-0 text-muted" />
+        <p className="mr-auto truncate">{children}</p>
+        {isSelected && <CheckIcon className="ml-2 size-4 shrink-0" />}
+      </div>
+    </components.Option>
+  );
+};
+
+const ProductSingleValue = ({ children, ...props }: SingleValueProps<ProductDefinition>) => {
+  const Icon = getProjectLucideIcon(props.data.type);
+  return (
+    <components.SingleValue {...props}>
+      <div className="flex flex-row items-center gap-2">
+        <Icon className="size-4 shrink-0 text-muted" />
+        <span className="truncate">{children}</span>
+      </div>
+    </components.SingleValue>
+  );
+};
 
 const EmailSchema = z.string().email().min(1).trim().toLowerCase();
 
@@ -296,39 +342,39 @@ export const AddOrgMemberModal = ({
   };
 
   return (
-    <Modal
-      isOpen={popUp?.addMember?.isOpen}
+    <Dialog
+      open={popUp?.addMember?.isOpen}
       onOpenChange={(isOpen) => {
         handlePopUpToggle("addMember", isOpen);
         setCompleteInviteLinks(null);
       }}
     >
-      <ModalContent
-        bodyClassName="overflow-visible"
-        title={`Invite others to ${currentOrg?.name}`}
-        subTitle={
-          <div>
-            {!completeInviteLinks && (
-              <div>An invite is specific to an email address and expires after 1 day.</div>
-            )}
-            {completeInviteLinks &&
-              "This Infisical instance does not have a email provider setup. Please share this invite link with the invitee manually"}
-          </div>
-        }
-      >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Invite others to {currentOrg?.name}</DialogTitle>
+          <DialogDescription>
+            {completeInviteLinks
+              ? "This Infisical instance does not have a email provider setup. Please share this invite link with the invitee manually"
+              : "An invite is specific to an email address and expires after 1 day."}
+          </DialogDescription>
+        </DialogHeader>
         {!completeInviteLinks && (
-          <form onSubmit={handleSubmit(onAddMembers)}>
+          <form onSubmit={handleSubmit(onAddMembers)} className="flex flex-col gap-4">
             <Controller
               control={control}
               name="emails"
               render={({ field, fieldState: { error } }) => (
-                <FormControl label="Emails" isError={Boolean(error)} errorText={error?.message}>
+                <Field>
+                  <FieldLabel htmlFor="add-org-member-emails">Emails</FieldLabel>
                   <TextArea
-                    {...field}
-                    className="ring-opacity-70 mt-1 h-20 w-full min-w-120 rounded-md border border-mineshaft-500 bg-mineshaft-900/70 px-2 py-1 text-sm text-bunker-300 ring-primary-800 outline-hidden transition-all placeholder:text-bunker-400 focus:ring-2"
+                    id="add-org-member-emails"
+                    className="h-20"
+                    isError={Boolean(error)}
                     placeholder="email@example.com, email2@example.com..."
+                    {...field}
                   />
-                </FormControl>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
               )}
             />
 
@@ -336,22 +382,36 @@ export const AddOrgMemberModal = ({
               control={control}
               name="organizationRole"
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  tooltipText="Select which organization role you want to assign to the user."
-                  label="Assign organization role"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                >
+                <Field>
+                  <FieldLabel
+                    htmlFor="add-org-member-org-role"
+                    className="flex items-center gap-1.5"
+                  >
+                    Assign organization role
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span>
+                          <Info className="size-3 text-muted" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-md">
+                        Select which organization role you want to assign to the user.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <FilterableSelect
+                    inputId="add-org-member-org-role"
                     placeholder="Select role..."
                     options={organizationRoles}
                     getOptionValue={(option) => option.slug}
                     getOptionLabel={(option) => option.name}
                     value={value}
                     onChange={onChange}
+                    isError={Boolean(error)}
                     components={{ Option: RoleOption }}
                   />
-                </FormControl>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
               )}
             />
 
@@ -359,14 +419,26 @@ export const AddOrgMemberModal = ({
               control={control}
               name="product"
               render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <FormControl
-                  tooltipText="Select which product to grant the users access to."
-                  label="Assign users to a product"
-                  isOptional
-                  isError={Boolean(error?.message)}
-                  errorText={error?.message}
-                >
+                <Field>
+                  <FieldLabel
+                    htmlFor="add-org-member-product"
+                    className="flex items-center gap-1.5"
+                  >
+                    Assign users to a product
+                    <span className="text-xs font-normal text-muted">(optional)</span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span>
+                          <Info className="size-3 text-muted" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-md">
+                        Select which product to grant the users access to.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
                   <FilterableSelect
+                    inputId="add-org-member-product"
                     value={value ?? null}
                     isLoading={isProjectsLoading}
                     onChange={(option) => {
@@ -374,12 +446,15 @@ export const AddOrgMemberModal = ({
                       setValue("projects", []);
                       setValue("projectRole", DEFAULT_PROJECT_ROLE);
                     }}
-                    getOptionLabel={(product) => product.name}
+                    getOptionLabel={(product) => getProductLabel(product)}
                     getOptionValue={(product) => product.type}
                     options={availableProducts}
                     placeholder="Select a product..."
+                    isError={Boolean(error?.message)}
+                    components={{ Option: ProductOption, SingleValue: ProductSingleValue }}
                   />
-                </FormControl>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
               )}
             />
 
@@ -388,13 +463,16 @@ export const AddOrgMemberModal = ({
                 control={control}
                 name="projects"
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    label="Assign users to projects"
-                    isOptional
-                    isError={Boolean(error?.message)}
-                    errorText={error?.message}
-                  >
+                  <Field>
+                    <FieldLabel
+                      htmlFor="add-org-member-projects"
+                      className="flex items-center gap-1.5"
+                    >
+                      Assign users to projects
+                      <span className="text-xs font-normal text-muted">(optional)</span>
+                    </FieldLabel>
                     <FilterableSelect
+                      inputId="add-org-member-projects"
                       isMulti
                       value={value}
                       onChange={onChange}
@@ -403,8 +481,10 @@ export const AddOrgMemberModal = ({
                       getOptionValue={(project) => project.id}
                       options={productProjects}
                       placeholder="Select projects..."
+                      isError={Boolean(error?.message)}
                     />
-                  </FormControl>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
                 )}
               />
             )}
@@ -414,29 +494,39 @@ export const AddOrgMemberModal = ({
                 control={control}
                 name="projectRole"
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <FormControl
-                    tooltipText={
-                      isSingletonProduct ? (
-                        "Select which role to assign to the users for this product."
-                      ) : (
-                        <>
-                          Select which role to assign to the users in the selected projects.
-                          <br />
-                          <br />
-                          When multiple projects are selected, only built-in roles are available for
-                          selection.
-                          <br />
-                          <br />
-                          You can assign users to additional projects after they&apos;ve been
-                          invited.
-                        </>
-                      )
-                    }
-                    label={isSingletonProduct ? "Product role" : "Project role"}
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                  >
+                  <Field>
+                    <FieldLabel
+                      htmlFor="add-org-member-project-role"
+                      className="flex items-center gap-1.5"
+                    >
+                      {isSingletonProduct ? "Product role" : "Project role"}
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>
+                            <Info className="size-3 text-muted" />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-md whitespace-pre-line">
+                          {isSingletonProduct ? (
+                            "Select which role to assign to the users for this product."
+                          ) : (
+                            <>
+                              Select which role to assign to the users in the selected projects.
+                              <br />
+                              <br />
+                              When multiple projects are selected, only built-in roles are available
+                              for selection.
+                              <br />
+                              <br />
+                              You can assign users to additional projects after they&apos;ve been
+                              invited.
+                            </>
+                          )}
+                        </TooltipContent>
+                      </Tooltip>
+                    </FieldLabel>
                     <FilterableSelect
+                      inputId="add-org-member-project-role"
                       isDisabled={!isSingletonProduct && selectedProjects.length === 0}
                       isLoading={Boolean(singleSelectedProjectId) && isProjectRolesLoading}
                       value={value}
@@ -445,31 +535,32 @@ export const AddOrgMemberModal = ({
                       getOptionValue={(option) => option.slug}
                       getOptionLabel={(option) => option.name}
                       placeholder="Select role..."
+                      isError={Boolean(error)}
                       components={{ Option: RoleOption }}
                     />
-                  </FormControl>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
                 )}
               />
             )}
 
-            <div className="mt-8 flex items-center">
+            <DialogFooter>
               <Button
-                className="mr-4"
-                size="sm"
-                type="submit"
-                isLoading={isSubmitting}
-                isDisabled={isSubmitting}
-              >
-                Add Member
-              </Button>
-              <Button
-                colorSchema="secondary"
-                variant="plain"
+                variant="ghost"
+                type="button"
                 onClick={() => handlePopUpToggle("addMember", false)}
               >
                 Cancel
               </Button>
-            </div>
+              <Button
+                variant="org"
+                type="submit"
+                isPending={isSubmitting}
+                isDisabled={isSubmitting}
+              >
+                Add Member
+              </Button>
+            </DialogFooter>
           </form>
         )}
         {completeInviteLinks && (
@@ -479,7 +570,7 @@ export const AddOrgMemberModal = ({
             ))}
           </div>
         )}
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -10,6 +10,7 @@ import { RoleOption } from "@app/components/roles";
 import {
   Button,
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -69,27 +70,29 @@ type ProductDefinition = {
   roles?: { slug: string; name: string; description: string }[];
 };
 
+// Names come from the shared getProjectTitle util so the select matches the Projects pages.
 const PRODUCT_DEFINITIONS: ProductDefinition[] = [
-  { type: ProjectType.SecretManager, name: "Secrets", isSingleton: false },
+  {
+    type: ProjectType.SecretManager,
+    name: getProjectTitle(ProjectType.SecretManager),
+    isSingleton: false
+  },
   {
     type: ProjectType.CertificateManager,
-    name: "Certificate Manager",
+    name: getProjectTitle(ProjectType.CertificateManager),
     isSingleton: true,
     roles: CERT_MANAGER_ROLES
   },
-  { type: ProjectType.KMS, name: "KMS", isSingleton: false },
-  { type: ProjectType.SSH, name: "SSH", isSingleton: false },
-  { type: ProjectType.SecretScanning, name: "Secret Scanning", isSingleton: false },
-  { type: ProjectType.PAM, name: "PAM", isSingleton: false },
-  { type: ProjectType.AI, name: "AI", isSingleton: false }
+  { type: ProjectType.KMS, name: getProjectTitle(ProjectType.KMS), isSingleton: false },
+  { type: ProjectType.SSH, name: getProjectTitle(ProjectType.SSH), isSingleton: false },
+  {
+    type: ProjectType.SecretScanning,
+    name: getProjectTitle(ProjectType.SecretScanning),
+    isSingleton: false
+  },
+  { type: ProjectType.PAM, name: getProjectTitle(ProjectType.PAM), isSingleton: false },
+  { type: ProjectType.AI, name: getProjectTitle(ProjectType.AI), isSingleton: false }
 ];
-
-// Prefer the shared project title (matches the Projects pages, e.g. "Secrets Management"), falling
-// back to the definition name for types the util doesn't map (e.g. AI).
-const getProductLabel = (product: ProductDefinition) => {
-  const title = getProjectTitle(product.type);
-  return title === product.type ? product.name : title;
-};
 
 // Render each product with its shared project icon (getProjectLucideIcon) so the select matches the
 // Projects pages and the org sidebar.
@@ -446,7 +449,7 @@ export const AddOrgMemberModal = ({
                       setValue("projects", []);
                       setValue("projectRole", DEFAULT_PROJECT_ROLE);
                     }}
-                    getOptionLabel={(product) => getProductLabel(product)}
+                    getOptionLabel={(product) => product.name}
                     getOptionValue={(product) => product.type}
                     options={availableProducts}
                     placeholder="Select a product..."
@@ -564,11 +567,20 @@ export const AddOrgMemberModal = ({
           </form>
         )}
         {completeInviteLinks && (
-          <div className="space-y-3">
-            {completeInviteLinks.map((invite) => (
-              <OrgInviteLink key={`invite-${invite.email}`} invite={invite} />
-            ))}
-          </div>
+          <>
+            <div className="space-y-3">
+              {completeInviteLinks.map((invite) => (
+                <OrgInviteLink key={`invite-${invite.email}`} invite={invite} />
+              ))}
+            </div>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="org">
+                  Done
+                </Button>
+              </DialogClose>
+            </DialogFooter>
+          </>
         )}
       </DialogContent>
     </Dialog>

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -89,9 +89,7 @@ const PRODUCT_DEFINITIONS: ProductDefinition[] = [
     type: ProjectType.SecretScanning,
     name: getProjectTitle(ProjectType.SecretScanning),
     isSingleton: false
-  },
-  { type: ProjectType.PAM, name: getProjectTitle(ProjectType.PAM), isSingleton: false },
-  { type: ProjectType.AI, name: getProjectTitle(ProjectType.AI), isSingleton: false }
+  }
 ];
 
 // Render each product with its shared project icon (getProjectLucideIcon) so the select matches the
@@ -123,8 +121,86 @@ const ProductSingleValue = ({ children, ...props }: SingleValueProps<ProductDefi
 
 const EmailSchema = z.string().email().min(1).trim().toLowerCase();
 
+// Zod's .email() accepts addresses the backend/DB reject: domain labels over 63 chars
+// (backend/src/lib/validator/validate-email.ts) and emails longer than the users table's
+// varchar(255) email/username columns. Mirror both here so oversized/malformed addresses are
+// caught inline instead of failing with a 400 (bad domain) or 500 (too long) from the API.
+const MAX_EMAIL_LENGTH = 255;
+const MAX_DOMAIN_LABEL_LENGTH = 63;
+const DOMAIN_LABEL_REGEX = /^[a-zA-Z0-9-]+$/;
+const TLD_REGEX = /^[a-zA-Z0-9]+$/;
+
+const isValidEmailDomain = (domain: string) => {
+  const labels = domain.split(".");
+  if (labels.length < 2) return false;
+
+  const tld = labels[labels.length - 1];
+  if (tld.length < 2 || !TLD_REGEX.test(tld)) return false;
+
+  return labels.every(
+    (label) =>
+      label.length > 0 &&
+      label.length <= MAX_DOMAIN_LABEL_LENGTH &&
+      !label.startsWith("-") &&
+      !label.endsWith("-") &&
+      DOMAIN_LABEL_REGEX.test(label)
+  );
+};
+
+const isValidEmail = (email: string) =>
+  email.length <= MAX_EMAIL_LENGTH &&
+  EmailSchema.safeParse(email).success &&
+  isValidEmailDomain(email.slice(email.indexOf("@") + 1));
+
+// Mirror the backend cap (inviteeEmails.array().max(100)) so oversized invites are rejected inline
+// before hitting the API.
+const MAX_INVITE_EMAILS = 100;
+
+const parseEmailList = (value: string) =>
+  value
+    .split(",")
+    .map((email) => email.trim())
+    .filter(Boolean);
+
 const addMemberFormSchema = z.object({
-  emails: z.string().min(1).trim().toLowerCase(),
+  emails: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .superRefine((value, ctx) => {
+      const emails = parseEmailList(value);
+
+      if (!emails.length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Please enter at least one email address."
+        });
+        return;
+      }
+
+      if (emails.length > MAX_INVITE_EMAILS) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `You can invite up to ${MAX_INVITE_EMAILS} users at a time.`
+        });
+      }
+
+      const invalidEmails = emails.filter((email) => !isValidEmail(email));
+
+      if (invalidEmails.length) {
+        const preview = invalidEmails
+          .slice(0, 3)
+          .map((email) => (email.length > 40 ? `${email.slice(0, 40)}...` : email))
+          .join(", ");
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            invalidEmails.length > 3
+              ? `${invalidEmails.length} invalid email addresses (e.g. ${preview}).`
+              : `Invalid email address${invalidEmails.length > 1 ? "es" : ""}: ${preview}.`
+        });
+      }
+    }),
   product: z
     .object({
       type: z.nativeEnum(ProjectType),
@@ -277,26 +353,7 @@ export const AddOrgMemberModal = ({
       }
     }
 
-    const parsedEmails = emails
-      .replace(/\s/g, "")
-      .split(",")
-      .map((email) => {
-        if (EmailSchema.safeParse(email).success) {
-          return email.trim();
-        }
-
-        return null;
-      });
-
-    if (parsedEmails.includes(null)) {
-      createNotification({
-        text: "Invalid email addresses provided.",
-        type: "error"
-      });
-      return;
-    }
-
-    const usernames = emails.split(",").map((email) => email.trim());
+    const usernames = parseEmailList(emails);
     const { data } = await addUsersMutateAsync({
       organizationId: currentOrg?.id,
       inviteeEmails: usernames,
@@ -371,7 +428,7 @@ export const AddOrgMemberModal = ({
                   <FieldLabel htmlFor="add-org-member-emails">Emails</FieldLabel>
                   <TextArea
                     id="add-org-member-emails"
-                    className="h-20"
+                    className="h-24"
                     isError={Boolean(error)}
                     placeholder="email@example.com, email2@example.com..."
                     {...field}
@@ -442,6 +499,7 @@ export const AddOrgMemberModal = ({
                   </FieldLabel>
                   <FilterableSelect
                     inputId="add-org-member-product"
+                    isClearable
                     value={value ?? null}
                     isLoading={isProjectsLoading}
                     onChange={(option) => {

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -349,7 +349,7 @@ export const AddOrgMemberModal = ({
         setCompleteInviteLinks(null);
       }}
     >
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Invite others to {currentOrg?.name}</DialogTitle>
           <DialogDescription>

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgInviteLink.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgInviteLink.tsx
@@ -1,9 +1,16 @@
-import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { twMerge } from "tailwind-merge";
+import { Check, Copy } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
-import { IconButton, Tooltip } from "@app/components/v2";
+import {
+  ButtonGroup,
+  Field,
+  FieldLabel,
+  IconButton,
+  Input,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useToggle } from "@app/hooks";
 
 type Props = {
@@ -13,7 +20,7 @@ type Props = {
 export const OrgInviteLink = ({ invite }: Props) => {
   const [isInviteLinkCopied, setInviteLinkCopied] = useToggle(false);
 
-  const copyTokenToClipboard = () => {
+  const copyLinkToClipboard = () => {
     if (isInviteLinkCopied) return;
 
     navigator.clipboard.writeText(invite.link);
@@ -26,30 +33,31 @@ export const OrgInviteLink = ({ invite }: Props) => {
   };
 
   return (
-    <div key={`invite-${invite.email}`}>
-      <p className="text-sm text-mineshaft-400">
-        Invite for <span className="font-medium">{invite.email}</span>
-      </p>
-      <div className="flex flex-col gap-1 rounded-md bg-white/4 p-2 text-base text-gray-400">
-        <p
-          className={twMerge(
-            "mr-4 line-clamp-1",
-            window.isSecureContext ? "overflow-hidden text-ellipsis whitespace-nowrap" : "break-all"
-          )}
-        >
-          {invite.link}
-        </p>
-        <Tooltip content={`Copy invitation link for ${invite.email}`}>
-          <IconButton
-            ariaLabel="copy icon"
-            colorSchema="secondary"
-            className="group relative"
-            onClick={() => copyTokenToClipboard()}
-          >
-            <FontAwesomeIcon icon={isInviteLinkCopied ? faCheck : faCopy} />
-          </IconButton>
+    <Field>
+      <FieldLabel htmlFor={`invite-link-${invite.email}`}>
+        Invite for <span className="font-medium text-foreground">{invite.email}</span>
+      </FieldLabel>
+      <ButtonGroup className="w-full">
+        <Input
+          id={`invite-link-${invite.email}`}
+          value={invite.link}
+          readOnly
+          aria-label={`Invitation link for ${invite.email}`}
+          className="font-mono"
+        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconButton
+              variant="outline"
+              aria-label={`Copy invitation link for ${invite.email}`}
+              onClick={copyLinkToClipboard}
+            >
+              {isInviteLinkCopied ? <Check /> : <Copy />}
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent>{isInviteLinkCopied ? "Copied" : "Copy"}</TooltipContent>
         </Tooltip>
-      </div>
-    </div>
+      </ButtonGroup>
+    </Field>
   );
 };


### PR DESCRIPTION
## Context

This PR migrates the org invite users modal to v3 components

## Screenshots

<img width="3456" height="1926" alt="CleanShot 2026-07-01 at 11 02 07@2x" src="https://github.com/user-attachments/assets/629091a5-cd6f-4cc1-aac2-5a5e07fe297e" />

## Steps to verify the change

- [ ] invite users
- [ ] test with different projects / role assignments

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)