### PR TITLE
fix(reminder): skip soft-deleted projects in getRemindersInWindow

### DIFF
--- a/backend/src/services/reminder/reminder-dal.ts
+++ b/backend/src/services/reminder/reminder-dal.ts
@@ -171,7 +171,9 @@ export const reminderDALFactory = (db: TDbClient) => {
         `${TableName.SecretFolder}.envId`,
         `${TableName.Environment}.id`
       )
+      .join<TProjects>(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
       .whereNull(`${TableName.Environment}.deleteAfter`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .where(`${TableName.Environment}.projectId`, projectId);
 
     const rawReminders = await query


### PR DESCRIPTION
## What

\`getRemindersInWindow\` (used by the insights service to enumerate reminders in a date range) joined \`project_environments\` and filtered \`Environment.deleteAfter\` but never joined \`projects\` or filtered \`Project.deleteAfter\`. Soft-deleting a project does not soft-delete its environments, so reminders for projects sitting in the delete grace window were still returned by the insights query.

The sibling helper \`findSecretDailyReminders\` in the same file already applies both filters — this brings the window query to parity.

## Fix

Adds \`Project\` join + \`whereNull(Project.deleteAfter)\`. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), and secret-approval-policy (#7107) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs, matches the sibling findSecretDailyReminders query)
- [x] The change is limited to the affected code path