### PR TITLE
feat(pam): create PAM project lazily on first use

### DIFF
--- a/backend/src/db/migrations/20260612142201_pam-revamp.ts
+++ b/backend/src/db/migrations/20260612142201_pam-revamp.ts
@@ -102,16 +102,18 @@ const mapToFolderAdminRoleRows = (activeRoles: TRoleRow[]) => {
   return [...mapped.values()];
 };
 
-const backfillPamProjectsForAllOrgs = async (knex: Knex) => {
-  const allOrgs = (await knex(TableName.Organization).select("id")) as Array<{ id: string }>;
+// Only orgs that already have PAM data get a consolidated project during the migration. Orgs with
+// no PAM data get one lazily on first PAM access (see pamProjectResolver), avoiding tens of
+// thousands of empty projects here. Chunked inserts keep even the migrated set fast.
+const backfillPamProjectsForOrgs = async (knex: Knex, orgIds: string[]) => {
   const orgToPamProject = new Map<string, string>();
 
-  for (let i = 0; i < allOrgs.length; i += PROJECT_INSERT_CHUNK) {
-    const orgChunk = allOrgs.slice(i, i + PROJECT_INSERT_CHUNK);
+  for (let i = 0; i < orgIds.length; i += PROJECT_INSERT_CHUNK) {
+    const orgChunk = orgIds.slice(i, i + PROJECT_INSERT_CHUNK);
 
     const insertedProjects = (await knex(TableName.Project)
       .insert(
-        orgChunk.map(({ id: orgId }) => ({
+        orgChunk.map((orgId) => ({
           name: "Privileged Access Manager",
           slug: slugify(`pam-${alphaNumericNanoId(4)}`),
           type: ProjectType.PAM,
@@ -210,7 +212,10 @@ export async function up(knex: Knex): Promise<void> {
   // Capture orgs that have a PAM project before backfill
   const orgsWithPam = await knex(TableName.Project).where("type", ProjectType.PAM).distinct("orgId").select("orgId");
 
-  const orgToPamProject = await backfillPamProjectsForAllOrgs(knex);
+  const orgToPamProject = await backfillPamProjectsForOrgs(
+    knex,
+    orgsWithPam.map((o) => o.orgId)
+  );
 
   // Drop old folders table and recreate with new schema
   await knex.raw(`UPDATE ${TableName.PamAccount} SET "folderId" = NULL WHERE "folderId" IS NOT NULL`);

--- a/backend/src/db/migrations/20260612142201_pam-revamp.ts
+++ b/backend/src/db/migrations/20260612142201_pam-revamp.ts
@@ -102,9 +102,8 @@ const mapToFolderAdminRoleRows = (activeRoles: TRoleRow[]) => {
   return [...mapped.values()];
 };
 
-// Only orgs that already have PAM data get a consolidated project during the migration. Orgs with
-// no PAM data get one lazily on first PAM access (see pamProjectResolver), avoiding tens of
-// thousands of empty projects here. Chunked inserts keep even the migrated set fast.
+// Only orgs with existing PAM data get a project here; the rest are created lazily on first access
+// (see pamProjectResolver) to avoid backfilling tens of thousands of empty projects.
 const backfillPamProjectsForOrgs = async (knex: Knex, orgIds: string[]) => {
   const orgToPamProject = new Map<string, string>();
 

--- a/backend/src/ee/routes/v1/pam-routers/index.ts
+++ b/backend/src/ee/routes/v1/pam-routers/index.ts
@@ -1,6 +1,7 @@
 import { registerPamAccountRouter } from "./pam-account-router";
 import { registerPamAccountTemplateRouter } from "./pam-account-template-router";
 import { registerPamFolderRouter } from "./pam-folder-router";
+import { registerPamProjectRouter } from "./pam-project-router";
 import {
   registerPamAccountMembershipRouter,
   registerPamFolderMembershipRouter,
@@ -11,6 +12,7 @@ import { registerPamSessionChunkRouter } from "./pam-session-chunk-router";
 import { registerPamSessionRouter, registerPamWebAccessRouter } from "./pam-session-router";
 
 export const registerPamRouters = async (server: FastifyZodProvider) => {
+  await server.register(registerPamProjectRouter, { prefix: "/project" });
   await server.register(registerPamAccountTemplateRouter, { prefix: "/account-templates" });
   await server.register(registerPamFolderRouter, { prefix: "/folders" });
   await server.register(registerPamFolderMembershipRouter, { prefix: "/folders" });

--- a/backend/src/ee/routes/v1/pam-routers/index.ts
+++ b/backend/src/ee/routes/v1/pam-routers/index.ts
@@ -1,12 +1,12 @@
 import { registerPamAccountRouter } from "./pam-account-router";
 import { registerPamAccountTemplateRouter } from "./pam-account-template-router";
 import { registerPamFolderRouter } from "./pam-folder-router";
-import { registerPamProjectRouter } from "./pam-project-router";
 import {
   registerPamAccountMembershipRouter,
   registerPamFolderMembershipRouter,
   registerPamProductMembershipRouter
 } from "./pam-membership-router";
+import { registerPamProjectRouter } from "./pam-project-router";
 import { registerPamResourceRoleRouter } from "./pam-resource-role-router";
 import { registerPamSessionChunkRouter } from "./pam-session-chunk-router";
 import { registerPamSessionRouter, registerPamWebAccessRouter } from "./pam-session-router";

--- a/backend/src/ee/routes/v1/pam-routers/pam-project-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-project-router.ts
@@ -10,6 +10,8 @@ export const registerPamProjectRouter = async (server: FastifyZodProvider) => {
     method: "GET",
     url: "/",
     schema: {
+      // Internal endpoint; PAM projects are never user-facing, so keep it out of the API docs
+      hide: true,
       operationId: "getPamProject",
       description: "Resolve the organization's Privileged Access Manager project, creating it on first access",
       tags: [ApiDocsTags.PamFolders],
@@ -21,8 +23,7 @@ export const registerPamProjectRouter = async (server: FastifyZodProvider) => {
     },
     config: { rateLimit: readLimit },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
-    // injectPamProjectId (preValidation) resolves and lazily bootstraps the project, so by the time
-    // this handler runs internalPamProjectId is always set.
+    // injectPamProjectId (preValidation) has already resolved/bootstrapped the project by now.
     handler: async (req) => ({ projectId: req.internalPamProjectId })
   });
 };

--- a/backend/src/ee/routes/v1/pam-routers/pam-project-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-project-router.ts
@@ -1,0 +1,28 @@
+import z from "zod";
+
+import { ApiDocsTags } from "@app/lib/api-docs/constants";
+import { readLimit } from "@app/server/config/rateLimiter";
+import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
+import { AuthMode } from "@app/services/auth/auth-type";
+
+export const registerPamProjectRouter = async (server: FastifyZodProvider) => {
+  server.route({
+    method: "GET",
+    url: "/",
+    schema: {
+      operationId: "getPamProject",
+      description: "Resolve the organization's Privileged Access Manager project, creating it on first access",
+      tags: [ApiDocsTags.PamFolders],
+      response: {
+        200: z.object({
+          projectId: z.string()
+        })
+      }
+    },
+    config: { rateLimit: readLimit },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    // injectPamProjectId (preValidation) resolves and lazily bootstraps the project, so by the time
+    // this handler runs internalPamProjectId is always set.
+    handler: async (req) => ({ projectId: req.internalPamProjectId })
+  });
+};

--- a/backend/src/ee/services/pam-account/pam-account-service.ts
+++ b/backend/src/ee/services/pam-account/pam-account-service.ts
@@ -608,9 +608,7 @@ export const pamAccountServiceFactory = (deps: TPamAccountServiceFactoryDep) => 
       ResourcePermissionSub.PamResource
     );
 
-    // The membership roster is only for member management, so don't disclose it to read-only callers
-    // (e.g. Connector/Requester have ReadAccounts but not ManageMembers) — that would leak the full
-    // list of users/groups/identities and their roles on the account and parent folder.
+    // Only member managers get the roster; read-only roles must not enumerate members.
     const canManageMembers = mergedPermission.can(
       ResourcePermissionPamResourceActions.ManageMembers,
       ResourcePermissionSub.PamResource

--- a/backend/src/ee/services/pam-account/pam-account-service.ts
+++ b/backend/src/ee/services/pam-account/pam-account-service.ts
@@ -608,9 +608,17 @@ export const pamAccountServiceFactory = (deps: TPamAccountServiceFactoryDep) => 
       ResourcePermissionSub.PamResource
     );
 
+    // The membership roster is only for member management, so don't disclose it to read-only callers
+    // (e.g. Connector/Requester have ReadAccounts but not ManageMembers) — that would leak the full
+    // list of users/groups/identities and their roles on the account and parent folder.
+    const canManageMembers = mergedPermission.can(
+      ResourcePermissionPamResourceActions.ManageMembers,
+      ResourcePermissionSub.PamResource
+    );
+
     return {
       permissions: packRules(mergedPermission.rules),
-      memberships: allMemberships
+      memberships: canManageMembers ? allMemberships : []
     };
   };
 

--- a/backend/src/ee/services/pam-folder/pam-folder-service.ts
+++ b/backend/src/ee/services/pam-folder/pam-folder-service.ts
@@ -212,9 +212,17 @@ export const pamFolderServiceFactory = ({
       ResourcePermissionSub.PamResource
     );
 
+    // The membership roster is only for member management, so don't disclose it to read-only callers
+    // (e.g. Connector/Requester have ReadFolder but not ManageMembers) — that would leak the full list
+    // of users/groups/identities and their roles on the folder.
+    const canManageMembers = permission.can(
+      ResourcePermissionPamResourceActions.ManageMembers,
+      ResourcePermissionSub.PamResource
+    );
+
     return {
       permissions: packRules(permission.rules),
-      memberships
+      memberships: canManageMembers ? memberships : []
     };
   };
 

--- a/backend/src/ee/services/pam-folder/pam-folder-service.ts
+++ b/backend/src/ee/services/pam-folder/pam-folder-service.ts
@@ -212,9 +212,7 @@ export const pamFolderServiceFactory = ({
       ResourcePermissionSub.PamResource
     );
 
-    // The membership roster is only for member management, so don't disclose it to read-only callers
-    // (e.g. Connector/Requester have ReadFolder but not ManageMembers) — that would leak the full list
-    // of users/groups/identities and their roles on the folder.
+    // Only member managers get the roster; read-only roles must not enumerate members.
     const canManageMembers = permission.can(
       ResourcePermissionPamResourceActions.ManageMembers,
       ResourcePermissionSub.PamResource

--- a/backend/src/ee/services/pam-project/pam-project-bootstrap.ts
+++ b/backend/src/ee/services/pam-project/pam-project-bootstrap.ts
@@ -21,6 +21,7 @@ type TBootstrapInput = {
   orgId: string;
   adminUserIds?: string[];
   adminIdentityIds?: string[];
+  adminGroupIds?: string[];
 };
 
 export type TDefaultTemplate = {
@@ -185,7 +186,7 @@ export const DEFAULT_ACCOUNT_TEMPLATES: TDefaultTemplate[] = [
 ];
 
 export const bootstrapPamProject = async (
-  { orgId, adminUserIds = [], adminIdentityIds = [] }: TBootstrapInput,
+  { orgId, adminUserIds = [], adminIdentityIds = [], adminGroupIds = [] }: TBootstrapInput,
   { projectDAL, membershipDAL, membershipRoleDAL }: TBootstrapDeps,
   tx: Knex
 ): Promise<{ project: TProjects; created: boolean }> => {
@@ -239,6 +240,29 @@ export const bootstrapPamProject = async (
         scopeOrgId: orgId,
         scopeProjectId: project.id,
         actorIdentityId: identityId,
+        isActive: true
+      },
+      tx
+    );
+
+    // eslint-disable-next-line no-await-in-loop
+    await membershipRoleDAL.create(
+      {
+        membershipId: membership.id,
+        role: ProjectMembershipRole.Admin
+      },
+      tx
+    );
+  }
+
+  for (const groupId of adminGroupIds) {
+    // eslint-disable-next-line no-await-in-loop
+    const membership = await membershipDAL.create(
+      {
+        scope: AccessScope.Project,
+        scopeOrgId: orgId,
+        scopeProjectId: project.id,
+        actorGroupId: groupId,
         isActive: true
       },
       tx

--- a/backend/src/ee/services/pam-project/pam-project-bootstrap.ts
+++ b/backend/src/ee/services/pam-project/pam-project-bootstrap.ts
@@ -209,60 +209,20 @@ export const bootstrapPamProject = async (
     tx
   );
 
-  for (const userId of adminUserIds) {
+  const adminActors: Array<{ actorUserId: string } | { actorIdentityId: string } | { actorGroupId: string }> = [
+    ...adminUserIds.map((actorUserId) => ({ actorUserId })),
+    ...adminIdentityIds.map((actorIdentityId) => ({ actorIdentityId })),
+    ...adminGroupIds.map((actorGroupId) => ({ actorGroupId }))
+  ];
+
+  for (const actor of adminActors) {
     // eslint-disable-next-line no-await-in-loop
     const membership = await membershipDAL.create(
       {
         scope: AccessScope.Project,
         scopeOrgId: orgId,
         scopeProjectId: project.id,
-        actorUserId: userId,
-        isActive: true
-      },
-      tx
-    );
-
-    // eslint-disable-next-line no-await-in-loop
-    await membershipRoleDAL.create(
-      {
-        membershipId: membership.id,
-        role: ProjectMembershipRole.Admin
-      },
-      tx
-    );
-  }
-
-  for (const identityId of adminIdentityIds) {
-    // eslint-disable-next-line no-await-in-loop
-    const membership = await membershipDAL.create(
-      {
-        scope: AccessScope.Project,
-        scopeOrgId: orgId,
-        scopeProjectId: project.id,
-        actorIdentityId: identityId,
-        isActive: true
-      },
-      tx
-    );
-
-    // eslint-disable-next-line no-await-in-loop
-    await membershipRoleDAL.create(
-      {
-        membershipId: membership.id,
-        role: ProjectMembershipRole.Admin
-      },
-      tx
-    );
-  }
-
-  for (const groupId of adminGroupIds) {
-    // eslint-disable-next-line no-await-in-loop
-    const membership = await membershipDAL.create(
-      {
-        scope: AccessScope.Project,
-        scopeOrgId: orgId,
-        scopeProjectId: project.id,
-        actorGroupId: groupId,
+        ...actor,
         isActive: true
       },
       tx

--- a/backend/src/ee/services/pam-project/pam-project-resolver.ts
+++ b/backend/src/ee/services/pam-project/pam-project-resolver.ts
@@ -1,33 +1,97 @@
-import { ProjectType } from "@app/db/schemas";
+import { Knex } from "knex";
+
+import { AccessScope, OrgMembershipRole, ProjectType, TableName } from "@app/db/schemas";
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { withCache } from "@app/lib/cache/with-cache";
-import { BadRequestError } from "@app/lib/errors";
+import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
+import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 
+import { bootstrapPamProject } from "./pam-project-bootstrap";
+
 type TResolverDeps = {
-  projectDAL: Pick<TProjectDALFactory, "find">;
+  db: Knex;
+  projectDAL: Pick<TProjectDALFactory, "find" | "findOne" | "create">;
+  membershipDAL: Pick<TMembershipDALFactory, "create">;
+  membershipRoleDAL: Pick<TMembershipRoleDALFactory, "create">;
   keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry">;
+};
+
+type TOrgAdminRow = {
+  actorUserId: string | null;
+  actorIdentityId: string | null;
+  actorGroupId: string | null;
 };
 
 export type TPamProjectResolverFactory = ReturnType<typeof pamProjectResolverFactory>;
 
-export const pamProjectResolverFactory = ({ projectDAL, keyStore }: TResolverDeps) => ({
-  resolve: (actorOrgId: string): Promise<string> =>
-    withCache({
-      keyStore,
-      key: KeyStorePrefixes.PamDefaultProject(actorOrgId),
-      ttlSeconds: KeyStoreTtls.PamDefaultProjectInSeconds,
-      fetcher: async () => {
-        const projects = await projectDAL.find(
-          { orgId: actorOrgId, type: ProjectType.PAM },
-          { sort: [["createdAt", "desc"]], limit: 1 }
-        );
-        if (projects.length === 0) {
-          throw new BadRequestError({
-            message: "This organization has no Privileged Access Manager project. Contact your administrator."
-          });
+export const pamProjectResolverFactory = ({
+  db,
+  projectDAL,
+  membershipDAL,
+  membershipRoleDAL,
+  keyStore
+}: TResolverDeps) => {
+  const findDefaultProjectId = async (orgId: string): Promise<string | null> => {
+    const projects = await projectDAL.find(
+      { orgId, type: ProjectType.PAM },
+      { sort: [["createdAt", "desc"]], limit: 1 }
+    );
+    return projects.length ? projects[0].id : null;
+  };
+
+  // Orgs with no PAM data get no consolidated project during the migration; the first PAM request
+  // creates it here, seeded with the org's current admins so it is immediately usable (otherwise
+  // no one could administer it — there is no org-admin fallback in the PAM permission model).
+  const ensureDefaultProject = (orgId: string): Promise<string> =>
+    db.transaction(async (tx) => {
+      // Serialize concurrent first-use bootstraps for the same org. There is no DB unique
+      // constraint to rely on (old zombie PAM projects also have type=pam, so an org can legitimately
+      // have several), and the advisory lock auto-releases when this transaction ends.
+      await tx.raw("SELECT pg_advisory_xact_lock(hashtext(?))", [`pam-bootstrap:${orgId}`]);
+
+      const adminRows = (await tx(TableName.Membership)
+        .join(TableName.MembershipRole, `${TableName.MembershipRole}.membershipId`, `${TableName.Membership}.id`)
+        .where(`${TableName.Membership}.scope`, AccessScope.Organization)
+        .where(`${TableName.Membership}.scopeOrgId`, orgId)
+        .where(`${TableName.Membership}.isActive`, true)
+        .where(`${TableName.MembershipRole}.role`, OrgMembershipRole.Admin)
+        .where(`${TableName.MembershipRole}.isTemporary`, false)
+        .select(
+          `${TableName.Membership}.actorUserId`,
+          `${TableName.Membership}.actorIdentityId`,
+          `${TableName.Membership}.actorGroupId`
+        )) as TOrgAdminRow[];
+
+      const uniq = (values: (string | null)[]) => [...new Set(values.filter((v): v is string => Boolean(v)))];
+
+      // bootstrapPamProject re-checks for an existing project inside this locked transaction, so a
+      // request that lost the race returns the winner's project instead of creating a duplicate.
+      const { project } = await bootstrapPamProject(
+        {
+          orgId,
+          adminUserIds: uniq(adminRows.map((r) => r.actorUserId)),
+          adminIdentityIds: uniq(adminRows.map((r) => r.actorIdentityId)),
+          adminGroupIds: uniq(adminRows.map((r) => r.actorGroupId))
+        },
+        { projectDAL, membershipDAL, membershipRoleDAL },
+        tx
+      );
+
+      return project.id;
+    });
+
+  return {
+    resolve: (actorOrgId: string): Promise<string> =>
+      withCache({
+        keyStore,
+        key: KeyStorePrefixes.PamDefaultProject(actorOrgId),
+        ttlSeconds: KeyStoreTtls.PamDefaultProjectInSeconds,
+        fetcher: async () => {
+          const existingId = await findDefaultProjectId(actorOrgId);
+          if (existingId) return existingId;
+          return ensureDefaultProject(actorOrgId);
         }
-        return projects[0].id;
-      }
-    })
-});
+      })
+  };
+};

--- a/backend/src/ee/services/pam-project/pam-project-resolver.ts
+++ b/backend/src/ee/services/pam-project/pam-project-resolver.ts
@@ -42,13 +42,24 @@ export const pamProjectResolverFactory = ({
 
   // Orgs with no PAM data get no consolidated project during the migration; the first PAM request
   // creates it here, seeded with the org's current admins so it is immediately usable (otherwise
-  // no one could administer it — there is no org-admin fallback in the PAM permission model).
+  // no one could administer it, since the PAM permission model has no org-admin fallback).
   const ensureDefaultProject = (orgId: string): Promise<string> =>
     db.transaction(async (tx) => {
       // Serialize concurrent first-use bootstraps for the same org. There is no DB unique
       // constraint to rely on (old zombie PAM projects also have type=pam, so an org can legitimately
       // have several), and the advisory lock auto-releases when this transaction ends.
       await tx.raw("SELECT pg_advisory_xact_lock(hashtext(?))", [`pam-bootstrap:${orgId}`]);
+
+      // Re-check inside the lock on the primary, with the same semantics as findDefaultProjectId
+      // (newest first, soft-deleted excluded). This resolves the race winner and, when several PAM
+      // projects exist (consolidated + old zombies), returns the consolidated one rather than an
+      // arbitrary row.
+      const existing = await tx(TableName.Project)
+        .where({ orgId, type: ProjectType.PAM })
+        .whereNull("deleteAfter")
+        .orderBy("createdAt", "desc")
+        .first("id");
+      if (existing) return existing.id;
 
       const adminRows = (await tx(TableName.Membership)
         .join(TableName.MembershipRole, `${TableName.MembershipRole}.membershipId`, `${TableName.Membership}.id`)
@@ -65,8 +76,6 @@ export const pamProjectResolverFactory = ({
 
       const uniq = (values: (string | null)[]) => [...new Set(values.filter((v): v is string => Boolean(v)))];
 
-      // bootstrapPamProject re-checks for an existing project inside this locked transaction, so a
-      // request that lost the race returns the winner's project instead of creating a duplicate.
       const { project } = await bootstrapPamProject(
         {
           orgId,

--- a/backend/src/ee/services/pam-project/pam-project-resolver.ts
+++ b/backend/src/ee/services/pam-project/pam-project-resolver.ts
@@ -32,8 +32,7 @@ export const pamProjectResolverFactory = ({
   membershipRoleDAL,
   keyStore
 }: TResolverDeps) => {
-  // projectDAL.find already excludes soft-deleted (deleteAfter) projects. Passing tx runs the read
-  // on the primary inside the caller's transaction (used for the in-lock re-check).
+  // Newest live PAM project (find() excludes soft-deleted); tx reads the primary for the in-lock re-check.
   const findDefaultProjectId = async (orgId: string, tx?: Knex): Promise<string | null> => {
     const projects = await projectDAL.find(
       { orgId, type: ProjectType.PAM },
@@ -42,19 +41,13 @@ export const pamProjectResolverFactory = ({
     return projects.length ? projects[0].id : null;
   };
 
-  // Orgs with no PAM data get no consolidated project during the migration; the first PAM request
-  // creates it here, seeded with the org's current admins so it is immediately usable (otherwise
-  // no one could administer it, since the PAM permission model has no org-admin fallback).
+  // Lazily create the project on first use, seeded with current org admins (PAM has no org-admin fallback).
   const ensureDefaultProject = (orgId: string): Promise<string> =>
     db.transaction(async (tx) => {
-      // Serialize concurrent first-use bootstraps for the same org. There is no DB unique
-      // constraint to rely on (old zombie PAM projects also have type=pam, so an org can legitimately
-      // have several), and the advisory lock auto-releases when this transaction ends.
+      // Serialize concurrent bootstraps; a unique constraint won't work since zombie projects share type=pam.
       await tx.raw("SELECT pg_advisory_xact_lock(hashtext(?))", [`pam-bootstrap:${orgId}`]);
 
-      // Re-check inside the lock on the primary (tx). Resolves the race winner and, when several PAM
-      // projects exist (consolidated + old zombies), returns the consolidated one rather than a
-      // stale/arbitrary row.
+      // Re-check inside the lock (race winner).
       const existingId = await findDefaultProjectId(orgId, tx);
       if (existingId) return existingId;
 

--- a/backend/src/ee/services/pam-project/pam-project-resolver.ts
+++ b/backend/src/ee/services/pam-project/pam-project-resolver.ts
@@ -32,10 +32,12 @@ export const pamProjectResolverFactory = ({
   membershipRoleDAL,
   keyStore
 }: TResolverDeps) => {
-  const findDefaultProjectId = async (orgId: string): Promise<string | null> => {
+  // projectDAL.find already excludes soft-deleted (deleteAfter) projects. Passing tx runs the read
+  // on the primary inside the caller's transaction (used for the in-lock re-check).
+  const findDefaultProjectId = async (orgId: string, tx?: Knex): Promise<string | null> => {
     const projects = await projectDAL.find(
       { orgId, type: ProjectType.PAM },
-      { sort: [["createdAt", "desc"]], limit: 1 }
+      { sort: [["createdAt", "desc"]], limit: 1, tx }
     );
     return projects.length ? projects[0].id : null;
   };
@@ -50,16 +52,11 @@ export const pamProjectResolverFactory = ({
       // have several), and the advisory lock auto-releases when this transaction ends.
       await tx.raw("SELECT pg_advisory_xact_lock(hashtext(?))", [`pam-bootstrap:${orgId}`]);
 
-      // Re-check inside the lock on the primary, with the same semantics as findDefaultProjectId
-      // (newest first, soft-deleted excluded). This resolves the race winner and, when several PAM
-      // projects exist (consolidated + old zombies), returns the consolidated one rather than an
-      // arbitrary row.
-      const existing = await tx(TableName.Project)
-        .where({ orgId, type: ProjectType.PAM })
-        .whereNull("deleteAfter")
-        .orderBy("createdAt", "desc")
-        .first("id");
-      if (existing) return existing.id;
+      // Re-check inside the lock on the primary (tx). Resolves the race winner and, when several PAM
+      // projects exist (consolidated + old zombies), returns the consolidated one rather than a
+      // stale/arbitrary row.
+      const existingId = await findDefaultProjectId(orgId, tx);
+      if (existingId) return existingId;
 
       const adminRows = (await tx(TableName.Membership)
         .join(TableName.MembershipRole, `${TableName.MembershipRole}.membershipId`, `${TableName.Membership}.id`)

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -259,10 +259,8 @@ export const pamSessionServiceFactory = ({
         sessionId
       };
     } else {
-      // Re-fetch (e.g. gateway restart/resume or a transient retry): the recording secrets are only
-      // issued once, so return the existing session key by decrypting the stored one. The upload
-      // token is left empty on purpose — the server only keeps its hash, and the gateway supplies its
-      // own disk-persisted token. Without this, a session spanning a gateway restart loses recording.
+      // On re-fetch (e.g. gateway restart) return the existing key; empty token since the gateway
+      // restores its own from disk and the server only keeps the token hash.
       const sessionKey = await decryptSessionKey({
         projectId: session.projectId,
         sessionId,

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -50,7 +50,7 @@ import {
 import { PamTemplateSettingsSchema } from "../pam-account-template/pam-account-template-schemas";
 import { TPamFolderDALFactory } from "../pam-folder/pam-folder-dal";
 import { PamRecordingStorageBackend } from "../pam-session-recording/pam-recording-enums";
-import { generateSessionRecordingSecrets } from "../pam-session-recording/pam-recording-secrets";
+import { decryptSessionKey, generateSessionRecordingSecrets } from "../pam-session-recording/pam-recording-secrets";
 import { ResourcePermissionPamResourceActions } from "../permission/resource-permission";
 import {
   AWS_STS_MIN_DURATION_SECONDS,
@@ -223,6 +223,14 @@ export const pamSessionServiceFactory = ({
       await pamSessionDAL.activateSession(sessionId);
     }
 
+    const templateSettingsParsed = account.templateSettings
+      ? PamTemplateSettingsSchema.safeParse(account.templateSettings)
+      : null;
+    const resolvedBackend =
+      templateSettingsParsed?.success && templateSettingsParsed.data.recordingStorageBackend
+        ? templateSettingsParsed.data.recordingStorageBackend
+        : PamRecordingStorageBackend.Postgres;
+
     let recording: {
       sessionKey: string;
       uploadToken: string;
@@ -243,17 +251,28 @@ export const pamSessionServiceFactory = ({
         gatewayUploadTokenHash: secrets.uploadTokenHash
       });
 
-      const templateSettingsParsed = account.templateSettings
-        ? PamTemplateSettingsSchema.safeParse(account.templateSettings)
-        : null;
-      const resolvedBackend =
-        templateSettingsParsed?.success && templateSettingsParsed.data.recordingStorageBackend
-          ? templateSettingsParsed.data.recordingStorageBackend
-          : PamRecordingStorageBackend.Postgres;
-
       recording = {
         sessionKey: secrets.sessionKey.toString("base64"),
         uploadToken: secrets.uploadToken.toString("base64"),
+        storageBackend: resolvedBackend,
+        projectId: session.projectId,
+        sessionId
+      };
+    } else {
+      // Re-fetch (e.g. gateway restart/resume or a transient retry): the recording secrets are only
+      // issued once, so return the existing session key by decrypting the stored one. The upload
+      // token is left empty on purpose — the server only keeps its hash, and the gateway supplies its
+      // own disk-persisted token. Without this, a session spanning a gateway restart loses recording.
+      const sessionKey = await decryptSessionKey({
+        projectId: session.projectId,
+        sessionId,
+        encryptedSessionKey: session.encryptedSessionKey,
+        kmsService
+      });
+
+      recording = {
+        sessionKey: sessionKey.toString("base64"),
+        uploadToken: "",
         storageBackend: resolvedBackend,
         projectId: session.projectId,
         sessionId

--- a/backend/src/ee/services/pam/CLAUDE.md
+++ b/backend/src/ee/services/pam/CLAUDE.md
@@ -81,6 +81,17 @@ PAM endpoints accept both `AuthMode.JWT` and `AuthMode.IDENTITY_ACCESS_TOKEN`, e
 
 Resource memberships are scoped to either a `PamFolder` or a `PamAccount` via the generic membership system (`ResourceType.PamFolder` / `ResourceType.PamAccount`).
 
+## Consolidated Project & Lazy Bootstrap
+
+There is exactly one PAM project (`ProjectType.PAM`) per org, holding all folders, accounts, templates, and memberships. New orgs get it eagerly at creation time. Orgs that had no PAM data at migration time get **no** project up front; it is created lazily on first PAM access. Code lives in `pam-project/`.
+
+- **`pamProjectResolverFactory` (`pam-project-resolver.ts`)** -- `resolve(orgId)` returns the project id, creating it on first use. It is wrapped in `withCache` (Redis, `KeyStorePrefixes.PamDefaultProject`, `PamDefaultProjectInSeconds` TTL); on a miss it calls `findDefaultProjectId` (newest `type=pam` project via `projectDAL.find`, already excludes soft-deleted) and falls back to `ensureDefaultProject`.
+- **`ensureDefaultProject`** serializes concurrent first-use bootstraps for an org with `SELECT pg_advisory_xact_lock(hashtext('pam-bootstrap:' || orgId))` inside a transaction, then **re-checks** `findDefaultProjectId(orgId, tx)` on the primary before creating. There is no DB unique constraint to lean on because old zombie PAM projects also have `type=pam`, so an org can legitimately have several rows; the lock + in-lock re-check is what prevents duplicates and picks the consolidated one. The lock auto-releases at transaction end.
+- **Admin seeding:** the bootstrap seeds the org's current admins (users, identities, and groups with a non-temporary org `admin` role) as PAM **project** admins. This is required because the PAM permission model has **no org-admin fallback** (`getProjectPermission` needs project-scoped membership) -- without seeding, no one could administer the freshly-created project.
+- **`bootstrapPamProject` (`pam-project-bootstrap.ts`)** creates the project, the `DEFAULT_ACCOUNT_TEMPLATES` (11 of them), and the admin memberships. It takes `adminUserIds` / `adminIdentityIds` / `adminGroupIds`; the migration and sub-org creation call it directly, the resolver derives those lists from current org admins.
+- **Request wiring:** the `injectPamProjectId` preValidation hook (on all `/api/v1/pam/*` routes) calls `resolve(actorOrgId)` and sets `req.internalPamProjectId`, so by the time any PAM handler runs the project exists. `GET /api/v1/pam/project` just returns that id -- the frontend hits it to trigger the lazy create for an org whose `getOrgById.pamProjectId` came back null, then seeds the id into its org cache.
+- **`getOrgById` derivation:** `pamProjectId` in the org DTO is derived from the newest `type=pam` project (nullable), it is **not** a stored column and is not resolved/bootstrapped there (keeps the read a pure query).
+
 ## Account Types
 
 Defined in `pam/pam-enums.ts` as `PamAccountType`. Each type's full config lives in `pam-account/pam-account-schemas.ts` in the `ACCOUNT_TYPE_CONFIGS` map. A config entry holds everything the backend and frontend need for that type:

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1645,7 +1645,10 @@ export const registerRoutes = async (
   });
 
   const pamProjectResolver = pamProjectResolverFactory({
+    db,
     projectDAL,
+    membershipDAL,
+    membershipRoleDAL,
     keyStore
   });
 

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -791,9 +791,7 @@ export const projectServiceFactory = ({
       });
     }
 
-    // PAM projects are not deletable here: the consolidated project is managed (one active project
-    // per org, recreated on demand), and any leftover pre-migration PAM projects still hold FK
-    // references from migrated accounts, so cascade-deleting them would break/erase that data.
+    // PAM projects are managed (one per org); deleting would also cascade FK-referenced migrated data.
     if (project.type === ProjectType.PAM) {
       throw new BadRequestError({
         message: "Privileged Access Manager projects cannot be deleted."

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -791,6 +791,13 @@ export const projectServiceFactory = ({
       });
     }
 
+    // PAM projects are managed (one per org) and cannot be deleted
+    if (project.type === ProjectType.PAM) {
+      throw new BadRequestError({
+        message: "Privileged Access Manager projects cannot be deleted."
+      });
+    }
+
     if (project.type === ProjectType.CertificateManager) {
       const certManagerProjects = await projectDAL.find({
         orgId: project.orgId,

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -791,7 +791,9 @@ export const projectServiceFactory = ({
       });
     }
 
-    // PAM projects are managed (one per org) and cannot be deleted
+    // PAM projects are not deletable here: the consolidated project is managed (one active project
+    // per org, recreated on demand), and any leftover pre-migration PAM projects still hold FK
+    // references from migrated accounts, so cascade-deleting them would break/erase that data.
     if (project.type === ProjectType.PAM) {
       throw new BadRequestError({
         message: "Privileged Access Manager projects cannot be deleted."

--- a/frontend/src/hooks/api/pam/queries.tsx
+++ b/frontend/src/hooks/api/pam/queries.tsx
@@ -30,6 +30,12 @@ import {
   TPamSession
 } from "./types";
 
+// Resolves the org's PAM project, creating it on first access (lazy bootstrap on the backend).
+export const fetchPamProjectId = async () => {
+  const { data } = await apiRequest.get<{ projectId: string }>("/api/v1/pam/project");
+  return data.projectId;
+};
+
 export const pamKeys = {
   all: ["pam"] as const,
   account: () => [...pamKeys.all, "account"] as const,

--- a/frontend/src/pages/pam/layout.tsx
+++ b/frontend/src/pages/pam/layout.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { BreadcrumbTypes } from "@app/components/v2";
 import { projectKeys } from "@app/hooks/api";
-import { fetchOrganizationById, organizationKeys } from "@app/hooks/api/organization/queries";
+import { organizationKeys } from "@app/hooks/api/organization/queries";
 import { Organization } from "@app/hooks/api/organization/types";
 import { fetchPamProjectId } from "@app/hooks/api/pam/queries";
 import { fetchProjectById } from "@app/hooks/api/projects/queries";
@@ -22,14 +22,14 @@ export const Route = createFileRoute(
     let pamProjectId = org?.pamProjectId;
     if (!pamProjectId) {
       // The org has no consolidated PAM project yet (lazy creation). Hitting the PAM endpoint
-      // bootstraps it server-side; refetch the org so pamProjectId is populated for the contexts
-      // that read it (ProjectContext / ProjectPermissionContext).
+      // bootstraps it server-side and returns its id. Patch it straight into the cached org so the
+      // contexts that read it (ProjectContext / ProjectPermissionContext) pick it up. We inject the
+      // id we just got rather than refetching the org, which avoids a round-trip and the read-replica
+      // lag window where getOrgById could still re-derive pamProjectId=null right after the write.
       pamProjectId = await fetchPamProjectId();
-      const refreshedOrg = await context.queryClient.fetchQuery({
-        queryKey: organizationKeys.getOrgById(params.orgId),
-        queryFn: () => fetchOrganizationById(params.orgId)
-      });
-      pamProjectId = refreshedOrg?.pamProjectId ?? pamProjectId;
+      context.queryClient.setQueryData<Organization>(organizationKeys.getOrgById(params.orgId), (old) =>
+        old ? { ...old, pamProjectId } : old
+      );
     }
 
     if (!pamProjectId) {

--- a/frontend/src/pages/pam/layout.tsx
+++ b/frontend/src/pages/pam/layout.tsx
@@ -26,9 +26,11 @@ export const Route = createFileRoute(
       // contexts that read it (ProjectContext / ProjectPermissionContext) pick it up. We inject the
       // id we just got rather than refetching the org, which avoids a round-trip and the read-replica
       // lag window where getOrgById could still re-derive pamProjectId=null right after the write.
-      pamProjectId = await fetchPamProjectId();
-      context.queryClient.setQueryData<Organization>(organizationKeys.getOrgById(params.orgId), (old) =>
-        old ? { ...old, pamProjectId } : old
+      const resolvedPamProjectId = await fetchPamProjectId();
+      pamProjectId = resolvedPamProjectId;
+      context.queryClient.setQueryData<Organization>(
+        organizationKeys.getOrgById(params.orgId),
+        (old) => (old ? { ...old, pamProjectId: resolvedPamProjectId } : old)
       );
     }
 

--- a/frontend/src/pages/pam/layout.tsx
+++ b/frontend/src/pages/pam/layout.tsx
@@ -21,11 +21,8 @@ export const Route = createFileRoute(
 
     let pamProjectId = org?.pamProjectId;
     if (!pamProjectId) {
-      // The org has no consolidated PAM project yet (lazy creation). Hitting the PAM endpoint
-      // bootstraps it server-side and returns its id. Patch it straight into the cached org so the
-      // contexts that read it (ProjectContext / ProjectPermissionContext) pick it up. We inject the
-      // id we just got rather than refetching the org, which avoids a round-trip and the read-replica
-      // lag window where getOrgById could still re-derive pamProjectId=null right after the write.
+      // Lazily bootstrap the project and patch its id into the cached org so the Project/ProjectPermission
+      // contexts pick it up (injecting the returned id avoids a refetch that could race read-replica lag).
       const resolvedPamProjectId = await fetchPamProjectId();
       pamProjectId = resolvedPamProjectId;
       context.queryClient.setQueryData<Organization>(

--- a/frontend/src/pages/pam/layout.tsx
+++ b/frontend/src/pages/pam/layout.tsx
@@ -2,8 +2,9 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { BreadcrumbTypes } from "@app/components/v2";
 import { projectKeys } from "@app/hooks/api";
-import { organizationKeys } from "@app/hooks/api/organization/queries";
+import { fetchOrganizationById, organizationKeys } from "@app/hooks/api/organization/queries";
 import { Organization } from "@app/hooks/api/organization/types";
+import { fetchPamProjectId } from "@app/hooks/api/pam/queries";
 import { fetchProjectById } from "@app/hooks/api/projects/queries";
 import { fetchUserProjectPermissions, roleQueryKeys } from "@app/hooks/api/roles/queries";
 import { PamLayout } from "@app/layouts/PamLayout";
@@ -18,7 +19,19 @@ export const Route = createFileRoute(
       organizationKeys.getOrgById(params.orgId)
     );
 
-    const pamProjectId = org?.pamProjectId;
+    let pamProjectId = org?.pamProjectId;
+    if (!pamProjectId) {
+      // The org has no consolidated PAM project yet (lazy creation). Hitting the PAM endpoint
+      // bootstraps it server-side; refetch the org so pamProjectId is populated for the contexts
+      // that read it (ProjectContext / ProjectPermissionContext).
+      pamProjectId = await fetchPamProjectId();
+      const refreshedOrg = await context.queryClient.fetchQuery({
+        queryKey: organizationKeys.getOrgById(params.orgId),
+        queryFn: () => fetchOrganizationById(params.orgId)
+      });
+      pamProjectId = refreshedOrg?.pamProjectId ?? pamProjectId;
+    }
+
     if (!pamProjectId) {
       throw redirect({
         to: "/organizations/$orgId/projects",


### PR DESCRIPTION
Creates an org's consolidated PAM project lazily on first use instead of eagerly for every org during the migration. Targets `pam-revamp`.

- The migration now only creates a project for orgs that already have PAM data; the rest are skipped.
- Orgs with no PAM data get their project created the first time someone opens PAM, guarded by a per-org lock so simultaneous requests can't create duplicates.
- That first-use creation seeds the org's admins (users, identities, and groups) as PAM admins. This also fixes a pre-existing bug: the eager migration created projects for empty orgs with no admins, which nobody could then administer.

Tested on a fresh database: empty orgs get no project from the migration; a data org still migrates correctly; 12 simultaneous first-use requests produce exactly one project; and org admins (user/identity/group) are seeded while non-admins are not.
