### PR TITLE
feat: corrected the usage reported url

### DIFF
--- a/backend/src/services/license-client/usage/usage-event-queue.ts
+++ b/backend/src/services/license-client/usage/usage-event-queue.ts
@@ -55,9 +55,8 @@ export const usageEventQueueFactory = ({
 
     const observedAt = new Date();
     const minuteBucketSeconds = Math.floor(observedAt.getTime() / 60_000) * 60;
-    await usageReporter.reportSnapshots([
+    await usageReporter.reportSnapshots(orgId, [
       {
-        org_id: orgId,
         feature_key: featureKey,
         value,
         observed_at: observedAt.toISOString(),

--- a/backend/src/services/license-client/usage/usage-metering.test.ts
+++ b/backend/src/services/license-client/usage/usage-metering.test.ts
@@ -220,9 +220,9 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
     await queue.handleUsageEvent(ORG_ID, MaxIdentities.key);
 
     expect(reportSnapshots).toHaveBeenCalledTimes(1);
-    const [snapshots] = reportSnapshots.mock.calls[0] as unknown as [TUsageSnapshot[]];
+    const [orgId, snapshots] = reportSnapshots.mock.calls[0] as unknown as [string, TUsageSnapshot[]];
+    expect(orgId).toBe(ORG_ID);
     expect(snapshots[0]).toMatchObject({
-      org_id: ORG_ID,
       feature_key: MaxIdentities.key,
       value: 42,
       source: "test-region"

--- a/backend/src/services/license-client/usage/usage-reporter.ts
+++ b/backend/src/services/license-client/usage/usage-reporter.ts
@@ -23,7 +23,7 @@ export const usageReporterFactory = (serverUrl: string, getBearerToken: () => st
       return;
     }
 
-    const url = new URL(`/v1/${orgId}/usage-snapshots`, serverUrl);
+    const url = new URL(`/v1/${encodeURIComponent(orgId)}/usage-snapshots`, serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${getBearerToken()}`, "Content-Type": "application/json" },

--- a/backend/src/services/license-client/usage/usage-reporter.ts
+++ b/backend/src/services/license-client/usage/usage-reporter.ts
@@ -3,10 +3,7 @@ import { logger } from "@app/lib/logger";
 
 import { mintServiceToken } from "../license-client-backends";
 
-const SNAPSHOTS_PATH = "/v1/usage/snapshots";
-
 export type TUsageSnapshot = {
-  org_id: string;
   feature_key: string;
   value: number;
   observed_at: string;
@@ -15,18 +12,18 @@ export type TUsageSnapshot = {
 };
 
 export type TUsageReporter = {
-  reportSnapshots: (snapshots: TUsageSnapshot[]) => Promise<void>;
+  reportSnapshots: (orgId: string, snapshots: TUsageSnapshot[]) => Promise<void>;
 };
 
 // getBearerToken is called per request so a cloud reporter can mint a fresh short-lived JWT each time
 // (a self-hosted reporter just returns its static license key).
 export const usageReporterFactory = (serverUrl: string, getBearerToken: () => string): TUsageReporter => ({
-  reportSnapshots: async (snapshots: TUsageSnapshot[]) => {
+  reportSnapshots: async (orgId: string, snapshots: TUsageSnapshot[]) => {
     if (!snapshots.length) {
       return;
     }
 
-    const url = new URL(SNAPSHOTS_PATH, serverUrl);
+    const url = new URL(`/v1/${orgId}/usage-snapshots`, serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${getBearerToken()}`, "Content-Type": "application/json" },


### PR DESCRIPTION
## Context

This PR corrects the URL for the usage reported moving the org id in format with the URL

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)