### PR TITLE
improvement: migrate org role modals to v3

### DIFF
--- a/frontend/src/pages/organization/RoleByIDPage/components/DuplicateOrgRoleModal.tsx
+++ b/frontend/src/pages/organization/RoleByIDPage/components/DuplicateOrgRoleModal.tsx
@@ -5,7 +5,22 @@ import { z } from "zod";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input, Modal, ModalContent, Spinner } from "@app/components/v2";
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  Input,
+  PageLoader
+} from "@app/components/v3";
 import { useOrganization, useSubscription } from "@app/context";
 import { useCreateOrgRole, useGetOrgRole } from "@app/hooks/api";
 import { TOrgRole } from "@app/hooks/api/roles/types";
@@ -86,60 +101,59 @@ const Content = ({ role, onClose }: ContentProps) => {
   return (
     <>
       <form onSubmit={handleSubmit(handleDuplicateRole)}>
-        <Controller
-          control={control}
-          defaultValue=""
-          name="name"
-          render={({ field, fieldState: { error } }) => (
-            <FormControl
-              label="Name"
-              isError={Boolean(error)}
-              errorText={error?.message}
-              isRequired
-            >
-              <Input {...field} placeholder="Billing Team" />
-            </FormControl>
-          )}
-        />
-        <Controller
-          control={control}
-          defaultValue=""
-          name="slug"
-          render={({ field, fieldState: { error } }) => (
-            <FormControl
-              label="Slug"
-              isError={Boolean(error)}
-              errorText={error?.message}
-              isRequired
-            >
-              <Input {...field} placeholder="billing" />
-            </FormControl>
-          )}
-        />
-        <Controller
-          control={control}
-          defaultValue=""
-          name="description"
-          render={({ field, fieldState: { error } }) => (
-            <FormControl label="Description" isError={Boolean(error)} errorText={error?.message}>
-              <Input {...field} placeholder="To manage billing" />
-            </FormControl>
-          )}
-        />
-        <div className="flex items-center">
-          <Button
-            className="mr-4"
-            size="sm"
-            type="submit"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting}
-          >
+        <FieldGroup>
+          <Controller
+            control={control}
+            defaultValue=""
+            name="name"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="name">Name</FieldLabel>
+                <Input id="name" placeholder="Billing Team" isError={Boolean(error)} {...field} />
+                <FieldError>{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+          <Controller
+            control={control}
+            defaultValue=""
+            name="slug"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="slug">Slug</FieldLabel>
+                <Input id="slug" placeholder="billing" isError={Boolean(error)} {...field} />
+                <FieldError>{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+          <Controller
+            control={control}
+            defaultValue=""
+            name="description"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="description">Description (optional)</FieldLabel>
+                <Input
+                  id="description"
+                  placeholder="To manage billing"
+                  isError={Boolean(error)}
+                  {...field}
+                />
+                <FieldError>{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+        </FieldGroup>
+        <DialogFooter className="mt-6">
+          <DialogClose asChild>
+            <Button type="button" variant="ghost">
+              Cancel
+            </Button>
+          </DialogClose>
+          <Button type="submit" variant="org" isPending={isSubmitting} isDisabled={isSubmitting}>
             Duplicate Role
           </Button>
-          <Button colorSchema="secondary" variant="plain" onClick={onClose}>
-            Cancel
-          </Button>
-        </div>
+        </DialogFooter>
       </form>
       <UpgradePlanModal
         isOpen={upgradePlanPopUp.upgradePlan.isOpen}
@@ -159,25 +173,27 @@ export const DuplicateOrgRoleModal = ({ isOpen, onOpenChange, roleId }: Props) =
   if (!roleId) return null;
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        title="Duplicate Role"
-        subTitle="Duplicate this role to create a new role with the same permissions."
-      >
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Duplicate Role</DialogTitle>
+          <DialogDescription>
+            Duplicate this role to create a new role with the same permissions.
+          </DialogDescription>
+        </DialogHeader>
         {/* eslint-disable-next-line no-nested-ternary */}
         {isPending ? (
-          <div className="flex h-full flex-col items-center justify-center py-2.5">
-            <Spinner size="lg" className="text-mineshaft-500" />
-            <p className="mt-4 text-sm text-mineshaft-400">Loading Role...</p>
+          <div className="h-32">
+            <PageLoader lottieClassName="w-16" />
           </div>
         ) : role ? (
           <Content role={role!} onClose={() => onOpenChange(false)} />
         ) : (
-          <p className="w-full text-center text-red">
+          <p className="w-full text-center text-danger">
             Error: could not find role with slug &#34;{roleId}&#34;
           </p>
         )}
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/organization/RoleByIDPage/components/RoleModal.tsx
+++ b/frontend/src/pages/organization/RoleByIDPage/components/RoleModal.tsx
@@ -6,7 +6,20 @@ import { z } from "zod";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input, Modal, ModalContent } from "@app/components/v2";
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
 import { useOrganization, useSubscription } from "@app/context";
 import { useCreateOrgRole, useGetOrgRole, useUpdateOrgRole } from "@app/hooks/api";
 import { usePopUp, UsePopUpState } from "@app/hooks/usePopUp";
@@ -127,80 +140,84 @@ export const RoleModal = ({ popUp, handlePopUpToggle }: Props) => {
 
   return (
     <>
-      <Modal
-        isOpen={popUp?.role?.isOpen}
+      <Dialog
+        open={popUp?.role?.isOpen}
         onOpenChange={(isOpen) => {
           handlePopUpToggle("role", isOpen);
           reset();
         }}
       >
-        <ModalContent title={`${popUp?.role?.data ? "Update" : "Create"} Role`}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{popUp?.role?.data ? "Update" : "Create"} Role</DialogTitle>
+          </DialogHeader>
           <form onSubmit={handleSubmit(onFormSubmit)}>
-            <Controller
-              control={control}
-              defaultValue=""
-              name="name"
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  label="Name"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  isRequired
-                >
-                  <Input {...field} placeholder="Billing Team" />
-                </FormControl>
-              )}
-            />
-            <Controller
-              control={control}
-              defaultValue=""
-              name="slug"
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  label="Slug"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                  isRequired
-                >
-                  <Input {...field} placeholder="billing" />
-                </FormControl>
-              )}
-            />
-            <Controller
-              control={control}
-              defaultValue=""
-              name="description"
-              render={({ field, fieldState: { error } }) => (
-                <FormControl
-                  label="Description"
-                  isError={Boolean(error)}
-                  errorText={error?.message}
-                >
-                  <Input {...field} placeholder="To manage billing" />
-                </FormControl>
-              )}
-            />
-            <div className="flex items-center">
+            <FieldGroup>
+              <Controller
+                control={control}
+                defaultValue=""
+                name="name"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="name">Name</FieldLabel>
+                    <Input
+                      id="name"
+                      placeholder="Billing Team"
+                      isError={Boolean(error)}
+                      {...field}
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+              <Controller
+                control={control}
+                defaultValue=""
+                name="slug"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="slug">Slug</FieldLabel>
+                    <Input id="slug" placeholder="billing" isError={Boolean(error)} {...field} />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+              <Controller
+                control={control}
+                defaultValue=""
+                name="description"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="description">Description (optional)</FieldLabel>
+                    <Input
+                      id="description"
+                      placeholder="To manage billing"
+                      isError={Boolean(error)}
+                      {...field}
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+            </FieldGroup>
+            <DialogFooter className="mt-6">
+              <DialogClose asChild>
+                <Button type="button" variant="ghost">
+                  Cancel
+                </Button>
+              </DialogClose>
               <Button
-                className="mr-4"
-                size="sm"
                 type="submit"
-                isLoading={isSubmitting}
+                variant="org"
+                isPending={isSubmitting}
                 isDisabled={isSubmitting}
               >
                 {popUp?.role?.data ? "Update" : "Create"}
               </Button>
-              <Button
-                colorSchema="secondary"
-                variant="plain"
-                onClick={() => handlePopUpToggle("role", false)}
-              >
-                Cancel
-              </Button>
-            </div>
+            </DialogFooter>
           </form>
-        </ModalContent>
-      </Modal>
+        </DialogContent>
+      </Dialog>
       <UpgradePlanModal
         isOpen={upgradePlanPopUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handleUpgradePlanPopUpToggle("upgradePlan", isOpen)}


### PR DESCRIPTION
## Context

Migrate the create org role and duplicate org role to v3 components 

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-07-01 at 14 20 22@2x" src="https://github.com/user-attachments/assets/e7004972-0ebb-4e35-95b4-1aca312b9f66" />
<img width="3456" height="1924" alt="CleanShot 2026-07-01 at 14 20 16@2x" src="https://github.com/user-attachments/assets/2c0ab954-d340-4c53-955e-1d496ebb6d08" />


## Steps to verify the change

- create role
- duplicate role

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)