### PR TITLE
fix: remove order by in audit log prune job

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-dal.ts
+++ b/backend/src/ee/services/audit-log/audit-log-dal.ts
@@ -241,7 +241,6 @@ export const auditLogDALFactory = (db: TDbClient) => {
           const findExpiredLogSubQuery = trx(TableName.AuditLog)
             .where("expiresAt", "<", today)
             .where("createdAt", "<", today) // to use audit log partition
-            .orderBy(`${TableName.AuditLog}.createdAt`, "desc")
             .select("id")
             .limit(AUDIT_LOG_PRUNE_BATCH_SIZE);
 


### PR DESCRIPTION
## Context

This PR removes the order by clause in our audit log prune job to help reduce query time

## Screenshots

n/a

## Steps to verify the change

- ship it

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)