### PR TITLE
feat: replace InfisicalStaticSecret doc with complete examples

### DIFF
--- a/docs/documentation/guides/governance-models.mdx
+++ b/docs/documentation/guides/governance-models.mdx
@@ -267,7 +267,7 @@ For Kubernetes environments, two primary integration patterns are available:
 | Approach | Centralized | Self-Service |
 |----------|-------------|--------------|
 | **Operator deployment** | Single cluster-wide instance managed by platform team | Teams may deploy namespace-scoped instances |
-| **Secret sync patterns** | Standardized CRD configurations | Teams define their own InfisicalSecret resources |
+| **Secret sync patterns** | Standardized CRD configurations | Teams define their own InfisicalStaticSecret resources |
 
 ### Agent and CLI
 

--- a/docs/integrations/platforms/kubernetes/infisical-dynamic-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-dynamic-secret-crd.mdx
@@ -179,8 +179,8 @@ spec:
     - `Owner`
 
     <Tip>
-      When creation policy is set to `Owner`, the `InfisicalSecret` CRD must be in
-      the same namespace as where the managed kubernetes secret.
+      When creation policy is set to `Owner`, the `InfisicalDynamicSecret` CRD must be in
+      the same namespace as the managed kubernetes secret.
     </Tip>
 
     This field is optional.
@@ -311,7 +311,7 @@ The available authentication methods are `universalAuth`, `kubernetesAuth`, `aws
 
   </Accordion>
   <Accordion title="kubernetesAuth">
-    The Kubernetes machine identity authentication method is used to authenticate with Infisical. The identity ID is stored in a field in the InfisicalSecret resource. This authentication method can only be used within a Kubernetes environment.
+    The Kubernetes machine identity authentication method is used to authenticate with Infisical. The identity ID is stored in a field in the InfisicalDynamicSecret resource. This authentication method can only be used within a Kubernetes environment.
     [Read more about Kubernetes Auth](/documentation/platform/identities/kubernetes-auth).
     Valid fields:
     - `identityId`: The identity ID of the machine identity you created.
@@ -405,7 +405,7 @@ The available authentication methods are `universalAuth`, `kubernetesAuth`, `aws
 
   </Accordion>
   <Accordion title="gcpIamAuth">
-    The GCP IAM machine identity authentication method is used to authenticate with Infisical. The identity ID is stored in a field in the InfisicalSecret resource. This authentication method can only be used both within and outside GCP environments.
+    The GCP IAM machine identity authentication method is used to authenticate with Infisical. The identity ID is stored in a field in the InfisicalDynamicSecret resource. This authentication method can only be used both within and outside GCP environments.
     [Read more about Azure Auth](/documentation/platform/identities/gcp-auth).
 
     Valid fields:
