### PR TITLE
feat(secrets-request-acess): revamp access request 

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
@@ -69,7 +69,9 @@ describe("verifyRequestedPermissions", () => {
         conditions: { secretPath: { $glob: "/test/*" } }
       }
     ]);
-    expect(() => verifyRequestedPermissions({ permissions })).toThrow("Permission environment is not a string");
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "secrets" is not allowed'
+    );
   });
 
   test("rejects permission without secret path", () => {
@@ -80,6 +82,170 @@ describe("verifyRequestedPermissions", () => {
         conditions: { environment: "dev" }
       }
     ]);
-    expect(() => verifyRequestedPermissions({ permissions })).toThrow("Permission path is not a string");
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "secrets" is not allowed'
+    );
+  });
+
+  test("accepts SecretFolders with a whitelisted action", () => {
+    const permissions = packRules([
+      {
+        action: "create",
+        subject: "secret-folders" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
+      }
+    ]);
+    const result = verifyRequestedPermissions({ permissions });
+    expect(result.envSlug).toBe("dev");
+  });
+
+  test("accepts DynamicSecrets with a whitelisted action", () => {
+    const permissions = packRules([
+      {
+        action: "lease",
+        subject: "dynamic-secrets" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
+      }
+    ]);
+    const result = verifyRequestedPermissions({ permissions });
+    expect(result.envSlug).toBe("dev");
+  });
+
+  test("accepts SecretRotation with a whitelisted action", () => {
+    const permissions = packRules([
+      {
+        action: "rotate-secrets",
+        subject: "secret-rotation" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
+      }
+    ]);
+    const result = verifyRequestedPermissions({ permissions });
+    expect(result.envSlug).toBe("dev");
+  });
+
+  test("accepts SecretImports with a whitelisted action", () => {
+    const permissions = packRules([
+      {
+        action: "edit",
+        subject: "secret-imports" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
+      }
+    ]);
+    const result = verifyRequestedPermissions({ permissions });
+    expect(result.envSlug).toBe("dev");
+  });
+
+  test("accepts HoneyTokens with a whitelisted action", () => {
+    const permissions = packRules([
+      {
+        action: "read-credentials",
+        subject: "honey-tokens" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
+      }
+    ]);
+    const result = verifyRequestedPermissions({ permissions });
+    expect(result.envSlug).toBe("dev");
+  });
+
+  test("rejects a subject outside the access-request whitelist", () => {
+    const permissions = packRules([
+      {
+        action: "read",
+        subject: "member" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/test/*" } }
+      }
+    ]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "member" is not allowed'
+    );
+  });
+
+  test("rejects an action excluded from the Secrets whitelist", () => {
+    const permissions = packRules([
+      {
+        action: "describeSecret",
+        subject: "secrets" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/test/*" } }
+      }
+    ]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "secrets" is not allowed'
+    );
+  });
+
+  test("rejects an action excluded from the SecretFolders whitelist", () => {
+    const permissions = packRules([
+      {
+        action: "read",
+        subject: "secret-folders" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/test/*" } }
+      }
+    ]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "secret-folders" is not allowed'
+    );
+  });
+
+  test("rejects an unrecognized condition key", () => {
+    const permissions = packRules([
+      {
+        action: "read",
+        subject: "secrets" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/test/*" }, secretName: "foo" }
+      }
+    ]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "secrets" is not allowed'
+    );
+  });
+
+  test("rejects secretPath given as a bare string instead of { $glob }", () => {
+    const permissions = packRules([
+      {
+        action: "read",
+        subject: "secrets" as const,
+        conditions: { environment: "dev", secretPath: "/test/*" }
+      }
+    ]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "secrets" is not allowed'
+    );
+  });
+
+  test("rejects a smuggled multi-subject rule", () => {
+    // Hand-crafted packed tuple simulating a request that bypasses packRules() client-side:
+    // unpackRules always splits the subject string on ",", so this decodes to two subjects.
+    const permissions = [["read", "secrets,member", { environment: "dev", secretPath: { $glob: "/test/*" } }]];
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      "Each permission rule in an access request must target exactly one resource type"
+    );
+  });
+
+  test("rejects an inverted (cannot) rule", () => {
+    const permissions = packRules([
+      {
+        action: "read",
+        subject: "secrets" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/test/*" } },
+        inverted: true
+      }
+    ]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "secrets" is not allowed'
+    );
+  });
+
+  test("rejects a batch mixing a valid rule with a disallowed rule", () => {
+    const permissions = packRules([
+      makeRule("read", "dev", "/apps/team-a/*"),
+      {
+        action: "read",
+        subject: "kms" as const,
+        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
+      }
+    ]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "kms" is not allowed'
+    );
   });
 });

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, test } from "vitest";
 import { verifyRequestedPermissions } from "./access-approval-request-fns";
 
 describe("verifyRequestedPermissions", () => {
-  const makeRule = (action: string, env: string, secretPath: string) => ({
+  const makeRule = (action: string, env: string, secretPath: string, subject = "secrets") => ({
     action,
-    subject: "secrets" as const,
+    subject,
     conditions: {
       environment: env,
       secretPath: { $glob: secretPath }
@@ -87,62 +87,14 @@ describe("verifyRequestedPermissions", () => {
     );
   });
 
-  test("accepts SecretFolders with a whitelisted action", () => {
-    const permissions = packRules([
-      {
-        action: "create",
-        subject: "secret-folders" as const,
-        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
-      }
-    ]);
-    const result = verifyRequestedPermissions({ permissions });
-    expect(result.envSlug).toBe("dev");
-  });
-
-  test("accepts DynamicSecrets with a whitelisted action", () => {
-    const permissions = packRules([
-      {
-        action: "lease",
-        subject: "dynamic-secrets" as const,
-        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
-      }
-    ]);
-    const result = verifyRequestedPermissions({ permissions });
-    expect(result.envSlug).toBe("dev");
-  });
-
-  test("accepts SecretRotation with a whitelisted action", () => {
-    const permissions = packRules([
-      {
-        action: "rotate-secrets",
-        subject: "secret-rotation" as const,
-        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
-      }
-    ]);
-    const result = verifyRequestedPermissions({ permissions });
-    expect(result.envSlug).toBe("dev");
-  });
-
-  test("accepts SecretImports with a whitelisted action", () => {
-    const permissions = packRules([
-      {
-        action: "edit",
-        subject: "secret-imports" as const,
-        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
-      }
-    ]);
-    const result = verifyRequestedPermissions({ permissions });
-    expect(result.envSlug).toBe("dev");
-  });
-
-  test("accepts HoneyTokens with a whitelisted action", () => {
-    const permissions = packRules([
-      {
-        action: "read-credentials",
-        subject: "honey-tokens" as const,
-        conditions: { environment: "dev", secretPath: { $glob: "/apps/team-a/*" } }
-      }
-    ]);
+  test.each([
+    ["secret-folders", "create"],
+    ["dynamic-secrets", "lease"],
+    ["secret-rotation", "rotate-secrets"],
+    ["secret-imports", "edit"],
+    ["honey-tokens", "read-credentials"]
+  ])("accepts %s with whitelisted action %s", (subject, action) => {
+    const permissions = packRules([makeRule(action, "dev", "/apps/team-a/*", subject)]);
     const result = verifyRequestedPermissions({ permissions });
     expect(result.envSlug).toBe("dev");
   });
@@ -160,10 +112,10 @@ describe("verifyRequestedPermissions", () => {
     );
   });
 
-  test("rejects an action excluded from the Secrets whitelist", () => {
+  test("rejects a secrets action outside ProjectPermissionSecretActions", () => {
     const permissions = packRules([
       {
-        action: "describeSecret",
+        action: "lease",
         subject: "secrets" as const,
         conditions: { environment: "dev", secretPath: { $glob: "/test/*" } }
       }
@@ -173,10 +125,10 @@ describe("verifyRequestedPermissions", () => {
     );
   });
 
-  test("rejects an action excluded from the SecretFolders whitelist", () => {
+  test("rejects a secret-folders action outside ProjectPermissionActions", () => {
     const permissions = packRules([
       {
-        action: "read",
+        action: "readValue",
         subject: "secret-folders" as const,
         conditions: { environment: "dev", secretPath: { $glob: "/test/*" } }
       }
@@ -222,14 +174,14 @@ describe("verifyRequestedPermissions", () => {
   });
 
   test("rejects an inverted (cannot) rule", () => {
-    const permissions = packRules([
-      {
-        action: "read",
-        subject: "secrets" as const,
-        conditions: { environment: "dev", secretPath: { $glob: "/test/*" } },
-        inverted: true
-      }
-    ]);
+    const permissions = packRules([{ ...makeRule("read", "dev", "/test/*"), inverted: true }]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(
+      'The requested permission for resource "secrets" is not allowed'
+    );
+  });
+
+  test("rejects a rule carrying extra attributes (field scoping, reason)", () => {
+    const permissions = packRules([{ ...makeRule("read", "dev", "/test/*"), fields: ["value"], reason: "why" }]);
     expect(() => verifyRequestedPermissions({ permissions })).toThrow(
       'The requested permission for resource "secrets" is not allowed'
     );

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
@@ -1,9 +1,11 @@
 import { PackRule, unpackRules } from "@casl/ability/extra";
 import { z } from "zod";
 
+import { PermissionConditionOperators } from "@app/lib/casl";
 import { BadRequestError } from "@app/lib/errors";
 
-import { CASL_ACTION_SCHEMA_ENUM, CASL_ACTION_SCHEMA_NATIVE_ENUM } from "../permission/permission-schemas";
+import { CASL_ACTION_SCHEMA_NATIVE_ENUM } from "../permission/permission-schemas";
+import { PermissionConditionSchema } from "../permission/permission-types";
 import {
   ProjectPermissionActions,
   ProjectPermissionDynamicSecretActions,
@@ -28,18 +30,48 @@ type TUnpackedAccessApprovalRequestRule = {
   conditions?: Record<string, any>;
   action: string | string[];
   subject: string | string[];
+  inverted?: boolean;
+  fields?: string[];
+  reason?: string;
 };
 
 // Exactly the conditions shape RequestAccessForm.tsx ever produces:
 // { environment: data.environmentSlug, secretPath: { $glob: data.secretPath } }.
 // .strict() at both levels so no other operator ($in/$eq/...) or key
 // (secretName, secretTags, connectionId, metadata, ...) can be smuggled in.
+// The $glob value reuses the same validator as every other permission surface.
 const AccessApprovalRequestConditionsSchema = z
   .object({
     environment: z.string().min(1),
-    secretPath: z.object({ $glob: z.string().min(1) }).strict()
+    secretPath: z.object({ $glob: PermissionConditionSchema[PermissionConditionOperators.$GLOB] }).strict()
   })
   .strict();
+
+// Every allowed rule has the same shape: one whitelisted subject, that subject's allowed
+// actions, and the exact conditions the form produces. The whole unpacked rule is parsed
+// (not a projection of it), with .strict() so no other CASL rule attribute (field-level
+// scoping, reasons) can ride along into the privilege that gets granted on approval.
+// `inverted` needs an explicit key: unpackRules() stamps `inverted: false` on every rule,
+// which strict() would otherwise reject, while a crafted request can smuggle
+// `inverted: true` (a "cannot" rule) that must fail; literal(false).optional() allows
+// exactly the former and rejects the latter.
+// TAction admits `V | V[]` because the CASL_ACTION_SCHEMA_* transforms, while always
+// returning an array at runtime, declare their output as the union (generic narrowing).
+const accessApprovalRequestRuleSchema = <
+  TSub extends ProjectPermissionSub,
+  TAction extends z.ZodType<string | string[], z.ZodTypeDef, unknown>
+>(
+  subject: TSub,
+  action: TAction
+) =>
+  z
+    .object({
+      subject: z.literal(subject),
+      action,
+      conditions: AccessApprovalRequestConditionsSchema,
+      inverted: z.literal(false).optional()
+    })
+    .strict();
 
 // The exact resources/actions the Request Access sheet's RESOURCE_CONFIGS can submit.
 // Access requests ask an approver to grant elevated access, so unlike custom project
@@ -47,46 +79,31 @@ const AccessApprovalRequestConditionsSchema = z
 // Kms, Role, etc). Every ProjectPermissionSub not listed below is rejected automatically:
 // z.discriminatedUnion has no catch-all branch, so any other subject literal fails with
 // Zod's own "Invalid discriminator value" issue.
-export const AccessApprovalRequestPermissionSchema = z.discriminatedUnion("subject", [
-  z.object({
-    subject: z.literal(ProjectPermissionSub.Secrets),
-    action: CASL_ACTION_SCHEMA_ENUM([
-      ProjectPermissionSecretActions.DescribeAndReadValue,
-      ProjectPermissionSecretActions.Create,
-      ProjectPermissionSecretActions.Edit,
-      ProjectPermissionSecretActions.Delete
-    ]),
-    conditions: AccessApprovalRequestConditionsSchema
-  }),
-  z.object({
-    subject: z.literal(ProjectPermissionSub.SecretFolders),
-    action: CASL_ACTION_SCHEMA_ENUM([
-      ProjectPermissionActions.Create,
-      ProjectPermissionActions.Edit,
-      ProjectPermissionActions.Delete
-    ]),
-    conditions: AccessApprovalRequestConditionsSchema
-  }),
-  z.object({
-    subject: z.literal(ProjectPermissionSub.DynamicSecrets),
-    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionDynamicSecretActions),
-    conditions: AccessApprovalRequestConditionsSchema
-  }),
-  z.object({
-    subject: z.literal(ProjectPermissionSub.SecretRotation),
-    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionSecretRotationActions),
-    conditions: AccessApprovalRequestConditionsSchema
-  }),
-  z.object({
-    subject: z.literal(ProjectPermissionSub.SecretImports),
-    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionActions),
-    conditions: AccessApprovalRequestConditionsSchema
-  }),
-  z.object({
-    subject: z.literal(ProjectPermissionSub.HoneyTokens),
-    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionHoneyTokenActions),
-    conditions: AccessApprovalRequestConditionsSchema
-  })
+const AccessApprovalRequestPermissionSchema = z.discriminatedUnion("subject", [
+  accessApprovalRequestRuleSchema(
+    ProjectPermissionSub.Secrets,
+    CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionSecretActions)
+  ),
+  accessApprovalRequestRuleSchema(
+    ProjectPermissionSub.SecretFolders,
+    CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionActions)
+  ),
+  accessApprovalRequestRuleSchema(
+    ProjectPermissionSub.DynamicSecrets,
+    CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionDynamicSecretActions)
+  ),
+  accessApprovalRequestRuleSchema(
+    ProjectPermissionSub.SecretRotation,
+    CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionSecretRotationActions)
+  ),
+  accessApprovalRequestRuleSchema(
+    ProjectPermissionSub.SecretImports,
+    CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionActions)
+  ),
+  accessApprovalRequestRuleSchema(
+    ProjectPermissionSub.HoneyTokens,
+    CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionHoneyTokenActions)
+  )
 ]);
 
 // unpackRules always splits subject/action on "," (even a single value becomes a
@@ -97,7 +114,6 @@ export const AccessApprovalRequestPermissionSchema = z.discriminatedUnion("subje
 const parseAccessApprovalRequestPermissions = (permissions: TUnpackedAccessApprovalRequestRule[]) =>
   permissions.map((rule) => {
     const subjects = Array.isArray(rule.subject) ? rule.subject : [rule.subject];
-    const actions = Array.isArray(rule.action) ? rule.action : [rule.action];
 
     if (subjects.length !== 1) {
       throw new BadRequestError({
@@ -105,11 +121,7 @@ const parseAccessApprovalRequestPermissions = (permissions: TUnpackedAccessAppro
       });
     }
 
-    const result = AccessApprovalRequestPermissionSchema.safeParse({
-      subject: subjects[0],
-      action: actions,
-      conditions: rule.conditions
-    });
+    const result = AccessApprovalRequestPermissionSchema.safeParse({ ...rule, subject: subjects[0] });
 
     if (!result.success) {
       throw new BadRequestError({
@@ -148,6 +160,7 @@ export const verifyRequestedPermissions = ({ permissions }: TVerifyPermission) =
       });
     }
 
+    // runtime is always an array; the schema's declared output keeps the bare-value union
     const actions = Array.isArray(p.action) ? p.action : [p.action];
     const subjectActions = actionsBySubject.get(p.subject) ?? new Set<string>();
     actions.forEach((action) => subjectActions.add(action));

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
@@ -1,7 +1,17 @@
 import { PackRule, unpackRules } from "@casl/ability/extra";
+import { z } from "zod";
 
 import { BadRequestError } from "@app/lib/errors";
 
+import { CASL_ACTION_SCHEMA_ENUM, CASL_ACTION_SCHEMA_NATIVE_ENUM } from "../permission/permission-schemas";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionDynamicSecretActions,
+  ProjectPermissionHoneyTokenActions,
+  ProjectPermissionSecretActions,
+  ProjectPermissionSecretRotationActions,
+  ProjectPermissionSub
+} from "../permission/project-permission";
 import { TVerifyPermission } from "./access-approval-request-types";
 
 // Turn a permission slug into a human-readable label, e.g. "dynamic-secrets" -> "Dynamic Secrets"
@@ -13,43 +23,124 @@ const humanizeSlug = (slug: string) =>
     .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
     .join(" ");
 
+type TUnpackedAccessApprovalRequestRule = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  conditions?: Record<string, any>;
+  action: string | string[];
+  subject: string | string[];
+};
+
+// Exactly the conditions shape RequestAccessForm.tsx ever produces:
+// { environment: data.environmentSlug, secretPath: { $glob: data.secretPath } }.
+// .strict() at both levels so no other operator ($in/$eq/...) or key
+// (secretName, secretTags, connectionId, metadata, ...) can be smuggled in.
+const AccessApprovalRequestConditionsSchema = z
+  .object({
+    environment: z.string().min(1),
+    secretPath: z.object({ $glob: z.string().min(1) }).strict()
+  })
+  .strict();
+
+// The exact resources/actions the Request Access sheet's RESOURCE_CONFIGS can submit.
+// Access requests ask an approver to grant elevated access, so unlike custom project
+// roles this must not accept arbitrary CASL subjects/actions (Member/GrantPrivileges,
+// Kms, Role, etc). Every ProjectPermissionSub not listed below is rejected automatically:
+// z.discriminatedUnion has no catch-all branch, so any other subject literal fails with
+// Zod's own "Invalid discriminator value" issue.
+export const AccessApprovalRequestPermissionSchema = z.discriminatedUnion("subject", [
+  z.object({
+    subject: z.literal(ProjectPermissionSub.Secrets),
+    action: CASL_ACTION_SCHEMA_ENUM([
+      ProjectPermissionSecretActions.DescribeAndReadValue,
+      ProjectPermissionSecretActions.Create,
+      ProjectPermissionSecretActions.Edit,
+      ProjectPermissionSecretActions.Delete
+    ]),
+    conditions: AccessApprovalRequestConditionsSchema
+  }),
+  z.object({
+    subject: z.literal(ProjectPermissionSub.SecretFolders),
+    action: CASL_ACTION_SCHEMA_ENUM([
+      ProjectPermissionActions.Create,
+      ProjectPermissionActions.Edit,
+      ProjectPermissionActions.Delete
+    ]),
+    conditions: AccessApprovalRequestConditionsSchema
+  }),
+  z.object({
+    subject: z.literal(ProjectPermissionSub.DynamicSecrets),
+    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionDynamicSecretActions),
+    conditions: AccessApprovalRequestConditionsSchema
+  }),
+  z.object({
+    subject: z.literal(ProjectPermissionSub.SecretRotation),
+    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionSecretRotationActions),
+    conditions: AccessApprovalRequestConditionsSchema
+  }),
+  z.object({
+    subject: z.literal(ProjectPermissionSub.SecretImports),
+    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionActions),
+    conditions: AccessApprovalRequestConditionsSchema
+  }),
+  z.object({
+    subject: z.literal(ProjectPermissionSub.HoneyTokens),
+    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(ProjectPermissionHoneyTokenActions),
+    conditions: AccessApprovalRequestConditionsSchema
+  })
+]);
+
+// unpackRules always splits subject/action on "," (even a single value becomes a
+// 1-element array), so a crafted packed tuple like ["read", "secrets,member", {...}]
+// unpacks to subject: ["secrets", "member"]. Require exactly one subject per rule so
+// that can't slip a second, forbidden subject past validation while still being
+// persisted verbatim.
+const parseAccessApprovalRequestPermissions = (permissions: TUnpackedAccessApprovalRequestRule[]) =>
+  permissions.map((rule) => {
+    const subjects = Array.isArray(rule.subject) ? rule.subject : [rule.subject];
+    const actions = Array.isArray(rule.action) ? rule.action : [rule.action];
+
+    if (subjects.length !== 1) {
+      throw new BadRequestError({
+        message: "Each permission rule in an access request must target exactly one resource type"
+      });
+    }
+
+    const result = AccessApprovalRequestPermissionSchema.safeParse({
+      subject: subjects[0],
+      action: actions,
+      conditions: rule.conditions
+    });
+
+    if (!result.success) {
+      throw new BadRequestError({
+        message: `The requested permission for resource "${subjects[0]}" is not allowed. Access requests may only target Secrets, Secret Folders, Dynamic Secrets, Secret Rotation, Secret Imports, or Honey Tokens, using the actions and "environment"/"secretPath" conditions available in the Request Access form.`,
+        details: result.error.issues
+      });
+    }
+
+    return result.data;
+  });
+
 export const verifyRequestedPermissions = ({ permissions }: TVerifyPermission) => {
-  const permission = unpackRules(
-    permissions as PackRule<{
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      conditions?: Record<string, any>;
-      action: string | string[];
-      subject: string | string[];
-    }>[]
-  );
+  const permission = unpackRules(permissions as PackRule<TUnpackedAccessApprovalRequestRule>[]);
 
   if (!permission || !permission.length) {
     throw new BadRequestError({ message: "No permission provided" });
   }
 
-  const firstPermission = permission[0];
+  const validatedPermissions = parseAccessApprovalRequestPermissions(permission);
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-  const permissionSecretPath = firstPermission.conditions?.secretPath?.$glob;
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const permissionEnv = firstPermission.conditions?.environment;
-
-  if (!permissionEnv || typeof permissionEnv !== "string") {
-    throw new BadRequestError({ message: "Permission environment is not a string" });
-  }
-  if (!permissionSecretPath || typeof permissionSecretPath !== "string") {
-    throw new BadRequestError({ message: "Permission path is not a string" });
-  }
+  const firstPermission = validatedPermissions[0];
+  const permissionEnv = firstPermission.conditions.environment;
+  const permissionSecretPath = firstPermission.conditions.secretPath.$glob;
 
   // Collect every requested subject and its actions (not just secret CRUD) so the approval
   // notifications surface the full scope of access being requested and nothing is hidden.
   const actionsBySubject = new Map<string, Set<string>>();
 
-  for (const p of permission) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const ruleEnv = p.conditions?.environment;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const rulePath = p.conditions?.secretPath?.$glob;
+  for (const p of validatedPermissions) {
+    const ruleEnv = p.conditions.environment;
+    const rulePath = p.conditions.secretPath.$glob;
 
     if (ruleEnv !== permissionEnv || rulePath !== permissionSecretPath) {
       throw new BadRequestError({
@@ -57,17 +148,10 @@ export const verifyRequestedPermissions = ({ permissions }: TVerifyPermission) =
       });
     }
 
-    const subjects = Array.isArray(p.subject) ? p.subject : [p.subject];
     const actions = Array.isArray(p.action) ? p.action : [p.action];
-
-    subjects.forEach((subject) => {
-      if (!subject) return;
-      const subjectActions = actionsBySubject.get(subject) ?? new Set<string>();
-      actions.forEach((action) => {
-        if (action) subjectActions.add(action);
-      });
-      actionsBySubject.set(subject, subjectActions);
-    });
+    const subjectActions = actionsBySubject.get(p.subject) ?? new Set<string>();
+    actions.forEach((action) => subjectActions.add(action));
+    actionsBySubject.set(p.subject, subjectActions);
   }
 
   const accessTypes = Array.from(actionsBySubject.entries()).map(

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
@@ -16,7 +16,6 @@ import {
   ShieldBanIcon,
   TimerIcon
 } from "lucide-react";
-import ms from "ms";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import {
@@ -97,6 +96,7 @@ import { ApprovalStatus, TWorkspaceUser } from "@app/hooks/api/types";
 
 import { RequestAccessModal } from "./components/RequestAccessModal";
 import { ReviewAccessRequestModal } from "./components/ReviewAccessModal";
+import { formatAccessDuration, parseAccessDurationMs } from "./AccessApprovalRequest.utils";
 
 type FilterMenuProps = {
   className?: string;
@@ -682,9 +682,10 @@ export const AccessApprovalRequest = ({
                           <Badge variant="info">
                             <TimerIcon />
                             <span className="whitespace-nowrap">
-                              {request.temporaryRange
-                                ? ms(ms(request.temporaryRange), { long: true })
-                                : "Temporary"}
+                              {(() => {
+                                const rangeMs = parseAccessDurationMs(request.temporaryRange);
+                                return rangeMs ? formatAccessDuration(rangeMs) : "Temporary";
+                              })()}
                             </span>
                           </Badge>
                         ) : (

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.utils.ts
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.utils.ts
@@ -1,0 +1,22 @@
+import ms from "ms";
+
+// Parse a user-supplied duration string ("30m", "2h", "1d") to milliseconds.
+// Returns undefined for anything ms() can't parse to a positive number.
+export const parseAccessDurationMs = (value?: string | null) => {
+  if (!value) return undefined;
+  try {
+    const parsed = ms(value);
+    return typeof parsed === "number" && parsed > 0 ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+// Single source for the access-duration copy so the label a requester previews in
+// RequestAccessForm matches what reviewers later see in ReviewAccessModal.
+export const getAccessDurationLabel = (isTemporary?: boolean, temporaryRange?: string | null) => {
+  if (!isTemporary || !temporaryRange) return "Permanent";
+  const rangeMs = parseAccessDurationMs(temporaryRange);
+  if (!rangeMs) return `Valid for ${temporaryRange} after approval`;
+  return `Valid for ${ms(rangeMs, { long: true })} after approval`;
+};

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.utils.ts
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.utils.ts
@@ -12,11 +12,35 @@ export const parseAccessDurationMs = (value?: string | null) => {
   }
 };
 
+const DURATION_UNITS = [
+  { label: "day", ms: 24 * 60 * 60 * 1000 },
+  { label: "hour", ms: 60 * 60 * 1000 },
+  { label: "minute", ms: 60 * 1000 },
+  { label: "second", ms: 1000 }
+] as const;
+
+// Break a duration into its exact day/hour/minute/second parts instead of letting
+// ms() round to a single unit (e.g. 90m -> "1 hour 30 minutes", not "2 hours").
+export const formatAccessDuration = (durationMs: number) => {
+  const parts: string[] = [];
+  let remaining = durationMs;
+
+  DURATION_UNITS.forEach(({ label, ms: unitMs }) => {
+    const count = Math.floor(remaining / unitMs);
+    if (count > 0) {
+      parts.push(`${count} ${label}${count === 1 ? "" : "s"}`);
+      remaining -= count * unitMs;
+    }
+  });
+
+  return parts.length ? parts.join(" ") : "0 seconds";
+};
+
 // Single source for the access-duration copy so the label a requester previews in
 // RequestAccessForm matches what reviewers later see in ReviewAccessModal.
 export const getAccessDurationLabel = (isTemporary?: boolean, temporaryRange?: string | null) => {
   if (!isTemporary || !temporaryRange) return "Permanent";
   const rangeMs = parseAccessDurationMs(temporaryRange);
   if (!rangeMs) return `Valid for ${temporaryRange} after approval`;
-  return `Valid for ${ms(rangeMs, { long: true })} after approval`;
+  return `Valid for ${formatAccessDuration(rangeMs)} after approval`;
 };

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -25,7 +25,6 @@ import { z } from "zod";
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import {
-  Badge,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -35,9 +34,6 @@ import {
   FieldDescription,
   FieldError,
   FieldLabel,
-  HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
   IconButton,
   Input,
   Select,
@@ -92,7 +88,6 @@ type TResourceConfig = {
   Icon: LucideIcon;
   // Tailwind extracts classes statically, so every tint must be a full literal string
   iconTileClassName: string;
-  chipSelectedClassName: string;
   countBadgeClassName: string;
   summaryIconClassName: string;
   actions: TResourceAction[];
@@ -104,8 +99,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Secrets",
     Icon: KeyIcon,
     iconTileClassName: "border-accent/10 bg-accent/15 text-accent",
-    chipSelectedClassName:
-      "border-accent/50 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/25",
     countBadgeClassName: "border-accent/10 bg-accent/15 text-accent",
     summaryIconClassName: "text-accent",
     actions: [
@@ -140,8 +133,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Folders",
     Icon: FolderIcon,
     iconTileClassName: "border-folder/10 bg-folder/15 text-folder",
-    chipSelectedClassName:
-      "border-folder/50 bg-folder/15 text-folder hover:border-folder/50 hover:bg-folder/25",
     countBadgeClassName: "border-folder/10 bg-folder/15 text-folder",
     summaryIconClassName: "text-folder",
     actions: [
@@ -170,8 +161,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Dynamic Secrets",
     Icon: FingerprintIcon,
     iconTileClassName: "border-dynamic-secret/10 bg-dynamic-secret/15 text-dynamic-secret",
-    chipSelectedClassName:
-      "border-dynamic-secret/50 bg-dynamic-secret/15 text-dynamic-secret hover:border-dynamic-secret/50 hover:bg-dynamic-secret/25",
     countBadgeClassName: "border-dynamic-secret/10 bg-dynamic-secret/15 text-dynamic-secret",
     summaryIconClassName: "text-dynamic-secret",
     actions: [
@@ -212,8 +201,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Secret Rotation",
     Icon: RefreshCwIcon,
     iconTileClassName: "border-secret-rotation/10 bg-secret-rotation/15 text-secret-rotation",
-    chipSelectedClassName:
-      "border-secret-rotation/50 bg-secret-rotation/15 text-secret-rotation hover:border-secret-rotation/50 hover:bg-secret-rotation/25",
     countBadgeClassName: "border-secret-rotation/10 bg-secret-rotation/15 text-secret-rotation",
     summaryIconClassName: "text-secret-rotation",
     actions: [
@@ -260,8 +247,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Secret Imports",
     Icon: ImportIcon,
     iconTileClassName: "border-import/10 bg-import/15 text-import",
-    chipSelectedClassName:
-      "border-import/50 bg-import/15 text-import hover:border-import/50 hover:bg-import/25",
     countBadgeClassName: "border-import/10 bg-import/15 text-import",
     summaryIconClassName: "text-import",
     actions: [
@@ -296,8 +281,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Honey Tokens",
     Icon: HexagonIcon,
     iconTileClassName: "border-yellow-700/10 bg-yellow-700/15 text-yellow-700",
-    chipSelectedClassName:
-      "border-yellow-700/50 bg-yellow-700/15 text-yellow-700 hover:border-yellow-700/50 hover:bg-yellow-700/25",
     countBadgeClassName: "border-yellow-700/10 bg-yellow-700/15 text-yellow-700",
     summaryIconClassName: "text-yellow-700",
     actions: [
@@ -473,13 +456,6 @@ export const RequestAccessForm = ({
       (config.subject !== ProjectPermissionSub.HoneyTokens || subscription?.honeyTokens)
   );
 
-  const summaryRows = resources.flatMap((resource) => {
-    const config = RESOURCE_CONFIGS.find((c) => c.subject === resource.subject);
-    if (!config) return [];
-    const selected = config.actions.filter((action) => resource.actions.includes(action.value));
-    return selected.length ? [{ config, selected }] : [];
-  });
-
   const totalSelectedActions = resources.reduce(
     (count, resource) => count + resource.actions.length,
     0
@@ -616,108 +592,100 @@ export const RequestAccessForm = ({
         </div>
         <Field>
           <FieldLabel>Resources & Permissions</FieldLabel>
-<<<<<<< HEAD
-          <div className="flex flex-col gap-3 rounded-lg border border-border bg-black/20 p-3">
-=======
-          <div className="flex flex-col gap-3">
->>>>>>> parent of 2aafcb29de (add background for resources)
-            {resourceFields.map((resourceField, index) => {
-              const config = RESOURCE_CONFIGS.find((c) => c.subject === resourceField.subject);
-              if (!config) return null;
-              const selectedValues = resources[index]?.actions ?? [];
+          {resourceFields.map((resourceField, index) => {
+            const config = RESOURCE_CONFIGS.find((c) => c.subject === resourceField.subject);
+            if (!config) return null;
+            const selectedValues = resources[index]?.actions ?? [];
 
-              return (
-                <div
-                  key={resourceField.id}
-                  className="overflow-hidden rounded-lg border border-border bg-card"
+            return (
+              <div
+                key={resourceField.id}
+                className="overflow-hidden rounded-lg border border-border bg-card"
+              >
+                <div className="flex items-center gap-2.5 border-b border-border px-3 py-2.5">
+                  <div
+                    className={cn(
+                      "flex size-7 items-center justify-center rounded-md border",
+                      config.iconTileClassName
+                    )}
+                  >
+                    <config.Icon className="size-4" />
+                  </div>
+                  <span className="text-sm font-medium text-foreground">{config.label}</span>
+                  <IconButton
+                    size="xs"
+                    variant="ghost-muted"
+                    className="ml-auto"
+                    aria-label={`Remove ${config.label}`}
+                    onClick={() => removeResource(index)}
+                  >
+                    <XIcon />
+                  </IconButton>
+                </div>
+                <div className="flex flex-wrap gap-2 p-3">
+                  {config.actions.map((action) => {
+                    const isSelected = selectedValues.includes(action.value);
+
+                    return (
+                      <Tooltip key={action.value}>
+                        <TooltipTrigger asChild>
+                          <Button
+                            size="xs"
+                            variant={isSelected ? "project" : "outline"}
+                            aria-pressed={isSelected}
+                            onClick={() => toggleAction(index, action.value)}
+                            className={cn(
+                              "rounded-md",
+                              !isSelected && "text-muted hover:text-foreground"
+                            )}
+                          >
+                            <action.Icon />
+                            {action.label}
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>{action.description}</TooltipContent>
+                      </Tooltip>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+          {availableResources.length > 0 && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  isFullWidth
+                  className="border-dashed text-label hover:text-foreground"
                 >
-                  <div className="flex items-center gap-2.5 border-b border-border px-3 py-2.5">
+                  <PlusIcon />
+                  Add resource type
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="start"
+                className="w-(--radix-dropdown-menu-trigger-width)"
+              >
+                {availableResources.map((config) => (
+                  <DropdownMenuItem
+                    key={config.subject}
+                    onSelect={() => appendResource({ subject: config.subject, actions: [] })}
+                  >
                     <div
                       className={cn(
-                        "flex size-7 items-center justify-center rounded-md border",
+                        "flex size-6 items-center justify-center rounded-sm border",
                         config.iconTileClassName
                       )}
                     >
-                      <config.Icon className="size-4" />
+                      <config.Icon className="size-3.5" />
                     </div>
-                    <span className="text-sm font-medium text-foreground">{config.label}</span>
-                    <IconButton
-                      size="xs"
-                      variant="ghost-muted"
-                      className="ml-auto"
-                      aria-label={`Remove ${config.label}`}
-                      onClick={() => removeResource(index)}
-                    >
-                      <XIcon />
-                    </IconButton>
-                  </div>
-                  <div className="flex flex-wrap gap-2 p-3">
-                    {config.actions.map((action) => {
-                      const isSelected = selectedValues.includes(action.value);
-
-                      return (
-                        <Tooltip key={action.value}>
-                          <TooltipTrigger asChild>
-                            <Button
-                              size="xs"
-                              variant="outline"
-                              aria-pressed={isSelected}
-                              onClick={() => toggleAction(index, action.value)}
-                              className={cn(
-                                "rounded-md",
-                                isSelected
-                                  ? config.chipSelectedClassName
-                                  : "text-muted hover:text-foreground"
-                              )}
-                            >
-                              <action.Icon />
-                              {action.label}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>{action.description}</TooltipContent>
-                        </Tooltip>
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            })}
-            {availableResources.length > 0 && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="outline"
-                    isFullWidth
-                    className="border-dashed text-label hover:text-foreground"
-                  >
-                    <PlusIcon />
-                    Add resource type
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  align="start"
-                  className="w-(--radix-dropdown-menu-trigger-width)"
-                >
-                  {availableResources.map((config) => (
-                    <DropdownMenuItem
-                      key={config.subject}
-                      onSelect={() => appendResource({ subject: config.subject, actions: [] })}
-                    >
-                      <div
-                        className={cn(
-                          "flex size-6 items-center justify-center rounded-sm border",
-                          config.iconTileClassName
-                        )}
-                      >
-                        <config.Icon className="size-3.5" />
-                      </div>
-                      {config.label}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-          </div>
+                    {config.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </Field>
         <Controller
           control={form.control}
@@ -779,43 +747,6 @@ export const RequestAccessForm = ({
             </Field>
           )}
         />
-        <div className="flex flex-col gap-2.5 rounded-lg border border-border bg-black/20 p-3">
-          <span className="text-xs font-medium tracking-wider text-muted uppercase">
-            Request Summary
-          </span>
-          {summaryRows.length ? (
-            <div className="flex flex-col gap-2">
-              {summaryRows.map(({ config, selected }) => (
-                <HoverCard key={config.subject} openDelay={150}>
-                  <HoverCardTrigger asChild>
-                    <div className="flex items-center gap-2">
-                      <config.Icon className={cn("size-3.5", config.summaryIconClassName)} />
-                      <span className="text-sm text-foreground">{config.label}</span>
-                      <Badge className={cn("ml-auto rounded-full", config.countBadgeClassName)}>
-                        {selected.length} {selected.length === 1 ? "permission" : "permissions"}
-                      </Badge>
-                    </div>
-                  </HoverCardTrigger>
-                  <HoverCardContent align="end" className="flex w-56 flex-col gap-1.5">
-                    {selected.map((action) => (
-                      <div
-                        key={action.value}
-                        className="flex items-center gap-2 text-sm text-foreground"
-                      >
-                        <action.Icon className={cn("size-3.5", config.summaryIconClassName)} />
-                        {action.label}
-                      </div>
-                    ))}
-                  </HoverCardContent>
-                </HoverCard>
-              ))}
-            </div>
-          ) : (
-            <span className="text-sm text-muted">
-              No resources added yet. Add a resource type to begin.
-            </span>
-          )}
-        </div>
       </div>
       <SheetFooter className="border-t">
         <Button

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { formatDistance } from "date-fns";
 import {
   BanIcon,
+  ChevronDownIcon,
+  ClockIcon,
   EyeIcon,
   FingerprintIcon,
   FolderIcon,
@@ -32,7 +35,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Field,
-  FieldDescription,
   FieldError,
   FieldLabel,
   HoverCard,
@@ -40,6 +42,9 @@ import {
   HoverCardTrigger,
   IconButton,
   Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -65,19 +70,6 @@ import {
 } from "@app/context/ProjectPermissionContext/types";
 import { useCreateAccessRequest } from "@app/hooks/api";
 import { TAccessApprovalPolicy } from "@app/hooks/api/types";
-
-const PERMANENT_DURATION_VALUE = "permanent";
-const CUSTOM_DURATION_VALUE = "custom";
-
-const DURATION_PRESETS = [
-  { label: "30 minutes", value: "30m" },
-  { label: "1 hour", value: "1h" },
-  { label: "12 hours", value: "12h" },
-  { label: "1 day", value: "1d" },
-  { label: "3 days", value: "3d" },
-  { label: "7 days", value: "7d" },
-  { label: "30 days", value: "30d" }
-];
 
 type TResourceAction = {
   value: string;
@@ -353,27 +345,18 @@ const requestAccessSchema = z.object({
     .refine((resources) => resources.some((resource) => resource.actions.length > 0), {
       message: "Select at least one permission"
     }),
-  duration: z
-    .object({
-      preset: z.string().min(1),
-      customValue: z.string().optional()
-    })
-    .superRefine((val, ctx) => {
-      if (val.preset !== CUSTOM_DURATION_VALUE) return;
-      let parsed: number | undefined;
-      try {
-        parsed = val.customValue ? ms(val.customValue) : undefined;
-      } catch {
-        parsed = undefined;
-      }
-      if (typeof parsed !== "number" || parsed <= 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["customValue"],
-          message: "Invalid duration. Use formats like 30m, 2h, 1d."
-        });
-      }
+  temporaryAccess: z.discriminatedUnion("isTemporary", [
+    z.object({
+      isTemporary: z.literal(true),
+      temporaryRange: z.string().min(1),
+      temporaryAccessStartTime: z.string().datetime(),
+      temporaryAccessEndTime: z.string().datetime().nullable().optional()
     }),
+    z.object({
+      isTemporary: z.literal(false),
+      temporaryRange: z.string().optional()
+    })
+  ]),
   note: z.string().max(255).optional()
 });
 
@@ -400,7 +383,7 @@ export const RequestAccessForm = ({
       environmentSlug: currentProject.environments?.[0]?.slug,
       secretPath: initialSecretPath ?? "",
       resources: [{ subject: ProjectPermissionSub.Secrets, actions: selectedActions }],
-      duration: { preset: PERMANENT_DURATION_VALUE, customValue: "1h" },
+      temporaryAccess: { isTemporary: false, temporaryRange: "1h" },
       note: ""
     }
   });
@@ -414,7 +397,7 @@ export const RequestAccessForm = ({
   const selectedEnvironment = form.watch("environmentSlug");
   const secretPath = form.watch("secretPath");
   const resources = form.watch("resources");
-  const durationPreset = form.watch("duration.preset");
+  const temporaryAccessField = form.watch("temporaryAccess");
 
   const selectablePaths = useMemo(
     () =>
@@ -434,10 +417,10 @@ export const RequestAccessForm = ({
     [policies, selectedEnvironment, secretPath]
   );
 
-  const maxDurationMs = matchedPolicy?.maxTimePeriod ? ms(matchedPolicy.maxTimePeriod) : null;
-  const allowedPresets = maxDurationMs
-    ? DURATION_PRESETS.filter((preset) => ms(preset.value) <= maxDurationMs)
-    : DURATION_PRESETS;
+  const isTemporary = temporaryAccessField?.isTemporary;
+  const isExpired =
+    temporaryAccessField.isTemporary &&
+    new Date() > new Date(temporaryAccessField.temporaryAccessEndTime || "");
 
   const isInitialMount = useRef(true);
   useEffect(() => {
@@ -447,24 +430,6 @@ export const RequestAccessForm = ({
     }
     form.setValue("secretPath", "", { shouldValidate: true });
   }, [selectedEnvironment]);
-
-  // policies with a max time period forbid permanent access and cap the range
-  useEffect(() => {
-    if (!maxDurationMs || !matchedPolicy?.maxTimePeriod) return;
-    const { preset } = form.getValues("duration");
-    const exceedsMax =
-      preset === PERMANENT_DURATION_VALUE ||
-      (preset !== CUSTOM_DURATION_VALUE && ms(preset) > maxDurationMs);
-    if (!exceedsMax) return;
-    const fallback = allowedPresets[allowedPresets.length - 1];
-    form.setValue(
-      "duration",
-      fallback
-        ? { preset: fallback.value, customValue: form.getValues("duration.customValue") }
-        : { preset: CUSTOM_DURATION_VALUE, customValue: matchedPolicy.maxTimePeriod },
-      { shouldValidate: true }
-    );
-  }, [matchedPolicy]);
 
   const addedSubjects = new Set(resources.map((resource) => resource.subject));
   const availableResources = RESOURCE_CONFIGS.filter(
@@ -503,15 +468,13 @@ export const RequestAccessForm = ({
       return;
     }
 
-    const isTemporary = data.duration.preset !== PERMANENT_DURATION_VALUE;
-    const temporaryRange =
-      data.duration.preset === CUSTOM_DURATION_VALUE
-        ? data.duration.customValue
-        : data.duration.preset;
+    const { isTemporary: isTemporaryRequest, temporaryRange } = data.temporaryAccess;
 
     if (
       matchedPolicy?.maxTimePeriod &&
-      (!isTemporary || !temporaryRange || ms(temporaryRange) > ms(matchedPolicy.maxTimePeriod))
+      (!isTemporaryRequest ||
+        !temporaryRange ||
+        ms(temporaryRange) > ms(matchedPolicy.maxTimePeriod))
     ) {
       createNotification({
         type: "error",
@@ -531,8 +494,8 @@ export const RequestAccessForm = ({
 
     await requestAccess.mutateAsync({
       projectSlug: currentProject.slug,
-      isTemporary,
-      ...(isTemporary && temporaryRange && { temporaryRange }),
+      isTemporary: isTemporaryRequest,
+      ...(isTemporaryRequest && temporaryRange && { temporaryRange }),
       permissions,
       note: data.note || undefined
     });
@@ -543,6 +506,42 @@ export const RequestAccessForm = ({
     });
     form.reset();
     if (onClose) onClose();
+  };
+
+  const handleGrant = () => {
+    const temporaryRange = form.getValues("temporaryAccess.temporaryRange");
+    if (!temporaryRange) {
+      form.setError(
+        "temporaryAccess.temporaryRange",
+        { type: "required", message: "Required" },
+        { shouldFocus: true }
+      );
+      return;
+    }
+    form.clearErrors("temporaryAccess.temporaryRange");
+    form.setValue(
+      "temporaryAccess",
+      {
+        isTemporary: true,
+        temporaryAccessStartTime: new Date().toISOString(),
+        temporaryRange,
+        temporaryAccessEndTime: new Date(new Date().getTime() + ms(temporaryRange)).toISOString()
+      },
+      { shouldDirty: true }
+    );
+  };
+
+  const handleCancelTemporary = () => {
+    form.setValue("temporaryAccess", {
+      isTemporary: false,
+      temporaryRange: form.getValues("temporaryAccess.temporaryRange")
+    });
+  };
+
+  const getAccessLabel = () => {
+    if (isExpired) return "Access expired";
+    if (!temporaryAccessField?.isTemporary) return "Permanent";
+    return formatDistance(new Date(temporaryAccessField.temporaryAccessEndTime || ""), new Date());
   };
 
   return (
@@ -616,150 +615,152 @@ export const RequestAccessForm = ({
         </div>
         <Field>
           <FieldLabel>Resources & Permissions</FieldLabel>
-          <div className="flex flex-col gap-3">
-            {resourceFields.map((resourceField, index) => {
-              const config = RESOURCE_CONFIGS.find((c) => c.subject === resourceField.subject);
-              if (!config) return null;
-              const selectedValues = resources[index]?.actions ?? [];
+          <div className="rounded-lg border border-border bg-black/20 p-3">
+            <div className="flex flex-col gap-3">
+              {resourceFields.map((resourceField, index) => {
+                const config = RESOURCE_CONFIGS.find((c) => c.subject === resourceField.subject);
+                if (!config) return null;
+                const selectedValues = resources[index]?.actions ?? [];
 
-              return (
-                <div
-                  key={resourceField.id}
-                  className="overflow-hidden rounded-lg border border-border bg-card"
-                >
-                  <div className="flex items-center gap-2.5 border-b border-border px-3 py-2.5">
-                    <div
-                      className={cn(
-                        "flex size-7 items-center justify-center rounded-md border",
-                        config.iconTileClassName
-                      )}
-                    >
-                      <config.Icon className="size-4" />
-                    </div>
-                    <span className="text-sm font-medium text-foreground">{config.label}</span>
-                    <IconButton
-                      size="xs"
-                      variant="ghost-muted"
-                      className="ml-auto"
-                      aria-label={`Remove ${config.label}`}
-                      onClick={() => removeResource(index)}
-                    >
-                      <XIcon />
-                    </IconButton>
-                  </div>
-                  <div className="flex flex-wrap gap-2 p-3">
-                    {config.actions.map((action) => {
-                      const isSelected = selectedValues.includes(action.value);
-
-                      return (
-                        <Tooltip key={action.value}>
-                          <TooltipTrigger asChild>
-                            <Button
-                              size="xs"
-                              variant="outline"
-                              aria-pressed={isSelected}
-                              onClick={() => toggleAction(index, action.value)}
-                              className={cn(
-                                "rounded-md",
-                                isSelected
-                                  ? config.chipSelectedClassName
-                                  : "text-muted hover:text-foreground"
-                              )}
-                            >
-                              <action.Icon />
-                              {action.label}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent>{action.description}</TooltipContent>
-                        </Tooltip>
-                      );
-                    })}
-                  </div>
-                </div>
-              );
-            })}
-            {availableResources.length > 0 && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    variant="outline"
-                    isFullWidth
-                    className="border-dashed text-label hover:text-foreground"
+                return (
+                  <div
+                    key={resourceField.id}
+                    className="overflow-hidden rounded-lg border border-border bg-card"
                   >
-                    <PlusIcon />
-                    Add resource type
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  align="start"
-                  className="w-(--radix-dropdown-menu-trigger-width)"
-                >
-                  {availableResources.map((config) => (
-                    <DropdownMenuItem
-                      key={config.subject}
-                      onSelect={() => appendResource({ subject: config.subject, actions: [] })}
-                    >
+                    <div className="flex items-center gap-2.5 border-b border-border px-3 py-2.5">
                       <div
                         className={cn(
-                          "flex size-6 items-center justify-center rounded-sm border",
+                          "flex size-7 items-center justify-center rounded-md border",
                           config.iconTileClassName
                         )}
                       >
-                        <config.Icon className="size-3.5" />
+                        <config.Icon className="size-4" />
                       </div>
-                      {config.label}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
+                      <span className="text-sm font-medium text-foreground">{config.label}</span>
+                      <IconButton
+                        size="xs"
+                        variant="ghost-muted"
+                        className="ml-auto"
+                        aria-label={`Remove ${config.label}`}
+                        onClick={() => removeResource(index)}
+                      >
+                        <XIcon />
+                      </IconButton>
+                    </div>
+                    <div className="flex flex-wrap gap-2 p-3">
+                      {config.actions.map((action) => {
+                        const isSelected = selectedValues.includes(action.value);
+
+                        return (
+                          <Tooltip key={action.value}>
+                            <TooltipTrigger asChild>
+                              <Button
+                                size="xs"
+                                variant="outline"
+                                aria-pressed={isSelected}
+                                onClick={() => toggleAction(index, action.value)}
+                                className={cn(
+                                  "rounded-md",
+                                  isSelected
+                                    ? config.chipSelectedClassName
+                                    : "text-muted hover:text-foreground"
+                                )}
+                              >
+                                <action.Icon />
+                                {action.label}
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>{action.description}</TooltipContent>
+                          </Tooltip>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })}
+              {availableResources.length > 0 && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      isFullWidth
+                      className="border-dashed text-label hover:text-foreground"
+                    >
+                      <PlusIcon />
+                      Add resource type
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="start"
+                    className="w-(--radix-dropdown-menu-trigger-width)"
+                  >
+                    {availableResources.map((config) => (
+                      <DropdownMenuItem
+                        key={config.subject}
+                        onSelect={() => appendResource({ subject: config.subject, actions: [] })}
+                      >
+                        <div
+                          className={cn(
+                            "flex size-6 items-center justify-center rounded-sm border",
+                            config.iconTileClassName
+                          )}
+                        >
+                          <config.Icon className="size-3.5" />
+                        </div>
+                        {config.label}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
           </div>
         </Field>
-        <Controller
-          control={form.control}
-          name="duration.preset"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel htmlFor="duration">Duration</FieldLabel>
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger id="duration" className="w-full">
-                  <SelectValue placeholder="Select a duration" />
-                </SelectTrigger>
-                <SelectContent position="popper">
-                  {!maxDurationMs && (
-                    <SelectItem value={PERMANENT_DURATION_VALUE}>Permanent</SelectItem>
-                  )}
-                  {allowedPresets.map((preset) => (
-                    <SelectItem value={preset.value} key={preset.value}>
-                      {preset.label}
-                    </SelectItem>
-                  ))}
-                  <SelectItem value={CUSTOM_DURATION_VALUE}>Custom</SelectItem>
-                </SelectContent>
-              </Select>
-              {matchedPolicy?.maxTimePeriod && (
-                <FieldDescription>
-                  Maximum duration allowed by policy: {matchedPolicy.maxTimePeriod}
-                </FieldDescription>
+        <Field>
+          <FieldLabel>Duration</FieldLabel>
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="outline" className="w-full justify-between capitalize">
+                <span className="flex items-center gap-2">
+                  {isTemporary && <ClockIcon className="size-3.5" />}
+                  {getAccessLabel()}
+                </span>
+                <ChevronDownIcon className="size-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="flex flex-col gap-4">
+              <div className="text-sm text-foreground">Configure timed access</div>
+              {isExpired && (
+                <Badge variant="danger" className="w-fit">
+                  Expired
+                </Badge>
               )}
-            </Field>
-          )}
-        />
-        {durationPreset === CUSTOM_DURATION_VALUE && (
-          <Controller
-            control={form.control}
-            name="duration.customValue"
-            render={({ field, fieldState: { error } }) => (
-              <Field>
-                <FieldLabel htmlFor="customDuration">
-                  <TtlFormLabel label="Custom Duration" />
-                </FieldLabel>
-                <Input id="customDuration" {...field} isError={Boolean(error?.message)} />
-                <FieldError errors={[error]} />
-              </Field>
-            )}
-          />
-        )}
+              <Controller
+                control={form.control}
+                name="temporaryAccess.temporaryRange"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="temporaryRange">
+                      <TtlFormLabel label="Validity" />
+                    </FieldLabel>
+                    <Input id="temporaryRange" {...field} isError={Boolean(error?.message)} />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+              <div className="flex items-center gap-2">
+                <Button size="xs" variant="project" onClick={handleGrant}>
+                  Grant
+                </Button>
+                {temporaryAccessField.isTemporary && (
+                  <Button size="xs" variant="danger" onClick={handleCancelTemporary}>
+                    Cancel
+                  </Button>
+                )}
+              </div>
+            </PopoverContent>
+          </Popover>
+        </Field>
         <Controller
           control={form.control}
           name="note"

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -511,7 +511,7 @@ export const RequestAccessForm = ({
       isInitialMount.current = false;
       return;
     }
-    form.setValue("secretPath", "", { shouldValidate: true });
+    form.setValue("secretPath", "", { shouldValidate: form.formState.isSubmitted });
   }, [selectedEnvironment]);
 
   // policies with a max time period forbid permanent access and cap the range
@@ -534,10 +534,10 @@ export const RequestAccessForm = ({
       (config.subject !== ProjectPermissionSub.HoneyTokens || subscription?.honeyTokens)
   );
 
-  const totalSelectedActions = resources.reduce(
-    (count, resource) => count + resource.actions.length,
-    0
-  );
+  // The "select at least one permission" refine reports on the resources array itself,
+  // which per-field revalidation never reaches, so it's cleared manually in toggleAction.
+  const resourcesFieldError = form.formState.errors.resources;
+  const resourcesError = resourcesFieldError?.root ?? resourcesFieldError;
 
   const toggleAction = (index: number, actionValue: string) => {
     const current = form.getValues(`resources.${index}.actions`);
@@ -545,6 +545,9 @@ export const RequestAccessForm = ({
       ? current.filter((value) => value !== actionValue)
       : [...current, actionValue];
     form.setValue(`resources.${index}.actions`, next, { shouldDirty: true });
+    if (form.getValues("resources").some((resource) => resource.actions.length > 0)) {
+      form.clearErrors("resources");
+    }
   };
 
   const handleRequestAccess = async (data: TRequestAccessForm) => {
@@ -626,7 +629,7 @@ export const RequestAccessForm = ({
           <Controller
             control={form.control}
             name="secretPath"
-            render={({ field }) => {
+            render={({ field, fieldState: { error } }) => {
               const secretPathField = (
                 <Field>
                   <FieldLabel htmlFor="secretPath">Secret Path</FieldLabel>
@@ -635,7 +638,7 @@ export const RequestAccessForm = ({
                     onValueChange={field.onChange}
                     disabled={!selectablePaths.length}
                   >
-                    <SelectTrigger id="secretPath" className="w-full">
+                    <SelectTrigger id="secretPath" className="w-full" isError={Boolean(error)}>
                       <SelectValue placeholder="Select a secret path" />
                     </SelectTrigger>
                     <SelectContent position="popper">
@@ -646,6 +649,7 @@ export const RequestAccessForm = ({
                       ))}
                     </SelectContent>
                   </Select>
+                  <FieldError errors={[error]} />
                 </Field>
               );
 
@@ -760,6 +764,7 @@ export const RequestAccessForm = ({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
+          <FieldError errors={[resourcesError]} />
         </Field>
         <DurationField form={form} matchedPolicy={matchedPolicy} maxDurationMs={maxDurationMs} />
         <Controller
@@ -783,7 +788,6 @@ export const RequestAccessForm = ({
           type="submit"
           variant="project"
           isPending={form.formState.isSubmitting || requestAccess.isPending}
-          isDisabled={!policies.length || !secretPath || totalSelectedActions === 0}
         >
           Request Access
         </Button>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
+import {
+  Controller,
+  useFieldArray,
+  useForm,
+  UseFormReturn,
+  useFormState,
+  useWatch
+} from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   BanIcon,
@@ -67,15 +74,11 @@ import {
 import { useCreateAccessRequest } from "@app/hooks/api";
 import { TAccessApprovalPolicy } from "@app/hooks/api/types";
 
-const parseDurationMs = (value?: string) => {
-  if (!value) return undefined;
-  try {
-    const parsed = ms(value);
-    return typeof parsed === "number" && parsed > 0 ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
-};
+import { getAccessDurationLabel, parseAccessDurationMs } from "../AccessApprovalRequest.utils";
+
+const INVALID_DURATION_MESSAGE = "Invalid duration. Use formats like 30m, 2h, 1d.";
+const policyMaxDurationMessage = (maxTimePeriod: string) =>
+  `Requested access duration is limited to ${maxTimePeriod} by policy`;
 
 type TResourceAction = {
   value: string;
@@ -345,11 +348,11 @@ const requestAccessSchema = z.object({
     })
     .superRefine((val, ctx) => {
       if (!val.isTemporary) return;
-      if (!parseDurationMs(val.temporaryRange)) {
+      if (!parseAccessDurationMs(val.temporaryRange)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["temporaryRange"],
-          message: "Invalid duration. Use formats like 30m, 2h, 1d."
+          message: INVALID_DURATION_MESSAGE
         });
       }
     }),
@@ -357,6 +360,100 @@ const requestAccessSchema = z.object({
 });
 
 type TRequestAccessForm = z.infer<typeof requestAccessSchema>;
+
+// Self-contained so keystrokes in the Validity input only re-render this field,
+// not the whole form (resource cards, selects, note) above it.
+const DurationField = ({
+  form,
+  matchedPolicy,
+  maxDurationMs
+}: {
+  form: UseFormReturn<TRequestAccessForm>;
+  matchedPolicy?: TAccessApprovalPolicy;
+  maxDurationMs: number | null;
+}) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+  const duration = useWatch({ control: form.control, name: "duration" });
+  const { errors } = useFormState({ control: form.control, name: "duration" });
+
+  const handleGrantTemporaryAccess = () => {
+    const rangeMs = parseAccessDurationMs(form.getValues("duration.temporaryRange"));
+    if (!rangeMs) {
+      form.setError(
+        "duration.temporaryRange",
+        { type: "custom", message: INVALID_DURATION_MESSAGE },
+        { shouldFocus: true }
+      );
+      return;
+    }
+    if (maxDurationMs && matchedPolicy?.maxTimePeriod && rangeMs > maxDurationMs) {
+      form.setError(
+        "duration.temporaryRange",
+        { type: "custom", message: policyMaxDurationMessage(matchedPolicy.maxTimePeriod) },
+        { shouldFocus: true }
+      );
+      return;
+    }
+    form.clearErrors("duration.temporaryRange");
+    form.setValue("duration.isTemporary", true, { shouldDirty: true });
+    setIsPopoverOpen(false);
+  };
+
+  const handleCancelTemporaryAccess = () => {
+    form.clearErrors("duration.temporaryRange");
+    form.setValue("duration.isTemporary", false, { shouldDirty: true });
+    setIsPopoverOpen(false);
+  };
+
+  return (
+    <Field>
+      <FieldLabel>Duration</FieldLabel>
+      <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
+        <PopoverTrigger asChild>
+          <Button variant="outline" className="w-full justify-between">
+            <span className="flex items-center gap-2">
+              {duration.isTemporary && <ClockIcon className="size-3.5" />}
+              {getAccessDurationLabel(duration.isTemporary, duration.temporaryRange)}
+            </span>
+            <ChevronDownIcon className="size-3.5" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="flex flex-col gap-4">
+          <div className="text-sm text-foreground">Configure timed access</div>
+          <Controller
+            control={form.control}
+            name="duration.temporaryRange"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="temporaryRange">
+                  <TtlFormLabel label="Validity" />
+                </FieldLabel>
+                <Input id="temporaryRange" {...field} isError={Boolean(error?.message)} />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+          <div className="flex items-center gap-2">
+            <Button size="xs" variant="project" onClick={handleGrantTemporaryAccess}>
+              Grant
+            </Button>
+            {duration.isTemporary && !maxDurationMs && (
+              <Button size="xs" variant="danger" onClick={handleCancelTemporaryAccess}>
+                Cancel
+              </Button>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+      {!isPopoverOpen && <FieldError errors={[errors.duration?.temporaryRange]} />}
+      {matchedPolicy?.maxTimePeriod && (
+        <FieldDescription>
+          Maximum duration allowed by policy: {matchedPolicy.maxTimePeriod}
+        </FieldDescription>
+      )}
+    </Field>
+  );
+};
 
 export const RequestAccessForm = ({
   policies,
@@ -401,8 +498,6 @@ export const RequestAccessForm = ({
   const selectedEnvironment = form.watch("environmentSlug");
   const secretPath = form.watch("secretPath");
   const resources = form.watch("resources");
-  const duration = form.watch("duration");
-  const [isDurationPopoverOpen, setIsDurationPopoverOpen] = useState(false);
 
   const selectablePaths = useMemo(
     () =>
@@ -437,7 +532,7 @@ export const RequestAccessForm = ({
   useEffect(() => {
     if (!maxDurationMs || !matchedPolicy?.maxTimePeriod) return;
     const { isTemporary, temporaryRange } = form.getValues("duration");
-    const rangeMs = parseDurationMs(temporaryRange);
+    const rangeMs = parseAccessDurationMs(temporaryRange);
     if (isTemporary && rangeMs && rangeMs <= maxDurationMs) return;
     form.setValue(
       "duration",
@@ -466,45 +561,6 @@ export const RequestAccessForm = ({
     form.setValue(`resources.${index}.actions`, next, { shouldDirty: true });
   };
 
-  const getAccessLabel = () => {
-    if (!duration.isTemporary || !duration.temporaryRange) return "Permanent";
-    const rangeMs = parseDurationMs(duration.temporaryRange);
-    if (!rangeMs) return `Valid for ${duration.temporaryRange} after approval`;
-    return `Valid for ${ms(rangeMs, { long: true })} after approval`;
-  };
-
-  const handleGrantTemporaryAccess = () => {
-    const rangeMs = parseDurationMs(form.getValues("duration.temporaryRange"));
-    if (!rangeMs) {
-      form.setError(
-        "duration.temporaryRange",
-        { type: "custom", message: "Invalid duration. Use formats like 30m, 2h, 1d." },
-        { shouldFocus: true }
-      );
-      return;
-    }
-    if (maxDurationMs && rangeMs > maxDurationMs) {
-      form.setError(
-        "duration.temporaryRange",
-        {
-          type: "custom",
-          message: `Duration cannot exceed the policy maximum of ${matchedPolicy?.maxTimePeriod}.`
-        },
-        { shouldFocus: true }
-      );
-      return;
-    }
-    form.clearErrors("duration.temporaryRange");
-    form.setValue("duration.isTemporary", true, { shouldDirty: true });
-    setIsDurationPopoverOpen(false);
-  };
-
-  const handleCancelTemporaryAccess = () => {
-    form.clearErrors("duration.temporaryRange");
-    form.setValue("duration.isTemporary", false, { shouldDirty: true });
-    setIsDurationPopoverOpen(false);
-  };
-
   const handleRequestAccess = async (data: TRequestAccessForm) => {
     if (!currentProject) {
       createNotification({
@@ -523,7 +579,7 @@ export const RequestAccessForm = ({
     ) {
       createNotification({
         type: "error",
-        text: `Requested access time range is limited to ${matchedPolicy.maxTimePeriod} by policy`,
+        text: policyMaxDurationMessage(matchedPolicy.maxTimePeriod),
         title: "Error"
       });
       return;
@@ -719,54 +775,7 @@ export const RequestAccessForm = ({
             </DropdownMenu>
           )}
         </Field>
-        <Field>
-          <FieldLabel>Duration</FieldLabel>
-          <Popover open={isDurationPopoverOpen} onOpenChange={setIsDurationPopoverOpen}>
-            <PopoverTrigger asChild>
-              <Button variant="outline" className="w-full justify-between">
-                <span className="flex items-center gap-2">
-                  {duration.isTemporary && <ClockIcon className="size-3.5" />}
-                  {getAccessLabel()}
-                </span>
-                <ChevronDownIcon className="size-3.5" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="flex flex-col gap-4">
-              <div className="text-sm text-foreground">Configure timed access</div>
-              <Controller
-                control={form.control}
-                name="duration.temporaryRange"
-                render={({ field, fieldState: { error } }) => (
-                  <Field>
-                    <FieldLabel htmlFor="temporaryRange">
-                      <TtlFormLabel label="Validity" />
-                    </FieldLabel>
-                    <Input id="temporaryRange" {...field} isError={Boolean(error?.message)} />
-                    <FieldError errors={[error]} />
-                  </Field>
-                )}
-              />
-              <div className="flex items-center gap-2">
-                <Button size="xs" variant="project" onClick={handleGrantTemporaryAccess}>
-                  Grant
-                </Button>
-                {duration.isTemporary && !maxDurationMs && (
-                  <Button size="xs" variant="danger" onClick={handleCancelTemporaryAccess}>
-                    Cancel
-                  </Button>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-          {!isDurationPopoverOpen && (
-            <FieldError errors={[form.formState.errors.duration?.temporaryRange]} />
-          )}
-          {matchedPolicy?.maxTimePeriod && (
-            <FieldDescription>
-              Maximum duration allowed by policy: {matchedPolicy.maxTimePeriod}
-            </FieldDescription>
-          )}
-        </Field>
+        <DurationField form={form} matchedPolicy={matchedPolicy} maxDurationMs={maxDurationMs} />
         <Controller
           control={form.control}
           name="note"

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -1,11 +1,8 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { formatDistance } from "date-fns";
 import {
   BanIcon,
-  ChevronDownIcon,
-  ClockIcon,
   EyeIcon,
   FingerprintIcon,
   FolderIcon,
@@ -35,6 +32,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   Field,
+  FieldDescription,
   FieldError,
   FieldLabel,
   HoverCard,
@@ -42,9 +40,6 @@ import {
   HoverCardTrigger,
   IconButton,
   Input,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -70,6 +65,19 @@ import {
 } from "@app/context/ProjectPermissionContext/types";
 import { useCreateAccessRequest } from "@app/hooks/api";
 import { TAccessApprovalPolicy } from "@app/hooks/api/types";
+
+const PERMANENT_DURATION_VALUE = "permanent";
+const CUSTOM_DURATION_VALUE = "custom";
+
+const DURATION_PRESETS = [
+  { label: "30 minutes", value: "30m" },
+  { label: "1 hour", value: "1h" },
+  { label: "12 hours", value: "12h" },
+  { label: "1 day", value: "1d" },
+  { label: "3 days", value: "3d" },
+  { label: "7 days", value: "7d" },
+  { label: "30 days", value: "30d" }
+];
 
 type TResourceAction = {
   value: string;
@@ -345,18 +353,27 @@ const requestAccessSchema = z.object({
     .refine((resources) => resources.some((resource) => resource.actions.length > 0), {
       message: "Select at least one permission"
     }),
-  temporaryAccess: z.discriminatedUnion("isTemporary", [
-    z.object({
-      isTemporary: z.literal(true),
-      temporaryRange: z.string().min(1),
-      temporaryAccessStartTime: z.string().datetime(),
-      temporaryAccessEndTime: z.string().datetime().nullable().optional()
-    }),
-    z.object({
-      isTemporary: z.literal(false),
-      temporaryRange: z.string().optional()
+  duration: z
+    .object({
+      preset: z.string().min(1),
+      customValue: z.string().optional()
     })
-  ]),
+    .superRefine((val, ctx) => {
+      if (val.preset !== CUSTOM_DURATION_VALUE) return;
+      let parsed: number | undefined;
+      try {
+        parsed = val.customValue ? ms(val.customValue) : undefined;
+      } catch {
+        parsed = undefined;
+      }
+      if (typeof parsed !== "number" || parsed <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["customValue"],
+          message: "Invalid duration. Use formats like 30m, 2h, 1d."
+        });
+      }
+    }),
   note: z.string().max(255).optional()
 });
 
@@ -383,7 +400,7 @@ export const RequestAccessForm = ({
       environmentSlug: currentProject.environments?.[0]?.slug,
       secretPath: initialSecretPath ?? "",
       resources: [{ subject: ProjectPermissionSub.Secrets, actions: selectedActions }],
-      temporaryAccess: { isTemporary: false, temporaryRange: "1h" },
+      duration: { preset: PERMANENT_DURATION_VALUE, customValue: "1h" },
       note: ""
     }
   });
@@ -397,7 +414,7 @@ export const RequestAccessForm = ({
   const selectedEnvironment = form.watch("environmentSlug");
   const secretPath = form.watch("secretPath");
   const resources = form.watch("resources");
-  const temporaryAccessField = form.watch("temporaryAccess");
+  const durationPreset = form.watch("duration.preset");
 
   const selectablePaths = useMemo(
     () =>
@@ -417,10 +434,10 @@ export const RequestAccessForm = ({
     [policies, selectedEnvironment, secretPath]
   );
 
-  const isTemporary = temporaryAccessField?.isTemporary;
-  const isExpired =
-    temporaryAccessField.isTemporary &&
-    new Date() > new Date(temporaryAccessField.temporaryAccessEndTime || "");
+  const maxDurationMs = matchedPolicy?.maxTimePeriod ? ms(matchedPolicy.maxTimePeriod) : null;
+  const allowedPresets = maxDurationMs
+    ? DURATION_PRESETS.filter((preset) => ms(preset.value) <= maxDurationMs)
+    : DURATION_PRESETS;
 
   const isInitialMount = useRef(true);
   useEffect(() => {
@@ -430,6 +447,24 @@ export const RequestAccessForm = ({
     }
     form.setValue("secretPath", "", { shouldValidate: true });
   }, [selectedEnvironment]);
+
+  // policies with a max time period forbid permanent access and cap the range
+  useEffect(() => {
+    if (!maxDurationMs || !matchedPolicy?.maxTimePeriod) return;
+    const { preset } = form.getValues("duration");
+    const exceedsMax =
+      preset === PERMANENT_DURATION_VALUE ||
+      (preset !== CUSTOM_DURATION_VALUE && ms(preset) > maxDurationMs);
+    if (!exceedsMax) return;
+    const fallback = allowedPresets[allowedPresets.length - 1];
+    form.setValue(
+      "duration",
+      fallback
+        ? { preset: fallback.value, customValue: form.getValues("duration.customValue") }
+        : { preset: CUSTOM_DURATION_VALUE, customValue: matchedPolicy.maxTimePeriod },
+      { shouldValidate: true }
+    );
+  }, [matchedPolicy]);
 
   const addedSubjects = new Set(resources.map((resource) => resource.subject));
   const availableResources = RESOURCE_CONFIGS.filter(
@@ -468,13 +503,15 @@ export const RequestAccessForm = ({
       return;
     }
 
-    const { isTemporary: isTemporaryRequest, temporaryRange } = data.temporaryAccess;
+    const isTemporary = data.duration.preset !== PERMANENT_DURATION_VALUE;
+    const temporaryRange =
+      data.duration.preset === CUSTOM_DURATION_VALUE
+        ? data.duration.customValue
+        : data.duration.preset;
 
     if (
       matchedPolicy?.maxTimePeriod &&
-      (!isTemporaryRequest ||
-        !temporaryRange ||
-        ms(temporaryRange) > ms(matchedPolicy.maxTimePeriod))
+      (!isTemporary || !temporaryRange || ms(temporaryRange) > ms(matchedPolicy.maxTimePeriod))
     ) {
       createNotification({
         type: "error",
@@ -494,8 +531,8 @@ export const RequestAccessForm = ({
 
     await requestAccess.mutateAsync({
       projectSlug: currentProject.slug,
-      isTemporary: isTemporaryRequest,
-      ...(isTemporaryRequest && temporaryRange && { temporaryRange }),
+      isTemporary,
+      ...(isTemporary && temporaryRange && { temporaryRange }),
       permissions,
       note: data.note || undefined
     });
@@ -506,42 +543,6 @@ export const RequestAccessForm = ({
     });
     form.reset();
     if (onClose) onClose();
-  };
-
-  const handleGrant = () => {
-    const temporaryRange = form.getValues("temporaryAccess.temporaryRange");
-    if (!temporaryRange) {
-      form.setError(
-        "temporaryAccess.temporaryRange",
-        { type: "required", message: "Required" },
-        { shouldFocus: true }
-      );
-      return;
-    }
-    form.clearErrors("temporaryAccess.temporaryRange");
-    form.setValue(
-      "temporaryAccess",
-      {
-        isTemporary: true,
-        temporaryAccessStartTime: new Date().toISOString(),
-        temporaryRange,
-        temporaryAccessEndTime: new Date(new Date().getTime() + ms(temporaryRange)).toISOString()
-      },
-      { shouldDirty: true }
-    );
-  };
-
-  const handleCancelTemporary = () => {
-    form.setValue("temporaryAccess", {
-      isTemporary: false,
-      temporaryRange: form.getValues("temporaryAccess.temporaryRange")
-    });
-  };
-
-  const getAccessLabel = () => {
-    if (isExpired) return "Access expired";
-    if (!temporaryAccessField?.isTemporary) return "Permanent";
-    return formatDistance(new Date(temporaryAccessField.temporaryAccessEndTime || ""), new Date());
   };
 
   return (
@@ -615,7 +616,11 @@ export const RequestAccessForm = ({
         </div>
         <Field>
           <FieldLabel>Resources & Permissions</FieldLabel>
+<<<<<<< HEAD
           <div className="flex flex-col gap-3 rounded-lg border border-border bg-black/20 p-3">
+=======
+          <div className="flex flex-col gap-3">
+>>>>>>> parent of 2aafcb29de (add background for resources)
             {resourceFields.map((resourceField, index) => {
               const config = RESOURCE_CONFIGS.find((c) => c.subject === resourceField.subject);
               if (!config) return null;
@@ -714,51 +719,51 @@ export const RequestAccessForm = ({
             )}
           </div>
         </Field>
-        <Field>
-          <FieldLabel>Duration</FieldLabel>
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button variant="outline" className="w-full justify-between capitalize">
-                <span className="flex items-center gap-2">
-                  {isTemporary && <ClockIcon className="size-3.5" />}
-                  {getAccessLabel()}
-                </span>
-                <ChevronDownIcon className="size-3.5" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="flex flex-col gap-4">
-              <div className="text-sm text-foreground">Configure timed access</div>
-              {isExpired && (
-                <Badge variant="danger" className="w-fit">
-                  Expired
-                </Badge>
+        <Controller
+          control={form.control}
+          name="duration.preset"
+          render={({ field }) => (
+            <Field>
+              <FieldLabel htmlFor="duration">Duration</FieldLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <SelectTrigger id="duration" className="w-full">
+                  <SelectValue placeholder="Select a duration" />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {!maxDurationMs && (
+                    <SelectItem value={PERMANENT_DURATION_VALUE}>Permanent</SelectItem>
+                  )}
+                  {allowedPresets.map((preset) => (
+                    <SelectItem value={preset.value} key={preset.value}>
+                      {preset.label}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value={CUSTOM_DURATION_VALUE}>Custom</SelectItem>
+                </SelectContent>
+              </Select>
+              {matchedPolicy?.maxTimePeriod && (
+                <FieldDescription>
+                  Maximum duration allowed by policy: {matchedPolicy.maxTimePeriod}
+                </FieldDescription>
               )}
-              <Controller
-                control={form.control}
-                name="temporaryAccess.temporaryRange"
-                render={({ field, fieldState: { error } }) => (
-                  <Field>
-                    <FieldLabel htmlFor="temporaryRange">
-                      <TtlFormLabel label="Validity" />
-                    </FieldLabel>
-                    <Input id="temporaryRange" {...field} isError={Boolean(error?.message)} />
-                    <FieldError errors={[error]} />
-                  </Field>
-                )}
-              />
-              <div className="flex items-center gap-2">
-                <Button size="xs" variant="project" onClick={handleGrant}>
-                  Grant
-                </Button>
-                {temporaryAccessField.isTemporary && (
-                  <Button size="xs" variant="danger" onClick={handleCancelTemporary}>
-                    Cancel
-                  </Button>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        </Field>
+            </Field>
+          )}
+        />
+        {durationPreset === CUSTOM_DURATION_VALUE && (
+          <Controller
+            control={form.control}
+            name="duration.customValue"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="customDuration">
+                  <TtlFormLabel label="Custom Duration" />
+                </FieldLabel>
+                <Input id="customDuration" {...field} isError={Boolean(error?.message)} />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+        )}
         <Controller
           control={form.control}
           name="note"

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -365,6 +365,7 @@ type TRequestAccessForm = z.infer<typeof requestAccessSchema>;
 export const RequestAccessForm = ({
   policies,
   onClose,
+  onDirtyChange,
   selectedActions = [],
   secretPath: initialSecretPath
 }: {
@@ -372,6 +373,7 @@ export const RequestAccessForm = ({
   selectedActions?: ProjectPermissionActions[];
   secretPath?: string;
   onClose?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
 }) => {
   const { currentProject } = useProject();
   const { subscription } = useSubscription();
@@ -387,6 +389,10 @@ export const RequestAccessForm = ({
       note: ""
     }
   });
+
+  useEffect(() => {
+    onDirtyChange?.(form.formState.isDirty);
+  }, [form.formState.isDirty, onDirtyChange]);
 
   const {
     fields: resourceFields,

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -93,8 +93,6 @@ type TResourceConfig = {
   Icon: LucideIcon;
   // Tailwind extracts classes statically, so every tint must be a full literal string
   iconTileClassName: string;
-  countBadgeClassName: string;
-  summaryIconClassName: string;
   actions: TResourceAction[];
 };
 
@@ -104,8 +102,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Secrets",
     Icon: KeyIcon,
     iconTileClassName: "border-accent/10 bg-accent/15 text-accent",
-    countBadgeClassName: "border-accent/10 bg-accent/15 text-accent",
-    summaryIconClassName: "text-accent",
     actions: [
       {
         value: ProjectPermissionActions.Read,
@@ -138,8 +134,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Folders",
     Icon: FolderIcon,
     iconTileClassName: "border-folder/10 bg-folder/15 text-folder",
-    countBadgeClassName: "border-folder/10 bg-folder/15 text-folder",
-    summaryIconClassName: "text-folder",
     actions: [
       {
         value: ProjectPermissionActions.Create,
@@ -166,8 +160,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Dynamic Secrets",
     Icon: FingerprintIcon,
     iconTileClassName: "border-dynamic-secret/10 bg-dynamic-secret/15 text-dynamic-secret",
-    countBadgeClassName: "border-dynamic-secret/10 bg-dynamic-secret/15 text-dynamic-secret",
-    summaryIconClassName: "text-dynamic-secret",
     actions: [
       {
         value: ProjectPermissionDynamicSecretActions.ReadRootCredential,
@@ -206,8 +198,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Secret Rotation",
     Icon: RefreshCwIcon,
     iconTileClassName: "border-secret-rotation/10 bg-secret-rotation/15 text-secret-rotation",
-    countBadgeClassName: "border-secret-rotation/10 bg-secret-rotation/15 text-secret-rotation",
-    summaryIconClassName: "text-secret-rotation",
     actions: [
       {
         value: ProjectPermissionSecretRotationActions.Read,
@@ -252,8 +242,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Secret Imports",
     Icon: ImportIcon,
     iconTileClassName: "border-import/10 bg-import/15 text-import",
-    countBadgeClassName: "border-import/10 bg-import/15 text-import",
-    summaryIconClassName: "text-import",
     actions: [
       {
         value: ProjectPermissionActions.Read,
@@ -286,8 +274,6 @@ const RESOURCE_CONFIGS: TResourceConfig[] = [
     label: "Honey Tokens",
     Icon: HexagonIcon,
     iconTileClassName: "border-yellow-700/10 bg-yellow-700/15 text-yellow-700",
-    countBadgeClassName: "border-yellow-700/10 bg-yellow-700/15 text-yellow-700",
-    summaryIconClassName: "text-yellow-700",
     actions: [
       {
         value: ProjectPermissionHoneyTokenActions.Read,

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -365,6 +365,7 @@ type TRequestAccessForm = z.infer<typeof requestAccessSchema>;
 export const RequestAccessForm = ({
   policies,
   onClose,
+  onSuccess,
   onDirtyChange,
   selectedActions = [],
   secretPath: initialSecretPath
@@ -373,6 +374,7 @@ export const RequestAccessForm = ({
   selectedActions?: ProjectPermissionActions[];
   secretPath?: string;
   onClose?: () => void;
+  onSuccess?: () => void;
   onDirtyChange?: (isDirty: boolean) => void;
 }) => {
   const { currentProject } = useProject();
@@ -524,7 +526,7 @@ export const RequestAccessForm = ({
       text: "Successfully requested access"
     });
     form.reset();
-    if (onClose) onClose();
+    onSuccess?.();
   };
 
   return (

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   BanIcon,
+  ChevronDownIcon,
+  ClockIcon,
   EyeIcon,
   FingerprintIcon,
   FolderIcon,
@@ -36,6 +38,9 @@ import {
   FieldLabel,
   IconButton,
   Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -62,18 +67,15 @@ import {
 import { useCreateAccessRequest } from "@app/hooks/api";
 import { TAccessApprovalPolicy } from "@app/hooks/api/types";
 
-const PERMANENT_DURATION_VALUE = "permanent";
-const CUSTOM_DURATION_VALUE = "custom";
-
-const DURATION_PRESETS = [
-  { label: "30 minutes", value: "30m" },
-  { label: "1 hour", value: "1h" },
-  { label: "12 hours", value: "12h" },
-  { label: "1 day", value: "1d" },
-  { label: "3 days", value: "3d" },
-  { label: "7 days", value: "7d" },
-  { label: "30 days", value: "30d" }
-];
+const parseDurationMs = (value?: string) => {
+  if (!value) return undefined;
+  try {
+    const parsed = ms(value);
+    return typeof parsed === "number" && parsed > 0 ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+};
 
 type TResourceAction = {
   value: string;
@@ -338,21 +340,15 @@ const requestAccessSchema = z.object({
     }),
   duration: z
     .object({
-      preset: z.string().min(1),
-      customValue: z.string().optional()
+      isTemporary: z.boolean(),
+      temporaryRange: z.string().optional()
     })
     .superRefine((val, ctx) => {
-      if (val.preset !== CUSTOM_DURATION_VALUE) return;
-      let parsed: number | undefined;
-      try {
-        parsed = val.customValue ? ms(val.customValue) : undefined;
-      } catch {
-        parsed = undefined;
-      }
-      if (typeof parsed !== "number" || parsed <= 0) {
+      if (!val.isTemporary) return;
+      if (!parseDurationMs(val.temporaryRange)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ["customValue"],
+          path: ["temporaryRange"],
           message: "Invalid duration. Use formats like 30m, 2h, 1d."
         });
       }
@@ -387,7 +383,7 @@ export const RequestAccessForm = ({
       environmentSlug: currentProject.environments?.[0]?.slug,
       secretPath: initialSecretPath ?? "",
       resources: [{ subject: ProjectPermissionSub.Secrets, actions: selectedActions }],
-      duration: { preset: PERMANENT_DURATION_VALUE, customValue: "1h" },
+      duration: { isTemporary: false, temporaryRange: "1h" },
       note: ""
     }
   });
@@ -405,7 +401,8 @@ export const RequestAccessForm = ({
   const selectedEnvironment = form.watch("environmentSlug");
   const secretPath = form.watch("secretPath");
   const resources = form.watch("resources");
-  const durationPreset = form.watch("duration.preset");
+  const duration = form.watch("duration");
+  const [isDurationPopoverOpen, setIsDurationPopoverOpen] = useState(false);
 
   const selectablePaths = useMemo(
     () =>
@@ -426,9 +423,6 @@ export const RequestAccessForm = ({
   );
 
   const maxDurationMs = matchedPolicy?.maxTimePeriod ? ms(matchedPolicy.maxTimePeriod) : null;
-  const allowedPresets = maxDurationMs
-    ? DURATION_PRESETS.filter((preset) => ms(preset.value) <= maxDurationMs)
-    : DURATION_PRESETS;
 
   const isInitialMount = useRef(true);
   useEffect(() => {
@@ -442,17 +436,12 @@ export const RequestAccessForm = ({
   // policies with a max time period forbid permanent access and cap the range
   useEffect(() => {
     if (!maxDurationMs || !matchedPolicy?.maxTimePeriod) return;
-    const { preset } = form.getValues("duration");
-    const exceedsMax =
-      preset === PERMANENT_DURATION_VALUE ||
-      (preset !== CUSTOM_DURATION_VALUE && ms(preset) > maxDurationMs);
-    if (!exceedsMax) return;
-    const fallback = allowedPresets[allowedPresets.length - 1];
+    const { isTemporary, temporaryRange } = form.getValues("duration");
+    const rangeMs = parseDurationMs(temporaryRange);
+    if (isTemporary && rangeMs && rangeMs <= maxDurationMs) return;
     form.setValue(
       "duration",
-      fallback
-        ? { preset: fallback.value, customValue: form.getValues("duration.customValue") }
-        : { preset: CUSTOM_DURATION_VALUE, customValue: matchedPolicy.maxTimePeriod },
+      { isTemporary: true, temporaryRange: matchedPolicy.maxTimePeriod },
       { shouldValidate: true }
     );
   }, [matchedPolicy]);
@@ -477,6 +466,45 @@ export const RequestAccessForm = ({
     form.setValue(`resources.${index}.actions`, next, { shouldDirty: true });
   };
 
+  const getAccessLabel = () => {
+    if (!duration.isTemporary || !duration.temporaryRange) return "Permanent";
+    const rangeMs = parseDurationMs(duration.temporaryRange);
+    if (!rangeMs) return `Valid for ${duration.temporaryRange} after approval`;
+    return `Valid for ${ms(rangeMs, { long: true })} after approval`;
+  };
+
+  const handleGrantTemporaryAccess = () => {
+    const rangeMs = parseDurationMs(form.getValues("duration.temporaryRange"));
+    if (!rangeMs) {
+      form.setError(
+        "duration.temporaryRange",
+        { type: "custom", message: "Invalid duration. Use formats like 30m, 2h, 1d." },
+        { shouldFocus: true }
+      );
+      return;
+    }
+    if (maxDurationMs && rangeMs > maxDurationMs) {
+      form.setError(
+        "duration.temporaryRange",
+        {
+          type: "custom",
+          message: `Duration cannot exceed the policy maximum of ${matchedPolicy?.maxTimePeriod}.`
+        },
+        { shouldFocus: true }
+      );
+      return;
+    }
+    form.clearErrors("duration.temporaryRange");
+    form.setValue("duration.isTemporary", true, { shouldDirty: true });
+    setIsDurationPopoverOpen(false);
+  };
+
+  const handleCancelTemporaryAccess = () => {
+    form.clearErrors("duration.temporaryRange");
+    form.setValue("duration.isTemporary", false, { shouldDirty: true });
+    setIsDurationPopoverOpen(false);
+  };
+
   const handleRequestAccess = async (data: TRequestAccessForm) => {
     if (!currentProject) {
       createNotification({
@@ -487,11 +515,7 @@ export const RequestAccessForm = ({
       return;
     }
 
-    const isTemporary = data.duration.preset !== PERMANENT_DURATION_VALUE;
-    const temporaryRange =
-      data.duration.preset === CUSTOM_DURATION_VALUE
-        ? data.duration.customValue
-        : data.duration.preset;
+    const { isTemporary, temporaryRange } = data.duration;
 
     if (
       matchedPolicy?.maxTimePeriod &&
@@ -695,51 +719,54 @@ export const RequestAccessForm = ({
             </DropdownMenu>
           )}
         </Field>
-        <Controller
-          control={form.control}
-          name="duration.preset"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel htmlFor="duration">Duration</FieldLabel>
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger id="duration" className="w-full">
-                  <SelectValue placeholder="Select a duration" />
-                </SelectTrigger>
-                <SelectContent position="popper">
-                  {!maxDurationMs && (
-                    <SelectItem value={PERMANENT_DURATION_VALUE}>Permanent</SelectItem>
-                  )}
-                  {allowedPresets.map((preset) => (
-                    <SelectItem value={preset.value} key={preset.value}>
-                      {preset.label}
-                    </SelectItem>
-                  ))}
-                  <SelectItem value={CUSTOM_DURATION_VALUE}>Custom</SelectItem>
-                </SelectContent>
-              </Select>
-              {matchedPolicy?.maxTimePeriod && (
-                <FieldDescription>
-                  Maximum duration allowed by policy: {matchedPolicy.maxTimePeriod}
-                </FieldDescription>
-              )}
-            </Field>
+        <Field>
+          <FieldLabel>Duration</FieldLabel>
+          <Popover open={isDurationPopoverOpen} onOpenChange={setIsDurationPopoverOpen}>
+            <PopoverTrigger asChild>
+              <Button variant="outline" className="w-full justify-between">
+                <span className="flex items-center gap-2">
+                  {duration.isTemporary && <ClockIcon className="size-3.5" />}
+                  {getAccessLabel()}
+                </span>
+                <ChevronDownIcon className="size-3.5" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="flex flex-col gap-4">
+              <div className="text-sm text-foreground">Configure timed access</div>
+              <Controller
+                control={form.control}
+                name="duration.temporaryRange"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="temporaryRange">
+                      <TtlFormLabel label="Validity" />
+                    </FieldLabel>
+                    <Input id="temporaryRange" {...field} isError={Boolean(error?.message)} />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+              <div className="flex items-center gap-2">
+                <Button size="xs" variant="project" onClick={handleGrantTemporaryAccess}>
+                  Grant
+                </Button>
+                {duration.isTemporary && !maxDurationMs && (
+                  <Button size="xs" variant="danger" onClick={handleCancelTemporaryAccess}>
+                    Cancel
+                  </Button>
+                )}
+              </div>
+            </PopoverContent>
+          </Popover>
+          {!isDurationPopoverOpen && (
+            <FieldError errors={[form.formState.errors.duration?.temporaryRange]} />
           )}
-        />
-        {durationPreset === CUSTOM_DURATION_VALUE && (
-          <Controller
-            control={form.control}
-            name="duration.customValue"
-            render={({ field, fieldState: { error } }) => (
-              <Field>
-                <FieldLabel htmlFor="customDuration">
-                  <TtlFormLabel label="Custom Duration" />
-                </FieldLabel>
-                <Input id="customDuration" {...field} isError={Boolean(error?.message)} />
-                <FieldError errors={[error]} />
-              </Field>
-            )}
-          />
-        )}
+          {matchedPolicy?.maxTimePeriod && (
+            <FieldDescription>
+              Maximum duration allowed by policy: {matchedPolicy.maxTimePeriod}
+            </FieldDescription>
+          )}
+        </Field>
         <Controller
           control={form.control}
           name="note"

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -615,105 +615,103 @@ export const RequestAccessForm = ({
         </div>
         <Field>
           <FieldLabel>Resources & Permissions</FieldLabel>
-          <div className="rounded-lg border border-border bg-black/20 p-3">
-            <div className="flex flex-col gap-3">
-              {resourceFields.map((resourceField, index) => {
-                const config = RESOURCE_CONFIGS.find((c) => c.subject === resourceField.subject);
-                if (!config) return null;
-                const selectedValues = resources[index]?.actions ?? [];
+          <div className="flex flex-col gap-3 rounded-lg border border-border bg-black/20 p-3">
+            {resourceFields.map((resourceField, index) => {
+              const config = RESOURCE_CONFIGS.find((c) => c.subject === resourceField.subject);
+              if (!config) return null;
+              const selectedValues = resources[index]?.actions ?? [];
 
-                return (
-                  <div
-                    key={resourceField.id}
-                    className="overflow-hidden rounded-lg border border-border bg-card"
+              return (
+                <div
+                  key={resourceField.id}
+                  className="overflow-hidden rounded-lg border border-border bg-card"
+                >
+                  <div className="flex items-center gap-2.5 border-b border-border px-3 py-2.5">
+                    <div
+                      className={cn(
+                        "flex size-7 items-center justify-center rounded-md border",
+                        config.iconTileClassName
+                      )}
+                    >
+                      <config.Icon className="size-4" />
+                    </div>
+                    <span className="text-sm font-medium text-foreground">{config.label}</span>
+                    <IconButton
+                      size="xs"
+                      variant="ghost-muted"
+                      className="ml-auto"
+                      aria-label={`Remove ${config.label}`}
+                      onClick={() => removeResource(index)}
+                    >
+                      <XIcon />
+                    </IconButton>
+                  </div>
+                  <div className="flex flex-wrap gap-2 p-3">
+                    {config.actions.map((action) => {
+                      const isSelected = selectedValues.includes(action.value);
+
+                      return (
+                        <Tooltip key={action.value}>
+                          <TooltipTrigger asChild>
+                            <Button
+                              size="xs"
+                              variant="outline"
+                              aria-pressed={isSelected}
+                              onClick={() => toggleAction(index, action.value)}
+                              className={cn(
+                                "rounded-md",
+                                isSelected
+                                  ? config.chipSelectedClassName
+                                  : "text-muted hover:text-foreground"
+                              )}
+                            >
+                              <action.Icon />
+                              {action.label}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>{action.description}</TooltipContent>
+                        </Tooltip>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+            {availableResources.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    isFullWidth
+                    className="border-dashed text-label hover:text-foreground"
                   >
-                    <div className="flex items-center gap-2.5 border-b border-border px-3 py-2.5">
+                    <PlusIcon />
+                    Add resource type
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="start"
+                  className="w-(--radix-dropdown-menu-trigger-width)"
+                >
+                  {availableResources.map((config) => (
+                    <DropdownMenuItem
+                      key={config.subject}
+                      onSelect={() => appendResource({ subject: config.subject, actions: [] })}
+                    >
                       <div
                         className={cn(
-                          "flex size-7 items-center justify-center rounded-md border",
+                          "flex size-6 items-center justify-center rounded-sm border",
                           config.iconTileClassName
                         )}
                       >
-                        <config.Icon className="size-4" />
+                        <config.Icon className="size-3.5" />
                       </div>
-                      <span className="text-sm font-medium text-foreground">{config.label}</span>
-                      <IconButton
-                        size="xs"
-                        variant="ghost-muted"
-                        className="ml-auto"
-                        aria-label={`Remove ${config.label}`}
-                        onClick={() => removeResource(index)}
-                      >
-                        <XIcon />
-                      </IconButton>
-                    </div>
-                    <div className="flex flex-wrap gap-2 p-3">
-                      {config.actions.map((action) => {
-                        const isSelected = selectedValues.includes(action.value);
-
-                        return (
-                          <Tooltip key={action.value}>
-                            <TooltipTrigger asChild>
-                              <Button
-                                size="xs"
-                                variant="outline"
-                                aria-pressed={isSelected}
-                                onClick={() => toggleAction(index, action.value)}
-                                className={cn(
-                                  "rounded-md",
-                                  isSelected
-                                    ? config.chipSelectedClassName
-                                    : "text-muted hover:text-foreground"
-                                )}
-                              >
-                                <action.Icon />
-                                {action.label}
-                              </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>{action.description}</TooltipContent>
-                          </Tooltip>
-                        );
-                      })}
-                    </div>
-                  </div>
-                );
-              })}
-              {availableResources.length > 0 && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="outline"
-                      isFullWidth
-                      className="border-dashed text-label hover:text-foreground"
-                    >
-                      <PlusIcon />
-                      Add resource type
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    align="start"
-                    className="w-(--radix-dropdown-menu-trigger-width)"
-                  >
-                    {availableResources.map((config) => (
-                      <DropdownMenuItem
-                        key={config.subject}
-                        onSelect={() => appendResource({ subject: config.subject, actions: [] })}
-                      >
-                        <div
-                          className={cn(
-                            "flex size-6 items-center justify-center rounded-sm border",
-                            config.iconTileClassName
-                          )}
-                        >
-                          <config.Icon className="size-3.5" />
-                        </div>
-                        {config.label}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-            </div>
+                      {config.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         </Field>
         <Field>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessForm.tsx
@@ -1,14 +1,23 @@
-import { useEffect, useMemo } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useEffect, useMemo, useRef } from "react";
+import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { formatDistance } from "date-fns";
 import {
-  ChevronDownIcon,
-  ClockIcon,
+  BanIcon,
   EyeIcon,
+  FingerprintIcon,
+  FolderIcon,
+  HexagonIcon,
+  ImportIcon,
+  KeyIcon,
+  KeyRoundIcon,
+  type LucideIcon,
   PencilIcon,
   PlusIcon,
-  Trash2Icon
+  RefreshCwIcon,
+  RotateCcwIcon,
+  TimerIcon,
+  Trash2Icon,
+  XIcon
 } from "lucide-react";
 import ms from "ms";
 import { z } from "zod";
@@ -18,17 +27,19 @@ import { createNotification } from "@app/components/notifications";
 import {
   Badge,
   Button,
-  Checkbox,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Field,
-  FieldContent,
   FieldDescription,
   FieldError,
   FieldLabel,
-  FieldTitle,
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+  IconButton,
   Input,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -40,40 +51,333 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
-import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
+import { cn } from "@app/components/v3/utils";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionDynamicSecretActions,
+  ProjectPermissionSub,
+  useProject,
+  useSubscription
+} from "@app/context";
+import {
+  ProjectPermissionHoneyTokenActions,
+  ProjectPermissionSecretRotationActions
+} from "@app/context/ProjectPermissionContext/types";
 import { useCreateAccessRequest } from "@app/hooks/api";
 import { TAccessApprovalPolicy } from "@app/hooks/api/types";
 
-const secretPermissionSchema = z.object({
-  secretPath: z.string().optional(),
-  environmentSlug: z.string(),
-  [ProjectPermissionActions.Edit]: z.boolean().optional(),
-  [ProjectPermissionActions.Read]: z.boolean().optional(),
-  [ProjectPermissionActions.Create]: z.boolean().optional(),
-  [ProjectPermissionActions.Delete]: z.boolean().optional(),
-  temporaryAccess: z.discriminatedUnion("isTemporary", [
-    z.object({
-      isTemporary: z.literal(true),
-      temporaryRange: z.string().min(1),
-      temporaryAccessStartTime: z.string().datetime(),
-      temporaryAccessEndTime: z.string().datetime().nullable().optional()
-    }),
-    z.object({
-      isTemporary: z.literal(false),
-      temporaryRange: z.string().optional()
+const PERMANENT_DURATION_VALUE = "permanent";
+const CUSTOM_DURATION_VALUE = "custom";
+
+const DURATION_PRESETS = [
+  { label: "30 minutes", value: "30m" },
+  { label: "1 hour", value: "1h" },
+  { label: "12 hours", value: "12h" },
+  { label: "1 day", value: "1d" },
+  { label: "3 days", value: "3d" },
+  { label: "7 days", value: "7d" },
+  { label: "30 days", value: "30d" }
+];
+
+type TResourceAction = {
+  value: string;
+  label: string;
+  description: string;
+  Icon: LucideIcon;
+};
+
+type TResourceConfig = {
+  subject: ProjectPermissionSub;
+  label: string;
+  Icon: LucideIcon;
+  // Tailwind extracts classes statically, so every tint must be a full literal string
+  iconTileClassName: string;
+  chipSelectedClassName: string;
+  countBadgeClassName: string;
+  summaryIconClassName: string;
+  actions: TResourceAction[];
+};
+
+const RESOURCE_CONFIGS: TResourceConfig[] = [
+  {
+    subject: ProjectPermissionSub.Secrets,
+    label: "Secrets",
+    Icon: KeyIcon,
+    iconTileClassName: "border-accent/10 bg-accent/15 text-accent",
+    chipSelectedClassName:
+      "border-accent/50 bg-accent/15 text-accent hover:border-accent/50 hover:bg-accent/25",
+    countBadgeClassName: "border-accent/10 bg-accent/15 text-accent",
+    summaryIconClassName: "text-accent",
+    actions: [
+      {
+        value: ProjectPermissionActions.Read,
+        label: "View",
+        description: "Read secret values",
+        Icon: EyeIcon
+      },
+      {
+        value: ProjectPermissionActions.Create,
+        label: "Create",
+        description: "Create new secrets",
+        Icon: PlusIcon
+      },
+      {
+        value: ProjectPermissionActions.Edit,
+        label: "Modify",
+        description: "Update existing secrets",
+        Icon: PencilIcon
+      },
+      {
+        value: ProjectPermissionActions.Delete,
+        label: "Delete",
+        description: "Delete existing secrets",
+        Icon: Trash2Icon
+      }
+    ]
+  },
+  {
+    subject: ProjectPermissionSub.SecretFolders,
+    label: "Folders",
+    Icon: FolderIcon,
+    iconTileClassName: "border-folder/10 bg-folder/15 text-folder",
+    chipSelectedClassName:
+      "border-folder/50 bg-folder/15 text-folder hover:border-folder/50 hover:bg-folder/25",
+    countBadgeClassName: "border-folder/10 bg-folder/15 text-folder",
+    summaryIconClassName: "text-folder",
+    actions: [
+      {
+        value: ProjectPermissionActions.Create,
+        label: "Create",
+        description: "Create new folders to organize secrets",
+        Icon: PlusIcon
+      },
+      {
+        value: ProjectPermissionActions.Edit,
+        label: "Modify",
+        description: "Rename or modify folder properties",
+        Icon: PencilIcon
+      },
+      {
+        value: ProjectPermissionActions.Delete,
+        label: "Delete",
+        description: "Delete folders and their contents",
+        Icon: Trash2Icon
+      }
+    ]
+  },
+  {
+    subject: ProjectPermissionSub.DynamicSecrets,
+    label: "Dynamic Secrets",
+    Icon: FingerprintIcon,
+    iconTileClassName: "border-dynamic-secret/10 bg-dynamic-secret/15 text-dynamic-secret",
+    chipSelectedClassName:
+      "border-dynamic-secret/50 bg-dynamic-secret/15 text-dynamic-secret hover:border-dynamic-secret/50 hover:bg-dynamic-secret/25",
+    countBadgeClassName: "border-dynamic-secret/10 bg-dynamic-secret/15 text-dynamic-secret",
+    summaryIconClassName: "text-dynamic-secret",
+    actions: [
+      {
+        value: ProjectPermissionDynamicSecretActions.ReadRootCredential,
+        label: "View",
+        description: "View the root credentials used for dynamic secret generation",
+        Icon: EyeIcon
+      },
+      {
+        value: ProjectPermissionDynamicSecretActions.CreateRootCredential,
+        label: "Create",
+        description: "Configure new root credentials for dynamic secrets",
+        Icon: PlusIcon
+      },
+      {
+        value: ProjectPermissionDynamicSecretActions.EditRootCredential,
+        label: "Modify",
+        description: "Update existing root credentials configuration",
+        Icon: PencilIcon
+      },
+      {
+        value: ProjectPermissionDynamicSecretActions.DeleteRootCredential,
+        label: "Delete",
+        description: "Delete root credentials configuration",
+        Icon: Trash2Icon
+      },
+      {
+        value: ProjectPermissionDynamicSecretActions.Lease,
+        label: "Lease",
+        description: "Create and revoke dynamic secret leases",
+        Icon: TimerIcon
+      }
+    ]
+  },
+  {
+    subject: ProjectPermissionSub.SecretRotation,
+    label: "Secret Rotation",
+    Icon: RefreshCwIcon,
+    iconTileClassName: "border-secret-rotation/10 bg-secret-rotation/15 text-secret-rotation",
+    chipSelectedClassName:
+      "border-secret-rotation/50 bg-secret-rotation/15 text-secret-rotation hover:border-secret-rotation/50 hover:bg-secret-rotation/25",
+    countBadgeClassName: "border-secret-rotation/10 bg-secret-rotation/15 text-secret-rotation",
+    summaryIconClassName: "text-secret-rotation",
+    actions: [
+      {
+        value: ProjectPermissionSecretRotationActions.Read,
+        label: "View",
+        description: "View secret rotation configurations",
+        Icon: EyeIcon
+      },
+      {
+        value: ProjectPermissionSecretRotationActions.ReadGeneratedCredentials,
+        label: "Read Credentials",
+        description: "Access rotated credential values",
+        Icon: KeyRoundIcon
+      },
+      {
+        value: ProjectPermissionSecretRotationActions.Create,
+        label: "Create",
+        description: "Create new secret rotation configuration",
+        Icon: PlusIcon
+      },
+      {
+        value: ProjectPermissionSecretRotationActions.Edit,
+        label: "Modify",
+        description: "Update rotation configuration",
+        Icon: PencilIcon
+      },
+      {
+        value: ProjectPermissionSecretRotationActions.Delete,
+        label: "Delete",
+        description: "Delete rotation configurations",
+        Icon: Trash2Icon
+      },
+      {
+        value: ProjectPermissionSecretRotationActions.RotateSecrets,
+        label: "Rotate",
+        description: "Manually trigger secret rotation",
+        Icon: RefreshCwIcon
+      }
+    ]
+  },
+  {
+    subject: ProjectPermissionSub.SecretImports,
+    label: "Secret Imports",
+    Icon: ImportIcon,
+    iconTileClassName: "border-import/10 bg-import/15 text-import",
+    chipSelectedClassName:
+      "border-import/50 bg-import/15 text-import hover:border-import/50 hover:bg-import/25",
+    countBadgeClassName: "border-import/10 bg-import/15 text-import",
+    summaryIconClassName: "text-import",
+    actions: [
+      {
+        value: ProjectPermissionActions.Read,
+        label: "View",
+        description: "View imported secrets from other projects",
+        Icon: EyeIcon
+      },
+      {
+        value: ProjectPermissionActions.Create,
+        label: "Create",
+        description: "Set up new secret imports",
+        Icon: PlusIcon
+      },
+      {
+        value: ProjectPermissionActions.Edit,
+        label: "Modify",
+        description: "Change import configuration",
+        Icon: PencilIcon
+      },
+      {
+        value: ProjectPermissionActions.Delete,
+        label: "Delete",
+        description: "Remove secret imports",
+        Icon: Trash2Icon
+      }
+    ]
+  },
+  {
+    subject: ProjectPermissionSub.HoneyTokens,
+    label: "Honey Tokens",
+    Icon: HexagonIcon,
+    iconTileClassName: "border-yellow-700/10 bg-yellow-700/15 text-yellow-700",
+    chipSelectedClassName:
+      "border-yellow-700/50 bg-yellow-700/15 text-yellow-700 hover:border-yellow-700/50 hover:bg-yellow-700/25",
+    countBadgeClassName: "border-yellow-700/10 bg-yellow-700/15 text-yellow-700",
+    summaryIconClassName: "text-yellow-700",
+    actions: [
+      {
+        value: ProjectPermissionHoneyTokenActions.Read,
+        label: "View",
+        description: "View honey tokens and events",
+        Icon: EyeIcon
+      },
+      {
+        value: ProjectPermissionHoneyTokenActions.ReadCredentials,
+        label: "Read Credentials",
+        description: "Reveal honey token credentials",
+        Icon: KeyRoundIcon
+      },
+      {
+        value: ProjectPermissionHoneyTokenActions.Create,
+        label: "Create",
+        description: "Create honey tokens",
+        Icon: PlusIcon
+      },
+      {
+        value: ProjectPermissionHoneyTokenActions.Edit,
+        label: "Modify",
+        description: "Update honey token metadata and mappings",
+        Icon: PencilIcon
+      },
+      {
+        value: ProjectPermissionHoneyTokenActions.Reset,
+        label: "Reset",
+        description: "Reset triggered honey tokens",
+        Icon: RotateCcwIcon
+      },
+      {
+        value: ProjectPermissionHoneyTokenActions.Revoke,
+        label: "Revoke",
+        description: "Revoke honey tokens and credentials",
+        Icon: BanIcon
+      }
+    ]
+  }
+];
+
+const requestAccessSchema = z.object({
+  environmentSlug: z.string().min(1),
+  secretPath: z.string().min(1, "Please select a secret path"),
+  resources: z
+    .object({
+      subject: z.nativeEnum(ProjectPermissionSub),
+      actions: z.string().array()
     })
-  ]),
-  note: z.string().optional()
+    .array()
+    .refine((resources) => resources.some((resource) => resource.actions.length > 0), {
+      message: "Select at least one permission"
+    }),
+  duration: z
+    .object({
+      preset: z.string().min(1),
+      customValue: z.string().optional()
+    })
+    .superRefine((val, ctx) => {
+      if (val.preset !== CUSTOM_DURATION_VALUE) return;
+      let parsed: number | undefined;
+      try {
+        parsed = val.customValue ? ms(val.customValue) : undefined;
+      } catch {
+        parsed = undefined;
+      }
+      if (typeof parsed !== "number" || parsed <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["customValue"],
+          message: "Invalid duration. Use formats like 30m, 2h, 1d."
+        });
+      }
+    }),
+  note: z.string().max(255).optional()
 });
 
-type TSecretPermissionForm = z.infer<typeof secretPermissionSchema>;
-
-const PERMISSIONS = [
-  { name: "read", label: "View", description: "Read secret values", Icon: EyeIcon },
-  { name: "create", label: "Create", description: "Create new secrets", Icon: PlusIcon },
-  { name: "edit", label: "Modify", description: "Update existing secrets", Icon: PencilIcon },
-  { name: "delete", label: "Delete", description: "Delete existing secrets", Icon: Trash2Icon }
-] as const;
+type TRequestAccessForm = z.infer<typeof requestAccessSchema>;
 
 export const RequestAccessForm = ({
   policies,
@@ -87,34 +391,30 @@ export const RequestAccessForm = ({
   onClose?: () => void;
 }) => {
   const { currentProject } = useProject();
+  const { subscription } = useSubscription();
   const requestAccess = useCreateAccessRequest();
 
-  const privilegeForm = useForm<TSecretPermissionForm>({
-    resolver: zodResolver(secretPermissionSchema),
+  const form = useForm<TRequestAccessForm>({
+    resolver: zodResolver(requestAccessSchema),
     defaultValues: {
       environmentSlug: currentProject.environments?.[0]?.slug,
-      secretPath: initialSecretPath,
-      read: selectedActions.includes(ProjectPermissionActions.Read),
-      edit: selectedActions.includes(ProjectPermissionActions.Edit),
-      create: selectedActions.includes(ProjectPermissionActions.Create),
-      delete: selectedActions.includes(ProjectPermissionActions.Delete),
-      temporaryAccess: {
-        isTemporary: false,
-        temporaryRange: "1h"
-      }
+      secretPath: initialSecretPath ?? "",
+      resources: [{ subject: ProjectPermissionSub.Secrets, actions: selectedActions }],
+      duration: { preset: PERMANENT_DURATION_VALUE, customValue: "1h" },
+      note: ""
     }
   });
 
-  const temporaryAccessField = privilegeForm.watch("temporaryAccess");
-  const selectedEnvironment = privilegeForm.watch("environmentSlug");
-  const secretPath = privilegeForm.watch("secretPath");
+  const {
+    fields: resourceFields,
+    append: appendResource,
+    remove: removeResource
+  } = useFieldArray({ control: form.control, name: "resources" });
 
-  const readAccess = privilegeForm.watch("read");
-  const createAccess = privilegeForm.watch("create");
-  const editAccess = privilegeForm.watch("edit");
-  const deleteAccess = privilegeForm.watch("delete");
-
-  const accessSelected = readAccess || createAccess || editAccess || deleteAccess;
+  const selectedEnvironment = form.watch("environmentSlug");
+  const secretPath = form.watch("secretPath");
+  const resources = form.watch("resources");
+  const durationPreset = form.watch("duration.preset");
 
   const selectablePaths = useMemo(
     () =>
@@ -124,18 +424,76 @@ export const RequestAccessForm = ({
     [policies, selectedEnvironment]
   );
 
+  const matchedPolicy = useMemo(
+    () =>
+      policies.find(
+        (policy) =>
+          policy.environments.some((env) => env.slug === selectedEnvironment) &&
+          policy.secretPath === secretPath
+      ),
+    [policies, selectedEnvironment, secretPath]
+  );
+
+  const maxDurationMs = matchedPolicy?.maxTimePeriod ? ms(matchedPolicy.maxTimePeriod) : null;
+  const allowedPresets = maxDurationMs
+    ? DURATION_PRESETS.filter((preset) => ms(preset.value) <= maxDurationMs)
+    : DURATION_PRESETS;
+
+  const isInitialMount = useRef(true);
   useEffect(() => {
-    privilegeForm.setValue("secretPath", "", {
-      shouldValidate: true
-    });
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+    form.setValue("secretPath", "", { shouldValidate: true });
   }, [selectedEnvironment]);
 
-  const isTemporary = temporaryAccessField?.isTemporary;
-  const isExpired =
-    temporaryAccessField.isTemporary &&
-    new Date() > new Date(temporaryAccessField.temporaryAccessEndTime || "");
+  // policies with a max time period forbid permanent access and cap the range
+  useEffect(() => {
+    if (!maxDurationMs || !matchedPolicy?.maxTimePeriod) return;
+    const { preset } = form.getValues("duration");
+    const exceedsMax =
+      preset === PERMANENT_DURATION_VALUE ||
+      (preset !== CUSTOM_DURATION_VALUE && ms(preset) > maxDurationMs);
+    if (!exceedsMax) return;
+    const fallback = allowedPresets[allowedPresets.length - 1];
+    form.setValue(
+      "duration",
+      fallback
+        ? { preset: fallback.value, customValue: form.getValues("duration.customValue") }
+        : { preset: CUSTOM_DURATION_VALUE, customValue: matchedPolicy.maxTimePeriod },
+      { shouldValidate: true }
+    );
+  }, [matchedPolicy]);
 
-  const handleRequestAccess = async (data: TSecretPermissionForm) => {
+  const addedSubjects = new Set(resources.map((resource) => resource.subject));
+  const availableResources = RESOURCE_CONFIGS.filter(
+    (config) =>
+      !addedSubjects.has(config.subject) &&
+      (config.subject !== ProjectPermissionSub.HoneyTokens || subscription?.honeyTokens)
+  );
+
+  const summaryRows = resources.flatMap((resource) => {
+    const config = RESOURCE_CONFIGS.find((c) => c.subject === resource.subject);
+    if (!config) return [];
+    const selected = config.actions.filter((action) => resource.actions.includes(action.value));
+    return selected.length ? [{ config, selected }] : [];
+  });
+
+  const totalSelectedActions = resources.reduce(
+    (count, resource) => count + resource.actions.length,
+    0
+  );
+
+  const toggleAction = (index: number, actionValue: string) => {
+    const current = form.getValues(`resources.${index}.actions`);
+    const next = current.includes(actionValue)
+      ? current.filter((value) => value !== actionValue)
+      : [...current, actionValue];
+    form.setValue(`resources.${index}.actions`, next, { shouldDirty: true });
+  };
+
+  const handleRequestAccess = async (data: TRequestAccessForm) => {
     if (!currentProject) {
       createNotification({
         type: "error",
@@ -145,249 +503,265 @@ export const RequestAccessForm = ({
       return;
     }
 
-    if (!data.secretPath) {
-      createNotification({
-        type: "error",
-        text: "Please select a secret path...",
-        title: "Error"
-      });
-      return;
-    }
-
-    const policy = policies.find(
-      (p) =>
-        p.environments.find((e) => e.slug === selectedEnvironment) && p.secretPath === secretPath
-    );
+    const isTemporary = data.duration.preset !== PERMANENT_DURATION_VALUE;
+    const temporaryRange =
+      data.duration.preset === CUSTOM_DURATION_VALUE
+        ? data.duration.customValue
+        : data.duration.preset;
 
     if (
-      policy?.maxTimePeriod &&
-      (!data.temporaryAccess.isTemporary ||
-        ms(data.temporaryAccess.temporaryRange) > ms(policy.maxTimePeriod))
+      matchedPolicy?.maxTimePeriod &&
+      (!isTemporary || !temporaryRange || ms(temporaryRange) > ms(matchedPolicy.maxTimePeriod))
     ) {
       createNotification({
         type: "error",
-        text: `Requested access time range is limited to ${policy.maxTimePeriod} by policy`,
+        text: `Requested access time range is limited to ${matchedPolicy.maxTimePeriod} by policy`,
         title: "Error"
       });
       return;
     }
 
-    const actions = [
-      { action: ProjectPermissionActions.Read, allowed: data.read },
-      { action: ProjectPermissionActions.Create, allowed: data.create },
-      { action: ProjectPermissionActions.Delete, allowed: data.delete },
-      { action: ProjectPermissionActions.Edit, allowed: data.edit }
-    ];
-    const conditions: Record<string, any> = { environment: data.environmentSlug };
-    if (data.secretPath) {
-      conditions.secretPath = { $glob: data.secretPath };
-    }
+    const conditions = {
+      environment: data.environmentSlug,
+      secretPath: { $glob: data.secretPath }
+    };
+    const permissions = data.resources.flatMap(({ subject, actions }) =>
+      actions.map((action) => ({ action, subject: [subject], conditions }))
+    );
+
     await requestAccess.mutateAsync({
-      ...data,
-      ...(data.temporaryAccess.isTemporary && {
-        temporaryRange: data.temporaryAccess.temporaryRange
-      }),
       projectSlug: currentProject.slug,
-      isTemporary: data.temporaryAccess.isTemporary,
-      permissions: actions
-        .filter(({ allowed }) => allowed)
-        .map(({ action }) => ({
-          action,
-          subject: [ProjectPermissionSub.Secrets],
-          conditions
-        })),
-      note: data.note
+      isTemporary,
+      ...(isTemporary && temporaryRange && { temporaryRange }),
+      permissions,
+      note: data.note || undefined
     });
 
     createNotification({
       type: "success",
       text: "Successfully requested access"
     });
-    privilegeForm.reset();
+    form.reset();
     if (onClose) onClose();
-  };
-
-  const handleGrant = () => {
-    const temporaryRange = privilegeForm.getValues("temporaryAccess.temporaryRange");
-    if (!temporaryRange) {
-      privilegeForm.setError(
-        "temporaryAccess.temporaryRange",
-        { type: "required", message: "Required" },
-        { shouldFocus: true }
-      );
-      return;
-    }
-    privilegeForm.clearErrors("temporaryAccess.temporaryRange");
-    privilegeForm.setValue(
-      "temporaryAccess",
-      {
-        isTemporary: true,
-        temporaryAccessStartTime: new Date().toISOString(),
-        temporaryRange,
-        temporaryAccessEndTime: new Date(new Date().getTime() + ms(temporaryRange)).toISOString()
-      },
-      { shouldDirty: true }
-    );
-  };
-
-  const handleCancelTemporary = () => {
-    privilegeForm.setValue("temporaryAccess", {
-      isTemporary: false,
-      temporaryRange: privilegeForm.getValues("temporaryAccess.temporaryRange")
-    });
-  };
-
-  const getAccessLabel = () => {
-    if (isExpired) return "Access expired";
-    if (!temporaryAccessField?.isTemporary) return "Permanent";
-    return formatDistance(new Date(temporaryAccessField.temporaryAccessEndTime || ""), new Date());
   };
 
   return (
     <form
-      onSubmit={privilegeForm.handleSubmit(handleRequestAccess)}
+      onSubmit={form.handleSubmit(handleRequestAccess)}
       className="flex flex-1 flex-col gap-4 overflow-hidden"
     >
       <div className="flex thin-scrollbar flex-1 flex-col gap-4 overflow-y-auto p-4">
-        <Controller
-          control={privilegeForm.control}
-          name="environmentSlug"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel htmlFor="environmentSlug">Environment</FieldLabel>
-              <Select value={field.value} onValueChange={field.onChange}>
-                <SelectTrigger id="environmentSlug" className="w-full">
-                  <SelectValue placeholder="Select an environment" />
-                </SelectTrigger>
-                <SelectContent position="popper">
-                  {currentProject?.environments?.map(({ slug, id, name }) => (
-                    <SelectItem value={slug} key={id}>
-                      {name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-          )}
-        />
-        <Controller
-          control={privilegeForm.control}
-          name="secretPath"
-          render={({ field }) => {
-            const secretPathField = (
+        <div className="grid grid-cols-2 gap-3">
+          <Controller
+            control={form.control}
+            name="environmentSlug"
+            render={({ field }) => (
               <Field>
-                <FieldLabel htmlFor="secretPath">Secret Path</FieldLabel>
-                <Select
-                  value={field.value || ""}
-                  onValueChange={field.onChange}
-                  disabled={!selectablePaths.length}
-                >
-                  <SelectTrigger id="secretPath" className="w-full">
-                    <SelectValue placeholder="Select a secret path" />
+                <FieldLabel htmlFor="environmentSlug">Environment</FieldLabel>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger id="environmentSlug" className="w-full">
+                    <SelectValue placeholder="Select an environment" />
                   </SelectTrigger>
                   <SelectContent position="popper">
-                    {selectablePaths.map((path) => (
-                      <SelectItem value={path} key={path}>
-                        {path}
+                    {currentProject?.environments?.map(({ slug, id, name }) => (
+                      <SelectItem value={slug} key={id}>
+                        {name}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
               </Field>
-            );
+            )}
+          />
+          <Controller
+            control={form.control}
+            name="secretPath"
+            render={({ field }) => {
+              const secretPathField = (
+                <Field>
+                  <FieldLabel htmlFor="secretPath">Secret Path</FieldLabel>
+                  <Select
+                    value={field.value || ""}
+                    onValueChange={field.onChange}
+                    disabled={!selectablePaths.length}
+                  >
+                    <SelectTrigger id="secretPath" className="w-full">
+                      <SelectValue placeholder="Select a secret path" />
+                    </SelectTrigger>
+                    <SelectContent position="popper">
+                      {selectablePaths.map((path) => (
+                        <SelectItem value={path} key={path}>
+                          {path}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+              );
 
-            if (selectablePaths.length) return secretPathField;
+              if (selectablePaths.length) return secretPathField;
 
-            return (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="w-full">{secretPathField}</div>
-                </TooltipTrigger>
-                <TooltipContent>
-                  The selected environment doesn&apos;t have any policies.
-                </TooltipContent>
-              </Tooltip>
-            );
-          }}
-        />
+              return (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="w-full">{secretPathField}</div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    The selected environment doesn&apos;t have any policies.
+                  </TooltipContent>
+                </Tooltip>
+              );
+            }}
+          />
+        </div>
         <Field>
-          <FieldLabel>Permissions</FieldLabel>
-          <div className="grid grid-cols-2 gap-2">
-            {PERMISSIONS.map(({ name, label, description, Icon }) => (
-              <Controller
-                key={name}
-                control={privilegeForm.control}
-                name={name}
-                render={({ field }) => (
-                  <FieldLabel htmlFor={`secret-${name}`} variant="project">
-                    <Field orientation="horizontal">
-                      <FieldContent>
-                        <FieldTitle>
-                          <Icon />
-                          {label}
-                        </FieldTitle>
-                        <FieldDescription>{description}</FieldDescription>
-                      </FieldContent>
-                      <Checkbox
-                        id={`secret-${name}`}
-                        variant="outline"
-                        isChecked={field.value}
-                        onCheckedChange={(isChecked) => field.onChange(isChecked)}
-                      />
-                    </Field>
-                  </FieldLabel>
-                )}
-              />
-            ))}
+          <FieldLabel>Resources & Permissions</FieldLabel>
+          <div className="flex flex-col gap-3">
+            {resourceFields.map((resourceField, index) => {
+              const config = RESOURCE_CONFIGS.find((c) => c.subject === resourceField.subject);
+              if (!config) return null;
+              const selectedValues = resources[index]?.actions ?? [];
+
+              return (
+                <div
+                  key={resourceField.id}
+                  className="overflow-hidden rounded-lg border border-border bg-card"
+                >
+                  <div className="flex items-center gap-2.5 border-b border-border px-3 py-2.5">
+                    <div
+                      className={cn(
+                        "flex size-7 items-center justify-center rounded-md border",
+                        config.iconTileClassName
+                      )}
+                    >
+                      <config.Icon className="size-4" />
+                    </div>
+                    <span className="text-sm font-medium text-foreground">{config.label}</span>
+                    <IconButton
+                      size="xs"
+                      variant="ghost-muted"
+                      className="ml-auto"
+                      aria-label={`Remove ${config.label}`}
+                      onClick={() => removeResource(index)}
+                    >
+                      <XIcon />
+                    </IconButton>
+                  </div>
+                  <div className="flex flex-wrap gap-2 p-3">
+                    {config.actions.map((action) => {
+                      const isSelected = selectedValues.includes(action.value);
+
+                      return (
+                        <Tooltip key={action.value}>
+                          <TooltipTrigger asChild>
+                            <Button
+                              size="xs"
+                              variant="outline"
+                              aria-pressed={isSelected}
+                              onClick={() => toggleAction(index, action.value)}
+                              className={cn(
+                                "rounded-md",
+                                isSelected
+                                  ? config.chipSelectedClassName
+                                  : "text-muted hover:text-foreground"
+                              )}
+                            >
+                              <action.Icon />
+                              {action.label}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent>{action.description}</TooltipContent>
+                        </Tooltip>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+            {availableResources.length > 0 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="outline"
+                    isFullWidth
+                    className="border-dashed text-label hover:text-foreground"
+                  >
+                    <PlusIcon />
+                    Add resource type
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="start"
+                  className="w-(--radix-dropdown-menu-trigger-width)"
+                >
+                  {availableResources.map((config) => (
+                    <DropdownMenuItem
+                      key={config.subject}
+                      onSelect={() => appendResource({ subject: config.subject, actions: [] })}
+                    >
+                      <div
+                        className={cn(
+                          "flex size-6 items-center justify-center rounded-sm border",
+                          config.iconTileClassName
+                        )}
+                      >
+                        <config.Icon className="size-3.5" />
+                      </div>
+                      {config.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         </Field>
-        <Field>
-          <FieldLabel>Duration</FieldLabel>
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button variant="outline" className="w-full justify-between capitalize">
-                <span className="flex items-center gap-2">
-                  {isTemporary && <ClockIcon className="size-3.5" />}
-                  {getAccessLabel()}
-                </span>
-                <ChevronDownIcon className="size-3.5" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent align="start" className="flex flex-col gap-4">
-              <div className="text-sm text-foreground">Configure timed access</div>
-              {isExpired && (
-                <Badge variant="danger" className="w-fit">
-                  Expired
-                </Badge>
-              )}
-              <Controller
-                control={privilegeForm.control}
-                name="temporaryAccess.temporaryRange"
-                render={({ field, fieldState: { error } }) => (
-                  <Field>
-                    <FieldLabel htmlFor="temporaryRange">
-                      <TtlFormLabel label="Validity" />
-                    </FieldLabel>
-                    <Input id="temporaryRange" {...field} isError={Boolean(error?.message)} />
-                    <FieldError errors={[error]} />
-                  </Field>
-                )}
-              />
-              <div className="flex items-center gap-2">
-                <Button size="xs" variant="project" onClick={handleGrant}>
-                  Grant
-                </Button>
-                {temporaryAccessField.isTemporary && (
-                  <Button size="xs" variant="danger" onClick={handleCancelTemporary}>
-                    Cancel
-                  </Button>
-                )}
-              </div>
-            </PopoverContent>
-          </Popover>
-        </Field>
         <Controller
-          control={privilegeForm.control}
+          control={form.control}
+          name="duration.preset"
+          render={({ field }) => (
+            <Field>
+              <FieldLabel htmlFor="duration">Duration</FieldLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <SelectTrigger id="duration" className="w-full">
+                  <SelectValue placeholder="Select a duration" />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {!maxDurationMs && (
+                    <SelectItem value={PERMANENT_DURATION_VALUE}>Permanent</SelectItem>
+                  )}
+                  {allowedPresets.map((preset) => (
+                    <SelectItem value={preset.value} key={preset.value}>
+                      {preset.label}
+                    </SelectItem>
+                  ))}
+                  <SelectItem value={CUSTOM_DURATION_VALUE}>Custom</SelectItem>
+                </SelectContent>
+              </Select>
+              {matchedPolicy?.maxTimePeriod && (
+                <FieldDescription>
+                  Maximum duration allowed by policy: {matchedPolicy.maxTimePeriod}
+                </FieldDescription>
+              )}
+            </Field>
+          )}
+        />
+        {durationPreset === CUSTOM_DURATION_VALUE && (
+          <Controller
+            control={form.control}
+            name="duration.customValue"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="customDuration">
+                  <TtlFormLabel label="Custom Duration" />
+                </FieldLabel>
+                <Input id="customDuration" {...field} isError={Boolean(error?.message)} />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+        )}
+        <Controller
+          control={form.control}
           name="note"
           render={({ field }) => (
             <Field>
@@ -401,15 +775,50 @@ export const RequestAccessForm = ({
             </Field>
           )}
         />
+        <div className="flex flex-col gap-2.5 rounded-lg border border-border bg-black/20 p-3">
+          <span className="text-xs font-medium tracking-wider text-muted uppercase">
+            Request Summary
+          </span>
+          {summaryRows.length ? (
+            <div className="flex flex-col gap-2">
+              {summaryRows.map(({ config, selected }) => (
+                <HoverCard key={config.subject} openDelay={150}>
+                  <HoverCardTrigger asChild>
+                    <div className="flex items-center gap-2">
+                      <config.Icon className={cn("size-3.5", config.summaryIconClassName)} />
+                      <span className="text-sm text-foreground">{config.label}</span>
+                      <Badge className={cn("ml-auto rounded-full", config.countBadgeClassName)}>
+                        {selected.length} {selected.length === 1 ? "permission" : "permissions"}
+                      </Badge>
+                    </div>
+                  </HoverCardTrigger>
+                  <HoverCardContent align="end" className="flex w-56 flex-col gap-1.5">
+                    {selected.map((action) => (
+                      <div
+                        key={action.value}
+                        className="flex items-center gap-2 text-sm text-foreground"
+                      >
+                        <action.Icon className={cn("size-3.5", config.summaryIconClassName)} />
+                        {action.label}
+                      </div>
+                    ))}
+                  </HoverCardContent>
+                </HoverCard>
+              ))}
+            </div>
+          ) : (
+            <span className="text-sm text-muted">
+              No resources added yet. Add a resource type to begin.
+            </span>
+          )}
+        </div>
       </div>
       <SheetFooter className="border-t">
         <Button
           type="submit"
           variant="project"
-          isPending={privilegeForm.formState.isSubmitting || requestAccess.isPending}
-          isDisabled={
-            !policies.length || !privilegeForm.formState.isValid || !secretPath || !accessSelected
-          }
+          isPending={form.formState.isSubmitting || requestAccess.isPending}
+          isDisabled={!policies.length || !secretPath || totalSelectedActions === 0}
         >
           Request Access
         </Button>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
@@ -18,7 +18,7 @@ export const RequestAccessModal = ({
 }) => {
   return (
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
-      <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-lg">
+      <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-2xl">
         <SheetHeader className="border-b">
           <SheetTitle>Request Access</SheetTitle>
           <SheetDescription>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
@@ -65,6 +65,7 @@ export const RequestAccessModal = ({
           </SheetHeader>
           <RequestAccessForm
             onClose={() => handleSheetOpenChange(false)}
+            onSuccess={closeSheet}
             onDirtyChange={setIsDirty}
             policies={policies}
             {...props}

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
@@ -39,7 +39,6 @@ export const RequestAccessModal = ({
 
   const closeSheet = () => {
     setConfirmDiscardOpen(false);
-    setIsDirty(false);
     onOpenChange(false);
   };
 
@@ -48,7 +47,6 @@ export const RequestAccessModal = ({
       setConfirmDiscardOpen(true);
       return;
     }
-    if (!nextOpen) setIsDirty(false);
     onOpenChange(nextOpen);
   };
 

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
@@ -1,4 +1,22 @@
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@app/components/v3";
+import { useState } from "react";
+import { AlertTriangleIcon } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@app/components/v3";
 import { ProjectPermissionActions } from "@app/context";
 import { TAccessApprovalPolicy } from "@app/hooks/api/types";
 
@@ -16,17 +34,63 @@ export const RequestAccessModal = ({
   selectedActions?: ProjectPermissionActions[];
   secretPath?: string;
 }) => {
+  const [isDirty, setIsDirty] = useState(false);
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+
+  const closeSheet = () => {
+    setConfirmDiscardOpen(false);
+    setIsDirty(false);
+    onOpenChange(false);
+  };
+
+  const handleSheetOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isDirty) {
+      setConfirmDiscardOpen(true);
+      return;
+    }
+    if (!nextOpen) setIsDirty(false);
+    onOpenChange(nextOpen);
+  };
+
   return (
-    <Sheet open={isOpen} onOpenChange={onOpenChange}>
-      <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-2xl">
-        <SheetHeader className="border-b">
-          <SheetTitle>Request Access</SheetTitle>
-          <SheetDescription>
-            Request access to secrets, folders and other resources based on the predefined policies.
-          </SheetDescription>
-        </SheetHeader>
-        <RequestAccessForm onClose={() => onOpenChange(false)} policies={policies} {...props} />
-      </SheetContent>
-    </Sheet>
+    <>
+      <Sheet open={isOpen} onOpenChange={handleSheetOpenChange}>
+        <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-2xl">
+          <SheetHeader className="border-b">
+            <SheetTitle>Request Access</SheetTitle>
+            <SheetDescription>
+              Request access to secrets, folders and other resources based on the predefined
+              policies.
+            </SheetDescription>
+          </SheetHeader>
+          <RequestAccessForm
+            onClose={() => handleSheetOpenChange(false)}
+            onDirtyChange={setIsDirty}
+            policies={policies}
+            {...props}
+          />
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog open={confirmDiscardOpen} onOpenChange={setConfirmDiscardOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <AlertTriangleIcon />
+            </AlertDialogMedia>
+            <AlertDialogTitle>Discard access request?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Your unsaved changes to this access request will be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Editing</AlertDialogCancel>
+            <AlertDialogAction variant="danger" onClick={closeSheet}>
+              Discard
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 };

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/RequestAccessModal.tsx
@@ -22,7 +22,7 @@ export const RequestAccessModal = ({
         <SheetHeader className="border-b">
           <SheetTitle>Request Access</SheetTitle>
           <SheetDescription>
-            Request access to any secrets and resources based on the predefined policies.
+            Request access to secrets, folders and other resources based on the predefined policies.
           </SheetDescription>
         </SheetHeader>
         <RequestAccessForm onClose={() => onOpenChange(false)} policies={policies} {...props} />

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/ReviewAccessModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/ReviewAccessModal.tsx
@@ -102,6 +102,8 @@ import {
 } from "@app/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils";
 import { EditAccessRequestModal } from "@app/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/EditAccessRequestModal";
 
+import { getAccessDurationLabel } from "../AccessApprovalRequest.utils";
+
 const getReviewedStatusSymbol = (status?: ApprovalStatus, isOrgMembershipActive?: boolean) => {
   if (status === ApprovalStatus.APPROVED)
     return (
@@ -333,15 +335,6 @@ export const ReviewAccessRequestModal = ({
       conditions: group.conditions ? formatConditions(group.conditions) : []
     }));
   }, [request.permissions]);
-
-  const getAccessLabel = () => {
-    if (!accessDetails.temporaryAccess.isTemporary || !accessDetails.temporaryAccess.temporaryRange)
-      return "Permanent";
-
-    return `Valid for ${ms(ms(accessDetails.temporaryAccess.temporaryRange), {
-      long: true
-    })} after approval`;
-  };
 
   const reviewAccessRequest = useReviewAccessRequest();
   const revokeAccessRequest = useRevokeAccessRequest();
@@ -781,7 +774,10 @@ export const ReviewAccessRequestModal = ({
                     <DetailLabel>Access Duration</DetailLabel>
                     <DetailValue>
                       <div className="flex items-center gap-1">
-                        {getAccessLabel()}
+                        {getAccessDurationLabel(
+                          accessDetails.temporaryAccess.isTemporary,
+                          accessDetails.temporaryAccess.temporaryRange
+                        )}
                         {request.isApprover && request.status === ApprovalStatus.PENDING && (
                           <>
                             <EditAccessRequestModal


### PR DESCRIPTION
## Context

Revamp the secret access request. It also hardens the backend validation, making sure we grant only the permissions that show up to the user. 

## Screenshots

<img width="1492" height="844" alt="image" src="https://github.com/user-attachments/assets/ffe7ed18-2b8b-4489-9a04-30301086978c" />

## Steps to verify the change
- create a secret access request
- validate the UI 
- check the backend validations

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)