### PR TITLE
feat(code-signing): prevent signers from approving their own signing requests

### DIFF
--- a/backend/src/services/approval-policy/approval-policy-service.ts
+++ b/backend/src/services/approval-policy/approval-policy-service.ts
@@ -1165,6 +1165,10 @@ export const approvalPolicyServiceFactory = ({
       throw new ForbiddenRequestError({ message: "You are not an eligible approver for this step" });
     }
 
+    if (policyType === ApprovalPolicyType.CertCodeSigning && request.requesterId === actor.id) {
+      throw new ForbiddenRequestError({ message: "You cannot approve your own signing request" });
+    }
+
     const hasApproved = currentStep.approvals.some((a) => a.approverUserId === actor.id);
     if (hasApproved) {
       throw new BadRequestError({ message: "You have already approved this request" });

--- a/backend/src/services/signer/signer-policy-service.ts
+++ b/backend/src/services/signer/signer-policy-service.ts
@@ -8,7 +8,7 @@ import {
   ResourcePermissionSignerActions,
   ResourcePermissionSub
 } from "@app/ee/services/permission/resource-permission";
-import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
 
 import {
@@ -619,6 +619,12 @@ export const signerPolicyServiceFactory = ({
 
     if (!dto.granteeUserId && !dto.granteeIdentityId) {
       throw new BadRequestError({ message: "granteeUserId or granteeIdentityId is required." });
+    }
+    if (
+      (dto.actor === ActorType.USER && dto.granteeUserId === dto.actorId) ||
+      (dto.actor === ActorType.IDENTITY && dto.granteeIdentityId === dto.actorId)
+    ) {
+      throw new ForbiddenRequestError({ message: "You cannot pre-approve signing access for yourself." });
     }
     if (!dto.requestedSignings && !dto.requestedWindowEnd) {
       throw new BadRequestError({ message: "Provide at least one of requestedSignings or requestedWindowEnd." });

--- a/docs/documentation/platform/pki/code-signing/approvals.mdx
+++ b/docs/documentation/platform/pki/code-signing/approvals.mdx
@@ -183,6 +183,10 @@ If you're an eligible approver for the **current** step of a pending request, an
   </Step>
 </Steps>
 
+<Note>
+  You can never approve your own signing request, even if you are listed as an approver for the current step. Administrators also cannot pre-approve signing for themselves. These rules are always enforced and cannot be disabled.
+</Note>
+
 ## Revoking access
 
 Administrators can revoke an active access record (or cancel a pending request) at any time. Hover the row on the Approvals tab; an **X** icon appears. Confirm in the dialog and:

--- a/frontend/src/pages/cert-manager/ApprovalRequestDetailPage/components/RequestActionsSection.tsx
+++ b/frontend/src/pages/cert-manager/ApprovalRequestDetailPage/components/RequestActionsSection.tsx
@@ -7,7 +7,7 @@ import { createNotification } from "@app/components/notifications";
 import { Button, FormLabel, Modal, ModalContent, TextArea } from "@app/components/v2";
 import { useProjectPermission, useUser } from "@app/context";
 import { usePopUp } from "@app/hooks";
-import { ApproverType } from "@app/hooks/api/approvalPolicies";
+import { ApprovalPolicyType, ApproverType } from "@app/hooks/api/approvalPolicies";
 import {
   ApprovalRequestStatus,
   ApprovalRequestStepStatus,
@@ -49,6 +49,10 @@ export const RequestActionsSection = ({ request }: Props) => {
   );
 
   if (!isApprover) {
+    return null;
+  }
+
+  if (request.type === ApprovalPolicyType.CertCodeSigning && request.requesterId === userId) {
     return null;
   }
 

--- a/frontend/src/pages/cert-manager/ApprovalsPage/components/CodeSigningRequestsTab/CodeSigningRequestsTab.tsx
+++ b/frontend/src/pages/cert-manager/ApprovalsPage/components/CodeSigningRequestsTab/CodeSigningRequestsTab.tsx
@@ -80,6 +80,8 @@ const checkIfUserNeedsToApprove = (
   userId: string,
   userGroups: string[]
 ): boolean => {
+  if (request.requesterId === userId) return false;
+
   const currentStep = request.steps.find(
     (step) => step.status === ApprovalRequestStepStatus.InProgress
   );

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/PreApproveSigningModal.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/PreApproveSigningModal.tsx
@@ -5,6 +5,7 @@ import ms from "ms";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
+import { useUser } from "@app/context";
 import {
   Button,
   Dialog,
@@ -87,6 +88,8 @@ export const PreApproveSigningModal = ({ isOpen, onOpenChange, signerId }: Props
   const preApprove = usePreApproveSigning();
   const [submitting, setSubmitting] = useState(false);
 
+  const { user } = useUser();
+
   const maxSignings = policy?.constraints?.maxSignings ?? null;
   const maxWindowDuration = policy?.constraints?.maxWindowDuration ?? null;
 
@@ -94,6 +97,8 @@ export const PreApproveSigningModal = ({ isOpen, onOpenChange, signerId }: Props
     const opts: MemberOption[] = [];
     (users.data?.members ?? []).forEach((m: TEffectiveSignerMember) => {
       if (!m.actorUserId) return;
+      // you cannot pre-approve signing for yourself, so don't offer yourself as a grantee
+      if (m.actorUserId === user?.id) return;
       if (m.role === SignerMemberRole.Auditor) return;
       opts.push({
         value: `user:${m.actorUserId}`,
@@ -111,7 +116,7 @@ export const PreApproveSigningModal = ({ isOpen, onOpenChange, signerId }: Props
       });
     });
     return opts;
-  }, [users.data, identities.data]);
+  }, [users.data, identities.data, user?.id]);
 
   const buildDefaults = (): FormData => {
     const now = Date.now();


### PR DESCRIPTION
## Context

Enforces that a code-signing requester can never approve their own signing request, and that an admin cannot pre-approve signing for themselves. Both are unconditional (no policy setting), so self-approval is blocked by design rather than by approval-policy configuration. PKI-286, First American Financial.

## Steps to verify the change

1. On a signer with an approval policy, add yourself as an eligible approver, submit a signing request, and confirm you cannot approve it (API returns 403; the UI hides the approve/reject action on your own request).
2. As an admin, try to pre-approve signing for yourself and confirm it's rejected.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)