### PR TITLE
fix(identity): guard identityDAL.findById result in updateIdentity

### DIFF
--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -262,7 +262,7 @@ export const identityServiceFactory = ({
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(id), () => identityDAL.findById(id));
 
     if (!identityDetails) {
-      throw new NotFoundError({ message: `Identity with ID '${id}' not found` });
+      throw new NotFoundError({ message: `Failed to find identity with id ${id}` });
     }
 
     if (identityDetails.projectId) {

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -261,6 +261,10 @@ export const identityServiceFactory = ({
 
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(id), () => identityDAL.findById(id));
 
+    if (!identityDetails) {
+      throw new NotFoundError({ message: `Identity with ID '${id}' not found` });
+    }
+
     if (identityDetails.projectId) {
       throw new BadRequestError({ message: `Identity is managed by project` });
     }


### PR DESCRIPTION
## What

Same bug class as #7255 / #7259 — \`updateIdentity\` fetches the target identity via \`requestMemoize\` + \`identityDAL.findById\` and then immediately reads \`identityDetails.projectId\` without checking whether the lookup returned a row. If it returns \`undefined\` (e.g. the identity was hard-deleted between the earlier org-membership validation and this second lookup, or any other reason the memoized fetch returns nothing), the request 500s with:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'projectId')
\`\`\`

## Fix

Adds a \`NotFoundError\` guard between the fetch and the field access. 500 becomes a clean 404 that names the missing identity id.

Same shape as the fix in #7259 for the membership-identity factories.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (defensive guard; hard to reproduce the exact identityDetails-undefined state without a test double)
- [x] The change is limited to the affected code path