### PR TITLE
fix(pam): drop removed resourceType column from sanitized schema

### DIFF
--- a/backend/src/db/sanitized-schema.yaml
+++ b/backend/src/db/sanitized-schema.yaml
@@ -749,7 +749,6 @@ tables:
       - id
       - projectId
       - accountId
-      - resourceType
       - resourceName
       - accountName
       - userId


### PR DESCRIPTION
The pam-revamp migration dropped `pam_sessions.resourceType`, but `sanitized-schema.yaml` still listed it, so `CREATE VIEW analytics.pam_sessions` failed on boot and took down startup in envs with `FAIL_ON_SANITIZED_SCHEMA_ERROR=true`. This removes `resourceType` from the `pam_sessions` entry; verified locally that the sanitized schema now builds cleanly.