### PR TITLE
fix(server): accept empty-body POST requests with no Content-Type header

### DIFF
--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -105,6 +105,22 @@ export const main = async ({
     }
   });
 
+  // Some clients (browsers, some SDKs) send POST requests with no body and no Content-Type header.
+  // Fastify's default parser lookup rejects these with FST_ERR_CTP_INVALID_MEDIA_TYPE (415), which
+  // then surfaces as a 500 through the error handler. This breaks endpoints that intentionally take
+  // no body — e.g. POST /me/webauthn/register, POST /auth/token, POST /auth/logout.
+  // A wildcard parser gracefully accepts an empty payload and leaves any non-empty body to the
+  // route-specific validator, which will reject it if the endpoint actually expected a body.
+  server.addContentTypeParser("*", { parseAs: "string" }, (req, body: string | Buffer, done) => {
+    const strBody = body instanceof Buffer ? body.toString() : body;
+    if (!strBody) {
+      done(null, undefined);
+      return;
+    }
+    const contentType = req.headers["content-type"] ?? "unknown";
+    done(new Error(`Unsupported Media Type: ${contentType}`), undefined);
+  });
+
   try {
     await server.register<FastifyCookieOptions>(cookie, {
       secret: appCfg.COOKIE_SECRET_SIGN_KEY

--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -118,7 +118,15 @@ export const main = async ({
       return;
     }
     const contentType = req.headers["content-type"] ?? "unknown";
-    done(new Error(`Unsupported Media Type: ${contentType}`), undefined);
+    // Attach Fastify's own 415 metadata so the global error handler returns the proper Unsupported
+    // Media Type response for non-empty bodies with an unmatched Content-Type, rather than a 500.
+    const err = new Error(`Unsupported Media Type: ${contentType}`) as Error & {
+      statusCode: number;
+      code: string;
+    };
+    err.statusCode = 415;
+    err.code = "FST_ERR_CTP_INVALID_MEDIA_TYPE";
+    done(err, undefined);
   });
 
   try {


### PR DESCRIPTION
Fixes #7122.

## What

Fastify's default content-type parser lookup rejects any request whose content-type doesn't match a registered parser with \`FST_ERR_CTP_INVALID_MEDIA_TYPE\` (415). That includes bodyless POSTs where the client (correctly per HTTP) sends **no Content-Type header at all** — the browser Fetch API does exactly this when \`fetch(url, { method: 'POST' })\` is called with no body. The 415 then surfaces to the client as a 500 through the global error handler.

The bug blocks \`POST /me/webauthn/register\` entirely (adding a passkey is impossible on affected instances) and intermittently blocks \`POST /auth/token\` and \`POST /auth/logout\`.

## Fix

Adds a wildcard content-type parser in \`app.ts\` that:

- **Accepts an empty payload** by returning \`undefined\`. Route-specific Zod body schemas will resolve to \`undefined\` for endpoints that don't declare a required body (the WebAuthn register route has no body schema, so this is exactly what it expects).
- **Rejects non-empty bodies** with an explicit \`Unsupported Media Type\` error, so anything that shows up with an unrecognized content-type and actual data still fails cleanly instead of silently being accepted.

The wildcard sits after the specific parsers (\`application/json\`, \`application/scim+json\`, \`application/jose+json\`, etc.), so those still run first for content types they match — only truly-unmatched requests fall through here.

Route-specific validators still enforce body presence on endpoints that actually need one; this doesn't relax validation anywhere.

## Repro

Per the issue: log in, go to Personal Settings → Authentication → Add Passkey, click Add. Backend log shows \`FST_ERR_CTP_INVALID_MEDIA_TYPE\` on \`POST /api/v1/user/me/webauthn/register\`; UI shows a 500 and passkey registration is impossible. With this fix the endpoint returns the WebAuthn challenge as expected.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (server-plugin change; behaviour verified by re-running the WebAuthn registration flow per the issue repro)
- [x] The change is limited to the affected code path