### PR TITLE
improvement(license-client): switch to org-scoped license-server paths

### DIFF
--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -27,18 +27,15 @@ import {
   TSubscriptionResponse
 } from "./license-client-types";
 
+// Token-scoped paths for the self-hosted (license-key) backend: the key identifies the license, so
+// no org_id is carried. The global catalog is org-independent and shared by both backends.
 const ENTITLEMENTS_PATH = "/v1/entitlements";
 const ENTITLEMENTS_REFRESH_PATH = "/v1/entitlements/refresh";
 const PRODUCTS_PATH = "/v1/products";
 const SUBSCRIPTION_PATH = "/v1/subscription";
-const CLOUD_PLAN_PATH = "/v1/cloud-plan";
-const BILLING_PROFILE_PATH = "/v1/billing/profile";
-const CHECKOUT_SESSION_PATH = "/v1/billing/checkout-session";
-const PORTAL_SESSION_PATH = "/v1/billing/portal-session";
-const SUBSCRIPTION_PREVIEW_PATH = "/v1/billing/subscription/preview";
-const SUBSCRIPTION_ITEMS_PATH = "/v1/billing/subscription/items";
-const SUBSCRIPTION_CANCEL_PATH = "/v1/billing/subscription/cancel";
-const SUBSCRIPTION_RESUME_PATH = "/v1/billing/subscription/resume";
+
+// Cloud (service-JWT) callers address the org in the path instead of an org_id query param.
+const orgScoped = (orgId: string, suffix: string): string => `/v1/organizations/${encodeURIComponent(orgId)}${suffix}`;
 
 // Issuer/audience/subject match the license server's in-code constants (it validates iss/aud against
 // them). They are public claims, not per-deployment config, so they live here rather than in env.
