### PR TITLE
fix: assorted sidebar visual fixes

### DIFF
--- a/frontend/src/components/v3/generic/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/v3/generic/Sidebar/Sidebar.tsx
@@ -566,7 +566,7 @@ function SidebarCollapsibleGroup({
   );
 
   return (
-    <SidebarGroup className={cn(isCollapsed ? "mt-1" : "mt-3", className)}>
+    <SidebarGroup className={cn(isCollapsed ? "mt-2" : "mt-3", className)}>
       {isCollapsed ? (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNav.tsx
@@ -74,7 +74,13 @@ export const OrgNav = () => {
           hidden: !isRootOrganization
         },
         { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" },
-        { label: "Settings", icon: Settings, pathSuffix: "settings", opensSubmenu: true }
+        {
+          label: "Settings",
+          icon: Settings,
+          pathSuffix: "settings",
+          activeMatch: /organizations\/[^/]+\/(sso|oauth-applications|networking)/,
+          opensSubmenu: true
+        }
       ]
     }
   ];


### PR DESCRIPTION
## Context

Noticed a couple of tiny UI bugs in the sidebar
- Collapsed state is off-by-one pixel (layout shift)
- Navigating back from Settings doesn't activate the link sometimes

## Screenshots

### Before

https://github.com/user-attachments/assets/88f0954c-412f-4883-ba98-c8ccc563d73b

### After

https://github.com/user-attachments/assets/f51bf6ea-b6fa-4b34-a327-293748b1d86f
