### PR TITLE
fix(frontend): prevent signup header from sticking to top edge

### DIFF
--- a/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
@@ -116,7 +116,7 @@ export const SignUpPage = ({ invite }: SignUpPageProps) => {
   };
 
   return (
-    <div className="relative flex max-h-screen min-h-screen flex-col overflow-y-auto bg-linear-to-tr from-card via-bunker-900 to-card px-4">
+    <div className="relative flex max-h-screen min-h-screen flex-col overflow-y-auto bg-linear-to-tr from-card via-bunker-900 to-card px-4 py-4">
       <AuthPageBackground />
       <Helmet>
         <title>{t("common.head-title", { title: t("signup.title") })}</title>


### PR DESCRIPTION
## Context

Closes #7166.

On the signup page, the content (OAuth buttons + email form) is tall enough to overflow the `max-h-screen` scroll container. When it overflows, the header, the logo and the top-right "Log In" button scrolls flush against the very top edge of the page with no breathing room.

This adds `py-4` to the signup page's scroll container (`frontend/src/pages/auth/SignUpPage/SignUpPage.tsx`), matching its existing `px-4` horizontal inset, so the header keeps a consistent top inset even when the content overflows. Scoped to the signup page only. The shared `AuthPageHeader` is untouched, so the login page (shorter content, no overflow) is unchanged.

## Screenshots

**Before:**
<img width="3024" height="1655" alt="signup-header-before" src="https://github.com/user-attachments/assets/654ddb98-9adc-487f-a3a1-81db83874624" />


**After:** 
<img width="3024" height="1582" alt="signup-header-after" src="https://github.com/user-attachments/assets/4dadc3cf-d20c-41ef-8648-2e555f0a326b" />


## Steps to verify the change

1. Open the signup page and reduce the viewport height so the content overflows.
2. Scroll to the top.
3. Before: the logo and "Log In" button sit flush against the top edge. After: they keep a top inset matching the horizontal padding.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [ ] Updated docs (if needed) — n/a
- [ ] Updated CLAUDE.md files (if needed) — n/a
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
