### PR TITLE
fix(telemetry): drop org ID from InfisicalCore metrics

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -293,6 +293,19 @@ Key plugins in `src/server/plugins/`:
 - `maintenanceMode.ts` — maintenance mode middleware
 - `ip.ts` — IP extraction and validation
 
+### Telemetry / Metrics
+
+OpenTelemetry metric setup lives in `src/lib/telemetry/`. Instruments are defined in `metrics.ts` (resolved lazily so they bind to the real MeterProvider installed by `instrumentation.ts` after boot).
+
+**Meter split by cardinality:**
+- **`InfisicalCore`** — the meter for all new metrics. A strict attribute allowlist (`INFISICAL_CORE_METER_ATTRIBUTES` in `telemetry-attributes.ts`) is applied via an SDK View, so **only bounded labels survive** — HTTP method, parameterized `http.route` template, and low-cardinality enums. This is the single choke point: any attribute passed at a call site that isn't in the allowlist is silently dropped.
+- **Legacy `Infisical` / `API` / `SecretSyncs` / `PkiSyncs` / `Integrations`** — have no View and carry unbounded per-actor labels. Dropped wholesale via `OTEL_DROP_HIGH_CARDINALITY_METERS=true` in multi-tenant/cloud.
+
+**Rules for InfisicalCore metrics:**
+- **No per-tenant / per-actor identifiers** as labels — no org id, user id/email, identity id, ip, user agent, request id, or free-form values (e.g. environment slug). These scale series count with customer count, which breaks CloudWatch's 1000-datapoint-per-OTLP-request limit and drives per-GB ingestion cost. Use the **audit log table** for per-org / per-actor breakdowns.
+- Adding a new label means adding it to the allowlist in `telemetry-attributes.ts`. Only add **bounded** keys (fixed enums / static route templates), and document why.
+- `http.route` must be the parameterized template (`req.routeOptions.url`), never the raw request path.
+
 ### Database Configuration
 
 Knex config in `src/db/knexfile.ts`. Loads `.env.migration` then `.env`. Supports `DB_CONNECTION_URI` or individual host/port/user/name/password fields. Optional SSL via `DB_ROOT_CERT` (base64-encoded CA cert). Connection pool: min 2, max 10. Migrations table: `infisical_migrations`. Separate audit log DB supported via `auditlog-migration:*` scripts. ClickHouse for analytics (optional).

