### PR TITLE
fix(secret-v2-bridge/secret-version): skip soft-deleted projects in PIT prune query

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-version-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-version-dal.ts
@@ -194,6 +194,7 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
         // Projects with version >= 3 will require to have all secret versions for PIT
         .andWhere(`${TableName.Project}.version`, "<", 3)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .delete();
     } catch (error) {
       throw new DatabaseError({


### PR DESCRIPTION
## What

The secret-version-v2 PIT prune query in \`secret-v2-bridge/secret-version-dal.ts\` joins \`projects\` (to read \`pitVersionLimit\` and \`project.version\`) but only filters \`Environment.deleteAfter\`, never \`Project.deleteAfter\`. Same pattern as the v1 prune fix in #7156 and the folder-version prune fix in #7155.

Soft-deleting a project does not soft-delete its environments, so the prune cron keeps trimming v2 secret-version history against projects sitting in the delete grace window — wasted DB work at best, racing with the cleanup worker at worst.

## Fix

Adds \`whereNull(Project.deleteAfter)\` to the prune query. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), app-connection (#7125), secret-approval-request-secret (#7126), secret-folder-version (#7155), secret-version v1 (#7156), and offline-usage-report (#7157) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path