### PR TITLE
feat(file-upload): allow certificate upload

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/ImportSecretsModal.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/ImportSecretsModal.tsx
@@ -16,13 +16,6 @@ import { twMerge } from "tailwind-merge";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
-  CsvDelimiter,
-  parseCsvToMatrix,
-  parseDotEnv,
-  parseJson,
-  parseYaml
-} from "@app/components/utilities/parseSecrets";
-import {
   Button,
   Dialog,
   DialogContent,
@@ -39,6 +32,7 @@ import {
   FieldContent,
   FieldLabel,
   IconButton,
+  Input,
   Switch,
   Table,
   TableBody,
@@ -60,6 +54,7 @@ import { useCreateWsTag, useGetWsTags } from "@app/hooks/api/tags/queries";
 import { SecretType } from "@app/hooks/api/types";
 
 import { CsvColumnMapDialog } from "./CsvColumnMapDialog";
+import { CsvData, parseSecretFile } from "./parseSecretFile";
 import { PasteSecretsDialog } from "./PasteSecretsDialog";
 import { TParsedEnv } from "./types";
 
@@ -96,13 +91,10 @@ const ImportSecretsContent = ({
   const [isDragActive, setDragActive] = useToggle();
   const [isImporting, setIsImporting] = useToggle();
   const [isPasteOpen, setIsPasteOpen] = useState(false);
-  const [csvData, setCsvData] = useState<{
-    headers: string[];
-    matrix: string[][];
-    delimiter: CsvDelimiter;
-  } | null>(null);
+  const [csvData, setCsvData] = useState<CsvData | null>(null);
   const [visibleSecretKeys, setVisibleSecretKeys] = useState<Set<string>>(new Set());
   const [shouldOverwrite, setShouldOverwrite] = useState(false);
+  const [keyOverrides, setKeyOverrides] = useState<Record<string, string>>({});
 
   const { mutateAsync: createSecretBatch } = useCreateSecretBatch();
   const { mutateAsync: updateSecretBatch } = useUpdateSecretBatch();
@@ -133,6 +125,11 @@ const ImportSecretsContent = ({
     ? Object.values(activeSecrets).some((s) => s.tagSlugs?.length)
     : false;
   const isWaitingForTags = canReadTags && hasTagsToResolve && isTagsLoading;
+  const hasInvalidKey = activeSecrets
+    ? Object.entries(activeSecrets).some(
+        ([key, s]) => s.isFileSecret && !(keyOverrides[key] ?? key).trim()
+      )
+    : false;
 
   const handleParsedSecrets = useCallback((env: TParsedEnv) => {
     if (!Object.keys(env).length) {
@@ -155,50 +152,7 @@ const ImportSecretsContent = ({
         return;
       }
 
-      const reader = new FileReader();
-      reader.onload = (event) => {
-        if (!event?.target?.result) {
-          createNotification({
-            type: "error",
-            text: "Invalid file contents."
-          });
-          return;
-        }
-
-        const src = event.target.result as ArrayBuffer;
-
-        switch (file.type) {
-          case "application/json":
-            handleParsedSecrets(parseJson(src));
-            break;
-          case "text/yaml":
-          case "application/x-yaml":
-          case "application/yaml":
-            handleParsedSecrets(parseYaml(src));
-            break;
-          case "text/csv": {
-            const { matrix: fullMatrix, delimiter } = parseCsvToMatrix(src);
-            if (!fullMatrix.length) {
-              createNotification({
-                type: "error",
-                text: "Failed to find secrets in CSV file. File might be empty."
-              });
-              return;
-            }
-            setCsvData({ headers: fullMatrix[0], matrix: fullMatrix.slice(1), delimiter });
-            return;
-          }
-          default:
-            handleParsedSecrets(parseDotEnv(src));
-            break;
-        }
-      };
-
-      try {
-        reader.readAsText(file);
-      } catch (error) {
-        console.log(error);
-      }
+      parseSecretFile(file, { onParsedSecrets: handleParsedSecrets, onCsvData: setCsvData });
     },
     [handleParsedSecrets]
   );
@@ -317,11 +271,17 @@ const ImportSecretsContent = ({
           {}
         );
 
+        // Resolve edited keys (file-based secrets can be renamed in the review table)
+        const resolvedEntries = Object.entries(activeSecrets).map(([origKey, secretData]) => ({
+          finalKey: (keyOverrides[origKey] ?? origKey).trim(),
+          secretData
+        }));
+
         // Split secrets into creates vs updates
-        const secretsToCreate = Object.entries(activeSecrets)
-          .filter(([key]) => !existingMap[key])
-          .map(([secretKey, secretData]) => ({
-            secretKey,
+        const secretsToCreate = resolvedEntries
+          .filter(({ finalKey }) => !existingMap[finalKey])
+          .map(({ finalKey, secretData }) => ({
+            secretKey: finalKey,
             secretValue: secretData.value,
             secretComment: secretData.comments.join("\n") || "",
             type: SecretType.Shared,
@@ -332,10 +292,10 @@ const ImportSecretsContent = ({
             skipMultilineEncoding: secretData.skipMultilineEncoding
           }));
 
-        const secretsToUpdate = Object.entries(activeSecrets)
-          .filter(([key]) => existingMap[key])
-          .map(([secretKey, secretData]) => ({
-            secretKey,
+        const secretsToUpdate = resolvedEntries
+          .filter(({ finalKey }) => existingMap[finalKey])
+          .map(({ finalKey, secretData }) => ({
+            secretKey: finalKey,
             secretValue: secretData.value,
             secretComment: secretData.comments.join("\n") || undefined,
             type: SecretType.Shared,
@@ -440,6 +400,7 @@ const ImportSecretsContent = ({
   const handleBack = () => {
     setParsedSecrets(null);
     setVisibleSecretKeys(new Set());
+    setKeyOverrides({});
   };
 
   const toggleSecretVisibility = (key: string) => {
@@ -506,14 +467,15 @@ const ImportSecretsContent = ({
                     {isDragActive ? "Drop your file here" : "Upload your secrets"}
                   </EmptyTitle>
                   <EmptyDescription>
-                    Drag and drop your .env, .json, .yml, or .csv files here, or click to browse
+                    Drag and drop your .env, .json, .yml, .csv, .pfx, .pem, or .crt files here, or
+                    click to browse
                   </EmptyDescription>
                 </EmptyHeader>
                 <input
                   type="file"
                   disabled={!isAllowed}
                   className="absolute top-0 left-0 h-full w-full cursor-pointer opacity-0"
-                  accept=".txt,.env,.yml,.yaml,.json,.csv"
+                  accept=".txt,.env,.yml,.yaml,.json,.csv,.pfx,.pem,.crt"
                   onChange={handleFileUpload}
                 />
               </Empty>
@@ -565,11 +527,25 @@ const ImportSecretsContent = ({
                   const hasTags = Boolean(secretData.tagSlugs?.length);
                   const hasMetadata = Boolean(secretData.secretMetadata?.length);
                   const hasSkipMl = secretData.skipMultilineEncoding === true;
+                  const editableKey = secretData.isFileSecret === true;
+                  const editedKey = keyOverrides[key] ?? key;
                   return (
                     <TableRow key={key}>
                       <TableCell isTruncatable className="w-1/2 overflow-hidden font-mono text-xs">
                         <div className="flex w-full items-center gap-1.5">
-                          <p className="truncate">{key}</p>
+                          {editableKey ? (
+                            <Input
+                              value={editedKey}
+                              onChange={(e) =>
+                                setKeyOverrides((prev) => ({ ...prev, [key]: e.target.value }))
+                              }
+                              isError={!editedKey.trim()}
+                              placeholder="Secret key"
+                              className="h-7 font-mono text-xs"
+                            />
+                          ) : (
+                            <p className="truncate">{key}</p>
+                          )}
                           {hasComments && (
                             <Tooltip>
                               <TooltipTrigger asChild>
@@ -711,7 +687,7 @@ const ImportSecretsContent = ({
           <Button
             variant="project"
             onClick={handleImport}
-            isDisabled={!selectedEnvs.length || isImporting || isWaitingForTags}
+            isDisabled={!selectedEnvs.length || isImporting || isWaitingForTags || hasInvalidKey}
             isPending={isImporting || isWaitingForTags}
           >
             Upload {secretCount} Secret{secretCount !== 1 ? "s" : ""}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/SecretDropzone.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/SecretDropzone.tsx
@@ -55,8 +55,50 @@ export const SecretDropzone = ({ onParsedSecrets, onAddSecret }: Props) => {
     onParsedSecrets(env);
   };
 
+  // Certificate and key files are imported verbatim: the filename becomes the
+  // secret key and the file contents become the value. Binary PFX files are
+  // base64-encoded, while PEM and CRT files are stored as plain text.
+  const parseCertificateFile = (file: File, extension: string) => {
+    const reader = new FileReader();
+
+    reader.onload = (event) => {
+      if (!event?.target?.result) {
+        createNotification({
+          type: "error",
+          text: "Invalid file contents."
+        });
+        return;
+      }
+
+      const result = event.target.result as string;
+      const value =
+        extension === "pfx"
+          ? // readAsDataURL yields "data:<mime>;base64,<data>", so keep only the base64 payload
+            result.slice(result.indexOf(",") + 1)
+          : result;
+
+      handleParsedSecrets({ [file.name]: { value, comments: [] } });
+    };
+
+    try {
+      if (extension === "pfx") {
+        reader.readAsDataURL(file);
+      } else {
+        reader.readAsText(file);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   const parseFile = (file?: File) => {
     if (!file) {
+      return;
+    }
+
+    const extension = file.name.split(".").pop()?.toLowerCase();
+    if (extension === "pfx" || extension === "pem" || extension === "crt") {
+      parseCertificateFile(file, extension);
       return;
     }
 
@@ -162,7 +204,7 @@ export const SecretDropzone = ({ onParsedSecrets, onAddSecret }: Props) => {
                   type="file"
                   disabled={!isAllowed}
                   className="absolute top-0 left-0 z-10 h-full w-full cursor-pointer opacity-0"
-                  accept=".txt,.env,.yml,.yaml,.json,.csv"
+                  accept=".txt,.env,.yml,.yaml,.json,.csv,.pfx,.pem,.crt"
                   onChange={handleFileUpload}
                 />
               )}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/SecretDropzone.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/SecretDropzone.tsx
@@ -5,13 +5,6 @@ import { twMerge } from "tailwind-merge";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
-  CsvDelimiter,
-  parseCsvToMatrix,
-  parseDotEnv,
-  parseJson,
-  parseYaml
-} from "@app/components/utilities/parseSecrets";
-import {
   Button,
   Empty,
   EmptyContent,
@@ -27,6 +20,7 @@ import { ProjectPermissionActions, ProjectPermissionSub } from "@app/context";
 import { useToggle } from "@app/hooks";
 
 import { CsvColumnMapDialog } from "./CsvColumnMapDialog";
+import { CsvData, parseSecretFile } from "./parseSecretFile";
 import { PasteSecretsDialog } from "./PasteSecretsDialog";
 import { TParsedEnv } from "./types";
 
@@ -38,11 +32,7 @@ type Props = {
 export const SecretDropzone = ({ onParsedSecrets, onAddSecret }: Props) => {
   const [isDragActive, setDragActive] = useToggle();
   const [isPasteOpen, setIsPasteOpen] = useState(false);
-  const [csvData, setCsvData] = useState<{
-    headers: string[];
-    matrix: string[][];
-    delimiter: CsvDelimiter;
-  } | null>(null);
+  const [csvData, setCsvData] = useState<CsvData | null>(null);
 
   const handleParsedSecrets = (env: TParsedEnv) => {
     if (!Object.keys(env).length) {
@@ -55,98 +45,8 @@ export const SecretDropzone = ({ onParsedSecrets, onAddSecret }: Props) => {
     onParsedSecrets(env);
   };
 
-  // Certificate and key files are imported verbatim: the filename becomes the
-  // secret key and the file contents become the value. Binary PFX files are
-  // base64-encoded, while PEM and CRT files are stored as plain text.
-  const parseCertificateFile = (file: File, extension: string) => {
-    const reader = new FileReader();
-
-    reader.onload = (event) => {
-      if (!event?.target?.result) {
-        createNotification({
-          type: "error",
-          text: "Invalid file contents."
-        });
-        return;
-      }
-
-      const result = event.target.result as string;
-      const value =
-        extension === "pfx"
-          ? // readAsDataURL yields "data:<mime>;base64,<data>", so keep only the base64 payload
-            result.slice(result.indexOf(",") + 1)
-          : result;
-
-      handleParsedSecrets({ [file.name]: { value, comments: [] } });
-    };
-
-    try {
-      if (extension === "pfx") {
-        reader.readAsDataURL(file);
-      } else {
-        reader.readAsText(file);
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
-  const parseFile = (file?: File) => {
-    if (!file) {
-      return;
-    }
-
-    const extension = file.name.split(".").pop()?.toLowerCase();
-    if (extension === "pfx" || extension === "pem" || extension === "crt") {
-      parseCertificateFile(file, extension);
-      return;
-    }
-
-    const reader = new FileReader();
-    reader.onload = (event) => {
-      if (!event?.target?.result) {
-        createNotification({
-          type: "error",
-          text: "Invalid file contents."
-        });
-        return;
-      }
-
-      const src = event.target.result as ArrayBuffer;
-
-      switch (file.type) {
-        case "application/json":
-          handleParsedSecrets(parseJson(src));
-          break;
-        case "text/yaml":
-        case "application/x-yaml":
-        case "application/yaml":
-          handleParsedSecrets(parseYaml(src));
-          break;
-        case "text/csv": {
-          const { matrix: fullMatrix, delimiter } = parseCsvToMatrix(src);
-          if (!fullMatrix.length) {
-            createNotification({
-              type: "error",
-              text: "Failed to find secrets in CSV file. File might be empty."
-            });
-            return;
-          }
-          setCsvData({ headers: fullMatrix[0], matrix: fullMatrix.slice(1), delimiter });
-          return;
-        }
-        default:
-          handleParsedSecrets(parseDotEnv(src));
-          break;
-      }
-    };
-
-    try {
-      reader.readAsText(file);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const parseFile = (file?: File) =>
+    parseSecretFile(file, { onParsedSecrets: handleParsedSecrets, onCsvData: setCsvData });
 
   const handleDrag = (e: DragEvent) => {
     e.preventDefault();
@@ -195,7 +95,8 @@ export const SecretDropzone = ({ onParsedSecrets, onAddSecret }: Props) => {
                 {isDragActive ? "Drop your file here" : "Upload your secrets"}
               </EmptyTitle>
               <EmptyDescription>
-                Drag and drop your .env, .json, .yml, or .csv files here or click to browse
+                Drag and drop your .env, .json, .yml, .csv, .pfx, .pem, or .crt files here or click
+                to browse
               </EmptyDescription>
             </EmptyHeader>
             <EmptyContent>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/parseSecretFile.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/parseSecretFile.ts
@@ -30,6 +30,13 @@ const parseCertificateFile = (
 ) => {
   const reader = new FileReader();
 
+  reader.onerror = () => {
+    createNotification({
+      type: "error",
+      text: "Failed to read file."
+    });
+  };
+
   reader.onload = (event) => {
     if (!event?.target?.result) {
       createNotification({
@@ -46,7 +53,16 @@ const parseCertificateFile = (
           result.slice(result.indexOf(",") + 1)
         : result;
 
-    onParsedSecrets({ [file.name]: { value, comments: [], isFileSecret: true } });
+    const skipMultilineEncoding = extension === "pem" || extension === "crt";
+
+    onParsedSecrets({
+      [file.name]: {
+        value,
+        comments: [],
+        isFileSecret: true,
+        skipMultilineEncoding
+      }
+    });
   };
 
   try {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/parseSecretFile.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/parseSecretFile.ts
@@ -1,0 +1,121 @@
+import { createNotification } from "@app/components/notifications";
+import {
+  CsvDelimiter,
+  parseCsvToMatrix,
+  parseDotEnv,
+  parseJson,
+  parseYaml
+} from "@app/components/utilities/parseSecrets";
+
+import { TParsedEnv } from "./types";
+
+export type CsvData = {
+  headers: string[];
+  matrix: string[][];
+  delimiter: CsvDelimiter;
+};
+
+type ParseSecretFileOptions = {
+  onParsedSecrets: (env: TParsedEnv) => void;
+  onCsvData: (data: CsvData) => void;
+};
+
+// Certificate and key files are imported verbatim: the filename becomes the
+// secret key and the file contents become the value. Binary PFX files are
+// base64-encoded, while PEM and CRT files are stored as plain text.
+const parseCertificateFile = (
+  file: File,
+  extension: string,
+  onParsedSecrets: (env: TParsedEnv) => void
+) => {
+  const reader = new FileReader();
+
+  reader.onload = (event) => {
+    if (!event?.target?.result) {
+      createNotification({
+        type: "error",
+        text: "Invalid file contents."
+      });
+      return;
+    }
+
+    const result = event.target.result as string;
+    const value =
+      extension === "pfx"
+        ? // readAsDataURL yields "data:<mime>;base64,<data>", so keep only the base64 payload
+          result.slice(result.indexOf(",") + 1)
+        : result;
+
+    onParsedSecrets({ [file.name]: { value, comments: [], isFileSecret: true } });
+  };
+
+  try {
+    if (extension === "pfx") {
+      reader.readAsDataURL(file);
+    } else {
+      reader.readAsText(file);
+    }
+  } catch (error) {
+    console.log(error);
+  }
+};
+
+export const parseSecretFile = (
+  file: File | undefined,
+  { onParsedSecrets, onCsvData }: ParseSecretFileOptions
+) => {
+  if (!file) {
+    return;
+  }
+
+  const extension = file.name.split(".").pop()?.toLowerCase();
+  if (extension === "pfx" || extension === "pem" || extension === "crt") {
+    parseCertificateFile(file, extension, onParsedSecrets);
+    return;
+  }
+
+  const reader = new FileReader();
+  reader.onload = (event) => {
+    if (!event?.target?.result) {
+      createNotification({
+        type: "error",
+        text: "Invalid file contents."
+      });
+      return;
+    }
+
+    const src = event.target.result as ArrayBuffer;
+
+    switch (file.type) {
+      case "application/json":
+        onParsedSecrets(parseJson(src));
+        break;
+      case "text/yaml":
+      case "application/x-yaml":
+      case "application/yaml":
+        onParsedSecrets(parseYaml(src));
+        break;
+      case "text/csv": {
+        const { matrix: fullMatrix, delimiter } = parseCsvToMatrix(src);
+        if (!fullMatrix.length) {
+          createNotification({
+            type: "error",
+            text: "Failed to find secrets in CSV file. File might be empty."
+          });
+          return;
+        }
+        onCsvData({ headers: fullMatrix[0], matrix: fullMatrix.slice(1), delimiter });
+        return;
+      }
+      default:
+        onParsedSecrets(parseDotEnv(src));
+        break;
+    }
+  };
+
+  try {
+    reader.readAsText(file);
+  } catch (error) {
+    console.log(error);
+  }
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/types.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/types.ts
@@ -6,5 +6,6 @@ export type TParsedEnv = Record<
     tagSlugs?: string[];
     secretMetadata?: { key: string; value: string }[];
     skipMultilineEncoding?: boolean;
+    isFileSecret?: boolean;
   }
 >;


### PR DESCRIPTION
## Context
Allow certificates to be stored as secrets in the secret manager project. Users will be able to change the name of the key, but by default this will be the file name. 


## Screenshots


## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)