### PR TITLE
fix(docker): allow-downgrades on pinned CVE-patch layer so clean builds don't fail

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -184,8 +184,10 @@ RUN apt-get update && apt-get install -y \
     openssh-client \
     && curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
     && apt-get update && apt-get install -y infisical=0.43.90 \
-    # Patch CVEs in base image packages (pinned versions for reproducibility)
-    && apt-get install -y --only-upgrade \
+    # Patch CVEs in base image packages (pinned versions for reproducibility).
+    # --allow-downgrades is required because some pins are older than what the base image now ships
+    # (e.g. libssl3t64) and we want the pinned CVE-patched version rather than whatever floats in.
+    && apt-get install -y --only-upgrade --allow-downgrades \
     libgnutls30t64=3.8.9-3+deb13u4 \
     libc6=2.41-12+deb13u3 \
     libc-bin=2.41-12+deb13u3 \

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -191,8 +191,10 @@ RUN apt-get update && apt-get install -y \
     smbclient \
     && curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | bash \
     && apt-get update && apt-get install -y infisical=0.43.90 \
-    # Patch CVEs in base image packages (pinned versions for reproducibility)
-    && apt-get install -y --only-upgrade \
+    # Patch CVEs in base image packages (pinned versions for reproducibility).
+    # --allow-downgrades is required because some pins are older than what the base image now ships
+    # (e.g. libssl3t64) and we want the pinned CVE-patched version rather than whatever floats in.
+    && apt-get install -y --only-upgrade --allow-downgrades \
     libgnutls30t64=3.8.9-3+deb13u4 \
     libc6=2.41-12+deb13u3 \
     libc-bin=2.41-12+deb13u3 \


### PR DESCRIPTION
Fixes #7134.

## What

Clean \`docker build\` on both \`Dockerfile.standalone-infisical\` and \`Dockerfile.fips.standalone-infisical\` currently fails at the CVE-pin layer with:

\`\`\`
The following packages will be DOWNGRADED:
  libssl3t64
1 upgraded, 0 newly installed, 1 downgraded, 1 to remove and 8 not upgraded.
E: Packages were downgraded and -y was used without --allow-downgrades.
\`\`\`

The Debian base image picked up a newer \`libssl3t64\` than the one we pin for CVE reproducibility. \`apt-get install -y --only-upgrade\` treats the pinned version as a downgrade and refuses without an explicit flag.

## Fix

Adds \`--allow-downgrades\` to the CVE-pin \`apt-get install\` in both Dockerfiles. Reproducibility of the exact CVE-patched versions is the intent of the pin, so honoring the pin (even when it means going below what the base image ships) is the correct behavior — the flag just makes that explicit to apt.

A short in-file comment explains why the flag is there so a future pin bump doesn't accidentally remove it.

## Repro / verify

Per the issue:

\`\`\`
docker build -t test -f Dockerfile.standalone-infisical --no-cache --pull .
docker build -t test -f Dockerfile.fips.standalone-infisical --no-cache --pull .
\`\`\`

Both should succeed after this change.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (Dockerfile change; verified locally by running the two docker build commands from the issue)
- [x] The change is limited to the affected code path