### PR TITLE
fix(membership-identity): guard identityDAL.findById result before reading fields

### DIFF
--- a/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
@@ -7,7 +7,7 @@ import {
   validatePrivilegeChangeOperation
 } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
-import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@app/lib/errors";
+import { BadRequestError, InternalServerError, NotFoundError, PermissionBoundaryError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
@@ -147,6 +147,9 @@ export const newOrgMembershipIdentityFactory = ({
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(dto.selector.identityId), () =>
       identityDAL.findById(dto.selector.identityId)
     );
+    if (!identityDetails) {
+      throw new NotFoundError({ message: `Identity with ID '${dto.selector.identityId}' not found` });
+    }
     if (identityDetails.projectId) {
       throw new BadRequestError({ message: "Failed to create organization membership for a project scoped identity" });
     }
@@ -169,6 +172,9 @@ export const newOrgMembershipIdentityFactory = ({
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(dto.selector.identityId), () =>
       identityDAL.findById(dto.selector.identityId)
     );
+    if (!identityDetails) {
+      throw new NotFoundError({ message: `Identity with ID '${dto.selector.identityId}' not found` });
+    }
     if (identityDetails.orgId !== dto.permission.rootOrgId) {
       throw new BadRequestError({ message: "Only identities from parent organization can do this operation" });
     }

--- a/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
@@ -60,6 +60,9 @@ export const newOrgMembershipIdentityFactory = ({
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(dto.data.identityId), () =>
       identityDAL.findById(dto.data.identityId)
     );
+    if (!identityDetails) {
+      throw new NotFoundError({ message: `Identity with ID '${dto.data.identityId}' not found` });
+    }
     if (identityDetails.orgId !== dto.permission.rootOrgId) {
       throw new BadRequestError({ message: "Only identities from parent organization can be invited" });
     }

--- a/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
@@ -11,7 +11,7 @@ import {
   ProjectPermissionIdentityActions,
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
-import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@app/lib/errors";
+import { BadRequestError, InternalServerError, NotFoundError, PermissionBoundaryError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
@@ -96,6 +96,9 @@ export const newProjectMembershipIdentityFactory = ({
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(dto.data.identityId), () =>
       identityDAL.findById(dto.data.identityId)
     );
+    if (!identityDetails) {
+      throw new NotFoundError({ message: `Identity with ID '${dto.data.identityId}' not found` });
+    }
     if (identityDetails.projectId) {
       throw new BadRequestError({ message: "Failed to create project membership for a project scoped identity" });
     }
@@ -170,6 +173,9 @@ export const newProjectMembershipIdentityFactory = ({
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(dto.selector.identityId), () =>
       identityDAL.findById(dto.selector.identityId)
     );
+    if (!identityDetails) {
+      throw new NotFoundError({ message: `Identity with ID '${dto.selector.identityId}' not found` });
+    }
     if (identityDetails.projectId && identityDetails.projectId !== scope.value) {
       throw new BadRequestError({ message: "Failed to update project membership for a project scoped identity" });
     }
@@ -229,6 +235,9 @@ export const newProjectMembershipIdentityFactory = ({
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(dto.selector.identityId), () =>
       identityDAL.findById(dto.selector.identityId)
     );
+    if (!identityDetails) {
+      throw new NotFoundError({ message: `Identity with ID '${dto.selector.identityId}' not found` });
+    }
     if (identityDetails.projectId) {
       throw new BadRequestError({ message: "Failed to delete project membership for a project scoped identity" });
     }


### PR DESCRIPTION
Fixes #7255.

## What

Five sites across the project and org membership-identity factories fetch \`identityDAL.findById(dto.selector.identityId)\` and then immediately read \`identityDetails.projectId\` or \`identityDetails.orgId\` without checking whether the lookup returned a row. If it returns \`undefined\` for any reason (identity gone, stale id, cache race), the request 500s with:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'projectId')
\`\`\`

which is what the reporter of #7255 hit trying to PATCH a machine identity's project role on v0.162.0.

## Fix

Adds a \`NotFoundError\` guard on all five sites:

- \`project-membership-identity-factory.onCreateMembershipIdentityGuard\`
- \`project-membership-identity-factory.onUpdateMembershipIdentityGuard\`
- \`project-membership-identity-factory.onDeleteMembershipIdentityGuard\`
- \`org-membership-identity-factory.onUpdateMembershipIdentityGuard\`
- \`org-membership-identity-factory.onDeleteMembershipIdentityGuard\`

The 500 now becomes a clean 404 that names the missing identity id, so operators can see what went wrong instead of getting a generic \`InternalServerError\`.

The \`membership-identity-service\` layer above still ensures a valid membership exists before running these guards, so the NotFoundError is a defense-in-depth net rather than a routine path — but it converts a hard crash into a diagnosable error either way.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (defensive guard; hard to reproduce the exact identityDetails-undefined state without a test double)
- [x] The change is limited to the affected code path