### PR TITLE
feat(helm): add configurable securityContext for restricted PSA

### DIFF
--- a/helm-charts/infisical-standalone-postgres/CHANGELOG.md
+++ b/helm-charts/infisical-standalone-postgres/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## 1.10.0 (July 3, 2026)
 Changes:
-* Added configurable `securityContext` for the Infisical app pod and container via `infisical.podSecurityContext` and `infisical.containerSecurityContext`. This allows the chart to run under the Kubernetes Pod Security "restricted" standard without external mutation.
-* The same `infisical.podSecurityContext` / `infisical.containerSecurityContext` values are also applied to the auto-bootstrap Job (`infisical.autoBootstrap.enabled`) and its init container, so a full install (including auto-bootstrap) is admitted in a `restricted`-enforced namespace.
-* Both keys ship with hardened, secure-by-default values that match the image's non-root `USER 1001`: pod defaults set `runAsNonRoot: true`, `runAsUser: 1001`, `fsGroup: 1001`, `seccompProfile.type: RuntimeDefault`; container defaults set `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`, `runAsNonRoot: true`, `runAsUser: 1001`.
-* `containerSecurityContext.readOnlyRootFilesystem` is kept `false` by default because the Node.js app writes temporary files. To enable it, mount `emptyDir` volumes for the app's writable paths (e.g. `/tmp`) via `infisical.extraVolumes` / `infisical.extraVolumeMounts`.
-* This change is backwards compatible, but the pod-spec change triggers a one-time rollout on upgrade. Set either key to `null` to render a pod spec without that security context block.
+* Added configurable `securityContext` via `infisical.podSecurityContext` and `infisical.containerSecurityContext`, with secure defaults so the Infisical Deployment and the auto-bootstrap Job run under the Kubernetes Pod Security "restricted" standard out of the box.
+* All hardening required by `restricted` lives in `containerSecurityContext`, so it applies only to Infisical's own containers. `podSecurityContext` sets just `fsGroup: 1001`, so your `extraContainers` and `extraInitContainers` keep their original user and are not forced to UID 1001.
+* `readOnlyRootFilesystem` stays `false` by default since the app writes temporary files. To enable it, mount `emptyDir` volumes for writable paths like `/tmp` via `infisical.extraVolumes` and `infisical.extraVolumeMounts`.
+* The bundled `ingress-nginx` subchart is not `restricted`-compliant by default. To run the whole release under `restricted`, disable it, move it to another namespace, or add your own restricted-safe controller overrides.
+* Backwards compatible. Upgrading triggers a one-time pod rollout. Set either key to `null` to omit its security context block.
 
 ## 1.9.0 (May 28, 2026)
 Changes:

--- a/helm-charts/infisical-standalone-postgres/CHANGELOG.md
+++ b/helm-charts/infisical-standalone-postgres/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.10.0 (July 3, 2026)
+Changes:
+* Added configurable `securityContext` for the Infisical app pod and container via `infisical.podSecurityContext` and `infisical.containerSecurityContext`. This allows the chart to run under the Kubernetes Pod Security "restricted" standard without external mutation.
+* The same `infisical.podSecurityContext` / `infisical.containerSecurityContext` values are also applied to the auto-bootstrap Job (`infisical.autoBootstrap.enabled`) and its init container, so a full install (including auto-bootstrap) is admitted in a `restricted`-enforced namespace.
+* Both keys ship with hardened, secure-by-default values that match the image's non-root `USER 1001`: pod defaults set `runAsNonRoot: true`, `runAsUser: 1001`, `fsGroup: 1001`, `seccompProfile.type: RuntimeDefault`; container defaults set `allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`, `runAsNonRoot: true`, `runAsUser: 1001`.
+* `containerSecurityContext.readOnlyRootFilesystem` is kept `false` by default because the Node.js app writes temporary files. To enable it, mount `emptyDir` volumes for the app's writable paths (e.g. `/tmp`) via `infisical.extraVolumes` / `infisical.extraVolumeMounts`.
+* This change is backwards compatible, but the pod-spec change triggers a one-time rollout on upgrade. Set either key to `null` to render a pod spec without that security context block.
+
 ## 1.9.0 (May 28, 2026)
 Changes:
 * Added support for sidecar containers via `infisical.extraContainers`, enabling use cases like HSM PKCS#11 client sidecars (e.g., Entrust nShield).

--- a/helm-charts/infisical-standalone-postgres/Chart.yaml
+++ b/helm-charts/infisical-standalone-postgres/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.0
+version: 1.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -1,6 +1,6 @@
 # infisical-standalone
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 A helm chart to deploy Infisical
 

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -18,6 +18,7 @@ A helm chart to deploy Infisical
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` | Overrides the full name of the release, affecting resource names |
 | infisical.affinity | object | `{}` | Node affinity settings for pod placement |
+| infisical.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Container-level security context applied to the Infisical container. Secure by default. `readOnlyRootFilesystem` is kept `false` because the Node.js app writes temporary files; to enable it, mount `emptyDir` volumes for the app's writable paths via `infisical.extraVolumes` / `infisical.extraVolumeMounts`. Set to `null` to omit the block. |
 | infisical.databaseSchemaMigrationJob.image.pullPolicy | string | `"IfNotPresent"` | Pulls image only if not present on the node |
 | infisical.databaseSchemaMigrationJob.image.repository | string | `"ghcr.io/groundnuty/k8s-wait-for"` | Image repository for migration wait job |
 | infisical.databaseSchemaMigrationJob.image.tag | string | `"no-root-v2.0"` | Image tag version |
@@ -36,6 +37,7 @@ A helm chart to deploy Infisical
 | infisical.kubeSecretRef | string | `"infisical-secrets"` | Kubernetes Secret reference containing Infisical root credentials |
 | infisical.name | string | `"infisical"` |  |
 | infisical.podAnnotations | object | `{}` | Custom annotations for Infisical pods |
+| infisical.podSecurityContext | object | `{"fsGroup":1001,"runAsNonRoot":true,"runAsUser":1001,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level security context applied to the Infisical pod. Secure by default; matches the image's non-root `USER 1001`. Set to `null` to omit the block. |
 | infisical.replicaCount | int | `2` | Number of pod replicas for high availability |
 | infisical.resources.limits.memory | string | `"600Mi"` | Memory limit for Infisical container |
 | infisical.resources.requests.cpu | string | `"350m"` | CPU request for Infisical container |

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -18,7 +18,7 @@ A helm chart to deploy Infisical
 |-----|------|---------|-------------|
 | fullnameOverride | string | `""` | Overrides the full name of the release, affecting resource names |
 | infisical.affinity | object | `{}` | Node affinity settings for pod placement |
-| infisical.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001}` | Container-level security context applied to the Infisical container. Secure by default. `readOnlyRootFilesystem` is kept `false` because the Node.js app writes temporary files; to enable it, mount `emptyDir` volumes for the app's writable paths via `infisical.extraVolumes` / `infisical.extraVolumeMounts`. Set to `null` to omit the block. |
+| infisical.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":false,"runAsNonRoot":true,"runAsUser":1001,"seccompProfile":{"type":"RuntimeDefault"}}` | Container-level security context for Infisical's containers, including the bootstrap Job. Secure by default and compliant with the Pod Security "restricted" standard on its own. `readOnlyRootFilesystem` stays `false` because the app writes temporary files; to enable it, mount `emptyDir` volumes for writable paths like `/tmp` via `infisical.extraVolumes` and `infisical.extraVolumeMounts`. Set to `null` to omit. |
 | infisical.databaseSchemaMigrationJob.image.pullPolicy | string | `"IfNotPresent"` | Pulls image only if not present on the node |
 | infisical.databaseSchemaMigrationJob.image.repository | string | `"ghcr.io/groundnuty/k8s-wait-for"` | Image repository for migration wait job |
 | infisical.databaseSchemaMigrationJob.image.tag | string | `"no-root-v2.0"` | Image tag version |
@@ -37,7 +37,7 @@ A helm chart to deploy Infisical
 | infisical.kubeSecretRef | string | `"infisical-secrets"` | Kubernetes Secret reference containing Infisical root credentials |
 | infisical.name | string | `"infisical"` |  |
 | infisical.podAnnotations | object | `{}` | Custom annotations for Infisical pods |
