### PR TITLE
fix(secret-folder-version): skip soft-deleted projects in PIT prune query

### DIFF
--- a/backend/src/services/secret-folder/secret-folder-version-dal.ts
+++ b/backend/src/services/secret-folder/secret-folder-version-dal.ts
@@ -87,6 +87,7 @@ export const secretFolderVersionDALFactory = (db: TDbClient) => {
         // Projects with version >= 3 will require to have all folder versions for PIT
         .andWhere(`${TableName.Project}.version`, "<", 3)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .delete();
     } catch (error) {
       throw new DatabaseError({


### PR DESCRIPTION
## What

The folder-version PIT prune query joins \`projects\` (to read \`pitVersionLimit\` and \`project.version\`) but only filters \`Environment.deleteAfter\`, never \`Project.deleteAfter\`. Soft-deleting a project does not soft-delete its environments, so the prune cron keeps trimming folder-version history against projects sitting in the delete grace window.

The impact is wasted DB work at best (running DELETEs against rows the cleanup worker is about to hard-delete anyway), and racing with the cleanup worker at worst.

## Fix

Adds \`whereNull(Project.deleteAfter)\` to the prune query. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), app-connection (#7125), and secret-approval-request-secret (#7126) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path