### PR TITLE
improvement: migrate upgrade modal to v3

### DIFF
--- a/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
+++ b/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
@@ -1,9 +1,19 @@
+import { SparklesIcon } from "lucide-react";
+
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Separator
+} from "@app/components/v3";
 import { INFISICAL_SCHEDULE_DEMO_LINK } from "@app/const/links";
 import { useOrganization, useSubscription } from "@app/context";
+import { useScopeVariant } from "@app/hooks";
 import { useGetOrgTrialUrl } from "@app/hooks/api";
-
-import { Button } from "../../v2/Button";
-import { Modal, ModalContent } from "../../v2/Modal";
 
 type Props = {
   isOpen?: boolean;
@@ -21,6 +31,7 @@ export const UpgradePlanModal = ({
   const { subscription } = useSubscription();
   const { currentOrg } = useOrganization();
   const { mutateAsync, isPending } = useGetOrgTrialUrl();
+  const scopeVariant = useScopeVariant();
 
   const getLink = () => {
     // self-hosting
@@ -72,30 +83,34 @@ export const UpgradePlanModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent title="Unleash Infisical's Full Power">
-        <p className="mb-2 text-bunker-300">{text}</p>
-        <p className="text-bunker-300">
-          Upgrade and get access to this, as well as to other powerful enhancements.
-        </p>
-        <div className="mt-8 flex items-center">
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2.5">
+            <SparklesIcon className="size-5 text-muted" />
+            Unleash Infisical&apos;s Full Power
+          </DialogTitle>
+          <DialogDescription>
+            Upgrade and get access to this, as well as to other powerful enhancements.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Separator />
+        <p className="text-sm leading-relaxed text-foreground">{text}</p>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange?.(false)}>
+            Cancel
+          </Button>
           <Button
-            isLoading={isPending}
-            colorSchema="primary"
+            variant={scopeVariant}
+            isPending={isPending}
+            isDisabled={isPending}
             onClick={handleUpgradeBtnClick}
-            className="mr-4"
           >
             {getUpgradePlanLabel()}
           </Button>
-          <Button
-            colorSchema="secondary"
-            variant="plain"
-            onClick={() => onOpenChange && onOpenChange(false)}
-          >
-            Cancel
-          </Button>
-        </div>
-      </ModalContent>
-    </Modal>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
+++ b/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
@@ -84,7 +84,8 @@ export const UpgradePlanModal = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-xl">
+      {/* z-[70] keeps this above legacy v2 modals (z-[60]) that open it, e.g. RoleModal */}
+      <DialogContent className="z-[70] sm:max-w-xl" overlayClassName="z-[70]">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2.5">
             <SparklesIcon className="size-5 text-muted" />


### PR DESCRIPTION
## Context

This PR migrates the upgrade modal to v3 components 

## Screenshots

<img width="3456" height="1926" alt="CleanShot 2026-07-01 at 11 46 06@2x" src="https://github.com/user-attachments/assets/11b78940-cc0f-4675-9f0c-0ae5d7fa06ff" />

## Steps to verify the change

- look at it 

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)