@@ -423,7 +423,7 @@ The available authentication methods are `universalAuth`, `kubernetesAuth`, `aws
 
   </Accordion>
   <Accordion title="gcpIdTokenAuth">
-    The GCP ID Token machine identity authentication method is used to authenticate with Infisical. The identity ID is stored in a field in the InfisicalSecret resource. This authentication method can only be used within GCP environments.
+    The GCP ID Token machine identity authentication method is used to authenticate with Infisical. The identity ID is stored in a field in the InfisicalDynamicSecret resource. This authentication method can only be used within GCP environments.
     [Read more about Azure Auth](/documentation/platform/identities/gcp-auth).
 
     Valid fields:

--- a/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
@@ -34,6 +34,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: ServiceAccount
     metadata:
       name: infisical-service-account
+      namespace: default
     ---
     # 2. Bind the service account to system:auth-delegator so it can
     #    validate tokens via the Kubernetes TokenReview API
@@ -48,12 +49,14 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     subjects:
       - kind: ServiceAccount
         name: infisical-service-account
+        namespace: default
     ---
     # 3. Kubernetes secret holding the machine identity ID
     apiVersion: v1
     kind: Secret
     metadata:
       name: kubernetes-credentials
+      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -63,6 +66,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalConnection
     metadata:
       name: my-infisical-connection
+      namespace: default
     spec:
       address: https://app.infisical.com
     ---
@@ -71,25 +75,31 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalAuth
     metadata:
       name: my-infisical-auth
+      namespace: default
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
+        namespace: default
       method: kubernetes
       kubernetes:
         identityIdRef:
           name: kubernetes-credentials
+          namespace: default
           key: identityId
         serviceAccountRef:
           name: infisical-service-account
+          namespace: default
     ---
     # 6. Sync secrets into a native Kubernetes Secret
     apiVersion: secrets.infisical.com/v1beta1
     kind: InfisicalStaticSecret
     metadata:
       name: my-static-secret
+      namespace: default
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
+        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -98,6 +108,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
+          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -112,6 +123,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: universal-auth-credentials
+      namespace: default
     type: Opaque
     stringData:
       clientId: <your-identity-client-id>
@@ -122,6 +134,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalConnection
     metadata:
       name: my-infisical-connection
+      namespace: default
     spec:
       address: https://app.infisical.com
     ---
@@ -130,16 +143,20 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalAuth
     metadata:
       name: my-infisical-auth
+      namespace: default
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
+        namespace: default
       method: universal
       universal:
         clientIdRef:
           name: universal-auth-credentials
+          namespace: default
           key: clientId
         clientSecretRef:
           name: universal-auth-credentials
+          namespace: default
           key: clientSecret
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -147,9 +164,11 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalStaticSecret
     metadata:
       name: my-static-secret
+      namespace: default
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
+        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -158,6 +177,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
+          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -172,6 +192,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: aws-iam-credentials
+      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -181,6 +202,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalConnection
     metadata:
       name: my-infisical-connection
+      namespace: default
     spec:
       address: https://app.infisical.com
     ---
@@ -189,13 +211,16 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalAuth
     metadata:
       name: my-infisical-auth
+      namespace: default
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
+        namespace: default
       method: aws-iam
       awsIam:
         identityIdRef:
           name: aws-iam-credentials
+          namespace: default
           key: identityId
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -203,9 +228,11 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalStaticSecret
     metadata:
       name: my-static-secret
+      namespace: default
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
+        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -214,6 +241,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
+          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -228,6 +256,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: azure-credentials
+      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -237,6 +266,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalConnection
     metadata:
       name: my-infisical-connection
+      namespace: default
     spec:
       address: https://app.infisical.com
     ---
@@ -245,13 +275,16 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalAuth
     metadata:
       name: my-infisical-auth
+      namespace: default
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
+        namespace: default
       method: azure
       azure:
         identityIdRef:
           name: azure-credentials
+          namespace: default
           key: identityId
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -259,9 +292,11 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalStaticSecret
     metadata:
       name: my-static-secret
+      namespace: default
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
+        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -270,6 +305,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
+          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -284,6 +320,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: gcp-id-token-credentials
+      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -293,6 +330,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalConnection
     metadata:
       name: my-infisical-connection
+      namespace: default
     spec:
       address: https://app.infisical.com
     ---
@@ -301,13 +339,16 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalAuth
     metadata:
       name: my-infisical-auth
+      namespace: default
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
+        namespace: default
       method: gcp-id-token
       gcpIdToken:
         identityIdRef:
           name: gcp-id-token-credentials
+          namespace: default
           key: identityId
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -315,9 +356,11 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalStaticSecret
     metadata:
       name: my-static-secret
+      namespace: default
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
+        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -326,6 +369,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
+          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -344,6 +388,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: gcp-iam-credentials
+      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -353,6 +398,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalConnection
     metadata:
       name: my-infisical-connection
+      namespace: default
     spec:
       address: https://app.infisical.com
     ---
@@ -361,13 +407,16 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalAuth
     metadata:
       name: my-infisical-auth
+      namespace: default
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
+        namespace: default
       method: gcp-iam
       gcpIam:
         identityIdRef:
           name: gcp-iam-credentials
+          namespace: default
           key: identityId
         serviceAccountKeyFilePath: /path/to/service-account-key.json
     ---
@@ -376,9 +425,11 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalStaticSecret
     metadata:
       name: my-static-secret
+      namespace: default
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
+        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -387,6 +438,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
+          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -401,6 +453,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: ldap-credentials
+      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -412,6 +465,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalConnection
     metadata:
       name: my-infisical-connection
+      namespace: default
     spec:
       address: https://app.infisical.com
     ---
@@ -420,19 +474,24 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalAuth
     metadata:
       name: my-infisical-auth
+      namespace: default
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
+        namespace: default
       method: ldap
       ldap:
         identityIdRef:
           name: ldap-credentials
+          namespace: default
           key: identityId
         usernameRef:
           name: ldap-credentials
+          namespace: default
           key: username
         passwordRef:
           name: ldap-credentials
+          namespace: default
           key: password
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -440,9 +499,11 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: InfisicalStaticSecret
     metadata:
       name: my-static-secret
+      namespace: default
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
+        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -451,6 +512,7 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
+          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```

