### PR TITLE
improvement(self-host): disable public signups after admin setup

### DIFF
--- a/backend/src/ee/services/audit-log/audit-log-queue.ts
+++ b/backend/src/ee/services/audit-log/audit-log-queue.ts
@@ -132,8 +132,7 @@ export const auditLogQueueServiceFactory = async ({
     await keyStore.streamAdd(AUDIT_LOG_STREAM_KEY, "*", { data: JSON.stringify(entry) });
     auditLogEnqueuedCounter.add(1, {
       "audit_log.event_type": entry.event?.type ?? "unknown",
-      "audit_log.actor_type": entry.actor?.type ?? "unknown",
-      "infisical.organization.id": entry.orgId
+      "audit_log.actor_type": entry.actor?.type ?? "unknown"
     });
   };
 

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -44,6 +44,7 @@ const SanitizedSuperAdminSchema = z.object({
   pageFrameContent: z.string().nullable().optional(),
   // Super admin-only fields (omitted for non-super-admin callers)
   instanceId: z.string().uuid().optional(),
+  createdAt: z.date().optional(),
   trustSamlEmails: z.boolean().nullish(),
   trustLdapEmails: z.boolean().nullish(),
   trustOidcEmails: z.boolean().nullish(),

--- a/backend/src/services/super-admin/super-admin-service.ts
+++ b/backend/src/services/super-admin/super-admin-service.ts
@@ -541,7 +541,11 @@ export const superAdminServiceFactory = ({
       orgName: initialOrganizationName
     });
 
-    await updateServerCfg({ initialized: true }, userInfo.user.id);
+    const shouldDisableSignUp = !appCfg.isCloud;
+    await updateServerCfg(
+      { initialized: true, ...(shouldDisableSignUp ? { allowSignUp: false } : {}) },
+      userInfo.user.id
+    );
     const token = await authService.generateUserTokens({
       userId: userInfo.user.id,
       authMethod: AuthMethod.EMAIL,
@@ -669,7 +673,15 @@ export const superAdminServiceFactory = ({
       return { identity: newIdentity, auth: tokenAuth, credentials: { token: generatedAccessToken } };
     });
 
-    await updateServerCfg({ initialized: true, adminIdentityIds: [identity.id] }, userInfo.user.id);
+    const shouldDisableSignUp = !appCfg.isCloud;
+    await updateServerCfg(
+      {
+        initialized: true,
+        adminIdentityIds: [identity.id],
+        ...(shouldDisableSignUp ? { allowSignUp: false } : {})
+      },
+      userInfo.user.id
+    );
 
     return {
       user: userInfo,

--- a/docs/self-hosting/guides/production-hardening.mdx
+++ b/docs/self-hosting/guides/production-hardening.mdx
@@ -143,6 +143,30 @@ Set proper site URL for your Infisical instance:
 SITE_URL="https://app.infisical.com"
 ```
 
+#### Public Signups Are Disabled After Admin Setup
+
+<Warning>
+  Leaving self-service signups open on a publicly reachable instance means anyone
+  can create an account without an invitation, which widens your attack surface.
+  Several features let an authenticated user configure outbound requests to
+  destinations they supply (App Connections, Webhooks, Audit Log Streams, Dynamic
+  Secrets, and similar). Infisical already routes these through an SSRF-safe
+  client that blocks internal and private IP ranges by default (see
+  [SSRF Protection](#server-side-request-forgery-ssrf-protection) above). 
+  Restricting who can reach those features limits exposure if that protection is ever relaxed (for example a
+  permissive `ALLOW_INTERNAL_IP_CONNECTIONS`).
+</Warning>
+
+On a self-hosted instance, self-service signups are **disabled by default** once
+the first super admin account is created. No configuration is required to get this
+hardened default. You can still invite users to your organization, and to
+provision additional users, prefer organization invitations over public signup.
+
+If you operate a trusted, internal instance and deliberately want open signups,
+re-enable them from the **Admin Console → Authentication** settings by setting
+**Allow user signups** to **Anyone**. The same control lets you disable signups
+again at any time.
+
 #### SMTP Security
 
 Use TLS for email communications:

--- a/docs/self-hosting/guides/production-hardening.mdx
+++ b/docs/self-hosting/guides/production-hardening.mdx
@@ -167,6 +167,15 @@ re-enable them from the **Admin Console → Authentication** settings by setting
 **Allow user signups** to **Anyone**. The same control lets you disable signups
 again at any time.
 
+<Note>
+  This hardened default applies to **new installations only**. It takes effect
+  when the first super admin account is created, so an instance that was already
+  initialized before upgrading keeps its existing **Allow user signups** setting
+  (open by default). If you run an existing self-hosted instance, verify this in
+  **Admin Console → Authentication** and set **Allow user signups** to
+  **Disabled** if you want the hardened behavior.
+</Note>
+
 #### SMTP Security
 
 Use TLS for email communications:

--- a/frontend/src/hooks/api/admin/types.ts
+++ b/frontend/src/hooks/api/admin/types.ts
@@ -69,6 +69,7 @@ export type TServerConfig = {
   isCrossProjectSecretSharingEnabled?: boolean;
   // Super admin-only fields (omitted for non-super-admin callers)
   instanceId?: string;
+  createdAt?: string;
   trustSamlEmails?: boolean;
   trustLdapEmails?: boolean;
   trustOidcEmails?: boolean;

--- a/frontend/src/layouts/AdminLayout/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout/AdminLayout.tsx
@@ -11,6 +11,7 @@ import { SmtpBanner } from "@app/layouts/OrganizationLayout/components/SmtpBanne
 
 import { InsecureConnectionBanner } from "../OrganizationLayout/components/InsecureConnectionBanner";
 import { AdminSidebar } from "./AdminSidebar";
+import { SignupDisabledBanner } from "./SignupDisabledBanner";
 
 export const AdminLayout = () => {
   const { config } = useServerConfig();
@@ -33,6 +34,7 @@ export const AdminLayout = () => {
         <div className="flex min-h-0 flex-1">
           <AdminSidebar />
           <div className="min-h-0 flex-1 overflow-y-auto bg-bunker-800 px-12 pt-10 pb-4 dark:scheme-dark">
+            <SignupDisabledBanner />
             <Outlet />
           </div>
         </div>

--- a/frontend/src/layouts/AdminLayout/SignupDisabledBanner/SignupDisabledBanner.tsx
+++ b/frontend/src/layouts/AdminLayout/SignupDisabledBanner/SignupDisabledBanner.tsx
@@ -1,0 +1,57 @@
+import { UserXIcon, XIcon } from "lucide-react";
+
+import { Alert, AlertDescription, AlertTitle, IconButton } from "@app/components/v3";
+import { useServerConfig } from "@app/context";
+import { useToggle } from "@app/hooks";
+
+const SIGNUP_BANNER_MAX_SERVER_AGE_DAYS = 7;
+const SIGNUP_BANNER_MAX_SERVER_AGE_MS = SIGNUP_BANNER_MAX_SERVER_AGE_DAYS * 24 * 60 * 60 * 1000;
+
+type ShouldShowSignupDisabledBannerArgs = {
+  allowSignUp?: boolean | null;
+  createdAt?: string | Date | null;
+};
+
+const shouldShowSignupDisabledBanner = ({
+  allowSignUp,
+  createdAt
+}: ShouldShowSignupDisabledBannerArgs): boolean => {
+  if (allowSignUp !== false) return false;
+  if (!createdAt) return false;
+
+  const createdAtMs = new Date(createdAt).getTime();
+  if (Number.isNaN(createdAtMs)) return false;
+
+  return Date.now() - createdAtMs < SIGNUP_BANNER_MAX_SERVER_AGE_MS;
+};
+
+export const SignupDisabledBanner = () => {
+  const { config } = useServerConfig();
+  const [isDismissed, setIsDismissed] = useToggle(false);
+
+  const shouldShow = shouldShowSignupDisabledBanner({
+    allowSignUp: config.allowSignUp,
+    createdAt: config.createdAt
+  });
+
+  if (!shouldShow || isDismissed) return null;
+
+  return (
+    <Alert variant="warning" className="relative mb-6 pr-10">
+      <UserXIcon />
+      <AlertTitle>Public user signups are disabled</AlertTitle>
+      <AlertDescription>
+        New users can only join through an organization invitation until you enable signups.{" "}
+      </AlertDescription>
+      <IconButton
+        variant="ghost"
+        size="xs"
+        aria-label="Dismiss banner"
+        onClick={() => setIsDismissed.on()}
+        className="absolute top-2 right-2 text-warning"
+      >
+        <XIcon />
+      </IconButton>
+    </Alert>
+  );
+};

--- a/frontend/src/layouts/AdminLayout/SignupDisabledBanner/index.ts
+++ b/frontend/src/layouts/AdminLayout/SignupDisabledBanner/index.ts
@@ -1,0 +1,1 @@
+export { SignupDisabledBanner } from "./SignupDisabledBanner";


### PR DESCRIPTION
## Context

Self-hosted instances left public signups open after the first super admin was created, so anyone who could reach the instance could register without an invitation. After initial setup, self-hosted instances now set `allowSignUp: false` automatically (cloud behavior is unchanged). Admins can re-enable signups from **Admin Console → Authentication**.

Also removes `infisical.organization.id` from audit-log enqueue metrics (it was already ignored, just a clean-up).

## Steps to verify the change

1. Deploy a fresh self-hosted instance and complete super admin setup (email or machine identity).
2. Confirm `allowSignUp` is `false` in server config / Admin Console → Authentication.
3. Confirm public signup is blocked; org invitations still work.
4. Re-enable **Allow user signups → Anyone** and confirm signup works again.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)