### PR TITLE
fix(secret): skip soft-deleted projects in secret-dal cross-project queries

### DIFF
--- a/backend/src/services/secret/secret-dal.ts
+++ b/backend/src/services/secret/secret-dal.ts
@@ -324,8 +324,10 @@ export const secretDALFactory = (db: TDbClient) => {
         .join(TableName.Secret, `${TableName.Secret}.id`, `${TableName.SecretReference}.secretId`)
         .join(TableName.SecretFolder, `${TableName.Secret}.folderId`, `${TableName.SecretFolder}.id`)
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
         .where("projectId", projectId)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .select(selectAllTableCols(TableName.SecretReference))
         .select("folderId");
       return docs;
@@ -340,8 +342,10 @@ export const secretDALFactory = (db: TDbClient) => {
       const docs = await (tx || db.replicaNode())(TableName.Secret)
         .join(TableName.SecretFolder, `${TableName.Secret}.folderId`, `${TableName.SecretFolder}.id`)
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
         .where("projectId", projectId)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         // not empty
         .whereNotNull("secretValueCiphertext")
         .select("secretValueTag", "secretValueCiphertext", "secretValueIV", `${TableName.Secret}.id` as "id");


### PR DESCRIPTION
## What

Two helpers in \`secret-dal.ts\` join \`project_environments\` and filter \`Environment.deleteAfter\` but never join \`projects\` or filter \`Project.deleteAfter\`:

- \`findReferencedSecretReferences\` — powers secret-reference resolution.
- \`findAllProjectSecretValues\` — the backfill helper that reads the entire project's secret-value ciphertext.

Soft-deleting a project does not soft-delete its environments, so both helpers still surface / re-expose data from projects sitting in the delete grace window. The backfill case is the more sensitive one — reading ciphertexts back through the code path effectively re-touches data the user is trying to have deleted.

## Fix

Adds the \`Project\` join + \`whereNull(Project.deleteAfter)\` to both. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), app-connection (#7125), secret-approval-request-secret (#7126), secret-folder-version (#7155), secret-version v1 (#7156), offline-usage-report (#7157), secret-v2-bridge/secret-version (#7167), project-folder-grant (#7168), telemetry (#7169), and secret-blind-index (#7187) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path