### PR TITLE
fix(app-connection): skip soft-deleted projects when listing linked secret rotations

### DIFF
--- a/backend/src/services/app-connection/app-connection-dal.ts
+++ b/backend/src/services/app-connection/app-connection-dal.ts
@@ -106,6 +106,7 @@ export const appConnectionDALFactory = (db: TDbClient) => {
       .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
       .whereNull(`${TableName.Environment}.deleteAfter`)
       .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .select(
         db.ref("name").withSchema(TableName.SecretRotationV2),
         db.ref("id").withSchema(TableName.SecretRotationV2),

--- a/backend/src/services/app-connection/app-connection-dal.ts
+++ b/backend/src/services/app-connection/app-connection-dal.ts
@@ -91,6 +91,7 @@ export const appConnectionDALFactory = (db: TDbClient) => {
     const secretSyncs = await (tx || db.replicaNode())(TableName.SecretSync)
       .where(`${TableName.SecretSync}.connectionId`, connectionId)
       .join(TableName.Project, `${TableName.SecretSync}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .select(
         db.ref("name").withSchema(TableName.SecretSync),
         db.ref("id").withSchema(TableName.SecretSync),
@@ -125,6 +126,7 @@ export const appConnectionDALFactory = (db: TDbClient) => {
         `${TableName.CertificateAuthority}.id`
       )
       .join(TableName.Project, `${TableName.CertificateAuthority}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .select(
         db.ref("name").withSchema(TableName.CertificateAuthority),
         db.ref("id").withSchema(TableName.ExternalCertificateAuthority),
@@ -139,6 +141,7 @@ export const appConnectionDALFactory = (db: TDbClient) => {
     const dataSources = await (tx || db.replicaNode())(TableName.SecretScanningDataSource)
       .where(`${TableName.SecretScanningDataSource}.connectionId`, connectionId)
       .join(TableName.Project, `${TableName.SecretScanningDataSource}.projectId`, `${TableName.Project}.id`)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .select(
         db.ref("name").withSchema(TableName.SecretScanningDataSource),
         db.ref("id").withSchema(TableName.SecretScanningDataSource),


### PR DESCRIPTION
## What

The secret-rotation listing helper inside \`app-connection-dal.ts\` (used when showing which secret rotations are tied to a given app connection) already joins \`TableName.Project\` but never filters \`Project.deleteAfter\`. Soft-deleting a project does not soft-delete its environments, so rotations for projects sitting in the delete grace window were still surfaced on the connection details view.

## Fix

One-line: add \`.whereNull(Project.deleteAfter)\` after the existing Project join. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), and reminder (#7124) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path