--- a/backend/src/ee/services/audit-log-stream-outbox/audit-log-stream-outbox-service.ts
+++ b/backend/src/ee/services/audit-log-stream-outbox/audit-log-stream-outbox-service.ts
@@ -240,8 +240,7 @@ export const auditLogStreamOutboxServiceFactory = ({
       const sendChunk = async (chunk: TAuditLogStreamOutboxRow[]) => {
         const deliveryStart = Date.now();
         const metricAttrs = {
-          "audit_log_stream.provider": provider,
-          "infisical.organization.id": orgId
+          "audit_log_stream.provider": provider
         };
         try {
           if (isSingleMode) {
@@ -327,7 +326,6 @@ export const auditLogStreamOutboxServiceFactory = ({
         }
         auditLogStreamDeliveryExhaustedCounter.add(exhausted.length, {
           "audit_log_stream.id": streamId,
-          "infisical.organization.id": orgId,
           "audit_log_stream.provider": provider
         });
       }
@@ -380,20 +378,16 @@ export const auditLogStreamOutboxServiceFactory = ({
       );
     }
     if (dropped.length > 0) {
-      // Stale claims that used up their attempts are dropped (no DLQ); count them
-      // alongside delivery-path exhaustions, keyed by the same stream/org dimensions.
-      // No provider attribute here — the row doesn't carry it and the sweep isn't tied
-      // to a specific delivery attempt.
-      const droppedByStream = new Map<string, { streamId: string; orgId: string; count: number }>();
-      for (const { streamId, orgId } of dropped) {
-        const entry = droppedByStream.get(streamId);
-        if (entry) entry.count += 1;
-        else droppedByStream.set(streamId, { streamId, orgId, count: 1 });
+      // Stale claims that used up their attempts are dropped (no DLQ); count them alongside
+      // delivery-path exhaustions, keyed by stream. No provider attribute here — the row doesn't carry
+      // it and the sweep isn't tied to a specific delivery attempt.
+      const droppedCountByStream = new Map<string, number>();
+      for (const { streamId } of dropped) {
+        droppedCountByStream.set(streamId, (droppedCountByStream.get(streamId) ?? 0) + 1);
       }
-      for (const { streamId, orgId, count } of droppedByStream.values()) {
+      for (const [streamId, count] of droppedCountByStream) {
         auditLogStreamDeliveryExhaustedCounter.add(count, {
-          "audit_log_stream.id": streamId,
-          "infisical.organization.id": orgId
+          "audit_log_stream.id": streamId
         });
       }
     }

--- a/backend/src/lib/telemetry/instrumentation.ts
+++ b/backend/src/lib/telemetry/instrumentation.ts
@@ -18,57 +18,9 @@ import tracer from "dd-trace";
 import dotenv from "dotenv";
 
 import { getTelemetryConfig } from "../config/env";
+import { HIGH_CARDINALITY_METER_NAMES, INFISICAL_CORE_METER_ATTRIBUTES } from "./telemetry-attributes";
 
 dotenv.config();
-
-// Strict allowlist of attribute keys that may appear on metrics emitted by the "InfisicalCore" meter.
-// Any attribute passed at a call site that's not in this list is silently dropped by the SDK View.
-// Cardinality control is centralized here. Call sites stay simple and a contributor adding an
-// unbounded label by mistake is caught automatically.
-//
-// If you need per-actor breakdowns, query the audit log table. It carries actorId, actorType, ip, userAgent and full event detail.
-const INFISICAL_CORE_METER_ATTRIBUTES = [
-  // HTTP semantics
-  "http.request.method",
-  "http.route",
-  "http.response.status_code",
-  // Tenant scope — bounded by org count
-  "infisical.organization.id",
-  "infisical.environment",
-  // Bounded enums
-  "infisical.auth.method",
-  "infisical.auth.result",
-  "queue.name",
-  "queue.state",
-  "job.name",
-  "error.type",
-  "outcome",
-  "attempts.exhausted",
-  "audit_log.event_type",
-  "audit_log.actor_type",
-  "audit_log.backend",
-  "audit_log.drop_reason",
-  "audit_log_stream.provider",
-  "audit_log_stream.id",
-  "scim.operation",
-  "sso.provider",
-  "sso.action",
-  "db.pool.state",
-  "cache.result",
-  "rate_limit.bucket",
-  // License Server v2 dual-read comparison (bounded: feature key set + a small set of diff kinds)
-  "license.feature",
-  "license.dual_read.kind",
-  // Build info gauge labels — single-value per deploy, no cardinality concern
-  "service.version",
-  "git.commit.sha",
-  "node.version"
-];
-
-// Every meter that predates the InfisicalCore allowlist. None have a View, so their per-actor / unbounded
-// labels (user.email, client.address, syncId, ...) flow through unchanged unless dropped wholesale via
-// OTEL_DROP_HIGH_CARDINALITY_METERS. Kept on by default for self-hosted; dropped in multi-tenant/cloud.
-const HIGH_CARDINALITY_METER_NAMES = ["Infisical", "API", "SecretSyncs", "PkiSyncs", "Integrations"];
 
 const initTelemetryInstrumentation = ({
   exportType,

--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -232,20 +232,6 @@ export const recordKmipOperationMetric = (params: {
 
 const isTelemetryEnabled = () => getConfig().OTEL_TELEMETRY_COLLECTION_ENABLED;
 
-/**
- * Pull only the keys that survive the InfisicalCore View allowlist (see instrumentation.ts):
- * organization.id. Returns an empty object when no request context is
- * available (e.g. queue workers / cron handlers) — those call sites pass their own tenant labels.
- */
-export const buildBaseAttributes = (): Record<string, string> => {
-  const attributes: Record<string, string> = {};
-
-  const orgId = requestContext.get(RequestContextKey.OrgId);
-  if (orgId) attributes["infisical.organization.id"] = orgId;
-
-  return attributes;
-};
-
 // Queue worker lifecycle metrics. Wired in queue-service.ts via worker.on('completed' | 'failed' | 'stalled').
 export const queueJobCounter = infisicalCoreMeter.createCounter("infisical.queue.job.count", {
   description: "Queue jobs processed by outcome (completed or failed)",
@@ -362,15 +348,14 @@ export const secretCacheOversizeSkipCounter = infisicalCoreMeter.createCounter(
 
 export const recordSecretCacheAccessMetric = (result: SecretCacheAccessResult) => {
   if (!isTelemetryEnabled()) return;
-  secretCacheAccessCounter.add(1, { ...buildBaseAttributes(), "cache.result": result });
+  secretCacheAccessCounter.add(1, { "cache.result": result });
 };
 
 export const recordSecretCacheWriteMetric = (params: { bytes: number; stored: boolean }) => {
   if (!isTelemetryEnabled()) return;
-  const attributes = buildBaseAttributes();
-  secretCacheEntryBytesHistogram.record(params.bytes, attributes);
+  secretCacheEntryBytesHistogram.record(params.bytes);
   if (!params.stored) {
-    secretCacheOversizeSkipCounter.add(1, attributes);
+    secretCacheOversizeSkipCounter.add(1);
   }
 };
 
@@ -432,7 +417,6 @@ export const recordAuthAttemptMetric = (params: {
     "infisical.auth.result": params.result
   };
   if (params.error !== undefined) attributes["error.type"] = classifyError(params.error);
-  if (params.orgId) attributes["infisical.organization.id"] = params.orgId;
   authAttemptDurationHistogram.record((performance.now() - params.startTime) / 1000, attributes);
 };
 
@@ -483,7 +467,6 @@ export const recordScimOperationMetric = (params: {
     "scim.operation": params.operation,
     outcome: params.outcome
   };
-  if (params.orgId) attributes["infisical.organization.id"] = params.orgId;
   if (params.error !== undefined) attributes["error.type"] = classifyError(params.error);
   scimOperationDurationHistogram.record((performance.now() - params.startTime) / 1000, attributes);
 };
@@ -515,7 +498,6 @@ export const recordSsoConfigChangeMetric = (params: {
     "sso.provider": params.provider,
     "sso.action": params.action
   };
-  if (params.orgId) attributes["infisical.organization.id"] = params.orgId;
   ssoConfigChangeCounter.add(1, attributes);
 };
 

--- a/backend/src/lib/telemetry/telemetry-attributes.ts
+++ b/backend/src/lib/telemetry/telemetry-attributes.ts
@@ -1,0 +1,42 @@
+// Allowlist for the "InfisicalCore" meter. Any attribute not listed is dropped by the SDK View.
+// Per-tenant/per-actor ids (org id, user id/email, identity id, ip, user agent, reqId) and free-form
+// values (environment slug) are excluded on purpose: they scale series with customer count. Use audit logs.
+export const INFISICAL_CORE_METER_ATTRIBUTES = [
+  // http.route must be the parameterized template (req.routeOptions.url), not the raw path.
+  "http.request.method",
+  "http.route",
+  "http.response.status_code",
+  // Bounded enums
+  "infisical.auth.method",
+  "infisical.auth.result",
+  "queue.name",
+  "queue.state",
+  "job.name",
+  "error.type",
+  "outcome",
+  "attempts.exhausted",
+  "audit_log.event_type",
+  "audit_log.actor_type",
+  "audit_log.backend",
+  "audit_log.drop_reason",
+  "audit_log_stream.provider",
+  "audit_log_stream.id",
+  "scim.operation",
+  "sso.provider",
+  "sso.action",
+  "db.pool.state",
+  "cache.result",
+  "rate_limit.bucket",
+  // License Server v2 dual-read comparison (bounded: feature key set + a small set of diff kinds)
+  "license.feature",
+  "license.dual_read.kind",
+  // Build info gauge labels — single-value per deploy, no cardinality concern
+  "service.version",
+  "git.commit.sha",
+  "node.version"
+];
+
+// Every meter that predates the InfisicalCore allowlist. None have a View, so their per-actor / unbounded
+// labels (user.email, client.address, syncId, ...) flow through unchanged unless dropped wholesale via
+// OTEL_DROP_HIGH_CARDINALITY_METERS. Kept on by default for self-hosted; dropped in multi-tenant/cloud.
+export const HIGH_CARDINALITY_METER_NAMES = ["Infisical", "API", "SecretSyncs", "PkiSyncs", "Integrations"];

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -173,7 +173,6 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         "http.route": route ?? "unknown",
         "error.type": classifyError(error)
       };
-      if (orgId) coreAttrs["infisical.organization.id"] = orgId;
       coreHttpErrorCounter.add(1, coreAttrs);
     }
 

--- a/docs/self-hosting/guides/monitoring-telemetry.mdx
+++ b/docs/self-hosting/guides/monitoring-telemetry.mdx
@@ -343,7 +343,7 @@ Replace `otel-collector:8889` with the actual hostname and port where your OpenT
 Infisical emits metrics on two OpenTelemetry meters simultaneously. Choose which to scrape based on your deployment scale.
 
 - **High-cardinality, per-actor meters:** the `Infisical` and `API` meters' original metrics (`infisical.http.server.request.*`, `infisical.http.server.error.count`, `infisical.secret.read.count`, `infisical.auth.attempt.count`, `infisical.kmip.operation.count`) include per-actor labels such as `user.email`, `identity.name`, `client.address`, `user_agent.original`, `organization.name`, `project.name`, `secret.path`, and `secret.name`. The `SecretSyncs`, `PkiSyncs`, and `Integrations` meters likewise carry unbounded labels such as `syncId`. Useful for self-hosted deployments where you want per-user visibility directly in Grafana. May become expensive at large scale (many users, identities, or IPs) due to label cardinality.
-- **`InfisicalCore` meter (bounded-cardinality):** all newer metrics (queue, audit log, permission cache, secret cache, rate limit, build info, `infisical.core.http.error.count`, authentication latency, token renewal, SSO config changes, SCIM provisioning, and database connection pool) use only `infisical.organization.id` and bounded enums as labels. No project IDs, names, emails, IPs, or user agents. Per-project and per-actor detail is available in audit logs instead.
+- **`InfisicalCore` meter (bounded-cardinality):** all newer metrics (queue, audit log, permission cache, secret cache, rate limit, build info, `infisical.core.http.error.count`, authentication latency, token renewal, SSO config changes, SCIM provisioning, and database connection pool) use **only bounded enums and static route templates** as labels (e.g. HTTP method, parameterized `http.route`, error type, outcome). A strict allowlist drops every other attribute at the SDK level, so **no tenant or actor identifiers are emitted**; no organization ID, project IDs, names, emails, IPs, or user agents. This keeps the series count independent of how many organizations, users, or identities you have. Per-org and per-actor detail is available in audit logs instead.
 
 All meters emit at the same time. If you are a self-hosted instance and find the per-actor labels useful, keep using the high-cardinality metrics. For larger or multi-tenant deployments, scrape only the `InfisicalCore` metrics to keep cardinality under control.
 
@@ -440,6 +440,21 @@ These metrics track all HTTP API requests to Infisical, including request counts
       - `client.address` (string, optional): IP address
       - `user_agent.original` (string, optional): User agent information
   </Accordion>
+
+  <Accordion title="API Errors (InfisicalCore)">
+    **Metric Name**: `infisical.core.http.error.count`
+
+    **Type**: Counter
+
+    **Unit**: `{error}`
+
+    **Description**: API errors with bounded error classification. The low-cardinality counterpart to `infisical.http.server.error.count`; same error volume, but labels are restricted to the InfisicalCore allowlist so the series count stays independent of org/user/identity count. Use this for alerting and dashboards at scale; use `infisical.http.server.error.count` (high-cardinality meter) when you need per-actor attribution. For per-org error breakdowns, query the audit log.
+
+    **Attributes**:
+      - `http.request.method` (string): HTTP method
+      - `http.route` (string): Parameterized route template where the error occurred (e.g. `/api/v1/secrets/:secretName`), never the raw path
+      - `error.type` (string): Bounded error classification
+  </Accordion>
 </AccordionGroup>
 
 ### Secret Operations Metrics
@@ -514,7 +529,6 @@ These metrics track authentication attempts and outcomes, enabling you to monito
       - `infisical.auth.method` (string): Authentication method (`email`, `saml`, `oidc`, `google`, `github`, `gitlab`, `ldap`, `universal-auth`, `kubernetes-auth`, `aws-auth`, `gcp-auth`, `azure-auth`, `oci-auth`, `alicloud-auth`, `tls-cert-auth`, `oidc-auth`, `jwt-auth`, `ldap-auth`, `spiffe-auth`)
       - `infisical.auth.result` (string): `success` or `failure`
       - `error.type` (string, optional): Bounded failure classification (present on failures)
-      - `infisical.organization.id` (string, optional): Organization ID when known
   </Accordion>
   <Accordion title="Token Renewal (InfisicalCore)">
     **Metric Name**: `infisical.auth.token.renewal.count`
@@ -558,7 +572,6 @@ These metrics track changes to SSO configuration, helping you detect unexpected 
     **Attributes** (bounded):
       - `sso.provider` (string): `saml`, `oidc`, or `ldap`
       - `sso.action` (string): `create` or `update`
-      - `infisical.organization.id` (string, optional): Organization ID
   </Accordion>
 </AccordionGroup>
 
@@ -579,7 +592,6 @@ These metrics track SCIM provisioning operations (user and group lifecycle), ena
     **Attributes** (bounded):
       - `scim.operation` (string): `create_user`, `update_user`, `replace_user`, `delete_user`, `create_group`, `update_group`, `replace_group`, `delete_group`
       - `outcome` (string): `success` or `failure`
-      - `infisical.organization.id` (string, optional): Organization ID
       - `error.type` (string, optional): Bounded failure classification (present on failures)
   </Accordion>
   <Accordion title="SCIM Operation Latency">
@@ -777,7 +789,6 @@ End-to-end audit-log pipeline observability: how many events get enqueued per ev
     **Attributes**:
       - `audit_log.event_type` (string): e.g. `LOGIN_USER`, `CREATE_SECRET`, ...
       - `audit_log.actor_type` (string): `user`, `identity`, `service`
-      - `infisical.organization.id` (string, optional)
   </Accordion>
 
   <Accordion title="Audit Log Persist Duration">
@@ -792,7 +803,6 @@ End-to-end audit-log pipeline observability: how many events get enqueued per ev
     **Attributes**:
       - `audit_log.backend` (string): `postgres` or `clickhouse`
       - `audit_log.event_type` (string)
-      - `infisical.organization.id` (string)
   </Accordion>
 
   <Accordion title="Audit Log Dropped">
@@ -807,7 +817,6 @@ End-to-end audit-log pipeline observability: how many events get enqueued per ev
     **Attributes**:
       - `audit_log.event_type` (string)
       - `audit_log.drop_reason` (string): `max_retries`
-      - `infisical.organization.id` (string, optional)
   </Accordion>
 </AccordionGroup>
 
@@ -827,7 +836,7 @@ Per-provider observability for the audit-log stream feature (Datadog, Splunk, Cu
 
     **Attributes**:
       - `audit_log_stream.provider` (string): `datadog`, `splunk`, `custom`, `azure`, `cribl`
-      - `infisical.organization.id` (string)
+      - `audit_log_stream.id` (string): stream config ID (on the exhausted-drop counter)
       - `outcome` (string): `success` or `failure`
       - `error.type` (string, only on failure): one of the closed enum values
   </Accordion>
@@ -841,7 +850,7 @@ Per-provider observability for the audit-log stream feature (Datadog, Splunk, Cu
 
     **Description**: Per-provider stream delivery latency (HTTP round trip to the SIEM).
 
-    **Attributes**: `audit_log_stream.provider`, `infisical.organization.id`, `outcome`, `error.type` (on failure)
+    **Attributes**: `audit_log_stream.provider`, `outcome`, `error.type` (on failure)
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Context

InfisicalCore metrics were still labeled with `infisical.organization.id`, which scales time series with org count and can hit CloudWatch OTLP limits in multi-tenant deployments.

This PR removes org ID (and other per-tenant labels) from InfisicalCore call sites, centralizes the attribute allowlist in `telemetry-attributes.ts`, and documents the bounded-cardinality model. Per-org/per-actor breakdowns remain available via audit logs.

**Before:** InfisicalCore metrics could include `infisical.organization.id` on auth, SCIM, SSO, secret cache, HTTP errors, and audit-log stream metrics.

**After:** Only bounded enums and static route templates survive the SDK View allowlist; org ID is dropped at the source and from the allowlist.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)