### PR TITLE
fix(auth-go): pass explicit accepted status for identity org membership check

### DIFF
--- a/backend-go/internal/services/auth/apiauth/authenticator.go
+++ b/backend-go/internal/services/auth/apiauth/authenticator.go
@@ -322,7 +322,7 @@ func (a *ApiAuthenticator) validateIdentityTokenClaims(ctx context.Context, clai
 	}
 
 	// 5. Check org membership.
-	membership, err := a.findEffectiveOrgMembership(ctx, auth.ActorTypeIdentity, identityID, orgID, "")
+	membership, err := a.findEffectiveOrgMembership(ctx, auth.ActorTypeIdentity, identityID, orgID, "accepted")
 	if err != nil {
 		return nil, errutil.DatabaseErr("Failed to check org membership").WithErrf("validateIdentityAccessToken(identityId=%s, orgId=%s): %w", identityID, orgID, err)
 	}

--- a/backend-go/tests/platform/auth/apiauthenticator_test.go
+++ b/backend-go/tests/platform/auth/apiauthenticator_test.go
@@ -1004,7 +1004,7 @@ func TestValidateIdentityAccessToken_NonAcceptedStatus(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		_, _ = stack.DB().Primary().Exec(context.Background(),
-			`UPDATE memberships SET status = NULL WHERE "actorIdentityId" = @identityID`,
+			`UPDATE memberships SET status = NULL WHERE "actorIdentityId" = @identityID AND scope = 'organization'`,
 			pgx.NamedArgs{"identityID": uuid.MustParse(identity.ID)})
 	})
 

--- a/backend-go/tests/platform/auth/apiauthenticator_test.go
+++ b/backend-go/tests/platform/auth/apiauthenticator_test.go
@@ -981,6 +981,39 @@ func TestValidateIdentityAccessToken_OrgMembershipInactive(t *testing.T) {
 	assert.Contains(t, err.Error(), "inactive")
 }
 
+func TestValidateIdentityAccessToken_NonAcceptedStatus(t *testing.T) {
+	nodejs := stack.NodeJS()
+
+	projName := "test-invited-" + uuid.New().String()[:8]
+	proj := nodejs.CreateProject(t, projName)
+	t.Cleanup(func() {
+		nodejs.DeleteProject(t, proj.ID)
+	})
+
+	identity := nodejs.CreateIdentity(t, "invited-identity-"+uuid.New().String()[:8])
+	nodejs.AddIdentityToProject(t, proj.ID, identity.ID, infra.Role("admin"))
+
+	token := nodejs.GetIdentityAccessToken(t, identity.ID)
+
+	// Set the org membership status to a non-accepted, non-null value.
+	_, err := stack.DB().Primary().Exec(context.Background(), `
+		UPDATE memberships
+		SET status = 'invited'
+		WHERE "actorIdentityId" = @identityID AND scope = 'organization'
+	`, pgx.NamedArgs{"identityID": uuid.MustParse(identity.ID)})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = stack.DB().Primary().Exec(context.Background(),
+			`UPDATE memberships SET status = NULL WHERE "actorIdentityId" = @identityID`,
+			pgx.NamedArgs{"identityID": uuid.MustParse(identity.ID)})
+	})
+
+	_, err = authenticator.ValidateIdentityAccessToken(context.Background(), token, "")
+
+	assertUnauthorized(t, err)
+	assert.Contains(t, err.Error(), "not a member")
+}
+
 // =============================================================================
 // Identity IP Blocklist Tests
 // =============================================================================


### PR DESCRIPTION
## Context

Closes #6650.

`findEffectiveOrgMembership` in `backend-go/internal/services/auth/apiauth/authenticator.go` silently defaults `filterStatus` to `"accepted"` when called with `""`. The identity access token validation path (`validateIdentityTokenClaims`) was the one caller relying on that implicit default, unlike the other two call sites in the same file and the Node.js counterpart (`identity-access-token-service.ts`), which all pass `"accepted"` explicitly.

I confirmed this isn't currently a live auth bypass/rejection bug in practice (identity org memberships are created with `status = NULL`, and the query already treats `NULL` as matching any filter), consistent with what `@nunoduartte` found on the issue thread. This PR removes the one spot depending on the implicit default and adds a regression test asserting that an org membership with an explicit non-accepted, non-null status (`invited`) is correctly rejected.

## Steps to verify the change

```bash
cd backend-go
go test -v -tags integration ./tests/platform/auth/... -run TestValidateIdentityAccessToken -count=1
```

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed) — not applicable
- [ ] Updated CLAUDE.md files (if needed) — not applicable, no architectural change
- [x] Read the contributing guide