### PR TITLE
fix(secret-folder): skip soft-deleted projects in findById + findByProjectId

### DIFF
--- a/backend/src/services/secret-folder/secret-folder-dal.ts
+++ b/backend/src/services/secret-folder/secret-folder-dal.ts
@@ -285,6 +285,7 @@ export const secretFolderDALFactory = (db: TDbClient) => {
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
         .whereNull(`${TableName.Environment}.deleteAfter`)
         .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .select(selectAllTableCols(TableName.SecretFolder))
         .select(
           db.ref("id").withSchema(TableName.Environment).as("envId"),
@@ -310,6 +311,7 @@ export const secretFolderDALFactory = (db: TDbClient) => {
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
         .whereNull(`${TableName.Environment}.deleteAfter`)
         .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .select(selectAllTableCols(TableName.SecretFolder))
         .where({ projectId })
         .select(


### PR DESCRIPTION
## What

Two helpers in \`secret-folder-dal.ts\` already join \`TableName.Project\` (to read \`projectVersion\`) but never filter \`Project.deleteAfter\`:

- \`findById\` (folder detail lookup)
- \`findByProjectId\` (in-file comment: \"special query for project migration\")

Soft-deleting a project does not soft-delete its environments, so both helpers still return folder rows for a project sitting in the delete grace window. \`findByProjectId\` is the more sensitive one — it feeds the project migration path, which shouldn't touch a project the user has already marked for deletion.

## Fix

Adds \`whereNull(Project.deleteAfter)\` after the existing Project join in both. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), app-connection (#7125), secret-approval-request-secret (#7126), secret-folder-version (#7155), secret-version v1 (#7156), offline-usage-report (#7157), secret-v2-bridge/secret-version (#7167), project-folder-grant (#7168), telemetry (#7169), secret-blind-index (#7187), and secret (#7188) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; same pattern as existing cross-project DALs)
- [x] The change is limited to the affected code path