### PR TITLE
docs(github): clarify self-hosted shared app setup

### DIFF
--- a/docs/integrations/app-connections/github.mdx
+++ b/docs/integrations/app-connections/github.mdx
@@ -66,11 +66,7 @@ Infisical supports three methods for connecting to GitHub.
                     - **App ID**: The App ID of your GitHub application
                     - **Private Key**: The Private Key of your GitHub application
 
-                    This creates the shared **Instance** GitHub App option that appears in project and organization app connections.
-
                     **Option 2: Environment Variables**
-
-                    This option also configures the same shared **Instance** GitHub App. Use it when you manage Infisical configuration via environment variables instead of the server admin panel.
 
                     Alternatively, you can add the new environment variables for the credentials of your GitHub application:
 
@@ -85,7 +81,7 @@ Infisical supports three methods for connecting to GitHub.
                         If your shared GitHub App is registered on a GitHub Enterprise Server instance, you must set `INF_APP_CONNECTION_GITHUB_APP_HOST` to that instance's hostname. Without it, the OAuth exchange will be directed to `github.com` instead of your GHES host.
                     </Note>
 
-                    Once configured, you can use the GitHub integration via app authentication. If you configured the credentials using environment variables, restart your Infisical instance for the changes to take effect. If you configured them through the server admin panel, allow approximately 5 minutes for the changes to propagate before the shared **Instance** option appears in the App Connections flow.
+                    Once configured, you can use the GitHub integration via app authentication. The server admin panel and environment-variable paths both configure the shared **Instance** GitHub App option shown in project and organization app connections. If you configured the credentials using environment variables, restart your Infisical instance for the changes to take effect. If you configured them through the server admin panel, allow approximately 5 minutes for the changes to propagate before the shared **Instance** option appears in the App Connections flow.
                 </Step>
             </Steps>
         </Accordion>
@@ -105,7 +101,7 @@ Infisical supports three methods for connecting to GitHub.
                 Select the **GitHub App** method.
 
                 Choose which GitHub App to use for the connection:
-                - **Instance** — the instance-default GitHub App configured by your Infisical server admin. If you followed the self-hosted setup above via the server admin panel, this is usually the option you want.
+                - **Instance** — the instance-default GitHub App configured by your Infisical server admin. If you followed the self-hosted setup above via the server admin panel or environment variables, this is usually the option you want.
                 - **Private** — a GitHub App registered under your organization. Select an existing one from the list, or click the gear to manage your private apps.
 
                 <Note>

--- a/docs/integrations/app-connections/github.mdx
+++ b/docs/integrations/app-connections/github.mdx
@@ -70,6 +70,8 @@ Infisical supports three methods for connecting to GitHub.
 
                     **Option 2: Environment Variables**
 
+                    This option also configures the same shared **Instance** GitHub App. Use it when you manage Infisical configuration via environment variables instead of the server admin panel.
+
                     Alternatively, you can add the new environment variables for the credentials of your GitHub application:
 
                     - `INF_APP_CONNECTION_GITHUB_APP_CLIENT_ID`: The **Client ID** of your GitHub application.

--- a/docs/integrations/app-connections/github.mdx
+++ b/docs/integrations/app-connections/github.mdx
@@ -55,7 +55,7 @@ Infisical supports three methods for connecting to GitHub.
 
                     Back in your Infisical instance, you can configure the GitHub App credentials in one of two ways:
 
-                    **Option 1: Server Admin Panel (Recommended)**
+                    **Option 1: Server Admin Panel (Recommended for an instance-default shared app)**
 
                     Navigate to the server admin panel > **Integrations** > **GitHub App** and enter the GitHub application credentials:
                     ![integrations github app admin panel](/images/integrations/github/app/self-hosted-github-app-admin-panel.png)
@@ -65,6 +65,8 @@ Infisical supports three methods for connecting to GitHub.
                     - **App Slug**: The Slug of your GitHub application (found in the URL)
                     - **App ID**: The App ID of your GitHub application
                     - **Private Key**: The Private Key of your GitHub application
+
+                    This creates the shared **Instance** GitHub App option that appears in project and organization app connections.
 
                     **Option 2: Environment Variables**
 
@@ -81,7 +83,7 @@ Infisical supports three methods for connecting to GitHub.
                         If your shared GitHub App is registered on a GitHub Enterprise Server instance, you must set `INF_APP_CONNECTION_GITHUB_APP_HOST` to that instance's hostname. Without it, the OAuth exchange will be directed to `github.com` instead of your GHES host.
                     </Note>
 
-                    Once configured, you can use the GitHub integration via app authentication. If you configured the credentials using environment variables, restart your Infisical instance for the changes to take effect. If you configured them through the server admin panel, allow approximately 5 minutes for the changes to propagate.
+                    Once configured, you can use the GitHub integration via app authentication. If you configured the credentials using environment variables, restart your Infisical instance for the changes to take effect. If you configured them through the server admin panel, allow approximately 5 minutes for the changes to propagate before the shared **Instance** option appears in the App Connections flow.
                 </Step>
             </Steps>
         </Accordion>
@@ -101,7 +103,7 @@ Infisical supports three methods for connecting to GitHub.
                 Select the **GitHub App** method.
 
                 Choose which GitHub App to use for the connection:
-                - **Instance** — the instance-default GitHub App configured by your Infisical server admin.
+                - **Instance** — the instance-default GitHub App configured by your Infisical server admin. If you followed the self-hosted setup above via the server admin panel, this is usually the option you want.
                 - **Private** — a GitHub App registered under your organization. Select an existing one from the list, or click the gear to manage your private apps.
 
                 <Note>


### PR DESCRIPTION
## Summary\n- clarify that the server admin panel creates the shared **Instance** GitHub App used by self-hosted deployments\n- explain that the **Instance** option may take a few minutes to appear after server-admin configuration\n- connect the self-hosted setup steps to the project app-connection picker so admins know when to choose **Instance** vs **Private**\n\n## Why\nIssue #6851 reports that self-hosted users follow the GitHub App docs but then do not know which app option to pick in the UI, because the page does not explicitly say that the server-admin setup produces the shared **Instance** option shown later in the connection flow.\n\n## Test Plan\n- docs-only change\n- reviewed the updated page for consistency and broken markdown\n\nCloses #6851