### PR TITLE
fix: improve the wording used to explain what the CA host means in ADCS

### DIFF
--- a/docs/integrations/app-connections/adcs.mdx
+++ b/docs/integrations/app-connections/adcs.mdx
@@ -26,7 +26,7 @@ Connect Infisical to Microsoft Active Directory Certificate Services (AD CS) thr
   </Step>
   <Step title="Configure Connection Details">
     - **Name**: Friendly name for this connection (for example, `production-adcs`)
-    - **CA Host**: The AD CS server hostname or IP reachable from the Gateway (for example, `ca01.corp.example.com`)
+    - **CA Host**: The network address the Gateway uses to reach your AD CS server. This can be a fully qualified domain name (for example, `ca01.corp.example.com`), a short hostname, or an IP address, as long as the Gateway can resolve and connect to it. Because the Gateway runs inside your network, this is almost always a private, internal address (a private DNS name or private IP) rather than a public one. Enter the address only: do not include a scheme (`https://`), port, or path, since AD CS is reached over DCOM (MS-WCCE).
     - **Username**: Domain account in the form `DOMAIN\username` or `username@domain.com`
     - **Password**: Password for the domain account
     - **Gateway**: The Gateway that can reach the AD CS server
@@ -37,3 +37,7 @@ Connect Infisical to Microsoft Active Directory Certificate Services (AD CS) thr
     Your **Microsoft ADCS Connection** is now available for use.
   </Step>
 </Steps>
+
+<Note>
+  A fully qualified domain name is recommended over an IP address. It keeps the connection stable if the server's IP changes and avoids the certificate hostname mismatches an IP can introduce. An IP address works as long as the Gateway can reach the server over it.
+</Note>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AdcsConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AdcsConnectionForm.tsx
@@ -194,7 +194,9 @@ export const AdcsConnectionForm = ({ appConnection, onSubmit }: Props) => {
                 placeholder="ca01.corp.example.com"
                 isError={Boolean(error?.message)}
               />
-              <FieldDescription>The CA server&apos;s DNS name, not a URL</FieldDescription>
+              <FieldDescription>
+                The address the Gateway uses to reach the CA server: an FQDN, hostname, or IP.
+              </FieldDescription>
               <FieldError errors={[error]} />
             </Field>
           )}


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)