### PR TITLE
fix(ldap): match group CNs case-insensitively per LDAP semantics

### DIFF
--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -646,14 +646,15 @@ export const ldapConfigServiceFactory = ({
     let user = await userDAL.transaction(async (tx) => {
       const newUser = await userDAL.findOne({ id: userAlias.userId }, tx);
       if (groups && !isStaleAlias) {
-        const ldapGroupIdsToBePartOf = (
-          await ldapGroupMapDAL.find({
-            ldapConfigId,
-            $in: {
-              ldapGroupCN: groups.map((group) => group.cn)
-            }
-          })
-        ).map((groupMap) => groupMap.groupId);
+        const allLdapGroupMaps = await ldapGroupMapDAL.find({
+          ldapConfigId
+        });
+
+        // cn equality in LDAP is case-insensitive (caseIgnoreMatch).
+        const userLdapGroupCns = new Set(groups.map((group) => group.cn.toLowerCase()));
+        const ldapGroupIdsToBePartOf = allLdapGroupMaps
+          .filter((groupMap) => userLdapGroupCns.has(groupMap.ldapGroupCN.toLowerCase()))
+          .map((groupMap) => groupMap.groupId);
 
         const groupsToBePartOf = await groupDAL.find({
           orgId,
@@ -662,10 +663,6 @@ export const ldapConfigServiceFactory = ({
           }
         });
         const toBePartOfGroupIdsSet = new Set(groupsToBePartOf.map((groupToBePartOf) => groupToBePartOf.id));
-
-        const allLdapGroupMaps = await ldapGroupMapDAL.find({
-          ldapConfigId
-        });
 
         const ldapGroupIdsCurrentlyPartOf = (
           await userGroupMembershipDAL.find({
@@ -887,7 +884,9 @@ export const ldapConfigServiceFactory = ({
     const groupSearchFilter = `(cn=${ldapGroupCN})`;
     const groups = await searchGroups(ldapConfig, groupSearchFilter, ldapConfig.groupSearchBase);
 
-    if (!groups.some((g) => g.cn === ldapGroupCN)) {
+    // cn equality in LDAP is case-insensitive (caseIgnoreMatch).
+    const matchedGroup = groups.find((g) => g.cn.toLowerCase() === ldapGroupCN.toLowerCase());
+    if (!matchedGroup) {
       throw new NotFoundError({
         message: "Failed to find LDAP Group CN"
       });
@@ -902,7 +901,7 @@ export const ldapConfigServiceFactory = ({
 
     const groupMap = await ldapGroupMapDAL.create({
       ldapConfigId,
-      ldapGroupCN,
+      ldapGroupCN: matchedGroup.cn,
       groupId: group.id
     });
 

--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -884,9 +884,19 @@ export const ldapConfigServiceFactory = ({
     const groupSearchFilter = `(cn=${ldapGroupCN})`;
     const groups = await searchGroups(ldapConfig, groupSearchFilter, ldapConfig.groupSearchBase);
 
-    // cn equality in LDAP is case-insensitive (caseIgnoreMatch).
-    const matchedGroup = groups.find((g) => g.cn.toLowerCase() === ldapGroupCN.toLowerCase());
+    // cn equality in LDAP is case-insensitive (caseIgnoreMatch). Prefer an exact-case
+    // match; fall back to a case-variant only when it is unambiguous, since distinct
+    // groups in different containers can have CNs differing only by case.
+    const candidateGroups = groups.filter((g) => g.cn.toLowerCase() === ldapGroupCN.toLowerCase());
+    const distinctCns = new Set(candidateGroups.map((g) => g.cn));
+    const matchedGroup =
+      candidateGroups.find((g) => g.cn === ldapGroupCN) ?? (distinctCns.size === 1 ? candidateGroups[0] : undefined);
     if (!matchedGroup) {
+      if (distinctCns.size > 1) {
+        throw new BadRequestError({
+          message: `Multiple LDAP groups match CN '${ldapGroupCN}' case-insensitively: ${[...distinctCns].join(", ")}. Enter the exact CN of the intended group.`
+        });
+      }
       throw new NotFoundError({
         message: "Failed to find LDAP Group CN"
       });

--- a/backend/src/ee/services/ldap-config/ldap-fns.test.ts
+++ b/backend/src/ee/services/ldap-config/ldap-fns.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+
+import { extractCnFromDn } from "./ldap-fns";
+
+describe("extractCnFromDn", () => {
+  test("extracts CN from an Active Directory style DN (uppercase attribute types)", () => {
+    expect(extractCnFromDn("CN=Infisical-Admins,OU=Groups,DC=corp,DC=example,DC=com")).toBe("Infisical-Admins");
+  });
+
+  test("extracts cn from an OpenLDAP style DN (lowercase attribute types)", () => {
+    expect(extractCnFromDn("cn=engineering,ou=groups,dc=example,dc=com")).toBe("engineering");
+  });
+
+  test("extracts Cn regardless of mixed casing", () => {
+    expect(extractCnFromDn("Cn=Team,DC=example,DC=com")).toBe("Team");
+  });
+
+  test("preserves the original casing of the CN value", () => {
+    expect(extractCnFromDn("CN=MiXeDCaSe,OU=Groups,DC=example,DC=com")).toBe("MiXeDCaSe");
+  });
+
+  test("returns undefined when the DN has no CN RDN", () => {
+    expect(extractCnFromDn("OU=Groups,DC=example,DC=com")).toBeUndefined();
+  });
+
+  test("extracts CN when it is not the leading RDN", () => {
+    expect(extractCnFromDn("OU=Groups,CN=Nested,DC=example,DC=com")).toBe("Nested");
+  });
+
+  test("handles a single-RDN DN with no trailing comma", () => {
+    expect(extractCnFromDn("cn=solo")).toBe("solo");
+  });
+
+  test("tolerates spaces after RDN separators", () => {
+    expect(extractCnFromDn("CN=Team, OU=Groups, DC=example, DC=com")).toBe("Team");
+  });
+
+  test("does not match cn= inside another RDN's value", () => {
+    expect(extractCnFromDn("OU=acn=trap,DC=example,DC=com")).toBeUndefined();
+  });
+
+  test("keeps ldapjs hex-escaped commas within the CN value intact", () => {
+    // ldapjs DN.toString() serializes an escaped comma as \2c, so the value
+    // contains no raw comma and the RDN split cannot cut it in half
+    expect(extractCnFromDn("CN=Smith\\2c John,OU=Groups,DC=example,DC=com")).toBe("Smith\\2c John");
+  });
+
+  test("does not corrupt offsets when a preceding value contains uppercase Unicode that expands under case folding", () => {
+    // "İ" (U+0130) lowercases to two code units, so whole-string toLowerCase()
+    // approaches shift indexes and would extract a corrupted value here
+    expect(extractCnFromDn("OU=İstanbul,CN=Admins,DC=example,DC=com")).toBe("Admins");
+  });
+});

--- a/backend/src/ee/services/ldap-config/ldap-fns.ts
+++ b/backend/src/ee/services/ldap-config/ldap-fns.ts
@@ -107,6 +107,19 @@ export const testLDAPConfig = async (ldapConfig: TTestLDAPConfigDTO): Promise<bo
 };
 
 /**
+ * Extract the value of the first CN RDN from an LDAP DN string.
+ * RFC 4514 attribute types are case-insensitive.
+ */
+export const extractCnFromDn = (dn: string): string | undefined => {
+  const cnRdn = dn
+    .split(",")
+    .map((rdn) => rdn.trim())
+    .find((rdn) => rdn.slice(0, 3).toLowerCase() === "cn=");
+
+  return cnRdn?.substring(3);
+};
+
+/**
  * Search for groups in the LDAP server
  * @param ldapConfig - The LDAP configuration to use
  * @param filter - The filter to use when searching for groups
@@ -143,12 +156,9 @@ export const searchGroups = async (
 
         res.on("searchEntry", (entry) => {
           const dn = entry.dn.toString();
-          const cnStartIndex = dn.indexOf("cn=");
+          const cn = extractCnFromDn(dn);
 
-          if (cnStartIndex !== -1) {
-            const valueStartIndex = cnStartIndex + 3;
-            const commaIndex = dn.indexOf(",", valueStartIndex);
-            const cn = dn.substring(valueStartIndex, commaIndex === -1 ? undefined : commaIndex);
+          if (cn !== undefined) {
             groups.push({ dn, cn });
           }
         });

--- a/backend/src/ee/services/ldap-config/ldap-fns.ts
+++ b/backend/src/ee/services/ldap-config/ldap-fns.ts
@@ -109,6 +109,11 @@ export const testLDAPConfig = async (ldapConfig: TTestLDAPConfigDTO): Promise<bo
 /**
  * Extract the value of the first CN RDN from an LDAP DN string.
  * RFC 4514 attribute types are case-insensitive.
+ *
+ * Expects the ldapjs DN.toString() serialization, which hex-escapes commas
+ * inside values (\2c), so splitting on "," cannot cut a value in half. A raw
+ * RFC 4514 string using the alternative `\,` escape form would be split
+ * mid-value; do not pass DNs from other sources.
  */
 export const extractCnFromDn = (dn: string): string | undefined => {
   const cnRdn = dn


### PR DESCRIPTION
## Context

This PR updates our ldap group mapping handling to be case insensitive in conformance with the RFC

## Screenshots

N/A

## Steps to verify the change

1. `make up-dev-ldap` (stack already running: `docker compose -f docker-compose.dev.yml --profile ldap up -d openldap phpldapadmin`)
2. `make seed-dev-ldap` (creates org `ldap`, admin `admin@ldap.com` / `password123!`, active LDAP config, directory users john/alice with group `infisical-users`)
3. `cd backend && npm run test:unit -- ldap-fns` and expect 11 passing

**Flow 1: AD-style uppercase DN (the reported bug).** slapd lowercases DN attribute types, so emulate AD with a mock:
4. Save as `/tmp/mock-ad.js`, run `cd backend && NODE_PATH=$PWD/node_modules node /tmp/mock-ad.js`:
```js
const ldapjs = require("@infisical/ldapjs");
const s = ldapjs.createServer();
s.bind("", (req, res, next) => { res.end(); return next(); });
s.search("OU=Groups,DC=corp,DC=example,DC=com", (req, res, next) => {
  res.send({ dn: "CN=AD-Platform-Team,OU=Groups,DC=corp,DC=example,DC=com",
    attributes: { objectClass: ["group"], cn: ["AD-Platform-Team"] } });
  res.end(); return next();
});
s.listen(3893, "0.0.0.0");
```
5. Point the seeded config at it:
```sql
UPDATE ldap_configs SET url='ldap://host.docker.internal:3893',
  "groupSearchBase"='OU=Groups,DC=corp,DC=example,DC=com';
```
6. UI: log in as `admin@ldap.com`, create a group, then add an LDAP group map with CN `AD-Platform-Team`. On `main` this fails with "Failed to find LDAP Group CN"; on this branch it creates.
7. Revert the config: `url='ldap://openldap:389'`, `"groupSearchBase"='ou=groups,dc=ldap,dc=com'`

**Flow 2: value casing + canonical storage (real OpenLDAP)**
8. Add a map typing CN `INFISICAL-USERS`. It creates, and the list shows the stored CN as `infisical-users` (directory canonical).

**Flow 3: login group sync**
9. `curl -X POST localhost:8080/api/v1/ldap/login -H 'Content-Type: application/json' -d '{"organizationSlug":"ldap","username":"john","password":"password123!"}'` and expect 200
10. John appears as a member of the mapped Infisical group(s) (UI Groups page, or `user_group_membership` in the DB).
11. Remove john from the LDAP group (`ldapmodify`; add alice first, `groupOfNames` needs one member), re-run step 9, and john's membership is removed.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)