### PR TITLE
fix(secret-approval-request-secret): skip soft-deleted projects in secret change enumeration

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-secret-dal.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-secret-dal.ts
@@ -396,7 +396,9 @@ export const secretApprovalRequestSecretDALFactory = (db: TDbClient) => {
         )
         .join(TableName.SecretFolder, `${TableName.SecretApprovalRequest}.folderId`, `${TableName.SecretFolder}.id`)
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .leftJoin(
           TableName.SecretApprovalRequestSecretTag,
           `${TableName.SecretApprovalRequestSecret}.id`,


### PR DESCRIPTION
## What

The \`findByRequestIds\` helper in \`secret-approval-request-secret-dal.ts\` (used to enumerate pending secret changes for one or more approval requests) joined \`project_environments\` and filtered \`Environment.deleteAfter\` but never joined \`projects\` or filtered \`Project.deleteAfter\`. Soft-deleting a project does not soft-delete its environments, so pending secret payloads for a soft-deleted project were still returned during the delete grace window.

The sibling \`secret-approval-request-dal\` (fixed in #7090, merged) already filters both — this brings the secret-change DAL to parity.

## Fix

Adds \`Project\` join + \`whereNull(Project.deleteAfter)\`. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), and app-connection (#7125) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; matches the sibling secret-approval-request-dal that already applies both filters)
- [x] The change is limited to the affected code path