### PR TITLE
feat: add edit-auth permission to machine identity permission set

### DIFF
--- a/backend/src/db/migrations/20260707000000_identity-edit-auth-permission.ts
+++ b/backend/src/db/migrations/20260707000000_identity-edit-auth-permission.ts
@@ -5,12 +5,12 @@ import { TableName } from "../schemas";
 
 // Auth-method configuration (attach/update) used to reuse the generic identity
 // `create`/`edit` actions. It now requires the dedicated `edit-auth` action. To
-// avoid silently stripping this ability from existing custom roles on upgrade,
-// grandfather `edit-auth` onto any custom role that could already configure auth
-// methods (i.e. has an identity rule referencing `create` or `edit`), preserving
-// each source rule's conditions so identity-scoping is retained.
+// avoid silently stripping this ability on upgrade, grandfather `edit-auth` onto
+// any stored permission set that could already configure auth methods (i.e. has
+// an identity rule referencing `create` or `edit`), preserving each source
+// rule's conditions so identity-scoping is retained.
 //
-// This mirrors BOTH allow (non-inverted) and deny (inverted) source rules: a role
+// This mirrors BOTH allow (non-inverted) and deny (inverted) source rules: a set
 // that broadly allows `edit` on identities but denies it for a specific
 // `identityId` must keep that exclusion for `edit-auth`, otherwise it could
 // configure auth methods on an identity it was explicitly barred from editing.
@@ -18,10 +18,20 @@ import { TableName } from "../schemas";
 // the last matching rule as the winner, so a deny that overrode an allow before
 // continues to override it for `edit-auth`.
 //
-// Both org roles (projectId IS NULL) and project roles live in the `roles`
-// table and use the same `identity` subject + action strings, so a single pass
-// covers both. Built-in roles (admin/member/no-access) are handled in code and
-// are not stored here, so they are unaffected.
+// Stored CASL rules live in two tables, both keyed by `id` with a `permissions`
+// column in the same packed format, so a single pass over each covers them:
+//  - `roles`: both org roles (projectId IS NULL) and project custom roles.
+//  - `additional_privileges`: per-actor privilege augmentations for BOTH users
+//    (actorUserId) and machine identities (actorIdentityId). Permission
+//    resolution reads this table's `permissions` for either actor, so an
+//    additional privilege granting identity create/edit would otherwise silently
+//    lose the ability to configure other identities' auth methods.
+// Built-in roles (admin/member/no-access) are handled in code and are not stored,
+// so they are unaffected. The legacy identity_project_additional_privilege /
+// project_user_additional_privilege tables are no longer read by permission
+// resolution, so they are intentionally not touched.
+
+const PERMISSIONED_TABLES = [TableName.Role, TableName.AdditionalPrivilege] as const;
 
 const IDENTITY_SUBJECT = "identity";
 const CREATE_ACTION = "create";
@@ -46,101 +56,109 @@ const conditionSignature = (conditions: unknown) =>
 // dedup key must include the inverted flag.
 const ruleSignature = (rule: CaslRule) => `${rule.inverted ? "deny" : "allow"}:${conditionSignature(rule.conditions)}`;
 
