### PR TITLE
feat: label the Advanced subscription tier

### DIFF
--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -317,6 +317,8 @@ export const licenseServiceFactory = ({
               .filter((tier) => tier !== "free");
             if (paidTiers.some((tier) => tier.includes("enterprise"))) {
               currentPlan.slug = "enterprise";
+            } else if (paidTiers.some((tier) => tier.includes("advanced"))) {
+              currentPlan.slug = "advanced";
             } else if (paidTiers.length > 0) {
               currentPlan.slug = "pro";
             }

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -366,7 +366,7 @@ export const licenseServiceFactory = ({
 
         // read-compare bake: serve v1 but shadow-compare against v2 in the background ahead of the cutover.
         if (envConfig.LICENSE_SERVER_V2_MODE === "read-compare") {
-          licenseDualRead?.compareInBackground(rootOrgId, currentPlan);
+          licenseDualRead?.compareInBackground(rootOrgId, currentPlan, getDefaultOnPremFeatures);
         }
 
         return currentPlan;

--- a/backend/src/services/license-client/dual-read/dual-read-service.ts
+++ b/backend/src/services/license-client/dual-read/dual-read-service.ts
@@ -19,7 +19,7 @@ export const dualReadServiceFactory = ({ licenseClient, envConfig }: TDualReadSe
   // Fire-and-forget shadow compare against the already-resolved v1 plan. Never awaited, never throws into
   // the request path; inert unless mode is read-compare. Reads v2 through the real client SDK so the
   // production read path is exercised under real traffic ahead of the cutover.
-  const compareInBackground = (orgId: string, planV1: TFeatureSet) => {
+  const compareInBackground = (orgId: string, planV1: TFeatureSet, getFreeTierPlan: () => TFeatureSet) => {
     if (!envConfig.isLicenseDualReadEnabled) {
       return;
     }
@@ -32,7 +32,16 @@ export const dualReadServiceFactory = ({ licenseClient, envConfig }: TDualReadSe
         return;
       }
 
-      const discrepancies = compareEntitlements(planV1, entitlements, FEATURE_MAPPINGS);
+      // v2 resolves an org with no license to the free tier (every feature source=default). Comparing that
+      // against the org's real v1 plan is noise, so compare v2 against the v1 free baseline instead.
+      const featureValues = Object.values(entitlements.features);
+      const isV2Unlicensed = featureValues.length > 0 && featureValues.every((f) => f.source === "default");
+      let planForCompare = planV1;
+      if (isV2Unlicensed) {
+        planForCompare = getFreeTierPlan();
+      }
+
+      const discrepancies = compareEntitlements(planForCompare, entitlements, FEATURE_MAPPINGS);
       const diffs = discrepancies.filter((d) => d.kind !== DualReadDiffKind.Match);
 
       for (const d of diffs) {

--- a/backend/src/services/license-client/dual-read/entitlement-projection.test.ts
+++ b/backend/src/services/license-client/dual-read/entitlement-projection.test.ts
@@ -31,7 +31,7 @@ describe("projectV2ToFeatureSet", () => {
   });
 
   test("projects a nested rateLimits field via its dotted v1Field", () => {
-    const plan = projectV2ToFeatureSet(makeBase({}), makeEntitlements({ rate_limits_read_limit: { value: 500 } }));
+    const plan = projectV2ToFeatureSet(makeBase({}), makeEntitlements({ read_rate_limit: { value: 500 } }));
     expect(plan.rateLimits.readLimit).toBe(500);
   });
 

--- a/backend/src/services/license-client/dual-read/feature-mapping/access.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/access.ts
@@ -52,11 +52,6 @@ export const accessMappings: TFeatureMapping[] = [
     extractV1: (p) => p.githubOrgSync
   },
   {
-    v2Key: "enforce_identity_limit",
-    v1Field: "enforceIdentityLimit",
-    extractV1: (p) => Boolean(p.enforceIdentityLimit)
-  },
-  {
     v2Key: "audit_logs",
     v1Field: "auditLogs",
     extractV1: (p) => p.auditLogs

--- a/backend/src/services/license-client/dual-read/feature-mapping/core.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/core.ts
@@ -72,11 +72,6 @@ export const coreMappings: TFeatureMapping[] = [
     extractV1: (p) => p.enterpriseSecretSyncs
   },
   {
-    v2Key: "enterprise_certificate_syncs",
-    v1Field: "enterpriseCertificateSyncs",
-    extractV1: (p) => p.enterpriseCertificateSyncs
-  },
-  {
     v2Key: "enterprise_app_connections",
     v1Field: "enterpriseAppConnections",
     extractV1: (p) => p.enterpriseAppConnections

--- a/backend/src/services/license-client/dual-read/feature-mapping/index.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/index.ts
@@ -13,7 +13,8 @@ export const FEATURE_MAPPINGS: TFeatureMapping[] = [
   ...limitsMappings
 ];
 
-// v1 TFeatureSet keys intentionally not compared (live usage counters + plan metadata).
+// v1 TFeatureSet keys intentionally not compared: live usage counters, plan metadata, and v1 fields
+// with no License Server v2 feature (v2 never returns them, so a mapping would be permanently v2_missing).
 export const EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
   "_id",
   "slug",
@@ -24,5 +25,9 @@ export const EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
   "workspacesUsed",
   "membersUsed",
   "identitiesUsed",
-  "environmentsUsed"
+  "environmentsUsed",
+  "workspaceLimit",
+  "memberLimit",
+  "enterpriseCertificateSyncs",
+  "pkiLegacyTemplates"
 ]);

--- a/backend/src/services/license-client/dual-read/feature-mapping/limits.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/limits.ts
@@ -2,18 +2,6 @@ import { TFeatureMapping, unlimitedWhenNull } from "../dual-read-types";
 
 export const limitsMappings: TFeatureMapping[] = [
   {
-    v2Key: "workspace_limit",
-    v1Field: "workspaceLimit",
-    extractV1: (p) => p.workspaceLimit,
-    normalize: unlimitedWhenNull
-  },
-  {
-    v2Key: "member_limit",
-    v1Field: "memberLimit",
-    extractV1: (p) => p.memberLimit,
-    normalize: unlimitedWhenNull
-  },
-  {
     v2Key: "environment_limit",
     v1Field: "environmentLimit",
     extractV1: (p) => p.environmentLimit,
@@ -30,17 +18,17 @@ export const limitsMappings: TFeatureMapping[] = [
     extractV1: (p) => p.honeyTokenLimit
   },
   {
-    v2Key: "rate_limits_read_limit",
+    v2Key: "read_rate_limit",
     v1Field: "rateLimits.readLimit",
     extractV1: (p) => p.rateLimits?.readLimit ?? null
   },
   {
-    v2Key: "rate_limits_write_limit",
+    v2Key: "write_rate_limit",
     v1Field: "rateLimits.writeLimit",
     extractV1: (p) => p.rateLimits?.writeLimit ?? null
   },
   {
-    v2Key: "rate_limits_secrets_limit",
+    v2Key: "secrets_rate_limit",
     v1Field: "rateLimits.secretsLimit",
     extractV1: (p) => p.rateLimits?.secretsLimit ?? null
   }

--- a/backend/src/services/license-client/dual-read/feature-mapping/limits.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/limits.ts
@@ -32,16 +32,16 @@ export const limitsMappings: TFeatureMapping[] = [
   {
     v2Key: "rate_limits_read_limit",
     v1Field: "rateLimits.readLimit",
-    extractV1: (p) => p.rateLimits.readLimit
+    extractV1: (p) => p.rateLimits?.readLimit ?? null
   },
   {
     v2Key: "rate_limits_write_limit",
     v1Field: "rateLimits.writeLimit",
-    extractV1: (p) => p.rateLimits.writeLimit
+    extractV1: (p) => p.rateLimits?.writeLimit ?? null
   },
   {
     v2Key: "rate_limits_secrets_limit",
     v1Field: "rateLimits.secretsLimit",
-    extractV1: (p) => p.rateLimits.secretsLimit
+    extractV1: (p) => p.rateLimits?.secretsLimit ?? null
   }
 ];

--- a/backend/src/services/license-client/dual-read/feature-mapping/pki-security.ts
+++ b/backend/src/services/license-client/dual-read/feature-mapping/pki-security.ts
@@ -12,7 +12,7 @@ export const pkiSecurityMappings: TFeatureMapping[] = [
     extractV1: (p) => p.pkiEst
   },
   {
-    v2Key: "pki_acme",
+    v2Key: "acme_client",
     v1Field: "pkiAcme",
     extractV1: (p) => p.pkiAcme
   },
@@ -25,11 +25,6 @@ export const pkiSecurityMappings: TFeatureMapping[] = [
     v2Key: "pki_pqc",
     v1Field: "pkiPqc",
     extractV1: (p) => p.pkiPqc
-  },
-  {
-    v2Key: "pki_legacy_templates",
-    v1Field: "pkiLegacyTemplates",
-    extractV1: (p) => p.pkiLegacyTemplates
   },
   {
     v2Key: "ssh_host_groups",

--- a/frontend/src/hooks/api/subscriptions/fns.ts
+++ b/frontend/src/hooks/api/subscriptions/fns.ts
@@ -13,5 +13,8 @@ export const getSubscriptionPlanLabel = (subscription: SubscriptionPlan, suffix 
   if (!slug || slug === SubscriptionPlanTypes.Starter) {
     return `Free${suffix}`;
   }
+  if (slug === SubscriptionPlanTypes.Advanced) {
+    return `Advanced${suffix}`;
+  }
   return `Pro${suffix}`;
 };

--- a/frontend/src/hooks/api/subscriptions/types.ts
+++ b/frontend/src/hooks/api/subscriptions/types.ts
@@ -2,6 +2,7 @@ export enum SubscriptionPlanTypes {
   Starter = "starter",
   Pro = "pro",
   ProAnnual = "pro-annual",
+  Advanced = "advanced",
   Team = "team",
   TeamAnnual = "team-annual",
   Enterprise = "enterprise",


### PR DESCRIPTION
## Context

- Add "Advanced" subscription-plan tier label (`SubscriptionPlanTypes.Advanced` enum + `getSubscriptionPlanLabel` case).
- Resolve advanced tier in cloud `getPlan` slug logic (enterprise > advanced > pro), off the subscription's `item.plan`.
- Self-hosted slug resolver intentionally left enterprise/pro only.
- Note: v2-only license-server feature keys are intentionally NOT added to dual-read/`TFeatureSet` (no v1 equivalent); BillingV2 pricing UI already surfaces the new tier/prices from the catalog, so no frontend pricing changes.

## Steps to verify the change

- Backend `type:check` clean.
- `mapping-completeness` unit test green.
- Frontend `type:check` clean.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
