### PR TITLE
fix: dashboard field empty issue with import paths

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -307,7 +307,9 @@ export const SecretTableRow = ({
             secretPath={secretPath}
             isVisible={isSecretVisible || isSingleEnvSecretsVisible}
             secretName={secretKey}
-            isEmpty={singleEnvSecret?.isEmpty || singleEnvImportedSecret?.secret?.isEmpty}
+            isEmpty={
+              singleEnvSecret ? singleEnvSecret.isEmpty : singleEnvImportedSecret?.secret?.isEmpty
+            }
             secretValueHidden={singleEnvSecret?.secretValueHidden || false}
             defaultValue={getDefaultValue(singleEnvSecret, singleEnvImportedSecret)}
             secretId={singleEnvSecret?.id}
@@ -583,7 +585,7 @@ export const SecretTableRow = ({
                               secretPath={secretPath}
                               isVisible={isSecretVisible}
                               secretName={secretKey}
-                              isEmpty={secret?.isEmpty || importedSecret?.secret?.isEmpty}
+                              isEmpty={secret ? secret.isEmpty : importedSecret?.secret?.isEmpty}
                               secretValueHidden={secret?.secretValueHidden || false}
                               defaultValue={getDefaultValue(secret, importedSecret)}
                               secretId={secret?.id}


### PR DESCRIPTION
## Context

On the Secret Overview page, a secret that has a real value in an environment could render as **EMPTY** when that same key is also brought in by an import (normal or replicated) whose value is empty. The environment comparison grid correctly showed a green "present" tick, but opening the per-env view or the expanded multi-env compare showed no value.

## Reproduction

1. In env A (e.g. `dev`), create a secret `TEST` with an empty value.
2. In env B (e.g. `staging`), create `TEST` with a real value, and add an import of env A at the same path.
3. Open the Secret Overview. Env B shows a green tick for `TEST`, but the per-env view and the expanded compare show EMPTY.

After the fix, env B shows the real local value in both views while the tick stays green. An environment that only receives the key via an empty import still correctly shows as empty.

## Screenshots

<img width="1570" height="480" alt="Screenshot 2026-07-08 at 12 37 47 AM" src="https://github.com/user-attachments/assets/939c7dab-2453-4255-926b-04450a7b3f79" />


## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)