### PR TITLE
fix(offline-usage-report): skip soft-deleted projects in per-project metric queries

### DIFF
--- a/backend/src/services/offline-usage-report/offline-usage-report-dal.ts
+++ b/backend/src/services/offline-usage-report/offline-usage-report-dal.ts
@@ -111,7 +111,9 @@ export const offlineUsageReportDALFactory = (db: TDbClient) => {
       .leftJoin(`${TableName.Environment} as e`, function joinActiveEnvForFolder() {
         this.on("sf.envId", "e.id").andOnNull("e.deleteAfter");
       })
-      .leftJoin(`${TableName.Project} as p`, "e.projectId", "p.id")
+      .leftJoin(`${TableName.Project} as p`, function joinActiveProjectForFolder() {
+        this.on("e.projectId", "p.id").andOnNull("p.deleteAfter");
+      })
       .where("p.type", ProjectType.SecretManager)
       .groupBy("p.id")
       .whereNotNull("p.id")) as Array<{ projectId: string; count: string }>;
@@ -148,7 +150,9 @@ export const offlineUsageReportDALFactory = (db: TDbClient) => {
       .leftJoin(`${TableName.Environment} as e`, function joinActiveEnvForFolder() {
         this.on("sf.envId", "e.id").andOnNull("e.deleteAfter");
       })
-      .leftJoin(`${TableName.Project} as p`, "e.projectId", "p.id")
+      .leftJoin(`${TableName.Project} as p`, function joinActiveProjectForFolder() {
+        this.on("e.projectId", "p.id").andOnNull("p.deleteAfter");
+      })
       .where("p.type", ProjectType.SecretManager)
       .groupBy("p.id", "p.name")
       .whereNotNull("p.id")) as Array<{ projectId: string; projectName: string; secretCount: string }>;

--- a/backend/src/services/offline-usage-report/offline-usage-report-dal.ts
+++ b/backend/src/services/offline-usage-report/offline-usage-report-dal.ts
@@ -86,6 +86,7 @@ export const offlineUsageReportDALFactory = (db: TDbClient) => {
     // Get total projects and projects by type
     const projectMetrics = (await db
       .from(TableName.Project)
+      .whereNull(`${TableName.Project}.deleteAfter`)
       .select("type")
       .count("* as count")
       .groupBy("type")) as Array<{ type: string; count: string }>;
@@ -134,10 +135,17 @@ export const offlineUsageReportDALFactory = (db: TDbClient) => {
   };
 
   const getSecretMetrics = async () => {
-    // Get total secrets
-    const totalSecretsResult = (await db.from(TableName.SecretV2).count("* as count").first()) as
-      | { count: string }
-      | undefined;
+    // Get total secrets, excluding secrets whose environment or project has been soft-deleted so
+    // this aggregate stays consistent with the per-project breakdown below.
+    const totalSecretsResult = (await db
+      .from(`${TableName.SecretV2} as s`)
+      .count("s.id as count")
+      .join(`${TableName.SecretFolder} as sf`, "s.folderId", "sf.id")
+      .join(`${TableName.Environment} as e`, "sf.envId", "e.id")
+      .join(`${TableName.Project} as p`, "e.projectId", "p.id")
+      .whereNull("e.deleteAfter")
+      .whereNull("p.deleteAfter")
+      .first()) as { count: string } | undefined;
 
     const totalSecrets = parseInt(totalSecretsResult?.count || "0", 10);
 


### PR DESCRIPTION
## What

The offline-usage-report DAL builds two per-project metric queries (\`getProjectMetrics\` / \`getSecretMetrics\`) that leftJoin projects for aggregation but never filter \`Project.deleteAfter\`. Soft-deleting a project does not soft-delete its environments, so the offline usage report bundled by self-hosted operators keeps counting secrets against projects sitting in the delete grace window.

## Fix

Adds \`andOnNull("p.deleteAfter")\` to each Project leftJoin so a soft-deleted project's rows have \`p\` columns nulled out; the subsequent \`whereNotNull("p.id")\` already in the query then drops them from the aggregation. Mirrors the existing env-side \`andOnNull\` pattern used in the same file.

Same behavior as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), app-connection (#7125), secret-approval-request-secret (#7126), secret-folder-version (#7155), and secret-version (#7156) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path