+const unpackPermissions = (permissions: unknown) =>
+  unpackRules((permissions ?? []) as Parameters<typeof unpackRules>[0]) as CaslRule[];
+
+const packPermissions = (rules: CaslRule[]) => JSON.stringify(packRules(rules as Parameters<typeof packRules>[0]));
+
+// up(): add an `edit-auth` rule mirroring each identity create/edit rule. Returns
+// null when nothing needs to change so the caller can skip the row.
+const addEditAuth = (rules: CaslRule[]): CaslRule[] | null => {
+  // Signatures (inverted flag + conditions) for which an edit-auth rule already
+  // exists, so we don't duplicate it.
+  const existingEditAuth = new Set(
+    rules
+      .filter((rule) => includes(rule.subject, IDENTITY_SUBJECT) && includes(rule.action, EDIT_AUTH_ACTION))
+      .map(ruleSignature)
+  );
+
+  // Source rules that scoped the ability to configure auth methods, in their
+  // original relative order. Both allows (grant edit-auth) and denies (exclude
+  // edit-auth) are mirrored so identity-scoping is preserved.
+  const sourceRules = rules.filter(
+    (rule) =>
+      includes(rule.subject, IDENTITY_SUBJECT) &&
+      (includes(rule.action, CREATE_ACTION) || includes(rule.action, EDIT_ACTION))
+  );
+
+  const rulesToAdd: CaslRule[] = [];
+  const addedSignatures = new Set<string>();
+  for (const rule of sourceRules) {
+    const signature = ruleSignature(rule);
+    if (!existingEditAuth.has(signature) && !addedSignatures.has(signature)) {
+      addedSignatures.add(signature);
+      const newRule: CaslRule =
+        rule.conditions === undefined
+          ? { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT }
+          : { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT, conditions: rule.conditions };
+      if (rule.inverted) newRule.inverted = true;
+      rulesToAdd.push(newRule);
+    }
+  }
+
+  if (rulesToAdd.length === 0) return null;
+  return [...rules, ...rulesToAdd];
+};
+
+// down(): strip edit-auth from identity rules (both allows and denies), mirroring
+// up(). Returns null when nothing changed so the caller can skip the row.
+const removeEditAuth = (rules: CaslRule[]): CaslRule[] | null => {
+  let wasModified = false;
+  const filteredRules = rules.reduce<CaslRule[]>((acc, rule) => {
+    if (!includes(rule.subject, IDENTITY_SUBJECT) || !includes(rule.action, EDIT_AUTH_ACTION)) {
+      acc.push(rule);
+      return acc;
+    }
+
+    wasModified = true;
+    if (Array.isArray(rule.action)) {
+      const withoutEditAuth = rule.action.filter((a) => a !== EDIT_AUTH_ACTION);
+      // Copy into a new rule so the original (shared) rule object is left untouched.
+      if (withoutEditAuth.length > 0) acc.push({ ...rule, action: withoutEditAuth });
+      return acc;
+    }
+    // Single action that is edit-auth, drop the rule entirely.
+    return acc;
+  }, []);
+
+  if (!wasModified) return null;
+  return filteredRules;
+};
+
+const transformTable = async (
+  trx: Knex,
+  tableName: (typeof PERMISSIONED_TABLES)[number],
+  transform: (rules: CaslRule[]) => CaslRule[] | null
+) => {
+  const rows = await trx(tableName).select("*");
+
+  const toUpdate = rows
+    .map((row) => {
+      const nextRules = transform(unpackPermissions(row.permissions));
+      if (nextRules === null) return null;
+      return { ...row, permissions: packPermissions(nextRules) };
+    })
+    .filter(Boolean) as typeof rows;
+
+  if (toUpdate.length > 0) {
+    await trx(tableName).insert(toUpdate).onConflict("id").merge();
+  }
+};
+
 export async function up(knex: Knex): Promise<void> {
   await knex.transaction(async (trx) => {
-    const customRoles = await trx(TableName.Role).select("*");
-
-    const toUpdate = customRoles
-      .map((role) => {
-        const rules = unpackRules((role.permissions ?? []) as Parameters<typeof unpackRules>[0]) as CaslRule[];
-
-        // Signatures (inverted flag + conditions) for which an edit-auth rule
-        // already exists, so we don't duplicate it.
-        const existingEditAuth = new Set(
-          rules
-            .filter((rule) => includes(rule.subject, IDENTITY_SUBJECT) && includes(rule.action, EDIT_AUTH_ACTION))
-            .map(ruleSignature)
-        );
-
-        // Source rules that scoped the ability to configure auth methods, in their
-        // original relative order. Both allows (grant edit-auth) and denies
-        // (exclude edit-auth) are mirrored so identity-scoping is preserved.
-        const sourceRules = rules.filter(
-          (rule) =>
-            includes(rule.subject, IDENTITY_SUBJECT) &&
-            (includes(rule.action, CREATE_ACTION) || includes(rule.action, EDIT_ACTION))
-        );
-
-        const rulesToAdd: CaslRule[] = [];
-        const addedSignatures = new Set<string>();
-        for (const rule of sourceRules) {
-          const signature = ruleSignature(rule);
-          if (!existingEditAuth.has(signature) && !addedSignatures.has(signature)) {
-            addedSignatures.add(signature);
-            const newRule: CaslRule =
-              rule.conditions === undefined
-                ? { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT }
-                : { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT, conditions: rule.conditions };
-            if (rule.inverted) newRule.inverted = true;
-            rulesToAdd.push(newRule);
-          }
-        }
-
-        if (rulesToAdd.length === 0) return null;
-
-        return {
-          ...role,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore-error packRules type mismatch
-          permissions: JSON.stringify(packRules([...rules, ...rulesToAdd]))
-        };
-      })
-      .filter(Boolean) as typeof customRoles;
-
-    if (toUpdate.length > 0) {
-      await trx(TableName.Role).insert(toUpdate).onConflict("id").merge();
+    for (const tableName of PERMISSIONED_TABLES) {
+      // eslint-disable-next-line no-await-in-loop
+      await transformTable(trx, tableName, addEditAuth);
     }
   });
 }
 
 export async function down(knex: Knex): Promise<void> {
   await knex.transaction(async (trx) => {
-    const customRoles = await trx(TableName.Role).select("*");
-
-    const toUpdate = customRoles
-      .map((role) => {
-        const rules = unpackRules((role.permissions ?? []) as Parameters<typeof unpackRules>[0]) as CaslRule[];
-
-        let wasModified = false;
-        const filteredRules = rules.filter((rule) => {
-          // Mirrors up(): strip edit-auth from identity rules, both allows and denies.
-          if (!includes(rule.subject, IDENTITY_SUBJECT) || !includes(rule.action, EDIT_AUTH_ACTION)) return true;
-
-          wasModified = true;
-          if (Array.isArray(rule.action)) {
-            const withoutEditAuth = rule.action.filter((a) => a !== EDIT_AUTH_ACTION);
-            if (withoutEditAuth.length === 0) return false;
-            // eslint-disable-next-line no-param-reassign
-            rule.action = withoutEditAuth;
-            return true;
-          }
-          // Single action that is edit-auth, remove the rule entirely.
-          return false;
-        });
-
-        if (!wasModified) return null;
-
-        return {
-          ...role,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore-error packRules type mismatch
-          permissions: JSON.stringify(packRules(filteredRules))
-        };
-      })
-      .filter(Boolean) as typeof customRoles;
-
-    if (toUpdate.length > 0) {
-      await trx(TableName.Role).insert(toUpdate).onConflict("id").merge();
+    for (const tableName of PERMISSIONED_TABLES) {
+      // eslint-disable-next-line no-await-in-loop
+      await transformTable(trx, tableName, removeEditAuth);
     }
   });
 }

--- a/backend/src/db/migrations/20260707000000_identity-edit-auth-permission.ts
+++ b/backend/src/db/migrations/20260707000000_identity-edit-auth-permission.ts
@@ -7,8 +7,16 @@ import { TableName } from "../schemas";
 // `create`/`edit` actions. It now requires the dedicated `edit-auth` action. To
 // avoid silently stripping this ability from existing custom roles on upgrade,
 // grandfather `edit-auth` onto any custom role that could already configure auth
-// methods (i.e. has a non-inverted identity rule granting `create` or `edit`),
-// preserving that rule's conditions so identity-scoping is retained.
+// methods (i.e. has an identity rule referencing `create` or `edit`), preserving
+// each source rule's conditions so identity-scoping is retained.
+//
+// This mirrors BOTH allow (non-inverted) and deny (inverted) source rules: a role
+// that broadly allows `edit` on identities but denies it for a specific
+// `identityId` must keep that exclusion for `edit-auth`, otherwise it could
+// configure auth methods on an identity it was explicitly barred from editing.
+// Source rules are mirrored in their original relative order, and CASL resolves
+// the last matching rule as the winner, so a deny that overrode an allow before
+// continues to override it for `edit-auth`.
 //
 // Both org roles (projectId IS NULL) and project roles live in the `roles`
 // table and use the same `identity` subject + action strings, so a single pass
@@ -34,6 +42,10 @@ const includes = (value: string | string[] | undefined, target: string) =>
 const conditionSignature = (conditions: unknown) =>
   conditions === undefined ? "__none__" : JSON.stringify(conditions);
 
+// An allow and a deny with identical conditions are distinct rules, so the
+// dedup key must include the inverted flag.
+const ruleSignature = (rule: CaslRule) => `${rule.inverted ? "deny" : "allow"}:${conditionSignature(rule.conditions)}`;
+
 export async function up(knex: Knex): Promise<void> {
   await knex.transaction(async (trx) => {
     const customRoles = await trx(TableName.Role).select("*");
@@ -42,20 +54,19 @@ export async function up(knex: Knex): Promise<void> {
       .map((role) => {
         const rules = unpackRules((role.permissions ?? []) as Parameters<typeof unpackRules>[0]) as CaslRule[];
 
-        // Condition signatures for which edit-auth is already granted (non-inverted).
+        // Signatures (inverted flag + conditions) for which an edit-auth rule
+        // already exists, so we don't duplicate it.
         const existingEditAuth = new Set(
           rules
-            .filter(
-              (rule) =>
-                !rule.inverted && includes(rule.subject, IDENTITY_SUBJECT) && includes(rule.action, EDIT_AUTH_ACTION)
-            )
-            .map((rule) => conditionSignature(rule.conditions))
+            .filter((rule) => includes(rule.subject, IDENTITY_SUBJECT) && includes(rule.action, EDIT_AUTH_ACTION))
+            .map(ruleSignature)
         );
 
-        // Source rules that granted the ability to configure auth methods.
+        // Source rules that scoped the ability to configure auth methods, in their
+        // original relative order. Both allows (grant edit-auth) and denies
+        // (exclude edit-auth) are mirrored so identity-scoping is preserved.
         const sourceRules = rules.filter(
           (rule) =>
-            !rule.inverted &&
             includes(rule.subject, IDENTITY_SUBJECT) &&
             (includes(rule.action, CREATE_ACTION) || includes(rule.action, EDIT_ACTION))
         );
@@ -63,14 +74,15 @@ export async function up(knex: Knex): Promise<void> {
         const rulesToAdd: CaslRule[] = [];
         const addedSignatures = new Set<string>();
         for (const rule of sourceRules) {
-          const signature = conditionSignature(rule.conditions);
+          const signature = ruleSignature(rule);
           if (!existingEditAuth.has(signature) && !addedSignatures.has(signature)) {
             addedSignatures.add(signature);
-            rulesToAdd.push(
+            const newRule: CaslRule =
               rule.conditions === undefined
                 ? { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT }
-                : { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT, conditions: rule.conditions }
-            );
+                : { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT, conditions: rule.conditions };
+            if (rule.inverted) newRule.inverted = true;
+            rulesToAdd.push(newRule);
           }
         }
 
@@ -101,8 +113,8 @@ export async function down(knex: Knex): Promise<void> {
 
         let wasModified = false;
         const filteredRules = rules.filter((rule) => {
-          if (rule.inverted || !includes(rule.subject, IDENTITY_SUBJECT) || !includes(rule.action, EDIT_AUTH_ACTION))
-            return true;
+          // Mirrors up(): strip edit-auth from identity rules, both allows and denies.
+          if (!includes(rule.subject, IDENTITY_SUBJECT) || !includes(rule.action, EDIT_AUTH_ACTION)) return true;
 
           wasModified = true;
           if (Array.isArray(rule.action)) {

--- a/backend/src/db/migrations/20260707000000_identity-edit-auth-permission.ts
+++ b/backend/src/db/migrations/20260707000000_identity-edit-auth-permission.ts
@@ -1,0 +1,134 @@
+import { packRules, unpackRules } from "@casl/ability/extra";
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+// Auth-method configuration (attach/update) used to reuse the generic identity
+// `create`/`edit` actions. It now requires the dedicated `edit-auth` action. To
+// avoid silently stripping this ability from existing custom roles on upgrade,
+// grandfather `edit-auth` onto any custom role that could already configure auth
+// methods (i.e. has a non-inverted identity rule granting `create` or `edit`),
+// preserving that rule's conditions so identity-scoping is retained.
+//
+// Both org roles (projectId IS NULL) and project roles live in the `roles`
+// table and use the same `identity` subject + action strings, so a single pass
+// covers both. Built-in roles (admin/member/no-access) are handled in code and
+// are not stored here, so they are unaffected.
+
+const IDENTITY_SUBJECT = "identity";
+const CREATE_ACTION = "create";
+const EDIT_ACTION = "edit";
+const EDIT_AUTH_ACTION = "edit-auth";
+
+type CaslRule = {
+  action: string | string[];
+  subject: string | string[];
+  conditions?: unknown;
+  inverted?: boolean;
+};
+
+// `unpackRules` normalises `subject`/`action` to array form, so accept either shape.
+const includes = (value: string | string[] | undefined, target: string) =>
+  value === target || (Array.isArray(value) && value.includes(target));
+
+const conditionSignature = (conditions: unknown) =>
+  conditions === undefined ? "__none__" : JSON.stringify(conditions);
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.transaction(async (trx) => {
+    const customRoles = await trx(TableName.Role).select("*");
+
+    const toUpdate = customRoles
+      .map((role) => {
+        const rules = unpackRules((role.permissions ?? []) as Parameters<typeof unpackRules>[0]) as CaslRule[];
+
+        // Condition signatures for which edit-auth is already granted (non-inverted).
+        const existingEditAuth = new Set(
+          rules
+            .filter(
+              (rule) =>
+                !rule.inverted && includes(rule.subject, IDENTITY_SUBJECT) && includes(rule.action, EDIT_AUTH_ACTION)
+            )
+            .map((rule) => conditionSignature(rule.conditions))
+        );
+
+        // Source rules that granted the ability to configure auth methods.
+        const sourceRules = rules.filter(
+          (rule) =>
+            !rule.inverted &&
+            includes(rule.subject, IDENTITY_SUBJECT) &&
+            (includes(rule.action, CREATE_ACTION) || includes(rule.action, EDIT_ACTION))
+        );
+
+        const rulesToAdd: CaslRule[] = [];
+        const addedSignatures = new Set<string>();
+        for (const rule of sourceRules) {
+          const signature = conditionSignature(rule.conditions);
+          if (!existingEditAuth.has(signature) && !addedSignatures.has(signature)) {
+            addedSignatures.add(signature);
+            rulesToAdd.push(
+              rule.conditions === undefined
+                ? { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT }
+                : { action: EDIT_AUTH_ACTION, subject: IDENTITY_SUBJECT, conditions: rule.conditions }
+            );
+          }
+        }
+
+        if (rulesToAdd.length === 0) return null;
+
+        return {
+          ...role,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore-error packRules type mismatch
+          permissions: JSON.stringify(packRules([...rules, ...rulesToAdd]))
+        };
+      })
+      .filter(Boolean) as typeof customRoles;
+
+    if (toUpdate.length > 0) {
+      await trx(TableName.Role).insert(toUpdate).onConflict("id").merge();
+    }
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.transaction(async (trx) => {
+    const customRoles = await trx(TableName.Role).select("*");
+
+    const toUpdate = customRoles
+      .map((role) => {
+        const rules = unpackRules((role.permissions ?? []) as Parameters<typeof unpackRules>[0]) as CaslRule[];
+
+        let wasModified = false;
+        const filteredRules = rules.filter((rule) => {
+          if (rule.inverted || !includes(rule.subject, IDENTITY_SUBJECT) || !includes(rule.action, EDIT_AUTH_ACTION))
+            return true;
+
+          wasModified = true;
+          if (Array.isArray(rule.action)) {
+            const withoutEditAuth = rule.action.filter((a) => a !== EDIT_AUTH_ACTION);
+            if (withoutEditAuth.length === 0) return false;
+            // eslint-disable-next-line no-param-reassign
+            rule.action = withoutEditAuth;
+            return true;
+          }
+          // Single action that is edit-auth, remove the rule entirely.
+          return false;
+        });
+
+        if (!wasModified) return null;
+
+        return {
+          ...role,
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore-error packRules type mismatch
+          permissions: JSON.stringify(packRules(filteredRules))
+        };
+      })
+      .filter(Boolean) as typeof customRoles;
+
+    if (toUpdate.length > 0) {
+      await trx(TableName.Role).insert(toUpdate).onConflict("id").merge();
+    }
+  });
+}

--- a/backend/src/ee/services/permission/default-roles.ts
+++ b/backend/src/ee/services/permission/default-roles.ts
@@ -237,7 +237,8 @@ const buildAdminPermissionRules = () => {
       ProjectPermissionIdentityActions.GetToken,
       ProjectPermissionIdentityActions.CreateToken,
       ProjectPermissionIdentityActions.DeleteToken,
-      ProjectPermissionIdentityActions.RevokeAuth
+      ProjectPermissionIdentityActions.RevokeAuth,
+      ProjectPermissionIdentityActions.EditAuth
     ],
     ProjectPermissionSub.Identity
   );

--- a/backend/src/ee/services/permission/identity-edit-auth-permission.test.ts
+++ b/backend/src/ee/services/permission/identity-edit-auth-permission.test.ts
@@ -1,0 +1,53 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+
+import { projectAdminPermissions, projectMemberPermissions } from "./default-roles";
+import {
+  orgAdminPermissions,
+  orgMemberPermissions,
+  OrgPermissionIdentityActions,
+  OrgPermissionSet,
+  OrgPermissionSubjects
+} from "./org-permission";
+import { ProjectPermissionIdentityActions, ProjectPermissionSet, ProjectPermissionSub } from "./project-permission";
+
+// Regression guard for the identity auth-method privilege-escalation fix.
+// Configuring an identity's auth methods (attach/update) is gated behind the
+// dedicated `edit-auth` action. The built-in Member role must NOT receive it,
+// otherwise a member could attach a trust-based auth method to a more-privileged
+// identity and authenticate as it. Admins must retain it.
+
+describe("Identity edit-auth permission decoupling", () => {
+  describe("Project roles", () => {
+    const admin = createMongoAbility<MongoAbility<ProjectPermissionSet>>(projectAdminPermissions);
+    const member = createMongoAbility<MongoAbility<ProjectPermissionSet>>(projectMemberPermissions);
+
+    test("admin can configure identity auth methods", () => {
+      expect(admin.can(ProjectPermissionIdentityActions.EditAuth, ProjectPermissionSub.Identity)).toBe(true);
+    });
+
+    test("member cannot configure identity auth methods", () => {
+      expect(member.can(ProjectPermissionIdentityActions.EditAuth, ProjectPermissionSub.Identity)).toBe(false);
+    });
+
+    test("member still has generic edit on identities (decoupled from auth config)", () => {
+      expect(member.can(ProjectPermissionIdentityActions.Edit, ProjectPermissionSub.Identity)).toBe(true);
+    });
+  });
+
+  describe("Organization roles", () => {
+    const admin = createMongoAbility<MongoAbility<OrgPermissionSet>>(orgAdminPermissions);
+    const member = createMongoAbility<MongoAbility<OrgPermissionSet>>(orgMemberPermissions);
+
+    test("admin can configure identity auth methods", () => {
+      expect(admin.can(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity)).toBe(true);
+    });
+
+    test("member cannot configure identity auth methods", () => {
+      expect(member.can(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity)).toBe(false);
+    });
+
+    test("member still has generic edit on identities (decoupled from auth config)", () => {
+      expect(member.can(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity)).toBe(true);
+    });
+  });
+});

--- a/backend/src/ee/services/permission/org-permission.ts
+++ b/backend/src/ee/services/permission/org-permission.ts
@@ -108,6 +108,7 @@ export enum OrgPermissionIdentityActions {
   Delete = "delete",
   GrantPrivileges = "grant-privileges",
   RevokeAuth = "revoke-auth",
+  EditAuth = "edit-auth",
   CreateToken = "create-token",
   GetToken = "get-token",
   DeleteToken = "delete-token"
@@ -503,6 +504,7 @@ const buildAdminPermission = () => {
   can(OrgPermissionIdentityActions.Delete, OrgPermissionSubjects.Identity);
   can(OrgPermissionIdentityActions.GrantPrivileges, OrgPermissionSubjects.Identity);
   can(OrgPermissionIdentityActions.RevokeAuth, OrgPermissionSubjects.Identity);
+  can(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
   can(OrgPermissionIdentityActions.CreateToken, OrgPermissionSubjects.Identity);
   can(OrgPermissionIdentityActions.GetToken, OrgPermissionSubjects.Identity);
   can(OrgPermissionIdentityActions.DeleteToken, OrgPermissionSubjects.Identity);

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -82,6 +82,7 @@ export enum ProjectPermissionIdentityActions {
   AssignAdditionalPrivileges = "assign-additional-privileges",
   AssumePrivileges = "assume-privileges",
   RevokeAuth = "revoke-auth",
+  EditAuth = "edit-auth",
   CreateToken = "create-token",
   GetToken = "get-token",
   DeleteToken = "delete-token"
@@ -407,6 +408,7 @@ export const ActionAllowedConditions: ActionAllowedConditionsType = {
     ],
     [ProjectPermissionIdentityActions.AssumePrivileges]: ["identityId"],
     [ProjectPermissionIdentityActions.RevokeAuth]: ["identityId"],
+    [ProjectPermissionIdentityActions.EditAuth]: ["identityId"],
     [ProjectPermissionIdentityActions.CreateToken]: ["identityId"],
     [ProjectPermissionIdentityActions.GetToken]: ["identityId"],
     [ProjectPermissionIdentityActions.DeleteToken]: ["identityId"]

--- a/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
+++ b/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
@@ -423,7 +423,10 @@ export const identityAliCloudAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
+++ b/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
@@ -307,7 +307,7 @@ export const identityAliCloudAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -320,7 +320,7 @@ export const identityAliCloudAuthServiceFactory = ({
         actorOrgId
       });
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -411,7 +411,7 @@ export const identityAliCloudAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -423,7 +423,7 @@ export const identityAliCloudAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -405,7 +405,7 @@ export const identityAwsAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -418,7 +418,7 @@ export const identityAwsAuthServiceFactory = ({
         scope: OrganizationActionScope.Any
       });
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -512,7 +512,7 @@ export const identityAwsAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -524,7 +524,7 @@ export const identityAwsAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -524,7 +524,10 @@ export const identityAwsAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
+++ b/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
@@ -306,7 +306,7 @@ export const identityAzureAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -319,7 +319,7 @@ export const identityAzureAuthServiceFactory = ({
         actorOrgId
       });
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -412,7 +412,7 @@ export const identityAzureAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -424,7 +424,7 @@ export const identityAzureAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
+++ b/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
@@ -424,7 +424,10 @@ export const identityAzureAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
+++ b/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
@@ -471,7 +471,10 @@ export const identityGcpAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
+++ b/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
@@ -351,7 +351,7 @@ export const identityGcpAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -364,7 +364,7 @@ export const identityGcpAuthServiceFactory = ({
         actorOrgId
       });
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -459,7 +459,7 @@ export const identityGcpAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -471,7 +471,7 @@ export const identityGcpAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -619,7 +619,10 @@ export const identityJwtAuthServiceFactory = ({
         actorOrgId
       });
 
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -470,7 +470,7 @@ export const identityJwtAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -484,7 +484,7 @@ export const identityJwtAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -606,7 +606,7 @@ export const identityJwtAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -619,7 +619,7 @@ export const identityJwtAuthServiceFactory = ({
         actorOrgId
       });
 
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -838,7 +838,7 @@ export const identityKubernetesAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -851,7 +851,7 @@ export const identityKubernetesAuthServiceFactory = ({
         actorOrgId
       });
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -1110,7 +1110,7 @@ export const identityKubernetesAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -1122,7 +1122,7 @@ export const identityKubernetesAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -1122,7 +1122,10 @@ export const identityKubernetesAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);
     const reformattedAccessTokenTrustedIps = accessTokenTrustedIps?.map((accessTokenTrustedIp) => {

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -392,12 +392,12 @@ export const identityLdapAuthServiceFactory = ({
       });
 
       ForbiddenError.from(projectPermission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
       ForbiddenError.from(orgPermission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -596,12 +596,12 @@ export const identityLdapAuthServiceFactory = ({
       });
 
       ForbiddenError.from(projectPermission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
       ForbiddenError.from(orgPermission).throwUnlessCan(
-        OrgPermissionIdentityActions.Edit,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }

--- a/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
+++ b/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
@@ -437,7 +437,10 @@ export const identityOciAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
+++ b/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
@@ -319,7 +319,7 @@ export const identityOciAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -332,7 +332,7 @@ export const identityOciAuthServiceFactory = ({
         actorOrgId
       });
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -425,7 +425,7 @@ export const identityOciAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -437,7 +437,7 @@ export const identityOciAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -644,7 +644,7 @@ export const identityOidcAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -658,7 +658,7 @@ export const identityOidcAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -767,7 +767,7 @@ export const identityOidcAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -780,7 +780,7 @@ export const identityOidcAuthServiceFactory = ({
         actorOrgId
       });
 
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -780,7 +780,10 @@ export const identityOidcAuthServiceFactory = ({
         actorOrgId
       });
 
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
+++ b/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
@@ -701,7 +701,10 @@ export const identitySpiffeAuthServiceFactory = ({
         actorOrgId
       });
 
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
+++ b/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
@@ -544,7 +544,7 @@ export const identitySpiffeAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -558,7 +558,7 @@ export const identitySpiffeAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -688,7 +688,7 @@ export const identitySpiffeAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -701,7 +701,7 @@ export const identitySpiffeAuthServiceFactory = ({
         actorOrgId
       });
 
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
+++ b/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
@@ -393,7 +393,7 @@ export const identityTlsCertAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -406,7 +406,7 @@ export const identityTlsCertAuthServiceFactory = ({
         actorOrgId
       });
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -506,7 +506,7 @@ export const identityTlsCertAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -518,7 +518,7 @@ export const identityTlsCertAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
+++ b/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
@@ -518,7 +518,10 @@ export const identityTlsCertAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.EditAuth, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-token-auth/identity-token-auth-service.ts
+++ b/backend/src/services/identity-token-auth/identity-token-auth-service.ts
@@ -123,7 +123,7 @@ export const identityTokenAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -136,7 +136,7 @@ export const identityTokenAuthServiceFactory = ({
         actorOrgId
       });
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -228,7 +228,7 @@ export const identityTokenAuthServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -240,7 +240,10 @@ export const identityTokenAuthServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -478,7 +478,7 @@ export const identityUaServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Create,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -492,7 +492,7 @@ export const identityUaServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        OrgPermissionIdentityActions.Create,
+        OrgPermissionIdentityActions.EditAuth,
         OrgPermissionSubjects.Identity
       );
     }
@@ -613,7 +613,7 @@ export const identityUaServiceFactory = ({
       });
 
       ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionIdentityActions.Edit,
+        ProjectPermissionIdentityActions.EditAuth,
         subject(ProjectPermissionSub.Identity, { identityId })
       );
     } else {
@@ -625,7 +625,10 @@ export const identityUaServiceFactory = ({
         actorAuthMethod,
         actorOrgId
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+      ForbiddenError.from(permission).throwUnlessCan(
+        OrgPermissionIdentityActions.EditAuth,
+        OrgPermissionSubjects.Identity
+      );
     }
 
     const plan = await licenseService.getPlan(identityMembershipOrg.scopeOrgId);

--- a/frontend/src/context/OrgPermissionContext/types.ts
+++ b/frontend/src/context/OrgPermissionContext/types.ts
@@ -154,6 +154,7 @@ export enum OrgPermissionIdentityActions {
   Delete = "delete",
   GrantPrivileges = "grant-privileges",
   RevokeAuth = "revoke-auth",
+  EditAuth = "edit-auth",
   CreateToken = "create-token",
   GetToken = "get-token",
   DeleteToken = "delete-token"

--- a/frontend/src/context/ProjectPermissionContext/types.ts
+++ b/frontend/src/context/ProjectPermissionContext/types.ts
@@ -109,6 +109,7 @@ export enum ProjectPermissionIdentityActions {
   AssignAdditionalPrivileges = "assign-additional-privileges",
   AssumePrivileges = "assume-privileges",
   RevokeAuth = "revoke-auth",
+  EditAuth = "edit-auth",
   CreateToken = "create-token",
   GetToken = "get-token",
   DeleteToken = "delete-token"

--- a/frontend/src/pages/organization/IdentityDetailsByIDPage/components/IdentityAuthenticationSection/IdentityAuthenticationSection.tsx
+++ b/frontend/src/pages/organization/IdentityDetailsByIDPage/components/IdentityAuthenticationSection/IdentityAuthenticationSection.tsx
@@ -46,7 +46,7 @@ export const IdentityAuthenticationSection = ({ identityId, handlePopUpOpen }: P
           ) && (
             <CardAction>
               <OrgPermissionCan
-                I={OrgPermissionIdentityActions.Edit}
+                I={OrgPermissionIdentityActions.EditAuth}
                 a={OrgPermissionSubjects.Identity}
               >
                 {(isAllowed) => (
@@ -88,7 +88,7 @@ export const IdentityAuthenticationSection = ({ identityId, handlePopUpOpen }: P
             </EmptyHeader>
             <EmptyContent>
               <OrgPermissionCan
-                I={OrgPermissionIdentityActions.Edit}
+                I={OrgPermissionIdentityActions.EditAuth}
                 a={OrgPermissionSubjects.Identity}
               >
                 {(isAllowed) => (

--- a/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
+++ b/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
@@ -86,6 +86,7 @@ const identityPermissionSchema = z
       [OrgPermissionIdentityActions.Create]: z.boolean().optional(),
       [OrgPermissionIdentityActions.GrantPrivileges]: z.boolean().optional(),
       [OrgPermissionIdentityActions.RevokeAuth]: z.boolean().optional(),
+      [OrgPermissionIdentityActions.EditAuth]: z.boolean().optional(),
       [OrgPermissionIdentityActions.CreateToken]: z.boolean().optional(),
       [OrgPermissionIdentityActions.GetToken]: z.boolean().optional(),
       [OrgPermissionIdentityActions.DeleteToken]: z.boolean().optional()
@@ -624,6 +625,11 @@ export const ORG_PERMISSION_OBJECT: Record<string, TOrgPermissionConfig> = {
         value: OrgPermissionIdentityActions.RevokeAuth,
         label: "Revoke Auth",
         description: "Revoke authentication for a machine identity"
+      },
+      {
+        value: OrgPermissionIdentityActions.EditAuth,
+        label: "Configure Auth Methods",
+        description: "Add or update authentication methods for a machine identity"
       },
       {
         value: OrgPermissionIdentityActions.CreateToken,

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/ProjectIdentityAuthSection.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/ProjectIdentityAuthSection.tsx
@@ -48,7 +48,7 @@ export const ProjectIdentityAuthenticationSection = ({ identity, refetchIdentity
             ) && (
               <CardAction>
                 <ProjectPermissionCan
-                  I={ProjectPermissionIdentityActions.Edit}
+                  I={ProjectPermissionIdentityActions.EditAuth}
                   a={subject(ProjectPermissionSub.Identity, {
                     identityId: identity.id
                   })}
@@ -92,7 +92,7 @@ export const ProjectIdentityAuthenticationSection = ({ identity, refetchIdentity
               </EmptyHeader>
               <EmptyContent>
                 <ProjectPermissionCan
-                  I={ProjectPermissionIdentityActions.Edit}
+                  I={ProjectPermissionIdentityActions.EditAuth}
                   a={subject(ProjectPermissionSub.Identity, {
                     identityId: identity.id
                   })}

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
@@ -493,6 +493,7 @@ export const ACTION_ALLOWED_CONDITIONS: ActionAllowedConditionsType = {
     ],
     [ProjectPermissionIdentityActions.AssumePrivileges]: ["identityId"],
     [ProjectPermissionIdentityActions.RevokeAuth]: ["identityId"],
+    [ProjectPermissionIdentityActions.EditAuth]: ["identityId"],
     [ProjectPermissionIdentityActions.CreateToken]: ["identityId"],
     [ProjectPermissionIdentityActions.GetToken]: ["identityId"],
     [ProjectPermissionIdentityActions.DeleteToken]: ["identityId"]
@@ -611,6 +612,7 @@ const IdentityPolicyActionSchema = createPolicySchemaWithConditions(
     [ProjectPermissionIdentityActions.AssignAdditionalPrivileges]: z.boolean().optional(),
     [ProjectPermissionIdentityActions.AssumePrivileges]: z.boolean().optional(),
     [ProjectPermissionIdentityActions.RevokeAuth]: z.boolean().optional(),
+    [ProjectPermissionIdentityActions.EditAuth]: z.boolean().optional(),
     [ProjectPermissionIdentityActions.GetToken]: z.boolean().optional(),
     [ProjectPermissionIdentityActions.CreateToken]: z.boolean().optional(),
     [ProjectPermissionIdentityActions.DeleteToken]: z.boolean().optional()
@@ -1270,6 +1272,7 @@ export const rolePermission2Form = (permissions: TProjectPermission[] = []) => {
             ProjectPermissionIdentityActions.AssumePrivileges
           );
           const canRevokeAuth = action.includes(ProjectPermissionIdentityActions.RevokeAuth);
+          const canEditAuth = action.includes(ProjectPermissionIdentityActions.EditAuth);
           const canCreateToken = action.includes(ProjectPermissionIdentityActions.CreateToken);
           const canGetToken = action.includes(ProjectPermissionIdentityActions.GetToken);
           const canDeleteToken = action.includes(ProjectPermissionIdentityActions.DeleteToken);
@@ -1286,6 +1289,7 @@ export const rolePermission2Form = (permissions: TProjectPermission[] = []) => {
               canAssignAdditionalPrivileges,
             [ProjectPermissionIdentityActions.AssumePrivileges]: canAssumePrivileges,
             [ProjectPermissionIdentityActions.RevokeAuth]: canRevokeAuth,
+            [ProjectPermissionIdentityActions.EditAuth]: canEditAuth,
             [ProjectPermissionIdentityActions.CreateToken]: canCreateToken,
             [ProjectPermissionIdentityActions.GetToken]: canGetToken,
             [ProjectPermissionIdentityActions.DeleteToken]: canDeleteToken,
@@ -2332,6 +2336,11 @@ export const PROJECT_PERMISSION_OBJECT: TProjectPermissionObject = {
         label: "Revoke Auth",
         value: ProjectPermissionIdentityActions.RevokeAuth,
         description: "Revoke authentication for a machine identity"
+      },
+      {
+        label: "Configure Auth Methods",
+        value: ProjectPermissionIdentityActions.EditAuth,
+        description: "Add or update authentication methods for a machine identity"
       },
       {
         label: "Create Token",

--- a/frontend/src/views/IdentityAuthMethods/IdentityAuthMethodSheet.tsx
+++ b/frontend/src/views/IdentityAuthMethods/IdentityAuthMethodSheet.tsx
@@ -215,8 +215,8 @@ export const IdentityAuthMethodSheet = ({
               type={projectId ? "project" : "org"}
               I={
                 projectId
-                  ? ProjectPermissionIdentityActions.Edit
-                  : OrgPermissionIdentityActions.Edit
+                  ? ProjectPermissionIdentityActions.EditAuth
+                  : OrgPermissionIdentityActions.EditAuth
               }
               a={
                 projectId

--- a/frontend/src/views/IdentityAuthMethods/IdentityAuthMethodsTable.tsx
+++ b/frontend/src/views/IdentityAuthMethods/IdentityAuthMethodsTable.tsx
@@ -121,8 +121,8 @@ export const IdentityAuthMethodsTable = ({
                         type={projectId ? "project" : "org"}
                         I={
                           projectId
-                            ? ProjectPermissionIdentityActions.Edit
-                            : OrgPermissionIdentityActions.Edit
+                            ? ProjectPermissionIdentityActions.EditAuth
+                            : OrgPermissionIdentityActions.EditAuth
                         }
                         a={
                           projectId


### PR DESCRIPTION
## Context

### Problem

Configuring an identity's authentication methods (attach/update) reused the generic **Identity Create/Edit** permissions, which are granted to the built-in **Member** role by default. As a result, a member could attach a trust-based authentication method (AWS, GCP, Azure, Kubernetes, OIDC, JWT, etc.) to an existing higher-privileged identity and then authenticate as that identity.

Token and secret generation was already protected by the **CreateToken**/**GetToken** permissions, but trust-based authentication methods bypass the token issuance flow, making them a privilege escalation path.

### Fix

Introduces a dedicated **EditAuth** identity permission (symmetric with the existing **RevokeAuth** permission) to gate attaching and updating authentication methods. This permission is granted to **Admin**, but not to **Member**.

- Added **EditAuth** to `OrgPermissionIdentityActions` and `ProjectPermissionIdentityActions`, granted it in the admin role builders and the default project admin role, and registered `identityId` as a conditionable field.
- Updated permission checks for attaching and updating authentication methods across all 13 identity auth-method services (both organization and project scopes) to use **EditAuth** instead of **Create/Edit**. Revoke, token, and gateway permission checks remain unchanged. This also fixes the existing LDAP update permission inconsistency.
- Added a migration to grandfather existing custom roles: any role that already has **Identity Create** or **Identity Edit** automatically receives **EditAuth**, preserving any existing conditions. This ensures self-hosted upgrades remain seamless. Built-in roles are code-defined and therefore unaffected.
- Frontend: added **EditAuth** to both permission enums and the organization/project role editors, and gated the add/edit authentication method UI behind the **EditAuth** permission.

### Testing

- Added unit tests verifying that **Admin** has **EditAuth** while **Member** does not, at both organization and project scopes. Members retain the generic **Identity Edit** permission.
- Backend and frontend type checks and linting pass.
- Validated migration up/down behavior, including condition preservation, deduplication, idempotency, and rollback.
## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)