@@ -79,8 +76,7 @@ export const licenseServerBackend = (
   region?: string
 ): TLicenseClientBackend => ({
   fetchEntitlements: async (org: TEntitlementOrg): Promise<TEntitlementsResponse> => {
-    const url = new URL(ENTITLEMENTS_PATH, serverUrl);
-    url.searchParams.set("org_id", org.id);
+    const url = new URL(orgScoped(org.id, "/entitlements"), serverUrl);
     if (org.name) {
       url.searchParams.set("org_name", org.name);
     }
@@ -101,8 +97,7 @@ export const licenseServerBackend = (
   },
 
   refreshEntitlements: async (org: TEntitlementOrg): Promise<void> => {
-    const url = new URL(ENTITLEMENTS_REFRESH_PATH, serverUrl);
-    url.searchParams.set("org_id", org.id);
+    const url = new URL(orgScoped(org.id, "/entitlements/refresh"), serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
@@ -127,8 +122,7 @@ export const licenseServerBackend = (
   // status "none"); both are "no subscription". Other non-2xx statuses (auth failure, 5xx) are real
   // errors and must surface so a paying org isn't shown the free state during an outage.
   fetchSubscription: async (orgId: string): Promise<TSubscriptionResponse | null> => {
-    const url = new URL(SUBSCRIPTION_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/subscription"), serverUrl);
     const res = await fetch(url, {
       method: "GET",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
@@ -153,8 +147,7 @@ export const licenseServerBackend = (
   // 404 means the org has no license/plan yet; treat as "no plan" so the usage meter falls back to
   // unknown limits. Other non-2xx statuses are real errors and surface.
   fetchCloudPlan: async (orgId: string): Promise<TCloudPlanResponse | null> => {
-    const url = new URL(CLOUD_PLAN_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/cloud-plan"), serverUrl);
     const res = await fetch(url, {
       method: "GET",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
@@ -171,8 +164,7 @@ export const licenseServerBackend = (
   // The server returns 200 with everything empty when the org has no Stripe customer yet; a 404
   // means the org has no license at all (same as /v1/subscription), so degrade to "no profile".
   fetchBillingProfile: async (orgId: string): Promise<TBillingProfileResponse | null> => {
-    const url = new URL(BILLING_PROFILE_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/billing/profile"), serverUrl);
     const res = await fetch(url, {
       method: "GET",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
@@ -187,8 +179,7 @@ export const licenseServerBackend = (
   },
 
   createCheckoutSession: async (orgId: string, payload: TCreateCheckoutPayload): Promise<TCheckoutResult> => {
-    const url = new URL(CHECKOUT_SESSION_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/billing/checkout-session"), serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}`, "Content-Type": "application/json" },
@@ -201,8 +192,7 @@ export const licenseServerBackend = (
   },
 
   createPortalSession: async (orgId: string, payload: TCreatePortalPayload): Promise<TSessionResponse> => {
-    const url = new URL(PORTAL_SESSION_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/billing/portal-session"), serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}`, "Content-Type": "application/json" },
@@ -218,8 +208,7 @@ export const licenseServerBackend = (
     orgId: string,
     payload: TSubscriptionPreviewPayload
   ): Promise<TSubscriptionPreview> => {
-    const url = new URL(SUBSCRIPTION_PREVIEW_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/subscription/preview"), serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}`, "Content-Type": "application/json" },
@@ -232,8 +221,7 @@ export const licenseServerBackend = (
   },
 
   addSubscriptionItems: async (orgId: string, payload: TAddSubscriptionItemsPayload): Promise<TCheckoutResult> => {
-    const url = new URL(SUBSCRIPTION_ITEMS_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/subscription/items"), serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}`, "Content-Type": "application/json" },
@@ -246,8 +234,7 @@ export const licenseServerBackend = (
   },
 
   removeSubscriptionItem: async (orgId: string, productId: string): Promise<TCheckoutResult> => {
-    const url = new URL(`${SUBSCRIPTION_ITEMS_PATH}/${encodeURIComponent(productId)}`, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, `/subscription/items/${encodeURIComponent(productId)}`), serverUrl);
     const res = await fetch(url, {
       method: "DELETE",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
@@ -259,8 +246,7 @@ export const licenseServerBackend = (
   },
 
   cancelSubscription: async (orgId: string): Promise<TCheckoutResult> => {
-    const url = new URL(SUBSCRIPTION_CANCEL_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/subscription/cancel"), serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
@@ -272,8 +258,7 @@ export const licenseServerBackend = (
   },
 
   resumeSubscription: async (orgId: string): Promise<TCheckoutResult> => {
-    const url = new URL(SUBSCRIPTION_RESUME_PATH, serverUrl);
-    url.searchParams.set("org_id", orgId);
+    const url = new URL(orgScoped(orgId, "/subscription/resume"), serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },

--- a/backend/src/services/license-client/usage/usage-reporter.ts
+++ b/backend/src/services/license-client/usage/usage-reporter.ts
@@ -23,7 +23,7 @@ export const usageReporterFactory = (serverUrl: string, getBearerToken: () => st
       return;
     }
 
-    const url = new URL(`/v1/${encodeURIComponent(orgId)}/usage-snapshots`, serverUrl);
+    const url = new URL(`/v1/organizations/${encodeURIComponent(orgId)}/usage-snapshots`, serverUrl);
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${getBearerToken()}`, "Content-Type": "application/json" },


### PR DESCRIPTION
## Context

The license server is reshaping its public API so org-scoped calls carry the org in the path instead of an `?org_id=` query param (Infisical/license-server-go#50). This updates the cloud license-client to match.

- Cloud backend builds `/v1/organizations/{orgId}/...` via an `orgScoped` helper and drops the `org_id` query param (keeps `org_name`/`org_slug`/`region`)
- `usage-reporter` posts to `/v1/organizations/{orgId}/usage-snapshots`
- Self-hosted (license-key) backend unchanged: token-scoped bare paths carry no org_id

Pairs with Infisical/license-server-go#50. Hard cutover for the service surface, so deploy together; safe under `LICENSE_SERVER_V2_MODE=read-compare`.

## Steps to verify the change

- `npm run type:check` (backend) passes
- `eslint` clean on the changed files

## Type

- [x] Improvement
- [x] Breaking

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally