### PR TITLE
fix(sidebar): close mobile sheet on route change

### DIFF
--- a/frontend/src/components/v3/generic/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/v3/generic/Sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
+import { useLocation } from "@tanstack/react-router";
 import { cva, type VariantProps } from "cva";
 import { ChevronDown, PanelLeftIcon } from "lucide-react";
 
@@ -82,6 +83,11 @@ function SidebarProvider({
 }) {
   const isMobile = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
+  const { pathname } = useLocation();
+
+  React.useEffect(() => {
+    setOpenMobile(false);
+  }, [pathname]);
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.


### PR DESCRIPTION
## Description

Fixes #7143.

The v3 `SidebarProvider` exposes an `openMobile` state that drives the Sheet overlay used on viewports below the `md` breakpoint (mobile, tablets, narrow desktop windows). Nothing was subscribed to the router, so when a user tapped a nav item the URL changed and the destination page rendered, but the overlay stayed put on top of it. Every navigation on narrow viewports required a manual dismiss to actually see the page you clicked to.

The fix subscribes `SidebarProvider` to `useLocation().pathname` from TanStack Router and resets `openMobile` to `false` when it changes. One change, all layouts covered — org, admin, project, product sub-org, and the server admin sidebar all route through this provider.

- Search-param-only navigation doesn't touch `pathname`, so pages that use URL state (filter, tab) don't cause a spurious close.
- The submenu-open state in `OrgSidebar` is separate from the sheet's own `open`, so opening "Settings" and picking a sub-item still works the same way — tapping the sub-item navigates and now closes the sheet in one step.

## Test plan

- [ ] Resize to < 1024px, open the sidebar via hamburger, tap any nav item — page navigates and sheet closes.
- [ ] Repeat for Settings → Product Settings (submenu path).
- [ ] On desktop (≥ 1024px), sidebar collapse/expand still works via keyboard shortcut and toggle.
- [ ] Changing only search params (e.g. secret filter) does not close the sidebar (verified via not touching `openMobile`).
