### PR TITLE
fix(secret-approval-request): guard user/env/project lookups in notification path

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1679,9 +1679,6 @@ export const secretApprovalRequestServiceFactory = ({
 
     const env = await projectEnvDAL.findOne({ slug: environment, projectId });
     const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
-    if (!user || !env) {
-      return secretApprovalRequest;
-    }
 
     const projectPath = `/organizations/${actorOrgId}/projects/secret-management/${projectId}`;
     const approvalPath = `${projectPath}/approval`;
@@ -1691,34 +1688,35 @@ export const secretApprovalRequestServiceFactory = ({
     const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
       projectDAL.findById(projectId)
     );
-    if (!project) {
-      return secretApprovalRequest;
-    }
-    await triggerWorkflowIntegrationNotification({
-      input: {
-        projectId,
-        notification: {
-          type: TriggerFeature.SECRET_APPROVAL,
-          payload: {
-            userEmail: user.email as string,
-            environment: env.name,
-            secretPath,
-            projectId,
-            projectName: project.name,
-            requestId: secretApprovalRequest.id,
-            secretKeys: [...new Set(Object.values(data).flatMap((arr) => arr?.map((item) => item.secretName) ?? []))],
-            approvalUrl
+    // Skip only the Slack/Teams workflow notification if any lookup missed;
+    // sendApprovalEmailsFn + telemetry below still run so approvers get pinged.
+    if (user && env && project) {
+      await triggerWorkflowIntegrationNotification({
+        input: {
+          projectId,
+          notification: {
+            type: TriggerFeature.SECRET_APPROVAL,
+            payload: {
+              userEmail: user.email as string,
+              environment: env.name,
+              secretPath,
+              projectId,
+              projectName: project.name,
+              requestId: secretApprovalRequest.id,
+              secretKeys: [...new Set(Object.values(data).flatMap((arr) => arr?.map((item) => item.secretName) ?? []))],
+              approvalUrl
+            }
           }
+        },
+        dependencies: {
+          projectDAL,
+          projectSlackConfigDAL,
+          kmsService,
+          projectMicrosoftTeamsConfigDAL,
+          microsoftTeamsService
         }
-      },
-      dependencies: {
-        projectDAL,
-        projectSlackConfigDAL,
-        kmsService,
-        projectMicrosoftTeamsConfigDAL,
-        microsoftTeamsService
-      }
-    });
+      });
+    }
 
     await sendApprovalEmailsFn({
       projectDAL,
@@ -1732,7 +1730,7 @@ export const secretApprovalRequestServiceFactory = ({
     void telemetryService
       .sendPostHogEvents({
         event: PostHogEventTypes.SecretApprovalRequestSubmitted,
-        distinctId: user.username ?? user.email ?? actorId,
+        distinctId: user?.username ?? user?.email ?? actorId,
         organizationId: actorOrgId,
         properties: {
           requestId: secretApprovalRequest.id,
@@ -2121,40 +2119,41 @@ export const secretApprovalRequestServiceFactory = ({
 
     const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
     const env = await projectEnvDAL.findOne({ slug: environment, projectId });
-    if (!user || !env) {
-      return secretApprovalRequest;
-    }
 
     const projectPath = `/organizations/${actorOrgId}/projects/secret-management/${project.id}`;
     const approvalPath = `${projectPath}/approval`;
     const cfg = getConfig();
     const approvalUrl = `${cfg.SITE_URL}${approvalPath}?requestId=${secretApprovalRequest.id}`;
 
-    await triggerWorkflowIntegrationNotification({
-      input: {
-        projectId,
-        notification: {
-          type: TriggerFeature.SECRET_APPROVAL,
-          payload: {
-            userEmail: user.email as string,
-            environment: env.name,
-            secretPath,
-            projectId,
-            projectName: project.name,
-            requestId: secretApprovalRequest.id,
-            secretKeys: [...new Set(Object.values(data).flatMap((arr) => arr?.map((item) => item.secretKey) ?? []))],
-            approvalUrl
+    // Skip only the Slack/Teams workflow notification if any lookup missed;
+    // sendApprovalEmailsFn + telemetry below still run so approvers get pinged.
+    if (user && env) {
+      await triggerWorkflowIntegrationNotification({
+        input: {
+          projectId,
+          notification: {
+            type: TriggerFeature.SECRET_APPROVAL,
+            payload: {
+              userEmail: user.email as string,
+              environment: env.name,
+              secretPath,
+              projectId,
+              projectName: project.name,
+              requestId: secretApprovalRequest.id,
+              secretKeys: [...new Set(Object.values(data).flatMap((arr) => arr?.map((item) => item.secretKey) ?? []))],
+              approvalUrl
+            }
           }
+        },
+        dependencies: {
+          projectDAL,
+          kmsService,
+          projectSlackConfigDAL,
+          microsoftTeamsService,
+          projectMicrosoftTeamsConfigDAL
         }
-      },
-      dependencies: {
-        projectDAL,
-        kmsService,
-        projectSlackConfigDAL,
-        microsoftTeamsService,
-        projectMicrosoftTeamsConfigDAL
-      }
-    });
+      });
+    }
 
     await sendApprovalEmailsFn({
       projectDAL,
@@ -2168,7 +2167,7 @@ export const secretApprovalRequestServiceFactory = ({
     void telemetryService
       .sendPostHogEvents({
         event: PostHogEventTypes.SecretApprovalRequestSubmitted,
-        distinctId: user.username ?? user.email ?? actorId,
+        distinctId: user?.username ?? user?.email ?? actorId,
         organizationId: actorOrgId,
         properties: {
           requestId: secretApprovalRequest.id,

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1679,6 +1679,9 @@ export const secretApprovalRequestServiceFactory = ({
 
     const env = await projectEnvDAL.findOne({ slug: environment, projectId });
     const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
+    if (!user || !env) {
+      return secretApprovalRequest;
+    }
 
     const projectPath = `/organizations/${actorOrgId}/projects/secret-management/${projectId}`;
     const approvalPath = `${projectPath}/approval`;
@@ -1688,6 +1691,9 @@ export const secretApprovalRequestServiceFactory = ({
     const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
       projectDAL.findById(projectId)
     );
+    if (!project) {
+      return secretApprovalRequest;
+    }
     await triggerWorkflowIntegrationNotification({
       input: {
         projectId,
@@ -2115,6 +2121,9 @@ export const secretApprovalRequestServiceFactory = ({
 
     const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
     const env = await projectEnvDAL.findOne({ slug: environment, projectId });
+    if (!user || !env) {
+      return secretApprovalRequest;
+    }
 
     const projectPath = `/organizations/${actorOrgId}/projects/secret-management/${project.id}`;
     const approvalPath = `${projectPath}/approval`;


### PR DESCRIPTION
## What

Both \`generateSecretApprovalRequest\` and \`generateSecretApprovalRequestV2Bridge\` run a Slack / Microsoft Teams workflow-notification block after the approval request is committed to the DB. They fetch \`user\`, \`env\`, and \`project\` via \`requestMemoize\` + DAL.findById and then read \`user.email\`, \`env.name\`, \`project.name\` without any null check. If any of the three come back \`undefined\` (deleted user between commit and notify, a slug that doesn't resolve, project gone), the notification block throws:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'email' / 'name')
\`\`\`

and the caller sees a **500** for a request that has **already committed** — leaving the approval request stuck without an ack path.

## Fix

Early-return guards on both notification blocks. If \`user\`, \`env\`, or \`project\` is undefined, we return the already-committed \`secretApprovalRequest\` (preserving each function's declared return shape) and simply skip the workflow notification. The DB write is not affected.

Same defensive shape as the \`identityDetails\` guard fixes in #7259 (membership-identity factories) and #7260 (identity-service). Read-then-use lookups need a null guard.

## Checklist

- [x] I have read the contributing guide
- [ ] I have added tests (defensive guard on the notification-side branch)
- [x] The change is limited to the affected code path