### PR TITLE
fix(auth): honor default org after SSO login and fix OIDC org switch 403

### DIFF
--- a/backend/src/services/org/org-dal.ts
+++ b/backend/src/services/org/org-dal.ts
@@ -255,10 +255,31 @@ export const orgDALFactory = (db: TDbClient) => {
             .andOn(`${TableName.Membership}.actorUserId`, db.raw("?", [dto.actorId]));
         })
         .whereNull(`${TableName.Organization}.rootOrgId`)
+        .leftJoin(TableName.SamlConfig, (qb) => {
+          qb.on(`${TableName.SamlConfig}.orgId`, "=", `${TableName.Organization}.id`).andOn(
+            `${TableName.SamlConfig}.isActive`,
+            "=",
+            db.raw("true")
+          );
+        })
+        .leftJoin(TableName.OidcConfig, (qb) => {
+          qb.on(`${TableName.OidcConfig}.orgId`, "=", `${TableName.Organization}.id`).andOn(
+            `${TableName.OidcConfig}.isActive`,
+            "=",
+            db.raw("true")
+          );
+        })
         .select(
           selectAllTableCols(TableName.Organization),
-          db.ref("createdAt").withSchema(TableName.Membership).as("userJoinedAt")
-        )) as (TOrganizations & { userJoinedAt: Date | null })[];
+          db.ref("createdAt").withSchema(TableName.Membership).as("userJoinedAt"),
+          db.raw(`
+            CASE
+              WHEN ${TableName.SamlConfig}."orgId" IS NOT NULL THEN 'saml'
+              WHEN ${TableName.OidcConfig}."orgId" IS NOT NULL THEN 'oidc'
+              ELSE ''
+            END as "orgAuthMethod"
+        `)
+        )) as (TOrganizations & { orgAuthMethod: string; userJoinedAt: Date | null })[];
 
       if (rootOrgs.length === 0) return [];
 

