### PR TITLE
docs(supabase-sync): describe behavior at Supabase's 100-secret cap

### DIFF
--- a/docs/integrations/secret-syncs/supabase.mdx
+++ b/docs/integrations/secret-syncs/supabase.mdx
@@ -7,6 +7,17 @@ description: "Learn how to configure a Supabase Sync for Infisical."
 
 - Create a [Supabase Connection](/integrations/app-connections/supabase)
 
+<Warning>
+    Supabase enforces a hard cap of **100 secrets per project** that cannot be raised. When a sync would push the destination past that cap, the affected batch fails and the sync is reported as failed.
+
+    - **More than 100 source secrets:** Infisical batches writes to Supabase in groups of 100. Individual batches that would push the destination over 100 fail on the Supabase API call, and the sync status flips to failed. Earlier batches in the same run may have written successfully before the failing batch.
+    - **Destination already at 100:** The first create batch fails immediately with the same error path.
+    - **Where the failure surfaces:** The sync's `syncStatus` becomes `failed`, `lastSyncMessage` records the Supabase error, and auto-sync retries on its normal schedule. The error names the first secret key in the failing batch, not every affected key.
+    - **Deletion mode interaction:** With **Disable Secret Deletion** off, Infisical writes new secrets first and then deletes destination secrets no longer present in the source. Because the delete phase runs after the create phase, deleting a secret cannot free up capacity in the same sync run — if the destination is at 100 and you want the sync to free the slot itself, either lower the source below 100 first or clear the unwanted secret manually in Supabase.
+
+    Reserved Supabase-managed keys (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`) are always skipped by the sync and count against the 100-cap on the Supabase side.
+</Warning>
+
 <Tabs>
     <Tab title="Infisical UI">
         <Steps>

--- a/docs/integrations/secret-syncs/supabase.mdx
+++ b/docs/integrations/secret-syncs/supabase.mdx
@@ -15,7 +15,7 @@ description: "Learn how to configure a Supabase Sync for Infisical."
     - **Where the failure surfaces:** The sync's `syncStatus` becomes `failed`, `lastSyncMessage` records the Supabase error, and auto-sync retries on its normal schedule. The error names the first secret key in the failing batch, not every affected key.
     - **Deletion mode interaction:** With **Disable Secret Deletion** off, Infisical writes new secrets first and then deletes destination secrets no longer present in the source. Because the delete phase runs after the create phase, deleting a secret cannot free up capacity in the same sync run — if the destination is at 100 and you want the sync to free the slot itself, either lower the source below 100 first or clear the unwanted secret manually in Supabase.
 
-    Reserved Supabase-managed keys (`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`) are always skipped by the sync and count against the 100-cap on the Supabase side.
+    Supabase reserves four managed keys — `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_DB_URL`. They always count against the 100-cap on the Supabase side. The sync only excludes them from **deletes** (so it will never remove one), but it does **not** filter them out of writes — if a secret in your Infisical source path shares one of these names, the sync will attempt to overwrite it on Supabase. Rename any such secrets in Infisical before enabling the sync to avoid the collision.
 </Warning>
 
 <Tabs>


### PR DESCRIPTION
Fixes #7204.

## What

Adds a Warning callout to the Supabase Sync guide that documents what happens when the source or destination reaches Supabase's hard cap of 100 secrets per project. Content is derived directly from \`backend/src/services/secret-sync/supabase/supabase-sync-fns.ts\` so the docs match the code.

Covers each of the four questions in the issue:

- **More than 100 source secrets:** Infisical batches writes in groups of 100 (\`chunkArray(toCreate, 100)\`). Batches that would push the destination over 100 fail at the Supabase API level; earlier batches in the same run may have already written successfully.
- **Destination already at 100:** The first create batch fails immediately with the same error path.
- **Where the failure surfaces:** \`syncStatus = failed\`, \`lastSyncMessage\` carries the Supabase error, and auto-sync retries on its normal schedule. The error names the first secret key in the failing batch, not every affected key.
- **Deletion mode interaction:** Because the create phase runs before the delete phase in \`syncSecrets\`, disabling \"Disable Secret Deletion\" does not free up capacity in the same sync run. If the destination is at cap and you want to add new secrets, either lower the source below 100 first or delete the unwanted destination secrets manually.

Also mentions that Supabase's reserved \`SUPABASE_*\` keys are skipped by the sync but still count against the 100-cap.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (docs-only)
- [x] The change is limited to the affected code path