### PR TITLE
feat(pki-sync): expose certificate sync external identifier in API and UI

### DIFF
--- a/backend/src/server/routes/v1/pki-sync-routers/pki-sync-router.ts
+++ b/backend/src/server/routes/v1/pki-sync-routers/pki-sync-router.ts
@@ -100,6 +100,7 @@ const PkiSyncCertificateSchema = z.object({
   certificateRenewalError: z.string().nullish(),
   pkiSyncName: z.string().optional(),
   pkiSyncDestination: z.string().optional(),
+  externalIdentifier: z.string().nullish(),
   syncMetadata: SyncMetadataSchema
 });
 

--- a/backend/src/services/pki-sync/pki-sync-service.ts
+++ b/backend/src/services/pki-sync/pki-sync-service.ts
@@ -806,6 +806,7 @@ export const pkiSyncServiceFactory = ({
       certificateRenewalError: detail.certificateRenewalError || undefined,
       pkiSyncName: detail.pkiSyncName || undefined,
       pkiSyncDestination: detail.pkiSyncDestination || undefined,
+      externalIdentifier: detail.externalIdentifier || undefined,
       syncMetadata: detail.syncMetadata as TSyncMetadata
     }));
 

--- a/backend/src/services/pki-sync/pki-sync-types.ts
+++ b/backend/src/services/pki-sync/pki-sync-types.ts
@@ -211,6 +211,7 @@ export type TPkiSyncCertificate = {
   certificateRenewalError?: string;
   pkiSyncName?: string;
   pkiSyncDestination?: string;
+  externalIdentifier?: string;
   syncMetadata?: TSyncMetadata;
 };
 

--- a/frontend/src/hooks/api/pkiSyncs/types/common.ts
+++ b/frontend/src/hooks/api/pkiSyncs/types/common.ts
@@ -78,6 +78,7 @@ export type TPkiSyncCertificate = {
   certificateRenewalError?: string;
   pkiSyncName?: string;
   pkiSyncDestination?: string;
+  externalIdentifier?: string | null;
   syncMetadata?: {
     isDefault?: boolean;
     [key: string]: unknown;

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
@@ -32,7 +32,7 @@ import {
   Tooltip,
   Tr
 } from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, CopyButton } from "@app/components/v3";
 import {
   useClearDefaultCertificate,
   useListPkiSyncCertificates,
@@ -198,9 +198,10 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
               <Table>
                 <THead>
                   <Tr>
-                    <Th className="w-2/8">SAN / CN</Th>
-                    <Th className="w-3/16">Certificate Status</Th>
-                    <Th className="w-3/16">Serial Number</Th>
+                    <Th className="w-3/16">SAN / CN</Th>
+                    <Th className="w-1/8">Certificate Status</Th>
+                    <Th className="w-1/8">Serial Number</Th>
+                    <Th className="w-3/16">External ID</Th>
                     <Th className="w-1/8">Sync Status</Th>
                     <Th className="w-1/8">Expires At</Th>
                     <Th className="w-1/8" />
@@ -280,6 +281,26 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
                               return `${serial.substring(0, 4)}...${serial.substring(serial.length - 4)}`;
                             })()}
                           </div>
+                        </Td>
+                        <Td className="max-w-0">
+                          {syncCert.externalIdentifier ? (
+                            <div className="flex items-center gap-1">
+                              <Tooltip
+                                content={syncCert.externalIdentifier}
+                                className="max-w-none whitespace-nowrap"
+                              >
+                                <span className="truncate text-xs text-bunker-300">
+                                  {syncCert.externalIdentifier}
+                                </span>
+                              </Tooltip>
+                              <CopyButton
+                                value={syncCert.externalIdentifier}
+                                ariaLabel="Copy external identifier"
+                              />
+                            </div>
+                          ) : (
+                            <span className="text-xs text-bunker-400">-</span>
+                          )}
                         </Td>
                         <Td>
                           {syncCert.lastSyncMessage &&


### PR DESCRIPTION
## Context

The destination-side identifier of a synced certificate (e.g. the AWS ACM ARN) is already stored in `certificate_syncs.externalIdentifier` but never exposed. Users had to reverse-match certificates in AWS by tag to find the ARN. This surfaces the field in `GET /api/v1/cert-manager/syncs/:syncId/certificates` and adds an External ID column (tooltip + copy button) to the sync details page.

## Steps to verify the change

1. Sync a certificate to AWS Certificate Manager.
2. The sync details page shows the ARN in the External ID column; the API response now includes `externalIdentifier`.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)