--- a/backend/src/services/org/org-schema.ts
+++ b/backend/src/services/org/org-schema.ts
@@ -39,6 +39,8 @@ export const sanitizedOrganizationSchema = OrganizationsSchema.pick({
 
 /** Zod schema for API response: root org (full info) with sub-orgs (basic info) */
 export const OrgWithSubOrgsSchema = sanitizedOrganizationSchema.extend({
+  // derived from the active SAML/OIDC config, not a column
+  orgAuthMethod: z.string(),
   userJoinedAt: z.date().optional().nullable(),
   subOrganizations: OrganizationsSchema.pick({
     id: true,

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -320,7 +320,8 @@ export const Navbar = () => {
 
       await logout.mutateAsync();
       if (org.orgAuthMethod === AuthMethod.OIDC) {
-        window.open(`/api/v1/sso/oidc/login?domain=${org.slug}`);
+        // orgSlug, not domain: the domain param is a verified email-domain lookup and 403s on a slug
+        window.open(`/api/v1/sso/oidc/login?orgSlug=${org.slug}`);
       } else {
         window.open(`/api/v1/sso/redirect/saml2/organizations/${org.slug}`);
       }

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrg.utils.ts
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrg.utils.ts
@@ -1,0 +1,33 @@
+import { jwtDecode } from "jwt-decode";
+
+import { getAuthToken } from "@app/hooks/api/reactQuery";
+import { AuthMethod, SAML_AUTH_METHODS } from "@app/hooks/api/users/types";
+
+type TOrgSsoEnforcement = {
+  authEnforced: boolean;
+  googleSsoAuthEnforced: boolean;
+  orgAuthMethod: string;
+};
+
+// User-facing error when the org enforces an SSO method the session token wasn't issued by,
+// else null. Mirrors the server-side selectOrganization check.
+export const getSsoEnforcementError = (org: TOrgSsoEnforcement): string | null => {
+  if (!org.authEnforced && !org.googleSsoAuthEnforced) return null;
+
+  const authToken = jwtDecode(getAuthToken()) as { authMethod: AuthMethod };
+
+  let ssoType = "";
+  if (org.googleSsoAuthEnforced && authToken.authMethod !== AuthMethod.GOOGLE) {
+    ssoType = "Google SSO";
+  } else if (org.orgAuthMethod === AuthMethod.OIDC && authToken.authMethod !== AuthMethod.OIDC) {
+    ssoType = "OIDC SSO";
+  } else if (
+    org.orgAuthMethod === AuthMethod.SAML &&
+    !SAML_AUTH_METHODS.includes(authToken.authMethod as (typeof SAML_AUTH_METHODS)[number])
+  ) {
+    ssoType = "SAML SSO";
+  }
+
+  if (!ssoType) return null;
+  return `This organization requires ${ssoType}. Please log out and re-login via your identity provider.`;
+};

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -12,6 +12,7 @@ import SecurityClient from "@app/components/utilities/SecurityClient";
 import { Button, ContentLoader, Input, Spinner } from "@app/components/v2";
 import { SessionStorageKeys } from "@app/const";
 import { ROUTE_PATHS } from "@app/const/routes";
+import { useServerConfig } from "@app/context";
 import { useToggle } from "@app/hooks";
 import {
   TOrgWithSubOrgs,
@@ -82,6 +83,7 @@ export const SelectOrgPage = () => {
   const { data: orgs, isPending: orgsLoading } = useGetOrganizationsWithSubOrgs();
   const selectOrg = useSelectOrganization();
   const { data: user, isPending: userLoading } = useGetUser();
+  const { config } = useServerConfig();
   const logout = useLogoutUser();
 
   const [shouldShowMfa, toggleShowMfa] = useToggle(false);
@@ -131,6 +133,23 @@ export const SelectOrgPage = () => {
     const term = searchTerm.toLowerCase();
     return selectedRootOrg.subOrganizations.filter((sub) => sub.name.toLowerCase().includes(term));
   }, [selectedRootOrg, searchTerm]);
+
+  // The org to enter without prompting: an explicit org_id (login flow, server-admin org access)
+  // or the instance default org, as long as the user is actually a member of it
+  const autoSelectOrgId = orgId || config.defaultAuthOrgId;
+  const autoSelectTarget = useMemo(() => {
+    if (!autoSelectOrgId || !orgs) return undefined;
+    const rootOrg = orgs.find((org) => org.id === autoSelectOrgId);
+    if (rootOrg) return { org: rootOrg };
+    const subOrgParent = orgs.find((org) =>
+      org.subOrganizations.some((sub) => sub.id === autoSelectOrgId)
+    );
+    return subOrgParent ? { org: subOrgParent, subOrgId: autoSelectOrgId } : undefined;
+  }, [orgs, autoSelectOrgId]);
+  // Breakglass logins and MFA continuations need the user to act on this page, so never auto-select there
+  const shouldAutoSelect = Boolean(autoSelectTarget) && !isBreakglassRoute && !mfaMethodFromSearch;
+  const [autoSelectDone, setAutoSelectDone] = useState(false);
+  const autoSelectAttempted = useRef(false);
 
   // For sub-orgs, inherit the root org's SSO settings but override the ID
   const handleSelectOrganization = async (org: TOrgWithSubOrgs, subOrgId?: string) => {
@@ -244,6 +263,16 @@ export const SelectOrgPage = () => {
       navigateUserToOrg({ navigate, organizationId: targetOrgId });
     }
   };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!shouldAutoSelect || !autoSelectTarget || autoSelectAttempted.current) return;
+    autoSelectAttempted.current = true;
+    handleSelectOrganization(autoSelectTarget.org, autoSelectTarget.subOrgId).finally(() =>
+      // on success this page unmounts; on failure the toast already fired, so fall back to the picker
+      setAutoSelectDone(true)
+    );
+  }, [shouldAutoSelect, autoSelectTarget]);
 
   // MFA pending from IdP redirect
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -369,7 +398,7 @@ export const SelectOrgPage = () => {
     );
   };
 
-  if (userLoading || !user) {
+  if (userLoading || !user || (shouldAutoSelect && !autoSelectDone)) {
     return (
       <div className="h-screen w-screen bg-bunker-800">
         <ContentLoader />

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
-import { Link, useNavigate, useRouter, useSearch } from "@tanstack/react-router";
+import { Link, useNavigate, useRouteContext, useRouter, useSearch } from "@tanstack/react-router";
 import { addSeconds, format, formatISO } from "date-fns";
-import { jwtDecode } from "jwt-decode";
 import { ChevronRight, LogIn, Search } from "lucide-react";
 
 import { Mfa } from "@app/components/auth/Mfa";
@@ -12,7 +11,6 @@ import SecurityClient from "@app/components/utilities/SecurityClient";
 import { Button, ContentLoader, Input, Spinner } from "@app/components/v2";
 import { SessionStorageKeys } from "@app/const";
 import { ROUTE_PATHS } from "@app/const/routes";
-import { useServerConfig } from "@app/context";
 import { useToggle } from "@app/hooks";
 import {
   TOrgWithSubOrgs,
@@ -22,10 +20,10 @@ import {
   useSelectOrganization
 } from "@app/hooks/api";
 import { MfaMethod, UserAgentType } from "@app/hooks/api/auth/types";
-import { getAuthToken, setAuthToken } from "@app/hooks/api/reactQuery";
-import { AuthMethod, SAML_AUTH_METHODS } from "@app/hooks/api/users/types";
+import { setAuthToken } from "@app/hooks/api/reactQuery";
 
 import { navigateUserToOrg } from "../LoginPage/Login.utils";
+import { getSsoEnforcementError } from "./SelectOrg.utils";
 
 const OrgRow = ({
   name,
@@ -72,19 +70,18 @@ export const SelectOrgPage = () => {
   const { t } = useTranslation();
   const router = useRouter();
   const search = useSearch({ from: ROUTE_PATHS.Auth.SelectOrgPage.id });
+  const { autoSelectErrorMessage } = useRouteContext({ from: ROUTE_PATHS.Auth.SelectOrgPage.id });
 
   const {
     org_id: orgId,
     callback_port: callbackPort,
     is_admin_login: isBreakglassRoute,
-    force: forceOrgPicker,
     mfa_method: mfaMethodFromSearch
   } = search;
 
   const { data: orgs, isPending: orgsLoading } = useGetOrganizationsWithSubOrgs();
   const selectOrg = useSelectOrganization();
   const { data: user, isPending: userLoading } = useGetUser();
-  const { config } = useServerConfig();
   const logout = useLogoutUser();
 
   const [shouldShowMfa, toggleShowMfa] = useToggle(false);
@@ -135,25 +132,6 @@ export const SelectOrgPage = () => {
     return selectedRootOrg.subOrganizations.filter((sub) => sub.name.toLowerCase().includes(term));
   }, [selectedRootOrg, searchTerm]);
 
-  // The org to enter without prompting: an explicit org_id (login flow, server-admin org access)
-  // or the instance default org, as long as the user is actually a member of it
-  const autoSelectOrgId = orgId || config.defaultAuthOrgId;
-  const autoSelectTarget = useMemo(() => {
-    if (!autoSelectOrgId || !orgs) return undefined;
-    const rootOrg = orgs.find((org) => org.id === autoSelectOrgId);
-    if (rootOrg) return { org: rootOrg };
-    const subOrgParent = orgs.find((org) =>
-      org.subOrganizations.some((sub) => sub.id === autoSelectOrgId)
-    );
-    return subOrgParent ? { org: subOrgParent, subOrgId: autoSelectOrgId } : undefined;
-  }, [orgs, autoSelectOrgId]);
-  // Breakglass logins, MFA continuations, and ?force=true all need the user to act on this page,
-  // so never auto-select there
-  const shouldAutoSelect =
-    Boolean(autoSelectTarget) && !isBreakglassRoute && !mfaMethodFromSearch && !forceOrgPicker;
-  const [autoSelectDone, setAutoSelectDone] = useState(false);
-  const autoSelectAttempted = useRef(false);
-
   // For sub-orgs, inherit the root org's SSO settings but override the ID
   const handleSelectOrganization = async (org: TOrgWithSubOrgs, subOrgId?: string) => {
     const targetOrgId = subOrgId || org.id;
@@ -167,34 +145,10 @@ export const SelectOrgPage = () => {
       return;
     }
 
-    if ((org.authEnforced || org.googleSsoAuthEnforced) && !canBypassOrgAuth) {
-      const authToken = jwtDecode(getAuthToken()) as { authMethod: AuthMethod };
-
-      let ssoRequired = false;
-      let ssoType = "";
-
-      if (org.googleSsoAuthEnforced && authToken.authMethod !== AuthMethod.GOOGLE) {
-        ssoRequired = true;
-        ssoType = "Google SSO";
-      } else if (
-        org.orgAuthMethod === AuthMethod.OIDC &&
-        authToken.authMethod !== AuthMethod.OIDC
-      ) {
-        ssoRequired = true;
-        ssoType = "OIDC SSO";
-      } else if (
-        org.orgAuthMethod === AuthMethod.SAML &&
-        !SAML_AUTH_METHODS.includes(authToken.authMethod as (typeof SAML_AUTH_METHODS)[number])
-      ) {
-        ssoRequired = true;
-        ssoType = "SAML SSO";
-      }
-
-      if (ssoRequired) {
-        createNotification({
-          text: `This organization requires ${ssoType}. Please log out and re-login via your identity provider.`,
-          type: "error"
-        });
+    if (!canBypassOrgAuth) {
+      const ssoEnforcementError = getSsoEnforcementError(org);
+      if (ssoEnforcementError) {
+        createNotification({ text: ssoEnforcementError, type: "error" });
         return;
       }
     }
@@ -267,28 +221,30 @@ export const SelectOrgPage = () => {
     }
   };
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // beforeLoad can't toast on cold loads (Toaster not yet mounted) so it hands failures here;
+  // the ref dedupes StrictMode's double effect run
+  const autoSelectErrorToasted = useRef<string | null>(null);
   useEffect(() => {
-    // also wait for the user query: the CLI callback branch needs user.email, and firing while it's
-    // pending would freeze user as undefined in this closure
-    if (!shouldAutoSelect || !autoSelectTarget || !user || autoSelectAttempted.current) return;
-    autoSelectAttempted.current = true;
-    handleSelectOrganization(autoSelectTarget.org, autoSelectTarget.subOrgId).finally(() =>
-      // on success this page unmounts; on failure the toast already fired, so fall back to the picker
-      setAutoSelectDone(true)
-    );
-  }, [shouldAutoSelect, autoSelectTarget, user]);
+    if (autoSelectErrorMessage && autoSelectErrorToasted.current !== autoSelectErrorMessage) {
+      autoSelectErrorToasted.current = autoSelectErrorMessage;
+      createNotification({ text: autoSelectErrorMessage, type: "error" });
+    }
+  }, [autoSelectErrorMessage]);
 
-  // MFA pending from IdP redirect
+  // MFA challenge handed off by beforeLoad's auto-select
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    const defaultOrg = orgs?.find((o) => o.id === orgId);
+    const rootOrg = orgs?.find((o) => o.id === orgId);
+    const subOrgParent = rootOrg
+      ? undefined
+      : orgs?.find((o) => o.subOrganizations.some((sub) => sub.id === orgId));
+    const mfaOrg = rootOrg ?? subOrgParent;
     const storedMfaToken = sessionStorage.getItem(SessionStorageKeys.MFA_TEMP_TOKEN);
-    if (mfaMethodFromSearch && storedMfaToken && defaultOrg) {
+    if (mfaMethodFromSearch && storedMfaToken && mfaOrg) {
       sessionStorage.removeItem(SessionStorageKeys.MFA_TEMP_TOKEN);
       SecurityClient.setMfaToken(storedMfaToken);
       toggleShowMfa.on();
-      mfaOrgInfo.current = { rootOrg: defaultOrg };
+      mfaOrgInfo.current = { rootOrg: mfaOrg, subOrgId: rootOrg ? undefined : orgId };
     }
   }, [mfaMethodFromSearch, orgs?.length, orgId]);
 
@@ -403,7 +359,7 @@ export const SelectOrgPage = () => {
     );
   };
 
-  if (userLoading || !user || (shouldAutoSelect && !autoSelectDone)) {
+  if (userLoading || !user) {
     return (
       <div className="h-screen w-screen bg-bunker-800">
         <ContentLoader />

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -77,6 +77,7 @@ export const SelectOrgPage = () => {
     org_id: orgId,
     callback_port: callbackPort,
     is_admin_login: isBreakglassRoute,
+    force: forceOrgPicker,
     mfa_method: mfaMethodFromSearch
   } = search;
 
@@ -146,8 +147,10 @@ export const SelectOrgPage = () => {
     );
     return subOrgParent ? { org: subOrgParent, subOrgId: autoSelectOrgId } : undefined;
   }, [orgs, autoSelectOrgId]);
-  // Breakglass logins and MFA continuations need the user to act on this page, so never auto-select there
-  const shouldAutoSelect = Boolean(autoSelectTarget) && !isBreakglassRoute && !mfaMethodFromSearch;
+  // Breakglass logins, MFA continuations, and ?force=true all need the user to act on this page,
+  // so never auto-select there
+  const shouldAutoSelect =
+    Boolean(autoSelectTarget) && !isBreakglassRoute && !mfaMethodFromSearch && !forceOrgPicker;
   const [autoSelectDone, setAutoSelectDone] = useState(false);
   const autoSelectAttempted = useRef(false);
 
@@ -266,13 +269,15 @@ export const SelectOrgPage = () => {
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
-    if (!shouldAutoSelect || !autoSelectTarget || autoSelectAttempted.current) return;
+    // also wait for the user query: the CLI callback branch needs user.email, and firing while it's
+    // pending would freeze user as undefined in this closure
+    if (!shouldAutoSelect || !autoSelectTarget || !user || autoSelectAttempted.current) return;
     autoSelectAttempted.current = true;
     handleSelectOrganization(autoSelectTarget.org, autoSelectTarget.subOrgId).finally(() =>
       // on success this page unmounts; on failure the toast already fired, so fall back to the picker
       setAutoSelectDone(true)
     );
-  }, [shouldAutoSelect, autoSelectTarget]);
+  }, [shouldAutoSelect, autoSelectTarget, user]);
 
   // MFA pending from IdP redirect
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/pages/auth/SelectOrgPage/route.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/route.tsx
@@ -11,11 +11,13 @@ import { authKeys, selectOrganization } from "@app/hooks/api/auth/queries";
 import { UserAgentType } from "@app/hooks/api/auth/types";
 import {
   fetchOrganizationsWithSubOrgs,
-  organizationKeys
+  organizationKeys,
+  TOrgWithSubOrgs
 } from "@app/hooks/api/organization/queries";
 import { onRequestError, setAuthToken } from "@app/hooks/api/reactQuery";
 import { fetchUserDetails, logoutUser } from "@app/hooks/api/users/queries";
 
+import { getSsoEnforcementError } from "./SelectOrg.utils";
 import { SelectOrgPage } from "./SelectOrgPage";
 
 export const SelectOrganizationPageQueryParams = z.object({
@@ -60,8 +62,14 @@ export const Route = createFileRoute("/_restrict-login-signup/login/select-organ
       });
     }
 
-    // Skip auto-select for MFA pending or force flag
-    if (search.mfa_method || search.force) return;
+    // Breakglass, MFA continuation, and ?force=true all need the user to act on this page
+    if (search.mfa_method || search.force || search.is_admin_login) {
+      return { autoSelectErrorMessage: undefined };
+    }
+
+    // Failures are handed to the component via route context; toasts fired here would be
+    // dropped on cold loads (Toaster not yet mounted)
+    let autoSelectErrorMessage: string | undefined;
 
     try {
       const orgsWithSubOrgs = await context.queryClient.ensureQueryData({
@@ -73,18 +81,40 @@ export const Route = createFileRoute("/_restrict-login-signup/login/select-organ
         throw redirect({ to: "/organizations/none" });
       }
 
-      // Auto-select only when exactly 1 root org with no sub-orgs
-      const hasSingleOrgWithNoSubOrgs =
-        orgsWithSubOrgs.length === 1 && orgsWithSubOrgs[0].subOrganizations.length === 0;
+      // Auto-select target: explicit org_id or the instance default org, membership required
+      const autoSelectOrgId = search.org_id || context.serverConfig?.defaultAuthOrgId;
+      let target: { org: TOrgWithSubOrgs; subOrgId?: string } | undefined;
 
-      if (hasSingleOrgWithNoSubOrgs) {
-        const orgId = orgsWithSubOrgs[0].id;
+      if (autoSelectOrgId) {
+        const rootOrg = orgsWithSubOrgs.find((org) => org.id === autoSelectOrgId);
+        const subOrgParent = rootOrg
+          ? undefined
+          : orgsWithSubOrgs.find((org) =>
+              org.subOrganizations.some((sub) => sub.id === autoSelectOrgId)
+            );
+        if (rootOrg) target = { org: rootOrg };
+        else if (subOrgParent) target = { org: subOrgParent, subOrgId: autoSelectOrgId };
+      }
 
-        // If org_id is specified and doesn't match the only org, let the page handle it
-        if (search.org_id && search.org_id !== orgId) return;
+      // Sole-org fallback, including when the requested org isn't one the user can enter
+      // (e.g. a default org they aren't a member of)
+      if (
+        !target &&
+        orgsWithSubOrgs.length === 1 &&
+        orgsWithSubOrgs[0].subOrganizations.length === 0
+      ) {
+        target = { org: orgsWithSubOrgs[0] };
+      }
+
+      // Pre-empt the server-side SSO-enforcement rejection so the picker shows with guidance
+      const ssoEnforcementError = target && getSsoEnforcementError(target.org);
+      if (ssoEnforcementError) {
+        autoSelectErrorMessage = ssoEnforcementError;
+      } else if (target) {
+        const targetOrgId = target.subOrgId || target.org.id;
 
         const result = await selectOrganization({
-          organizationId: orgId,
+          organizationId: targetOrgId,
           userAgent: search.callback_port ? UserAgentType.CLI : undefined
         });
 
@@ -95,7 +125,7 @@ export const Route = createFileRoute("/_restrict-login-signup/login/select-organ
             to: "/login/select-organization",
             search: {
               mfa_method: result.mfaMethod,
-              org_id: orgId,
+              org_id: targetOrgId,
               callback_port: search.callback_port
             }
           });
@@ -129,7 +159,7 @@ export const Route = createFileRoute("/_restrict-login-signup/login/select-organ
 
         throw redirect({
           to: "/organizations/$orgId/projects",
-          params: { orgId }
+          params: { orgId: targetOrgId }
         });
       }
     } catch (error) {
@@ -142,7 +172,7 @@ export const Route = createFileRoute("/_restrict-login-signup/login/select-organ
       // never fires for it — surface SMTP errors manually and log the user out.
       if (typeof error === "object" && error !== null && "response" in error) {
         const { response } = error as {
-          response?: { data?: { error?: string; message?: string } };
+          response?: { status?: number; data?: { error?: string; message?: string } };
         };
         if (response?.data?.error === "SmtpError") {
           onRequestError(error);
@@ -157,7 +187,14 @@ export const Route = createFileRoute("/_restrict-login-signup/login/select-organ
           await logoutUser().catch(() => {}); // best-effort — redirect must always fire
           throw redirect({ to: "/login" });
         }
+        // Surface user-actionable select failures on the picker; 401s are session-expiry
+        // noise the axios interceptor already handles
+        if (response?.status !== 401 && response?.data?.message) {
+          autoSelectErrorMessage = response.data.message;
+        }
       }
     }
+
+    return { autoSelectErrorMessage };
   }
 });


### PR DESCRIPTION
## Context

Fixes two regressions from the auth revamp (#5947), first shipped in v0.159.14:

- The navbar org switcher opened /api/v1/sso/oidc/login?domain=<slug> when switching to an OIDC-enforced org. The domain param is a verified email-domain lookup, so the request always failed with a raw 403 JSON page after logging the user out. Pass orgSlug instead, like the login page does.

- The select-organization page no longer auto-selected an org: the SSO callback lands there without org_id, and the rewritten page had dropped the auto-select effect, so users always saw the org picker even with a default organization configured. Auto-select the org_id search param (login flow, server-admin org access) or the instance default org when the user is a member of it, skipping breakglass logins and pending MFA continuations. A failed attempt falls back to the picker with the existing error toast.

## Screenshots

N/A

## Steps to verify the change

- `make dev-up-oidc`
- `make seed-dev-oidc`
- set default org to oidc org
- add second org that oidc user can access
- verify default org is auto-selected
- verify changing from the second org to the oidc org from the top nav doesn't 403
- verify breakglass bypass still works as expected

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)