### PR TITLE
feat: support JSON and plain text variables in CF workers sync

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -3071,6 +3071,10 @@ export const SecretSyncs = {
     AZURE_KEY_VAULT: {
       disableCertificateImport:
         "Whether Infisical should skip importing certificate objects from Azure Key Vault when syncing secrets."
+    },
+    CLOUDFLARE_WORKERS: {
+      syncNonSecretBindings:
+        "Whether Infisical should also sync plaintext and JSON variable bindings in addition to secret bindings."
     }
   },
   DESTINATION_CONFIG: {

--- a/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
+++ b/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
@@ -68,8 +68,10 @@ const getSecretKeys = async (secretSync: TCloudflareWorkersSyncWithCredentials):
 
   const secrets = secretsResponse.data.result.map((s) => ({ key: s.name, type: s.type }));
 
+  const SYNCABLE_BINDING_TYPES = new Set(["plain_text", "json"]);
+
   const nonSecretBindings = (settingsResponse.data.result.bindings || [])
-    .filter((b) => b.type !== "secret_text")
+    .filter((b) => SYNCABLE_BINDING_TYPES.has(b.type))
     .map((b) => ({ key: b.name, type: b.type }));
 
   const secretKeySet = new Set(secrets.map((s) => s.key));

--- a/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
+++ b/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
@@ -60,9 +60,14 @@ const throwOnUndeployedVersionError = (err: unknown) => {
   throw err;
 };
 
-const getSecretKeys = async (
+type TCloudflareBindings = {
+  secrets: TCloudflareSecretMetadata[];
+  nonSecretBindings: TCloudflareSecretMetadata[];
+};
+
+const getCloudflareBindings = async (
   secretSync: TCloudflareWorkersSyncWithCredentials
-): Promise<TCloudflareSecretMetadata[]> => {
+): Promise<TCloudflareBindings> => {
   const {
     destinationConfig,
     connection: {
@@ -94,14 +99,14 @@ const getSecretKeys = async (
 
   const SYNCABLE_BINDING_TYPES = new Set(["plain_text", "json"]);
 
+  const secretKeySet = new Set(secrets.map((s) => s.key));
   const nonSecretBindings = (settingsResponse.data.result.bindings || [])
-    .filter((b) => SYNCABLE_BINDING_TYPES.has(b.type))
+    .filter((b) => SYNCABLE_BINDING_TYPES.has(b.type) && !secretKeySet.has(b.name))
     .map((b) => ({ key: b.name, type: b.type }));
 
-  const secretKeySet = new Set(secrets.map((s) => s.key));
-  const uniqueNonSecretBindings = nonSecretBindings.filter((v) => !secretKeySet.has(v.key));
-
-  return [...secrets, ...uniqueNonSecretBindings];
+  // We need to know both types because cloudflare prevents secrets and variables (plaintext or JSON)
+  // to have the same name.
+  return { secrets, nonSecretBindings };
 };
 
 export const CloudflareWorkersSyncFns = {
@@ -113,16 +118,31 @@ export const CloudflareWorkersSyncFns = {
       destinationConfig: { scriptId }
     } = secretSync;
 
-    const existingSecrets = await getSecretKeys(secretSync);
+    const shouldSyncNonSecretBindings = Boolean(secretSync.syncOptions.syncNonSecretBindings);
+    const { secrets: existingSecretBindings, nonSecretBindings } = await getCloudflareBindings(secretSync);
+
+    const existingSecrets = shouldSyncNonSecretBindings
+      ? [...existingSecretBindings, ...nonSecretBindings]
+      : existingSecretBindings;
+
+    const nonSecretBindingKeys = new Set(nonSecretBindings.map((b) => b.key));
     const existingSecretsMap = Object.fromEntries(existingSecrets.map(({ key, type }) => [key, type]));
     const secretMapKeys = new Set(Object.keys(secretMap));
+
+    // We cannot sync secrets that have the same name as a non-secret
+    // if shouldSyncNonSecretBindings = false. This happens because
+    // Cloudflare will reject the request due to name conflicts. A secret
+    // cannot have the same name as a non-secret variable.
+    const syncableEntries = Object.entries(secretMap).filter(
+      ([key]) => shouldSyncNonSecretBindings || !nonSecretBindingKeys.has(key)
+    );
 
     const bindingEntries: Array<[string, { value: string }]> = [];
     const secretEntries: Array<[string, { value: string }]> = [];
 
-    for (const [key, val] of Object.entries(secretMap)) {
+    for (const [key, val] of syncableEntries) {
       const existingType = existingSecretsMap[key];
-      if (existingType && existingType !==  CLOUDFLARE_SECRET_TYPE) {
+      if (existingType && existingType !== CLOUDFLARE_SECRET_TYPE) {
         bindingEntries.push([key, val]);
       } else {
         secretEntries.push([key, val]);
@@ -148,7 +168,7 @@ export const CloudflareWorkersSyncFns = {
         $validateJsonBindings(settingsData.result.bindings, updatedBindingMap);
 
         const updatedBindings = settingsData.result.bindings.map((binding) => {
-          if (binding.type !==  CLOUDFLARE_SECRET_TYPE && updatedBindingMap[binding.name] !== undefined) {
+          if (binding.type !== CLOUDFLARE_SECRET_TYPE && updatedBindingMap[binding.name] !== undefined) {
             const newValue = updatedBindingMap[binding.name].value;
             if (binding.type === "json") {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -181,7 +201,7 @@ export const CloudflareWorkersSyncFns = {
         await delayMs(Math.max(0, applyJitter(100, 200)));
         await request.put(
           `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets`,
-          { name: key, text: val.value, type:  CLOUDFLARE_SECRET_TYPE },
+          { name: key, text: val.value, type: CLOUDFLARE_SECRET_TYPE },
           {
             headers: {
               Authorization: `Bearer ${apiToken}`,
@@ -206,8 +226,8 @@ export const CloudflareWorkersSyncFns = {
         return !isInNewSecretMap && isManagedBySchema;
       });
 
-      const secretTypeToDelete = secretsToDelete.filter((s) => s.type ===  CLOUDFLARE_SECRET_TYPE);
-      const bindingTypeToDelete = secretsToDelete.filter((s) => s.type !==  CLOUDFLARE_SECRET_TYPE);
+      const secretTypeToDelete = secretsToDelete.filter((s) => s.type === CLOUDFLARE_SECRET_TYPE);
+      const bindingTypeToDelete = secretsToDelete.filter((s) => s.type !== CLOUDFLARE_SECRET_TYPE);
 
       try {
         /* eslint-disable no-await-in-loop */
@@ -277,7 +297,13 @@ export const CloudflareWorkersSyncFns = {
       destinationConfig: { scriptId }
     } = secretSync;
 
-    const existingSecretNames = await getSecretKeys(secretSync);
+    const shouldSyncNonSecretBindings = Boolean(secretSync.syncOptions.syncNonSecretBindings);
+    const { secrets: existingSecretBindings, nonSecretBindings } = await getCloudflareBindings(secretSync);
+
+    const existingSecretNames = shouldSyncNonSecretBindings
+      ? [...existingSecretBindings, ...nonSecretBindings]
+      : existingSecretBindings;
+
     const secretMapToRemoveKeys = new Set(Object.keys(secretMap));
 
     const secretsToRemove = existingSecretNames.filter((existingSecret) => {
@@ -289,8 +315,8 @@ export const CloudflareWorkersSyncFns = {
       return secretMapToRemoveKeys.has(existingSecret.key) && isManagedBySchema;
     });
 
-    const secretTypeToRemove = secretsToRemove.filter((s) => s.type ===  CLOUDFLARE_SECRET_TYPE);
-    const bindingTypeToRemove = secretsToRemove.filter((s) => s.type !==  CLOUDFLARE_SECRET_TYPE);
+    const secretTypeToRemove = secretsToRemove.filter((s) => s.type === CLOUDFLARE_SECRET_TYPE);
+    const bindingTypeToRemove = secretsToRemove.filter((s) => s.type !== CLOUDFLARE_SECRET_TYPE);
 
     try {
       /* eslint-disable no-await-in-loop */

--- a/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
+++ b/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
@@ -12,6 +12,7 @@ import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
 import { TCloudflareWorkersSyncWithCredentials } from "./cloudflare-workers-types";
 
 const CLOUDFLARE_UNDEPLOYED_VERSION_ERROR_CODE = 10215;
+const CLOUDFLARE_SECRET_TYPE = "secret_text";
 
 type TCloudflareErrorResponse = {
   errors?: Array<{ code: number; message: string }>;
@@ -20,6 +21,27 @@ type TCloudflareErrorResponse = {
 type TCloudflareSecretMetadata = {
   key: string;
   type: string;
+};
+
+const $validateJsonBindings = (
+  bindings: Array<{ type: string; name: string }>,
+  updatedBindingMap: Record<string, { value: string }>
+) => {
+  const invalidJsonBindings: string[] = [];
+  for (const binding of bindings) {
+    if (binding.type === "json" && updatedBindingMap[binding.name] !== undefined) {
+      try {
+        JSON.parse(updatedBindingMap[binding.name].value);
+      } catch {
+        invalidJsonBindings.push(binding.name);
+      }
+    }
+  }
+  if (invalidJsonBindings.length > 0) {
+    throw new BadRequestError({
+      message: `The following bindings already exist in Cloudflare as JSON variables but the values provided are not valid JSON: ${invalidJsonBindings.join(", ")}`
+    });
+  }
 };
 
 const throwOnUndeployedVersionError = (err: unknown) => {
@@ -100,7 +122,7 @@ export const CloudflareWorkersSyncFns = {
 
     for (const [key, val] of Object.entries(secretMap)) {
       const existingType = existingSecretsMap[key];
-      if (existingType && existingType !== "secret_text") {
+      if (existingType && existingType !==  CLOUDFLARE_SECRET_TYPE) {
         bindingEntries.push([key, val]);
       } else {
         secretEntries.push([key, val]);
@@ -108,22 +130,6 @@ export const CloudflareWorkersSyncFns = {
     }
 
     try {
-      /* eslint-disable no-await-in-loop */
-      for (const [key, val] of secretEntries) {
-        await delayMs(Math.max(0, applyJitter(100, 200)));
-        await request.put(
-          `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets`,
-          { name: key, text: val.value, type: "secret_text" },
-          {
-            headers: {
-              Authorization: `Bearer ${apiToken}`,
-              "Content-Type": "application/json"
-            }
-          }
-        );
-      }
-      /* eslint-enable no-await-in-loop */
-
       if (bindingEntries.length > 0) {
         const { data: settingsData } = await request.get<{
           result: { bindings: Array<{ type: string; name: string; text?: string; json?: string }> };
@@ -138,18 +144,15 @@ export const CloudflareWorkersSyncFns = {
         );
 
         const updatedBindingMap = Object.fromEntries(bindingEntries);
+
+        $validateJsonBindings(settingsData.result.bindings, updatedBindingMap);
+
         const updatedBindings = settingsData.result.bindings.map((binding) => {
-          if (binding.type !== "secret_text" && updatedBindingMap[binding.name] !== undefined) {
+          if (binding.type !==  CLOUDFLARE_SECRET_TYPE && updatedBindingMap[binding.name] !== undefined) {
             const newValue = updatedBindingMap[binding.name].value;
             if (binding.type === "json") {
-              try {
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-                return { ...binding, json: JSON.parse(newValue) };
-              } catch {
-                throw new BadRequestError({
-                  message: `"${binding.name}" already exists in cloudflare as a JSON variable: the value you provided is not valid JSON`
-                });
-              }
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+              return { ...binding, json: JSON.parse(newValue) };
             }
             return { ...binding, text: newValue };
           }
@@ -172,6 +175,22 @@ export const CloudflareWorkersSyncFns = {
           }
         );
       }
+
+      /* eslint-disable no-await-in-loop */
+      for (const [key, val] of secretEntries) {
+        await delayMs(Math.max(0, applyJitter(100, 200)));
+        await request.put(
+          `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets`,
+          { name: key, text: val.value, type:  CLOUDFLARE_SECRET_TYPE },
+          {
+            headers: {
+              Authorization: `Bearer ${apiToken}`,
+              "Content-Type": "application/json"
+            }
+          }
+        );
+      }
+      /* eslint-enable no-await-in-loop */
     } catch (err) {
       throwOnUndeployedVersionError(err);
     }
@@ -187,8 +206,8 @@ export const CloudflareWorkersSyncFns = {
         return !isInNewSecretMap && isManagedBySchema;
       });
 
-      const secretTypeToDelete = secretsToDelete.filter((s) => s.type === "secret_text");
-      const bindingTypeToDelete = secretsToDelete.filter((s) => s.type !== "secret_text");
+      const secretTypeToDelete = secretsToDelete.filter((s) => s.type ===  CLOUDFLARE_SECRET_TYPE);
+      const bindingTypeToDelete = secretsToDelete.filter((s) => s.type !==  CLOUDFLARE_SECRET_TYPE);
 
       try {
         /* eslint-disable no-await-in-loop */
@@ -270,8 +289,8 @@ export const CloudflareWorkersSyncFns = {
       return secretMapToRemoveKeys.has(existingSecret.key) && isManagedBySchema;
     });
 
-    const secretTypeToRemove = secretsToRemove.filter((s) => s.type === "secret_text");
-    const bindingTypeToRemove = secretsToRemove.filter((s) => s.type !== "secret_text");
+    const secretTypeToRemove = secretsToRemove.filter((s) => s.type ===  CLOUDFLARE_SECRET_TYPE);
+    const bindingTypeToRemove = secretsToRemove.filter((s) => s.type !==  CLOUDFLARE_SECRET_TYPE);
 
     try {
       /* eslint-disable no-await-in-loop */

--- a/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
+++ b/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
@@ -17,6 +17,11 @@ type TCloudflareErrorResponse = {
   errors?: Array<{ code: number; message: string }>;
 };
 
+type TCloudflareSecretMetadata = {
+  key: string;
+  type: string;
+};
+
 const throwOnUndeployedVersionError = (err: unknown) => {
   if (
     err instanceof AxiosError &&
@@ -33,7 +38,7 @@ const throwOnUndeployedVersionError = (err: unknown) => {
   throw err;
 };
 
-const getSecretKeys = async (secretSync: TCloudflareWorkersSyncWithCredentials): Promise<string[]> => {
+const getSecretKeys = async (secretSync: TCloudflareWorkersSyncWithCredentials): Promise<TCloudflareSecretMetadata[]> => {
   const {
     destinationConfig,
     connection: {
@@ -41,19 +46,36 @@ const getSecretKeys = async (secretSync: TCloudflareWorkersSyncWithCredentials):
     }
   } = secretSync;
 
-  const { data } = await request.get<{
-    result: Array<{ name: string }>;
-  }>(
-    `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${destinationConfig.scriptId}/secrets`,
-    {
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-        Accept: "application/json"
-      }
-    }
-  );
+  const headers = {
+    Authorization: `Bearer ${apiToken}`,
+    Accept: "application/json"
+  };
 
-  return data.result.map((s) => s.name);
+  const [secretsResponse, settingsResponse] = await Promise.all([
+    request.get<{
+      result: Array<{ name: string; type: string }>;
+    }>(
+      `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${destinationConfig.scriptId}/secrets`,
+      { headers }
+    ),
+    request.get<{
+      result: { bindings: Array<{ type: string; name: string; text?: string }> };
+    }>(
+      `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${destinationConfig.scriptId}/settings`,
+      { headers }
+    )
+  ]);
+
+  const secrets = secretsResponse.data.result.map((s) => ({ key: s.name, type: s.type }));
+
+  const nonSecretBindings = (settingsResponse.data.result.bindings || [])
+    .filter((b) => b.type !== "secret_text")
+    .map((b) => ({ key: b.name, type: b.type }));
+
+  const secretKeySet = new Set(secrets.map((s) => s.key));
+  const uniqueNonSecretBindings = nonSecretBindings.filter((v) => !secretKeySet.has(v.key));
+
+  return [...secrets, ...uniqueNonSecretBindings];
 };
 
 export const CloudflareWorkersSyncFns = {
@@ -65,11 +87,24 @@ export const CloudflareWorkersSyncFns = {
       destinationConfig: { scriptId }
     } = secretSync;
 
-    const existingSecretNames = await getSecretKeys(secretSync);
+    const existingSecrets = await getSecretKeys(secretSync);
+    const existingSecretsMap = Object.fromEntries(existingSecrets.map(({key, type}) => ([key, type])));
     const secretMapKeys = new Set(Object.keys(secretMap));
 
+    const bindingEntries: Array<[string, { value: string }]> = [];
+    const secretEntries: Array<[string, { value: string }]> = [];
+
+    for (const [key, val] of Object.entries(secretMap)) {
+      const existingType = existingSecretsMap[key];
+      if (existingType && existingType !== "secret_text") {
+        bindingEntries.push([key, val]);
+      } else {
+        secretEntries.push([key, val]);
+      }
+    }
+
     try {
-      for await (const [key, val] of Object.entries(secretMap)) {
+      for (const [key, val] of secretEntries) {
         await delayMs(Math.max(0, applyJitter(100, 200)));
         await request.put(
           `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets`,
@@ -82,18 +117,57 @@ export const CloudflareWorkersSyncFns = {
           }
         );
       }
+
+      if (bindingEntries.length > 0) {
+        const { data: settingsData } = await request.get<{
+          result: { bindings: Array<{ type: string; name: string; text?: string; json?: string }> };
+        }>(
+          `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/settings`,
+          {
+            headers: {
+              Authorization: `Bearer ${apiToken}`,
+              Accept: "application/json"
+            }
+          }
+        );
+
+        const updatedBindingMap = Object.fromEntries(bindingEntries);
+        const updatedBindings = settingsData.result.bindings.map((binding) => {
+          if (binding.type !== "secret_text" && updatedBindingMap[binding.name] !== undefined) {
+            const newValue = updatedBindingMap[binding.name].value;
+            if (binding.type === "json") {
+              return { ...binding, json: JSON.parse(newValue) };
+            }
+            return { ...binding, text: newValue };
+          }
+          return binding;
+        });
+
+        const formData = new FormData();
+        formData.append("settings", new Blob([JSON.stringify({ bindings: updatedBindings })], { type: "application/json" }));
+
+        await request.patch(
+          `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/settings`,
+          formData,
+          {
+            headers: {
+              Authorization: `Bearer ${apiToken}`
+            }
+          }
+        );
+      }
     } catch (err) {
       throwOnUndeployedVersionError(err);
     }
 
     if (!secretSync.syncOptions.disableSecretDeletion) {
-      const secretsToDelete = existingSecretNames.filter((existingKey) => {
+      const secretsToDelete = existingSecrets.filter((existingSecret) => {
         const isManagedBySchema = matchesSchema(
-          existingKey,
+          existingSecret.key,
           secretSync.environment?.slug || "",
           secretSync.syncOptions.keySchema
         );
-        const isInNewSecretMap = secretMapKeys.has(existingKey);
+        const isInNewSecretMap = secretMapKeys.has(existingSecret.key);
         return !isInNewSecretMap && isManagedBySchema;
       });
 
@@ -131,18 +205,18 @@ export const CloudflareWorkersSyncFns = {
     const secretMapToRemoveKeys = new Set(Object.keys(secretMap));
 
     try {
-      for await (const existingKey of existingSecretNames) {
+      for await (const existingSecret of existingSecretNames) {
         const isManagedBySchema = matchesSchema(
-          existingKey,
+          existingSecret.key,
           secretSync.environment?.slug || "",
           secretSync.syncOptions.keySchema
         );
-        const isInSecretMapToRemove = secretMapToRemoveKeys.has(existingKey);
+        const isInSecretMapToRemove = secretMapToRemoveKeys.has(existingSecret.key);
 
         if (isInSecretMapToRemove && isManagedBySchema) {
           await delayMs(Math.max(0, applyJitter(100, 200)));
           await request.delete(
-            `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets/${existingKey}`,
+            `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets/${existingSecret}`,
             {
               headers: {
                 Authorization: `Bearer ${apiToken}`

--- a/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
+++ b/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
@@ -136,7 +136,13 @@ export const CloudflareWorkersSyncFns = {
           if (binding.type !== "secret_text" && updatedBindingMap[binding.name] !== undefined) {
             const newValue = updatedBindingMap[binding.name].value;
             if (binding.type === "json") {
-              return { ...binding, json: JSON.parse(newValue) };
+              try {
+                return { ...binding, json: JSON.parse(newValue) };
+              } catch {
+                throw new BadRequestError({
+                  message: `"${binding.name}" already existgs in cloudflare as a JSON variable: the value you provided is not valid JSON`
+                });
+              }
             }
             return { ...binding, text: newValue };
           }
@@ -171,11 +177,50 @@ export const CloudflareWorkersSyncFns = {
         return !isInNewSecretMap && isManagedBySchema;
       });
 
+      const secretTypeToDelete = secretsToDelete.filter((s) => s.type === "secret_text");
+      const bindingTypeToDelete = secretsToDelete.filter((s) => s.type !== "secret_text");
+
       try {
-        for await (const key of secretsToDelete) {
+        for (const secret of secretTypeToDelete) {
           await delayMs(Math.max(0, applyJitter(100, 200)));
           await request.delete(
-            `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets/${key}`,
+            `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets/${secret.key}`,
+            {
+              headers: {
+                Authorization: `Bearer ${apiToken}`
+              }
+            }
+          );
+        }
+
+        if (bindingTypeToDelete.length > 0) {
+          const bindingKeysToDelete = new Set(bindingTypeToDelete.map((b) => b.key));
+
+          const { data: settingsData } = await request.get<{
+            result: { bindings: Array<{ type: string; name: string; text?: string; json?: string }> };
+          }>(
+            `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/settings`,
+            {
+              headers: {
+                Authorization: `Bearer ${apiToken}`,
+                Accept: "application/json"
+              }
+            }
+          );
+
+          const filteredBindings = settingsData.result.bindings.filter(
+            (binding) => !bindingKeysToDelete.has(binding.name)
+          );
+
+          const formData = new FormData();
+          formData.append(
+            "settings",
+            new Blob([JSON.stringify({ bindings: filteredBindings })], { type: "application/json" })
+          );
+
+          await request.patch(
+            `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/settings`,
+            formData,
             {
               headers: {
                 Authorization: `Bearer ${apiToken}`
@@ -204,26 +249,65 @@ export const CloudflareWorkersSyncFns = {
     const existingSecretNames = await getSecretKeys(secretSync);
     const secretMapToRemoveKeys = new Set(Object.keys(secretMap));
 
-    try {
-      for await (const existingSecret of existingSecretNames) {
-        const isManagedBySchema = matchesSchema(
-          existingSecret.key,
-          secretSync.environment?.slug || "",
-          secretSync.syncOptions.keySchema
-        );
-        const isInSecretMapToRemove = secretMapToRemoveKeys.has(existingSecret.key);
+    const secretsToRemove = existingSecretNames.filter((existingSecret) => {
+      const isManagedBySchema = matchesSchema(
+        existingSecret.key,
+        secretSync.environment?.slug || "",
+        secretSync.syncOptions.keySchema
+      );
+      return secretMapToRemoveKeys.has(existingSecret.key) && isManagedBySchema;
+    });
 
-        if (isInSecretMapToRemove && isManagedBySchema) {
-          await delayMs(Math.max(0, applyJitter(100, 200)));
-          await request.delete(
-            `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets/${existingSecret}`,
-            {
-              headers: {
-                Authorization: `Bearer ${apiToken}`
-              }
+    const secretTypeToRemove = secretsToRemove.filter((s) => s.type === "secret_text");
+    const bindingTypeToRemove = secretsToRemove.filter((s) => s.type !== "secret_text");
+
+    try {
+      for (const secret of secretTypeToRemove) {
+        await delayMs(Math.max(0, applyJitter(100, 200)));
+        await request.delete(
+          `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/secrets/${secret.key}`,
+          {
+            headers: {
+              Authorization: `Bearer ${apiToken}`
             }
-          );
-        }
+          }
+        );
+      }
+
+      if (bindingTypeToRemove.length > 0) {
+        const bindingKeysToRemove = new Set(bindingTypeToRemove.map((b) => b.key));
+
+        const { data: settingsData } = await request.get<{
+          result: { bindings: Array<{ type: string; name: string; text?: string; json?: string }> };
+        }>(
+          `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/settings`,
+          {
+            headers: {
+              Authorization: `Bearer ${apiToken}`,
+              Accept: "application/json"
+            }
+          }
+        );
+
+        const filteredBindings = settingsData.result.bindings.filter(
+          (binding) => !bindingKeysToRemove.has(binding.name)
+        );
+
+        const formData = new FormData();
+        formData.append(
+          "settings",
+          new Blob([JSON.stringify({ bindings: filteredBindings })], { type: "application/json" })
+        );
+
+        await request.patch(
+          `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/settings`,
+          formData,
+          {
+            headers: {
+              Authorization: `Bearer ${apiToken}`
+            }
+          }
+        );
       }
     } catch (err) {
       throwOnUndeployedVersionError(err);

--- a/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
+++ b/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
@@ -38,7 +38,9 @@ const throwOnUndeployedVersionError = (err: unknown) => {
   throw err;
 };
 
-const getSecretKeys = async (secretSync: TCloudflareWorkersSyncWithCredentials): Promise<TCloudflareSecretMetadata[]> => {
+const getSecretKeys = async (
+  secretSync: TCloudflareWorkersSyncWithCredentials
+): Promise<TCloudflareSecretMetadata[]> => {
   const {
     destinationConfig,
     connection: {
@@ -90,7 +92,7 @@ export const CloudflareWorkersSyncFns = {
     } = secretSync;
 
     const existingSecrets = await getSecretKeys(secretSync);
-    const existingSecretsMap = Object.fromEntries(existingSecrets.map(({key, type}) => ([key, type])));
+    const existingSecretsMap = Object.fromEntries(existingSecrets.map(({ key, type }) => [key, type]));
     const secretMapKeys = new Set(Object.keys(secretMap));
 
     const bindingEntries: Array<[string, { value: string }]> = [];
@@ -106,6 +108,7 @@ export const CloudflareWorkersSyncFns = {
     }
 
     try {
+      /* eslint-disable no-await-in-loop */
       for (const [key, val] of secretEntries) {
         await delayMs(Math.max(0, applyJitter(100, 200)));
         await request.put(
@@ -119,6 +122,7 @@ export const CloudflareWorkersSyncFns = {
           }
         );
       }
+      /* eslint-enable no-await-in-loop */
 
       if (bindingEntries.length > 0) {
         const { data: settingsData } = await request.get<{
@@ -139,10 +143,11 @@ export const CloudflareWorkersSyncFns = {
             const newValue = updatedBindingMap[binding.name].value;
             if (binding.type === "json") {
               try {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
                 return { ...binding, json: JSON.parse(newValue) };
               } catch {
                 throw new BadRequestError({
-                  message: `"${binding.name}" already existgs in cloudflare as a JSON variable: the value you provided is not valid JSON`
+                  message: `"${binding.name}" already exists in cloudflare as a JSON variable: the value you provided is not valid JSON`
                 });
               }
             }
@@ -152,7 +157,10 @@ export const CloudflareWorkersSyncFns = {
         });
 
         const formData = new FormData();
-        formData.append("settings", new Blob([JSON.stringify({ bindings: updatedBindings })], { type: "application/json" }));
+        formData.append(
+          "settings",
+          new Blob([JSON.stringify({ bindings: updatedBindings })], { type: "application/json" })
+        );
 
         await request.patch(
           `${IntegrationUrls.CLOUDFLARE_WORKERS_API_URL}/client/v4/accounts/${accountId}/workers/scripts/${scriptId}/settings`,
@@ -183,6 +191,7 @@ export const CloudflareWorkersSyncFns = {
       const bindingTypeToDelete = secretsToDelete.filter((s) => s.type !== "secret_text");
 
       try {
+        /* eslint-disable no-await-in-loop */
         for (const secret of secretTypeToDelete) {
           await delayMs(Math.max(0, applyJitter(100, 200)));
           await request.delete(
@@ -194,6 +203,7 @@ export const CloudflareWorkersSyncFns = {
             }
           );
         }
+        /* eslint-enable no-await-in-loop */
 
         if (bindingTypeToDelete.length > 0) {
           const bindingKeysToDelete = new Set(bindingTypeToDelete.map((b) => b.key));
@@ -264,6 +274,7 @@ export const CloudflareWorkersSyncFns = {
     const bindingTypeToRemove = secretsToRemove.filter((s) => s.type !== "secret_text");
 
     try {
+      /* eslint-disable no-await-in-loop */
       for (const secret of secretTypeToRemove) {
         await delayMs(Math.max(0, applyJitter(100, 200)));
         await request.delete(
@@ -275,6 +286,7 @@ export const CloudflareWorkersSyncFns = {
           }
         );
       }
+      /* eslint-enable no-await-in-loop */
 
       if (bindingTypeToRemove.length > 0) {
         const bindingKeysToRemove = new Set(bindingTypeToRemove.map((b) => b.key));

--- a/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-schemas.ts
+++ b/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-schemas.ts
@@ -25,11 +25,19 @@ const CloudflareWorkersSyncDestinationConfigSchema = z.object({
     .describe(SecretSyncs.DESTINATION_CONFIG.CLOUDFLARE_WORKERS.scriptId)
 });
 
+const CloudflareWorkersSyncAdditionalOptionsSchema = z.object({
+  syncNonSecretBindings: z
+    .boolean()
+    .optional()
+    .describe(SecretSyncs.ADDITIONAL_SYNC_OPTIONS.CLOUDFLARE_WORKERS.syncNonSecretBindings)
+});
+
 const CloudflareWorkersSyncOptionsConfig: TSyncOptionsConfig = { canImportSecrets: false };
 
 export const CloudflareWorkersSyncSchema = BaseSecretSyncSchema(
   SecretSync.CloudflareWorkers,
-  CloudflareWorkersSyncOptionsConfig
+  CloudflareWorkersSyncOptionsConfig,
+  CloudflareWorkersSyncAdditionalOptionsSchema
 )
   .extend({
     destination: z.literal(SecretSync.CloudflareWorkers),
@@ -39,14 +47,16 @@ export const CloudflareWorkersSyncSchema = BaseSecretSyncSchema(
 
 export const CreateCloudflareWorkersSyncSchema = GenericCreateSecretSyncFieldsSchema(
   SecretSync.CloudflareWorkers,
-  CloudflareWorkersSyncOptionsConfig
+  CloudflareWorkersSyncOptionsConfig,
+  CloudflareWorkersSyncAdditionalOptionsSchema
 ).extend({
   destinationConfig: CloudflareWorkersSyncDestinationConfigSchema
 });
 
 export const UpdateCloudflareWorkersSyncSchema = GenericUpdateSecretSyncFieldsSchema(
   SecretSync.CloudflareWorkers,
-  CloudflareWorkersSyncOptionsConfig
+  CloudflareWorkersSyncOptionsConfig,
+  CloudflareWorkersSyncAdditionalOptionsSchema
 ).extend({
   destinationConfig: CloudflareWorkersSyncDestinationConfigSchema.optional()
 });

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/CloudflareWorkersSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/CloudflareWorkersSyncFields.tsx
@@ -1,8 +1,12 @@
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { SingleValue } from "react-select";
+import { Info } from "lucide-react";
 
 import { SecretSyncConnectionField } from "@app/components/secret-syncs/forms/SecretSyncConnectionField";
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Field,
   FieldContent,
   FieldError,
@@ -61,6 +65,15 @@ export const CloudflareWorkersSyncFields = () => {
           </Field>
         )}
       />
+      <Alert variant="info">
+        <Info />
+        <AlertTitle>Binding types are preserved</AlertTitle>
+        <AlertDescription>
+          Cloudflare Workers supports secret text, plain text, and JSON bindings. If a binding
+          already exists on the worker, its type will not be changed during sync. New bindings
+          created by Infisical will default to secret text.
+        </AlertDescription>
+      </Alert>
     </FieldGroup>
   );
 };

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/CloudflareWorkersSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/CloudflareWorkersSyncFields.tsx
@@ -1,12 +1,8 @@
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { SingleValue } from "react-select";
-import { Info } from "lucide-react";
 
 import { SecretSyncConnectionField } from "@app/components/secret-syncs/forms/SecretSyncConnectionField";
 import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
   Field,
   FieldContent,
   FieldError,
@@ -65,15 +61,6 @@ export const CloudflareWorkersSyncFields = () => {
           </Field>
         )}
       />
-      <Alert variant="info">
-        <Info />
-        <AlertTitle>Binding types are preserved</AlertTitle>
-        <AlertDescription>
-          Cloudflare Workers supports secret text, plain text, and JSON bindings. If a binding
-          already exists on the worker, its type will not be changed during sync. New bindings
-          created by Infisical will default to secret text.
-        </AlertDescription>
-      </Alert>
     </FieldGroup>
   );
 };

--- a/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/CloudflareWorkersSyncOptionsFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/CloudflareWorkersSyncOptionsFields.tsx
@@ -1,0 +1,66 @@
+import { Controller, useFormContext } from "react-hook-form";
+import { TriangleAlert } from "lucide-react";
+
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  Label,
+  Switch
+} from "@app/components/v3";
+import { SecretSync } from "@app/hooks/api/secretSyncs";
+
+import { TSecretSyncForm } from "../schemas";
+
+export const CloudflareWorkersSyncOptionsFields = () => {
+  const { control, watch } = useFormContext<
+    TSecretSyncForm & { destination: SecretSync.CloudflareWorkers }
+  >();
+
+  const disableSecretDeletion = watch("syncOptions.disableSecretDeletion");
+  const syncNonSecretBindings = watch("syncOptions.syncNonSecretBindings");
+
+  return (
+    <>
+      <Controller
+        name="syncOptions.syncNonSecretBindings"
+        control={control}
+        render={({ field: { value, onChange }, fieldState: { error } }) => (
+          <Field className="mb-4">
+            <Field orientation="horizontal">
+              <FieldContent>
+                <Label htmlFor="sync-non-secret-bindings">Sync plaintext and JSON variables</Label>
+                <FieldDescription>
+                  When enabled, Infisical will also sync plaintext and JSON variable bindings in
+                  addition to secret bindings.
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                id="sync-non-secret-bindings"
+                variant="project"
+                checked={value}
+                onCheckedChange={onChange}
+              />
+            </Field>
+            <FieldError errors={[error]} />
+          </Field>
+        )}
+      />
+      {syncNonSecretBindings && !disableSecretDeletion && (
+        <Alert variant="warning" className="mb-4">
+          <TriangleAlert />
+          <AlertTitle>Plaintext and JSON variables may be deleted</AlertTitle>
+          <AlertDescription>
+            With secret deletion enabled and non-secret binding sync turned on, any plaintext or
+            JSON variables in Cloudflare Workers that are not present in Infisical will be removed
+            during a sync. Toggle &quot;Disable secret deletion&quot; above to prevent this.
+          </AlertDescription>
+        </Alert>
+      )}
+    </>
+  );
+};

--- a/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/CloudflareWorkersSyncOptionsFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/CloudflareWorkersSyncOptionsFields.tsx
@@ -36,7 +36,8 @@ export const CloudflareWorkersSyncOptionsFields = () => {
                 <Label htmlFor="sync-non-secret-bindings">Sync plaintext and JSON variables</Label>
                 <FieldDescription>
                   When enabled, Infisical will also sync plaintext and JSON variable bindings in
-                  addition to secret bindings.
+                  addition to secret bindings. Infisical can only update existing plaintext and JSON
+                  bindings on Cloudflare Workers, not create new ones.
                 </FieldDescription>
               </FieldContent>
               <Switch

--- a/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
@@ -31,6 +31,7 @@ import { InitialSyncAlerts } from "../SecretSyncInitialSyncBehaviorFields";
 import { AwsParameterStoreSyncOptionsFields } from "./AwsParameterStoreSyncOptionsFields";
 import { AwsSecretsManagerSyncOptionsFields } from "./AwsSecretsManagerSyncOptionsFields";
 import { AzureKeyVaultSyncOptionsFields } from "./AzureKeyVaultSyncOptionsFields";
+import { CloudflareWorkersSyncOptionsFields } from "./CloudflareWorkersSyncOptionsFields";
 import { FlyioSyncOptionsFields } from "./FlyioSyncOptionsFields";
 import { QoverySyncOptionsFields } from "./QoverySyncOptionsFields";
 import { RenderSyncOptionsFields } from "./RenderSyncOptionsFields";
@@ -115,8 +116,10 @@ export const SecretSyncOptionsFields = ({ hideInitialSync, children }: Props) =>
     case SecretSync.OCIVault:
     case SecretSync.Heroku:
     case SecretSync.GitLab:
-    case SecretSync.CloudflarePages:
     case SecretSync.CloudflareWorkers:
+      AdditionalSyncOptionsFieldsComponent = <CloudflareWorkersSyncOptionsFields />;
+      break;
+    case SecretSync.CloudflarePages:
     case SecretSync.Zabbix:
     case SecretSync.Railway:
     case SecretSync.Checkly:

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/CloudflareWorkersReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/CloudflareWorkersReviewFields.tsx
@@ -1,8 +1,27 @@
 import { useFormContext } from "react-hook-form";
 
 import { TSecretSyncForm } from "@app/components/secret-syncs/forms/schemas";
-import { Detail, DetailLabel, DetailValue } from "@app/components/v3";
+import { Badge, Detail, DetailLabel, DetailValue } from "@app/components/v3";
 import { SecretSync } from "@app/hooks/api/secretSyncs";
+
+export const CloudflareWorkersSyncOptionsReviewFields = () => {
+  const { watch } = useFormContext<
+    TSecretSyncForm & { destination: SecretSync.CloudflareWorkers }
+  >();
+
+  const [{ syncNonSecretBindings }] = watch(["syncOptions"]);
+
+  return (
+    <Detail>
+      <DetailLabel>Sync Plaintext and JSON Variables</DetailLabel>
+      <DetailValue>
+        <Badge variant={syncNonSecretBindings ? "success" : "danger"}>
+          {syncNonSecretBindings ? "Enabled" : "Disabled"}
+        </Badge>
+      </DetailValue>
+    </Detail>
+  );
+};
 
 export const CloudflareWorkersSyncReviewFields = () => {
   const { watch } = useFormContext<

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
@@ -37,7 +37,10 @@ import { ChefSyncReviewFields } from "./ChefSyncReviewFields";
 import { CircleCISyncReviewFields } from "./CircleCISyncReviewFields";
 import { Cloud66SyncReviewFields } from "./Cloud66SyncReviewFields";
 import { CloudflarePagesSyncReviewFields } from "./CloudflarePagesReviewFields";
-import { CloudflareWorkersSyncReviewFields } from "./CloudflareWorkersReviewFields";
+import {
+  CloudflareWorkersSyncOptionsReviewFields,
+  CloudflareWorkersSyncReviewFields
+} from "./CloudflareWorkersReviewFields";
 import { DatabricksSyncReviewFields } from "./DatabricksSyncReviewFields";
 import { DevinSyncReviewFields } from "./DevinSyncReviewFields";
 import { DigitalOceanAppPlatformSyncReviewFields } from "./DigitalOceanAppPlatformSyncReviewFields";
@@ -176,6 +179,7 @@ export const SecretSyncReviewFields = () => {
       break;
     case SecretSync.CloudflareWorkers:
       DestinationFieldsComponent = <CloudflareWorkersSyncReviewFields />;
+      AdditionalSyncOptionsFieldsComponent = <CloudflareWorkersSyncOptionsReviewFields />;
       break;
     case SecretSync.Zabbix:
       DestinationFieldsComponent = <ZabbixSyncReviewFields />;

--- a/frontend/src/components/secret-syncs/forms/schemas/cloudflare-workers-sync-destination-schema.ts
+++ b/frontend/src/components/secret-syncs/forms/schemas/cloudflare-workers-sync-destination-schema.ts
@@ -3,7 +3,11 @@ import { z } from "zod";
 import { BaseSecretSyncSchema } from "@app/components/secret-syncs/forms/schemas/base-secret-sync-schema";
 import { SecretSync } from "@app/hooks/api/secretSyncs";
 
-export const CloudflareWorkersSyncDestinationSchema = BaseSecretSyncSchema().merge(
+export const CloudflareWorkersSyncDestinationSchema = BaseSecretSyncSchema(
+  z.object({
+    syncNonSecretBindings: z.boolean().optional().default(false)
+  })
+).merge(
   z.object({
     destination: z.literal(SecretSync.CloudflareWorkers),
     destinationConfig: z.object({

--- a/frontend/src/hooks/api/secretSyncs/types/cloudflare-workers-sync.ts
+++ b/frontend/src/hooks/api/secretSyncs/types/cloudflare-workers-sync.ts
@@ -1,6 +1,6 @@
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { SecretSync } from "@app/hooks/api/secretSyncs";
-import { TRootSecretSync } from "@app/hooks/api/secretSyncs/types/root-sync";
+import { RootSyncOptions, TRootSecretSync } from "@app/hooks/api/secretSyncs/types/root-sync";
 
 export type TCloudflareWorkersSync = TRootSecretSync & {
   destination: SecretSync.CloudflareWorkers;
@@ -11,5 +11,8 @@ export type TCloudflareWorkersSync = TRootSecretSync & {
     app: AppConnection.Cloudflare;
     name: string;
     id: string;
+  };
+  syncOptions: RootSyncOptions & {
+    syncNonSecretBindings?: boolean;
   };
 };


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Secret name conflicts with non-secret variables in Cloudflare would cause the sync to fail. Now, it saves the secret as the original type of the variable: secret, plain_text or JSON.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)