### PR TITLE
feat(roles): add personal override action on secrets resource

### DIFF
--- a/backend/src/ee/services/permission/permission-fns.test.ts
+++ b/backend/src/ee/services/permission/permission-fns.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 
 import { conditionsMatcher } from "@app/lib/casl";
 
-import { expandLegacyForbidActions } from "./permission-fns";
+import { expandLegacyForbidActions, throwIfMissingSecretPersonalOverridePermission } from "./permission-fns";
 import {
   ProjectPermissionActions,
   ProjectPermissionGroupActions,
@@ -181,5 +181,69 @@ describe("expandLegacyForbidActions", () => {
     // In prod: allow rules still apply
     expect(ability.can(ProjectPermissionSecretActions.ReadValue, prodSecret)).toBe(true);
     expect(ability.can(ProjectPermissionSecretActions.DescribeAndReadValue, prodSecret)).toBe(true);
+  });
+});
+
+describe("throwIfMissingSecretPersonalOverridePermission", () => {
+  const buildAbility = (rules: Rule[]) => createMongoAbility<ProjectPermissionSet>(rules, { conditionsMatcher });
+
+  test("passes when the actor has PersonalOverride but not the shared fallback action", () => {
+    const ability = buildAbility([
+      allow({
+        action: [ProjectPermissionSecretActions.PersonalOverride],
+        subject: ProjectPermissionSub.Secrets
+      })
+    ]);
+    expect(() =>
+      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create)
+    ).not.toThrow();
+  });
+
+  test("passes when the actor has the shared fallback action but not PersonalOverride", () => {
+    const ability = buildAbility([
+      allow({
+        action: [ProjectPermissionSecretActions.Create],
+        subject: ProjectPermissionSub.Secrets
+      })
+    ]);
+    expect(() =>
+      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create)
+    ).not.toThrow();
+  });
+
+  test("throws when the actor has neither PersonalOverride nor the shared fallback action", () => {
+    const ability = buildAbility([
+      allow({
+        action: [ProjectPermissionSecretActions.ReadValue],
+        subject: ProjectPermissionSub.Secrets
+      })
+    ]);
+    expect(() =>
+      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create)
+    ).toThrow();
+  });
+
+  test("respects conditions on the PersonalOverride rule", () => {
+    const ability = buildAbility([
+      allow({
+        action: [ProjectPermissionSecretActions.PersonalOverride],
+        subject: ProjectPermissionSub.Secrets,
+        conditions: { environment: "dev" }
+      })
+    ]);
+
+    expect(() =>
+      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create, {
+        environment: "dev",
+        secretPath: "/"
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create, {
+        environment: "prod",
+        secretPath: "/"
+      })
+    ).toThrow();
   });
 });

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -50,6 +50,41 @@ export function throwIfMissingSecretReadValueOrDescribePermission(
   }
 }
 
