### PR TITLE
fix(telemetry): skip soft-deleted projects in instance-stats counts

### DIFF
--- a/backend/src/services/telemetry/telemetry-dal.ts
+++ b/backend/src/services/telemetry/telemetry-dal.ts
@@ -70,11 +70,21 @@ export const telemetryDALFactory = (db: TDbClient) => {
           return parseInt(result || "0", 10);
         })(),
         countTable(db, TableName.Identity),
-        countTable(db, TableName.Project),
+        (async () => {
+          const result = (await db(TableName.Project).whereNull("deleteAfter").count().first())?.count as string;
+          return parseInt(result || "0", 10);
+        })(),
         countTable(db, TableName.Secret),
         countTable(db, TableName.SecretV2),
         (async () => {
-          const result = (await db(TableName.Environment).whereNull("deleteAfter").count().first())?.count as string;
+          const result = (
+            await db(TableName.Environment)
+              .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+              .whereNull(`${TableName.Environment}.deleteAfter`)
+              .whereNull(`${TableName.Project}.deleteAfter`)
+              .count()
+              .first()
+          )?.count as string;
           return parseInt(result || "0", 10);
         })(),
         countTable(db, TableName.SecretSync),
@@ -168,6 +178,7 @@ export const telemetryDALFactory = (db: TDbClient) => {
 
       // Project type breakdown
       const projectTypeRows = (await db(TableName.Project)
+        .whereNull("deleteAfter")
         .select("type")
         .count("* as count")
         .groupBy("type")) as unknown as { type: string; count: string }[];
@@ -199,6 +210,7 @@ export const telemetryDALFactory = (db: TDbClient) => {
       const orgUserMap = new Map(orgUserRows.map((r) => [r.scopeOrgId, parseInt(String(r.count), 10)]));
 
       const orgProjectRows = (await db(TableName.Project)
+        .whereNull("deleteAfter")
         .select("orgId")
         .count("* as count")
         .groupBy("orgId")) as unknown as { orgId: string; count: string }[];


### PR DESCRIPTION
## What

\`getTelemetryInstanceStats\` reports several counts to the telemetry endpoint. Four of them silently included soft-deleted projects because they read \`TableName.Project\` raw or filtered only \`Environment.deleteAfter\`:

- \`projects\` total (was \`countTable\`, raw)
- \`environments\` total (filtered \`Environment.deleteAfter\` only, no \`Project.deleteAfter\`)
- \`projectTypeBreakdown\` (raw)
- \`orgProjectRows\` → \`organizationBreakdown.projects\` (raw)

Soft-deleting a project does not soft-delete its environments, so the reported instance stats over-counted both projects and environments during the delete grace window. The CSV report and cloud-side dashboards were inflated for as long as the grace window lasted.

## Fix

Adds \`whereNull(Project.deleteAfter)\` to each of the four project-facing queries and joins Project into the environment count so it can honor the same filter. Other per-resource counts (secrets, dynamic-secret, rotations, syncs, etc.) are left alone in this PR to keep the diff focused; they can follow the same pattern in later work if the reported inflation matters there.

Same shape as previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), app-connection (#7125), secret-approval-request-secret (#7126), secret-folder-version (#7155), secret-version v1 (#7156), offline-usage-report (#7157), secret-v2-bridge/secret-version (#7167), and project-folder-grant (#7168) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path