### PR TITLE
fix: mark subjectAltName critical when leaf subject is empty

### DIFF
--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -2446,9 +2446,10 @@ export const internalCertificateAuthorityServiceFactory = ({
       }
     }
 
+    const finalSubject = subjectOverride || csrObj.subject;
+
     if (altNamesArray.length) {
       // RFC 5280 4.1.2.6: subjectAltName must be marked critical when the subject is an empty sequence.
-      const finalSubject = subjectOverride || csrObj.subject;
       const altNamesExtension = new x509.SubjectAlternativeNameExtension(
         altNamesArray,
         finalSubject.trim().length === 0
@@ -2471,7 +2472,7 @@ export const internalCertificateAuthorityServiceFactory = ({
     const serialNumber = createSerialNumber();
     const leafCert = await signer.createCertificate({
       serialNumber,
-      subject: subjectOverride || csrObj.subject,
+      subject: finalSubject,
       issuer: caCertObj.subject,
       notBefore: notBeforeDate,
       notAfter: notAfterDate,

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -1970,7 +1970,8 @@ export const internalCertificateAuthorityServiceFactory = ({
           return altNameType;
         });
 
-      const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
+      // RFC 5280 4.1.2.6: subjectAltName must be marked critical when the subject is an empty sequence
+      const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, leafDn.trim().length === 0);
       extensions.push(altNamesExtension);
     }
 
@@ -2423,9 +2424,6 @@ export const internalCertificateAuthorityServiceFactory = ({
           }
           return altNameType;
         });
-
-      const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
-      extensions.push(altNamesExtension);
     } else {
       // attempt to read from CSR if altNames is not explicitly provided
       const sanExtension = csrObj.extensions.find((ext) => ext.type === "2.5.29.17");
@@ -2449,7 +2447,12 @@ export const internalCertificateAuthorityServiceFactory = ({
     }
 
     if (altNamesArray.length) {
-      const altNamesExtension = new x509.SubjectAlternativeNameExtension(altNamesArray, false);
+      // RFC 5280 4.1.2.6: subjectAltName must be marked critical when the subject is an empty sequence.
+      const finalSubject = subjectOverride || csrObj.subject;
+      const altNamesExtension = new x509.SubjectAlternativeNameExtension(
+        altNamesArray,
+        finalSubject.trim().length === 0
+      );
       extensions.push(altNamesExtension);
     }
 


### PR DESCRIPTION
## Context

Empty-subject internal-CA now get a critical `subjectAltName` per RFC 5280 4.1.2.6. Also removes a duplicate SAN extension on the explicit-altNames path.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)