### PR TITLE
docs(claude): add cron job alarm requirement to backend guide

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -213,6 +213,8 @@ Recurring work runs through the cron manager in `src/lib/cron/cron-job.ts` (`cro
    };
    ```
 
+3. Add a corresponding alarm in the infrastructure repo so the new job is monitored. Follow the existing pattern in `infisical-shared-cloud/modules/redis_alarms/main.tf` — every cron job must have an alarm defined there. Don't ship a new cron job without wiring up its alarm.
+
 **Handler contract**:
 - Each scheduled fire runs exactly once across the fleet: pods race for a per-run redlock, the winner executes the handler, and the others no-op. You don't need in-handler locking to guard against concurrent pods.
 - Handlers must be idempotent at the boundary of `handlerTimeoutMs` (default 5 min). A timeout marks the run failed-final and waits for the next fire — it does NOT retry the same fire, because the timed-out handler may still be running.


### PR DESCRIPTION
## Context

Adds a step to the cron job registration checklist in `backend/CLAUDE.md`: every new cron job must have a corresponding alarm in the infrastructure repo (`infisical-shared-cloud/modules/redis_alarms/main.tf`). This documents an existing operational requirement so new jobs aren't shipped without monitoring.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)