### PR TITLE
feat(kms): add ECC_SECG_P256K1 key algorithm

### DIFF
--- a/backend/src/lib/crypto/sign/signing.test.ts
+++ b/backend/src/lib/crypto/sign/signing.test.ts
@@ -1,0 +1,200 @@
+import nodeCrypto from "node:crypto";
+
+// logger is initialized at app boot and is undefined under unit tests; stub it so failure
+// paths surface their real result instead of a "logger is undefined" error
+vi.mock("@app/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+// eslint-disable-next-line import/first
+import { BadRequestError } from "@app/lib/errors";
+
+// eslint-disable-next-line import/first
+import { normalizeEcdsaSignatureToLowS, signingService } from "./signing";
+// eslint-disable-next-line import/first
+import { AsymmetricKeyAlgorithm, SigningAlgorithm } from "./types";
+
+const SECP256K1_N = BigInt("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+const SECP256K1_HALF_N = SECP256K1_N / BigInt(2);
+
+const parseDerSignature = (sig: Buffer): { r: bigint; s: bigint } => {
+  expect(sig[0]).toBe(0x30);
+  let offset = 2;
+  const readInt = (): bigint => {
+    expect(sig[offset]).toBe(0x02);
+    const length = sig[offset + 1];
+    const bytes = sig.subarray(offset + 2, offset + 2 + length);
+    offset += 2 + length;
+    return BigInt(`0x${bytes.toString("hex")}`);
+  };
+  const r = readInt();
+  const s = readInt();
+  return { r, s };
+};
+
+const encodeDerSignature = (r: bigint, s: bigint): Buffer => {
+  const toDerInt = (value: bigint) => {
+    let hex = value.toString(16);
+    if (hex.length % 2 === 1) hex = `0${hex}`;
+    let bytes = Buffer.from(hex, "hex");
+    if (bytes[0] >= 0x80) bytes = Buffer.concat([Buffer.from([0x00]), bytes]);
+    return Buffer.concat([Buffer.from([0x02, bytes.length]), bytes]);
+  };
+  const body = Buffer.concat([toDerInt(r), toDerInt(s)]);
+  return Buffer.concat([Buffer.from([0x30, body.length]), body]);
+};
+
+describe("signingService ECC_SECG_P256K1", () => {
+  const service = signingService(AsymmetricKeyAlgorithm.ECC_SECG_P256K1);
+  const data = Buffer.from("signing service test payload");
+
+  test("generates a PKCS8 PEM private key on the secp256k1 curve with an SPKI DER public key", async () => {
+    const privateKey = await service.generateAsymmetricPrivateKey();
+    expect(privateKey.toString("utf8")).toContain("-----BEGIN PRIVATE KEY-----");
+
+    const keyObj = nodeCrypto.createPrivateKey({ key: privateKey, format: "pem", type: "pkcs8" });
+    expect(keyObj.asymmetricKeyType).toBe("ec");
+    expect(keyObj.asymmetricKeyDetails?.namedCurve).toBe("secp256k1");
+
+    const publicKey = await service.getPublicKeyFromPrivateKey(privateKey);
+    // secp256k1 OID 1.3.132.0.10
+    expect(publicKey.toString("hex")).toContain("06052b8104000a");
+    // SPKI ends with the uncompressed EC point: 0x04 marker + 64 bytes of coordinates
+    expect(publicKey.length).toBeGreaterThan(65);
+    expect(publicKey.subarray(-65)[0]).toBe(0x04);
+  });
+
+  test("signs and verifies raw data", async () => {
+    const privateKey = await service.generateAsymmetricPrivateKey();
+    const publicKey = await service.getPublicKeyFromPrivateKey(privateKey);
+
+    const signature = await service.sign(data, privateKey, SigningAlgorithm.ECDSA_SHA_256, false);
+
+    await expect(service.verify(data, signature, publicKey, SigningAlgorithm.ECDSA_SHA_256, false)).resolves.toBe(true);
+    await expect(
+      service.verify(Buffer.from("tampered payload"), signature, publicKey, SigningAlgorithm.ECDSA_SHA_256, false)
+    ).resolves.toBe(false);
+  });
+
+  test("signs and verifies an externally computed 32-byte digest", async () => {
+    const privateKey = await service.generateAsymmetricPrivateKey();
+    const publicKey = await service.getPublicKeyFromPrivateKey(privateKey);
+    // arbitrary 32-byte digest — provenance must not matter, only length
+    const digest = nodeCrypto.randomBytes(32);
+
+    const signature = await service.sign(digest, privateKey, SigningAlgorithm.ECDSA_SHA_256, true);
+
+    await expect(service.verify(digest, signature, publicKey, SigningAlgorithm.ECDSA_SHA_256, true)).resolves.toBe(
+      true
+    );
+    await expect(
+      service.verify(nodeCrypto.randomBytes(32), signature, publicKey, SigningAlgorithm.ECDSA_SHA_256, true)
+    ).resolves.toBe(false);
+  }, 30000);
+
+  test("always emits canonical low-s signatures on both the raw and digest paths", async () => {
+    const privateKey = await service.generateAsymmetricPrivateKey();
+
+    for (let i = 0; i < 12; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const rawSig = await service.sign(data, privateKey, SigningAlgorithm.ECDSA_SHA_256, false);
+      expect(parseDerSignature(rawSig).s <= SECP256K1_HALF_N).toBe(true);
+
+      // eslint-disable-next-line no-await-in-loop
+      const digestSig = await service.sign(
+        nodeCrypto.randomBytes(32),
+        privateKey,
+        SigningAlgorithm.ECDSA_SHA_256,
+        true
+      );
+      expect(parseDerSignature(digestSig).s <= SECP256K1_HALF_N).toBe(true);
+    }
+  }, 60000);
+
+  test("still verifies non-canonical high-s signatures", async () => {
+    const privateKey = await service.generateAsymmetricPrivateKey();
+    const publicKey = await service.getPublicKeyFromPrivateKey(privateKey);
+
+    const signature = await service.sign(data, privateKey, SigningAlgorithm.ECDSA_SHA_256, false);
+    const { r, s } = parseDerSignature(signature);
+    const highSSignature = encodeDerSignature(r, SECP256K1_N - s);
+
+    await expect(service.verify(data, highSSignature, publicKey, SigningAlgorithm.ECDSA_SHA_256, false)).resolves.toBe(
+      true
+    );
+  });
+
+  test("rejects signing algorithms other than ECDSA_SHA_256", async () => {
+    const privateKey = await service.generateAsymmetricPrivateKey();
+    const publicKey = await service.getPublicKeyFromPrivateKey(privateKey);
+    const signature = await service.sign(data, privateKey, SigningAlgorithm.ECDSA_SHA_256, false);
+
+    for (const signingAlgorithm of [
+      SigningAlgorithm.ECDSA_SHA_384,
+      SigningAlgorithm.ECDSA_SHA_512,
+      SigningAlgorithm.RSASSA_PSS_SHA_256,
+      SigningAlgorithm.RSASSA_PKCS1_V1_5_SHA_256
+    ]) {
+      // eslint-disable-next-line no-await-in-loop
+      await expect(service.sign(data, privateKey, signingAlgorithm, false)).rejects.toThrow(BadRequestError);
+    }
+
+    await expect(service.verify(data, signature, publicKey, SigningAlgorithm.ECDSA_SHA_384, false)).rejects.toThrow(
+      BadRequestError
+    );
+  });
+
+  test("does not verify signatures against a different key", async () => {
+    const privateKey = await service.generateAsymmetricPrivateKey();
+    const otherPrivateKey = await service.generateAsymmetricPrivateKey();
+    const otherPublicKey = await service.getPublicKeyFromPrivateKey(otherPrivateKey);
+
+    const signature = await service.sign(data, privateKey, SigningAlgorithm.ECDSA_SHA_256, false);
+
+    await expect(service.verify(data, signature, otherPublicKey, SigningAlgorithm.ECDSA_SHA_256, false)).resolves.toBe(
+      false
+    );
+  });
+});
+
+describe("normalizeEcdsaSignatureToLowS", () => {
+  test("returns low-s signatures unchanged", () => {
+    const signature = encodeDerSignature(BigInt(5), BigInt(7));
+    expect(normalizeEcdsaSignatureToLowS(signature, SECP256K1_N).equals(signature)).toBe(true);
+  });
+
+  test("flips high-s signatures and preserves r", () => {
+    const r = SECP256K1_N - BigInt(1);
+    const signature = encodeDerSignature(r, SECP256K1_N - BigInt(7));
+
+    const normalized = parseDerSignature(normalizeEcdsaSignatureToLowS(signature, SECP256K1_N));
+    expect(normalized.r).toBe(r);
+    expect(normalized.s).toBe(BigInt(7));
+  });
+
+  test("rejects malformed input", () => {
+    expect(() => normalizeEcdsaSignatureToLowS(Buffer.from("not a signature"), SECP256K1_N)).toThrow(BadRequestError);
+    expect(() => normalizeEcdsaSignatureToLowS(Buffer.from([0x30, 0x02, 0x01, 0x01]), SECP256K1_N)).toThrow(
+      BadRequestError
+    );
+  });
+});
+
+describe("signingService ECC_NIST_P256 regression", () => {
+  const service = signingService(AsymmetricKeyAlgorithm.ECC_NIST_P256);
+  const data = Buffer.from("p256 regression payload");
+
+  test("keeps multi-hash ECDSA support and round-trips on both paths", async () => {
+    const privateKey = await service.generateAsymmetricPrivateKey();
+    const publicKey = await service.getPublicKeyFromPrivateKey(privateKey);
+
+    const rawSig = await service.sign(data, privateKey, SigningAlgorithm.ECDSA_SHA_384, false);
+    await expect(service.verify(data, rawSig, publicKey, SigningAlgorithm.ECDSA_SHA_384, false)).resolves.toBe(true);
+
+    const digest = nodeCrypto.createHash("sha256").update(data).digest();
+    const digestSig = await service.sign(digest, privateKey, SigningAlgorithm.ECDSA_SHA_256, true);
+    await expect(service.verify(digest, digestSig, publicKey, SigningAlgorithm.ECDSA_SHA_256, true)).resolves.toBe(
+      true
+    );
+  }, 30000);
+});

--- a/backend/src/lib/crypto/sign/signing.ts
+++ b/backend/src/lib/crypto/sign/signing.ts
@@ -39,6 +39,46 @@ export const KMS_TO_OPENSSL_NAME: Partial<Record<AsymmetricKeyAlgorithm, string>
   [AsymmetricKeyAlgorithm.ML_DSA_87]: "ML-DSA-87"
 };
 
+// secp256k1 group order (n). Signatures on this curve are normalized to low-s form because
+// many verifiers on this curve enforce canonical signatures and reject s > n/2 (malleability).
+const SECP256K1_ORDER = BigInt("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141");
+
+const readDerInteger = (der: Buffer, offset: number): { value: bigint; nextOffset: number } => {
+  const length = der[offset + 1];
+  if (der[offset] !== 0x02 || length === 0 || length >= 0x80) {
+    throw new BadRequestError({ message: "Invalid ECDSA signature: malformed DER integer" });
+  }
+  const start = offset + 2;
+  const end = start + length;
+  if (end > der.length) {
+    throw new BadRequestError({ message: "Invalid ECDSA signature: truncated DER integer" });
+  }
+  return { value: BigInt(`0x${der.subarray(start, end).toString("hex")}`), nextOffset: end };
+};
+
+const encodeDerInteger = (value: bigint): Buffer => {
+  let hex = value.toString(16);
+  if (hex.length % 2 === 1) hex = `0${hex}`;
+  let bytes = Buffer.from(hex, "hex");
+  if (bytes[0] >= 0x80) bytes = Buffer.concat([Buffer.from([0x00]), bytes]);
+  return Buffer.concat([Buffer.from([0x02, bytes.length]), bytes]);
+};
+
+export const normalizeEcdsaSignatureToLowS = (signature: Buffer, curveOrder: bigint): Buffer => {
+  if (signature[0] !== 0x30 || signature[1] >= 0x80) {
+    throw new BadRequestError({ message: "Invalid ECDSA signature: expected DER sequence" });
+  }
+  const { value: r, nextOffset } = readDerInteger(signature, 2);
+  const { value: s } = readDerInteger(signature, nextOffset);
+
+  if (s <= curveOrder / BigInt(2)) {
+    return signature;
+  }
+
+  const body = Buffer.concat([encodeDerInteger(r), encodeDerInteger(curveOrder - s)]);
+  return Buffer.concat([Buffer.from([0x30, body.length]), body]);
+};
+
 /**
  * Service for cryptographic signing and verification operations using asymmetric keys
  *
@@ -107,6 +147,8 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
         return { full: "secp384r1", short: "p384" };
       case AsymmetricKeyAlgorithm.ECC_NIST_P521:
         return { full: "secp521r1", short: "p521" };
+      case AsymmetricKeyAlgorithm.ECC_SECG_P256K1:
+        return { full: "secp256k1", short: "k256" };
       default:
         throw new Error(`Unsupported EC curve: ${keyAlgorithm}`);
     }
@@ -129,6 +171,12 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
       throw new BadRequestError({ message: `KMS ECC key cannot be used with ${signingAlgorithm}` });
     }
 
+    if (algorithm === AsymmetricKeyAlgorithm.ECC_SECG_P256K1 && signingAlgorithm !== SigningAlgorithm.ECDSA_SHA_256) {
+      throw new BadRequestError({
+        message: `KMS ${algorithm} key can only be used with ${SigningAlgorithm.ECDSA_SHA_256} signing algorithm`
+      });
+    }
+
     if (isPqcKey) {
       if (!isPqcAlgorithm || (signingAlgorithm as string) !== (algorithm as string)) {
         throw new BadRequestError({
@@ -137,6 +185,11 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
       }
     }
   };
+
+  const $toCanonicalSignature = (signature: Buffer): Buffer =>
+    algorithm === AsymmetricKeyAlgorithm.ECC_SECG_P256K1
+      ? normalizeEcdsaSignatureToLowS(signature, SECP256K1_ORDER)
+      : signature;
 
   const $signRsaDigest = async (
     digest: Buffer,
@@ -371,6 +424,7 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     [AsymmetricKeyAlgorithm.ECC_NIST_P256]: $verifyEccDigest,
     [AsymmetricKeyAlgorithm.ECC_NIST_P384]: $verifyEccDigest,
     [AsymmetricKeyAlgorithm.ECC_NIST_P521]: $verifyEccDigest,
+    [AsymmetricKeyAlgorithm.ECC_SECG_P256K1]: $verifyEccDigest,
     [AsymmetricKeyAlgorithm.RSA_4096]: $verifyRsaDigest
   };
 
@@ -388,6 +442,7 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     [AsymmetricKeyAlgorithm.ECC_NIST_P256]: $signEccDigest,
     [AsymmetricKeyAlgorithm.ECC_NIST_P384]: $signEccDigest,
     [AsymmetricKeyAlgorithm.ECC_NIST_P521]: $signEccDigest,
+    [AsymmetricKeyAlgorithm.ECC_SECG_P256K1]: $signEccDigest,
     [AsymmetricKeyAlgorithm.RSA_4096]: $signRsaDigest
   };
 
@@ -425,7 +480,7 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
       }
 
       const signature = await signFunction(data, privateKey, hashAlgorithm, signingAlgorithm);
-      return signature;
+      return $toCanonicalSignature(signature);
     }
 
     const privateKeyObject = crypto.nativeCrypto.createPrivateKey({
@@ -449,10 +504,12 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
       // For ECDSA signatures
       const signer = crypto.nativeCrypto.createSign(hashAlgorithm);
       signer.update(data);
-      return signer.sign({
-        key: privateKeyObject,
-        dsaEncoding: "der"
-      });
+      return $toCanonicalSignature(
+        signer.sign({
+          key: privateKeyObject,
+          dsaEncoding: "der"
+        })
+      );
     }
     throw new BadRequestError({
       message: `Signing algorithm ${signingAlgorithm} not implemented`

--- a/backend/src/lib/crypto/sign/types.ts
+++ b/backend/src/lib/crypto/sign/types.ts
@@ -19,6 +19,7 @@ export enum AsymmetricKeyAlgorithm {
   ECC_NIST_P256 = "ECC_NIST_P256",
   ECC_NIST_P384 = "ECC_NIST_P384",
   ECC_NIST_P521 = "ECC_NIST_P521",
+  ECC_SECG_P256K1 = "ECC_SECG_P256K1",
   ML_DSA_44 = "ML_DSA_44",
   ML_DSA_65 = "ML_DSA_65",
   ML_DSA_87 = "ML_DSA_87"

--- a/backend/src/services/cmek/cmek-service.ts
+++ b/backend/src/services/cmek/cmek-service.ts
@@ -4,6 +4,7 @@ import { ActionProjectType } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionCmekActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import { crypto } from "@app/lib/crypto/cryptography";
 import { AsymmetricKeyAlgorithm, isPqcKeyAlgorithm, SigningAlgorithm, signingService } from "@app/lib/crypto/sign";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
@@ -294,6 +295,12 @@ export const cmekServiceFactory = ({
       return { signingAlgorithms: [encryptionAlgorithm as unknown as SigningAlgorithm], projectId: key.projectId };
     }
 
+    // secp256k1 pairs its 256-bit group with a 256-bit digest only, unlike the NIST curves
+    // which historically accepted every ECDSA hash variant here
+    if ((encryptionAlgorithm as string) === AsymmetricKeyAlgorithm.ECC_SECG_P256K1) {
+      return { signingAlgorithms: [SigningAlgorithm.ECDSA_SHA_256], projectId: key.projectId };
+    }
+
     const algos = [
       {
         keyAlgorithm: "rsa",
@@ -426,7 +433,14 @@ export const cmekServiceFactory = ({
         }
 
         let publicKey: string | undefined;
-        if (asymmetricAlgorithms.has(key.encryptionAlgorithm)) {
+        // deriving the public key is an EC operation the FIPS provider rejects for secp256k1;
+        // the stored key material itself can still be exported
+        const canDerivePublicKey =
+          asymmetricAlgorithms.has(key.encryptionAlgorithm) &&
+          !(
+            key.encryptionAlgorithm === (AsymmetricKeyAlgorithm.ECC_SECG_P256K1 as string) && crypto.isFipsModeEnabled()
+          );
+        if (canDerivePublicKey) {
           const pubKeyBuffer = await signingService(
             key.encryptionAlgorithm as AsymmetricKeyAlgorithm
           ).getPublicKeyFromPrivateKey(materialEntry.keyMaterial);

--- a/backend/src/services/kms/kms-fns.test.ts
+++ b/backend/src/services/kms/kms-fns.test.ts
@@ -1,0 +1,59 @@
+import { SymmetricKeyAlgorithm } from "@app/lib/crypto/cipher";
+import { crypto } from "@app/lib/crypto/cryptography";
+import { AsymmetricKeyAlgorithm } from "@app/lib/crypto/sign";
+import { BadRequestError } from "@app/lib/errors";
+
+import { verifyKeyTypeAndAlgorithm } from "./kms-fns";
+import { KmsKeyUsage } from "./kms-types";
+
+vi.mock("@app/lib/crypto/cryptography", () => ({
+  crypto: {
+    isFipsModeEnabled: vi.fn(() => false)
+  }
+}));
+
+describe("verifyKeyTypeAndAlgorithm", () => {
+  beforeEach(() => {
+    vi.mocked(crypto.isFipsModeEnabled).mockReset();
+    vi.mocked(crypto.isFipsModeEnabled).mockReturnValue(false);
+  });
+
+  test("accepts symmetric algorithms for encrypt/decrypt keys and asymmetric for sign/verify keys", () => {
+    expect(verifyKeyTypeAndAlgorithm(KmsKeyUsage.ENCRYPT_DECRYPT, SymmetricKeyAlgorithm.AES_GCM_256)).toBe(true);
+
+    for (const algorithm of Object.values(AsymmetricKeyAlgorithm)) {
+      expect(verifyKeyTypeAndAlgorithm(KmsKeyUsage.SIGN_VERIFY, algorithm)).toBe(true);
+    }
+  });
+
+  test("rejects mismatched key usage and algorithm families", () => {
+    expect(() => verifyKeyTypeAndAlgorithm(KmsKeyUsage.ENCRYPT_DECRYPT, AsymmetricKeyAlgorithm.ECC_NIST_P256)).toThrow(
+      BadRequestError
+    );
+    expect(() => verifyKeyTypeAndAlgorithm(KmsKeyUsage.SIGN_VERIFY, SymmetricKeyAlgorithm.AES_GCM_256)).toThrow(
+      BadRequestError
+    );
+    expect(() =>
+      verifyKeyTypeAndAlgorithm(KmsKeyUsage.SIGN_VERIFY, AsymmetricKeyAlgorithm.ECC_NIST_P256, {
+        forceType: KmsKeyUsage.ENCRYPT_DECRYPT
+      })
+    ).toThrow(BadRequestError);
+  });
+
+  test("rejects ECC_SECG_P256K1 in FIPS mode but allows it otherwise", () => {
+    expect(verifyKeyTypeAndAlgorithm(KmsKeyUsage.SIGN_VERIFY, AsymmetricKeyAlgorithm.ECC_SECG_P256K1)).toBe(true);
+
+    vi.mocked(crypto.isFipsModeEnabled).mockReturnValue(true);
+    expect(() => verifyKeyTypeAndAlgorithm(KmsKeyUsage.SIGN_VERIFY, AsymmetricKeyAlgorithm.ECC_SECG_P256K1)).toThrow(
+      BadRequestError
+    );
+  });
+
+  test("never consults FIPS mode for other algorithms", () => {
+    verifyKeyTypeAndAlgorithm(KmsKeyUsage.ENCRYPT_DECRYPT, SymmetricKeyAlgorithm.AES_GCM_256);
+    verifyKeyTypeAndAlgorithm(KmsKeyUsage.SIGN_VERIFY, AsymmetricKeyAlgorithm.ECC_NIST_P256);
+    verifyKeyTypeAndAlgorithm(KmsKeyUsage.SIGN_VERIFY, AsymmetricKeyAlgorithm.ML_DSA_44);
+
+    expect(crypto.isFipsModeEnabled).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/kms/kms-fns.ts
+++ b/backend/src/services/kms/kms-fns.ts
@@ -1,4 +1,5 @@
 import { SymmetricKeyAlgorithm } from "@app/lib/crypto/cipher";
+import { crypto } from "@app/lib/crypto/cryptography";
 import { AsymmetricKeyAlgorithm } from "@app/lib/crypto/sign";
 import { BadRequestError } from "@app/lib/errors";
 
@@ -43,6 +44,14 @@ export const verifyKeyTypeAndAlgorithm = (
     if (!Object.values(AsymmetricKeyAlgorithm).includes(algorithm as AsymmetricKeyAlgorithm)) {
       throw new BadRequestError({
         message: `Unsupported sign/verify algorithm for sign/verify key: ${algorithm as string}`
+      });
+    }
+
+    // the FIPS OpenSSL provider does not include the secp256k1 curve; keep the algorithm
+    // check first so the FIPS lookup never runs on the encrypt/decrypt hot path
+    if (algorithm === AsymmetricKeyAlgorithm.ECC_SECG_P256K1 && crypto.isFipsModeEnabled()) {
+      throw new BadRequestError({
+        message: `Algorithm ${algorithm as string} is not supported in FIPS mode of operation`
       });
     }
 

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -642,6 +642,24 @@ export const kmsServiceFactory = ({
               message: `Key material does not match the declared algorithm. Expected an EC P-256 key.`
             });
           }
+        } else if (algorithm === AsymmetricKeyAlgorithm.ECC_NIST_P384) {
+          if (keyType !== "ec" || keyDetails?.namedCurve !== "secp384r1") {
+            throw new BadRequestError({
+              message: `Key material does not match the declared algorithm. Expected an EC P-384 key.`
+            });
+          }
+        } else if (algorithm === AsymmetricKeyAlgorithm.ECC_NIST_P521) {
+          if (keyType !== "ec" || keyDetails?.namedCurve !== "secp521r1") {
+            throw new BadRequestError({
+              message: `Key material does not match the declared algorithm. Expected an EC P-521 key.`
+            });
+          }
+        } else if (algorithm === AsymmetricKeyAlgorithm.ECC_SECG_P256K1) {
+          if (keyType !== "ec" || keyDetails?.namedCurve !== "secp256k1") {
+            throw new BadRequestError({
+              message: `Key material does not match the declared algorithm. Expected an EC secp256k1 key.`
+            });
+          }
         }
       }
     }

--- a/frontend/src/hooks/api/cmeks/types.ts
+++ b/frontend/src/hooks/api/cmeks/types.ts
@@ -137,6 +137,9 @@ export enum CmekOrderBy {
 export enum AsymmetricKeyAlgorithm {
   RSA_4096 = "RSA_4096",
   ECC_NIST_P256 = "ECC_NIST_P256",
+  ECC_NIST_P384 = "ECC_NIST_P384",
+  ECC_NIST_P521 = "ECC_NIST_P521",
+  ECC_SECG_P256K1 = "ECC_SECG_P256K1",
   ML_DSA_44 = "ML_DSA_44",
   ML_DSA_65 = "ML_DSA_65",
   ML_DSA_87 = "ML_DSA_87"

--- a/frontend/src/pages/kms/OverviewPage/components/CmekModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekModal.tsx
@@ -22,7 +22,7 @@ import {
   FieldTitle,
   Switch
 } from "@app/components/v3";
-import { useProject, useSubscription } from "@app/context";
+import { useProject, useServerConfig, useSubscription } from "@app/context";
 import { keyUsageDefaultOption, kmsKeyUsageOptions } from "@app/helpers/kms";
 import {
   AllowedEncryptionKeyAlgorithms,
@@ -62,6 +62,7 @@ const CmekForm = ({ onComplete, cmek }: FormProps) => {
   const projectId = currentProject.id;
   const isUpdate = !!cmek;
   const { subscription } = useSubscription();
+  const { config: serverConfig } = useServerConfig();
 
   const {
     control,
@@ -192,6 +193,13 @@ const CmekForm = ({ onComplete, cmek }: FormProps) => {
                           );
                         }
                         if (selectedKeyUsage === KmsKeyUsage.SIGN_VERIFY) {
+                          // secp256k1 is not available in FIPS mode of operation
+                          if (
+                            value === (AsymmetricKeyAlgorithm.ECC_SECG_P256K1 as string) &&
+                            serverConfig?.fipsEnabled
+                          ) {
+                            return false;
+                          }
                           return Object.values(AsymmetricKeyAlgorithm).includes(
                             value as unknown as AsymmetricKeyAlgorithm
                           );

--- a/frontend/src/pages/kms/OverviewPage/components/CmekSignModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekSignModal.tsx
@@ -19,7 +19,7 @@ import {
 } from "@app/components/v2";
 import { getDefaultSigningAlgorithm } from "@app/helpers/kms";
 import { useTimedReset } from "@app/hooks";
-import { SigningAlgorithm, TCmek, useCmekSign } from "@app/hooks/api/cmeks";
+import { AsymmetricKeyAlgorithm, SigningAlgorithm, TCmek, useCmekSign } from "@app/hooks/api/cmeks";
 
 const formSchema = z.object({
   data: z.string(),
@@ -77,6 +77,8 @@ const SignForm = ({ cmek }: FormProps) => {
     if (cmek?.encryptionAlgorithm?.startsWith("ML_DSA"))
       return (a as string) === (cmek.encryptionAlgorithm as string);
     if (cmek?.encryptionAlgorithm?.startsWith("RSA")) return a.toLowerCase().startsWith("rsa");
+    if ((cmek?.encryptionAlgorithm as string) === AsymmetricKeyAlgorithm.ECC_SECG_P256K1)
+      return a === SigningAlgorithm.ECDSA_SHA_256;
     return a.toLowerCase().startsWith("ecdsa");
   });
 

--- a/frontend/src/pages/kms/OverviewPage/components/CmekVerifyModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekVerifyModal.tsx
@@ -20,7 +20,12 @@ import {
 } from "@app/components/v2";
 import { Badge } from "@app/components/v3";
 import { getDefaultSigningAlgorithm } from "@app/helpers/kms";
-import { SigningAlgorithm, TCmek, useCmekVerify } from "@app/hooks/api/cmeks";
+import {
+  AsymmetricKeyAlgorithm,
+  SigningAlgorithm,
+  TCmek,
+  useCmekVerify
+} from "@app/hooks/api/cmeks";
 import { isBase64 } from "@app/lib/fn/base64";
 
 const formSchema = z.object({
@@ -95,6 +100,8 @@ const VerifyForm = ({ cmek }: FormProps) => {
     if (cmek?.encryptionAlgorithm?.startsWith("ML_DSA"))
       return (a as string) === (cmek.encryptionAlgorithm as string);
     if (cmek?.encryptionAlgorithm?.startsWith("RSA")) return a.toLowerCase().startsWith("rsa");
+    if ((cmek?.encryptionAlgorithm as string) === AsymmetricKeyAlgorithm.ECC_SECG_P256K1)
+      return a === SigningAlgorithm.ECDSA_SHA_256;
     return a.toLowerCase().startsWith("ecdsa");
   });
 


### PR DESCRIPTION
## Context

Adds secp256k1 (`ECC_SECG_P256K1`) as a sign/verify key algorithm for KMS — full-stack (API + dashboard), restricted to `ECDSA_SHA_256`, emitting canonical low-s signatures, validated on import, and rejected in FIPS mode since the FIPS provider doesn't include the curve.

## Steps to verify the change

1. Create a Sign/Verify key with the `ECC_SECG_P256K1` algorithm (UI or `POST /api/v1/kms/keys`)
2. Sign and verify data with `ECDSA_SHA_256`, including a 32-byte digest with `isDigest: true`; other signing algorithms return 400
3. Fetch the public key and check `GET /keys/:keyId/signing-algorithms` only lists `ECDSA_SHA_256`
4. `cd backend && npm run test:unit` — new coverage in `signing.test.ts` and `kms-fns.test.ts`

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)