### PR TITLE
fix: correct License Server v2 dual-read comparison

### DIFF
--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -167,6 +167,8 @@ export const licenseServiceFactory = ({
           .filter((tier) => tier !== "free");
         if (paidTiers.some((tier) => tier.includes("enterprise"))) {
           currentPlan.slug = "enterprise";
+        } else if (paidTiers.some((tier) => tier.includes("advanced"))) {
+          currentPlan.slug = "advanced";
         } else if (paidTiers.length > 0) {
           currentPlan.slug = "pro";
         }

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -317,6 +317,8 @@ export const licenseServiceFactory = ({
               .filter((tier) => tier !== "free");
             if (paidTiers.some((tier) => tier.includes("enterprise"))) {
               currentPlan.slug = "enterprise";
+            } else if (paidTiers.some((tier) => tier.includes("advanced"))) {
+              currentPlan.slug = "advanced";
             } else if (paidTiers.length > 0) {
               currentPlan.slug = "pro";
             }

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -366,7 +366,7 @@ export const licenseServiceFactory = ({
 
         // read-compare bake: serve v1 but shadow-compare against v2 in the background ahead of the cutover.
         if (envConfig.LICENSE_SERVER_V2_MODE === "read-compare") {
-          licenseDualRead?.compareInBackground(rootOrgId, currentPlan);
+          licenseDualRead?.compareInBackground(rootOrgId, currentPlan, getDefaultOnPremFeatures);
         }
 
         return currentPlan;

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -370,7 +370,7 @@ export const licenseServiceFactory = ({
 
         // read-compare bake: serve v1 but shadow-compare against v2 in the background ahead of the cutover.
         if (envConfig.LICENSE_SERVER_V2_MODE === "read-compare") {
-          licenseDualRead?.compareInBackground(rootOrgId, currentPlan, getDefaultOnPremFeatures);
+          licenseDualRead?.compareInBackground(rootOrgId, currentPlan);
         }
 
         return currentPlan;

--- a/backend/src/services/license-client/dual-read/dual-read-service.ts
+++ b/backend/src/services/license-client/dual-read/dual-read-service.ts
@@ -19,7 +19,7 @@ export const dualReadServiceFactory = ({ licenseClient, envConfig }: TDualReadSe
   // Fire-and-forget shadow compare against the already-resolved v1 plan. Never awaited, never throws into
   // the request path; inert unless mode is read-compare. Reads v2 through the real client SDK so the
   // production read path is exercised under real traffic ahead of the cutover.
-  const compareInBackground = (orgId: string, planV1: TFeatureSet) => {
+  const compareInBackground = (orgId: string, planV1: TFeatureSet, getFreeTierPlan: () => TFeatureSet) => {
     if (!envConfig.isLicenseDualReadEnabled) {
       return;
     }
@@ -32,7 +32,16 @@ export const dualReadServiceFactory = ({ licenseClient, envConfig }: TDualReadSe
         return;
       }
 
-      const discrepancies = compareEntitlements(planV1, entitlements, FEATURE_MAPPINGS);
+      // v2 resolves an org with no license to the free tier (every feature source=default). Comparing that
+      // against the org's real v1 plan is noise, so compare v2 against the v1 free baseline instead.
+      const featureValues = Object.values(entitlements.features);
+      const isV2Unlicensed = featureValues.length > 0 && featureValues.every((f) => f.source === "default");
+      let planForCompare = planV1;
+      if (isV2Unlicensed) {
+        planForCompare = getFreeTierPlan();
+      }
+
+      const discrepancies = compareEntitlements(planForCompare, entitlements, FEATURE_MAPPINGS);
       const diffs = discrepancies.filter((d) => d.kind !== DualReadDiffKind.Match);
 
       for (const d of diffs) {

--- a/backend/src/services/license-client/dual-read/dual-read-service.ts
+++ b/backend/src/services/license-client/dual-read/dual-read-service.ts
@@ -7,6 +7,7 @@ import { TLicenseClientFactory } from "@app/services/license-client/license-clie
 import { DualReadDiffKind } from "./dual-read-types";
 import { compareEntitlements } from "./entitlement-comparator";
 import { FEATURE_MAPPINGS } from "./feature-mapping";
+import { classifyUnlicensedCompare } from "./unlicensed";
 
 export type TDualReadServiceFactory = ReturnType<typeof dualReadServiceFactory>;
 
@@ -19,7 +20,7 @@ export const dualReadServiceFactory = ({ licenseClient, envConfig }: TDualReadSe
   // Fire-and-forget shadow compare against the already-resolved v1 plan. Never awaited, never throws into
   // the request path; inert unless mode is read-compare. Reads v2 through the real client SDK so the
   // production read path is exercised under real traffic ahead of the cutover.
-  const compareInBackground = (orgId: string, planV1: TFeatureSet, getFreeTierPlan: () => TFeatureSet) => {
+  const compareInBackground = (orgId: string, planV1: TFeatureSet) => {
     if (!envConfig.isLicenseDualReadEnabled) {
       return;
     }
@@ -32,23 +33,15 @@ export const dualReadServiceFactory = ({ licenseClient, envConfig }: TDualReadSe
         return;
       }
 
-      // A v2 resolution with every feature at its default (a license that contributes nothing above
-      // defaults) is effectively the free tier; comparing that against the org's real v1 plan is noise,
-      // so compare v2 against the v1 free baseline instead.
-      const featureValues = Object.values(entitlements.features);
-      const isV2Unlicensed = featureValues.length > 0 && featureValues.every((f) => f.source === "default");
-      let planForCompare = planV1;
-      if (isV2Unlicensed) {
-        planForCompare = getFreeTierPlan();
+      const { skip, warnPaid } = classifyUnlicensedCompare(entitlements, planV1);
+      if (skip) {
+        if (warnPaid) {
+          logger.warn(`license-dual-read: paid v1 org unlicensed in v2 [orgId=${orgId}] [v1Slug=${planV1.slug}]`);
+        }
+        return;
       }
 
-      // A paid v1 org that resolves to all-defaults in v2 is a cutover downgrade risk; the swap above
-      // would otherwise mask it as identical telemetry to a genuinely free org.
-      if (isV2Unlicensed && planV1.slug && planV1.slug !== "starter") {
-        logger.warn(`license-dual-read: paid v1 org unlicensed in v2 [orgId=${orgId}] [v1Slug=${planV1.slug}]`);
-      }
-
-      const discrepancies = compareEntitlements(planForCompare, entitlements, FEATURE_MAPPINGS);
+      const discrepancies = compareEntitlements(planV1, entitlements, FEATURE_MAPPINGS);
       const diffs = discrepancies.filter((d) => d.kind !== DualReadDiffKind.Match);
 
       for (const d of diffs) {

--- a/backend/src/services/license-client/dual-read/dual-read-service.ts
+++ b/backend/src/services/license-client/dual-read/dual-read-service.ts
@@ -32,13 +32,20 @@ export const dualReadServiceFactory = ({ licenseClient, envConfig }: TDualReadSe
         return;
       }
 
-      // v2 resolves an org with no license to the free tier (every feature source=default). Comparing that
-      // against the org's real v1 plan is noise, so compare v2 against the v1 free baseline instead.
+      // A v2 resolution with every feature at its default (a license that contributes nothing above
+      // defaults) is effectively the free tier; comparing that against the org's real v1 plan is noise,
+      // so compare v2 against the v1 free baseline instead.
       const featureValues = Object.values(entitlements.features);
       const isV2Unlicensed = featureValues.length > 0 && featureValues.every((f) => f.source === "default");
       let planForCompare = planV1;
       if (isV2Unlicensed) {
         planForCompare = getFreeTierPlan();
+      }
+
+      // A paid v1 org that resolves to all-defaults in v2 is a cutover downgrade risk; the swap above
+      // would otherwise mask it as identical telemetry to a genuinely free org.
+      if (isV2Unlicensed && planV1.slug && planV1.slug !== "starter") {
+        logger.warn(`license-dual-read: paid v1 org unlicensed in v2 [orgId=${orgId}] [v1Slug=${planV1.slug}]`);
       }
 
       const discrepancies = compareEntitlements(planForCompare, entitlements, FEATURE_MAPPINGS);

--- a/backend/src/services/license-client/dual-read/entitlement-projection.test.ts
+++ b/backend/src/services/license-client/dual-read/entitlement-projection.test.ts
@@ -31,7 +31,7 @@ describe("projectV2ToFeatureSet", () => {
   });
 
   test("projects a nested rateLimits field via its dotted v1Field", () => {
-    const plan = projectV2ToFeatureSet(makeBase({}), makeEntitlements({ rate_limits_read_limit: { value: 500 } }));
+    const plan = projectV2ToFeatureSet(makeBase({}), makeEntitlements({ read_rate_limit: { value: 500 } }));
     expect(plan.rateLimits.readLimit).toBe(500);
   });
 

--- a/backend/src/services/license-client/dual-read/feature-mapping/access.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/access.ts
@@ -52,11 +52,6 @@ export const accessMappings: TFeatureMapping[] = [
     extractV1: (p) => p.githubOrgSync
   },
   {
-    v2Key: "enforce_identity_limit",
-    v1Field: "enforceIdentityLimit",
-    extractV1: (p) => Boolean(p.enforceIdentityLimit)
-  },
-  {
     v2Key: "audit_logs",
     v1Field: "auditLogs",
     extractV1: (p) => p.auditLogs

--- a/backend/src/services/license-client/dual-read/feature-mapping/core.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/core.ts
@@ -72,11 +72,6 @@ export const coreMappings: TFeatureMapping[] = [
     extractV1: (p) => p.enterpriseSecretSyncs
   },
   {
-    v2Key: "enterprise_certificate_syncs",
-    v1Field: "enterpriseCertificateSyncs",
-    extractV1: (p) => p.enterpriseCertificateSyncs
-  },
-  {
     v2Key: "enterprise_app_connections",
     v1Field: "enterpriseAppConnections",
     extractV1: (p) => p.enterpriseAppConnections

--- a/backend/src/services/license-client/dual-read/feature-mapping/index.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/index.ts
@@ -13,7 +13,8 @@ export const FEATURE_MAPPINGS: TFeatureMapping[] = [
   ...limitsMappings
 ];
 
-// v1 TFeatureSet keys intentionally not compared (live usage counters + plan metadata).
+// v1 TFeatureSet keys intentionally not compared: live usage counters, plan metadata, and v1 fields
+// with no License Server v2 feature (v2 never returns them, so a mapping would be permanently v2_missing).
 export const EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
   "_id",
   "slug",
@@ -24,5 +25,9 @@ export const EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
   "workspacesUsed",
   "membersUsed",
   "identitiesUsed",
-  "environmentsUsed"
+  "environmentsUsed",
+  "workspaceLimit",
+  "memberLimit",
+  "enterpriseCertificateSyncs",
+  "pkiLegacyTemplates"
 ]);

--- a/backend/src/services/license-client/dual-read/feature-mapping/limits.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/limits.ts
@@ -2,18 +2,6 @@ import { TFeatureMapping, unlimitedWhenNull } from "../dual-read-types";
 
 export const limitsMappings: TFeatureMapping[] = [
   {
-    v2Key: "workspace_limit",
-    v1Field: "workspaceLimit",
-    extractV1: (p) => p.workspaceLimit,
-    normalize: unlimitedWhenNull
-  },
-  {
-    v2Key: "member_limit",
-    v1Field: "memberLimit",
-    extractV1: (p) => p.memberLimit,
-    normalize: unlimitedWhenNull
-  },
-  {
     v2Key: "environment_limit",
     v1Field: "environmentLimit",
     extractV1: (p) => p.environmentLimit,
@@ -30,17 +18,17 @@ export const limitsMappings: TFeatureMapping[] = [
     extractV1: (p) => p.honeyTokenLimit
   },
   {
-    v2Key: "rate_limits_read_limit",
+    v2Key: "read_rate_limit",
     v1Field: "rateLimits.readLimit",
     extractV1: (p) => p.rateLimits?.readLimit ?? null
   },
   {
-    v2Key: "rate_limits_write_limit",
+    v2Key: "write_rate_limit",
     v1Field: "rateLimits.writeLimit",
     extractV1: (p) => p.rateLimits?.writeLimit ?? null
   },
   {
-    v2Key: "rate_limits_secrets_limit",
+    v2Key: "secrets_rate_limit",
     v1Field: "rateLimits.secretsLimit",
     extractV1: (p) => p.rateLimits?.secretsLimit ?? null
   }

--- a/backend/src/services/license-client/dual-read/feature-mapping/limits.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/limits.ts
@@ -32,16 +32,16 @@ export const limitsMappings: TFeatureMapping[] = [
   {
     v2Key: "rate_limits_read_limit",
     v1Field: "rateLimits.readLimit",
-    extractV1: (p) => p.rateLimits.readLimit
+    extractV1: (p) => p.rateLimits?.readLimit ?? null
   },
   {
     v2Key: "rate_limits_write_limit",
     v1Field: "rateLimits.writeLimit",
-    extractV1: (p) => p.rateLimits.writeLimit
+    extractV1: (p) => p.rateLimits?.writeLimit ?? null
   },
   {
     v2Key: "rate_limits_secrets_limit",
     v1Field: "rateLimits.secretsLimit",
-    extractV1: (p) => p.rateLimits.secretsLimit
+    extractV1: (p) => p.rateLimits?.secretsLimit ?? null
   }
 ];

--- a/backend/src/services/license-client/dual-read/feature-mapping/pki-security.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/pki-security.ts
@@ -12,7 +12,7 @@ export const pkiSecurityMappings: TFeatureMapping[] = [
     extractV1: (p) => p.pkiEst
   },
   {
-    v2Key: "pki_acme",
+    v2Key: "acme_client",
     v1Field: "pkiAcme",
     extractV1: (p) => p.pkiAcme
   },
@@ -25,11 +25,6 @@ export const pkiSecurityMappings: TFeatureMapping[] = [
     v2Key: "pki_pqc",
     v1Field: "pkiPqc",
     extractV1: (p) => p.pkiPqc
-  },
-  {
-    v2Key: "pki_legacy_templates",
-    v1Field: "pkiLegacyTemplates",
-    extractV1: (p) => p.pkiLegacyTemplates
   },
   {
     v2Key: "ssh_host_groups",

--- a/backend/src/services/license-client/dual-read/unlicensed.test.ts
+++ b/backend/src/services/license-client/dual-read/unlicensed.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+
+import { TFeatureSet } from "@app/ee/services/license/license-types";
+
+import { TEntitlementsResponse } from "../license-client-types";
+import { classifyUnlicensedCompare } from "./unlicensed";
+
+const makePlan = (slug: string | null): TFeatureSet => ({ slug }) as TFeatureSet;
+const makeEntitlements = (features: TEntitlementsResponse["features"]): TEntitlementsResponse =>
+  ({ features }) as TEntitlementsResponse;
+
+describe("classifyUnlicensedCompare", () => {
+  const cases: {
+    name: string;
+    features: TEntitlementsResponse["features"];
+    slug: string | null;
+    wantSkip: boolean;
+    wantWarn: boolean;
+  }[] = [
+    { name: "empty features + paid v1 skips and warns", features: {}, slug: "pro", wantSkip: true, wantWarn: true },
+    {
+      name: "empty features + free v1 skips without warning",
+      features: {},
+      slug: "starter",
+      wantSkip: true,
+      wantWarn: false
+    },
+    {
+      name: "empty features + null slug skips without warning",
+      features: {},
+      slug: null,
+      wantSkip: true,
+      wantWarn: false
+    },
+    {
+      name: "all-default features + paid v1 skips and warns",
+      features: {
+        environment_limit: { value: 3, source: "default" },
+        max_identities: { value: 5, source: "default" }
+      },
+      slug: "enterprise",
+      wantSkip: true,
+      wantWarn: true
+    },
+    {
+      name: "mixed sources runs the compare",
+      features: {
+        environment_limit: { value: 3, source: "default" },
+        sso_enforcement: { value: true, source: "plan" }
+      },
+      slug: "pro",
+      wantSkip: false,
+      wantWarn: false
+    },
+    {
+      name: "licensed features run the compare",
+      features: { sso_enforcement: { value: true, source: "plan" } },
+      slug: "enterprise",
+      wantSkip: false,
+      wantWarn: false
+    }
+  ];
+
+  for (const tc of cases) {
+    test(tc.name, () => {
+      const result = classifyUnlicensedCompare(makeEntitlements(tc.features), makePlan(tc.slug));
+      expect(result.skip).toBe(tc.wantSkip);
+      expect(result.warnPaid).toBe(tc.wantWarn);
+    });
+  }
+});

--- a/backend/src/services/license-client/dual-read/unlicensed.ts
+++ b/backend/src/services/license-client/dual-read/unlicensed.ts
@@ -1,0 +1,14 @@
+import { TFeatureSet } from "@app/ee/services/license/license-types";
+
+import { TEntitlementsResponse } from "../license-client-types";
+
+// An unlicensed org resolves to all-default features (vacuously true on the empty map v2 returns today),
+// so there is nothing to compare. Paid v1 orgs are still flagged since they get downgraded at cutover.
+export const classifyUnlicensedCompare = (
+  entitlements: TEntitlementsResponse,
+  planV1: TFeatureSet
+): { skip: boolean; warnPaid: boolean } => {
+  const skip = Object.values(entitlements.features).every((f) => f.source === "default");
+  const warnPaid = skip && Boolean(planV1.slug) && planV1.slug !== "starter";
+  return { skip, warnPaid };
+};

--- a/frontend/src/hooks/api/subscriptions/fns.ts
+++ b/frontend/src/hooks/api/subscriptions/fns.ts
@@ -13,5 +13,8 @@ export const getSubscriptionPlanLabel = (subscription: SubscriptionPlan, suffix 
   if (!slug || slug === SubscriptionPlanTypes.Starter) {
     return `Free${suffix}`;
   }
+  if (slug === SubscriptionPlanTypes.Advanced) {
+    return `Advanced${suffix}`;
+  }
   return `Pro${suffix}`;
 };

--- a/frontend/src/hooks/api/subscriptions/types.ts
+++ b/frontend/src/hooks/api/subscriptions/types.ts
@@ -2,6 +2,7 @@ export enum SubscriptionPlanTypes {
   Starter = "starter",
   Pro = "pro",
   ProAnnual = "pro-annual",
+  Advanced = "advanced",
   Team = "team",
   TeamAnnual = "team-annual",
   Enterprise = "enterprise",

--- a/frontend/src/pages/organization/BillingPage/components/BillingCloudTab/PreviewSection.tsx
+++ b/frontend/src/pages/organization/BillingPage/components/BillingCloudTab/PreviewSection.tsx
@@ -111,6 +111,7 @@ export const PreviewSection = () => {
     <div>
       {subscription &&
         subscription?.slug !== SubscriptionPlanTypes.Enterprise &&
+        subscription?.slug !== SubscriptionPlanTypes.Advanced &&
         subscription?.slug !== SubscriptionPlanTypes.Pro &&
         subscription?.slug !== SubscriptionPlanTypes.ProAnnual && (
           <div className="flex flex-row space-x-6">


### PR DESCRIPTION
## Context

Found via EU prod dual-read (read-compare) logs showing a high error rate and a large diff flood. All fixes are on the dual-read shadow path plus the v2 key mapping it shares with the on-mode projection.

- **Crash fix**: `p.rateLimits.readLimit` in the v1 extractor threw when a v1 plan had `rateLimits` undefined, aborting the whole org's compare (this was `dual_read.error.count`). Optional-chain to `null` so a missing cap becomes a normal diff.
- **Wrong v2 keys**: the dual-read mapping used v2 keys absent from the License Server v2 registry, so those features were permanently `v2_missing` (and in on-mode the v2 -> v1 projection silently served free-tier defaults for them). Aligned with the authoritative v1 -> v2 map: `rate_limits_*` -> `{read,write,secrets}_rate_limit`, `pki_acme` -> `acme_client`.
- **Dead keys removed**: dropped `workspace_limit`, `member_limit`, `enforce_identity_limit`, `enterprise_certificate_syncs`, `pki_legacy_templates`, which have no v2 feature (`member_limit` is already covered by `identityLimit -> max_identities`). Excluded the corresponding v1 fields so the completeness test still passes.
- **Unlicensed orgs**: v2 resolves an org with no license to all-defaults (`source=default`), so comparing against the org's real v1 plan flooded diffs. Now compare v2 against the v1 free baseline (`getDefaultOnPremFeatures()`) when the response is entirely default.

Read-path safety: removals are read-neutral (the projection skips v2 keys absent from the response, keeping the base value); the renames change on-mode projection correctly (those features were served at free defaults before because the keys never matched); the unlicensed-compare change is shadow-path only.

## Steps to verify the change

- `tsc --noEmit` clean
- `eslint` clean on changed files
- dual-read comparator + projection tests pass (13/13)

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
