### PR TITLE
fix(secret-v2-bridge): skip soft-deleted projects in intra-project reference lookups

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -962,8 +962,10 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
         .join(TableName.SecretV2, `${TableName.SecretV2}.id`, `${TableName.SecretReferenceV2}.secretId`)
         .join(TableName.SecretFolder, `${TableName.SecretV2}.folderId`, `${TableName.SecretFolder}.id`)
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
         .where("projectId", projectId)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .select(selectAllTableCols(TableName.SecretReferenceV2))
         .select("folderId");
 
@@ -990,11 +992,13 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
         .join(TableName.SecretV2, `${TableName.SecretV2}.id`, `${TableName.SecretReferenceV2}.secretId`)
         .join(TableName.SecretFolder, `${TableName.SecretV2}.folderId`, `${TableName.SecretFolder}.id`)
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
         .where({
           [`${TableName.SecretFolder}.isReserved` as "isReserved"]: false
         })
         .where("projectId", projectId)
         .whereNull(`${TableName.Environment}.deleteAfter`)
+        .whereNull(`${TableName.Project}.deleteAfter`)
         .select(selectAllTableCols(TableName.SecretReferenceV2))
         .select("folderId");
 


### PR DESCRIPTION
## What

Two helpers in \`secret-v2-bridge-dal.ts\` that resolve secret-reference dependencies within a single project — \`findReferencedSecretReferences\` and \`findReferencedSecretReferencesBySecretKey\` — join \`project_environments\` and filter \`Environment.deleteAfter\` but never join \`projects\` or filter \`Project.deleteAfter\`.

The sibling cross-project reference helpers a few lines below (\`findCrossProjectSecretReferencesByTargetSecretKey\` and \`findCrossProjectSecretReferencesByTargetFolder\`) already filter both — this brings the intra-project variants to parity.

## Fix

Adds the \`Project\` join + \`whereNull(Project.deleteAfter)\` to both intra-project helpers. Same shape as the previously shipped webhook (#6970), integration (#6983), secret-rotation-v2 (#7002), dynamic-secret (#7065), snapshot (#7066), folder-commit (#7067), honey-token (#7088), secret-import (#7089), secret-approval-request (#7090, merged), access-approval-request (#7105), access-approval-policy (#7106), secret-approval-policy (#7107), reminder (#7124), app-connection (#7125), secret-approval-request-secret (#7126), secret-folder-version (#7155), secret-version v1 (#7156), offline-usage-report (#7157), secret-v2-bridge/secret-version (#7167), project-folder-grant (#7168), telemetry (#7169), secret-blind-index (#7187), secret (#7188), and secret-folder (#7189) fixes.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (DAL-only change; brings the intra-project reference helpers to parity with the cross-project ones in the same file)
- [x] The change is limited to the affected code path