### PR TITLE
fix(billing): show live usage on per-unit product dimensions

### DIFF
--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -13,6 +13,7 @@ import {
   TSubscriptionPreviewPayload,
   TSubscriptionResponse
 } from "@app/services/license-client/license-client-types";
+import { TMeteredFeature } from "@app/services/license-client/usage";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 
 import { isV2SelfHostedLicenseKey } from "../license/license-fns";
@@ -45,6 +46,9 @@ type TLicenseV2ServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "countAllOrgMembers">;
   identityOrgMembershipDAL: Pick<TIdentityOrgDALFactory, "countAllOrgIdentities">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
+  // Feature-keyed live-count fns (the same source the usage meter uses), so per-unit dimensions can
+  // show real utilization instead of the zero the license server reports for non-metered dimensions.
+  meteredFeatures: TMeteredFeature[];
   licenseClient: Pick<
     TLicenseClientFactory,
     | "getEntitlements"
@@ -303,7 +307,8 @@ export const licenseV2ServiceFactory = ({
   orgDAL,
   identityOrgMembershipDAL,
   permissionService,
-  licenseClient
+  licenseClient,
+  meteredFeatures
 }: TLicenseV2ServiceFactoryDep) => {
   // A self-hosted v2 license is managed out-of-band: the billing surface is read-only. Self-serve
   // mutations don't need an explicit guard here, the self-hosted license client rejects them itself.
@@ -336,6 +341,46 @@ export const licenseV2ServiceFactory = ({
     );
   };
 
+  const counterByFeatureKey = new Map(meteredFeatures.map((metered) => [metered.feature.key, metered.count]));
+
+  // Live per-org usage for the subscription's non-metered dimensions, keyed by feature key. Only the
+  // feature keys that have a counter and appear as a non-metered dimension are counted, once each,
+  // in parallel. A count failure is logged and dropped so the overview still renders.
+  const resolveLiveUsage = async (
+    orgId: string,
+    subscription: TSubscriptionResponse | null
+  ): Promise<Map<string, number>> => {
+    const usage = new Map<string, number>();
+    if (!subscription) {
+      return usage;
+    }
+
+    const featureKeys = new Set<string>();
+    subscription.items.forEach((item) => {
+      item.dimensions.forEach((dimension) => {
+        if (!dimension.metered && dimension.featureKey && counterByFeatureKey.has(dimension.featureKey)) {
+          featureKeys.add(dimension.featureKey);
+        }
+      });
+    });
+
+    await Promise.all(
+      [...featureKeys].map(async (featureKey) => {
+        const count = counterByFeatureKey.get(featureKey);
+        if (!count) {
+          return;
+        }
+        try {
+          usage.set(featureKey, await count(orgId));
+        } catch (error) {
+          logger.error(error, `billing-v2: failed to count live usage [orgId=${orgId}, feature=${featureKey}]`);
+        }
+      })
+    );
+
+    return usage;
+  };
+
   // Fold the subscription items and the entitlement features sourced from a product into a single
   // per-product entitlement map, keyed by the server's product ids.
   const buildEntitlements = async (org: TEntitlementOrg, subscription: TSubscriptionResponse | null) => {
@@ -362,6 +407,12 @@ export const licenseV2ServiceFactory = ({
       }
     }
 
+    // The license server only tracks usage for metered dimensions, so per-unit ones come back with
+    // used=0. Overlay live counts from the same feature-keyed counters the usage meter uses, matched
+    // on the stable feature key (dimension keys drift). Metered dimensions keep the server's period
+    // peak, which is the billed figure. Counts are fetched once per distinct feature key.
+    const liveUsageByFeatureKey = await resolveLiveUsage(org.id, subscription);
+
     if (subscription) {
       subscription.items.forEach((item) => {
         // Resolve the pinned per-dimension contract into a display-ready list: label/noun from the
@@ -373,13 +424,18 @@ export const licenseV2ServiceFactory = ({
           const metered = dimension.metered ?? false;
           const hasRate = dimension.rateCents !== null && dimension.rateCents !== undefined;
           const hasFreeBand = dimension.freeBand !== null && dimension.freeBand !== undefined;
+          let used = dimension.used ?? 0;
+          const liveUsed = dimension.featureKey ? liveUsageByFeatureKey.get(dimension.featureKey) : undefined;
+          if (!metered && liveUsed !== undefined) {
+            used = liveUsed;
+          }
           return {
             key: dimension.key,
             label: labelByDimension.get(catalogKey) ?? dimension.key,
             noun: nounByDimension.get(catalogKey) ?? dimension.unit ?? dimension.key,
             unit: dimension.unit ?? nounByDimension.get(catalogKey) ?? dimension.key,
             metered,
-            used: dimension.used ?? 0,
+            used,
             limit: dimension.limit ?? null,
             ...(metered && hasFreeBand ? { freeBand: dimension.freeBand as number } : {}),
             ...(metered && hasRate ? { rate: centsToDollars(dimension.rateCents) } : {})

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -343,14 +343,17 @@ export const licenseV2ServiceFactory = ({
 
   const counterByFeatureKey = new Map(meteredFeatures.map((metered) => [metered.feature.key, metered.count]));
 
-  // Live per-org usage for the subscription's non-metered dimensions, keyed by feature key. Only the
-  // feature keys that have a counter and appear as a non-metered dimension are counted, once each,
-  // in parallel. A count failure is logged and dropped so the overview still renders.
+  // Live per-org usage for the subscription's non-metered dimensions, keyed by feature key. Seeded
+  // values (e.g. the shared member+identity pool, computed once for the Usage card) win, so a
+  // dimension that also has its own count elsewhere on the page reads the same number. The rest are
+  // counted once each, in parallel, via the same counters the usage meter uses. A count failure is
+  // logged and dropped so the overview still renders.
   const resolveLiveUsage = async (
     orgId: string,
-    subscription: TSubscriptionResponse | null
+    subscription: TSubscriptionResponse | null,
+    seed: Map<string, number>
   ): Promise<Map<string, number>> => {
-    const usage = new Map<string, number>();
+    const usage = new Map<string, number>(seed);
     if (!subscription) {
       return usage;
     }
@@ -358,7 +361,12 @@ export const licenseV2ServiceFactory = ({
     const featureKeys = new Set<string>();
     subscription.items.forEach((item) => {
       item.dimensions.forEach((dimension) => {
-        if (!dimension.metered && dimension.featureKey && counterByFeatureKey.has(dimension.featureKey)) {
+        if (
+          !dimension.metered &&
+          dimension.featureKey &&
+          !usage.has(dimension.featureKey) &&
+          counterByFeatureKey.has(dimension.featureKey)
+        ) {
           featureKeys.add(dimension.featureKey);
         }
       });
@@ -383,7 +391,11 @@ export const licenseV2ServiceFactory = ({
 
   // Fold the subscription items and the entitlement features sourced from a product into a single
   // per-product entitlement map, keyed by the server's product ids.
-  const buildEntitlements = async (org: TEntitlementOrg, subscription: TSubscriptionResponse | null) => {
+  const buildEntitlements = async (
+    org: TEntitlementOrg,
+    subscription: TSubscriptionResponse | null,
+    liveUsageSeed: Map<string, number>
+  ) => {
     const entitlements: Record<string, BillingV2Entitlement> = {};
 
     const labelByDimension = new Map<string, string>();
@@ -408,10 +420,9 @@ export const licenseV2ServiceFactory = ({
     }
 
     // The license server only tracks usage for metered dimensions, so per-unit ones come back with
-    // used=0. Overlay live counts from the same feature-keyed counters the usage meter uses, matched
-    // on the stable feature key (dimension keys drift). Metered dimensions keep the server's period
-    // peak, which is the billed figure. Counts are fetched once per distinct feature key.
-    const liveUsageByFeatureKey = await resolveLiveUsage(org.id, subscription);
+    // used=0. Overlay live counts, matched on the stable feature key (dimension keys drift). Metered
+    // dimensions keep the server's period peak, which is the billed figure.
+    const liveUsageByFeatureKey = await resolveLiveUsage(org.id, subscription, liveUsageSeed);
 
     if (subscription) {
       subscription.items.forEach((item) => {
@@ -631,9 +642,12 @@ export const licenseV2ServiceFactory = ({
       logger.error(error, `billing-v2: failed to read billing profile [orgId=${orgId}]`);
     }
 
+    // The identity dimension caps against the same shared member+identity pool the Usage card shows,
+    // so seed its usage from that one figure instead of a separate count that could diverge from it.
     const entitlements = await buildEntitlements(
       { id: orgId, name: organization.name, slug: organization.slug },
-      subscription
+      subscription,
+      new Map([[IDENTITY_LIMIT_FEATURE_KEY, members + identities]])
     );
     // Org-wide projected metered usage (dollars): the summary adds this to recurringAmount for the
     // next-month total, so every product's estimate is summed once here.

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -367,7 +367,7 @@ export const licenseV2ServiceFactory = ({
     await Promise.all(
       [...featureKeys].map(async (featureKey) => {
         const count = counterByFeatureKey.get(featureKey);
-        if (!count) {
+        if (count === undefined) {
           return;
         }
         try {

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -829,7 +829,8 @@ export const registerRoutes = async (
     orgDAL,
     identityOrgMembershipDAL,
     permissionService,
-    licenseClient
+    licenseClient,
+    meteredFeatures
   });
 
   // Project events SSE service (for clients to subscribe to secret mutation events)

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -91,6 +91,9 @@ export const catalogResponseSchema = z
 const subscriptionItemDimensionSchema = z
   .object({
     key: z.string(),
+    // Stable feature key the dimension caps against; used to overlay live per-org usage. Dimension
+    // keys drift (e.g. a display rename), so usage is matched on this, not on key.
+    featureKey: z.string().nullish(),
     unit: z.string().optional(),
     metered: z.boolean().default(false),
     aggregation: z.string().optional(),


### PR DESCRIPTION
## Context

The billing overview's per-product usage meters always read empty (`used: 0`) for per-unit (non-metered) product dimensions (identities, certs, internal CAs, PAM resources). The License Server only tracks usage for *metered* dimensions, so those per-unit counts never reached the client, even though this backend already owns them.

`buildEntitlements` now overlays live per-org counts onto non-metered dimensions, reusing the same feature-keyed counters the usage meter uses (`buildMeteredFeatures`: `max_identities`, `max_active_certs`, `max_internal_cas`, `max_resources`), matched on the dimension's stable `featureKey`. Metered dimensions keep the server's period-peak `used` (the billed figure), and the metered usage estimate (`estimatedUsageAmount`) is untouched. Counts are fetched once per distinct feature key, in parallel; a count failure is logged and dropped so the overview still renders.

Depends on the License Server sending dimension `featureKey`: Infisical/license-server-go#52. Degrades gracefully (no overlay, i.e. today's behavior) until that ships, so no deploy ordering is required.

Note: the identity dimension resolves via `countOrgUsersAndIdentities` (members + identities, the count the `max_identities` cap is actually enforced against), which can differ from the separately-computed seat-pool tile in edge cases (sub-orgs, pending members).

## Screenshots

Pending live verification against a running cloud stack.

## Steps to verify the change

- Open Billing for a cloud org on a per-unit plan (e.g. SM Pro).
- The per-product usage meters now show real utilization (e.g. Identities 3 / 50) instead of 0 / 50.

Verified so far: type-check + eslint clean, adversarial review (no correctness bugs). Live billing-page run pending.

## Type

- [x] Fix

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