+// Personal secret overrides can be managed either by the dedicated PersonalOverride action or by
+// whoever already has the matching shared-secret action (Create/Edit/Delete). This lets a role grant
+// personal-override-only access while existing shared-secret writers keep managing overrides.
+export function throwIfMissingSecretPersonalOverridePermission(
+  permission: MongoAbility<ProjectPermissionSet> | PureAbility,
+  fallbackAction: Extract<
+    ProjectPermissionSecretActions,
+    ProjectPermissionSecretActions.Create | ProjectPermissionSecretActions.Edit | ProjectPermissionSecretActions.Delete
+  >,
+  subjectFields?: SecretSubjectFields
+) {
+  try {
+    if (subjectFields) {
+      ForbiddenError.from(permission).throwUnlessCan(
+        ProjectPermissionSecretActions.PersonalOverride,
+        subject(ProjectPermissionSub.Secrets, subjectFields)
+      );
+    } else {
+      ForbiddenError.from(permission).throwUnlessCan(
+        ProjectPermissionSecretActions.PersonalOverride,
+        ProjectPermissionSub.Secrets
+      );
+    }
+  } catch {
+    if (subjectFields) {
+      ForbiddenError.from(permission).throwUnlessCan(
+        fallbackAction,
+        subject(ProjectPermissionSub.Secrets, subjectFields)
+      );
+    } else {
+      ForbiddenError.from(permission).throwUnlessCan(fallbackAction, ProjectPermissionSub.Secrets);
+    }
+  }
+}
+
 export function hasSecretReadValueOrDescribePermission(
   permission: MongoAbility<ProjectPermissionSet>,
   action: Extract<

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -48,7 +48,8 @@ export enum ProjectPermissionSecretActions {
   ReadValue = "readValue",
   Create = "create",
   Edit = "edit",
-  Delete = "delete"
+  Delete = "delete",
+  PersonalOverride = "personal-override"
 }
 
 export enum ProjectPermissionCmekActions {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -354,7 +354,7 @@ export const secretV2BridgeServiceFactory = ({
         environment,
         secretPath,
         secretName,
-        secretTags: tags?.map((el) => el.slug)
+        secretTags: doesSecretExist?.tags?.map((el) => el.slug)
       });
     } else {
       ForbiddenError.from(permission).throwUnlessCan(

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -889,9 +889,9 @@ export const secretV2BridgeServiceFactory = ({
         throw new BadRequestError({ message: "Cannot delete honey token secrets" });
     }
 
-    let sharedSecretForOverride;
     if (secretToDelete.type === SecretType.Personal) {
-      sharedSecretForOverride = await secretDAL.findOne({
+      // check the shared secret that this personal secret overrides to get the tags
+      const sharedSecretForOverride = await secretDAL.findOne({
         key: inputSecret.secretName,
         type: SecretType.Shared,
         folderId
@@ -905,19 +905,16 @@ export const secretV2BridgeServiceFactory = ({
       });
     }
 
-    const secretTagsForPermissionCheck = (
-      secretToDelete.type === SecretType.Personal ? sharedSecretForOverride : secretToDelete
-    )?.tags?.map((el) => el.slug);
-
-    ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionSecretActions.Delete,
-      subject(ProjectPermissionSub.Secrets, {
-        environment,
-        secretPath,
-        secretName: secretToDelete.key,
-        secretTags: secretTagsForPermissionCheck
-      })
-    );
+    if (secretToDelete.type !== SecretType.Personal)
+      ForbiddenError.from(permission).throwUnlessCan(
+        ProjectPermissionSecretActions.Delete,
+        subject(ProjectPermissionSub.Secrets, {
+          environment,
+          secretPath,
+          secretName: secretToDelete.key,
+          secretTags: secretToDelete.tags?.map((el) => el.slug)
+        })
+      );
 
     try {
       const deletedSecret = await secretDAL.transaction(async (tx) => {
@@ -976,7 +973,7 @@ export const secretV2BridgeServiceFactory = ({
           environment,
           secretPath,
           secretName: secretToDelete.key,
-          secretTags: secretTagsForPermissionCheck
+          secretTags: secretToDelete.tags?.map((el) => el.slug)
         }
       );
 

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -876,12 +876,8 @@ export const secretV2BridgeServiceFactory = ({
     const secretToDelete = await secretDAL.findOne({
       key: inputSecret.secretName,
       folderId,
-      ...(inputSecret.type === SecretType.Shared
-        ? {}
-        : {
-            type: SecretType.Personal,
-            userId: actorId
-          })
+      type: inputSecret.type,
+      ...(inputSecret.type === SecretType.Personal ? { userId: actorId } : {})
     });
     if (!secretToDelete) throw new NotFoundError({ message: "Secret not found" });
     if (inputSecret.type === SecretType.Shared) {
@@ -889,7 +885,7 @@ export const secretV2BridgeServiceFactory = ({
         throw new BadRequestError({ message: "Cannot delete honey token secrets" });
     }
 
-    if (secretToDelete.type === SecretType.Personal) {
+    if (inputSecret.type === SecretType.Personal) {
       // check the shared secret that this personal secret overrides to get the tags
       const sharedSecretForOverride = await secretDAL.findOne({
         key: inputSecret.secretName,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -13,6 +13,7 @@ import {
 import { TPermissionDALFactory } from "@app/ee/services/permission/permission-dal";
 import {
   hasSecretReadValueOrDescribePermission,
+  throwIfMissingSecretPersonalOverridePermission,
   throwIfMissingSecretReadValueOrDescribePermission
 } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -348,15 +349,24 @@ export const secretV2BridgeServiceFactory = ({
 
     const { secretName, type, ...inputSecretData } = inputSecret;
 
-    ForbiddenError.from(permission).throwUnlessCan(
-      ProjectPermissionSecretActions.Create,
-      subject(ProjectPermissionSub.Secrets, {
+    if (type === SecretType.Personal) {
+      throwIfMissingSecretPersonalOverridePermission(permission, ProjectPermissionSecretActions.Create, {
         environment,
         secretPath,
         secretName,
         secretTags: tags?.map((el) => el.slug)
-      })
-    );
+      });
+    } else {
+      ForbiddenError.from(permission).throwUnlessCan(
+        ProjectPermissionSecretActions.Create,
+        subject(ProjectPermissionSub.Secrets, {
+          environment,
+          secretPath,
+          secretName,
+          secretTags: tags?.map((el) => el.slug)
+        })
+      );
+    }
 
     const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
       projectDAL.findById(projectId)
@@ -544,6 +554,7 @@ export const secretV2BridgeServiceFactory = ({
     let secret;
     let secretId: string;
     if (inputSecret.type === SecretType.Personal) {
+      // Ther personal override rule was not added here to avoid regression with existing personal overrides
       const personalSecretToModify = await secretDAL.findOne({
         key: inputSecret.secretName,
         type: SecretType.Personal,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -877,7 +877,7 @@ export const secretV2BridgeServiceFactory = ({
       key: inputSecret.secretName,
       folderId,
       type: inputSecret.type,
-      ...(inputSecret.type === SecretType.Personal ? { userId: actorId } : {})
+      ...(inputSecret.type === SecretType.Personal && { userId: actorId })
     });
     if (!secretToDelete) throw new NotFoundError({ message: "Secret not found" });
     if (inputSecret.type === SecretType.Shared) {
@@ -901,7 +901,7 @@ export const secretV2BridgeServiceFactory = ({
       });
     }
 
-    if (secretToDelete.type !== SecretType.Personal)
+    if (inputSecret.type === SecretType.Shared)
       ForbiddenError.from(permission).throwUnlessCan(
         ProjectPermissionSecretActions.Delete,
         subject(ProjectPermissionSub.Secrets, {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -554,10 +554,17 @@ export const secretV2BridgeServiceFactory = ({
     let secret;
     let secretId: string;
     if (inputSecret.type === SecretType.Personal) {
+      const sharedSecretForOverride = await secretDAL.findOne({
+        key: inputSecret.secretName,
+        type: SecretType.Shared,
+        folderId
+      });
+
       throwIfMissingSecretPersonalOverridePermission(permission, ProjectPermissionSecretActions.Edit, {
         environment,
         secretPath,
-        secretName: inputSecret.secretName
+        secretName: inputSecret.secretName,
+        secretTags: sharedSecretForOverride?.tags?.map((el) => el.slug)
       });
 
       const personalSecretToModify = await secretDAL.findOne({
@@ -882,13 +889,25 @@ export const secretV2BridgeServiceFactory = ({
         throw new BadRequestError({ message: "Cannot delete honey token secrets" });
     }
 
+    let sharedSecretForOverride;
     if (secretToDelete.type === SecretType.Personal) {
+      sharedSecretForOverride = await secretDAL.findOne({
+        key: inputSecret.secretName,
+        type: SecretType.Shared,
+        folderId
+      });
+
       throwIfMissingSecretPersonalOverridePermission(permission, ProjectPermissionSecretActions.Delete, {
         environment,
         secretPath,
-        secretName: inputSecret.secretName
+        secretName: inputSecret.secretName,
+        secretTags: sharedSecretForOverride?.tags?.map((el) => el.slug)
       });
     }
+
+    const secretTagsForPermissionCheck = (
+      secretToDelete.type === SecretType.Personal ? sharedSecretForOverride : secretToDelete
+    )?.tags?.map((el) => el.slug);
 
     ForbiddenError.from(permission).throwUnlessCan(
       ProjectPermissionSecretActions.Delete,
@@ -896,7 +915,7 @@ export const secretV2BridgeServiceFactory = ({
         environment,
         secretPath,
         secretName: secretToDelete.key,
-        secretTags: secretToDelete.tags?.map((el) => el.slug)
+        secretTags: secretTagsForPermissionCheck
       })
     );
 
@@ -957,7 +976,7 @@ export const secretV2BridgeServiceFactory = ({
           environment,
           secretPath,
           secretName: secretToDelete.key,
-          secretTags: secretToDelete.tags?.map((el) => el.slug)
+          secretTags: secretTagsForPermissionCheck
         }
       );
 

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -554,7 +554,12 @@ export const secretV2BridgeServiceFactory = ({
     let secret;
     let secretId: string;
     if (inputSecret.type === SecretType.Personal) {
-      // Ther personal override rule was not added here to avoid regression with existing personal overrides
+      throwIfMissingSecretPersonalOverridePermission(permission, ProjectPermissionSecretActions.Edit, {
+        environment,
+        secretPath,
+        secretName: inputSecret.secretName
+      });
+
       const personalSecretToModify = await secretDAL.findOne({
         key: inputSecret.secretName,
         type: SecretType.Personal,
@@ -877,16 +882,23 @@ export const secretV2BridgeServiceFactory = ({
         throw new BadRequestError({ message: "Cannot delete honey token secrets" });
     }
 
-    if (secretToDelete.type !== SecretType.Personal)
-      ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionSecretActions.Delete,
-        subject(ProjectPermissionSub.Secrets, {
-          environment,
-          secretPath,
-          secretName: secretToDelete.key,
-          secretTags: secretToDelete.tags?.map((el) => el.slug)
-        })
-      );
+    if (secretToDelete.type === SecretType.Personal) {
+      throwIfMissingSecretPersonalOverridePermission(permission, ProjectPermissionSecretActions.Delete, {
+        environment,
+        secretPath,
+        secretName: inputSecret.secretName
+      });
+    }
+
+    ForbiddenError.from(permission).throwUnlessCan(
+      ProjectPermissionSecretActions.Delete,
+      subject(ProjectPermissionSub.Secrets, {
+        environment,
+        secretPath,
+        secretName: secretToDelete.key,
+        secretTags: secretToDelete.tags?.map((el) => el.slug)
+      })
+    );
 
     try {
       const deletedSecret = await secretDAL.transaction(async (tx) => {

--- a/frontend/src/context/ProjectPermissionContext/types.ts
+++ b/frontend/src/context/ProjectPermissionContext/types.ts
@@ -24,7 +24,8 @@ export enum ProjectPermissionSecretActions {
   Create = "create",
   Edit = "edit",
   Delete = "delete",
-  Subscribe = "subscribe"
+  Subscribe = "subscribe",
+  PersonalOverride = "personal-override"
 }
 
 export enum ProjectPermissionDynamicSecretActions {

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -130,7 +130,10 @@ export const mergePersonalSecrets = (rawSecrets: SecretV3Raw[]) => {
       sec.valueOverride = personalSecret.value;
       sec.overrideAction = "modified";
       sec.isOverrideEmpty = personalSecret.isEmpty;
-      sec.secretValueHidden = false;
+      // NOTE: do not force `secretValueHidden = false` here. It reflects whether the SHARED value is
+      // readable; a user with only the personal-override permission can read their override but not the
+      // shared value. Keep the shared entry's real value so the shared row renders the no-access state
+      // instead of attempting a forbidden fetch. Override display is gated on the override's own fields.
     }
   });
 

--- a/frontend/src/lib/fn/permission.ts
+++ b/frontend/src/lib/fn/permission.ts
@@ -387,6 +387,39 @@ export function hasSecretReadValueOrDescribePermission(
   return canNewPermission || canOldPermission;
 }
 
+// Personal secret overrides can be managed either by the dedicated PersonalOverride action or by
+// whoever already holds the matching shared-secret action (Create/Edit/Delete). This mirrors the
+// backend throwIfMissingSecretPersonalOverridePermission check so the UI shows the same controls.
+export function hasSecretPersonalOverridePermission(
+  permission: MongoAbility<ProjectPermissionSet>,
+  action: Extract<
+    ProjectPermissionSecretActions,
+    | ProjectPermissionSecretActions.Create
+    | ProjectPermissionSecretActions.Edit
+    | ProjectPermissionSecretActions.Delete
+  >,
+  subjectFields?: SecretSubjectFields
+) {
+  let canPersonalOverride = false;
+  let canFallback = false;
+
+  if (subjectFields) {
+    canPersonalOverride = permission.can(
+      ProjectPermissionSecretActions.PersonalOverride,
+      subject(ProjectPermissionSub.Secrets, subjectFields)
+    );
+    canFallback = permission.can(action, subject(ProjectPermissionSub.Secrets, subjectFields));
+  } else {
+    canPersonalOverride = permission.can(
+      ProjectPermissionSecretActions.PersonalOverride,
+      ProjectPermissionSub.Secrets
+    );
+    canFallback = permission.can(action, ProjectPermissionSub.Secrets);
+  }
+
+  return canPersonalOverride || canFallback;
+}
+
 // ─── Grant condition extractors ─────────────────────────────────────
 
 // Member extractors

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
@@ -99,7 +99,8 @@ const SecretPolicyActionSchema = z.object({
   [ProjectPermissionSecretActions.Edit]: z.boolean().optional(),
   [ProjectPermissionSecretActions.Delete]: z.boolean().optional(),
   [ProjectPermissionSecretActions.Create]: z.boolean().optional(),
-  [ProjectPermissionSecretActions.Subscribe]: z.boolean().optional()
+  [ProjectPermissionSecretActions.Subscribe]: z.boolean().optional(),
+  [ProjectPermissionSecretActions.PersonalOverride]: z.boolean().optional()
 });
 
 const ApprovalPolicyActionSchema = z.object({
@@ -1186,6 +1187,9 @@ export const rolePermission2Form = (permissions: TProjectPermission[] = []) => {
           const canDelete = action.includes(ProjectPermissionSecretActions.Delete);
           const canCreate = action.includes(ProjectPermissionSecretActions.Create);
           const canSubscribe = action.includes(ProjectPermissionSecretActions.Subscribe);
+          const canPersonalOverride = action.includes(
+            ProjectPermissionSecretActions.PersonalOverride
+          );
 
           // from above statement we are sure it won't be undefined
           formVal[subject]!.push({
@@ -1196,6 +1200,7 @@ export const rolePermission2Form = (permissions: TProjectPermission[] = []) => {
             edit: canEdit,
             delete: canDelete,
             subscribe: canSubscribe,
+            [ProjectPermissionSecretActions.PersonalOverride]: canPersonalOverride,
             conditions: conditions ? convertCaslConditionToFormOperator(conditions) : [],
             inverted
           });
@@ -2076,6 +2081,12 @@ export const PROJECT_PERMISSION_OBJECT: TProjectPermissionObject = {
         label: "Create",
         description: "Create new secrets in the project",
         value: ProjectPermissionSecretActions.Create
+      },
+      {
+        label: "Personal Override",
+        description:
+          "Create, modify, and delete personal secret overrides. Does not grant access to shared secrets.",
+        value: ProjectPermissionSecretActions.PersonalOverride
       }
     ]
   },

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -91,7 +91,10 @@ import { useGetSecretValue } from "@app/hooks/api/dashboard/queries";
 import { Reminder } from "@app/hooks/api/reminders/types";
 import { PendingAction } from "@app/hooks/api/secretFolders/types";
 import { ProjectEnv, SecretType, SecretV3RawSanitized, WsTag } from "@app/hooks/api/types";
-import { hasSecretReadValueOrDescribePermission } from "@app/lib/fn/permission";
+import {
+  hasSecretPersonalOverridePermission,
+  hasSecretReadValueOrDescribePermission
+} from "@app/lib/fn/permission";
 import { AddShareSecretModal } from "@app/pages/organization/SecretSharingPage/components/ShareSecret/AddShareSecretModal";
 import { CollapsibleSecretImports } from "@app/pages/secret-manager/SecretDashboardPage/components/SecretListView/CollapsibleSecretImports";
 import { HIDDEN_SECRET_VALUE } from "@app/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem";
@@ -880,6 +883,11 @@ export const SecretEditTableRow = ({
       secretName,
       secretTags: ["*"]
     })
+  );
+  const canCreatePersonalOverride = hasSecretPersonalOverridePermission(
+    permission,
+    ProjectPermissionSecretActions.Create,
+    { environment, secretPath, secretName, secretTags: ["*"] }
   );
 
   const isReadOnly =
@@ -1673,60 +1681,48 @@ export const SecretEditTableRow = ({
                         : ""}
                 </TooltipContent>
               </Tooltip>
-              <ProjectPermissionCan
-                I={ProjectPermissionActions.Create}
-                a={subject(ProjectPermissionSub.Secrets, {
-                  environment,
-                  secretPath,
-                  secretName,
-                  secretTags: ["*"]
-                })}
+              <Tooltip
+                open={
+                  isPendingBatchChange ||
+                  isCreatable ||
+                  isImportedSecret ||
+                  isOverride ||
+                  !canCreatePersonalOverride
+                    ? undefined
+                    : false
+                }
+                disableHoverableContent
               >
-                {(isAllowed) => (
-                  <Tooltip
-                    open={
+                <TooltipTrigger className="block w-full">
+                  <DropdownMenuItem
+                    className="px-2.5 py-1.5 text-xs"
+                    onClick={() => onAddOverride?.()}
+                    isDisabled={
                       isPendingBatchChange ||
                       isCreatable ||
                       isImportedSecret ||
                       isOverride ||
-                      !isAllowed
-                        ? undefined
-                        : false
+                      !canCreatePersonalOverride
                     }
-                    disableHoverableContent
                   >
-                    <TooltipTrigger className="block w-full">
-                      <DropdownMenuItem
-                        className="px-2.5 py-1.5 text-xs"
-                        onClick={() => onAddOverride?.()}
-                        isDisabled={
-                          isPendingBatchChange ||
-                          isCreatable ||
-                          isImportedSecret ||
-                          isOverride ||
-                          !isAllowed
-                        }
-                      >
-                        <GitBranchIcon />
-                        Add Override
-                      </DropdownMenuItem>
-                    </TooltipTrigger>
-                    <TooltipContent side="left">
-                      {isPendingBatchChange
-                        ? "Discard Pending Changes First"
-                        : !isAllowed
-                          ? "Access Denied"
-                          : isOverride
-                            ? "Override Already Exists"
-                            : isImportedSecret
-                              ? "Cannot Override Imported Secret"
-                              : isCreatable
-                                ? "Create Secret First"
-                                : "Add Personal Override"}
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-              </ProjectPermissionCan>
+                    <GitBranchIcon />
+                    Add Override
+                  </DropdownMenuItem>
+                </TooltipTrigger>
+                <TooltipContent side="left">
+                  {isPendingBatchChange
+                    ? "Discard Pending Changes First"
+                    : !canCreatePersonalOverride
+                      ? "Access Denied"
+                      : isOverride
+                        ? "Override Already Exists"
+                        : isImportedSecret
+                          ? "Cannot Override Imported Secret"
+                          : isCreatable
+                            ? "Create Secret First"
+                            : "Add Personal Override"}
+                </TooltipContent>
+              </Tooltip>
               <Tooltip
                 open={
                   isPendingBatchChange ||

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { subject } from "@casl/ability";
 import {
   CopyIcon,
   EditIcon,
@@ -13,7 +12,6 @@ import {
 import { twMerge } from "tailwind-merge";
 
 import { createNotification } from "@app/components/notifications";
-import { ProjectPermissionCan } from "@app/components/permissions";
 import { InfisicalSecretInput } from "@app/components/v2/InfisicalSecretInput";
 import {
   AlertDialog,
@@ -30,10 +28,12 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
-import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
+import { useProject, useProjectPermission } from "@app/context";
+import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
 import { useToggle } from "@app/hooks";
 import { useGetSecretValue } from "@app/hooks/api/dashboard/queries";
 import { SecretType } from "@app/hooks/api/types";
+import { hasSecretPersonalOverridePermission } from "@app/lib/fn/permission";
 import { HIDDEN_SECRET_VALUE } from "@app/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem";
 
 type Props = {
@@ -81,6 +81,14 @@ export const SecretOverrideRow = ({
   isSingleEnvView
 }: Props) => {
   const { currentProject } = useProject();
+  const { permission } = useProjectPermission();
+  const canSaveOverride = hasSecretPersonalOverridePermission(
+    permission,
+    isCreatingOverride
+      ? ProjectPermissionSecretActions.Create
+      : ProjectPermissionSecretActions.Edit,
+    { environment, secretPath, secretName, secretTags: ["*"] }
+  );
   const [isOverrideFieldFocused, setIsOverrideFieldFocused] = useToggle();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isHoveringActionZone, setIsHoveringActionZone] = useState(false);
@@ -226,35 +234,23 @@ export const SecretOverrideRow = ({
             isSingleEnvView ? "-top-[1.5px] -right-2.5" : "top-[0px] -right-1.5"
           )}
         >
-          <ProjectPermissionCan
-            I={isCreatingOverride ? ProjectPermissionActions.Create : ProjectPermissionActions.Edit}
-            a={subject(ProjectPermissionSub.Secrets, {
-              environment,
-              secretPath,
-              secretName,
-              secretTags: ["*"]
-            })}
-          >
-            {(isAllowed) => (
-              <div>
-                <Tooltip>
-                  <TooltipTrigger>
-                    <IconButton
-                      size="xs"
-                      variant="success"
-                      isDisabled={isSubmitting || !isAllowed}
-                      onClick={handleSubmit(handleFormSubmit)}
-                    >
-                      <SaveIcon />
-                    </IconButton>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {isCreatingOverride ? "Create Override" : "Save Override"}
-                  </TooltipContent>
-                </Tooltip>
-              </div>
-            )}
-          </ProjectPermissionCan>
+          <div>
+            <Tooltip>
+              <TooltipTrigger>
+                <IconButton
+                  size="xs"
+                  variant="success"
+                  isDisabled={isSubmitting || !canSaveOverride}
+                  onClick={handleSubmit(handleFormSubmit)}
+                >
+                  <SaveIcon />
+                </IconButton>
+              </TooltipTrigger>
+              <TooltipContent>
+                {isCreatingOverride ? "Create Override" : "Save Override"}
+              </TooltipContent>
+            </Tooltip>
+          </div>
           <div>
             <Tooltip>
               <TooltipTrigger asChild>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretDetailSidebar.tsx
@@ -107,8 +107,13 @@ export const SecretDetailSidebar = ({
 
   const { mutateAsync: redactSecretValue } = useRedactSecretValue();
 
+  // A personal override is always readable by its owner, so its fetch must not depend on the shared
+  // value's `secretValueHidden` (true when the user lacks read access to the shared secret).
   const canFetchSecretValue =
-    Boolean(originalSecret) && !originalSecret.secretValueHidden && !originalSecret.isEmpty;
+    Boolean(originalSecret) &&
+    (originalSecret?.idOverride
+      ? !originalSecret.isOverrideEmpty
+      : !originalSecret.secretValueHidden && !originalSecret.isEmpty);
 
   const fetchSecretValueParams = {
     environment,
@@ -162,10 +167,8 @@ export const SecretDetailSidebar = ({
   const getOverrideDefaultValue = () => {
     if (isLoadingSecretValue) return HIDDEN_SECRET_VALUE;
 
-    if (secret.secretValueHidden) {
-      return canEditSecretValue ? HIDDEN_SECRET_VALUE : "";
-    }
-
+    // The personal override is always readable by its owner; it is not gated on the shared value's
+    // `secretValueHidden`.
     if (isErrorFetchingSecretValue) return "Error loading secret value...";
 
     return secret.valueOverride || "";

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -41,7 +41,10 @@ import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { twMerge } from "tailwind-merge";
 
 import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
-import { hasSecretReadValueOrDescribePermission } from "@app/lib/fn/permission";
+import {
+  hasSecretPersonalOverridePermission,
+  hasSecretReadValueOrDescribePermission
+} from "@app/lib/fn/permission";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faEyeSlash,
@@ -249,6 +252,11 @@ export const SecretItem = memo(
     const isOverridden =
       overrideAction === SecretActionType.Created || overrideAction === SecretActionType.Modified;
     const hasTagsApplied = Boolean(fields.length);
+    const canManageOverride = hasSecretPersonalOverridePermission(
+      permission,
+      ProjectPermissionSecretActions.Create,
+      { environment, secretPath, secretName, secretTags: selectedTagSlugs }
+    );
 
     const autoSaveChanges = useCallback(
       async (data: TFormSchema) => {
@@ -733,42 +741,30 @@ export const SecretItem = memo(
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>
-                  <ProjectPermissionCan
-                    I={ProjectPermissionActions.Create}
-                    a={subject(ProjectPermissionSub.Secrets, {
-                      environment,
-                      secretPath,
-                      secretName,
-                      secretTags: selectedTagSlugs
-                    })}
-                  >
-                    {(isAllowed) => (
-                      <IconButton
-                        ariaLabel="override-value"
-                        isDisabled={!isAllowed || isManagedSecret}
-                        variant="plain"
-                        size="sm"
-                        onClick={handleOverrideClick}
-                        className={twMerge(
-                          "w-0 overflow-hidden p-0 group-hover:w-5",
-                          isOverridden && "w-5 text-primary"
-                        )}
-                      >
-                        <Tooltip
-                          content={
-                            isManagedSecret
-                              ? `Unavailable for ${isHoneyTokenSecret ? "honey token" : "rotated"} secrets`
-                              : `${isOverridden ? "Remove" : "Add"} Override`
-                          }
-                        >
-                          <FontAwesomeSymbol
-                            symbolName={FontAwesomeSpriteName.Override}
-                            className="h-3.5 w-3.5"
-                          />
-                        </Tooltip>
-                      </IconButton>
+                  <IconButton
+                    ariaLabel="override-value"
+                    isDisabled={!canManageOverride || isManagedSecret}
+                    variant="plain"
+                    size="sm"
+                    onClick={handleOverrideClick}
+                    className={twMerge(
+                      "w-0 overflow-hidden p-0 group-hover:w-5",
+                      isOverridden && "w-5 text-primary"
                     )}
-                  </ProjectPermissionCan>
+                  >
+                    <Tooltip
+                      content={
+                        isManagedSecret
+                          ? `Unavailable for ${isHoneyTokenSecret ? "honey token" : "rotated"} secrets`
+                          : `${isOverridden ? "Remove" : "Add"} Override`
+                      }
+                    >
+                      <FontAwesomeSymbol
+                        symbolName={FontAwesomeSpriteName.Override}
+                        className="h-3.5 w-3.5"
+                      />
+                    </Tooltip>
+                  </IconButton>
                   <Popover>
                     <ProjectPermissionCan
                       I={ProjectPermissionActions.Edit}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -254,11 +254,17 @@ export const SecretItem = memo(
     const isOverridden =
       overrideAction === SecretActionType.Created || overrideAction === SecretActionType.Modified;
     const hasTagsApplied = Boolean(fields.length);
-    const canManageOverride = hasSecretPersonalOverridePermission(
+    // Adding a personal override creates a personal secret, which the backend gates on the
+    // Create/PersonalOverride permission — so mirror that check for the "add" case.
+    const canAddOverride = hasSecretPersonalOverridePermission(
       permission,
       ProjectPermissionSecretActions.Create,
       { environment, secretPath, secretName, secretTags: selectedTagSlugs }
     );
+    // Removing an existing override deletes the user's own personal secret, which the backend allows
+    // for any owner without a permission check. So only gate the add case; allow removal whenever the
+    // row is already overridden.
+    const canManageOverride = isOverridden || canAddOverride;
 
     const autoSaveChanges = useCallback(
       async (data: TFormSchema) => {

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -130,9 +130,13 @@ export const SecretItem = memo(
 
     const [isFieldFocused, setIsFieldFocused] = useToggle();
 
+    // A personal override is always readable by its owner, so its fetch/display must not depend on the
+    // shared value's `secretValueHidden` (which is true when the user lacks read access to the shared secret).
+    const hasPersonalOverride = Boolean(originalSecret.idOverride);
     const canFetchSecretValue =
-      !originalSecret.secretValueHidden &&
-      !originalSecret.isEmpty &&
+      (hasPersonalOverride
+        ? !originalSecret.isOverrideEmpty
+        : !originalSecret.secretValueHidden && !originalSecret.isEmpty) &&
       pendingAction !== PendingAction.Create;
 
     const fetchSecretValueParams = {
@@ -140,7 +144,7 @@ export const SecretItem = memo(
       secretPath,
       secretKey: originalSecret.originalKey || originalSecret.key,
       projectId: currentProject.id,
-      isOverride: Boolean(originalSecret.idOverride)
+      isOverride: hasPersonalOverride
     };
 
     const {
@@ -200,10 +204,8 @@ export const SecretItem = memo(
     const getOverrideDefaultValue = () => {
       if (isLoadingSecretValue) return undefined;
 
-      if (secret.secretValueHidden && !isPending) {
-        return canEditSecretValue ? HIDDEN_SECRET_VALUE : "";
-      }
-
+      // The personal override belongs to the current user and is always readable by them, so it is not
+      // gated on the shared value's `secretValueHidden`.
       if (isErrorFetchingSecretValue) return undefined;
 
       return secret.valueOverride || "";


### PR DESCRIPTION
## Context

This adds a new action `personal-override` which allow users that have the `describe` and the new action to create personal overrides without having access to the actual secret

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

### Scenario 1: user is a member (has create, delete, edit and describe) on secrets can still add overrides. 
- Create a user which is a member 
- make sure that he can still add overrides 


### Scenario 2: user has `describe` and `personal-override` action 
- create a user that has only `describe` and `personal-override`
- check that he can create personal override
- validate that they don't have access to the shared secrets 

### scenario 3: user has only `describe`
- create a user that has only `describe`
- validate that they cannot add a personal override


## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)