### PR TITLE
feat: validate Azure Key Vault URLs

### DIFF
--- a/backend/src/lib/validator/index.ts
+++ b/backend/src/lib/validator/index.ts
@@ -12,5 +12,11 @@ export {
   validateSmbPassword,
   validateWindowsUsername
 } from "./validate-smb";
-export { blockLocalAndPrivateIpAddresses, ssrfSafeGet, ssrfSafePost, validateSsrfUrl } from "./validate-url";
+export {
+  blockLocalAndPrivateIpAddresses,
+  isValidAzureKeyVaultUrl,
+  ssrfSafeGet,
+  ssrfSafePost,
+  validateSsrfUrl
+} from "./validate-url";
 export { isUuidV4 } from "./validate-uuid";

--- a/backend/src/lib/validator/validate-url.test.ts
+++ b/backend/src/lib/validator/validate-url.test.ts
@@ -1,4 +1,4 @@
-import { isFQDN } from "./validate-url";
+import { isFQDN, isValidAzureKeyVaultUrl } from "./validate-url";
 
 describe("isFQDN", () => {
   test("Non wildcard", () => {
@@ -11,5 +11,31 @@ describe("isFQDN", () => {
 
   test("Wildcard FQDN fails on option allow_wildcard false", () => {
     expect(isFQDN("*.example.com")).toBeFalsy();
+  });
+});
+
+describe("isValidAzureKeyVaultUrl", () => {
+  test.each([
+    "https://my-vault.vault.azure.net",
+    "https://my-vault.vault.azure.net/",
+    "https://My-Vault.VAULT.AZURE.NET",
+    "https://vault.azure.net"
+  ])("accepts legitimate Azure Key Vault URL: %s", (url) => {
+    expect(isValidAzureKeyVaultUrl(url)).toBe(true);
+  });
+
+  test.each([
+    "https://evil.com",
+    "http://my-vault.vault.azure.net",
+    "https://my-vault.vault.azure.net.evil.com",
+    "https://evil.com/my-vault.vault.azure.net",
+    "https://vault.azure.net.evil.com",
+    "https://legit.vault.azure.net@evil.com",
+    "https://vault-azure-net.evil.com",
+    "ftp://my-vault.vault.azure.net",
+    "not-a-url",
+    ""
+  ])("rejects non Azure Key Vault URL: %s", (url) => {
+    expect(isValidAzureKeyVaultUrl(url)).toBe(false);
   });
 });

--- a/backend/src/lib/validator/validate-url.test.ts
+++ b/backend/src/lib/validator/validate-url.test.ts
@@ -18,8 +18,7 @@ describe("isValidAzureKeyVaultUrl", () => {
   test.each([
     "https://my-vault.vault.azure.net",
     "https://my-vault.vault.azure.net/",
-    "https://My-Vault.VAULT.AZURE.NET",
-    "https://vault.azure.net"
+    "https://My-Vault.VAULT.AZURE.NET"
   ])("accepts legitimate Azure Key Vault URL: %s", (url) => {
     expect(isValidAzureKeyVaultUrl(url)).toBe(true);
   });
@@ -34,7 +33,21 @@ describe("isValidAzureKeyVaultUrl", () => {
     "https://vault-azure-net.evil.com",
     "ftp://my-vault.vault.azure.net",
     "not-a-url",
-    ""
+    "",
+    // apex with no vault-name label is not a real data-plane endpoint
+    "https://vault.azure.net",
+    // empty vault-name label
+    "https://.vault.azure.net",
+    // custom port / path / query / fragment are not the data-plane base URL
+    "https://my-vault.vault.azure.net:4443/foo",
+    "https://my-vault.vault.azure.net:8443",
+    "https://my-vault.vault.azure.net/certificates",
+    "https://my-vault.vault.azure.net/?foo=bar",
+    "https://my-vault.vault.azure.net/#frag",
+    // embedded credentials
+    "https://user:pass@my-vault.vault.azure.net",
+    // multi-label prefix is not a valid vault name
+    "https://foo.bar.vault.azure.net"
   ])("rejects non Azure Key Vault URL: %s", (url) => {
     expect(isValidAzureKeyVaultUrl(url)).toBe(false);
   });

--- a/backend/src/lib/validator/validate-url.ts
+++ b/backend/src/lib/validator/validate-url.ts
@@ -42,22 +42,23 @@ export const blockLocalAndPrivateIpAddresses = async (url: string, isGateway = f
   if (isInternalIp && !allowInternal) throw new BadRequestError({ message: "Local IPs not allowed as URL" });
 };
 
+const AZURE_KEY_VAULT_HOST_REGEX = new RE2(/^[a-z0-9]([a-z0-9-]*[a-z0-9])?\.vault\.azure\.net$/);
+
 /**
- * Validates that a URL points at a legitimate Azure Key Vault data-plane host.
- * The Azure AD access token minted for these syncs is scoped to
- * `https://vault.azure.net/.default`, and certificate private keys / secret
- * values are sent to this host, so accepting any URL would leak both the bearer
- * token and the private key material to an attacker-controlled server.
+ * Validates that a URL is a legitimate Azure Key Vault data-plane base URL
+ * (`https://<vault-name>.vault.azure.net`).
  */
 export const isValidAzureKeyVaultUrl = (url: string): boolean => {
   try {
-    const { protocol, hostname } = new URL(url);
+    const parsed = new URL(url);
 
-    if (protocol !== "https:") return false;
+    if (parsed.protocol !== "https:") return false;
+    if (parsed.username || parsed.password) return false;
+    if (parsed.port) return false;
+    if (parsed.search || parsed.hash) return false;
+    if (parsed.pathname !== "/" && parsed.pathname !== "") return false;
 
-    const normalizedHost = hostname.toLowerCase();
-
-    return normalizedHost === "vault.azure.net" || normalizedHost.endsWith(".vault.azure.net");
+    return AZURE_KEY_VAULT_HOST_REGEX.test(parsed.hostname.toLowerCase());
   } catch {
     return false;
   }

--- a/backend/src/lib/validator/validate-url.ts
+++ b/backend/src/lib/validator/validate-url.ts
@@ -42,6 +42,27 @@ export const blockLocalAndPrivateIpAddresses = async (url: string, isGateway = f
   if (isInternalIp && !allowInternal) throw new BadRequestError({ message: "Local IPs not allowed as URL" });
 };
 
+/**
+ * Validates that a URL points at a legitimate Azure Key Vault data-plane host.
+ * The Azure AD access token minted for these syncs is scoped to
+ * `https://vault.azure.net/.default`, and certificate private keys / secret
+ * values are sent to this host, so accepting any URL would leak both the bearer
+ * token and the private key material to an attacker-controlled server.
+ */
+export const isValidAzureKeyVaultUrl = (url: string): boolean => {
+  try {
+    const { protocol, hostname } = new URL(url);
+
+    if (protocol !== "https:") return false;
+
+    const normalizedHost = hostname.toLowerCase();
+
+    return normalizedHost === "vault.azure.net" || normalizedHost.endsWith(".vault.azure.net");
+  } catch {
+    return false;
+  }
+};
+
 type FQDNOptions = {
   require_tld?: boolean;
   allow_underscores?: boolean;

--- a/backend/src/services/pki-sync/azure-key-vault/azure-key-vault-pki-sync-schemas.ts
+++ b/backend/src/services/pki-sync/azure-key-vault/azure-key-vault-pki-sync-schemas.ts
@@ -10,12 +10,9 @@ import { PkiSyncSchema } from "@app/services/pki-sync/pki-sync-schemas";
 import { AZURE_KEY_VAULT_CERTIFICATE_NAMING } from "./azure-key-vault-pki-sync-constants";
 
 export const AzureKeyVaultPkiSyncConfigSchema = z.object({
-  vaultBaseUrl: z
-    .string()
-    .url("Invalid vault base URL format")
-    .refine(isValidAzureKeyVaultUrl, {
-      message: "Vault base URL must be a valid Azure Key Vault URL (https://<vault-name>.vault.azure.net)"
-    })
+  vaultBaseUrl: z.string().url("Invalid vault base URL format").refine(isValidAzureKeyVaultUrl, {
+    message: "Vault base URL must be a valid Azure Key Vault URL (https://<vault-name>.vault.azure.net)"
+  })
 });
 
 export const AzureKeyVaultPkiSyncOptionsSchema = z.object({

--- a/backend/src/services/pki-sync/azure-key-vault/azure-key-vault-pki-sync-schemas.ts
+++ b/backend/src/services/pki-sync/azure-key-vault/azure-key-vault-pki-sync-schemas.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 
+import { isValidAzureKeyVaultUrl } from "@app/lib/validator";
 import { openApiHidden } from "@app/server/lib/schemas";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { buildCertificateNameSchemaTestName } from "@app/services/pki-sync/pki-sync-certificate-name-fns";
@@ -9,7 +10,12 @@ import { PkiSyncSchema } from "@app/services/pki-sync/pki-sync-schemas";
 import { AZURE_KEY_VAULT_CERTIFICATE_NAMING } from "./azure-key-vault-pki-sync-constants";
 
 export const AzureKeyVaultPkiSyncConfigSchema = z.object({
-  vaultBaseUrl: z.string().url()
+  vaultBaseUrl: z
+    .string()
+    .url("Invalid vault base URL format")
+    .refine(isValidAzureKeyVaultUrl, {
+      message: "Vault base URL must be a valid Azure Key Vault URL (https://<vault-name>.vault.azure.net)"
+    })
 });
 
 export const AzureKeyVaultPkiSyncOptionsSchema = z.object({

--- a/backend/src/services/secret-sync/azure-key-vault/azure-key-vault-sync-schemas.ts
+++ b/backend/src/services/secret-sync/azure-key-vault/azure-key-vault-sync-schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { SecretSyncs } from "@app/lib/api-docs";
+import { isValidAzureKeyVaultUrl } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { SecretSync } from "@app/services/secret-sync/secret-sync-enums";
 import {
@@ -17,6 +18,9 @@ const AzureKeyVaultSyncDestinationConfigSchema = z.object({
     .string()
     .url("Invalid vault base URL format")
     .min(1, "Vault base URL required")
+    .refine(isValidAzureKeyVaultUrl, {
+      message: "Vault base URL must be a valid Azure Key Vault URL (https://<vault-name>.vault.azure.net)"
+    })
     .describe(SecretSyncs.DESTINATION_CONFIG.AZURE_KEY_VAULT.vaultBaseUrl)
 });
 


### PR DESCRIPTION
## Context

Azure Key Vault syncs now confirm that the vault URL points to a valid Azure Key Vault address before saving. This keeps configurations pointed at the intended destination and applies to both certificate and secret syncs.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)