### PR TITLE
fix(docker): use numeric UID for non-root user in standalone images

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -50,7 +50,7 @@ RUN groupadd -r -g 1001 nodejs && useradd -r -u 1001 -g nodejs non-root-user
 
 COPY --from=frontend-builder --chown=non-root-user:nodejs /app/dist ./
 
-USER non-root-user
+USER 1001
 
 ##
 ## BACKEND
@@ -189,7 +189,7 @@ RUN apt-get update && apt-get install -y \
     libgnutls30t64=3.8.9-3+deb13u4 \
     libc6=2.41-12+deb13u3 \
     libc-bin=2.41-12+deb13u3 \
-    libssl3t64=3.5.6-1~deb13u1 \
+    libssl3t64=3.5.6-1~deb13u2 \
     dpkg=1.22.22 \
     libcap2 \
     libnghttp2-14=1.64.0-1.1+deb13u1 \
@@ -297,6 +297,7 @@ RUN grep -v 'import "./lib/telemetry/instrumentation.mjs";' dist/main.mjs > dist
 RUN ln -sf /usr/local/lib64/ossl-modules /usr/local/lib/ossl-modules || \
     ln -sf /usr/local/lib/ossl-modules /usr/local/lib64/ossl-modules
 
-USER non-root-user
+# Use numeric UID so Kubernetes can verify the image runs as non-root.
+USER 1001
 
 CMD ["./standalone-entrypoint.sh"]

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -52,7 +52,7 @@ RUN useradd --system --uid 1001 --gid nodejs non-root-user
 
 COPY --from=frontend-builder --chown=non-root-user:nodejs /app/dist ./
 
-USER non-root-user
+USER 1001
 
 ##
 ## BACKEND
@@ -196,7 +196,7 @@ RUN apt-get update && apt-get install -y \
     libgnutls30t64=3.8.9-3+deb13u4 \
     libc6=2.41-12+deb13u3 \
     libc-bin=2.41-12+deb13u3 \
-    libssl3t64=3.5.6-1~deb13u1 \
+    libssl3t64=3.5.6-1~deb13u2 \
     dpkg=1.22.22 \
     libcap2 \
     libnghttp2-14=1.64.0-1.1+deb13u1 \
@@ -298,6 +298,7 @@ ENV TELEMETRY_ENABLED true
 EXPOSE 8080
 EXPOSE 443
 
-USER non-root-user
+# Use numeric UID so Kubernetes can verify the image runs as non-root
+USER 1001
 
 CMD ["./standalone-entrypoint.sh"]


### PR DESCRIPTION
## Context

Standalone Docker images used `USER non-root-user` (username). Kubernetes security policies often require a numeric UID to verify the container runs as non-root; a username alone may not satisfy that check.

This PR switches both standalone Dockerfiles to `USER 1001` (matching the existing `non-root-user` UID) and bumps `libssl3t64` from `3.5.6-1~deb13u1` to `3.5.6-1~deb13u2`.

## Steps to verify the change

- [ ] Build `Dockerfile.standalone-infisical` and confirm the final stage runs as UID 1001 (`docker inspect --format='{{.Config.User}}'`)
- [ ] Build `Dockerfile.fips.standalone-infisical` and confirm the same
- [ ] Deploy to a cluster with a `runAsNonRoot` / numeric UID policy and confirm the pod starts successfully
- [ ] Smoke-test the standalone container (API + UI)

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)