### PR TITLE
improvement: adjust secret insights styling

### DIFF
--- a/frontend/src/pages/secret-manager/InsightsPage/components/AuditReportsCard.tsx
+++ b/frontend/src/pages/secret-manager/InsightsPage/components/AuditReportsCard.tsx
@@ -170,11 +170,11 @@ export const AuditReportsCard = () => {
             <Table containerClassName="overflow-x-hidden" className="table-fixed">
               <TableHeader>
                 <TableRow>
-                  <TableHead className="h-10 w-[30%]">REPORTS</TableHead>
-                  <TableHead className="h-10 w-[28%]">RECIPIENTS</TableHead>
-                  <TableHead className="h-10 w-[14%]">STATUS</TableHead>
-                  <TableHead className="h-10">REQUESTED</TableHead>
-                  <TableHead className="h-10 w-12" />
+                  <TableHead className="w-[30%]">Reports</TableHead>
+                  <TableHead className="w-[28%]">Recipients</TableHead>
+                  <TableHead className="w-[14%]">Status</TableHead>
+                  <TableHead>Requested</TableHead>
+                  <TableHead className="w-12" />
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -210,9 +210,7 @@ export const AuditReportsCard = () => {
                     </TableCell>
                     <TableCell isTruncatable className="max-w-0">
                       {report.emailRecipients.length <= 1 ? (
-                        <span className="block truncate text-muted">
-                          {report.emailRecipients[0] ?? ""}
-                        </span>
+                        <span className="block truncate">{report.emailRecipients[0] ?? ""}</span>
                       ) : (
                         <TooltipProvider>
                           <Tooltip>
@@ -237,9 +235,7 @@ export const AuditReportsCard = () => {
                       <ReportStatusBadge report={report} />
                     </TableCell>
                     <TableCell>
-                      <span className="text-muted">
-                        {formatRelative(new Date(report.createdAt), new Date())}
-                      </span>
+                      <span>{formatRelative(new Date(report.createdAt), new Date())}</span>
                     </TableCell>
                     <TableCell className="pr-5">
                       <ProjectPermissionCan

--- a/frontend/src/pages/secret-manager/InsightsPage/components/DuplicatedSecretsCard.tsx
+++ b/frontend/src/pages/secret-manager/InsightsPage/components/DuplicatedSecretsCard.tsx
@@ -5,7 +5,7 @@ import {
   AlertTriangleIcon,
   ArrowRightIcon,
   FolderIcon,
-  KeyRoundIcon,
+  KeyIcon,
   LayersIcon,
   Loader2Icon,
   LockIcon
@@ -232,23 +232,23 @@ export const DuplicatedSecretsCard = () => {
                         containerClassName="rounded-t-none overflow-x-hidden"
                         className="table-fixed"
                       >
-                        <TableHeader className="bg-mineshaft-800">
+                        <TableHeader>
                           <TableRow>
-                            <TableHead className="h-10 w-[35%]">SECRET KEY</TableHead>
-                            <TableHead className="h-10 w-[25%]">ENVIRONMENT</TableHead>
-                            <TableHead className="h-10">PATH</TableHead>
-                            <TableHead className="h-10 w-12" />
+                            <TableHead className="w-[35%]">Secret Key</TableHead>
+                            <TableHead className="w-[25%]">Environment</TableHead>
+                            <TableHead>Path</TableHead>
+                            <TableHead className="w-12" />
                           </TableRow>
                         </TableHeader>
                         <TableBody>
                           {group.secrets.map((entry, idx) => (
                             <TableRow
                               key={`${entry.key}-${entry.environment.slug}-${entry.secretPath}-${String(idx)}`}
-                              className="group/row bg-mineshaft-900"
+                              className="group/row"
                             >
                               <TableCell isTruncatable className="max-w-60">
                                 <div className="flex items-center gap-2">
-                                  <KeyRoundIcon className="size-4 shrink-0 text-muted" />
+                                  <KeyIcon className="size-4 shrink-0 text-muted" />
                                   <span className="truncate font-mono">{entry.key}</span>
                                 </div>
                               </TableCell>
@@ -258,8 +258,8 @@ export const DuplicatedSecretsCard = () => {
                                 </Badge>
                               </TableCell>
                               <TableCell>
-                                <div className="flex items-center gap-2 text-muted">
-                                  <FolderIcon className="size-3.5 shrink-0" />
+                                <div className="flex items-center gap-2">
+                                  <FolderIcon className="size-3.5 shrink-0 text-folder" />
                                   <span className="truncate">{entry.secretPath}</span>
                                 </div>
                               </TableCell>


### PR DESCRIPTION
## Context

Minor UI adjustments to secret access insights

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-07-02 at 11 27 15@2x" src="https://github.com/user-attachments/assets/0847b918-2d7a-488e-aad2-7734b87d41c4" />

## Steps to verify the change

- look

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)