### PR TITLE
fix(secret-blind-index): skip soft-deleted projects in helper queries

### DIFF
--- a/backend/src/services/secret-blind-index/secret-blind-index-dal.ts
+++ b/backend/src/services/secret-blind-index/secret-blind-index-dal.ts
@@ -13,17 +13,14 @@ export const secretBlindIndexDALFactory = (db: TDbClient) => {
   const countOfSecretsWithNullSecretBlindIndex = async (projectId: string, tx?: Knex) => {
     try {
       const doc = await (tx || db.replicaNode())(TableName.Secret)
-        .leftJoin(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.Secret}.folderId`)
-        .leftJoin(TableName.Environment, function joinActiveEnvForFolder() {
+        .innerJoin(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.Secret}.folderId`)
+        .innerJoin(TableName.Environment, function joinActiveEnvForFolder() {
           this.on(`${TableName.Environment}.id`, `${TableName.SecretFolder}.envId`).andOnNull(
             `${TableName.Environment}.deleteAfter`
           );
         })
-        .leftJoin(TableName.Project, function joinActiveProjectForFolder() {
-          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
-            `${TableName.Project}.deleteAfter`
-          );
-        })
+        .innerJoin(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where({ projectId })
         .whereNull("secretBlindIndex")
         .count(`${TableName.Secret}.id` as "id");
@@ -36,17 +33,14 @@ export const secretBlindIndexDALFactory = (db: TDbClient) => {
   const findAllSecretsByProjectId = async (projectId: string, tx?: Knex) => {
     try {
       const docs = await (tx || db.replicaNode())(TableName.Secret)
-        .leftJoin(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.Secret}.folderId`)
-        .leftJoin(TableName.Environment, function joinActiveEnvForFolder() {
+        .innerJoin(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.Secret}.folderId`)
+        .innerJoin(TableName.Environment, function joinActiveEnvForFolder() {
           this.on(`${TableName.Environment}.id`, `${TableName.SecretFolder}.envId`).andOnNull(
             `${TableName.Environment}.deleteAfter`
           );
         })
-        .leftJoin(TableName.Project, function joinActiveProjectForFolder() {
-          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
-            `${TableName.Project}.deleteAfter`
-          );
-        })
+        .innerJoin(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where({ projectId })
         .select(selectAllTableCols(TableName.Secret))
         .select(
@@ -62,17 +56,14 @@ export const secretBlindIndexDALFactory = (db: TDbClient) => {
   const findSecretsByProjectId = async (projectId: string, secretIds: string[], tx?: Knex) => {
     try {
       const docs = await (tx || db.replicaNode())(TableName.Secret)
-        .leftJoin(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.Secret}.folderId`)
-        .leftJoin(TableName.Environment, function joinActiveEnvForFolder() {
+        .innerJoin(TableName.SecretFolder, `${TableName.SecretFolder}.id`, `${TableName.Secret}.folderId`)
+        .innerJoin(TableName.Environment, function joinActiveEnvForFolder() {
           this.on(`${TableName.Environment}.id`, `${TableName.SecretFolder}.envId`).andOnNull(
             `${TableName.Environment}.deleteAfter`
           );
         })
-        .leftJoin(TableName.Project, function joinActiveProjectForFolder() {
-          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
-            `${TableName.Project}.deleteAfter`
-          );
-        })
+        .innerJoin(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .where({ projectId })
         .whereIn(`${TableName.Secret}.id`, secretIds)
         .select(selectAllTableCols(TableName.Secret))

--- a/backend/src/services/secret-blind-index/secret-blind-index-dal.ts
+++ b/backend/src/services/secret-blind-index/secret-blind-index-dal.ts
@@ -19,6 +19,11 @@ export const secretBlindIndexDALFactory = (db: TDbClient) => {
             `${TableName.Environment}.deleteAfter`
           );
         })
+        .leftJoin(TableName.Project, function joinActiveProjectForFolder() {
+          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
+            `${TableName.Project}.deleteAfter`
+          );
+        })
         .where({ projectId })
         .whereNull("secretBlindIndex")
         .count(`${TableName.Secret}.id` as "id");
@@ -35,6 +40,11 @@ export const secretBlindIndexDALFactory = (db: TDbClient) => {
         .leftJoin(TableName.Environment, function joinActiveEnvForFolder() {
           this.on(`${TableName.Environment}.id`, `${TableName.SecretFolder}.envId`).andOnNull(
             `${TableName.Environment}.deleteAfter`
+          );
+        })
+        .leftJoin(TableName.Project, function joinActiveProjectForFolder() {
+          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
+            `${TableName.Project}.deleteAfter`
           );
         })
         .where({ projectId })
@@ -56,6 +66,11 @@ export const secretBlindIndexDALFactory = (db: TDbClient) => {
         .leftJoin(TableName.Environment, function joinActiveEnvForFolder() {
           this.on(`${TableName.Environment}.id`, `${TableName.SecretFolder}.envId`).andOnNull(
             `${TableName.Environment}.deleteAfter`
+          );
+        })
+        .leftJoin(TableName.Project, function joinActiveProjectForFolder() {
+          this.on(`${TableName.Environment}.projectId`, `${TableName.Project}.id`).andOnNull(
+            `${TableName.Project}.deleteAfter`
           );
         })
         .where({ projectId })


### PR DESCRIPTION
## What

Three helper queries in \`secret-blind-index-dal.ts\` — \`countOfSecretsWithNullSecretBlindIndex\`, and two find variants — leftJoin \`project_environments\` with \`andOnNull(Environment.deleteAfter)\` but never touch \`projects\`. Soft-deleting a project does not soft-delete its environments, so blind-index maintenance helpers keep counting / returning secret rows against projects sitting in the delete grace window.

## Fix

Adds an active-project leftJoin \`andOnNull(Project.deleteAfter)\` after each env join. The existing \`where({ projectId })\` predicate scopes correctly; and if the project has been soft-deleted, env.projectId is nulled out by the env-side \`andOnNull\`, causing the project join to fail so the row is effectively excluded from the aggregation.

Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), app-connection (#7125), secret-approval-request-secret (#7126), secret-folder-version (#7155), secret-version v1 (#7156), offline-usage-report (#7157), secret-v2-bridge/secret-version (#7167), project-folder-grant (#7168), and telemetry (#7169) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path