--- a/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
@@ -34,7 +34,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: ServiceAccount
     metadata:
       name: infisical-service-account
-      namespace: default
     ---
     # 2. Bind the service account to system:auth-delegator so it can
     #    validate tokens via the Kubernetes TokenReview API
@@ -49,14 +48,12 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     subjects:
       - kind: ServiceAccount
         name: infisical-service-account
-        namespace: default
     ---
     # 3. Kubernetes secret holding the machine identity ID
     apiVersion: v1
     kind: Secret
     metadata:
       name: kubernetes-credentials
-      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -77,16 +74,13 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
-        namespace: default
       method: kubernetes
       kubernetes:
         identityIdRef:
           name: kubernetes-credentials
-          namespace: default
           key: identityId
         serviceAccountRef:
           name: infisical-service-account
-          namespace: default
     ---
     # 6. Sync secrets into a native Kubernetes Secret
     apiVersion: secrets.infisical.com/v1beta1
@@ -96,7 +90,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
-        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -105,7 +98,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
-          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -120,7 +112,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: universal-auth-credentials
-      namespace: default
     type: Opaque
     stringData:
       clientId: <your-identity-client-id>
@@ -142,16 +133,13 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
-        namespace: default
       method: universal
       universal:
         clientIdRef:
           name: universal-auth-credentials
-          namespace: default
           key: clientId
         clientSecretRef:
           name: universal-auth-credentials
-          namespace: default
           key: clientSecret
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -162,7 +150,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
-        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -171,7 +158,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
-          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -186,7 +172,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: aws-iam-credentials
-      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -207,12 +192,10 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
-        namespace: default
       method: aws-iam
       awsIam:
         identityIdRef:
           name: aws-iam-credentials
-          namespace: default
           key: identityId
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -223,7 +206,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
-        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -232,7 +214,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
-          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -247,7 +228,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: azure-credentials
-      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -268,12 +248,10 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
-        namespace: default
       method: azure
       azure:
         identityIdRef:
           name: azure-credentials
-          namespace: default
           key: identityId
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -284,7 +262,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
-        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -293,7 +270,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
-          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -308,7 +284,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: gcp-id-token-credentials
-      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -329,12 +304,10 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
-        namespace: default
       method: gcp-id-token
       gcpIdToken:
         identityIdRef:
           name: gcp-id-token-credentials
-          namespace: default
           key: identityId
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -345,7 +318,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
-        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -354,7 +326,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
-          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -363,13 +334,16 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
   <Accordion title="GCP IAM Auth">
     Uses a GCP service account key file for authentication. Works both inside and outside GCP.
 
+    <Note>
+      The `serviceAccountKeyFilePath` must point to a file that exists inside the **operator pod**. You will need to create a Kubernetes Secret with your GCP service account key and mount it as a volume in the operator Deployment (or via Helm values). See the [GCP IAM Auth](/documentation/platform/identities/gcp-auth) guide for details.
+    </Note>
+
     ```yaml complete-gcp-iam-auth.yaml
     # 1. Kubernetes secret holding the machine identity ID
     apiVersion: v1
     kind: Secret
     metadata:
       name: gcp-iam-credentials
-      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -390,12 +364,10 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
-        namespace: default
       method: gcp-iam
       gcpIam:
         identityIdRef:
           name: gcp-iam-credentials
-          namespace: default
           key: identityId
         serviceAccountKeyFilePath: /path/to/service-account-key.json
     ---
@@ -407,7 +379,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
-        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -416,7 +387,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
-          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```
@@ -431,7 +401,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     kind: Secret
     metadata:
       name: ldap-credentials
-      namespace: default
     type: Opaque
     stringData:
       identityId: <your-machine-identity-id>
@@ -454,20 +423,16 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalConnectionRef:
         name: my-infisical-connection
-        namespace: default
       method: ldap
       ldap:
         identityIdRef:
           name: ldap-credentials
-          namespace: default
           key: identityId
         usernameRef:
           name: ldap-credentials
-          namespace: default
           key: username
         passwordRef:
           name: ldap-credentials
-          namespace: default
           key: password
     ---
     # 4. Sync secrets into a native Kubernetes Secret
@@ -478,7 +443,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
     spec:
       infisicalAuthRef:
         name: my-infisical-auth
-        namespace: default
       syncOptions:
         refreshInterval: 60s
       sources:
@@ -487,7 +451,6 @@ For more details on each resource, see the [InfisicalConnection](/integrations/p
           secretPath: /
       targets:
         - name: managed-secret
-          namespace: default
           kind: Secret
           creationPolicy: Owner
     ```

--- a/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
@@ -20,7 +20,7 @@ Before creating an `InfisicalStaticSecret`, you need:
 Each example below contains every resource you need to apply: the credential `Secret`, `InfisicalConnection`, `InfisicalAuth`, and `InfisicalStaticSecret`.
 Copy the one that matches your environment, replace the placeholder values, and `kubectl apply -f` it.
 
-For more details on each resource, see the [InfisicalConnection](/integrations/platforms/kubernetes/infisical-connection-crd) and [InfisicalAuth](/integrations/platforms/kubernetes/infisical-auth-crd) documentation.
+For more details on each resource, see the [InfisicalConnection](/integrations/platforms/kubernetes/infisical-connection-crd) and [InfisicalAuth](/integrations/platforms/kubernetes/infisical-auth-crd) documentation or access our [samples](https://github.com/Infisical/kubernetes-operator/tree/main/examples/v1beta1/infisicalstaticsecret).
 
 <AccordionGroup>
   <Accordion title="Kubernetes Auth (Recommended)">

--- a/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
+++ b/docs/integrations/platforms/kubernetes/infisical-static-secret-crd.mdx
@@ -15,40 +15,484 @@ Before creating an `InfisicalStaticSecret`, you need:
 1. An [InfisicalConnection](/integrations/platforms/kubernetes/infisical-connection-crd) resource configured with your Infisical host and TLS settings.
 2. An [InfisicalAuth](/integrations/platforms/kubernetes/infisical-auth-crd) resource configured with your machine identity authentication method.
 
-### Example
+### Examples
 
-```yaml infisical-static-secret.yaml
-apiVersion: secrets.infisical.com/v1beta1
-kind: InfisicalStaticSecret
-metadata:
-  name: my-static-secret
-  labels:
-    label-to-be-passed-to-managed-secret: sample-value
-  annotations:
-    example.com/annotation-to-be-passed-to-managed-secret: "sample-value"
-spec:
-  infisicalAuthRef:
-    name: my-infisical-auth
-    namespace: default
+Each example below contains every resource you need to apply: the credential `Secret`, `InfisicalConnection`, `InfisicalAuth`, and `InfisicalStaticSecret`.
+Copy the one that matches your environment, replace the placeholder values, and `kubectl apply -f` it.
 
-  syncOptions:
-    refreshInterval: 60s
-    instantUpdates: false
+For more details on each resource, see the [InfisicalConnection](/integrations/platforms/kubernetes/infisical-connection-crd) and [InfisicalAuth](/integrations/platforms/kubernetes/infisical-auth-crd) documentation.
 
-  sources:
-    - projectId: <your-project-id>
-      environmentSlug: dev
-      secretPath: /
-    - projectSlug: another-project
-      environmentSlug: dev
-      secretPath: /
+<AccordionGroup>
+  <Accordion title="Kubernetes Auth (Recommended)">
+    Best for workloads already running in Kubernetes.
 
-  targets:
-    - name: managed-secret
+    This example uses **short-lived service account tokens**. If you prefer to use a Gateway as the token reviewer instead, see the [Kubernetes Auth guide](/documentation/platform/identities/kubernetes-auth) for alternative setup options.
+
+    ```yaml complete-kubernetes-auth.yaml
+    # 1. Service account used by the operator for token review
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: infisical-service-account
       namespace: default
-      kind: Secret
-      creationPolicy: Owner
-```
+    ---
+    # 2. Bind the service account to system:auth-delegator so it can
+    #    validate tokens via the Kubernetes TokenReview API
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: infisical-service-account-role-binding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: system:auth-delegator
+    subjects:
+      - kind: ServiceAccount
+        name: infisical-service-account
+        namespace: default
+    ---
+    # 3. Kubernetes secret holding the machine identity ID
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: kubernetes-credentials
+      namespace: default
+    type: Opaque
+    stringData:
+      identityId: <your-machine-identity-id>
+    ---
+    # 4. Connection to the Infisical instance
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalConnection
+    metadata:
+      name: my-infisical-connection
+    spec:
+      address: https://app.infisical.com
+    ---
+    # 5. Auth using a Kubernetes service account token
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: my-infisical-auth
+    spec:
+      infisicalConnectionRef:
+        name: my-infisical-connection
+        namespace: default
+      method: kubernetes
+      kubernetes:
+        identityIdRef:
+          name: kubernetes-credentials
+          namespace: default
+          key: identityId
+        serviceAccountRef:
+          name: infisical-service-account
+          namespace: default
+    ---
+    # 6. Sync secrets into a native Kubernetes Secret
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalStaticSecret
+    metadata:
+      name: my-static-secret
+    spec:
+      infisicalAuthRef:
+        name: my-infisical-auth
+        namespace: default
+      syncOptions:
+        refreshInterval: 60s
+      sources:
+        - projectId: <your-project-id>
+          environmentSlug: dev
+          secretPath: /
+      targets:
+        - name: managed-secret
+          namespace: default
+          kind: Secret
+          creationPolicy: Owner
+    ```
+  </Accordion>
+
+  <Accordion title="Universal Auth">
+    Platform-agnostic authentication using a client ID and client secret. Works in any environment.
+
+    ```yaml complete-universal-auth.yaml
+    # 1. Kubernetes secret holding the client credentials
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: universal-auth-credentials
+      namespace: default
+    type: Opaque
+    stringData:
+      clientId: <your-identity-client-id>
+      clientSecret: <your-identity-client-secret>
+    ---
+    # 2. Connection to the Infisical instance
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalConnection
+    metadata:
+      name: my-infisical-connection
+    spec:
+      address: https://app.infisical.com
+    ---
+    # 3. Auth using Universal Auth credentials
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: my-infisical-auth
+    spec:
+      infisicalConnectionRef:
+        name: my-infisical-connection
+        namespace: default
+      method: universal
+      universal:
+        clientIdRef:
+          name: universal-auth-credentials
+          namespace: default
+          key: clientId
+        clientSecretRef:
+          name: universal-auth-credentials
+          namespace: default
+          key: clientSecret
+    ---
+    # 4. Sync secrets into a native Kubernetes Secret
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalStaticSecret
+    metadata:
+      name: my-static-secret
+    spec:
+      infisicalAuthRef:
+        name: my-infisical-auth
+        namespace: default
+      syncOptions:
+        refreshInterval: 60s
+      sources:
+        - projectId: <your-project-id>
+          environmentSlug: dev
+          secretPath: /
+      targets:
+        - name: managed-secret
+          namespace: default
+          kind: Secret
+          creationPolicy: Owner
+    ```
+  </Accordion>
+
+  <Accordion title="AWS IAM Auth">
+    For workloads running in AWS (EC2, Lambda, EKS). The operator uses the instance's IAM role to authenticate.
+
+    ```yaml complete-aws-iam-auth.yaml
+    # 1. Kubernetes secret holding the machine identity ID
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: aws-iam-credentials
+      namespace: default
+    type: Opaque
+    stringData:
+      identityId: <your-machine-identity-id>
+    ---
+    # 2. Connection to the Infisical instance
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalConnection
+    metadata:
+      name: my-infisical-connection
+    spec:
+      address: https://app.infisical.com
+    ---
+    # 3. Auth using AWS IAM
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: my-infisical-auth
+    spec:
+      infisicalConnectionRef:
+        name: my-infisical-connection
+        namespace: default
+      method: aws-iam
+      awsIam:
+        identityIdRef:
+          name: aws-iam-credentials
+          namespace: default
+          key: identityId
+    ---
+    # 4. Sync secrets into a native Kubernetes Secret
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalStaticSecret
+    metadata:
+      name: my-static-secret
+    spec:
+      infisicalAuthRef:
+        name: my-infisical-auth
+        namespace: default
+      syncOptions:
+        refreshInterval: 60s
+      sources:
+        - projectId: <your-project-id>
+          environmentSlug: dev
+          secretPath: /
+      targets:
+        - name: managed-secret
+          namespace: default
+          kind: Secret
+          creationPolicy: Owner
+    ```
+  </Accordion>
+
+  <Accordion title="Azure Auth">
+    For workloads running in Azure. Uses the Azure managed identity attached to the compute resource.
+
+    ```yaml complete-azure-auth.yaml
+    # 1. Kubernetes secret holding the machine identity ID
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: azure-credentials
+      namespace: default
+    type: Opaque
+    stringData:
+      identityId: <your-machine-identity-id>
+    ---
+    # 2. Connection to the Infisical instance
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalConnection
+    metadata:
+      name: my-infisical-connection
+    spec:
+      address: https://app.infisical.com
+    ---
+    # 3. Auth using Azure managed identity
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: my-infisical-auth
+    spec:
+      infisicalConnectionRef:
+        name: my-infisical-connection
+        namespace: default
+      method: azure
+      azure:
+        identityIdRef:
+          name: azure-credentials
+          namespace: default
+          key: identityId
+    ---
+    # 4. Sync secrets into a native Kubernetes Secret
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalStaticSecret
+    metadata:
+      name: my-static-secret
+    spec:
+      infisicalAuthRef:
+        name: my-infisical-auth
+        namespace: default
+      syncOptions:
+        refreshInterval: 60s
+      sources:
+        - projectId: <your-project-id>
+          environmentSlug: dev
+          secretPath: /
+      targets:
+        - name: managed-secret
+          namespace: default
+          kind: Secret
+          creationPolicy: Owner
+    ```
+  </Accordion>
+
+  <Accordion title="GCP ID Token Auth">
+    For workloads running in GCP. Uses the GCP metadata server to obtain an ID token.
+
+    ```yaml complete-gcp-id-token-auth.yaml
+    # 1. Kubernetes secret holding the machine identity ID
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: gcp-id-token-credentials
+      namespace: default
+    type: Opaque
+    stringData:
+      identityId: <your-machine-identity-id>
+    ---
+    # 2. Connection to the Infisical instance
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalConnection
+    metadata:
+      name: my-infisical-connection
+    spec:
+      address: https://app.infisical.com
+    ---
+    # 3. Auth using a GCP ID token
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: my-infisical-auth
+    spec:
+      infisicalConnectionRef:
+        name: my-infisical-connection
+        namespace: default
+      method: gcp-id-token
+      gcpIdToken:
+        identityIdRef:
+          name: gcp-id-token-credentials
+          namespace: default
+          key: identityId
+    ---
+    # 4. Sync secrets into a native Kubernetes Secret
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalStaticSecret
+    metadata:
+      name: my-static-secret
+    spec:
+      infisicalAuthRef:
+        name: my-infisical-auth
+        namespace: default
+      syncOptions:
+        refreshInterval: 60s
+      sources:
+        - projectId: <your-project-id>
+          environmentSlug: dev
+          secretPath: /
+      targets:
+        - name: managed-secret
+          namespace: default
+          kind: Secret
+          creationPolicy: Owner
+    ```
+  </Accordion>
+
+  <Accordion title="GCP IAM Auth">
+    Uses a GCP service account key file for authentication. Works both inside and outside GCP.
+
+    ```yaml complete-gcp-iam-auth.yaml
+    # 1. Kubernetes secret holding the machine identity ID
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: gcp-iam-credentials
+      namespace: default
+    type: Opaque
+    stringData:
+      identityId: <your-machine-identity-id>
+    ---
+    # 2. Connection to the Infisical instance
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalConnection
+    metadata:
+      name: my-infisical-connection
+    spec:
+      address: https://app.infisical.com
+    ---
+    # 3. Auth using GCP IAM with a service account key
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: my-infisical-auth
+    spec:
+      infisicalConnectionRef:
+        name: my-infisical-connection
+        namespace: default
+      method: gcp-iam
+      gcpIam:
+        identityIdRef:
+          name: gcp-iam-credentials
+          namespace: default
+          key: identityId
+        serviceAccountKeyFilePath: /path/to/service-account-key.json
+    ---
+    # 4. Sync secrets into a native Kubernetes Secret
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalStaticSecret
+    metadata:
+      name: my-static-secret
+    spec:
+      infisicalAuthRef:
+        name: my-infisical-auth
+        namespace: default
+      syncOptions:
+        refreshInterval: 60s
+      sources:
+        - projectId: <your-project-id>
+          environmentSlug: dev
+          secretPath: /
+      targets:
+        - name: managed-secret
+          namespace: default
+          kind: Secret
+          creationPolicy: Owner
+    ```
+  </Accordion>
+
+  <Accordion title="LDAP Auth">
+    Authenticates using LDAP credentials (username and password).
+
+    ```yaml complete-ldap-auth.yaml
+    # 1. Kubernetes secret holding LDAP credentials and the machine identity ID
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ldap-credentials
+      namespace: default
+    type: Opaque
+    stringData:
+      identityId: <your-machine-identity-id>
+      username: <your-ldap-username>
+      password: <your-ldap-password>
+    ---
+    # 2. Connection to the Infisical instance
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalConnection
+    metadata:
+      name: my-infisical-connection
+    spec:
+      address: https://app.infisical.com
+    ---
+    # 3. Auth using LDAP
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalAuth
+    metadata:
+      name: my-infisical-auth
+    spec:
+      infisicalConnectionRef:
+        name: my-infisical-connection
+        namespace: default
+      method: ldap
+      ldap:
+        identityIdRef:
+          name: ldap-credentials
+          namespace: default
+          key: identityId
+        usernameRef:
+          name: ldap-credentials
+          namespace: default
+          key: username
+        passwordRef:
+          name: ldap-credentials
+          namespace: default
+          key: password
+    ---
+    # 4. Sync secrets into a native Kubernetes Secret
+    apiVersion: secrets.infisical.com/v1beta1
+    kind: InfisicalStaticSecret
+    metadata:
+      name: my-static-secret
+    spec:
+      infisicalAuthRef:
+        name: my-infisical-auth
+        namespace: default
+      syncOptions:
+        refreshInterval: 60s
+      sources:
+        - projectId: <your-project-id>
+          environmentSlug: dev
+          secretPath: /
+      targets:
+        - name: managed-secret
+          namespace: default
+          kind: Secret
+          creationPolicy: Owner
+    ```
+  </Accordion>
+</AccordionGroup>
 
 ## CRD properties
 


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Replaces the `infisicalStaticSecret` with a complete example including `InfisicalConnection`, `InfisicalAuth`, and `InfisicalStaticSecret`, so users can just replace the placeholders and apply it.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)