### PR TITLE
fix: add missing init on the license service for getMigrationEncryptionServices

### DIFF
--- a/backend/src/db/migrations/20260612142201_pam-revamp.ts
+++ b/backend/src/db/migrations/20260612142201_pam-revamp.ts
@@ -275,7 +275,12 @@ export async function up(knex: Knex): Promise<void> {
   const kmsRootConfigDAL = kmsRootConfigDALFactory(knex);
   const envConfig = await getMigrationEnvConfig(superAdminDAL, hsmService, kmsRootConfigDAL);
   const keyStore = inMemoryKeyStore();
-  const { kmsService } = await getMigrationEncryptionServices({ envConfig, keyStore, db: knex });
+  const { kmsService } = await getMigrationEncryptionServices({
+    envConfig,
+    keyStore,
+    db: knex,
+    skipHsmLicenseCheck: true
+  });
 
   const getProjectCipher = async (projectId: string) =>
     kmsService.createCipherPairWithDataKey({ type: KmsDataKey.SecretManager, projectId }, knex);

--- a/backend/src/db/migrations/utils/services.ts
+++ b/backend/src/db/migrations/utils/services.ts
@@ -29,6 +29,7 @@ type TDependencies = {
   envConfig: TMigrationEnvConfig;
   db: Knex;
   keyStore: TKeyStoreFactory;
+  skipHsmLicenseCheck?: boolean;
 };
 
 type THsmServiceDependencies = {
@@ -49,7 +50,12 @@ export const getMigrationHsmService = async ({ envConfig }: THsmServiceDependenc
   return { hsmService };
 };
 
-export const getMigrationEncryptionServices = async ({ envConfig, db, keyStore }: TDependencies) => {
+export const getMigrationEncryptionServices = async ({
+  envConfig,
+  db,
+  keyStore,
+  skipHsmLicenseCheck = false
+}: TDependencies) => {
   // ----- DAL dependencies -----
   const orgDAL = orgDALFactory(db);
   const licenseDAL = licenseDALFactory(db);
@@ -88,8 +94,6 @@ export const getMigrationEncryptionServices = async ({ envConfig, db, keyStore }
     envConfig
   });
 
-  await licenseService.init();
-
   // ----- HSM startup -----
 
   const { hsmService } = await getMigrationHsmService({ envConfig });
@@ -97,7 +101,7 @@ export const getMigrationEncryptionServices = async ({ envConfig, db, keyStore }
   const hsmStatus = await isHsmActiveAndEnabled({
     hsmService,
     kmsRootConfigDAL,
-    licenseService
+    licenseService: skipHsmLicenseCheck ? undefined : licenseService
   });
 
   // if the encryption strategy is software - user needs to provide an encryption key

--- a/backend/src/db/migrations/utils/services.ts
+++ b/backend/src/db/migrations/utils/services.ts
@@ -88,6 +88,8 @@ export const getMigrationEncryptionServices = async ({ envConfig, db, keyStore }
     envConfig
   });
 
+  await licenseService.init();
+
   // ----- HSM startup -----
 
   const { hsmService } = await getMigrationHsmService({ envConfig });


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)