### PR TITLE
feat: Add support for self-hosted users to configure audit log stream

### DIFF
--- a/backend/src/ee/services/audit-log-stream/audit-log-stream-fns.ts
+++ b/backend/src/ee/services/audit-log-stream/audit-log-stream-fns.ts
@@ -1,4 +1,6 @@
 import { TAuditLogs, TAuditLogStreams } from "@app/db/schemas";
+import { getConfig } from "@app/lib/config/env";
+import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
 
@@ -11,6 +13,9 @@ import { getCustomProviderListItem } from "./custom/custom-provider-fns";
 import { getDatadogProviderListItem } from "./datadog/datadog-provider-fns";
 import { getSplunkProviderListItem } from "./splunk/splunk-provider-fns";
 import { getSumoLogicProviderListItem } from "./sumo-logic/sumo-logic-provider-fns";
+
+export const blockAuditLogStreamInternalIps = (url: string) =>
+  blockLocalAndPrivateIpAddresses(url, false, getConfig().AUDIT_LOG_STREAM_ALLOW_INTERNAL_IP);
 
 export const listProviderOptions = () => {
   return [

--- a/backend/src/ee/services/audit-log-stream/azure/azure-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/azure/azure-provider-factory.ts
@@ -2,9 +2,9 @@ import { RawAxiosRequestHeaders } from "axios";
 
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
-import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
 import { AUDIT_LOG_STREAM_BATCH_TIMEOUT, AUDIT_LOG_STREAM_TIMEOUT } from "../../audit-log/audit-log-queue";
+import { blockAuditLogStreamInternalIps } from "../audit-log-stream-fns";
 import {
   TLogStreamFactoryBatchStreamLog,
   TLogStreamFactoryGetProviderBatchLimit,
@@ -48,7 +48,7 @@ export const AzureProviderFactory = () => {
   }) => {
     const { tenantId, clientId, clientSecret, dceUrl, dcrId, cltName } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(dceUrl);
+    await blockAuditLogStreamInternalIps(dceUrl);
 
     const token = await getAzureToken(tenantId, clientId, clientSecret);
 
@@ -81,7 +81,7 @@ export const AzureProviderFactory = () => {
 
     const { tenantId, clientId, clientSecret, dceUrl, dcrId, cltName } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(dceUrl);
+    await blockAuditLogStreamInternalIps(dceUrl);
 
     const token = await getAzureToken(tenantId, clientId, clientSecret);
 

--- a/backend/src/ee/services/audit-log-stream/cribl/cribl-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/cribl/cribl-provider-factory.ts
@@ -2,9 +2,9 @@ import { RawAxiosRequestHeaders } from "axios";
 
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
-import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
 import { AUDIT_LOG_STREAM_BATCH_TIMEOUT, AUDIT_LOG_STREAM_TIMEOUT } from "../../audit-log/audit-log-queue";
+import { blockAuditLogStreamInternalIps } from "../audit-log-stream-fns";
 import {
   TLogStreamFactoryBatchStreamLog,
   TLogStreamFactoryGetProviderBatchLimit,
@@ -19,7 +19,7 @@ export const CriblProviderFactory = () => {
   }) => {
     const { url, token } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(url);
+    await blockAuditLogStreamInternalIps(url);
 
     const streamHeaders: RawAxiosRequestHeaders = {
       "Content-Type": "application/json",
@@ -47,7 +47,7 @@ export const CriblProviderFactory = () => {
 
     const { url, token } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(url);
+    await blockAuditLogStreamInternalIps(url);
 
     const streamHeaders: RawAxiosRequestHeaders = {
       "Content-Type": "application/x-ndjson",
@@ -65,7 +65,7 @@ export const CriblProviderFactory = () => {
   const streamLog: TLogStreamFactoryStreamLog<TCriblProviderCredentials> = async ({ credentials, auditLog }) => {
     const { url, token } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(url);
+    await blockAuditLogStreamInternalIps(url);
 
     const streamHeaders: RawAxiosRequestHeaders = {
       "Content-Type": "application/json",

--- a/backend/src/ee/services/audit-log-stream/custom/custom-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/custom/custom-provider-factory.ts
@@ -2,9 +2,9 @@ import { RawAxiosRequestHeaders } from "axios";
 
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
-import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
 import { AUDIT_LOG_STREAM_BATCH_TIMEOUT, AUDIT_LOG_STREAM_TIMEOUT } from "../../audit-log/audit-log-queue";
+import { blockAuditLogStreamInternalIps } from "../audit-log-stream-fns";
 import {
   TLogStreamFactoryBatchStreamLog,
   TLogStreamFactoryGetProviderBatchLimit,
@@ -19,7 +19,7 @@ export const CustomProviderFactory = () => {
   }) => {
     const { url, headers } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(url);
+    await blockAuditLogStreamInternalIps(url);
 
     const streamHeaders: RawAxiosRequestHeaders = { "Content-Type": "application/json" };
     if (headers.length) {
@@ -53,7 +53,7 @@ export const CustomProviderFactory = () => {
 
     const { url, headers } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(url);
+    await blockAuditLogStreamInternalIps(url);
 
     const streamHeaders: RawAxiosRequestHeaders = { "Content-Type": "application/json" };
 
@@ -72,7 +72,7 @@ export const CustomProviderFactory = () => {
   const streamLog: TLogStreamFactoryStreamLog<TCustomProviderCredentials> = async ({ credentials, auditLog }) => {
     const { url, headers } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(url);
+    await blockAuditLogStreamInternalIps(url);
 
     const streamHeaders: RawAxiosRequestHeaders = { "Content-Type": "application/json" };
 

--- a/backend/src/ee/services/audit-log-stream/datadog/datadog-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/datadog/datadog-provider-factory.ts
@@ -3,9 +3,9 @@ import { RawAxiosRequestHeaders } from "axios";
 import { getConfig } from "@app/lib/config/env";
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
-import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
 import { AUDIT_LOG_STREAM_BATCH_TIMEOUT, AUDIT_LOG_STREAM_TIMEOUT } from "../../audit-log/audit-log-queue";
+import { blockAuditLogStreamInternalIps } from "../audit-log-stream-fns";
 import {
   TLogStreamFactoryBatchStreamLog,
   TLogStreamFactoryGetProviderBatchLimit,
@@ -33,7 +33,7 @@ export const DatadogProviderFactory = () => {
   }) => {
     const { url, token } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(url);
+    await blockAuditLogStreamInternalIps(url);
 
     const streamHeaders: RawAxiosRequestHeaders = { "Content-Type": "application/json", "DD-API-KEY": token };
 
@@ -57,7 +57,7 @@ export const DatadogProviderFactory = () => {
 
     const { url, token } = credentials;
 
-    await blockLocalAndPrivateIpAddresses(url);
+    await blockAuditLogStreamInternalIps(url);
 
     const streamHeaders: RawAxiosRequestHeaders = { "Content-Type": "application/json", "DD-API-KEY": token };
 

--- a/backend/src/ee/services/audit-log-stream/splunk/splunk-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/splunk/splunk-provider-factory.ts
@@ -3,9 +3,9 @@ import { RawAxiosRequestHeaders } from "axios";
 import { getConfig } from "@app/lib/config/env";
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
-import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
 import { AUDIT_LOG_STREAM_BATCH_TIMEOUT, AUDIT_LOG_STREAM_TIMEOUT } from "../../audit-log/audit-log-queue";
+import { blockAuditLogStreamInternalIps } from "../audit-log-stream-fns";
 import {
   TLogStreamFactoryBatchStreamLog,
   TLogStreamFactoryGetProviderBatchLimit,
@@ -33,7 +33,7 @@ async function createSplunkUrl(hostname: string) {
     throw new BadRequestError({ message: `Invalid Splunk hostname provided: ${(error as Error).message}` });
   }
 
-  await blockLocalAndPrivateIpAddresses(`https://${parsedHostname}`);
+  await blockAuditLogStreamInternalIps(`https://${parsedHostname}`);
 
   return `https://${parsedHostname}:8088/services/collector/event`;
 }

--- a/backend/src/ee/services/audit-log-stream/sumo-logic/sumo-logic-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/sumo-logic/sumo-logic-provider-factory.ts
@@ -1,5 +1,6 @@
 import { RawAxiosRequestHeaders } from "axios";
 
+import { getConfig } from "@app/lib/config/env";
 import { BadRequestError } from "@app/lib/errors";
 import { safeRequest } from "@app/lib/validator";
 
@@ -30,7 +31,8 @@ export const SumoLogicProviderFactory = () => {
     await safeRequest
       .post(url, JSON.stringify({ ping: "ok" }), {
         headers: buildStreamHeaders(credentials, "application/json"),
-        timeout: AUDIT_LOG_STREAM_TIMEOUT
+        timeout: AUDIT_LOG_STREAM_TIMEOUT,
+        allowPrivateIps: getConfig().AUDIT_LOG_STREAM_ALLOW_INTERNAL_IP
       })
       .catch((err) => {
         throw new BadRequestError({ message: `Failed to connect with Sumo Logic: ${(err as Error)?.message}` });
@@ -51,7 +53,8 @@ export const SumoLogicProviderFactory = () => {
 
     await safeRequest.post(url, body, {
       headers: buildStreamHeaders(credentials, "application/x-ndjson"),
-      timeout: AUDIT_LOG_STREAM_BATCH_TIMEOUT
+      timeout: AUDIT_LOG_STREAM_BATCH_TIMEOUT,
+      allowPrivateIps: getConfig().AUDIT_LOG_STREAM_ALLOW_INTERNAL_IP
     });
   };
 

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -386,6 +386,7 @@ const envSchema = z
     RELAY_AUTH_SECRET: zpStr(z.string().optional()),
 
     DYNAMIC_SECRET_ALLOW_INTERNAL_IP: zodStrBool.default("false"),
+    AUDIT_LOG_STREAM_ALLOW_INTERNAL_IP: zodStrBool.default("false"),
     DYNAMIC_SECRET_AWS_ACCESS_KEY_ID: zpStr(z.string().optional()).default(
       process.env.INF_APP_CONNECTION_AWS_ACCESS_KEY_ID
     ),

--- a/backend/src/lib/validator/validate-url.ts
+++ b/backend/src/lib/validator/validate-url.ts
@@ -10,7 +10,7 @@ import { request } from "@app/lib/config/request";
 import { BadRequestError } from "../errors";
 import { isPrivateIp } from "../ip/ipRange";
 
-export const blockLocalAndPrivateIpAddresses = async (url: string, isGateway = false) => {
+export const blockLocalAndPrivateIpAddresses = async (url: string, isGateway = false, allowInternalIp = false) => {
   const appCfg = getConfig();
 
   if (appCfg.isDevelopmentMode || isGateway) return;
@@ -21,11 +21,13 @@ export const blockLocalAndPrivateIpAddresses = async (url: string, isGateway = f
     throw new BadRequestError({ message: "URLs with user credentials (e.g., user:pass@) are not allowed" });
   }
 
+  const allowInternal = allowInternalIp || appCfg.ALLOW_INTERNAL_IP_CONNECTIONS;
+
   const inputHostIps: string[] = [];
   if (isIP(validUrl.hostname)) {
     inputHostIps.push(validUrl.hostname);
   } else {
-    if (validUrl.hostname === "localhost" || validUrl.hostname === "host.docker.internal") {
+    if (!allowInternal && (validUrl.hostname === "localhost" || validUrl.hostname === "host.docker.internal")) {
       throw new BadRequestError({ message: "Local IPs not allowed as URL" });
     }
     const entries = await dns.lookup(validUrl.hostname, { all: true });
@@ -37,8 +39,7 @@ export const blockLocalAndPrivateIpAddresses = async (url: string, isGateway = f
     inputHostIps.push(...entries.map(({ address }) => address));
   }
   const isInternalIp = inputHostIps.some((el) => isPrivateIp(el));
-  if (isInternalIp && !appCfg.ALLOW_INTERNAL_IP_CONNECTIONS)
-    throw new BadRequestError({ message: "Local IPs not allowed as URL" });
+  if (isInternalIp && !allowInternal) throw new BadRequestError({ message: "Local IPs not allowed as URL" });
 };
 
 type FQDNOptions = {

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -62,6 +62,10 @@ Example values:
 >
   Determines whether App Connections, Dynamic Secrets, and PKI Certificate
   Discovery jobs are permitted to connect with internal/private IP addresses.
+
+  <Warning>
+    Relaxes the SSRF protection. Only enable it if you trust the users who can configure streams.
+  </Warning>
 </ParamField>
 
 <ParamField
@@ -224,6 +228,14 @@ ClickHouse can be used as an alternative audit log storage backend for high-volu
 
 <ParamField query="DISABLE_AUDIT_LOG_GENERATION" type="string" default="false">
   Disable audit log generation entirely. When set to `true`, no audit log events are produced — neither PostgreSQL, ClickHouse, nor audit log streams will receive events.
+</ParamField>
+
+<ParamField query="AUDIT_LOG_STREAM_ALLOW_INTERNAL_IP" type="bool" default="false" optional>
+  Determines whether Audit Log Streams are permitted to connect with internal/private IP addresses.
+
+  <Warning>
+    Relaxes the SSRF protection. Only enable it if you trust the users who can configure streams.
+  </Warning>
 </ParamField>
 
 ### Redis


### PR DESCRIPTION
## Context

This provides self hosted user option to disable internal url protection for audit log stream. This is done for users deploying Infisical in a closed environment and users are all trusted ones.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Create a stream with internal url
2. Test the stream

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)