### PR TITLE
fix: drop modal z index for those that inline app connection to prevent inproper hierarchy

### DIFF
--- a/frontend/src/components/pki-syncs/CreatePkiSyncModal.tsx
+++ b/frontend/src/components/pki-syncs/CreatePkiSyncModal.tsx
@@ -66,10 +66,11 @@ export const CreatePkiSyncModal = ({
         onOpenChange(isOpen);
       }}
     >
-      {/* Sit below the v3 overlay layer (z-50) so the inline "Create Connection" Sheet and its v3
-          Select menus stack above this modal instead of being buried behind it. */}
+      {/* z-50 (not the v2 default z-[60]) so the inline "Create Connection" Sheet and its v3 Select
+          menus (all z-50, portaled later) stack above this modal instead of being buried behind it,
+          while the backdrop still covers page chrome up to z-50 by portal order. */}
       <ModalContent
-        overlayClassName="z-40"
+        overlayClassName="z-50"
         title={
           selectedSync ? (
             <PkiSyncModalHeader isConfigured={false} destination={selectedSync} />
@@ -77,7 +78,7 @@ export const CreatePkiSyncModal = ({
             "Add Sync"
           )
         }
-        className="z-40 max-w-3xl"
+        className="z-50 max-w-3xl"
         bodyClassName={selectedSync ? "overflow-visible" : undefined}
         subTitle={
           selectedSync ? undefined : "Select a third-party service to sync certificates to."

--- a/frontend/src/components/pki-syncs/CreatePkiSyncModal.tsx
+++ b/frontend/src/components/pki-syncs/CreatePkiSyncModal.tsx
@@ -66,7 +66,10 @@ export const CreatePkiSyncModal = ({
         onOpenChange(isOpen);
       }}
     >
+      {/* Sit below the v3 overlay layer (z-50) so the inline "Create Connection" Sheet and its v3
+          Select menus stack above this modal instead of being buried behind it. */}
       <ModalContent
+        overlayClassName="z-40"
         title={
           selectedSync ? (
             <PkiSyncModalHeader isConfigured={false} destination={selectedSync} />
@@ -74,7 +77,7 @@ export const CreatePkiSyncModal = ({
             "Add Sync"
           )
         }
-        className="max-w-3xl"
+        className="z-40 max-w-3xl"
         bodyClassName={selectedSync ? "overflow-visible" : undefined}
         subTitle={
           selectedSync ? undefined : "Select a third-party service to sync certificates to."

--- a/frontend/src/components/pki-syncs/EditPkiSyncModal.tsx
+++ b/frontend/src/components/pki-syncs/EditPkiSyncModal.tsx
@@ -15,11 +15,14 @@ type Props = {
 export const EditPkiSyncModal = ({ pkiSync, onOpenChange, fields, ...props }: Props) => {
   if (!pkiSync) return null;
 
-  const modalClassName = fields === PkiSyncEditFields.Mappings ? "max-w-4xl" : "max-w-2xl";
+  // z-40 keeps this modal below the v3 overlay layer (z-50) so the inline "Create Connection" Sheet
+  // and its v3 Select menus stack above it instead of being buried behind it.
+  const modalClassName = fields === PkiSyncEditFields.Mappings ? "z-40 max-w-4xl" : "z-40 max-w-2xl";
 
   return (
     <Modal {...props} onOpenChange={onOpenChange}>
       <ModalContent
+        overlayClassName="z-40"
         title={<PkiSyncModalHeader isConfigured destination={pkiSync.destination} />}
         className={modalClassName}
         bodyClassName="overflow-visible"

--- a/frontend/src/components/pki-syncs/EditPkiSyncModal.tsx
+++ b/frontend/src/components/pki-syncs/EditPkiSyncModal.tsx
@@ -15,14 +15,16 @@ type Props = {
 export const EditPkiSyncModal = ({ pkiSync, onOpenChange, fields, ...props }: Props) => {
   if (!pkiSync) return null;
 
-  // z-40 keeps this modal below the v3 overlay layer (z-50) so the inline "Create Connection" Sheet
-  // and its v3 Select menus stack above it instead of being buried behind it.
-  const modalClassName = fields === PkiSyncEditFields.Mappings ? "z-40 max-w-4xl" : "z-40 max-w-2xl";
+  // z-50 (not the v2 default z-[60]) so the inline "Create Connection" Sheet and its v3 Select
+  // menus (all z-50, portaled later) stack above this modal instead of being buried behind it,
+  // while the backdrop still covers page chrome up to z-50 by portal order.
+  const modalClassName =
+    fields === PkiSyncEditFields.Mappings ? "z-50 max-w-4xl" : "z-50 max-w-2xl";
 
   return (
     <Modal {...props} onOpenChange={onOpenChange}>
       <ModalContent
-        overlayClassName="z-40"
+        overlayClassName="z-50"
         title={<PkiSyncModalHeader isConfigured destination={pkiSync.destination} />}
         className={modalClassName}
         bodyClassName="overflow-visible"

--- a/frontend/src/components/secret-rotations-v2/CreateSecretRotationV2Modal.tsx
+++ b/frontend/src/components/secret-rotations-v2/CreateSecretRotationV2Modal.tsx
@@ -109,7 +109,10 @@ export const CreateSecretRotationV2Modal = ({ onOpenChange, isOpen, ...props }: 
         onOpenChange(open);
       }}
     >
+      {/* Sit below the v3 overlay layer (z-50) so the inline "Create Connection" Sheet and its v3
+          Select menus stack above this modal instead of being buried behind it. */}
       <ModalContent
+        overlayClassName="z-40"
         title={
           selectedRotation ? (
             <SecretRotationV2ModalHeader isConfigured={false} type={selectedRotation} />
@@ -120,7 +123,7 @@ export const CreateSecretRotationV2Modal = ({ onOpenChange, isOpen, ...props }: 
             </div>
           )
         }
-        className={selectedRotation ? "max-w-2xl" : "max-w-3xl"}
+        className={selectedRotation ? "z-40 max-w-2xl" : "z-40 max-w-3xl"}
         subTitle={
           selectedRotation ? undefined : "Select a provider to create a secret rotation for."
         }

--- a/frontend/src/components/secret-rotations-v2/CreateSecretRotationV2Modal.tsx
+++ b/frontend/src/components/secret-rotations-v2/CreateSecretRotationV2Modal.tsx
@@ -109,10 +109,11 @@ export const CreateSecretRotationV2Modal = ({ onOpenChange, isOpen, ...props }: 
         onOpenChange(open);
       }}
     >
-      {/* Sit below the v3 overlay layer (z-50) so the inline "Create Connection" Sheet and its v3
-          Select menus stack above this modal instead of being buried behind it. */}
+      {/* z-50 (not the v2 default z-[60]) so the inline "Create Connection" Sheet and its v3 Select
+          menus (all z-50, portaled later) stack above this modal instead of being buried behind it,
+          while the backdrop still covers page chrome up to z-50 by portal order. */}
       <ModalContent
-        overlayClassName="z-40"
+        overlayClassName="z-50"
         title={
           selectedRotation ? (
             <SecretRotationV2ModalHeader isConfigured={false} type={selectedRotation} />
@@ -123,7 +124,7 @@ export const CreateSecretRotationV2Modal = ({ onOpenChange, isOpen, ...props }: 
             </div>
           )
         }
-        className={selectedRotation ? "z-40 max-w-2xl" : "z-40 max-w-3xl"}
+        className={selectedRotation ? "z-50 max-w-2xl" : "z-50 max-w-3xl"}
         subTitle={
           selectedRotation ? undefined : "Select a provider to create a secret rotation for."
         }

--- a/frontend/src/components/secret-scanning/CreateSecretScanningDataSourceModal.tsx
+++ b/frontend/src/components/secret-scanning/CreateSecretScanningDataSourceModal.tsx
@@ -102,10 +102,11 @@ export const CreateSecretScanningDataSourceModal = ({ onOpenChange, isOpen, ...p
         onOpenChange(open);
       }}
     >
-      {/* Sit below the v3 overlay layer (z-50) so the inline "Create Connection" Sheet and its v3
-          Select menus stack above this modal instead of being buried behind it. */}
+      {/* z-50 (not the v2 default z-[60]) so the inline "Create Connection" Sheet and its v3 Select
+          menus (all z-50, portaled later) stack above this modal instead of being buried behind it,
+          while the backdrop still covers page chrome up to z-50 by portal order. */}
       <ModalContent
-        overlayClassName="z-40"
+        overlayClassName="z-50"
         title={
           selectedDataSource ? (
             <SecretScanningDataSourceModalHeader isConfigured={false} type={selectedDataSource} />
@@ -116,7 +117,7 @@ export const CreateSecretScanningDataSourceModal = ({ onOpenChange, isOpen, ...p
             </div>
           )
         }
-        className={selectedDataSource ? "z-40 max-w-2xl" : "z-40 max-w-3xl"}
+        className={selectedDataSource ? "z-50 max-w-2xl" : "z-50 max-w-3xl"}
         subTitle={
           selectedDataSource ? undefined : "Select a data source to configure secret scanning for."
         }

--- a/frontend/src/components/secret-scanning/CreateSecretScanningDataSourceModal.tsx
+++ b/frontend/src/components/secret-scanning/CreateSecretScanningDataSourceModal.tsx
@@ -102,7 +102,10 @@ export const CreateSecretScanningDataSourceModal = ({ onOpenChange, isOpen, ...p
         onOpenChange(open);
       }}
     >
+      {/* Sit below the v3 overlay layer (z-50) so the inline "Create Connection" Sheet and its v3
+          Select menus stack above this modal instead of being buried behind it. */}
       <ModalContent
+        overlayClassName="z-40"
         title={
           selectedDataSource ? (
             <SecretScanningDataSourceModalHeader isConfigured={false} type={selectedDataSource} />
@@ -113,7 +116,7 @@ export const CreateSecretScanningDataSourceModal = ({ onOpenChange, isOpen, ...p
             </div>
           )
         }
-        className={selectedDataSource ? "max-w-2xl" : "max-w-3xl"}
+        className={selectedDataSource ? "z-40 max-w-2xl" : "z-40 max-w-3xl"}
         subTitle={
           selectedDataSource ? undefined : "Select a data source to configure secret scanning for."
         }


### PR DESCRIPTION
## Context

This PR fixes a z index issue for v2 modals that inline app connection creation

## Screenshots

<img width="3456" height="1918" alt="CleanShot 2026-07-06 at 11 38 24@2x" src="https://github.com/user-attachments/assets/6a401ed5-aa50-47bc-9b6a-317ef3633bba" />

## Steps to verify the change

verify inline app creation from cert, data source and secret rotation open above v2 modal

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)