### PR TITLE
fix: check connection id to define if sync is duplicated or not

### DIFF
--- a/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
+++ b/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
@@ -492,6 +492,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
       tags: [ApiDocsTags.SecretSyncs],
       body: z.object({
         destinationConfig: z.unknown(),
+        connectionId: z.string().uuid().optional(),
         excludeSyncId: z.string().uuid().optional(),
         projectId: z.string().uuid()
       }),
@@ -504,12 +505,13 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      const { destinationConfig, excludeSyncId, projectId } = req.body;
+      const { destinationConfig, connectionId, excludeSyncId, projectId } = req.body;
 
       const result = await server.services.secretSync.checkDuplicateDestination(
         {
           destinationConfig: destinationConfig as Record<string, unknown>,
           destination,
+          connectionId,
           excludeSyncId,
           projectId
         },

--- a/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
+++ b/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
@@ -493,6 +493,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
       body: z.object({
         destinationConfig: z.unknown(),
         connectionId: z.string().uuid().optional(),
+        syncOptions: z.record(z.unknown()).optional(),
         excludeSyncId: z.string().uuid().optional(),
         projectId: z.string().uuid()
       }),
@@ -505,13 +506,14 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      const { destinationConfig, connectionId, excludeSyncId, projectId } = req.body;
+      const { destinationConfig, connectionId, syncOptions, excludeSyncId, projectId } = req.body;
 
       const result = await server.services.secretSync.checkDuplicateDestination(
         {
           destinationConfig: destinationConfig as Record<string, unknown>,
           destination,
           connectionId,
+          syncOptions,
           excludeSyncId,
           projectId
         },

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -228,63 +228,24 @@ export const validateAwsConnectionCredentials = async (appConnection: TAwsConnec
   return appConnection.credentials;
 };
 
-const extractAccountIdFromArn = (roleArn: string): string | null => {
-  const match = roleArn.match(/^arn:aws[^:]*:iam::(\d{12}):/);
-  return match ? match[1] : null;
-};
+export const getAwsAccountId = async (appConnection: TAwsConnectionConfig): Promise<string | null> => {
+  try {
+    const awsConfig = await getAwsConnectionConfig(appConnection);
 
-// eslint-disable-next-line no-bitwise
-const extractAccountIdFromAccessKey = (accessKeyId: string): string | null => {
-  if (accessKeyId.length < 16) return null;
+    const stsEndpoint =
+      appConnection.method === AwsConnectionMethod.AssumeRole ? appConnection.credentials.stsEndpoint : undefined;
+    const stsRegion = getStsSigningRegion(stsEndpoint);
 
-  const trimmed = accessKeyId.slice(4);
-  const base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    const sts = new STSClient({
+      region: stsRegion.region ?? awsConfig.region,
+      credentials: awsConfig.credentials,
+      ...(stsEndpoint && stsRegion.isValidEndpoint ? { endpoint: stsEndpoint } : {})
+    });
 
-  const bits: number[] = [];
-  for (const char of trimmed) {
-    const val = base32Chars.indexOf(char.toUpperCase());
-    if (val === -1) return null;
-    for (let i = 4; i >= 0; i -= 1) {
-      // eslint-disable-next-line no-bitwise
-      bits.push((val >> i) & 1);
-    }
+    const response = await sts.send(new GetCallerIdentityCommand({}));
+    return response.Account ?? null;
+  } catch (error) {
+    logger.error(error, "Failed to retrieve AWS account ID via STS");
+    return null;
   }
-
-  const bytes: number[] = [];
-  for (let i = 0; i < 6 * 8 && i < bits.length; i += 8) {
-    let byte = 0;
-    for (let j = 0; j < 8 && i + j < bits.length; j += 1) {
-      // eslint-disable-next-line no-bitwise
-      byte = (byte << 1) | bits[i + j];
-    }
-    bytes.push(byte);
-  }
-
-  if (bytes.length < 6) return null;
-
-  let num = 0n;
-  for (const byte of bytes) {
-    // eslint-disable-next-line no-bitwise
-    num = (num << 8n) | BigInt(byte);
-  }
-  const mask = 0x7fffffffff80n;
-  // eslint-disable-next-line no-bitwise
-  const accountId = ((num & mask) >> 7n).toString();
-
-  return accountId.padStart(12, "0");
-};
-
-export const extractAwsAccountId = (connection: {
-  method: string;
-  credentials: { roleArn?: string; accessKeyId?: string };
-}): string | null => {
-  if (connection.method === AwsConnectionMethod.AssumeRole && connection.credentials.roleArn) {
-    return extractAccountIdFromArn(connection.credentials.roleArn);
-  }
-
-  if (connection.method === AwsConnectionMethod.AccessKey && connection.credentials.accessKeyId) {
-    return extractAccountIdFromAccessKey(connection.credentials.accessKeyId);
-  }
-
-  return null;
 };

--- a/backend/src/services/app-connection/aws/aws-connection-fns.ts
+++ b/backend/src/services/app-connection/aws/aws-connection-fns.ts
@@ -227,3 +227,64 @@ export const validateAwsConnectionCredentials = async (appConnection: TAwsConnec
 
   return appConnection.credentials;
 };
+
+const extractAccountIdFromArn = (roleArn: string): string | null => {
+  const match = roleArn.match(/^arn:aws[^:]*:iam::(\d{12}):/);
+  return match ? match[1] : null;
+};
+
+// eslint-disable-next-line no-bitwise
+const extractAccountIdFromAccessKey = (accessKeyId: string): string | null => {
+  if (accessKeyId.length < 16) return null;
+
+  const trimmed = accessKeyId.slice(4);
+  const base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+  const bits: number[] = [];
+  for (const char of trimmed) {
+    const val = base32Chars.indexOf(char.toUpperCase());
+    if (val === -1) return null;
+    for (let i = 4; i >= 0; i -= 1) {
+      // eslint-disable-next-line no-bitwise
+      bits.push((val >> i) & 1);
+    }
+  }
+
+  const bytes: number[] = [];
+  for (let i = 0; i < 6 * 8 && i < bits.length; i += 8) {
+    let byte = 0;
+    for (let j = 0; j < 8 && i + j < bits.length; j += 1) {
+      // eslint-disable-next-line no-bitwise
+      byte = (byte << 1) | bits[i + j];
+    }
+    bytes.push(byte);
+  }
+
+  if (bytes.length < 6) return null;
+
+  let num = 0n;
+  for (const byte of bytes) {
+    // eslint-disable-next-line no-bitwise
+    num = (num << 8n) | BigInt(byte);
+  }
+  const mask = 0x7fffffffff80n;
+  // eslint-disable-next-line no-bitwise
+  const accountId = ((num & mask) >> 7n).toString();
+
+  return accountId.padStart(12, "0");
+};
+
+export const extractAwsAccountId = (connection: {
+  method: string;
+  credentials: { roleArn?: string; accessKeyId?: string };
+}): string | null => {
+  if (connection.method === AwsConnectionMethod.AssumeRole && connection.credentials.roleArn) {
+    return extractAccountIdFromArn(connection.credentials.roleArn);
+  }
+
+  if (connection.method === AwsConnectionMethod.AccessKey && connection.credentials.accessKeyId) {
+    return extractAccountIdFromAccessKey(connection.credentials.accessKeyId);
+  }
+
+  return null;
+};

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -213,12 +213,14 @@ export const SECRET_SYNC_SKIP_FIELDS_MAP: Record<SecretSync, string[]> = {
 
 const defaultDuplicateCheck: DestinationDuplicateCheckFn = () => true;
 const awsDuplicateCheck: DestinationDuplicateCheckFn = ({ existingConnectionId, newConnectionId }) => {
-    // TODO: we should also check the AWS account id here, otherwise
-    // two connections to the same account would cause issues.
-    // If assume role: get account id from ARN
-    // If credentials, use AWS_ACCESS_ID to infer the account id
-    return existingConnectionId === newConnectionId;
-  };
+  if (!newConnectionId) return true;
+
+  // TODO: we should also check the AWS account id here, otherwise
+  // two connections to the same account would cause issues.
+  // If assume role: get account id from ARN
+  // If credentials, use AWS_ACCESS_ID to infer the account id
+  return existingConnectionId === newConnectionId;
+};
 
 export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {
   [SecretSync.AWSParameterStore]: awsDuplicateCheck,

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -215,7 +215,13 @@ const defaultDuplicateCheck: DestinationDuplicateCheckFn = () => true;
 
 export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {
   [SecretSync.AWSParameterStore]: defaultDuplicateCheck,
-  [SecretSync.AWSSecretsManager]: defaultDuplicateCheck,
+  [SecretSync.AWSSecretsManager]: (_existingConfig, _newConfig, existingConnectionId, newConnectionId) => {
+    // TODO: we should also check the AWS account id here, otherwise
+    // two connections to the same account would cause issues.
+    // If assume role: get account id from ARN
+    // If credentials, use AWS_ACCESS_ID to infer the account id
+    return existingConnectionId === newConnectionId;
+  },
   [SecretSync.GitHub]: defaultDuplicateCheck,
   [SecretSync.GCPSecretManager]: defaultDuplicateCheck,
   [SecretSync.AzureKeyVault]: defaultDuplicateCheck,

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -1,5 +1,6 @@
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { extractAwsAccountId } from "@app/services/app-connection/aws/aws-connection-fns";
+import { TAwsConnection } from "@app/services/app-connection/aws/aws-connection-types";
 import { SecretSync, SecretSyncPlanType } from "@app/services/secret-sync/secret-sync-enums";
 import { DestinationDuplicateCheckFn } from "@app/services/secret-sync/secret-sync-types";
 
@@ -227,8 +228,8 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({
     decryptConnection(newConnectionId)
   ]);
 
-  const existingAccountId = extractAwsAccountId(existingConn);
-  const newAccountId = extractAwsAccountId(newConn);
+  const existingAccountId = extractAwsAccountId(existingConn as TAwsConnection);
+  const newAccountId = extractAwsAccountId(newConn as TAwsConnection);
 
   if (!existingAccountId || !newAccountId) return false;
 
@@ -257,7 +258,7 @@ export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDupl
   [SecretSync.Render]: defaultDuplicateCheck,
   [SecretSync.Flyio]: defaultDuplicateCheck,
   [SecretSync.TriggerDev]: defaultDuplicateCheck,
-  [SecretSync.GitLab]: ({ existingConfig, newConfig }) => {
+  [SecretSync.GitLab]: async ({ existingConfig, newConfig }) => {
     const existingTargetEnv = existingConfig.targetEnvironment as string | undefined;
     const newTargetEnv = newConfig.targetEnvironment as string | undefined;
 

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -215,7 +215,7 @@ const defaultDuplicateCheck: DestinationDuplicateCheckFn = () => true;
 
 export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {
   [SecretSync.AWSParameterStore]: defaultDuplicateCheck,
-  [SecretSync.AWSSecretsManager]: (_existingConfig, _newConfig, existingConnectionId, newConnectionId) => {
+  [SecretSync.AWSSecretsManager]: ({ existingConnectionId, newConnectionId }) => {
     // TODO: we should also check the AWS account id here, otherwise
     // two connections to the same account would cause issues.
     // If assume role: get account id from ARN
@@ -241,7 +241,7 @@ export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDupl
   [SecretSync.Render]: defaultDuplicateCheck,
   [SecretSync.Flyio]: defaultDuplicateCheck,
   [SecretSync.TriggerDev]: defaultDuplicateCheck,
-  [SecretSync.GitLab]: (existingConfig, newConfig) => {
+  [SecretSync.GitLab]: ({ existingConfig, newConfig }) => {
     const existingTargetEnv = existingConfig.targetEnvironment as string | undefined;
     const newTargetEnv = newConfig.targetEnvironment as string | undefined;
 

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -1,5 +1,5 @@
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
-import { extractAwsAccountId } from "@app/services/app-connection/aws/aws-connection-fns";
+import { buildAwsConnectionConfig, getAwsAccountId } from "@app/services/app-connection/aws/aws-connection-fns";
 import { TAwsConnection } from "@app/services/app-connection/aws/aws-connection-types";
 import { SecretSync, SecretSyncPlanType } from "@app/services/secret-sync/secret-sync-enums";
 import { DestinationDuplicateCheckFn } from "@app/services/secret-sync/secret-sync-types";
@@ -214,26 +214,34 @@ export const SECRET_SYNC_SKIP_FIELDS_MAP: Record<SecretSync, string[]> = {
 };
 
 const defaultDuplicateCheck: DestinationDuplicateCheckFn = async () => true;
-const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({
-  existingConnectionId,
-  newConnectionId,
-  decryptConnection
-}) => {
-  if (!newConnectionId) return true;
-  if (existingConnectionId === newConnectionId) return true;
-  if (!existingConnectionId) return false;
+const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, newSync, decryptConnection }) => {
+  if (!newSync.connectionId) return true;
+
+  const existingKeySchema = (existingSync.syncOptions?.keySchema as string) ?? "";
+  const newKeySchema = (newSync.syncOptions?.keySchema as string) ?? "";
+
+  if (existingSync.connectionId === newSync.connectionId) {
+    return existingKeySchema === newKeySchema;
+  }
+
+  if (!existingSync.connectionId) return false;
 
   const [existingConn, newConn] = await Promise.all([
-    decryptConnection(existingConnectionId),
-    decryptConnection(newConnectionId)
+    decryptConnection(existingSync.connectionId),
+    decryptConnection(newSync.connectionId)
   ]);
 
-  const existingAccountId = extractAwsAccountId(existingConn as TAwsConnection);
-  const newAccountId = extractAwsAccountId(newConn as TAwsConnection);
+  const existingAwsConn = existingConn as TAwsConnection;
+  const newAwsConn = newConn as TAwsConnection;
+
+  const [existingAccountId, newAccountId] = await Promise.all([
+    getAwsAccountId(buildAwsConnectionConfig(existingAwsConn, existingAwsConn.credentials)),
+    getAwsAccountId(buildAwsConnectionConfig(newAwsConn, newAwsConn.credentials))
+  ]);
 
   if (!existingAccountId || !newAccountId) return false;
 
-  return existingAccountId === newAccountId;
+  return existingAccountId === newAccountId && existingKeySchema === newKeySchema;
 };
 
 export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {
@@ -258,7 +266,10 @@ export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDupl
   [SecretSync.Render]: defaultDuplicateCheck,
   [SecretSync.Flyio]: defaultDuplicateCheck,
   [SecretSync.TriggerDev]: defaultDuplicateCheck,
-  [SecretSync.GitLab]: async ({ existingConfig, newConfig }) => {
+  [SecretSync.GitLab]: async ({ existingSync, newSync }) => {
+    const existingConfig = existingSync.destinationConfig;
+    const newConfig = newSync.destinationConfig;
+
     const existingTargetEnv = existingConfig.targetEnvironment as string | undefined;
     const newTargetEnv = newConfig.targetEnvironment as string | undefined;
 

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -220,8 +220,12 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
   const existingKeySchema = (existingSync.syncOptions?.keySchema as string) ?? "";
   const newKeySchema = (newSync.syncOptions?.keySchema as string) ?? "";
 
+  // Mismatched keySchemas can still conflict (e.g. sync A with keySchema "INFISICAL_{{secretKey}}" and secret HOST
+  // vs sync B without keySchema and secret INFISICAL_HOST will write to the same destination key).
+  const hasKeySchemaConflict = !existingKeySchema || !newKeySchema || existingKeySchema === newKeySchema;
+
   if (existingSync.connectionId === newSync.connectionId) {
-    return existingKeySchema === newKeySchema;
+    return hasKeySchemaConflict;
   }
 
   if (!existingSync.connectionId) return false;
@@ -241,7 +245,7 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
 
   if (!existingAccountId || !newAccountId) return false;
 
-  return existingAccountId === newAccountId && existingKeySchema === newKeySchema;
+  return existingAccountId === newAccountId && hasKeySchemaConflict;
 };
 
 export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -212,16 +212,17 @@ export const SECRET_SYNC_SKIP_FIELDS_MAP: Record<SecretSync, string[]> = {
 };
 
 const defaultDuplicateCheck: DestinationDuplicateCheckFn = () => true;
-
-export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {
-  [SecretSync.AWSParameterStore]: defaultDuplicateCheck,
-  [SecretSync.AWSSecretsManager]: ({ existingConnectionId, newConnectionId }) => {
+const awsDuplicateCheck: DestinationDuplicateCheckFn = ({ existingConnectionId, newConnectionId }) => {
     // TODO: we should also check the AWS account id here, otherwise
     // two connections to the same account would cause issues.
     // If assume role: get account id from ARN
     // If credentials, use AWS_ACCESS_ID to infer the account id
     return existingConnectionId === newConnectionId;
-  },
+  };
+
+export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {
+  [SecretSync.AWSParameterStore]: awsDuplicateCheck,
+  [SecretSync.AWSSecretsManager]: awsDuplicateCheck,
   [SecretSync.GitHub]: defaultDuplicateCheck,
   [SecretSync.GCPSecretManager]: defaultDuplicateCheck,
   [SecretSync.AzureKeyVault]: defaultDuplicateCheck,

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -1,4 +1,5 @@
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
+import { extractAwsAccountId } from "@app/services/app-connection/aws/aws-connection-fns";
 import { SecretSync, SecretSyncPlanType } from "@app/services/secret-sync/secret-sync-enums";
 import { DestinationDuplicateCheckFn } from "@app/services/secret-sync/secret-sync-types";
 
@@ -211,15 +212,27 @@ export const SECRET_SYNC_SKIP_FIELDS_MAP: Record<SecretSync, string[]> = {
   [SecretSync.Cloud66]: ["stackName"]
 };
 
-const defaultDuplicateCheck: DestinationDuplicateCheckFn = () => true;
-const awsDuplicateCheck: DestinationDuplicateCheckFn = ({ existingConnectionId, newConnectionId }) => {
+const defaultDuplicateCheck: DestinationDuplicateCheckFn = async () => true;
+const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({
+  existingConnectionId,
+  newConnectionId,
+  decryptConnection
+}) => {
   if (!newConnectionId) return true;
+  if (existingConnectionId === newConnectionId) return true;
+  if (!existingConnectionId) return false;
 
-  // TODO: we should also check the AWS account id here, otherwise
-  // two connections to the same account would cause issues.
-  // If assume role: get account id from ARN
-  // If credentials, use AWS_ACCESS_ID to infer the account id
-  return existingConnectionId === newConnectionId;
+  const [existingConn, newConn] = await Promise.all([
+    decryptConnection(existingConnectionId),
+    decryptConnection(newConnectionId)
+  ]);
+
+  const existingAccountId = extractAwsAccountId(existingConn);
+  const newAccountId = extractAwsAccountId(newConn);
+
+  if (!existingAccountId || !newAccountId) return false;
+
+  return existingAccountId === newAccountId;
 };
 
 export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -288,12 +288,12 @@ export const secretSyncServiceFactory = ({
         try {
           const baseFieldsMatch = deepEqualSkipFields(sync.destinationConfig, destinationConfig, skipFields);
           if (baseFieldsMatch) {
-            return DESTINATION_DUPLICATE_CHECK_MAP[destination](
-              sync.destinationConfig as Record<string, unknown>,
-              destinationConfig,
-              sync.connectionId,
-              connectionId ?? null
-            );
+            return DESTINATION_DUPLICATE_CHECK_MAP[destination]({
+              existingConfig: sync.destinationConfig as Record<string, unknown>,
+              newConfig: destinationConfig,
+              existingConnectionId: sync.connectionId,
+              newConnectionId: connectionId ?? null
+            });
           }
           return false;
         } catch {
@@ -506,7 +506,7 @@ export const secretSyncServiceFactory = ({
           {
             destination,
             destinationConfig: params.destinationConfig,
-            connectionId: connectionId ?? secretSync.connectionId,
+            connectionId: params.connectionId ?? connectionId,
             projectId: secretSync.projectId,
             excludeSyncId: secretSync.id
           },

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -255,7 +255,7 @@ export const secretSyncServiceFactory = ({
   };
 
   const checkDuplicateDestination = async (
-    { destination, destinationConfig, excludeSyncId, projectId }: TCheckDuplicateDestinationDTO,
+    { destination, destinationConfig, connectionId, excludeSyncId, projectId }: TCheckDuplicateDestinationDTO,
     actor: OrgServiceActor
   ) => {
     const skipFields = SECRET_SYNC_SKIP_FIELDS_MAP[destination];
@@ -290,7 +290,9 @@ export const secretSyncServiceFactory = ({
           if (baseFieldsMatch) {
             return DESTINATION_DUPLICATE_CHECK_MAP[destination](
               sync.destinationConfig as Record<string, unknown>,
-              destinationConfig
+              destinationConfig,
+              sync.connectionId,
+              connectionId ?? null
             );
           }
           return false;
@@ -369,6 +371,7 @@ export const secretSyncServiceFactory = ({
         {
           destination: params.destination,
           destinationConfig: params.destinationConfig,
+          connectionId: params.connectionId,
           projectId
         },
         actor
@@ -503,6 +506,7 @@ export const secretSyncServiceFactory = ({
           {
             destination,
             destinationConfig: params.destinationConfig,
+            connectionId: connectionId ?? secretSync.connectionId,
             projectId: secretSync.projectId,
             excludeSyncId: secretSync.id
           },

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -10,6 +10,7 @@ import {
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
+import { logger } from "@app/lib/logger";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
 import { deepEqualSkipFields } from "@app/lib/fn/object";
@@ -358,7 +359,9 @@ export const secretSyncServiceFactory = ({
           });
           duplicateProjectId = duplicateProject;
         } catch {
-          // actor lacks access to the duplicate's project -- do not reveal it
+          logger.warn(
+            `Duplicate secret sync destination detected but actor has no access to conflicting project [actorId=${actor.id}] [duplicateProjectId=${duplicateProject}]`
+          );
         }
       }
 

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -16,7 +16,9 @@ import { deepEqualSkipFields } from "@app/lib/fn/object";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { OrgServiceActor } from "@app/lib/types";
+import { decryptAppConnectionCredentials } from "@app/services/app-connection/app-connection-fns";
 import { TAppConnectionServiceFactory } from "@app/services/app-connection/app-connection-service";
+import { TAppConnection } from "@app/services/app-connection/app-connection-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectBotServiceFactory } from "@app/services/project-bot/project-bot-service";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
@@ -280,31 +282,48 @@ export const secretSyncServiceFactory = ({
     try {
       const existingSyncs = await secretSyncDAL.findByDestinationAndOrgId(destination, actor.orgId);
 
-      const duplicates = existingSyncs.filter((sync) => {
-        if (sync.id === excludeSyncId) {
-          return false;
+      const decryptConnection = async (connId: string): Promise<TAppConnection> => {
+        const conn = await appConnectionDAL.findById(connId);
+        if (!conn || conn.orgId !== actor.orgId) {
+          throw new NotFoundError({ message: `App connection with ID "${connId}" not found` });
         }
+        const credentials = await decryptAppConnectionCredentials({
+          orgId: conn.orgId,
+          encryptedCredentials: conn.encryptedCredentials,
+          kmsService,
+          projectId: conn.projectId
+        });
+        return { ...conn, credentials } as TAppConnection;
+      };
 
-        try {
-          const baseFieldsMatch = deepEqualSkipFields(sync.destinationConfig, destinationConfig, skipFields);
-          if (baseFieldsMatch) {
-            return DESTINATION_DUPLICATE_CHECK_MAP[destination]({
+      const candidates = existingSyncs.filter((sync) => {
+        if (sync.id === excludeSyncId) return false;
+        return deepEqualSkipFields(sync.destinationConfig, destinationConfig, skipFields);
+      });
+
+      const duplicateCheckResults = await Promise.all(
+        candidates.map(async (sync) => {
+          try {
+            const isDuplicate = await DESTINATION_DUPLICATE_CHECK_MAP[destination]({
               existingConfig: sync.destinationConfig as Record<string, unknown>,
               newConfig: destinationConfig,
               existingConnectionId: sync.connectionId,
-              newConnectionId: connectionId ?? null
+              newConnectionId: connectionId ?? null,
+              decryptConnection
             });
+            return isDuplicate ? sync : null;
+          } catch {
+            return null;
           }
-          return false;
-        } catch {
-          return false;
-        }
-      });
+        })
+      );
+
+      const duplicates = duplicateCheckResults.filter(Boolean);
 
       const hasDuplicate = duplicates.length > 0;
       return {
         hasDuplicate,
-        duplicateProjectId: hasDuplicate ? duplicates[0].projectId : undefined
+        duplicateProjectId: hasDuplicate ? duplicates[0]!.projectId : undefined
       };
     } catch (error) {
       return { hasDuplicate: false, duplicateProjectId: undefined };

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -12,8 +12,8 @@ import {
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
-import { logger } from "@app/lib/logger";
 import { deepEqualSkipFields } from "@app/lib/fn/object";
+import { logger } from "@app/lib/logger";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { OrgServiceActor } from "@app/lib/types";

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -494,7 +494,7 @@ export const secretSyncServiceFactory = ({
 
     let { folderId } = secretSync;
 
-    if (params.destinationConfig) {
+    if (params.destinationConfig || params.connectionId) {
       // getProjectPermission above throws NotFoundError if the project doesn't exist and
       // guarantees actor.orgId === project.orgId — no separate project lookup needed.
       const organization = await requestMemoize(requestMemoKeys.orgFindById(actor.orgId), () =>
@@ -505,7 +505,7 @@ export const secretSyncServiceFactory = ({
         const duplicateCheck = await checkDuplicateDestination(
           {
             destination,
-            destinationConfig: params.destinationConfig,
+            destinationConfig: params.destinationConfig ?? (secretSync.destinationConfig as Record<string, unknown>),
             connectionId: params.connectionId ?? connectionId,
             projectId: secretSync.projectId,
             excludeSyncId: secretSync.id

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -557,7 +557,7 @@ export const secretSyncServiceFactory = ({
 
     let { folderId } = secretSync;
 
-    if (params.destinationConfig || params.connectionId) {
+    if (params.destinationConfig || params.connectionId || params.syncOptions) {
       // getProjectPermission above throws NotFoundError if the project doesn't exist and
       // guarantees actor.orgId === project.orgId — no separate project lookup needed.
       const organization = await requestMemoize(requestMemoKeys.orgFindById(actor.orgId), () =>

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -257,7 +257,14 @@ export const secretSyncServiceFactory = ({
   };
 
   const checkDuplicateDestination = async (
-    { destination, destinationConfig, connectionId, excludeSyncId, projectId }: TCheckDuplicateDestinationDTO,
+    {
+      destination,
+      destinationConfig,
+      connectionId,
+      syncOptions,
+      excludeSyncId,
+      projectId
+    }: TCheckDuplicateDestinationDTO,
     actor: OrgServiceActor
   ) => {
     const skipFields = SECRET_SYNC_SKIP_FIELDS_MAP[destination];
@@ -282,18 +289,27 @@ export const secretSyncServiceFactory = ({
     try {
       const existingSyncs = await secretSyncDAL.findByDestinationAndOrgId(destination, actor.orgId);
 
-      const decryptConnection = async (connId: string): Promise<TAppConnection> => {
-        const conn = await appConnectionDAL.findById(connId);
-        if (!conn || conn.orgId !== actor.orgId) {
-          throw new NotFoundError({ message: `App connection with ID "${connId}" not found` });
-        }
-        const credentials = await decryptAppConnectionCredentials({
-          orgId: conn.orgId,
-          encryptedCredentials: conn.encryptedCredentials,
-          kmsService,
-          projectId: conn.projectId
-        });
-        return { ...conn, credentials } as TAppConnection;
+      const connectionCache = new Map<string, Promise<TAppConnection>>();
+      const decryptConnection = (connId: string): Promise<TAppConnection> => {
+        const cached = connectionCache.get(connId);
+        if (cached) return cached;
+
+        const promise = (async () => {
+          const conn = await appConnectionDAL.findById(connId);
+          if (!conn || conn.orgId !== actor.orgId) {
+            throw new NotFoundError({ message: `App connection with ID "${connId}" not found` });
+          }
+          const credentials = await decryptAppConnectionCredentials({
+            orgId: conn.orgId,
+            encryptedCredentials: conn.encryptedCredentials,
+            kmsService,
+            projectId: conn.projectId
+          });
+          return { ...conn, credentials } as TAppConnection;
+        })();
+
+        connectionCache.set(connId, promise);
+        return promise;
       };
 
       const candidates = existingSyncs.filter((sync) => {
@@ -305,10 +321,16 @@ export const secretSyncServiceFactory = ({
         candidates.map(async (sync) => {
           try {
             const isDuplicate = await DESTINATION_DUPLICATE_CHECK_MAP[destination]({
-              existingConfig: sync.destinationConfig as Record<string, unknown>,
-              newConfig: destinationConfig,
-              existingConnectionId: sync.connectionId,
-              newConnectionId: connectionId ?? null,
+              existingSync: {
+                connectionId: sync.connectionId,
+                syncOptions: (sync.syncOptions as Record<string, unknown>) ?? null,
+                destinationConfig: sync.destinationConfig as Record<string, unknown>
+              },
+              newSync: {
+                connectionId: connectionId ?? null,
+                syncOptions: syncOptions ?? null,
+                destinationConfig
+              },
               decryptConnection
             });
             return isDuplicate ? sync : null;
@@ -391,6 +413,7 @@ export const secretSyncServiceFactory = ({
           destination: params.destination,
           destinationConfig: params.destinationConfig,
           connectionId: params.connectionId,
+          syncOptions: params.syncOptions as Record<string, unknown> | undefined,
           projectId
         },
         actor
@@ -526,6 +549,9 @@ export const secretSyncServiceFactory = ({
             destination,
             destinationConfig: params.destinationConfig ?? (secretSync.destinationConfig as Record<string, unknown>),
             connectionId: params.connectionId ?? connectionId,
+            syncOptions:
+              (params.syncOptions as Record<string, unknown> | undefined) ??
+              (secretSync.syncOptions as Record<string, unknown> | null),
             projectId: secretSync.projectId,
             excludeSyncId: secretSync.id
           },

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -10,9 +10,9 @@ import {
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
-import { logger } from "@app/lib/logger";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
+import { logger } from "@app/lib/logger";
 import { deepEqualSkipFields } from "@app/lib/fn/object";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -343,9 +343,28 @@ export const secretSyncServiceFactory = ({
       const duplicates = duplicateCheckResults.filter(Boolean);
 
       const hasDuplicate = duplicates.length > 0;
+
+      let duplicateProjectId: string | undefined;
+      if (hasDuplicate) {
+        const duplicateProject = duplicates[0]!.projectId;
+        try {
+          await permissionService.getProjectPermission({
+            actor: actor.type,
+            actorId: actor.id,
+            actorAuthMethod: actor.authMethod,
+            actorOrgId: actor.orgId,
+            actionProjectType: ActionProjectType.SecretManager,
+            projectId: duplicateProject
+          });
+          duplicateProjectId = duplicateProject;
+        } catch {
+          // actor lacks access to the duplicate's project -- do not reveal it
+        }
+      }
+
       return {
         hasDuplicate,
-        duplicateProjectId: hasDuplicate ? duplicates[0]!.projectId : undefined
+        duplicateProjectId
       };
     } catch (error) {
       return { hasDuplicate: false, duplicateProjectId: undefined };
@@ -421,7 +440,9 @@ export const secretSyncServiceFactory = ({
       if (duplicateCheck.hasDuplicate) {
         throw new BadRequestError({
           message: `A secret sync with this destination already exists${
-            duplicateCheck.duplicateProjectId ? ` in project ${duplicateCheck.duplicateProjectId}` : ""
+            duplicateCheck.duplicateProjectId
+              ? ` in project ${duplicateCheck.duplicateProjectId}`
+              : " in another project in your organization"
           }.`
         });
       }

--- a/backend/src/services/secret-sync/secret-sync-types.ts
+++ b/backend/src/services/secret-sync/secret-sync-types.ts
@@ -570,12 +570,12 @@ export type TSecretMap = Record<
   }
 >;
 
-export type DestinationDuplicateCheckFn = (
-  existingConfig: Record<string, unknown>,
-  newConfig: Record<string, unknown>,
-  existingConnectionId: string | null,
-  newConnectionId: string | null
-) => boolean;
+export type DestinationDuplicateCheckFn = (opts: {
+  existingConfig: Record<string, unknown>;
+  newConfig: Record<string, unknown>;
+  existingConnectionId: string | null;
+  newConnectionId: string | null;
+}) => boolean;
 
 export type TPreSaveTransformDeps = {
   secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "findOne">;

--- a/backend/src/services/secret-sync/secret-sync-types.ts
+++ b/backend/src/services/secret-sync/secret-sync-types.ts
@@ -475,6 +475,7 @@ export type TCheckDuplicateDestinationDTO = {
   destination: SecretSync;
   destinationConfig: Record<string, unknown>;
   connectionId?: string | null;
+  syncOptions?: Record<string, unknown> | null;
   excludeSyncId?: string;
   projectId: string;
 };
@@ -571,11 +572,15 @@ export type TSecretMap = Record<
   }
 >;
 
+export type DuplicateCheckSyncFields = {
+  connectionId: string | null;
+  syncOptions: Record<string, unknown> | null;
+  destinationConfig: Record<string, unknown>;
+};
+
 export type DestinationDuplicateCheckFn = (opts: {
-  existingConfig: Record<string, unknown>;
-  newConfig: Record<string, unknown>;
-  existingConnectionId: string | null;
-  newConnectionId: string | null;
+  existingSync: DuplicateCheckSyncFields;
+  newSync: DuplicateCheckSyncFields;
   decryptConnection: (connectionId: string) => Promise<TAppConnection>;
 }) => Promise<boolean>;
 

--- a/backend/src/services/secret-sync/secret-sync-types.ts
+++ b/backend/src/services/secret-sync/secret-sync-types.ts
@@ -49,6 +49,7 @@ import {
 } from "@app/services/secret-sync/windmill";
 
 import { TAppConnectionDALFactory } from "../app-connection/app-connection-dal";
+import { TAppConnection } from "../app-connection/app-connection-types";
 import { TKmsServiceFactory } from "../kms/kms-service";
 import { TSecretV2BridgeDALFactory } from "../secret-v2-bridge/secret-v2-bridge-dal";
 import {
@@ -575,7 +576,8 @@ export type DestinationDuplicateCheckFn = (opts: {
   newConfig: Record<string, unknown>;
   existingConnectionId: string | null;
   newConnectionId: string | null;
-}) => boolean;
+  decryptConnection: (connectionId: string) => Promise<TAppConnection>;
+}) => Promise<boolean>;
 
 export type TPreSaveTransformDeps = {
   secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "findOne">;

--- a/backend/src/services/secret-sync/secret-sync-types.ts
+++ b/backend/src/services/secret-sync/secret-sync-types.ts
@@ -473,6 +473,7 @@ export type TDeleteSecretSyncDTO = {
 export type TCheckDuplicateDestinationDTO = {
   destination: SecretSync;
   destinationConfig: Record<string, unknown>;
+  connectionId?: string | null;
   excludeSyncId?: string;
   projectId: string;
 };
@@ -571,7 +572,9 @@ export type TSecretMap = Record<
 
 export type DestinationDuplicateCheckFn = (
   existingConfig: Record<string, unknown>,
-  newConfig: Record<string, unknown>
+  newConfig: Record<string, unknown>,
+  existingConnectionId: string | null,
+  newConnectionId: string | null
 ) => boolean;
 
 export type TPreSaveTransformDeps = {

--- a/frontend/src/components/secret-syncs/forms/CreateSecretSyncForm.tsx
+++ b/frontend/src/components/secret-syncs/forms/CreateSecretSyncForm.tsx
@@ -214,6 +214,7 @@ export const CreateSecretSyncForm = ({
   const { hasDuplicate } = useDuplicateDestinationCheck({
     destination,
     projectId: currentProject?.id || "",
+    connectionId: watch("connection")?.id,
     enabled: true,
     destinationConfig: watch("destinationConfig")
   });

--- a/frontend/src/components/secret-syncs/forms/CreateSecretSyncForm.tsx
+++ b/frontend/src/components/secret-syncs/forms/CreateSecretSyncForm.tsx
@@ -215,6 +215,7 @@ export const CreateSecretSyncForm = ({
     destination,
     projectId: currentProject?.id || "",
     connectionId: watch("connection")?.id,
+    syncOptions: watch("syncOptions"),
     enabled: true,
     destinationConfig: watch("destinationConfig")
   });

--- a/frontend/src/components/secret-syncs/forms/DuplicateDestinationConfirmationModal.tsx
+++ b/frontend/src/components/secret-syncs/forms/DuplicateDestinationConfirmationModal.tsx
@@ -47,14 +47,18 @@ export const DuplicateDestinationConfirmationModal = ({
             </span>
           </AlertDialogDescription>
         </AlertDialogHeader>
-        {duplicateProjectId && (
-          <p className="text-xs text-mineshaft-400">
-            Duplicate found in project ID:{" "}
-            <code className="rounded-sm bg-mineshaft-600 px-1 py-0.5 text-mineshaft-200">
-              {duplicateProjectId}
-            </code>
-          </p>
-        )}
+        <p className="text-xs text-mineshaft-400">
+          {duplicateProjectId ? (
+            <>
+              Duplicate found in project ID:{" "}
+              <code className="rounded-sm bg-mineshaft-600 px-1 py-0.5 text-mineshaft-200">
+                {duplicateProjectId}
+              </code>
+            </>
+          ) : (
+            "Duplicate found in another project in your organization."
+          )}
+        </p>
         {!isDisabled && <p className="text-sm">Are you sure you want to continue?</p>}
         <AlertDialogFooter>
           <AlertDialogCancel isDisabled={isLoading}>

--- a/frontend/src/components/secret-syncs/forms/EditSecretSyncForm.tsx
+++ b/frontend/src/components/secret-syncs/forms/EditSecretSyncForm.tsx
@@ -156,6 +156,7 @@ export const EditSecretSyncForm = ({ secretSync, onComplete, onDirtyChange, onCa
     secretSync.projectId,
     secretSync.id,
     formMethods.watch("connection")?.id,
+    formMethods.watch("syncOptions"),
     { enabled: checkDuplicateEnabled && Boolean(destinationConfigToCheck) }
   );
 

--- a/frontend/src/components/secret-syncs/forms/EditSecretSyncForm.tsx
+++ b/frontend/src/components/secret-syncs/forms/EditSecretSyncForm.tsx
@@ -155,6 +155,7 @@ export const EditSecretSyncForm = ({ secretSync, onComplete, onDirtyChange, onCa
     destinationConfigToCheck,
     secretSync.projectId,
     secretSync.id,
+    formMethods.watch("connection")?.id,
     { enabled: checkDuplicateEnabled && Boolean(destinationConfigToCheck) }
   );
 

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
@@ -99,6 +99,7 @@ export const SecretSyncReviewFields = () => {
   const { hasDuplicate, duplicateProjectId, isChecking } = useDuplicateDestinationCheck({
     destination,
     projectId: currentProject?.id || "",
+    connectionId: connection?.id,
     enabled: true,
     destinationConfig: watch("destinationConfig")
   });

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
@@ -292,14 +292,18 @@ export const SecretSyncReviewFields = () => {
                   ? "Another secret sync in your organization is already configured with the same destination. Your organization does not allow duplicate destination configurations."
                   : "Another secret sync in your organization is already configured with the same destination. This may lead to conflicts or unexpected behavior."}
               </p>
-              {duplicateProjectId && (
-                <p>
-                  Duplicate found in project ID:{" "}
-                  <code className="rounded-sm bg-foreground/10 px-1 py-0.5 font-mono">
-                    {duplicateProjectId}
-                  </code>
-                </p>
-              )}
+              <p>
+                {duplicateProjectId ? (
+                  <>
+                    Duplicate found in project ID:{" "}
+                    <code className="rounded-sm bg-foreground/10 px-1 py-0.5 font-mono">
+                      {duplicateProjectId}
+                    </code>
+                  </>
+                ) : (
+                  "Duplicate found in another project in your organization."
+                )}
+              </p>
             </AlertDescription>
           </Alert>
         )}

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
@@ -100,6 +100,7 @@ export const SecretSyncReviewFields = () => {
     destination,
     projectId: currentProject?.id || "",
     connectionId: connection?.id,
+    syncOptions: watch("syncOptions"),
     enabled: true,
     destinationConfig: watch("destinationConfig")
   });

--- a/frontend/src/hooks/api/secretSyncs/queries.tsx
+++ b/frontend/src/hooks/api/secretSyncs/queries.tsx
@@ -120,7 +120,12 @@ export const useCheckDuplicateDestination = (
   >
 ) => {
   return useQuery({
-    queryKey: secretSyncKeys.duplicateCheck(destination, destinationConfig, connectionId, excludeSyncId),
+    queryKey: secretSyncKeys.duplicateCheck(
+      destination,
+      destinationConfig,
+      connectionId,
+      excludeSyncId
+    ),
     queryFn: async () => {
       const { data } = await apiRequest.post<{
         hasDuplicate: boolean;

--- a/frontend/src/hooks/api/secretSyncs/queries.tsx
+++ b/frontend/src/hooks/api/secretSyncs/queries.tsx
@@ -19,6 +19,7 @@ export const secretSyncKeys = {
     destination: SecretSync,
     destinationConfig: unknown,
     connectionId?: string,
+    syncOptions?: unknown,
     excludeSyncId?: string
   ) =>
     [
@@ -27,6 +28,7 @@ export const secretSyncKeys = {
       "duplicate-check",
       destinationConfig,
       connectionId,
+      syncOptions,
       excludeSyncId
     ] as const
 };
@@ -109,6 +111,7 @@ export const useCheckDuplicateDestination = (
   projectId: string,
   excludeSyncId?: string,
   connectionId?: string,
+  syncOptions?: unknown,
   options?: Omit<
     UseQueryOptions<
       { hasDuplicate: boolean; duplicateProjectId?: string },
@@ -124,6 +127,7 @@ export const useCheckDuplicateDestination = (
       destination,
       destinationConfig,
       connectionId,
+      syncOptions,
       excludeSyncId
     ),
     queryFn: async () => {
@@ -133,6 +137,7 @@ export const useCheckDuplicateDestination = (
       }>(`/api/v1/secret-syncs/${destination}/check-destination`, {
         destinationConfig,
         connectionId,
+        syncOptions,
         excludeSyncId,
         projectId
       });

--- a/frontend/src/hooks/api/secretSyncs/queries.tsx
+++ b/frontend/src/hooks/api/secretSyncs/queries.tsx
@@ -15,12 +15,18 @@ export const secretSyncKeys = {
   list: (projectId: string) => [...secretSyncKeys.all, "list", projectId] as const,
   byId: (destination: SecretSync, syncId: string) =>
     [...secretSyncKeys.all, destination, "by-id", syncId] as const,
-  duplicateCheck: (destination: SecretSync, destinationConfig: unknown, excludeSyncId?: string) =>
+  duplicateCheck: (
+    destination: SecretSync,
+    destinationConfig: unknown,
+    connectionId?: string,
+    excludeSyncId?: string
+  ) =>
     [
       ...secretSyncKeys.all,
       destination,
       "duplicate-check",
       destinationConfig,
+      connectionId,
       excludeSyncId
     ] as const
 };
@@ -102,6 +108,7 @@ export const useCheckDuplicateDestination = (
   destinationConfig: unknown,
   projectId: string,
   excludeSyncId?: string,
+  connectionId?: string,
   options?: Omit<
     UseQueryOptions<
       { hasDuplicate: boolean; duplicateProjectId?: string },
@@ -113,13 +120,14 @@ export const useCheckDuplicateDestination = (
   >
 ) => {
   return useQuery({
-    queryKey: secretSyncKeys.duplicateCheck(destination, destinationConfig, excludeSyncId),
+    queryKey: secretSyncKeys.duplicateCheck(destination, destinationConfig, connectionId, excludeSyncId),
     queryFn: async () => {
       const { data } = await apiRequest.post<{
         hasDuplicate: boolean;
         duplicateProjectId?: string;
       }>(`/api/v1/secret-syncs/${destination}/check-destination`, {
         destinationConfig,
+        connectionId,
         excludeSyncId,
         projectId
       });

--- a/frontend/src/hooks/api/secretSyncs/useDuplicateDestinationCheck.ts
+++ b/frontend/src/hooks/api/secretSyncs/useDuplicateDestinationCheck.ts
@@ -7,6 +7,7 @@ type UseDuplicateDestinationCheckProps = {
   projectId: string;
   excludeSyncId?: string;
   connectionId?: string;
+  syncOptions?: unknown;
   enabled?: boolean;
   destinationConfig?: unknown;
 };
@@ -16,6 +17,7 @@ export const useDuplicateDestinationCheck = ({
   projectId,
   excludeSyncId,
   connectionId,
+  syncOptions,
   enabled = true,
   destinationConfig
 }: UseDuplicateDestinationCheckProps) => {
@@ -42,6 +44,7 @@ export const useDuplicateDestinationCheck = ({
     projectId,
     excludeSyncId,
     connectionId,
+    syncOptions,
     {
       enabled: shouldCheck,
       staleTime: 0,

--- a/frontend/src/hooks/api/secretSyncs/useDuplicateDestinationCheck.ts
+++ b/frontend/src/hooks/api/secretSyncs/useDuplicateDestinationCheck.ts
@@ -36,11 +36,18 @@ export const useDuplicateDestinationCheck = ({
     isLoading,
     error,
     refetch
-  } = useCheckDuplicateDestination(destination, destinationConfig, projectId, excludeSyncId, connectionId, {
-    enabled: shouldCheck,
-    staleTime: 0,
-    gcTime: 0
-  });
+  } = useCheckDuplicateDestination(
+    destination,
+    destinationConfig,
+    projectId,
+    excludeSyncId,
+    connectionId,
+    {
+      enabled: shouldCheck,
+      staleTime: 0,
+      gcTime: 0
+    }
+  );
 
   return {
     hasDuplicate: shouldCheck ? Boolean(duplicateData?.hasDuplicate) : false,

--- a/frontend/src/hooks/api/secretSyncs/useDuplicateDestinationCheck.ts
+++ b/frontend/src/hooks/api/secretSyncs/useDuplicateDestinationCheck.ts
@@ -6,6 +6,7 @@ type UseDuplicateDestinationCheckProps = {
   destination: SecretSync;
   projectId: string;
   excludeSyncId?: string;
+  connectionId?: string;
   enabled?: boolean;
   destinationConfig?: unknown;
 };
@@ -14,6 +15,7 @@ export const useDuplicateDestinationCheck = ({
   destination,
   projectId,
   excludeSyncId,
+  connectionId,
   enabled = true,
   destinationConfig
 }: UseDuplicateDestinationCheckProps) => {
@@ -34,7 +36,7 @@ export const useDuplicateDestinationCheck = ({
     isLoading,
     error,
     refetch
-  } = useCheckDuplicateDestination(destination, destinationConfig, projectId, excludeSyncId, {
+  } = useCheckDuplicateDestination(destination, destinationConfig, projectId, excludeSyncId, connectionId, {
     enabled: shouldCheck,
     staleTime: 0,
     gcTime: 0


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Two syncs pointing to AWS SM in the same region, but different accounts would be flagged as duplicates. This includes the connection id as part of the duplication detection.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)