### PR TITLE
feat(pam): automatically add org-admins to PAM and allow access requests to PAM

### DIFF
--- a/backend/src/ee/services/pam-membership/pam-membership-service.ts
+++ b/backend/src/ee/services/pam-membership/pam-membership-service.ts
@@ -15,6 +15,7 @@ import { ApprovalPolicyScope } from "@app/services/approval-policy/approval-poli
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
 import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
+import { TProjectAccessRequestDALFactory } from "@app/services/project/project-access-request-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import { PamMemberKind, PamProductRole, PamResourceRole } from "../pam/pam-enums";
@@ -44,6 +45,7 @@ type TPamMembershipServiceFactoryDep = {
   >;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "create" | "find" | "delete" | "update">;
   approvalPolicyDAL: Pick<TApprovalPolicyDALFactory, "deleteStepApproversBySubject">;
+  projectAccessRequestDAL: Pick<TProjectAccessRequestDALFactory, "delete">;
   pamFolderDAL: Pick<TPamFolderDALFactory, "findById">;
   pamAccountDAL: Pick<TPamAccountDALFactory, "findById">;
   userDAL: Pick<TUserDALFactory, "findById" | "find">;
@@ -81,6 +83,7 @@ export const pamMembershipServiceFactory = ({
   membershipDAL,
   membershipRoleDAL,
   approvalPolicyDAL,
+  projectAccessRequestDAL,
   pamFolderDAL,
   pamAccountDAL,
   userDAL,
@@ -299,6 +302,13 @@ export const pamMembershipServiceFactory = ({
 
       const membershipRole = await membershipRoleDAL.create({ membershipId: membership.id, role }, tx);
 
+      // The Members tab's "Add Member" UI actually adds users via the generic project-membership
+      // endpoint (whose factory already clears this), not this one. This covers direct API callers
+      // of this PAM-specific endpoint so their pending request doesn't linger either.
+      if (kind === PamMemberKind.User) {
+        await projectAccessRequestDAL.delete({ projectId, requesterUserId: id }, tx);
+      }
+
       return {
         membershipId: membership.id,
         userId: kind === PamMemberKind.User ? id : undefined,
@@ -390,6 +400,9 @@ export const pamMembershipServiceFactory = ({
         );
         // eslint-disable-next-line no-await-in-loop
         const membershipRole = await membershipRoleDAL.create({ membershipId: membership.id, role }, tx);
+        // See addProductMember above for why this endpoint needs its own cleanup call.
+        // eslint-disable-next-line no-await-in-loop
+        await projectAccessRequestDAL.delete({ projectId, requesterUserId: userId }, tx);
         results.push({
           membershipId: membership.id,
           userId,

--- a/backend/src/ee/services/pam-membership/pam-membership-service.ts
+++ b/backend/src/ee/services/pam-membership/pam-membership-service.ts
@@ -302,9 +302,7 @@ export const pamMembershipServiceFactory = ({
 
       const membershipRole = await membershipRoleDAL.create({ membershipId: membership.id, role }, tx);
 
-      // The Members tab's "Add Member" UI actually adds users via the generic project-membership
-      // endpoint (whose factory already clears this), not this one. This covers direct API callers
-      // of this PAM-specific endpoint so their pending request doesn't linger either.
+      // For direct API callers; the UI's Add Member flow uses the generic endpoint, which already clears this.
       if (kind === PamMemberKind.User) {
         await projectAccessRequestDAL.delete({ projectId, requesterUserId: id }, tx);
       }

--- a/backend/src/ee/services/pam-membership/pam-membership-service.ts
+++ b/backend/src/ee/services/pam-membership/pam-membership-service.ts
@@ -398,7 +398,6 @@ export const pamMembershipServiceFactory = ({
         );
         // eslint-disable-next-line no-await-in-loop
         const membershipRole = await membershipRoleDAL.create({ membershipId: membership.id, role }, tx);
-        // See addProductMember above for why this endpoint needs its own cleanup call.
         // eslint-disable-next-line no-await-in-loop
         await projectAccessRequestDAL.delete({ projectId, requesterUserId: userId }, tx);
         results.push({

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1670,6 +1670,7 @@ export const registerRoutes = async (
     membershipDAL,
     membershipRoleDAL,
     approvalPolicyDAL,
+    projectAccessRequestDAL,
     pamFolderDAL,
     pamAccountDAL,
     userDAL,

--- a/backend/src/services/org-admin/org-admin-service.ts
+++ b/backend/src/services/org-admin/org-admin-service.ts
@@ -93,28 +93,20 @@ export const orgAdminServiceFactory = ({
     const project = await projectDAL.findOne({ id: projectId, orgId: actorOrgId });
     if (!project) throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
 
-    // check already there exist a membership if there return it
-    const projectMembership = await membershipUserDAL.findOne({
-      scopeProjectId: projectId,
-      scope: AccessScope.Project,
-      actorUserId: actorId
-    });
-    if (projectMembership) {
-      // reset and make the user admin
-      await membershipUserDAL.transaction(async (tx) => {
-        await membershipRoleDAL.delete({ membershipId: projectMembership.id }, tx);
-        await membershipRoleDAL.create(
-          {
-            membershipId: projectMembership.id,
-            role: ProjectMembershipRole.Admin
-          },
-          tx
-        );
-      });
-      return { isExistingMember: true, membership: projectMembership };
-    }
+    // Reads inside this transaction so it sees the primary, not a possibly-lagging replica, in
+    // case a caller (e.g. PAM's bootstrap) just wrote this actor's membership moments earlier.
+    const { isExistingMember, membership: updatedMembership } = await membershipUserDAL.transaction(async (tx) => {
+      const projectMembership = await membershipUserDAL.findOne(
+        { scopeProjectId: projectId, scope: AccessScope.Project, actorUserId: actorId },
+        tx
+      );
 
-    const updatedMembership = await membershipUserDAL.transaction(async (tx) => {
+      if (projectMembership) {
+        await membershipRoleDAL.delete({ membershipId: projectMembership.id }, tx);
+        await membershipRoleDAL.create({ membershipId: projectMembership.id, role: ProjectMembershipRole.Admin }, tx);
+        return { isExistingMember: true, membership: projectMembership };
+      }
+
       const newProjectMembership = await membershipUserDAL.create(
         {
           scopeProjectId: projectId,
@@ -126,8 +118,12 @@ export const orgAdminServiceFactory = ({
       );
       await membershipRoleDAL.create({ membershipId: newProjectMembership.id, role: ProjectMembershipRole.Admin }, tx);
 
-      return newProjectMembership;
+      return { isExistingMember: false, membership: newProjectMembership };
     });
+
+    if (isExistingMember) {
+      return { isExistingMember: true, membership: updatedMembership };
+    }
 
     const projectMembers = await projectMembershipDAL.findAllProjectMembers(projectId);
     const projectAdmins = projectMembers.filter(

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -217,8 +217,7 @@ type TProjectServiceFactoryDep = {
 
 export type TProjectServiceFactory = ReturnType<typeof projectServiceFactory>;
 
-// Used by requestProjectAccess to build the admin-facing callback link/notification copy.
-// Types not listed here fall back to the raw project type/name.
+// Cosmetic overrides for requestProjectAccess; unlisted types fall back to the raw type/name.
 const PROJECT_ACCESS_REQUEST_URL_SLUGS: Partial<Record<ProjectType, string>> = {
   [ProjectType.SecretManager]: "secret-management",
   [ProjectType.CertificateManager]: "cert-manager"

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -217,6 +217,18 @@ type TProjectServiceFactoryDep = {
 
 export type TProjectServiceFactory = ReturnType<typeof projectServiceFactory>;
 
+// Used by requestProjectAccess to build the admin-facing callback link/notification copy.
+// Types not listed here fall back to the raw project type/name.
+const PROJECT_ACCESS_REQUEST_URL_SLUGS: Partial<Record<ProjectType, string>> = {
+  [ProjectType.SecretManager]: "secret-management",
+  [ProjectType.CertificateManager]: "cert-manager"
+};
+
+const PROJECT_ACCESS_REQUEST_PRODUCT_LABELS: Partial<Record<ProjectType, string>> = {
+  [ProjectType.CertificateManager]: "Certificate Manager",
+  [ProjectType.PAM]: "Privileged Access Manager"
+};
+
 export const projectServiceFactory = ({
   projectDAL,
   projectSshConfigDAL,
@@ -2523,16 +2535,16 @@ export const projectServiceFactory = ({
     );
     const appCfg = getConfig();
 
-    let projectTypeUrl = project.type;
-    if (project.type === ProjectType.SecretManager) {
-      projectTypeUrl = "secret-management";
-    } else if (project.type === ProjectType.CertificateManager) {
-      projectTypeUrl = "cert-manager";
-    }
+    const projectTypeUrl = PROJECT_ACCESS_REQUEST_URL_SLUGS[project.type as ProjectType] ?? project.type;
+    const encodedRequesterEmail = encodeURIComponent(userDetails.email ?? "");
 
-    const callbackPath = `/organizations/${project.orgId}/projects/${projectTypeUrl}/${project.id}/access-management?selectedTab=members&requesterEmail=${userDetails.email}`;
+    // PAM is a per-org singleton with no project-scoped route, unlike other product types
+    const callbackPath =
+      project.type === ProjectType.PAM
+        ? `/organizations/${project.orgId}/pam/access-management?selectedTab=members&requesterEmail=${encodedRequesterEmail}`
+        : `/organizations/${project.orgId}/projects/${projectTypeUrl}/${project.id}/access-management?selectedTab=members&requesterEmail=${encodedRequesterEmail}`;
 
-    const productLabel = project.type === ProjectType.CertificateManager ? "Certificate Manager" : null;
+    const productLabel = PROJECT_ACCESS_REQUEST_PRODUCT_LABELS[project.type as ProjectType] ?? null;
     const notificationTitle = productLabel ? `${productLabel} Access Request` : "Project Access Request";
     const notificationBody = productLabel
       ? `**${userDetails.firstName} ${userDetails.lastName}** (${userDetails.email}) has requested access to **${productLabel}**.`

--- a/frontend/src/hooks/api/organization/queries.tsx
+++ b/frontend/src/hooks/api/organization/queries.tsx
@@ -115,12 +115,13 @@ export const fetchOrganizationById = async (id: string) => {
   return organization;
 };
 
-export const useGetOrganizationById = (id: string) => {
+export const useGetOrganizationById = (id: string, options?: { enabled?: boolean }) => {
   return useQuery({
     queryKey: organizationKeys.getOrgById(id),
     queryFn: async () => {
       return fetchOrganizationById(id);
-    }
+    },
+    enabled: options?.enabled ?? true
   });
 };
 

--- a/frontend/src/hooks/api/pam/queries.tsx
+++ b/frontend/src/hooks/api/pam/queries.tsx
@@ -50,8 +50,7 @@ export const fetchPamProjectId = async () => {
   return data.projectId;
 };
 
-// Shared by any imperative (non-hook) call site that needs the org's PAM project id — skips the
-// network round-trip when the caller already has it cached (e.g. from the org context).
+// For imperative (non-hook) callers; skips the fetch when the id is already cached.
 export const resolvePamProjectId = async (cachedPamProjectId?: string | null) =>
   cachedPamProjectId ?? fetchPamProjectId();
 

--- a/frontend/src/hooks/api/pam/queries.tsx
+++ b/frontend/src/hooks/api/pam/queries.tsx
@@ -50,6 +50,11 @@ export const fetchPamProjectId = async () => {
   return data.projectId;
 };
 
+// Shared by any imperative (non-hook) call site that needs the org's PAM project id — skips the
+// network round-trip when the caller already has it cached (e.g. from the org context).
+export const resolvePamProjectId = async (cachedPamProjectId?: string | null) =>
+  cachedPamProjectId ?? fetchPamProjectId();
+
 export const pamKeys = {
   all: ["pam"] as const,
   account: () => [...pamKeys.all, "account"] as const,

--- a/frontend/src/lib/fn/requesterStatus.ts
+++ b/frontend/src/lib/fn/requesterStatus.ts
@@ -6,9 +6,7 @@ export type TRequesterStatus = {
   userId?: string;
 };
 
-// Shared by the "add member" modals (generic and PAM) to resolve the `?requesterEmail=` deep link
-// from a project-access-request email into a display label and pre-fill target.
-// `memberUsernames` accepts a Set or Map since call sites already build one or the other.
+// Resolves the ?requesterEmail= deep link into a display label and pre-fill target.
 export const getRequesterStatus = (
   requesterEmail: string | undefined,
   orgUsers: OrgUser[] | undefined,

--- a/frontend/src/lib/fn/requesterStatus.ts
+++ b/frontend/src/lib/fn/requesterStatus.ts
@@ -1,0 +1,32 @@
+import { OrgUser } from "@app/hooks/api/users/types";
+
+export type TRequesterStatus = {
+  isProjectUser: boolean;
+  userLabel: string;
+  userId?: string;
+};
+
+// Shared by the "add member" modals (generic and PAM) to resolve the `?requesterEmail=` deep link
+// from a project-access-request email into a display label and pre-fill target.
+// `memberUsernames` accepts a Set or Map since call sites already build one or the other.
+export const getRequesterStatus = (
+  requesterEmail: string | undefined,
+  orgUsers: OrgUser[] | undefined,
+  memberUsernames: { has: (username: string) => boolean }
+): TRequesterStatus => {
+  if (!requesterEmail) return { isProjectUser: false, userLabel: "" };
+
+  const isProjectUser = memberUsernames.has(requesterEmail);
+  const userDetails = orgUsers?.find((el) => el.user.username === requesterEmail);
+
+  let userLabel = "";
+  if (userDetails) {
+    const { firstName, lastName, email } = userDetails.user;
+    userLabel =
+      firstName && lastName
+        ? `${firstName} ${lastName}`
+        : firstName || lastName || (email as string);
+  }
+
+  return { isProjectUser, userLabel, userId: userDetails?.id };
+};

--- a/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
@@ -243,8 +243,7 @@ export const ProjectCategoryOverview = () => {
   };
 
   const enterPamProject = async () => {
-    // PAM is a per-org singleton with no dedicated "instance" concept; resolving it here also
-    // lazily bootstraps the project for orgs that don't have one yet (safe for any org member).
+    // Also lazily bootstraps the PAM project for orgs that don't have one yet.
     let pamProjectId: string;
     try {
       pamProjectId = await resolvePamProjectId(currentOrg?.pamProjectId);

--- a/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
@@ -34,6 +34,7 @@ import {
 import { useGetOrgProductStats, useGetUserProjects } from "@app/hooks/api";
 import { useCertManagerInstanceState } from "@app/hooks/api/certManagerInstance";
 import { useOrgAdminAccessProject } from "@app/hooks/api/orgAdmin/mutation";
+import { resolvePamProjectId } from "@app/hooks/api/pam/queries";
 import { Project, ProjectType } from "@app/hooks/api/projects/types";
 
 type ActiveProducts = Exclude<ProjectType, ProjectType.AI | ProjectType.SSH>;
@@ -120,6 +121,8 @@ export const ProjectCategoryOverview = () => {
   const [pendingCertManagerProjectId, setPendingCertManagerProjectId] = useState<string | null>(
     null
   );
+  const [isPamRequestAccessOpen, setIsPamRequestAccessOpen] = useState(false);
+  const [pendingPamProjectId, setPendingPamProjectId] = useState<string | null>(null);
 
   const orgDefaultCertManagerProjectId = certManagerInstance?.activeProjectId ?? null;
   const cmInstances = useMemo(
@@ -232,6 +235,61 @@ export const ProjectCategoryOverview = () => {
     await enterCertManagerProject(projectId);
   };
 
+  const navigateToPam = () => {
+    navigate({
+      to: "/organizations/$orgId/pam/access",
+      params: { orgId: currentOrg?.id ?? "" }
+    });
+  };
+
+  const enterPamProject = async () => {
+    // PAM is a per-org singleton with no dedicated "instance" concept; resolving it here also
+    // lazily bootstraps the project for orgs that don't have one yet (safe for any org member).
+    let pamProjectId: string;
+    try {
+      pamProjectId = await resolvePamProjectId(currentOrg?.pamProjectId);
+    } catch (err) {
+      createNotification({
+        type: "error",
+        text:
+          err instanceof Error
+            ? err.message
+            : "Failed to resolve the Privileged Access Manager project."
+      });
+      return;
+    }
+
+    const isMember = projects.some((p) => p.id === pamProjectId);
+    if (isMember) {
+      navigateToPam();
+      return;
+    }
+
+    setPendingPamProjectId(pamProjectId);
+
+    if (isOrgAdmin) {
+      try {
+        await orgAdminAccessProject.mutateAsync({ projectId: pamProjectId });
+        navigateToPam();
+      } catch (err) {
+        createNotification({
+          type: "error",
+          text:
+            err instanceof Error
+              ? err.message
+              : "Failed to join the Privileged Access Manager project."
+        });
+      }
+    } else if (canRequestAccess) {
+      setIsPamRequestAccessOpen(true);
+    } else {
+      createNotification({
+        type: "error",
+        text: "You don't have access to Privileged Access Manager."
+      });
+    }
+  };
+
   const handleTileClick = async (type: ProjectType) => {
     const orgId = currentOrg?.id || "";
 
@@ -250,10 +308,7 @@ export const ProjectCategoryOverview = () => {
     }
 
     if (type === ProjectType.PAM) {
-      navigate({
-        to: "/organizations/$orgId/pam/access",
-        params: { orgId }
-      });
+      await enterPamProject();
       return;
     }
 
@@ -294,6 +349,13 @@ export const ProjectCategoryOverview = () => {
     ? ({
         id: requestAccessTarget.id,
         name: requestAccessTarget.name
+      } as Project)
+    : undefined;
+
+  const pamRequestAccessProject: Project | undefined = pendingPamProjectId
+    ? ({
+        id: pendingPamProjectId,
+        name: "Privileged Access Manager"
       } as Project)
     : undefined;
 
@@ -387,6 +449,13 @@ export const ProjectCategoryOverview = () => {
         onOpenChange={setIsRequestAccessOpen}
         project={requestAccessProject}
         subTitle="Requesting access to Certificate Manager. You may include an optional note for admins to review your request."
+      />
+
+      <RequestProjectAccessModal
+        isOpen={isPamRequestAccessOpen}
+        onOpenChange={setIsPamRequestAccessOpen}
+        project={pamRequestAccessProject}
+        subTitle="Requesting access to Privileged Access Manager. You may include an optional note for admins to review your request."
       />
 
       <CertManagerNotConfiguredModal

--- a/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/components/ProjectCategoryOverview.tsx
@@ -141,6 +141,17 @@ export const ProjectCategoryOverview = () => {
   const isCertManagerAccessBlocked =
     cmInstances.length > 0 && !isOrgAdmin && !canRequestAccess && !isCertManagerMember;
 
+  const isPamMember = useMemo(
+    () =>
+      Boolean(
+        currentOrg?.pamProjectId &&
+          projects.some((project) => project.id === currentOrg.pamProjectId)
+      ),
+    [currentOrg?.pamProjectId, projects]
+  );
+  const isPamAccessBlocked =
+    Boolean(currentOrg?.pamProjectId) && !isOrgAdmin && !canRequestAccess && !isPamMember;
+
   const certManagerActiveProjectId = useMemo(() => {
     const cookieValue = currentOrg?.id ? getCertManagerActiveProjectCookie(currentOrg.id) : null;
     if (cookieValue && cmInstances.some((p) => p.id === cookieValue)) return cookieValue;
@@ -410,7 +421,11 @@ export const ProjectCategoryOverview = () => {
             </>
           );
 
-          if (type === ProjectType.CertificateManager && isCertManagerAccessBlocked) {
+          const isAccessBlocked =
+            (type === ProjectType.CertificateManager && isCertManagerAccessBlocked) ||
+            (type === ProjectType.PAM && isPamAccessBlocked);
+
+          if (isAccessBlocked) {
             return (
               <Tooltip key={type}>
                 <TooltipTrigger asChild>
@@ -419,8 +434,8 @@ export const ProjectCategoryOverview = () => {
                   </div>
                 </TooltipTrigger>
                 <TooltipContent>
-                  You don&apos;t have access to Certificate Manager. Ask an organization admin for
-                  access.
+                  You don&apos;t have access to {getProjectTitle(type)}. Ask an organization admin
+                  for access.
                 </TooltipContent>
               </Tooltip>
             );
@@ -452,7 +467,10 @@ export const ProjectCategoryOverview = () => {
 
       <RequestProjectAccessModal
         isOpen={isPamRequestAccessOpen}
-        onOpenChange={setIsPamRequestAccessOpen}
+        onOpenChange={(isOpen) => {
+          setIsPamRequestAccessOpen(isOpen);
+          if (!isOpen) setPendingPamProjectId(null);
+        }}
         project={pamRequestAccessProject}
         subTitle="Requesting access to Privileged Access Manager. You may include an optional note for admins to review your request."
       />

--- a/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
@@ -73,8 +73,12 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
     if (requesterEmail && requesterStatus.userId && !requesterStatus.isProjectUser) {
       setSelectedUsers([{ value: requesterStatus.userId, label: requesterStatus.userLabel }]);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [requesterEmail, requesterStatus.userId]);
+  }, [
+    requesterEmail,
+    requesterStatus.userId,
+    requesterStatus.isProjectUser,
+    requesterStatus.userLabel
+  ]);
 
   const clearRequesterEmail = () => {
     if (requesterEmail) {

--- a/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/InviteMemberModal.tsx
@@ -1,7 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Alert,
+  AlertDescription,
   Button,
   Dialog,
   DialogContent,
@@ -16,6 +19,7 @@ import {
 import { useOrganization, useProject } from "@app/context";
 import { useAddUserToWsNonE2EE, useGetOrgUsers, useGetWorkspaceUsers } from "@app/hooks/api";
 import { ProjectMembershipRole } from "@app/hooks/api/roles/types";
+import { getRequesterStatus } from "@app/lib/fn/requesterStatus";
 
 import { ProductRoleOptionList } from "./ProductRoleOptionList";
 
@@ -33,6 +37,12 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
   const { currentProject } = useProject();
   const { currentOrg } = useOrganization();
   const { mutate: addUser, isPending } = useAddUserToWsNonE2EE();
+  const navigate = useNavigate({ from: "" });
+
+  const requesterEmail = useSearch({
+    strict: false,
+    select: (el) => (el as { requesterEmail?: string })?.requesterEmail
+  });
 
   const [selectedUsers, setSelectedUsers] = useState<SelectOption[]>([]);
   const [selectedRole, setSelectedRole] = useState<string>(ProjectMembershipRole.Member);
@@ -40,8 +50,9 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
   const { data: members } = useGetWorkspaceUsers(currentProject.id);
   const { data: orgUsers } = useGetOrgUsers(currentOrg.id);
 
+  const wsUsernames = useMemo(() => new Set(members?.map((m) => m.user.username)), [members]);
+
   const availableUsers = useMemo(() => {
-    const wsUsernames = new Set(members?.map((m) => m.user.username));
     return (orgUsers || [])
       .filter(({ user: u }) => !wsUsernames.has(u.username))
       .map(({ id, inviteEmail, user: { firstName, lastName, email } }) => ({
@@ -51,11 +62,30 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
             ? `${firstName} ${lastName}`
             : firstName || lastName || email || inviteEmail
       }));
-  }, [orgUsers, members]);
+  }, [orgUsers, wsUsernames]);
+
+  const requesterStatus = useMemo(
+    () => getRequesterStatus(requesterEmail, orgUsers, wsUsernames),
+    [requesterEmail, orgUsers, wsUsernames]
+  );
+
+  useEffect(() => {
+    if (requesterEmail && requesterStatus.userId && !requesterStatus.isProjectUser) {
+      setSelectedUsers([{ value: requesterStatus.userId, label: requesterStatus.userLabel }]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [requesterEmail, requesterStatus.userId]);
+
+  const clearRequesterEmail = () => {
+    if (requesterEmail) {
+      navigate({ search: (prev) => ({ ...prev, requesterEmail: "" }) });
+    }
+  };
 
   const handleClose = () => {
     setSelectedUsers([]);
     setSelectedRole(ProjectMembershipRole.Member);
+    clearRequesterEmail();
     onOpenChange(false);
   };
 
@@ -90,7 +120,13 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
   };
 
   return (
-    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) clearRequesterEmail();
+        onOpenChange(open);
+      }}
+    >
       <DialogContent className="overflow-visible sm:max-w-xl">
         <DialogHeader>
           <DialogTitle>Add Member</DialogTitle>
@@ -118,6 +154,22 @@ export const InviteMemberModal = ({ isOpen, onOpenChange }: Props) => {
             </FieldLabel>
             <ProductRoleOptionList value={selectedRole} onChange={setSelectedRole} />
           </Field>
+
+          {requesterEmail && requesterStatus.isProjectUser && (
+            <Alert variant="danger">
+              <AlertDescription>
+                Requested user is already a member of this product.
+              </AlertDescription>
+            </Alert>
+          )}
+          {requesterEmail && !requesterStatus.isProjectUser && requesterStatus.userId && (
+            <Alert>
+              <AlertDescription>
+                Assign a role to provide access to requesting user{" "}
+                <b>{requesterStatus.userLabel}</b>.
+              </AlertDescription>
+            </Alert>
+          )}
         </div>
 
         <DialogFooter>

--- a/frontend/src/pages/pam/PamAccessControlPage/components/MembersTab.tsx
+++ b/frontend/src/pages/pam/PamAccessControlPage/components/MembersTab.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useSearch } from "@tanstack/react-router";
 import { MoreHorizontalIcon, PencilIcon, Plus, SearchIcon, Trash2Icon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
@@ -51,6 +52,17 @@ export const MembersTab = () => {
 
   const { data: members = [], isPending } = useGetWorkspaceUsers(currentProject.id);
   const deleteMember = useRemovePamProductUserMember();
+
+  const requesterEmail = useSearch({
+    strict: false,
+    select: (el) => (el as { requesterEmail?: string })?.requesterEmail
+  });
+
+  useEffect(() => {
+    if (requesterEmail) {
+      setIsInviteOpen(true);
+    }
+  }, [requesterEmail]);
 
   const filteredMembers = useMemo(
     () =>

--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/AddMemberModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/AddMemberModal.tsx
@@ -42,6 +42,7 @@ import {
 import { ProjectType, ProjectVersion } from "@app/hooks/api/projects/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 import { filterByGrantConditions, getMemberAssignRoleConditions } from "@app/lib/fn/permission";
+import { getRequesterStatus } from "@app/lib/fn/requesterStatus";
 
 const addMemberFormSchema = z.object({
   orgMemberships: z
@@ -203,23 +204,12 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
             ? `${firstName} ${lastName}`
             : firstName || lastName || email || inviteEmail
       }));
-    const requesterStatus = { isProjectUser: wsUserUsernames.has(requesterEmail), userLabel: "" };
-    if (!requesterStatus.isProjectUser) {
-      const userDetails = orgUsers?.find((el) => el.user.username === requesterEmail);
-      if (userDetails) {
-        const { user } = userDetails;
-        const label =
-          user.firstName && user.lastName
-            ? `${user.firstName} ${user.lastName}`
-            : user.firstName || user.lastName || (user.email as string);
-        requesterStatus.userLabel = label;
-        setValue("orgMemberships", [
-          {
-            value: userDetails.id,
-            label
-          }
-        ]);
-      }
+
+    const requesterStatus = getRequesterStatus(requesterEmail, orgUsers, wsUserUsernames);
+    if (!requesterStatus.isProjectUser && requesterStatus.userId) {
+      setValue("orgMemberships", [
+        { value: requesterStatus.userId, label: requesterStatus.userLabel }
+      ]);
     }
 
     return { list, requesterStatus };

--- a/frontend/src/pages/public/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/pages/public/ErrorPage/ErrorPage.tsx
@@ -20,6 +20,11 @@ import { useTimedReset } from "@app/hooks";
 
 import { ProjectAccessError } from "./components";
 
+const isProjectAccessDeniedError = (error: unknown): error is AxiosError =>
+  error instanceof AxiosError &&
+  error.status === 403 &&
+  error.response?.data?.error === "ProjectMembershipNotFound";
+
 const STATUS_LABELS: Record<number, string> = {
   400: "Bad Request",
   401: "Unauthorized",
@@ -57,11 +62,7 @@ export const ErrorPage = ({ error }: ErrorComponentProps) => {
     setIsFullScreen(rect.top < 2 && rect.left < 2 && window.innerWidth - rect.width < 4);
   }, []);
 
-  if (
-    error instanceof AxiosError &&
-    error.status === 403 &&
-    error.response?.data?.error === "User not a part of the specified project"
-  ) {
+  if (isProjectAccessDeniedError(error)) {
     return <ProjectAccessError />;
   }
 

--- a/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
+++ b/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
@@ -15,12 +15,8 @@ type ProjectAccessErrorProps = {
   projectId?: string;
 };
 
-// PAM is a per-org singleton with no $projectId route param, unlike other product routes, so this
-// screen can't read the project id off the route the normal way when it fires for a PAM page. Its
-// beforeLoad throws from a parent route's error boundary (TanStack attributes a beforeLoad failure
-// to the nearest already-matched ancestor, not the failing route itself), so a PAM-specific
-// errorComponent on the PAM route never runs either. Derive the org id from the URL instead.
-// Keep in sync with the PAM route path declared in `frontend/src/pages/pam/layout.tsx`.
+// PAM has no $projectId route param, and TanStack attributes beforeLoad failures to the nearest
+// matched ancestor rather than the failing route, so derive the org id from the URL. Keep in sync with pam/layout.tsx.
 const getPamOrgIdFromPath = () =>
   window.location.pathname.match(/\/organizations\/([^/]+)\/pam(\/|$)/)?.[1];
 

--- a/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
+++ b/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
@@ -9,8 +9,22 @@ import { OrgPermissionSubjects } from "@app/context";
 import { OrgPermissionAdminConsoleAction } from "@app/context/OrgPermissionContext/types";
 import { usePopUp } from "@app/hooks";
 import { useOrgAdminAccessProject, useSearchProjects } from "@app/hooks/api";
+import { useGetOrganizationById } from "@app/hooks/api/organization/queries";
 
-export const ProjectAccessError = () => {
+type ProjectAccessErrorProps = {
+  projectId?: string;
+};
+
+// PAM is a per-org singleton with no $projectId route param, unlike other product routes, so this
+// screen can't read the project id off the route the normal way when it fires for a PAM page. Its
+// beforeLoad throws from a parent route's error boundary (TanStack attributes a beforeLoad failure
+// to the nearest already-matched ancestor, not the failing route itself), so a PAM-specific
+// errorComponent on the PAM route never runs either. Derive the org id from the URL instead.
+// Keep in sync with the PAM route path declared in `frontend/src/pages/pam/layout.tsx`.
+const getPamOrgIdFromPath = () =>
+  window.location.pathname.match(/\/organizations\/([^/]+)\/pam(\/|$)/)?.[1];
+
+export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessErrorProps = {}) => {
   const orgAdminAccessProject = useOrgAdminAccessProject();
 
   const navigate = useNavigate();
@@ -19,9 +33,17 @@ export const ProjectAccessError = () => {
     "requestAccessConfirmation"
   ] as const);
 
-  const { projectId } = useParams({
+  const { projectId: routeProjectId } = useParams({
     strict: false
   });
+
+  const needsPamFallback = !projectIdProp && !routeProjectId;
+  const pamOrgId = needsPamFallback ? getPamOrgIdFromPath() : undefined;
+  const { data: pamOrg } = useGetOrganizationById(pamOrgId ?? "", {
+    enabled: Boolean(pamOrgId)
+  });
+
+  const projectId = projectIdProp ?? routeProjectId ?? pamOrg?.pamProjectId ?? undefined;
 
   const { data, isPending: isProjectLoading } = useSearchProjects({
     projectIds: projectId ? [projectId] : [],
@@ -43,7 +65,7 @@ export const ProjectAccessError = () => {
   };
 
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    <div className="flex h-full min-h-screen w-full items-center justify-center bg-bunker-800">
       <AccessRestrictedBanner
         body={
           <>

--- a/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
+++ b/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
@@ -61,7 +61,11 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
   };
 
   return (
-    <div className="flex h-full min-h-screen w-full items-center justify-center bg-bunker-800">
+    <div
+      className={`flex h-full w-full items-center justify-center ${
+        needsPamFallback ? "min-h-screen bg-background" : ""
+      }`}
+    >
       <AccessRestrictedBanner
         body={
           <>


### PR DESCRIPTION
## Context

PAM's org home page tile always navigated straight into the product regardless of membership, causing non-members to hit a raw 403. This brings PAM to parity with Cert Manager: org admins self-join instantly, regular members get an in-place "Request Access" modal, and the Members tab auto-opens with the requester pre-filled when an admin follows the emailed link.

## Steps to verify the change

1. As an org admin who is not yet a PAM member, click the Privileged Access Manager tile on the org home page. Confirm you're silently added as a PAM admin and land in PAM directly, no error page.
2. As a plain org member with no PAM access, click the same tile. Confirm the "Request Access" modal opens in place (no navigation), and submitting it notifies current PAM admins.
3. As a PAM admin, open the emailed link. Confirm it lands on the Members tab with the "Add Member" dialog already open and the requester pre-filled.

## Type

- [x] Fix
- [x] Feature

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the contributing guide