-| infisical.podSecurityContext | object | `{"fsGroup":1001,"runAsNonRoot":true,"runAsUser":1001,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level security context applied to the Infisical pod. Secure by default; matches the image's non-root `USER 1001`. Set to `null` to omit the block. |
+| infisical.podSecurityContext | object | `{"fsGroup":1001}` | Pod-level security context for the Infisical pod. Sets only `fsGroup` so mounted volumes are writable by the non-root user. Other hardening lives in `containerSecurityContext`, so `extraContainers` and `extraInitContainers` keep their original user. Set to `null` to omit. |
 | infisical.replicaCount | int | `2` | Number of pod replicas for high availability |
 | infisical.resources.limits.memory | string | `"600Mi"` | Memory limit for Infisical container |
 | infisical.resources.requests.cpu | string | `"350m"` | CPU request for Infisical container |

--- a/helm-charts/infisical-standalone-postgres/templates/bootstrap-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/bootstrap-job.yaml
@@ -21,6 +21,9 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       serviceAccountName: {{ include "infisical.serviceAccountName" . }}
+    {{- with $infisicalValues.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- if $infisicalValues.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml $infisicalValues.image.imagePullSecrets | nindent 6 }}
@@ -29,6 +32,9 @@ spec:
       initContainers:
       - name: wait-for-infisical
         image: curlimages/curl:8.14.1
+        {{- with $infisicalValues.containerSecurityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         command: ['sh', '-c']
         args:
         - |
@@ -42,6 +48,9 @@ spec:
         - name: infisical-bootstrap
           image: "infisical/cli:{{ $infisicalValues.autoBootstrap.image.tag }}"
           imagePullPolicy: {{ $infisicalValues.image.pullPolicy | default "IfNotPresent" }}
+          {{- with $infisicalValues.containerSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - bootstrap
             - --domain=http://{{ include "infisical.fullname" . }}:8080

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -26,6 +26,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ include "infisical.serviceAccountName" . }}
+    {{- with $infisicalValues.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with $infisicalValues.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
@@ -54,6 +57,9 @@ spec:
       - name: {{ template "infisical.name" . }}-{{ $infisicalValues.name }}
         image: "{{ $infisicalValues.image.repository }}:{{ $infisicalValues.image.tag }}"
         imagePullPolicy: {{ $infisicalValues.image.pullPolicy }}
+        {{- with $infisicalValues.containerSecurityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /api/status

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -99,24 +99,24 @@ infisical:
   # --     value: /etc/ssl/certs/ca-certificates.crt
   extraEnv: []
 
-  # -- Pod-level security context applied to the Infisical pod. Secure by default.
-  # -- The Infisical image runs as non-root UID 1001 (see Dockerfile `USER 1001`).
+  # -- Pod-level security context for the Infisical pod. Sets only `fsGroup` so mounted volumes
+  # -- are writable by the non-root user. Other hardening lives in `containerSecurityContext`,
+  # -- so `extraContainers` and `extraInitContainers` keep their original user. Set to `null` to omit.
   podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 1001
     fsGroup: 1001
-    seccompProfile:
-      type: RuntimeDefault
 
-  # -- Container-level security context applied to the Infisical container. Secure by default.
-  # -- `readOnlyRootFilesystem` is kept false because the Node.js app writes temporary files.
-  # -- To enable it, mount emptyDir volumes for the app's writable paths (e.g. /tmp) via
-  # -- `infisical.extraVolumes` / `infisical.extraVolumeMounts`.
+  # -- Container-level security context for Infisical's containers, including the bootstrap Job.
+  # -- Secure by default and compliant with the Pod Security "restricted" standard on its own.
+  # -- `readOnlyRootFilesystem` stays false because the app writes temporary files; to enable it,
+  # -- mount emptyDir volumes for writable paths like /tmp via `infisical.extraVolumes` and
+  # -- `infisical.extraVolumeMounts`. Set to `null` to omit.
   containerSecurityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: false
     runAsNonRoot: true
     runAsUser: 1001
+    seccompProfile:
+      type: RuntimeDefault
     capabilities:
       drop: ["ALL"]
 

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -99,6 +99,27 @@ infisical:
   # --     value: /etc/ssl/certs/ca-certificates.crt
   extraEnv: []
 
+  # -- Pod-level security context applied to the Infisical pod. Secure by default.
+  # -- The Infisical image runs as non-root UID 1001 (see Dockerfile `USER 1001`).
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1001
+    fsGroup: 1001
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- Container-level security context applied to the Infisical container. Secure by default.
+  # -- `readOnlyRootFilesystem` is kept false because the Node.js app writes temporary files.
+  # -- To enable it, mount emptyDir volumes for the app's writable paths (e.g. /tmp) via
+  # -- `infisical.extraVolumes` / `infisical.extraVolumeMounts`.
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 1001
+    capabilities:
+      drop: ["ALL"]
+
   resources:
     limits:
       # -- Memory limit for Infisical container


### PR DESCRIPTION
## Context

The `infisical-standalone-postgres` chart did not set pod/container `securityContext`, so operators in `restricted` Pod Security namespaces had to patch manifests externally. This adds configurable `infisical.podSecurityContext` and `infisical.containerSecurityContext` with secure defaults aligned to the image's non-root `USER 1001`, applied to the Infisical Deployment and the auto-bootstrap Job (including its init container). Set either key to `null` to omit the block. Backwards compatible, but upgrades trigger a one-time pod rollout.

Chart version bumped to `1.10.0`.

## Steps to verify the change

- [ ] `helm lint helm-charts/infisical-standalone-postgres`
- [ ] `helm template` with default values — Deployment has pod + container `securityContext`
- [ ] `helm template` with `infisical.autoBootstrap.enabled=true` — bootstrap Job has the same contexts on pod, init container, and main container
- [ ] `helm template` with both SC keys set to `null` — bootstrap Job matches pre-change output
- [ ] Deploy into a namespace with `pod-security.kubernetes.io/enforce=restricted` — pods admitted and reach Ready
- [ ] Confirm app runs as uid/gid 1001; `/tmp` writable with default `readOnlyRootFilesystem: false`

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)