### PR TITLE
fix: revert use of key schema to detect duplicate syncs

### DIFF
--- a/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
+++ b/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
@@ -506,14 +506,13 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      const { destinationConfig, connectionId, syncOptions, excludeSyncId, projectId } = req.body;
+      const { destinationConfig, connectionId, excludeSyncId, projectId } = req.body;
 
       const result = await server.services.secretSync.checkDuplicateDestination(
         {
           destinationConfig: destinationConfig as Record<string, unknown>,
           destination,
           connectionId,
-          syncOptions,
           excludeSyncId,
           projectId
         },

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -236,7 +236,9 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
     getAwsAccountId(buildAwsConnectionConfig(newAwsConn, newAwsConn.credentials))
   ]);
 
-  if (!existingAccountId || !newAccountId) return false;
+  // If we can't verify the account id of any of the syncs, for safety reasons, we should
+  // tag it as duplicates. Better fail here than cause sync conflicts later.
+  if (!existingAccountId || !newAccountId) return true;
 
   return existingAccountId === newAccountId;
 };

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -236,9 +236,7 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
     getAwsAccountId(buildAwsConnectionConfig(newAwsConn, newAwsConn.credentials))
   ]);
 
-  // If we can't verify the account id of any of the syncs, for safety reasons, we should
-  // tag it as duplicates. Better fail here than cause sync conflicts later.
-  if (!existingAccountId || !newAccountId) return true;
+  if (!existingAccountId || !newAccountId) return false;
 
   return existingAccountId === newAccountId;
 };

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -217,15 +217,8 @@ const defaultDuplicateCheck: DestinationDuplicateCheckFn = async () => true;
 const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, newSync, decryptConnection }) => {
   if (!newSync.connectionId) return true;
 
-  const existingKeySchema = (existingSync.syncOptions?.keySchema as string) ?? "";
-  const newKeySchema = (newSync.syncOptions?.keySchema as string) ?? "";
-
-  // Mismatched keySchemas can still conflict (e.g. sync A with keySchema "INFISICAL_{{secretKey}}" and secret HOST
-  // vs sync B without keySchema and secret INFISICAL_HOST will write to the same destination key).
-  const hasKeySchemaConflict = !existingKeySchema || !newKeySchema || existingKeySchema === newKeySchema;
-
   if (existingSync.connectionId === newSync.connectionId) {
-    return hasKeySchemaConflict;
+    return true;
   }
 
   if (!existingSync.connectionId) return false;
@@ -245,7 +238,7 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
 
   if (!existingAccountId || !newAccountId) return false;
 
-  return existingAccountId === newAccountId && hasKeySchemaConflict;
+  return existingAccountId === newAccountId;
 };
 
 export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -324,12 +324,10 @@ export const secretSyncServiceFactory = ({
             const isDuplicate = await DESTINATION_DUPLICATE_CHECK_MAP[destination]({
               existingSync: {
                 connectionId: sync.connectionId,
-                syncOptions: (sync.syncOptions as Record<string, unknown>) ?? null,
                 destinationConfig: sync.destinationConfig as Record<string, unknown>
               },
               newSync: {
                 connectionId: connectionId ?? null,
-                syncOptions: syncOptions ?? null,
                 destinationConfig
               },
               decryptConnection

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -258,14 +258,7 @@ export const secretSyncServiceFactory = ({
   };
 
   const checkDuplicateDestination = async (
-    {
-      destination,
-      destinationConfig,
-      connectionId,
-      syncOptions,
-      excludeSyncId,
-      projectId
-    }: TCheckDuplicateDestinationDTO,
+    { destination, destinationConfig, connectionId, excludeSyncId, projectId }: TCheckDuplicateDestinationDTO,
     actor: OrgServiceActor
   ) => {
     const skipFields = SECRET_SYNC_SKIP_FIELDS_MAP[destination];
@@ -433,7 +426,6 @@ export const secretSyncServiceFactory = ({
           destination: params.destination,
           destinationConfig: params.destinationConfig,
           connectionId: params.connectionId,
-          syncOptions: params.syncOptions as Record<string, unknown> | undefined,
           projectId
         },
         actor
@@ -558,7 +550,7 @@ export const secretSyncServiceFactory = ({
 
     let { folderId } = secretSync;
 
-    if (params.destinationConfig || params.connectionId || params.syncOptions) {
+    if (params.destinationConfig || params.connectionId) {
       // getProjectPermission above throws NotFoundError if the project doesn't exist and
       // guarantees actor.orgId === project.orgId — no separate project lookup needed.
       const organization = await requestMemoize(requestMemoKeys.orgFindById(actor.orgId), () =>
@@ -571,9 +563,6 @@ export const secretSyncServiceFactory = ({
             destination,
             destinationConfig: params.destinationConfig ?? (secretSync.destinationConfig as Record<string, unknown>),
             connectionId: params.connectionId ?? connectionId,
-            syncOptions:
-              (params.syncOptions as Record<string, unknown> | undefined) ??
-              (secretSync.syncOptions as Record<string, unknown> | null),
             projectId: secretSync.projectId,
             excludeSyncId: secretSync.id
           },

--- a/backend/src/services/secret-sync/secret-sync-types.ts
+++ b/backend/src/services/secret-sync/secret-sync-types.ts
@@ -574,7 +574,6 @@ export type TSecretMap = Record<
 
 export type DuplicateCheckSyncFields = {
   connectionId: string | null;
-  syncOptions: Record<string, unknown> | null;
   destinationConfig: Record<string, unknown>;
 };
 

--- a/backend/src/services/secret-sync/secret-sync-types.ts
+++ b/backend/src/services/secret-sync/secret-sync-types.ts
@@ -475,7 +475,6 @@ export type TCheckDuplicateDestinationDTO = {
   destination: SecretSync;
   destinationConfig: Record<string, unknown>;
   connectionId?: string | null;
-  syncOptions?: Record<string, unknown> | null;
   excludeSyncId?: string;
   projectId: string;
 };

--- a/frontend/src/components/secret-syncs/forms/CreateSecretSyncForm.tsx
+++ b/frontend/src/components/secret-syncs/forms/CreateSecretSyncForm.tsx
@@ -215,7 +215,6 @@ export const CreateSecretSyncForm = ({
     destination,
     projectId: currentProject?.id || "",
     connectionId: watch("connection")?.id,
-    syncOptions: watch("syncOptions"),
     enabled: true,
     destinationConfig: watch("destinationConfig")
   });

--- a/frontend/src/components/secret-syncs/forms/EditSecretSyncForm.tsx
+++ b/frontend/src/components/secret-syncs/forms/EditSecretSyncForm.tsx
@@ -156,7 +156,6 @@ export const EditSecretSyncForm = ({ secretSync, onComplete, onDirtyChange, onCa
     secretSync.projectId,
     secretSync.id,
     formMethods.watch("connection")?.id,
-    formMethods.watch("syncOptions"),
     { enabled: checkDuplicateEnabled && Boolean(destinationConfigToCheck) }
   );
 

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
@@ -103,7 +103,6 @@ export const SecretSyncReviewFields = () => {
     destination,
     projectId: currentProject?.id || "",
     connectionId: connection?.id,
-    syncOptions: watch("syncOptions"),
     enabled: true,
     destinationConfig: watch("destinationConfig")
   });

--- a/frontend/src/hooks/api/secretSyncs/queries.tsx
+++ b/frontend/src/hooks/api/secretSyncs/queries.tsx
@@ -19,7 +19,6 @@ export const secretSyncKeys = {
     destination: SecretSync,
     destinationConfig: unknown,
     connectionId?: string,
-    syncOptions?: unknown,
     excludeSyncId?: string
   ) =>
     [
@@ -28,7 +27,6 @@ export const secretSyncKeys = {
       "duplicate-check",
       destinationConfig,
       connectionId,
-      syncOptions,
       excludeSyncId
     ] as const
 };
@@ -111,7 +109,6 @@ export const useCheckDuplicateDestination = (
   projectId: string,
   excludeSyncId?: string,
   connectionId?: string,
-  syncOptions?: unknown,
   options?: Omit<
     UseQueryOptions<
       { hasDuplicate: boolean; duplicateProjectId?: string },
@@ -127,7 +124,6 @@ export const useCheckDuplicateDestination = (
       destination,
       destinationConfig,
       connectionId,
-      syncOptions,
       excludeSyncId
     ),
     queryFn: async () => {
@@ -137,7 +133,6 @@ export const useCheckDuplicateDestination = (
       }>(`/api/v1/secret-syncs/${destination}/check-destination`, {
         destinationConfig,
         connectionId,
-        syncOptions,
         excludeSyncId,
         projectId
       });

--- a/frontend/src/hooks/api/secretSyncs/useDuplicateDestinationCheck.ts
+++ b/frontend/src/hooks/api/secretSyncs/useDuplicateDestinationCheck.ts
@@ -7,7 +7,6 @@ type UseDuplicateDestinationCheckProps = {
   projectId: string;
   excludeSyncId?: string;
   connectionId?: string;
-  syncOptions?: unknown;
   enabled?: boolean;
   destinationConfig?: unknown;
 };
@@ -17,7 +16,6 @@ export const useDuplicateDestinationCheck = ({
   projectId,
   excludeSyncId,
   connectionId,
-  syncOptions,
   enabled = true,
   destinationConfig
 }: UseDuplicateDestinationCheckProps) => {
@@ -44,7 +42,6 @@ export const useDuplicateDestinationCheck = ({
     projectId,
     excludeSyncId,
     connectionId,
-    syncOptions,
     {
       enabled: shouldCheck,
       staleTime: 0,


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Remove `keySchema` from the secret sync duplication detection.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)