### PR TITLE
feat: improved metering ui to showcase the information needed for user

### DIFF
--- a/backend/src/ee/routes/v1/license-v2-router.ts
+++ b/backend/src/ee/routes/v1/license-v2-router.ts
@@ -68,9 +68,27 @@ const BillingV2InvoiceSchema = z.object({
   pdfUrl: z.string()
 });
 
+const BillingV2EntitlementDimSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  noun: z.string(),
+  unit: z.string(),
+  metered: z.boolean(),
+  used: z.number(),
+  limit: z.number().nullable(),
+  // Present for metered dimensions: the included allowance and per-unit overage rate (dollars).
+  freeBand: z.number().optional(),
+  rate: z.number().optional()
+});
+
 const BillingV2EntitlementSchema = z.object({
   entitled: z.boolean(),
   planTier: z.string().optional(),
+  // Fixed recurring charge and estimated metered usage for the product (dollars); the headline is
+  // their sum. dimensions drives the per-dimension usage bars.
+  amount: z.number().optional(),
+  estimatedUsageAmount: z.number().optional(),
+  dimensions: BillingV2EntitlementDimSchema.array().optional(),
   limit: z.number().nullable().optional(),
   used: z.number().optional(),
   unit: z.string().nullable().optional()
@@ -110,7 +128,8 @@ const BillingV2OverviewSchema = z.object({
     })
     .nullable(),
   invoices: BillingV2InvoiceSchema.array(),
-  entitlements: z.record(BillingV2EntitlementSchema)
+  entitlements: z.record(BillingV2EntitlementSchema),
+  estimatedUsageAmount: z.number()
 });
 
 const BillingV2PreviewLineSchema = z.object({
@@ -119,13 +138,26 @@ const BillingV2PreviewLineSchema = z.object({
   proration: z.boolean()
 });
 
+const BillingV2EstimatedUsageLineSchema = z.object({
+  dimension: z.string(),
+  unit: z.string(),
+  peak: z.number(),
+  freeBand: z.number(),
+  rate: z.number(),
+  amount: z.number()
+});
+
 const BillingV2PreviewSchema = z.object({
   currency: z.string(),
   prorationAmount: z.number(),
   nextInvoiceTotal: z.number(),
   nextRecurringTotal: z.number(),
   prorationDate: z.number(),
-  lines: BillingV2PreviewLineSchema.array()
+  lines: BillingV2PreviewLineSchema.array(),
+  // Projected metered usage (dollars) and its breakdown; estimatedTotal = nextRecurringTotal + usage.
+  estimatedUsage: z.number(),
+  estimatedUsageLines: BillingV2EstimatedUsageLineSchema.array(),
+  estimatedTotal: z.number()
 });
 
 // Subscription mutations mirror the checkout result: the change applies in place and the affected

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -23,6 +23,7 @@ import {
   BillingV2CompareRow,
   BillingV2Dim,
   BillingV2Entitlement,
+  BillingV2EntitlementDim,
   BillingV2Model,
   BillingV2Overview,
   BillingV2Plan,
@@ -340,15 +341,19 @@ export const licenseV2ServiceFactory = ({
   const buildEntitlements = async (org: TEntitlementOrg, subscription: TSubscriptionResponse | null) => {
     const entitlements: Record<string, BillingV2Entitlement> = {};
 
-    // Dimension nouns (the unit a limit counts, e.g. "certificate") live on the catalog, keyed by
-    // dimension. Only fetch it when a subscription item actually carries a limit to name.
+    const labelByDimension = new Map<string, string>();
     const nounByDimension = new Map<string, string>();
-    const hasLimits = Boolean(subscription?.items.some((item) => Object.keys(item.limits).length > 0));
-    if (hasLimits) {
+    // Fetch the catalog when any item carries dimensions or limits to name; the pinned subscription
+    // dimensions supply used/limit/rate, the catalog supplies each dimension's label and noun.
+    const needsCatalog = Boolean(
+      subscription?.items.some((item) => item.dimensions.length > 0 || Object.keys(item.limits).length > 0)
+    );
+    if (needsCatalog) {
       try {
         const catalog = await licenseClient.getCatalog();
         catalog?.products.forEach((product) => {
           product.dimensions.forEach((dimension) => {
+            labelByDimension.set(`${product.id}:${dimension.key}`, dimension.label);
             nounByDimension.set(`${product.id}:${dimension.key}`, dimension.noun);
           });
         });
@@ -359,11 +364,53 @@ export const licenseV2ServiceFactory = ({
 
     if (subscription) {
       subscription.items.forEach((item) => {
-        // Surface one dimension's used count, limit, and noun together so the rendered
-        // "{used} / {limit} {unit}" always describes the same thing. "Most constraining" = the
-        // highest utilization (closest to, or furthest past, its cap), i.e. the limit the customer
-        // is likeliest to hit. Each limit is paired with its OWN quantity; taking Math.max across all
-        // quantities could otherwise report a different dimension's count than the resolved unit.
+        // Resolve the pinned per-dimension contract into a display-ready list: label/noun from the
+        // catalog, metered/used/limit/rate/freeBand from the org's pinned subscription version. Money
+        // is converted to dollars here so *Cents fields never reach the client. rate/freeBand are set
+        // only for metered dimensions; per-unit dimensions get their rate from the catalog client-side.
+        const dimensions: BillingV2EntitlementDim[] = item.dimensions.map((dimension) => {
+          const catalogKey = `${item.productId}:${dimension.key}`;
+          const metered = dimension.metered ?? false;
+          const hasRate = dimension.rateCents !== null && dimension.rateCents !== undefined;
+          const hasFreeBand = dimension.freeBand !== null && dimension.freeBand !== undefined;
+          return {
+            key: dimension.key,
+            label: labelByDimension.get(catalogKey) ?? dimension.key,
+            noun: nounByDimension.get(catalogKey) ?? dimension.unit ?? dimension.key,
+            unit: dimension.unit ?? nounByDimension.get(catalogKey) ?? dimension.key,
+            metered,
+            used: dimension.used ?? 0,
+            limit: dimension.limit ?? null,
+            ...(metered && hasFreeBand ? { freeBand: dimension.freeBand as number } : {}),
+            ...(metered && hasRate ? { rate: centsToDollars(dimension.rateCents) } : {})
+          };
+        });
+
+        // Estimated metered usage cost for the period: sum of max(0, used - freeBand) * rate over the
+        // metered dimensions. Fixed recurring (item.amount) excludes this per the contract.
+        const estimatedUsageAmount = dimensions.reduce((sum, dimension) => {
+          if (!dimension.metered || dimension.rate === undefined) {
+            return sum;
+          }
+          return sum + Math.max(0, dimension.used - (dimension.freeBand ?? 0)) * dimension.rate;
+        }, 0);
+
+        // Collapsed "most constraining" summary retained for callers that render a single limit line
+        // (the product sheet). Derived from the resolved dimensions when present, else from the legacy
+        // limits/quantities maps for older license servers. "Most constraining" = the highest
+        // utilization (closest to, or furthest past, its cap), i.e. the limit the customer is likeliest
+        // to hit; each limit is paired with its OWN quantity so the resolved unit matches the count.
+        const limitPairs: [string, number][] =
+          dimensions.length > 0
+            ? dimensions
+                .filter((dimension) => dimension.limit !== null)
+                .map((dimension) => [dimension.key, dimension.limit as number])
+            : Object.entries(item.limits);
+        const usedForKey = (key: string): number =>
+          dimensions.length > 0
+            ? (dimensions.find((dimension) => dimension.key === key)?.used ?? 0)
+            : (item.quantities[key] ?? 0);
+
         let used = 0;
         let limit: number | null = null;
         let limitKey: string | null = null;
@@ -371,8 +418,8 @@ export const licenseV2ServiceFactory = ({
         // Plain for-of (not forEach): assignments inside a closure don't refine the outer
         // variable's type, so after a forEach TS still sees limitKey as null and the `limitKey ?`
         // branch below collapses to `never`. A same-scope loop lets control-flow keep it string|null.
-        for (const [key, dimensionLimit] of Object.entries(item.limits)) {
-          const dimensionUsed = item.quantities[key] ?? 0;
+        for (const [key, dimensionLimit] of limitPairs) {
+          const dimensionUsed = usedForKey(key);
           // An unlimited (<= 0) cap can't be "hit"; only a positive cap yields a real ratio.
           const utilization =
             // eslint-disable-next-line no-nested-ternary
@@ -387,7 +434,16 @@ export const licenseV2ServiceFactory = ({
 
         const unit = limitKey ? (nounByDimension.get(`${item.productId}:${limitKey}`) ?? null) : null;
 
-        entitlements[item.productId] = { entitled: true, planTier: item.plan, used, limit, unit };
+        entitlements[item.productId] = {
+          entitled: true,
+          planTier: item.plan,
+          amount: item.amount !== undefined ? centsToDollars(item.amount) : undefined,
+          estimatedUsageAmount,
+          dimensions: dimensions.length > 0 ? dimensions : undefined,
+          used,
+          limit,
+          unit
+        };
       });
     }
 
@@ -519,6 +575,17 @@ export const licenseV2ServiceFactory = ({
       logger.error(error, `billing-v2: failed to read billing profile [orgId=${orgId}]`);
     }
 
+    const entitlements = await buildEntitlements(
+      { id: orgId, name: organization.name, slug: organization.slug },
+      subscription
+    );
+    // Org-wide projected metered usage (dollars): the summary adds this to recurringAmount for the
+    // next-month total, so every product's estimate is summed once here.
+    const estimatedUsageAmount = Object.values(entitlements).reduce(
+      (sum, entitlement) => sum + (entitlement.estimatedUsageAmount ?? 0),
+      0
+    );
+
     const overview: BillingV2Overview = {
       // Self-hosted is a read-only, managed view: the UI hides payment/invoices/details and shows the
       // "managed by your account team" banner off these two fields.
@@ -538,10 +605,8 @@ export const licenseV2ServiceFactory = ({
       payment,
       billingDetails,
       invoices,
-      entitlements: await buildEntitlements(
-        { id: orgId, name: organization.name, slug: organization.slug },
-        subscription
-      )
+      entitlements,
+      estimatedUsageAmount
     };
 
     return { overview };
@@ -652,6 +717,7 @@ export const licenseV2ServiceFactory = ({
     }
 
     const preview = await licenseClient.previewSubscriptionChange(orgId, payload);
+    const estimatedUsage = centsToDollars(preview.estimatedUsageCents);
     return {
       preview: {
         currency: preview.currency,
@@ -663,7 +729,21 @@ export const licenseV2ServiceFactory = ({
           description: line.description,
           amount: centsToDollars(line.amount),
           proration: line.proration
-        }))
+        })),
+        estimatedUsage,
+        estimatedUsageLines: preview.estimatedUsageLines.map((line) => ({
+          dimension: line.dimension,
+          unit: line.unit ?? line.dimension,
+          peak: line.peak,
+          freeBand: line.freeBand,
+          rate: centsToDollars(line.rateCents),
+          amount: centsToDollars(line.amountCents)
+        })),
+        // Fall back to nextRecurringTotal + estimatedUsage when an older server omits estimatedTotal.
+        estimatedTotal:
+          preview.estimatedTotal !== null && preview.estimatedTotal !== undefined
+            ? centsToDollars(preview.estimatedTotal)
+            : centsToDollars(preview.nextRecurringTotal) + estimatedUsage
       }
     };
   };

--- a/backend/src/ee/services/license-v2/license-v2-types.ts
+++ b/backend/src/ee/services/license-v2/license-v2-types.ts
@@ -67,11 +67,33 @@ export type BillingV2Invoice = {
   pdfUrl: string;
 };
 
+// One metered/priced dimension of an active product, resolved for display: label/noun come from the
+// catalog, the rest from the org's pinned subscription version. rate/freeBand (dollars/allowance) are
+// present only for metered dimensions; per-unit dimensions get their rate from the catalog client-side.
+export type BillingV2EntitlementDim = {
+  key: string;
+  label: string;
+  noun: string;
+  unit: string;
+  metered: boolean;
+  used: number;
+  limit: number | null;
+  freeBand?: number;
+  rate?: number;
+};
+
 export type BillingV2Entitlement = {
   entitled: boolean;
   // Tier the org is currently subscribed to for this product (from the subscription item), so the UI
   // can mark the matching plan card as the active one. Absent for feature-only entitlements.
   planTier?: string;
+  // Fixed recurring charge for this product (dollars); excludes metered usage per the contract.
+  amount?: number;
+  // Estimated metered usage cost for the current period (dollars); 0 when the product has no metered
+  // usage. The product headline is amount + estimatedUsageAmount.
+  estimatedUsageAmount?: number;
+  // Every priced/metered dimension of the product, for the per-dimension usage bars.
+  dimensions?: BillingV2EntitlementDim[];
   limit?: number | null;
   used?: number;
   // Singular noun for the limited dimension (e.g. "certificate"), resolved from the catalog so the
@@ -111,6 +133,9 @@ export type BillingV2Overview = {
   } | null;
   invoices: BillingV2Invoice[];
   entitlements: Record<string, BillingV2Entitlement>;
+  // Estimated metered usage cost for the current period across all products (dollars). Added to
+  // recurringAmount for the projected next-month total shown in the summary.
+  estimatedUsageAmount: number;
 };
 
 export type TGetBillingV2OverviewDTO = {
@@ -152,6 +177,17 @@ export type BillingV2PreviewLine = {
   proration: boolean;
 };
 
+// A projected metered usage line for a change preview. rate/amount are dollars; peak is the projected
+// period usage (peak for a max-aggregated dimension) and freeBand the included allowance.
+export type BillingV2EstimatedUsageLine = {
+  dimension: string;
+  unit: string;
+  peak: number;
+  freeBand: number;
+  rate: number;
+  amount: number;
+};
+
 export type BillingV2Preview = {
   currency: string;
   prorationAmount: number;
@@ -159,6 +195,11 @@ export type BillingV2Preview = {
   nextRecurringTotal: number;
   prorationDate: number;
   lines: BillingV2PreviewLine[];
+  // Projected metered usage for the period (dollars) and its per-dimension breakdown. estimatedTotal
+  // is nextRecurringTotal + estimatedUsage.
+  estimatedUsage: number;
+  estimatedUsageLines: BillingV2EstimatedUsageLine[];
+  estimatedTotal: number;
 };
 
 export type TPreviewBillingV2ChangeDTO = {

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -85,13 +85,30 @@ export const catalogResponseSchema = z
   })
   .passthrough();
 
+// Per-dimension metered usage on a subscription item. metered/aggregation/freeBand/rateCents come
+// from the org's pinned plan version (not the global feature flag); freeBand/rateCents are only
+// meaningful for metered dimensions. Additive + permissive so an older server (no dimensions) parses.
+const subscriptionItemDimensionSchema = z
+  .object({
+    key: z.string(),
+    unit: z.string().optional(),
+    metered: z.boolean().default(false),
+    aggregation: z.string().optional(),
+    used: z.number().default(0),
+    limit: z.number().nullish(),
+    freeBand: z.number().nullish(),
+    rateCents: z.number().nullish()
+  })
+  .passthrough();
+
 const subscriptionItemSchema = z
   .object({
     productId: z.string(),
     plan: z.string(),
     quantities: z.record(z.string(), z.number()),
     limits: z.record(z.string(), z.number()),
-    amount: z.number().optional()
+    amount: z.number().optional(),
+    dimensions: z.array(subscriptionItemDimensionSchema).default([])
   })
   .passthrough();
 
@@ -132,6 +149,20 @@ const subscriptionPreviewLineSchema = z
   })
   .passthrough();
 
+// Projected metered cost for the change, computed by the server. estimatedUsageCents is the summed
+// projection; estimatedTotal = nextRecurringTotal + estimatedUsageCents. All additive/nullish so an
+// older server that omits them still parses (the service falls back to nextRecurringTotal).
+const subscriptionPreviewUsageLineSchema = z
+  .object({
+    dimension: z.string(),
+    unit: z.string().optional(),
+    peak: z.number().default(0),
+    freeBand: z.number().default(0),
+    rateCents: z.number().default(0),
+    amountCents: z.number().default(0)
+  })
+  .passthrough();
+
 export const subscriptionPreviewResponseSchema = z
   .object({
     currency: z.string(),
@@ -139,7 +170,10 @@ export const subscriptionPreviewResponseSchema = z
     nextInvoiceTotal: z.number(),
     nextRecurringTotal: z.number(),
     prorationDate: z.number(),
-    lines: z.array(subscriptionPreviewLineSchema).default([])
+    lines: z.array(subscriptionPreviewLineSchema).default([]),
+    estimatedUsageCents: z.number().default(0),
+    estimatedUsageLines: z.array(subscriptionPreviewUsageLineSchema).default([]),
+    estimatedTotal: z.number().nullish()
   })
   .passthrough();
 

--- a/frontend/src/hooks/api/billingV2/index.tsx
+++ b/frontend/src/hooks/api/billingV2/index.tsx
@@ -15,6 +15,8 @@ export type {
   BillingV2CompareRow,
   BillingV2Dim,
   BillingV2Entitlement,
+  BillingV2EntitlementDim,
+  BillingV2EstimatedUsageLine,
   BillingV2Invoice,
   BillingV2Model,
   BillingV2Overview,

--- a/frontend/src/hooks/api/billingV2/types.ts
+++ b/frontend/src/hooks/api/billingV2/types.ts
@@ -69,10 +69,32 @@ export type BillingV2Invoice = {
   pdfUrl: string | null;
 };
 
+// One priced/metered dimension of an active product, resolved for display by the backend. rate and
+// freeBand (dollars/allowance) are present only for metered dimensions; per-unit dimensions get their
+// rate from the catalog on the client.
+export type BillingV2EntitlementDim = {
+  key: string;
+  label: string;
+  noun: string;
+  unit: string;
+  metered: boolean;
+  used: number;
+  limit: number | null;
+  freeBand?: number;
+  rate?: number;
+};
+
 export type BillingV2Entitlement = {
   entitled: boolean;
   // Tier the org is currently subscribed to for this product; lets the UI mark the active plan card.
   planTier?: string;
+  // Fixed recurring charge for this product (dollars); excludes metered usage.
+  amount?: number;
+  // Estimated metered usage cost for the current period (dollars). The product headline is
+  // amount + estimatedUsageAmount.
+  estimatedUsageAmount?: number;
+  // Every priced/metered dimension of the product, for the per-dimension usage bars.
+  dimensions?: BillingV2EntitlementDim[];
   limit?: number | null;
   used?: number;
   // Singular noun for the limited dimension (e.g. "certificate"); rendered, pluralized, beside the count.
@@ -93,6 +115,9 @@ export type BillingV2Overview = {
     identities: number;
     identityLimit: number | null;
   };
+  // Projected metered usage across all products (dollars); added to recurringAmount for the summary's
+  // next-month total.
+  estimatedUsageAmount: number;
   payment: BillingV2PaymentMethod;
   billingDetails: {
     name: string;
@@ -142,6 +167,17 @@ export type BillingV2PreviewLine = {
   proration: boolean;
 };
 
+// A projected metered usage line for a change preview. rate/amount are dollars; peak is the projected
+// period usage and freeBand the included allowance.
+export type BillingV2EstimatedUsageLine = {
+  dimension: string;
+  unit: string;
+  peak: number;
+  freeBand: number;
+  rate: number;
+  amount: number;
+};
+
 // prorationAmount is signed: positive is charged now (an add), negative is a credit toward the next
 // invoice (a removal). prorationDate is the timestamp the preview was computed at, for display only.
 export type BillingV2Preview = {
@@ -151,6 +187,11 @@ export type BillingV2Preview = {
   nextRecurringTotal: number;
   prorationDate: number;
   lines: BillingV2PreviewLine[];
+  // Projected metered usage for the period (dollars) and its breakdown; estimatedTotal is
+  // nextRecurringTotal + estimatedUsage.
+  estimatedUsage: number;
+  estimatedUsageLines: BillingV2EstimatedUsageLine[];
+  estimatedTotal: number;
 };
 
 export type BillingV2MutationResult = {

--- a/frontend/src/pages/organization/BillingV2Page/billing-v2-data.ts
+++ b/frontend/src/pages/organization/BillingV2Page/billing-v2-data.ts
@@ -1,4 +1,10 @@
-import { BillingV2Cadence, BillingV2CatalogProduct, BillingV2Dim } from "@app/hooks/api";
+import {
+  BillingV2Cadence,
+  BillingV2CatalogProduct,
+  BillingV2Dim,
+  BillingV2Entitlement,
+  BillingV2EntitlementDim
+} from "@app/hooks/api";
 
 type BillingV2ProBase = { monthly: number; annual: number };
 
@@ -70,4 +76,81 @@ export const isMeteredCadence = (dim: BillingV2Dim, cad: BillingV2Cadence): bool
     return dim.meteredAnnual ?? false;
   }
   return dim.meteredMonthly ?? false;
+};
+
+// Fixed recurring + estimated metered usage for a product (dollars). This is the product card
+// headline; the metered portion is a projection, so callers show an "est." qualifier when it's > 0.
+export const productTotal = (entitlement?: BillingV2Entitlement): number =>
+  (entitlement?.amount ?? 0) + (entitlement?.estimatedUsageAmount ?? 0);
+
+// The per-unit rate to display for a dimension (dollars): the pinned metered rate when the backend
+// sent one, otherwise the catalog's per-unit price for the active cadence. null when neither exists.
+export const dimRate = (
+  dim: BillingV2EntitlementDim,
+  product: BillingV2CatalogProduct | undefined,
+  planTier: string | undefined,
+  cadence: BillingV2Cadence
+): number | null => {
+  if (dim.rate !== undefined && dim.rate !== null) {
+    return dim.rate;
+  }
+  const plan = product?.plans.find((candidate) => candidate.tier === planTier) ?? product?.plans[0];
+  const catalogDim = plan?.dims.find((candidate) => candidate.key === dim.key);
+  if (!catalogDim) {
+    return null;
+  }
+  return unitPrice(catalogDim, cadence);
+};
+
+// The billed quantity for a dimension: for a metered dimension it's the overage above the included
+// free band; for a per-unit dimension it's the used count.
+export const dimBilledQuantity = (dim: BillingV2EntitlementDim): number => {
+  if (dim.metered) {
+    return Math.max(0, dim.used - (dim.freeBand ?? 0));
+  }
+  return dim.used;
+};
+
+// Fill percentage (0-100) for a dimension's usage bar, or null when there's no finite cap to fill
+// against (unlimited or usage-based). Mirrors the utilization semantics used server-side.
+export const usagePct = (used: number, limit: number | null): number | null => {
+  if (limit === null || limit <= 0) {
+    return null;
+  }
+  return Math.min(100, (used / limit) * 100);
+};
+
+// Human-readable price breakdown for a product card, e.g. "1 CA × $500 + 84 certificates × $3" or
+// "Flat · up to 10 resources". Priced/metered dimensions read as "{qty} {units} × ${rate}"; flat
+// dimensions (a cap with no per-unit rate) read as "up to {limit} {units}". Returns null when nothing
+// is priced. Illustrative only: the authoritative total is the product headline (amount + usage).
+export const productBreakdown = (
+  entitlement: BillingV2Entitlement | undefined,
+  product: BillingV2CatalogProduct | undefined,
+  cadence: BillingV2Cadence
+): string | null => {
+  const dims = entitlement?.dimensions ?? [];
+  if (dims.length === 0) {
+    return null;
+  }
+
+  const pricedTerms: string[] = [];
+  const flatTerms: string[] = [];
+  dims.forEach((dim) => {
+    const rate = dimRate(dim, product, entitlement?.planTier, cadence);
+    if (rate !== null && rate > 0) {
+      const qty = dimBilledQuantity(dim);
+      pricedTerms.push(`${qty.toLocaleString()} ${pluralizeUnit(dim.noun)} × ${fmtMoney(rate)}`);
+    } else if (dim.limit !== null) {
+      flatTerms.push(`up to ${dim.limit.toLocaleString()} ${pluralizeUnit(dim.noun)}`);
+    }
+  });
+
+  if (pricedTerms.length > 0) {
+    return [...pricedTerms, ...flatTerms].join(" + ");
+  }
+  if (flatTerms.length > 0) {
+    return `Flat · ${flatTerms.join(" + ")}`;
+  }
+  return null;
 };

--- a/frontend/src/pages/organization/BillingV2Page/components/AddProductModal.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/AddProductModal.tsx
@@ -98,12 +98,22 @@ export const AddProductModal = ({ orgId, product, plan, cadence, onClose }: Prop
                   {fmtMoney(dueToday, 2)}
                 </span>
               </div>
-              <div className="flex items-center justify-between">
-                <span className="text-mineshaft-300">New recurring total</span>
-                <span className="font-semibold text-foreground tabular-nums">
-                  {fmtMoney(preview.data.nextRecurringTotal, 2)}
-                </span>
-              </div>
+              {preview.data.estimatedUsage > 0 && (
+                <>
+                  <div className="flex items-center justify-between">
+                    <span className="text-mineshaft-300">Estimated usage this period</span>
+                    <span className="font-semibold text-foreground tabular-nums">
+                      ~{fmtMoney(preview.data.estimatedUsage, 2)}
+                    </span>
+                  </div>
+                  <div className="flex items-center justify-between border-t border-border pt-1.5">
+                    <span className="text-mineshaft-300">New Recurring total</span>
+                    <span className="font-semibold text-foreground tabular-nums">
+                      ~{fmtMoney(preview.data.estimatedTotal, 2)}
+                    </span>
+                  </div>
+                </>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/Overview.tsx
@@ -43,13 +43,25 @@ import {
 } from "@app/components/v3";
 import { cn } from "@app/components/v3/utils";
 import {
+  BillingV2Cadence,
   BillingV2CatalogProduct,
   BillingV2Entitlement,
+  BillingV2EntitlementDim,
   BillingV2Invoice,
   BillingV2Overview
 } from "@app/hooks/api";
 
-import { fmtMoney, intervalWord, pluralizeUnit } from "../billing-v2-data";
+import {
+  cadenceWordShort,
+  dimRate,
+  fmtMoney,
+  intervalToCadence,
+  intervalWord,
+  pluralizeUnit,
+  productBreakdown,
+  productTotal,
+  usagePct
+} from "../billing-v2-data";
 import { ActiveBadge, ProductIcon } from "./shared";
 
 export type BillingV2Mode = "self-serve" | "managed";
@@ -238,11 +250,16 @@ const StatusBadge = ({ subState }: { subState: BillingV2RenderState }) => {
   return <ActiveBadge />;
 };
 
+// Projected next-month cost: fixed recurring plus estimated metered usage across all products.
+const nextMonthTotal = (overview: BillingV2Overview): number =>
+  (overview.recurringAmount ?? 0) + (overview.estimatedUsageAmount ?? 0);
+
 const recurringLabel = (overview: BillingV2Overview): string => {
-  if (!overview.recurringAmount) {
+  const total = nextMonthTotal(overview);
+  if (!total) {
     return "Free";
   }
-  return `${fmtMoney(overview.recurringAmount)} / ${intervalWord(overview.interval)}`;
+  return `${fmtMoney(total)} / ${intervalWord(overview.interval)}`;
 };
 
 type StatTone = "success" | "info" | "warning" | "danger" | "org";
@@ -297,9 +314,15 @@ const StatTile = ({ title, tone, icon, value, footer }: StatTileProps) => (
 
 const SummaryCard = ({ overview }: SummaryCardProps) => {
   const status = STATUS_VISUAL[overview.subState];
-  const recurringNote = overview.recurringAmount
-    ? `Billed ${intervalWord(overview.interval)}ly`
-    : "No recurring charges";
+  const total = nextMonthTotal(overview);
+  const usage = overview.estimatedUsageAmount ?? 0;
+  const hasUsage = usage > 0;
+  let recurringNote = "No recurring charges";
+  if (total) {
+    recurringNote = hasUsage
+      ? `Includes ~${fmtMoney(usage)} est. usage`
+      : `Billed ${intervalWord(overview.interval)}ly`;
+  }
 
   return (
     <div className="flex flex-col gap-4 lg:flex-row">
@@ -318,10 +341,15 @@ const SummaryCard = ({ overview }: SummaryCardProps) => {
         footer={<span className="text-xs text-muted">All products renew together</span>}
       />
       <StatTile
-        title="Recurring total"
+        title="Next month"
         tone="org"
         icon={<CreditCard />}
-        value={recurringLabel(overview)}
+        value={
+          <span className="flex items-baseline gap-1.5">
+            {recurringLabel(overview)}
+            {hasUsage && <span className="text-xs font-normal text-muted">est.</span>}
+          </span>
+        }
         footer={<span className="text-xs text-muted">{recurringNote}</span>}
       />
     </div>
@@ -410,23 +438,65 @@ const UsageCard = ({ overview }: UsageCardProps) => {
   );
 };
 
+// Capitalize a plan tier ("pro" -> "Pro") for the badge beside an active product's name.
+const tierLabel = (tier: string): string => tier.charAt(0).toUpperCase() + tier.slice(1);
+
+type DimensionMeterProps = {
+  dim: BillingV2EntitlementDim;
+  product: BillingV2CatalogProduct;
+  planTier?: string;
+  cadence: BillingV2Cadence;
+};
+
+// One usage bar for a product dimension: "{used} / {limit} · $rate/unit/mo" with a fill bar. A
+// dimension with no finite cap (unlimited or usage-based) shows a running count and no bar.
+const DimensionMeter = ({ dim, product, planTier, cadence }: DimensionMeterProps) => {
+  const rate = dimRate(dim, product, planTier, cadence);
+  const pct = usagePct(dim.used, dim.limit);
+  const rateNote =
+    rate !== null && rate > 0 ? `${fmtMoney(rate)}/${dim.noun}/${cadenceWordShort(cadence)}` : null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline justify-between gap-2.5 text-xs">
+        <span className="text-muted">{dim.label}</span>
+        <span className="text-muted tabular-nums">
+          <span className="font-medium text-foreground">{dim.used.toLocaleString()}</span>
+          {dim.limit !== null ? ` / ${dim.limit.toLocaleString()}` : ` ${pluralizeUnit(dim.noun)}`}
+          {rateNote && <span> · {rateNote}</span>}
+        </span>
+      </div>
+      {pct !== null && (
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
+          <div className="h-full rounded-full bg-org transition-all" style={{ width: `${pct}%` }} />
+        </div>
+      )}
+    </div>
+  );
+};
+
 type ProductRowProps = {
   prod: BillingV2CatalogProduct;
   entitlement?: BillingV2Entitlement;
+  cadence: BillingV2Cadence;
+  interval: "month" | "year" | null;
+  renewsOn: string | null;
   readOnly?: boolean;
   onManage: (id: string) => void;
   onContact: (prod: BillingV2CatalogProduct) => void;
 };
 
-const ProductRow = ({ prod, entitlement, readOnly, onManage, onContact }: ProductRowProps) => {
+const ProductRow = ({
+  prod,
+  entitlement,
+  cadence,
+  interval,
+  renewsOn,
+  readOnly,
+  onManage,
+  onContact
+}: ProductRowProps) => {
   const entitled = Boolean(entitlement?.entitled);
-  let limitNote: string | null = null;
-  if (entitled && entitlement && entitlement.limit !== null && entitlement.limit !== undefined) {
-    const used = entitlement.used ?? 0;
-    const unit = entitlement.unit ? ` ${pluralizeUnit(entitlement.unit)}` : "";
-    limitNote = `${used.toLocaleString()} / ${entitlement.limit.toLocaleString()}${unit}`;
-  }
-
   const selfServe = prod.plans.some((plan) => plan.selfServe);
   const salesLed = prod.plans.some((plan) => plan.salesLed);
 
@@ -454,24 +524,71 @@ const ProductRow = ({ prod, entitlement, readOnly, onManage, onContact }: Produc
     }
   }
 
-  return (
-    <div className="flex items-center gap-4 border-t border-border py-4 first:border-t-0">
-      <ProductIcon product={prod} />
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-sm font-semibold text-foreground">{prod.name}</span>
-          {prod.addon && <Badge variant="neutral">Add-on</Badge>}
-          {entitled ? <ActiveBadge /> : <Badge variant="neutral">Inactive</Badge>}
+  // Inactive product: compact row with the tagline and an upgrade / contact action.
+  if (!entitled) {
+    return (
+      <div className="flex items-center gap-4 border-t border-border py-4 first:border-t-0">
+        <ProductIcon product={prod} />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-semibold text-foreground">{prod.name}</span>
+            {prod.addon && <Badge variant="neutral">Add-on</Badge>}
+            <Badge variant="neutral">Inactive</Badge>
+          </div>
+          <div className="text-xs text-muted">{prod.tagline || prod.desc}</div>
         </div>
-        <div className="text-xs text-muted">{prod.tagline || prod.desc}</div>
+        {action && <div className="flex shrink-0 items-center gap-1.5">{action}</div>}
       </div>
-      {limitNote && (
+    );
+  }
+
+  // Active product: headline all-in total (fixed recurring + estimated metered usage), the renewal
+  // date, a price breakdown line, and one usage bar per dimension.
+  const dims = entitlement?.dimensions ?? [];
+  const total = productTotal(entitlement);
+  const hasUsage = (entitlement?.estimatedUsageAmount ?? 0) > 0;
+  const breakdown = productBreakdown(entitlement, prod, cadence);
+
+  return (
+    <div className="flex flex-col gap-3 border-t border-border py-4 first:border-t-0">
+      <div className="flex items-center gap-4">
+        <ProductIcon product={prod} />
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm font-semibold text-foreground">{prod.name}</span>
+            {entitlement?.planTier && (
+              <Badge variant="neutral">{tierLabel(entitlement.planTier)}</Badge>
+            )}
+            {prod.addon && <Badge variant="neutral">Add-on</Badge>}
+            <ActiveBadge />
+          </div>
+          {renewsOn && <div className="text-xs text-muted">Renews {renewsOn}</div>}
+        </div>
         <div className="flex shrink-0 flex-col items-end gap-0.5">
-          <span className="text-xs font-semibold text-foreground">{limitNote}</span>
-          <span className="text-xs text-muted">in use</span>
+          <div className="flex items-baseline gap-1">
+            <span className="text-sm font-semibold text-foreground tabular-nums">
+              {fmtMoney(total)}
+            </span>
+            <span className="text-xs text-muted">/ {intervalWord(interval)}</span>
+            {hasUsage && <span className="text-[10px] text-muted">est.</span>}
+          </div>
+          {breakdown && <span className="text-xs text-muted">{breakdown}</span>}
+        </div>
+        {action && <div className="flex shrink-0 items-center gap-1.5">{action}</div>}
+      </div>
+      {dims.length > 0 && (
+        <div className="flex flex-col gap-3 pl-[52px]">
+          {dims.map((dim) => (
+            <DimensionMeter
+              key={dim.key}
+              dim={dim}
+              product={prod}
+              planTier={entitlement?.planTier}
+              cadence={cadence}
+            />
+          ))}
         </div>
       )}
-      {action && <div className="flex shrink-0 items-center gap-1.5">{action}</div>}
     </div>
   );
 };
@@ -484,38 +601,44 @@ type ProductsCardProps = {
   onContact: (prod: BillingV2CatalogProduct) => void;
 };
 
-const ProductsCard = ({ overview, catalog, readOnly, onManage, onContact }: ProductsCardProps) => (
-  <Card>
-    <CardHeader>
-      <CardTitle>
-        <Package className="size-4 text-accent" />
-        Products
-      </CardTitle>
-      <CardDescription>Everything you can run on your subscription.</CardDescription>
-    </CardHeader>
-    <CardContent>
-      {catalog.length === 0 ? (
-        <CardEmpty
-          title="No products available"
-          description="Products will appear here once they're available."
-        />
-      ) : (
-        <div className="flex flex-col">
-          {catalog.map((prod) => (
-            <ProductRow
-              key={prod.id}
-              prod={prod}
-              entitlement={overview.entitlements[prod.id]}
-              readOnly={readOnly}
-              onManage={onManage}
-              onContact={onContact}
-            />
-          ))}
-        </div>
-      )}
-    </CardContent>
-  </Card>
-);
+const ProductsCard = ({ overview, catalog, readOnly, onManage, onContact }: ProductsCardProps) => {
+  const cadence = intervalToCadence(overview.interval);
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Package className="size-4 text-accent" />
+          Products
+        </CardTitle>
+        <CardDescription>Everything you can run on your subscription.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {catalog.length === 0 ? (
+          <CardEmpty
+            title="No products available"
+            description="Products will appear here once they're available."
+          />
+        ) : (
+          <div className="flex flex-col">
+            {catalog.map((prod) => (
+              <ProductRow
+                key={prod.id}
+                prod={prod}
+                entitlement={overview.entitlements[prod.id]}
+                cadence={cadence}
+                interval={overview.interval}
+                renewsOn={overview.nextBillingDate}
+                readOnly={readOnly}
+                onManage={onManage}
+                onContact={onContact}
+              />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
 
 type PaymentCardProps = {
   overview: BillingV2Overview;

--- a/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/RemoveProductModal.tsx
@@ -184,7 +184,7 @@ export const RemoveProductModal = ({ orgId, product, onClose, onRemoved }: Props
               <div className="flex items-center justify-between">
                 <span className="text-mineshaft-300">New recurring total</span>
                 <span className="font-semibold text-foreground tabular-nums">
-                  {fmtMoney(preview.data.nextRecurringTotal, 2)}
+                  {fmtMoney(preview.data.estimatedTotal, 2)}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## Context

Implemented the changes to show the metering UI for the billing and the new preview usage calculation 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)