### PR TITLE
feat: allow multiple projects to be selected in project grants

### DIFF
--- a/backend/src/server/routes/v1/project-folder-grant-router.ts
+++ b/backend/src/server/routes/v1/project-folder-grant-router.ts
@@ -19,6 +19,7 @@ export const registerProjectFolderGrantRouter = async (server: FastifyZodProvide
         200: z.object({
           grants: ProjectFolderGrantsSchema.extend({
             folderName: z.string(),
+            secretPath: z.string(),
             environmentName: z.string(),
             environmentSlug: z.string(),
             targetProjectName: z.string(),
@@ -52,6 +53,7 @@ export const registerProjectFolderGrantRouter = async (server: FastifyZodProvide
         200: z.object({
           grants: ProjectFolderGrantsSchema.extend({
             folderName: z.string(),
+            secretPath: z.string(),
             environmentName: z.string(),
             environmentSlug: z.string(),
             sourceProjectName: z.string(),

--- a/backend/src/services/project-folder-grant/project-folder-grant-service.ts
+++ b/backend/src/services/project-folder-grant/project-folder-grant-service.ts
@@ -175,7 +175,8 @@ export const projectFolderGrantServiceFactory = ({
     const grants = await projectFolderGrantDAL.listBySourceProject(sourceProjectId);
 
     const folderIds = grants.map((g) => g.sourceFolderId);
-    const folderPaths = folderIds.length > 0 ? await folderDAL.findSecretPathByFolderIds(sourceProjectId, folderIds) : [];
+    const folderPaths =
+      folderIds.length > 0 ? await folderDAL.findSecretPathByFolderIds(sourceProjectId, folderIds) : [];
 
     return grants.map((g, i) => ({
       ...g,

--- a/backend/src/services/project-folder-grant/project-folder-grant-service.ts
+++ b/backend/src/services/project-folder-grant/project-folder-grant-service.ts
@@ -172,7 +172,15 @@ export const projectFolderGrantServiceFactory = ({
       ProjectPermissionSub.ProjectFolderGrant
     );
 
-    return projectFolderGrantDAL.listBySourceProject(sourceProjectId);
+    const grants = await projectFolderGrantDAL.listBySourceProject(sourceProjectId);
+
+    const folderIds = grants.map((g) => g.sourceFolderId);
+    const folderPaths = folderIds.length > 0 ? await folderDAL.findSecretPathByFolderIds(sourceProjectId, folderIds) : [];
+
+    return grants.map((g, i) => ({
+      ...g,
+      secretPath: folderPaths[i]?.path ?? "/"
+    }));
   };
 
   const listGrantsForTargetProject = async ({
@@ -195,7 +203,30 @@ export const projectFolderGrantServiceFactory = ({
       actionProjectType: ActionProjectType.SecretManager
     });
 
-    return projectFolderGrantDAL.listByTargetProject(targetProjectId);
+    const grants = await projectFolderGrantDAL.listByTargetProject(targetProjectId);
+
+    const grantsBySourceProject = new Map<string, typeof grants>();
+    for (const g of grants) {
+      const list = grantsBySourceProject.get(g.sourceProjectId) ?? [];
+      list.push(g);
+      grantsBySourceProject.set(g.sourceProjectId, list);
+    }
+
+    const pathsByGrantId = new Map<string, string>();
+    await Promise.all(
+      Array.from(grantsBySourceProject.entries()).map(async ([srcProjectId, projectGrants]) => {
+        const folderIds = projectGrants.map((g) => g.sourceFolderId);
+        const folderPaths = await folderDAL.findSecretPathByFolderIds(srcProjectId, folderIds);
+        projectGrants.forEach((g, i) => {
+          pathsByGrantId.set(g.id, folderPaths[i]?.path ?? "/");
+        });
+      })
+    );
+
+    return grants.map((g) => ({
+      ...g,
+      secretPath: pathsByGrantId.get(g.id) ?? "/"
+    }));
   };
 
   const getGrantUsage = async ({

--- a/frontend/src/hooks/api/projectFolderGrants/types.ts
+++ b/frontend/src/hooks/api/projectFolderGrants/types.ts
@@ -6,6 +6,7 @@ export type TProjectFolderGrant = {
   createdAt: string;
   updatedAt: string;
   folderName: string;
+  secretPath: string;
   environmentName: string;
   environmentSlug: string;
   targetProjectName: string;
@@ -20,6 +21,7 @@ export type TProjectFolderGrantReceived = {
   createdAt: string;
   updatedAt: string;
   folderName: string;
+  secretPath: string;
   environmentName: string;
   environmentSlug: string;
   sourceProjectName: string;

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -72,7 +72,7 @@ const groupGrantsByProject = (grants: TProjectFolderGrant[]): ProjectGroup[] => 
     let oldestDate = projectGrants[0].createdAt;
 
     projectGrants.forEach((g) => {
-      const folder = g.folderName === "root" ? "/" : `/${g.folderName}`;
+      const folder = g.secretPath;
       folderSet.add(folder);
       grantMatrix.set(`${folder}:${g.environmentSlug}`, g);
       if (g.createdAt < oldestDate) oldestDate = g.createdAt;

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -53,12 +53,12 @@ type ProjectGroup = {
 };
 
 const groupGrantsByProject = (grants: TProjectFolderGrant[]): ProjectGroup[] => {
-  const byProject = new Map<string, TProjectFolderGrant[]>();
-  for (const grant of grants) {
-    const existing = byProject.get(grant.targetProjectId) ?? [];
+  const byProject = grants.reduce((map, grant) => {
+    const existing = map.get(grant.targetProjectId) ?? [];
     existing.push(grant);
-    byProject.set(grant.targetProjectId, existing);
-  }
+    map.set(grant.targetProjectId, existing);
+    return map;
+  }, new Map<string, TProjectFolderGrant[]>());
 
   return Array.from(byProject.entries()).map(([targetProjectId, projectGrants]) => {
     const uniqueEnvs = new Set(projectGrants.map((g) => g.environmentSlug));
@@ -277,8 +277,7 @@ export const CrossProjectSharingSection = () => {
                             <div className="flex items-center justify-end gap-1.5 text-xs whitespace-nowrap text-muted">
                               <KeyRound className="size-3 shrink-0" />
                               <span className="tabular-nums">
-                                {grant.secretCount}{" "}
-                                {grant.secretCount === 1 ? "secret" : "secrets"}
+                                {grant.secretCount} {grant.secretCount === 1 ? "secret" : "secrets"}
                               </span>
                             </div>
                           </TableCell>

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -311,9 +311,7 @@ export const CrossProjectSharingSection = () => {
                 </AccordionTrigger>
                 <AccordionContent>
                   {(() => {
-                    const grantedSlugs = new Set(
-                      projectGroup.grants.map((g) => g.environmentSlug)
-                    );
+                    const grantedSlugs = new Set(projectGroup.grants.map((g) => g.environmentSlug));
                     const visibleEnvs = currentProject.environments.filter((env) =>
                       grantedSlugs.has(env.slug)
                     );
@@ -340,9 +338,7 @@ export const CrossProjectSharingSection = () => {
                                 </div>
                               </TableCell>
                               {visibleEnvs.map((env) => {
-                                const grant = projectGroup.grantMatrix.get(
-                                  `${folder}:${env.slug}`
-                                );
+                                const grant = projectGroup.grantMatrix.get(`${folder}:${env.slug}`);
                                 return (
                                   <TableCell key={env.slug} className="text-center">
                                     {grant ? (

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -27,8 +27,16 @@ import {
   CardHeader,
   CardTitle,
   DocumentationLinkBadge,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
   IconButton,
-  Input
+  Input,
+  Table,
+  TableBody,
+  TableCell,
+  TableRow
 } from "@app/components/v3";
 import { useProject } from "@app/context";
 import {
@@ -227,12 +235,14 @@ export const CrossProjectSharingSection = () => {
         <Badge variant="neutral">{projectGroups.length}</Badge>
       </div>
       {grants.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-md border border-mineshaft-700 py-10 text-center">
-          <p className="text-sm font-medium text-mineshaft-300">No projects have access yet</p>
-          <p className="mt-1 text-xs text-mineshaft-500">
-            Share secrets to grant another project read access.
-          </p>
-        </div>
+        <Empty>
+          <EmptyHeader>
+            <EmptyTitle>No projects have access yet</EmptyTitle>
+            <EmptyDescription>
+              Share secrets to grant another project read access.
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       ) : (
         <Accordion type="multiple" defaultValue={projectGroups.map((g) => g.targetProjectId)}>
           {projectGroups.map((projectGroup) => (
@@ -249,39 +259,42 @@ export const CrossProjectSharingSection = () => {
                 </div>
               </AccordionTrigger>
               <AccordionContent>
-                <div className="divide-y divide-mineshaft-700 rounded-md border border-mineshaft-700">
-                  {projectGroup.grants.map((grant) => (
-                    <div
-                      key={grant.id}
-                      className="grid items-center gap-x-3 px-4 py-3"
-                      style={{
-                        gridTemplateColumns: "minmax(7rem,max-content) 1fr auto 1.75rem"
-                      }}
-                    >
-                      <Badge variant="neutral" className="gap-1.5">
-                        <Layers className="size-3" />
-                        {grant.environmentName}
-                      </Badge>
-                      <div className="flex min-w-0 items-center gap-2">
-                        <ArrowRight className="size-3.5 shrink-0 text-mineshaft-400" />
-                        <FolderPath folderName={grant.folderName} />
-                      </div>
-                      <div className="flex items-center justify-end gap-1.5 text-xs whitespace-nowrap text-mineshaft-400">
-                        <KeyRound className="size-3 shrink-0" />
-                        <span className="tabular-nums">
-                          {grant.secretCount} {grant.secretCount === 1 ? "secret" : "secrets"}
-                        </span>
-                      </div>
-                      <IconButton
-                        variant="ghost-muted"
-                        size="xs"
-                        onClick={() => setGrantToDelete(grant)}
-                      >
-                        <Trash2 />
-                      </IconButton>
-                    </div>
-                  ))}
-                </div>
+                <Table>
+                  <TableBody>
+                    {projectGroup.grants.map((grant) => (
+                      <TableRow key={grant.id}>
+                        <TableCell>
+                          <div className="flex items-center gap-2">
+                            <Badge variant="neutral" className="gap-1.5">
+                              <Layers className="size-3" />
+                              {grant.environmentName}
+                            </Badge>
+                            <ArrowRight className="size-3.5 shrink-0 text-muted" />
+                            <FolderPath folderName={grant.folderName} />
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex items-center justify-end gap-1.5 text-xs whitespace-nowrap text-muted">
+                            <KeyRound className="size-3 shrink-0" />
+                            <span className="tabular-nums">
+                              {grant.secretCount}{" "}
+                              {grant.secretCount === 1 ? "secret" : "secrets"}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell className="w-10">
+                          <IconButton
+                            variant="ghost-muted"
+                            size="xs"
+                            onClick={() => setGrantToDelete(grant)}
+                          >
+                            <Trash2 />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
               </AccordionContent>
             </AccordionItem>
           ))}

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { ArrowRight, Box, FolderIcon, KeyRound, Layers, Plus, SlashIcon, Trash2 } from "lucide-react";
+import { ArrowRight, Box, FolderIcon, KeyRound, Layers, Plus, Trash2 } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -16,11 +16,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Badge,
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
   Button,
   Card,
   CardContent,
@@ -52,6 +47,8 @@ type ProjectGroup = {
   targetProjectId: string;
   targetProjectName: string;
   totalSecrets: number;
+  uniqueEnvCount: number;
+  uniqueFolderCount: number;
   grants: TProjectFolderGrant[];
 };
 
@@ -63,31 +60,19 @@ const groupGrantsByProject = (grants: TProjectFolderGrant[]): ProjectGroup[] => 
     byProject.set(grant.targetProjectId, existing);
   }
 
-  return Array.from(byProject.entries()).map(([targetProjectId, projectGrants]) => ({
-    targetProjectId,
-    targetProjectName: projectGrants[0].targetProjectName,
-    totalSecrets: projectGrants.reduce((sum, g) => sum + g.secretCount, 0),
-    grants: projectGrants
-  }));
-};
+  return Array.from(byProject.entries()).map(([targetProjectId, projectGrants]) => {
+    const uniqueEnvs = new Set(projectGrants.map((g) => g.environmentSlug));
+    const uniqueFolders = new Set(projectGrants.map((g) => g.folderName));
 
-type FolderPathProps = { folderName: string };
-
-const FolderPath = ({ folderName }: FolderPathProps) => {
-  const isRoot = folderName === "root";
-  return (
-    <Breadcrumb>
-      <BreadcrumbList className="flex-nowrap gap-1 sm:gap-1">
-        <BreadcrumbItem>
-          <FolderIcon className="size-3.5" />
-        </BreadcrumbItem>
-        <BreadcrumbSeparator>
-          <SlashIcon className="size-3 -rotate-12" />
-        </BreadcrumbSeparator>
-        {!isRoot && <BreadcrumbPage className="text-muted">{folderName}</BreadcrumbPage>}
-      </BreadcrumbList>
-    </Breadcrumb>
-  );
+    return {
+      targetProjectId,
+      targetProjectName: projectGrants[0].targetProjectName,
+      totalSecrets: projectGrants.reduce((sum, g) => sum + g.secretCount, 0),
+      uniqueEnvCount: uniqueEnvs.size,
+      uniqueFolderCount: uniqueFolders.size,
+      grants: projectGrants
+    };
+  });
 };
 
 type DeleteGrantDialogProps = {
@@ -230,76 +215,92 @@ export const CrossProjectSharingSection = () => {
         </p>
       </CardHeader>
       <CardContent>
-      <div className="mb-2 flex items-center gap-2">
-        <span className="text-sm text-mineshaft-400">Linked Projects</span>
-        <Badge variant="neutral">{projectGroups.length}</Badge>
-      </div>
-      {grants.length === 0 ? (
-        <Empty>
-          <EmptyHeader>
-            <EmptyTitle>No projects have access yet</EmptyTitle>
-            <EmptyDescription>
-              Share secrets to grant another project read access.
-            </EmptyDescription>
-          </EmptyHeader>
-        </Empty>
-      ) : (
-        <Accordion type="multiple" defaultValue={projectGroups.map((g) => g.targetProjectId)}>
-          {projectGroups.map((projectGroup) => (
-            <AccordionItem key={projectGroup.targetProjectId} value={projectGroup.targetProjectId}>
-              <AccordionTrigger>
-                <div className="flex flex-1 items-center justify-between">
-                  <Badge variant="project" className="gap-1.5">
-                    <Box className="size-3" />
-                    {projectGroup.targetProjectName}
-                  </Badge>
-                  <span className="mr-2 text-xs text-muted">
-                    {projectGroup.totalSecrets} secrets shared
-                  </span>
-                </div>
-              </AccordionTrigger>
-              <AccordionContent>
-                <Table>
-                  <TableBody>
-                    {projectGroup.grants.map((grant) => (
-                      <TableRow key={grant.id}>
-                        <TableCell>
-                          <div className="flex items-center gap-2">
-                            <Badge variant="neutral" className="gap-1.5">
-                              <Layers className="size-3" />
-                              {grant.environmentName}
-                            </Badge>
-                            <ArrowRight className="size-3.5 shrink-0 text-muted" />
-                            <FolderPath folderName={grant.folderName} />
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <div className="flex items-center justify-end gap-1.5 text-xs whitespace-nowrap text-muted">
-                            <KeyRound className="size-3 shrink-0" />
-                            <span className="tabular-nums">
-                              {grant.secretCount}{" "}
-                              {grant.secretCount === 1 ? "secret" : "secrets"}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell className="w-10">
-                          <IconButton
-                            variant="ghost-muted"
-                            size="xs"
-                            onClick={() => setGrantToDelete(grant)}
-                          >
-                            <Trash2 />
-                          </IconButton>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </AccordionContent>
-            </AccordionItem>
-          ))}
-        </Accordion>
-      )}
+        <div className="mb-2 flex items-center gap-2">
+          <span className="text-sm text-mineshaft-400">Granted Projects</span>
+          <Badge variant="neutral">{projectGroups.length}</Badge>
+        </div>
+        {grants.length === 0 ? (
+          <Empty>
+            <EmptyHeader>
+              <EmptyTitle>No projects have access yet</EmptyTitle>
+              <EmptyDescription>
+                Share secrets to grant another project read access.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <Accordion type="multiple" defaultValue={projectGroups.map((g) => g.targetProjectId)}>
+            {projectGroups.map((projectGroup) => (
+              <AccordionItem
+                key={projectGroup.targetProjectId}
+                value={projectGroup.targetProjectId}
+              >
+                <AccordionTrigger>
+                  <div className="flex flex-1 items-center gap-3">
+                    <Badge variant="project" className="gap-1.5">
+                      <Box className="size-3" />
+                      {projectGroup.targetProjectName}
+                    </Badge>
+                    <span className="text-xs text-muted">
+                      {projectGroup.uniqueEnvCount}{" "}
+                      {projectGroup.uniqueEnvCount === 1 ? "environment" : "environments"}
+                      {" · "}
+                      {projectGroup.uniqueFolderCount}{" "}
+                      {projectGroup.uniqueFolderCount === 1 ? "folder" : "folders"}
+                      {" · "}
+                      {projectGroup.totalSecrets}{" "}
+                      {projectGroup.totalSecrets === 1 ? "secret" : "secrets"}
+                    </span>
+                  </div>
+                </AccordionTrigger>
+                <AccordionContent>
+                  <Table>
+                    <TableBody>
+                      {projectGroup.grants.map((grant) => (
+                        <TableRow key={grant.id}>
+                          <TableCell>
+                            <div className="flex items-center gap-2">
+                              <Badge variant="neutral" className="gap-1.5">
+                                <Layers className="size-3" />
+                                {grant.environmentName}
+                              </Badge>
+                              <ArrowRight className="size-3.5 shrink-0 text-muted" />
+                              <div className="flex items-center gap-1.5">
+                                <FolderIcon className="size-3.5 text-muted" />
+                                <span className="text-sm text-muted">
+                                  {grant.folderName === "root" ? "/" : `/${grant.folderName}`}
+                                </span>
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-1.5 text-xs whitespace-nowrap text-muted">
+                              <KeyRound className="size-3 shrink-0" />
+                              <span className="tabular-nums">
+                                {grant.secretCount}{" "}
+                                {grant.secretCount === 1 ? "secret" : "secrets"}
+                              </span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="w-10">
+                            <IconButton
+                              variant="ghost-muted"
+                              size="xs"
+                              onClick={() => setGrantToDelete(grant)}
+                            >
+                              <Trash2 />
+                            </IconButton>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        )}
+      </CardContent>
       <DeleteGrantDialog
         grant={grantToDelete}
         onOpenChange={(open) => {
@@ -307,7 +308,6 @@ export const CrossProjectSharingSection = () => {
         }}
         sourceProjectId={currentProject.id}
       />
-    </CardContent>
     </Card>
   );
 };

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -239,6 +239,7 @@ export const CrossProjectSharingSection = () => {
             isOpen={isShareSheetOpen}
             onOpenChange={handleSheetOpenChange}
             editData={editData}
+            existingGrants={grants}
           />
         </div>
         <p className="max-w-2xl text-sm text-accent">
@@ -309,42 +310,55 @@ export const CrossProjectSharingSection = () => {
                   </div>
                 </AccordionTrigger>
                 <AccordionContent>
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Folder</TableHead>
-                        {currentProject.environments.map((env) => (
-                          <TableHead key={env.slug} className="text-center">
-                            {env.name}
-                          </TableHead>
-                        ))}
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {projectGroup.folders.map((folder) => (
-                        <TableRow key={folder}>
-                          <TableCell>
-                            <div className="flex items-center gap-1.5">
-                              <FolderIcon className="size-3.5 text-muted" />
-                              <span className="text-sm">{folder}</span>
-                            </div>
-                          </TableCell>
-                          {currentProject.environments.map((env) => {
-                            const grant = projectGroup.grantMatrix.get(`${folder}:${env.slug}`);
-                            return (
-                              <TableCell key={env.slug} className="text-center">
-                                {grant ? (
-                                  <Check className="mx-auto size-4 text-success" />
-                                ) : (
-                                  <Minus className="mx-auto size-4 text-muted" />
-                                )}
+                  {(() => {
+                    const grantedSlugs = new Set(
+                      projectGroup.grants.map((g) => g.environmentSlug)
+                    );
+                    const visibleEnvs = currentProject.environments.filter((env) =>
+                      grantedSlugs.has(env.slug)
+                    );
+
+                    return (
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Folder</TableHead>
+                            {visibleEnvs.map((env) => (
+                              <TableHead key={env.slug} className="text-center">
+                                {env.name}
+                              </TableHead>
+                            ))}
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {projectGroup.folders.map((folder) => (
+                            <TableRow key={folder}>
+                              <TableCell>
+                                <div className="flex items-center gap-1.5">
+                                  <FolderIcon className="size-3.5 text-muted" />
+                                  <span className="text-sm">{folder}</span>
+                                </div>
                               </TableCell>
-                            );
-                          })}
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
+                              {visibleEnvs.map((env) => {
+                                const grant = projectGroup.grantMatrix.get(
+                                  `${folder}:${env.slug}`
+                                );
+                                return (
+                                  <TableCell key={env.slug} className="text-center">
+                                    {grant ? (
+                                      <Check className="mx-auto size-4 text-success" />
+                                    ) : (
+                                      <Minus className="mx-auto size-4 text-muted" />
+                                    )}
+                                  </TableCell>
+                                );
+                              })}
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    );
+                  })()}
                 </AccordionContent>
               </AccordionItem>
             ))}

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -1,5 +1,8 @@
 import { useMemo, useState } from "react";
-import { ArrowRight, Box, FolderIcon, KeyRound, Layers, Plus, Trash2 } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { format } from "date-fns";
+import { Box, Check, FolderIcon, Minus, Pencil, Plus, Trash2 } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -31,24 +34,27 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableHead,
+  TableHeader,
   TableRow
 } from "@app/components/v3";
+import { apiRequest } from "@app/config/request";
 import { useProject } from "@app/context";
 import {
   TProjectFolderGrant,
-  useDeleteProjectFolderGrant,
-  useGetProjectFolderGrantUsage,
   useListProjectFolderGrants
 } from "@app/hooks/api/projectFolderGrants";
+import { projectFolderGrantKeys } from "@app/hooks/api/projectFolderGrants/queries";
 
-import { ShareSecretsSheet } from "./ShareSecretsSheet";
+import { ShareSecretsEditData, ShareSecretsSheet } from "./ShareSecretsSheet";
 
 type ProjectGroup = {
   targetProjectId: string;
   targetProjectName: string;
   totalSecrets: number;
-  uniqueEnvCount: number;
-  uniqueFolderCount: number;
+  folders: string[];
+  grantMatrix: Map<string, TProjectFolderGrant>;
+  oldestGrantDate: string;
   grants: TProjectFolderGrant[];
 };
 
@@ -61,89 +67,90 @@ const groupGrantsByProject = (grants: TProjectFolderGrant[]): ProjectGroup[] => 
   }, new Map<string, TProjectFolderGrant[]>());
 
   return Array.from(byProject.entries()).map(([targetProjectId, projectGrants]) => {
-    const uniqueEnvs = new Set(projectGrants.map((g) => g.environmentSlug));
-    const uniqueFolders = new Set(projectGrants.map((g) => g.folderName));
+    const folderSet = new Set<string>();
+    const grantMatrix = new Map<string, TProjectFolderGrant>();
+    let oldestDate = projectGrants[0].createdAt;
+
+    projectGrants.forEach((g) => {
+      const folder = g.folderName === "root" ? "/" : `/${g.folderName}`;
+      folderSet.add(folder);
+      grantMatrix.set(`${folder}:${g.environmentSlug}`, g);
+      if (g.createdAt < oldestDate) oldestDate = g.createdAt;
+    });
 
     return {
       targetProjectId,
       targetProjectName: projectGrants[0].targetProjectName,
       totalSecrets: projectGrants.reduce((sum, g) => sum + g.secretCount, 0),
-      uniqueEnvCount: uniqueEnvs.size,
-      uniqueFolderCount: uniqueFolders.size,
+      folders: Array.from(folderSet).sort(),
+      grantMatrix,
+      oldestGrantDate: oldestDate,
       grants: projectGrants
     };
   });
 };
 
-type DeleteGrantDialogProps = {
-  grant: TProjectFolderGrant | null;
+type DeleteProjectGrantsDialogProps = {
+  grants: TProjectFolderGrant[];
+  projectName: string;
+  isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   sourceProjectId: string;
 };
 
 const CONFIRMATION_KEYWORD = "confirm";
 
-const DeleteGrantDialog = ({ grant, onOpenChange, sourceProjectId }: DeleteGrantDialogProps) => {
+const DeleteProjectGrantsDialog = ({
+  grants,
+  projectName,
+  isOpen,
+  onOpenChange,
+  sourceProjectId
+}: DeleteProjectGrantsDialogProps) => {
   const [confirmation, setConfirmation] = useState("");
-  const deleteGrant = useDeleteProjectFolderGrant();
-  const { data: usage, isLoading: isLoadingUsage } = useGetProjectFolderGrantUsage(
-    grant?.id ?? "",
-    sourceProjectId,
-    Boolean(grant)
-  );
+  const [isDeleting, setIsDeleting] = useState(false);
+  const queryClient = useQueryClient();
 
-  const totalUsage = (usage?.importCount ?? 0) + (usage?.referenceCount ?? 0);
   const isConfirmed = confirmation === CONFIRMATION_KEYWORD;
 
   const handleConfirmDelete = async () => {
-    if (!grant || !isConfirmed) return;
+    if (!isConfirmed || grants.length === 0) return;
+
+    setIsDeleting(true);
     try {
-      await deleteGrant.mutateAsync({ grantId: grant.id, sourceProjectId });
-      createNotification({ text: "Grant removed", type: "success" });
+      await Promise.all(
+        grants.map((g) =>
+          apiRequest
+            .delete(`/api/v1/project-folder-grants/${g.id}`, {
+              params: { sourceProjectId }
+            })
+            .catch((err) => {
+              if (axios.isAxiosError(err) && err.response?.status === 404) return;
+              throw err;
+            })
+        )
+      );
+
+      await queryClient.invalidateQueries({
+        queryKey: projectFolderGrantKeys.listByProject(sourceProjectId)
+      });
+      await queryClient.invalidateQueries({
+        queryKey: projectFolderGrantKeys.listReceived(grants[0].targetProjectId)
+      });
+
+      createNotification({ text: "All grants removed", type: "success" });
       onOpenChange(false);
     } catch (err) {
       console.error(err);
-      createNotification({ text: "Failed to remove grant", type: "error" });
+      createNotification({ text: "Failed to remove grants", type: "error" });
+    } finally {
+      setIsDeleting(false);
     }
-  };
-
-  const renderDescription = () => {
-    if (isLoadingUsage) {
-      return "Checking for active usage...";
-    }
-
-    if (totalUsage > 0) {
-      const parts: string[] = [];
-      if (usage!.importCount > 0) {
-        parts.push(
-          `${usage!.importCount} secret ${usage!.importCount === 1 ? "import" : "imports"}`
-        );
-      }
-      if (usage!.referenceCount > 0) {
-        parts.push(
-          `${usage!.referenceCount} secret ${usage!.referenceCount === 1 ? "reference" : "references"}`
-        );
-      }
-      return (
-        <>
-          This grant is actively used by {parts.join(" and ")} in{" "}
-          <strong>{grant?.targetProjectName}</strong>. Removing it will break{" "}
-          {totalUsage === 1 ? "that link" : "those links"}.
-        </>
-      );
-    }
-
-    return (
-      <>
-        This will revoke <strong>{grant?.targetProjectName}</strong>&apos;s access to the shared
-        secrets. This action cannot be undone.
-      </>
-    );
   };
 
   return (
     <AlertDialog
-      open={Boolean(grant)}
+      open={isOpen}
       onOpenChange={(open) => {
         if (!open) setConfirmation("");
         onOpenChange(open);
@@ -151,8 +158,11 @@ const DeleteGrantDialog = ({ grant, onOpenChange, sourceProjectId }: DeleteGrant
     >
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Remove Grant</AlertDialogTitle>
-          <AlertDialogDescription>{renderDescription()}</AlertDialogDescription>
+          <AlertDialogTitle>Remove All Grants</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will revoke <strong>{projectName}</strong>&apos;s access to all {grants.length}{" "}
+            shared {grants.length === 1 ? "grant" : "grants"}. This action cannot be undone.
+          </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="w-full pb-4">
           <p className="mb-2 text-sm text-muted">
@@ -171,8 +181,8 @@ const DeleteGrantDialog = ({ grant, onOpenChange, sourceProjectId }: DeleteGrant
           <AlertDialogAction
             variant="danger"
             onClick={handleConfirmDelete}
-            isPending={deleteGrant.isPending}
-            disabled={!isConfirmed || isLoadingUsage}
+            isPending={isDeleting}
+            disabled={!isConfirmed}
           >
             Remove
           </AlertDialogAction>
@@ -184,12 +194,27 @@ const DeleteGrantDialog = ({ grant, onOpenChange, sourceProjectId }: DeleteGrant
 
 export const CrossProjectSharingSection = () => {
   const [isShareSheetOpen, setIsShareSheetOpen] = useState(false);
-  const [grantToDelete, setGrantToDelete] = useState<TProjectFolderGrant | null>(null);
+  const [editData, setEditData] = useState<ShareSecretsEditData | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ProjectGroup | null>(null);
   const { currentProject } = useProject();
 
   const { data: grants = [] } = useListProjectFolderGrants(currentProject.id);
 
   const projectGroups = useMemo(() => groupGrantsByProject(grants), [grants]);
+
+  const handleEdit = (group: ProjectGroup) => {
+    setEditData({
+      targetProjectId: group.targetProjectId,
+      targetProjectName: group.targetProjectName,
+      grants: group.grants
+    });
+    setIsShareSheetOpen(true);
+  };
+
+  const handleSheetOpenChange = (open: boolean) => {
+    setIsShareSheetOpen(open);
+    if (!open) setEditData(null);
+  };
 
   return (
     <Card className="mb-6">
@@ -199,11 +224,22 @@ export const CrossProjectSharingSection = () => {
             Cross-Project Secret Sharing
             <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/secret-reference#cross-project-secret-sharing" />
           </CardTitle>
-          <Button variant="project" size="sm" onClick={() => setIsShareSheetOpen(true)}>
+          <Button
+            variant="project"
+            size="sm"
+            onClick={() => {
+              setEditData(null);
+              setIsShareSheetOpen(true);
+            }}
+          >
             <Plus className="size-3.5" />
             Share Secrets
           </Button>
-          <ShareSecretsSheet isOpen={isShareSheetOpen} onOpenChange={setIsShareSheetOpen} />
+          <ShareSecretsSheet
+            isOpen={isShareSheetOpen}
+            onOpenChange={handleSheetOpenChange}
+            editData={editData}
+          />
         </div>
         <p className="max-w-2xl text-sm text-accent">
           Grant another project read access to a slice of this project&apos;s secrets. The target
@@ -216,7 +252,7 @@ export const CrossProjectSharingSection = () => {
       </CardHeader>
       <CardContent>
         <div className="mb-2 flex items-center gap-2">
-          <span className="text-sm text-mineshaft-400">Granted Projects</span>
+          <span className="text-sm text-mineshaft-400">Linked Projects</span>
           <Badge variant="neutral">{projectGroups.length}</Badge>
         </div>
         {grants.length === 0 ? (
@@ -242,54 +278,69 @@ export const CrossProjectSharingSection = () => {
                       {projectGroup.targetProjectName}
                     </Badge>
                     <span className="text-xs text-muted">
-                      {projectGroup.uniqueEnvCount}{" "}
-                      {projectGroup.uniqueEnvCount === 1 ? "environment" : "environments"}
-                      {" · "}
-                      {projectGroup.uniqueFolderCount}{" "}
-                      {projectGroup.uniqueFolderCount === 1 ? "folder" : "folders"}
-                      {" · "}
                       {projectGroup.totalSecrets}{" "}
-                      {projectGroup.totalSecrets === 1 ? "secret" : "secrets"}
+                      {projectGroup.totalSecrets === 1 ? "secret" : "secrets"} shared
                     </span>
+                  </div>
+                  <div className="flex items-center gap-2 pr-2">
+                    <span className="text-xs text-muted">
+                      {format(new Date(projectGroup.oldestGrantDate), "MMM d, yyyy")}
+                    </span>
+                    <IconButton
+                      variant="ghost-muted"
+                      size="xs"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEdit(projectGroup);
+                      }}
+                    >
+                      <Pencil />
+                    </IconButton>
+                    <IconButton
+                      variant="ghost-muted"
+                      size="xs"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeleteTarget(projectGroup);
+                      }}
+                    >
+                      <Trash2 />
+                    </IconButton>
                   </div>
                 </AccordionTrigger>
                 <AccordionContent>
                   <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Folder</TableHead>
+                        {currentProject.environments.map((env) => (
+                          <TableHead key={env.slug} className="text-center">
+                            {env.name}
+                          </TableHead>
+                        ))}
+                      </TableRow>
+                    </TableHeader>
                     <TableBody>
-                      {projectGroup.grants.map((grant) => (
-                        <TableRow key={grant.id}>
+                      {projectGroup.folders.map((folder) => (
+                        <TableRow key={folder}>
                           <TableCell>
-                            <div className="flex items-center gap-2">
-                              <Badge variant="neutral" className="gap-1.5">
-                                <Layers className="size-3" />
-                                {grant.environmentName}
-                              </Badge>
-                              <ArrowRight className="size-3.5 shrink-0 text-muted" />
-                              <div className="flex items-center gap-1.5">
-                                <FolderIcon className="size-3.5 text-muted" />
-                                <span className="text-sm text-muted">
-                                  {grant.folderName === "root" ? "/" : `/${grant.folderName}`}
-                                </span>
-                              </div>
+                            <div className="flex items-center gap-1.5">
+                              <FolderIcon className="size-3.5 text-muted" />
+                              <span className="text-sm">{folder}</span>
                             </div>
                           </TableCell>
-                          <TableCell className="text-right">
-                            <div className="flex items-center justify-end gap-1.5 text-xs whitespace-nowrap text-muted">
-                              <KeyRound className="size-3 shrink-0" />
-                              <span className="tabular-nums">
-                                {grant.secretCount} {grant.secretCount === 1 ? "secret" : "secrets"}
-                              </span>
-                            </div>
-                          </TableCell>
-                          <TableCell className="w-10">
-                            <IconButton
-                              variant="ghost-muted"
-                              size="xs"
-                              onClick={() => setGrantToDelete(grant)}
-                            >
-                              <Trash2 />
-                            </IconButton>
-                          </TableCell>
+                          {currentProject.environments.map((env) => {
+                            const grant = projectGroup.grantMatrix.get(`${folder}:${env.slug}`);
+                            return (
+                              <TableCell key={env.slug} className="text-center">
+                                {grant ? (
+                                  <Check className="mx-auto size-4 text-success" />
+                                ) : (
+                                  <Minus className="mx-auto size-4 text-muted" />
+                                )}
+                              </TableCell>
+                            );
+                          })}
                         </TableRow>
                       ))}
                     </TableBody>
@@ -300,10 +351,12 @@ export const CrossProjectSharingSection = () => {
           </Accordion>
         )}
       </CardContent>
-      <DeleteGrantDialog
-        grant={grantToDelete}
+      <DeleteProjectGrantsDialog
+        grants={deleteTarget?.grants ?? []}
+        projectName={deleteTarget?.targetProjectName ?? ""}
+        isOpen={Boolean(deleteTarget)}
         onOpenChange={(open) => {
-          if (!open) setGrantToDelete(null);
+          if (!open) setDeleteTarget(null);
         }}
         sourceProjectId={currentProject.id}
       />

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -1,17 +1,12 @@
-import { useState } from "react";
-import {
-  ArrowRight,
-  Box,
-  FolderIcon,
-  KeyRound,
-  Layers,
-  Plus,
-  SlashIcon,
-  Trash2
-} from "lucide-react";
+import { useMemo, useState } from "react";
+import { ArrowRight, Box, FolderIcon, KeyRound, Layers, Plus, SlashIcon, Trash2 } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -27,6 +22,10 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
   Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
   DocumentationLinkBadge,
   IconButton,
   Input
@@ -41,6 +40,29 @@ import {
 
 import { ShareSecretsSheet } from "./ShareSecretsSheet";
 
+type ProjectGroup = {
+  targetProjectId: string;
+  targetProjectName: string;
+  totalSecrets: number;
+  grants: TProjectFolderGrant[];
+};
+
+const groupGrantsByProject = (grants: TProjectFolderGrant[]): ProjectGroup[] => {
+  const byProject = new Map<string, TProjectFolderGrant[]>();
+  for (const grant of grants) {
+    const existing = byProject.get(grant.targetProjectId) ?? [];
+    existing.push(grant);
+    byProject.set(grant.targetProjectId, existing);
+  }
+
+  return Array.from(byProject.entries()).map(([targetProjectId, projectGrants]) => ({
+    targetProjectId,
+    targetProjectName: projectGrants[0].targetProjectName,
+    totalSecrets: projectGrants.reduce((sum, g) => sum + g.secretCount, 0),
+    grants: projectGrants
+  }));
+};
+
 type FolderPathProps = { folderName: string };
 
 const FolderPath = ({ folderName }: FolderPathProps) => {
@@ -51,14 +73,10 @@ const FolderPath = ({ folderName }: FolderPathProps) => {
         <BreadcrumbItem>
           <FolderIcon className="size-3.5" />
         </BreadcrumbItem>
-        {!isRoot && (
-          <>
-            <BreadcrumbSeparator>
-              <SlashIcon className="size-3 -rotate-12" />
-            </BreadcrumbSeparator>
-            <BreadcrumbPage className="text-muted">{folderName}</BreadcrumbPage>
-          </>
-        )}
+        <BreadcrumbSeparator>
+          <SlashIcon className="size-3 -rotate-12" />
+        </BreadcrumbSeparator>
+        {!isRoot && <BreadcrumbPage className="text-muted">{folderName}</BreadcrumbPage>}
       </BreadcrumbList>
     </Breadcrumb>
   );
@@ -178,30 +196,35 @@ export const CrossProjectSharingSection = () => {
 
   const { data: grants = [] } = useListProjectFolderGrants(currentProject.id);
 
+  const projectGroups = useMemo(() => groupGrantsByProject(grants), [grants]);
+
   return (
-    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-      <div className="flex w-full items-center justify-between">
-        <div className="flex items-center gap-2">
-          <p className="text-xl font-medium">Cross-Project Secret Sharing</p>
-          <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/secret-reference#cross-project-secret-sharing" />
+    <Card className="mb-6">
+      <CardHeader>
+        <div className="flex w-full items-center justify-between">
+          <CardTitle>
+            Cross-Project Secret Sharing
+            <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/secret-reference#cross-project-secret-sharing" />
+          </CardTitle>
+          <Button variant="project" size="sm" onClick={() => setIsShareSheetOpen(true)}>
+            <Plus className="size-3.5" />
+            Share Secrets
+          </Button>
+          <ShareSecretsSheet isOpen={isShareSheetOpen} onOpenChange={setIsShareSheetOpen} />
         </div>
-        <Button variant="project" size="sm" onClick={() => setIsShareSheetOpen(true)}>
-          <Plus className="size-3.5" />
-          Share Secrets
-        </Button>
-        <ShareSecretsSheet isOpen={isShareSheetOpen} onOpenChange={setIsShareSheetOpen} />
-      </div>
-      <p className="mt-2 mb-4 max-w-2xl text-sm text-gray-400">
-        Grant another project read access to a slice of this project&apos;s secrets. The target
-        project can then import them, or reference them inline with{" "}
-        <code className="rounded bg-mineshaft-700 px-1 py-0.5 font-mono text-xs text-yellow-200">
-          ${"{@project-a.SECRET}"}
-        </code>
-        .
-      </p>
+        <p className="max-w-2xl text-sm text-accent">
+          Grant another project read access to a slice of this project&apos;s secrets. The target
+          project can then import them, or reference them inline with{" "}
+          <code className="rounded bg-mineshaft-700 px-1 py-0.5 font-mono text-xs text-yellow-200">
+            ${"{@project-a.SECRET}"}
+          </code>
+          .
+        </p>
+      </CardHeader>
+      <CardContent>
       <div className="mb-2 flex items-center gap-2">
-        <span className="text-sm text-mineshaft-400">Granted Access</span>
-        <Badge variant="neutral">{grants.length}</Badge>
+        <span className="text-sm text-mineshaft-400">Linked Projects</span>
+        <Badge variant="neutral">{projectGroups.length}</Badge>
       </div>
       {grants.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-md border border-mineshaft-700 py-10 text-center">
@@ -211,46 +234,58 @@ export const CrossProjectSharingSection = () => {
           </p>
         </div>
       ) : (
-        <div className="divide-y divide-mineshaft-700 rounded-md border border-mineshaft-700">
-          {grants.map((grant) => (
-            <div
-              key={grant.id}
-              className="grid items-center gap-x-3 px-4 py-3"
-              style={{ gridTemplateColumns: "minmax(7rem,max-content) 1fr auto 1.75rem" }}
-            >
-              {/* env */}
-              <Badge variant="neutral" className="gap-1.5">
-                <Layers className="size-3" />
-                {grant.environmentName}
-              </Badge>
-
-              {/* folder path → project name */}
-              <div className="flex min-w-0 items-center gap-2">
-                <FolderPath folderName={grant.folderName} />
-                <ArrowRight className="size-3.5 shrink-0 text-mineshaft-400" />
-                <div className="flex min-w-0 items-center gap-1.5">
-                  <Box className="size-3.5 shrink-0 text-mineshaft-300" />
-                  <span className="truncate text-sm font-medium text-mineshaft-100">
-                    {grant.targetProjectName}
+        <Accordion type="multiple" defaultValue={projectGroups.map((g) => g.targetProjectId)}>
+          {projectGroups.map((projectGroup) => (
+            <AccordionItem key={projectGroup.targetProjectId} value={projectGroup.targetProjectId}>
+              <AccordionTrigger>
+                <div className="flex flex-1 items-center justify-between">
+                  <Badge variant="project" className="gap-1.5">
+                    <Box className="size-3" />
+                    {projectGroup.targetProjectName}
+                  </Badge>
+                  <span className="mr-2 text-xs text-muted">
+                    {projectGroup.totalSecrets} secrets shared
                   </span>
                 </div>
-              </div>
-
-              {/* secret count */}
-              <div className="flex items-center justify-end gap-1.5 text-xs whitespace-nowrap text-mineshaft-400">
-                <KeyRound className="size-3 shrink-0" />
-                <span className="tabular-nums">
-                  {grant.secretCount} shared {grant.secretCount === 1 ? "secret" : "secrets"}
-                </span>
-              </div>
-
-              {/* delete */}
-              <IconButton variant="ghost-muted" size="xs" onClick={() => setGrantToDelete(grant)}>
-                <Trash2 />
-              </IconButton>
-            </div>
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="divide-y divide-mineshaft-700 rounded-md border border-mineshaft-700">
+                  {projectGroup.grants.map((grant) => (
+                    <div
+                      key={grant.id}
+                      className="grid items-center gap-x-3 px-4 py-3"
+                      style={{
+                        gridTemplateColumns: "minmax(7rem,max-content) 1fr auto 1.75rem"
+                      }}
+                    >
+                      <Badge variant="neutral" className="gap-1.5">
+                        <Layers className="size-3" />
+                        {grant.environmentName}
+                      </Badge>
+                      <div className="flex min-w-0 items-center gap-2">
+                        <ArrowRight className="size-3.5 shrink-0 text-mineshaft-400" />
+                        <FolderPath folderName={grant.folderName} />
+                      </div>
+                      <div className="flex items-center justify-end gap-1.5 text-xs whitespace-nowrap text-mineshaft-400">
+                        <KeyRound className="size-3 shrink-0" />
+                        <span className="tabular-nums">
+                          {grant.secretCount} {grant.secretCount === 1 ? "secret" : "secrets"}
+                        </span>
+                      </div>
+                      <IconButton
+                        variant="ghost-muted"
+                        size="xs"
+                        onClick={() => setGrantToDelete(grant)}
+                      >
+                        <Trash2 />
+                      </IconButton>
+                    </div>
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
           ))}
-        </div>
+        </Accordion>
       )}
       <DeleteGrantDialog
         grant={grantToDelete}
@@ -259,6 +294,7 @@ export const CrossProjectSharingSection = () => {
         }}
         sourceProjectId={currentProject.id}
       />
-    </div>
+    </CardContent>
+    </Card>
   );
 };

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -59,7 +59,12 @@ type SourceEntry = {
 
 const EMPTY_ENTRY: SourceEntry = { environment: "", secretPath: "/" };
 
-const entryKey = (e: SourceEntry) => `${e.environment}:${e.secretPath}`;
+const normalizePath = (p: string) => {
+  const segments = p.split("/").filter(Boolean);
+  return segments.length === 0 ? "/" : `/${segments.join("/")}`;
+};
+
+const entryKey = (e: SourceEntry) => `${e.environment}:${normalizePath(e.secretPath)}`;
 
 export type ShareSecretsEditData = {
   targetProjectId: string;
@@ -189,21 +194,26 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
     if (editData) {
       const initialEntries: SourceEntry[] = editData.grants.map((g) => ({
         environment: g.environmentSlug,
-        secretPath: g.folderName === "root" ? "/" : `/${g.folderName}`
+        secretPath: g.secretPath
       }));
       setEntries(initialEntries.length > 0 ? initialEntries : [{ ...EMPTY_ENTRY }]);
       setEditingIndex(null);
-
-      const matchingProject = projects.find((p) => p.id === editData.targetProjectId);
-      if (matchingProject) {
-        setTargetProjects([matchingProject]);
-      }
+      setTargetProjects([]);
     } else {
       setEntries([{ ...EMPTY_ENTRY }]);
       setEditingIndex(0);
       setTargetProjects([]);
     }
-  }, [isOpen, editData, projects]);
+  }, [isOpen, editData]);
+
+  useEffect(() => {
+    if (!isOpen || !editData || targetProjects.length > 0) return;
+
+    const matchingProject = projects.find((p) => p.id === editData.targetProjectId);
+    if (matchingProject) {
+      setTargetProjects([matchingProject]);
+    }
+  }, [isOpen, editData, projects, targetProjects.length]);
 
   const availableProjects = projects.filter((p) => p.id !== currentProject.id);
 
@@ -274,7 +284,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
           editData.grants.map((g) =>
             entryKey({
               environment: g.environmentSlug,
-              secretPath: g.folderName === "root" ? "/" : `/${g.folderName}`
+              secretPath: g.secretPath
             })
           )
         );
@@ -282,7 +292,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
         editData.grants.forEach((g) => {
           const key = entryKey({
             environment: g.environmentSlug,
-            secretPath: g.folderName === "root" ? "/" : `/${g.folderName}`
+            secretPath: g.secretPath
           });
           if (!currentKeys.has(key)) {
             operations.push(removeGrant({ grantId: g.id, sourceProjectId: currentProject.id }));

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { SingleValue } from "react-select";
+import { MultiValue } from "react-select";
 import { TriangleAlert } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
@@ -27,7 +27,10 @@ import {
   SheetTitle
 } from "@app/components/v3";
 import { useProject } from "@app/context";
-import { useCreateProjectFolderGrant } from "@app/hooks/api/projectFolderGrants";
+import {
+  useCreateProjectFolderGrant,
+  useListProjectFolderGrants
+} from "@app/hooks/api/projectFolderGrants";
 import { useGetUserProjectsByType } from "@app/hooks/api/projects";
 import { Project, ProjectType } from "@app/hooks/api/projects/types";
 import { useGetSecretImports } from "@app/hooks/api/secretImports";
@@ -41,7 +44,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
   const { currentProject } = useProject();
   const [environment, setEnvironment] = useState("");
   const [folderPath, setFolderPath] = useState("/");
-  const [targetProject, setTargetProject] = useState<Project | null>(null);
+  const [targetProjects, setTargetProjects] = useState<Project[]>([]);
 
   const { data: projects = [], isPending: isProjectsLoading } = useGetUserProjectsByType(
     ProjectType.SecretManager
@@ -52,25 +55,41 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
     path: folderPath,
     options: { enabled: Boolean(environment) && Boolean(folderPath) }
   });
+  const { data: existingGrants = [] } = useListProjectFolderGrants(currentProject.id);
   const createGrant = useCreateProjectFolderGrant();
 
-  const availableProjects = projects.filter((p) => p.id !== currentProject.id);
+  const expectedFolderName =
+    folderPath === "/" ? "root" : folderPath.split("/").filter(Boolean).pop() ?? "root";
+
+  const grantedProjectIds = new Set(
+    existingGrants
+      .filter((g) => g.environmentSlug === environment && g.folderName === expectedFolderName)
+      .map((g) => g.targetProjectId)
+  );
+
+  const availableProjects = projects.filter(
+    (p) => p.id !== currentProject.id && !grantedProjectIds.has(p.id)
+  );
 
   const handleSubmit = async () => {
-    if (!environment || !targetProject || !folderPath) return;
+    if (!environment || targetProjects.length === 0 || !folderPath) return;
 
     try {
-      await createGrant.mutateAsync({
-        sourceProjectId: currentProject.id,
-        environment,
-        secretPath: folderPath,
-        targetProjectId: targetProject.id
-      });
+      await Promise.all(
+        targetProjects.map((project) =>
+          createGrant.mutateAsync({
+            sourceProjectId: currentProject.id,
+            environment,
+            secretPath: folderPath,
+            targetProjectId: project.id
+          })
+        )
+      );
       createNotification({ text: "Access granted successfully", type: "success" });
       onOpenChange(false);
       setEnvironment("");
       setFolderPath("/");
-      setTargetProject(null);
+      setTargetProjects([]);
     } catch (err) {
       console.error(err);
       createNotification({ text: "Failed to create grant", type: "error" });
@@ -95,7 +114,13 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
 
             <Field>
               <FieldLabel>Environment</FieldLabel>
-              <Select value={environment} onValueChange={setEnvironment}>
+              <Select
+                value={environment}
+                onValueChange={(val) => {
+                  setEnvironment(val);
+                  setTargetProjects([]);
+                }}
+              >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Select environment" />
                 </SelectTrigger>
@@ -113,7 +138,10 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
               <FieldLabel>Folder path</FieldLabel>
               <SecretPathInput
                 value={folderPath}
-                onChange={setFolderPath}
+                onChange={(val) => {
+                  setFolderPath(val);
+                  setTargetProjects([]);
+                }}
                 environment={environment}
                 placeholder="/"
               />
@@ -139,10 +167,11 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
               </p>
 
               <Field>
-                <FieldLabel>Target project</FieldLabel>
+                <FieldLabel>Target projects</FieldLabel>
                 <FilterableSelect
-                  value={targetProject}
-                  onChange={(option) => setTargetProject(option as SingleValue<Project>)}
+                  isMulti
+                  value={targetProjects}
+                  onChange={(options) => setTargetProjects([...(options as MultiValue<Project>)])}
                   isLoading={isProjectsLoading}
                   options={availableProjects}
                   placeholder="Search projects..."
@@ -160,7 +189,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
           </SheetClose>
           <Button
             variant="project"
-            disabled={!environment || !targetProject || !folderPath}
+            disabled={!environment || targetProjects.length === 0 || !folderPath}
             isPending={createGrant.isPending}
             onClick={handleSubmit}
           >

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -196,7 +196,12 @@ type Props = {
   existingGrants?: TProjectFolderGrant[];
 };
 
-export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData, existingGrants = [] }: Props) => {
+export const ShareSecretsSheet = ({
+  isOpen,
+  onOpenChange,
+  editData,
+  existingGrants = []
+}: Props) => {
   const { currentProject } = useProject();
   const [groups, setGroups] = useState<EnvironmentGroup[]>([{ environment: "", secretPaths: [] }]);
   const [targetProjects, setTargetProjects] = useState<Project[]>([]);

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -2,28 +2,13 @@ import { useEffect, useState } from "react";
 import { MultiValue } from "react-select";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import {
-  ArrowRight,
-  Box,
-  FolderIcon,
-  Layers,
-  Pencil,
-  Plus,
-  Trash2,
-  TriangleAlert
-} from "lucide-react";
+import { ArrowDown, Box, FolderIcon, Layers, Plus, Trash2, X } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
-  Alert,
-  AlertDescription,
-  Badge,
   Button,
-  Card,
   Field,
-  FieldDescription,
   FieldGroup,
-  FieldLabel,
   FilterableSelect,
   IconButton,
   SecretPathInput,
@@ -50,21 +35,25 @@ import {
 } from "@app/hooks/api/projectFolderGrants/types";
 import { useGetUserProjectsByType } from "@app/hooks/api/projects";
 import { Project, ProjectType } from "@app/hooks/api/projects/types";
-import { useGetSecretImports } from "@app/hooks/api/secretImports";
+import { useGetProjectFolders } from "@app/hooks/api/secretFolders/queries";
 
-type SourceEntry = {
+type EnvironmentGroup = {
   environment: string;
-  secretPath: string;
+  secretPaths: string[];
 };
-
-const EMPTY_ENTRY: SourceEntry = { environment: "", secretPath: "/" };
 
 const normalizePath = (p: string) => {
   const segments = p.split("/").filter(Boolean);
   return segments.length === 0 ? "/" : `/${segments.join("/")}`;
 };
 
-const entryKey = (e: SourceEntry) => `${e.environment}:${normalizePath(e.secretPath)}`;
+const flattenGroups = (groups: EnvironmentGroup[]) =>
+  groups.flatMap((g) =>
+    g.secretPaths.map((sp) => ({ environment: g.environment, secretPath: sp }))
+  );
+
+const entryKey = (environment: string, secretPath: string) =>
+  `${environment}:${normalizePath(secretPath)}`;
 
 export type ShareSecretsEditData = {
   targetProjectId: string;
@@ -72,101 +61,137 @@ export type ShareSecretsEditData = {
   grants: TProjectFolderGrant[];
 };
 
-type SourceEntryRowProps = {
-  entry: SourceEntry;
-  index: number;
-  environments: { id: string; slug: string; name: string }[];
-  onChange: (index: number, updated: Partial<SourceEntry>) => void;
+type PathAdderProps = {
+  environment: string;
+  existingPaths: string[];
+  onAdd: (path: string) => void;
 };
 
-const SourceEntryRow = ({ entry, index, environments, onChange }: SourceEntryRowProps) => {
+const PathAdder = ({ environment, existingPaths, onAdd }: PathAdderProps) => {
   const { currentProject } = useProject();
-  const { data: secretImports = [] } = useGetSecretImports({
+  const [value, setValue] = useState("/");
+
+  const normalized = normalizePath(value);
+  const isRoot = normalized === "/";
+  const parentPath = isRoot ? "/" : normalized.substring(0, normalized.lastIndexOf("/")) || "/";
+  const folderName = isRoot ? "" : (normalized.split("/").filter(Boolean).pop() ?? "");
+
+  const { data: folders = [] } = useGetProjectFolders({
     projectId: currentProject.id,
-    environment: entry.environment,
-    path: entry.secretPath,
-    options: { enabled: Boolean(entry.environment) && Boolean(entry.secretPath) }
+    environment,
+    path: parentPath,
+    options: { enabled: Boolean(environment) && !isRoot }
   });
 
+  const pathExists = isRoot || folders.some((f) => f.name === folderName);
+  const canAdd = value.trim().length > 0 && !existingPaths.includes(normalized) && pathExists;
+
+  const handleAdd = () => {
+    if (!canAdd) return;
+    onAdd(normalized);
+    setValue("/");
+  };
+
   return (
-    <div className="flex flex-col gap-3">
-      <Field>
-        <FieldLabel>Environment</FieldLabel>
-        <Select
-          value={entry.environment}
-          onValueChange={(val) => onChange(index, { environment: val, secretPath: "/" })}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Select environment" />
-          </SelectTrigger>
-          <SelectContent position="popper">
-            {environments.map((env) => (
-              <SelectItem key={env.id} value={env.slug}>
-                {env.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </Field>
-
-      <Field>
-        <FieldLabel>Folder path</FieldLabel>
+    <div className="flex items-center gap-2">
+      <div className="flex-1">
         <SecretPathInput
-          value={entry.secretPath}
-          onChange={(val) => onChange(index, { secretPath: val })}
-          environment={entry.environment}
-          placeholder="/"
+          value={value}
+          onChange={setValue}
+          environment={environment}
+          placeholder="Add a folder path..."
+          onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleAdd();
+            }
+          }}
         />
-        <FieldDescription>
-          Secrets at this path become available to the target project.
-        </FieldDescription>
-      </Field>
-
-      {secretImports.length > 0 && (
-        <Alert variant="warning">
-          <TriangleAlert />
-          <AlertDescription>
-            This folder contains secret imports. Imports aren&apos;t re-shared across projects, so
-            only the folder&apos;s own static secrets will be shared with the target project.
-          </AlertDescription>
-        </Alert>
-      )}
+      </div>
+      <IconButton variant="ghost-muted" size="sm" onClick={handleAdd} isDisabled={!canAdd}>
+        <Plus />
+      </IconButton>
     </div>
   );
 };
 
-type CompactEntryRowProps = {
-  entry: SourceEntry;
-  envName: string;
-  onEdit: () => void;
-  onRemove: () => void;
+type EnvironmentGroupRowProps = {
+  group: EnvironmentGroup;
+  index: number;
+  environments: { id: string; slug: string; name: string }[];
+  onChangeEnvironment: (index: number, env: string) => void;
+  onAddPath: (index: number, path: string) => void;
+  onRemovePath: (index: number, pathIndex: number) => void;
+  onRemoveGroup: (index: number) => void;
 };
 
-const CompactEntryRow = ({ entry, envName, onEdit, onRemove }: CompactEntryRowProps) => (
-  <div className="flex items-center gap-2 px-3 py-2">
-    <div className="flex flex-1 items-center gap-2">
-      <Badge variant="neutral" className="gap-1.5">
-        <Layers className="size-3" />
-        {envName}
-      </Badge>
-      <ArrowRight className="size-3.5 shrink-0 text-muted" />
-      <div className="flex items-center gap-1.5">
-        <FolderIcon className="size-3.5 text-muted" />
-        <span className="text-sm text-muted">
-          {entry.secretPath === "/" ? "/" : entry.secretPath}
-        </span>
+const EnvironmentGroupRow = ({
+  group,
+  index,
+  environments,
+  onChangeEnvironment,
+  onAddPath,
+  onRemovePath,
+  onRemoveGroup
+}: EnvironmentGroupRowProps) => {
+  const envName = environments.find((e) => e.slug === group.environment)?.name;
+
+  return (
+    <div className="overflow-hidden rounded-md border border-border">
+      <div className="flex items-center gap-2 px-3 py-2.5">
+        <Layers className="size-4 shrink-0 text-muted" />
+        {group.environment ? (
+          <span className="flex-1 text-sm font-medium">{envName ?? group.environment}</span>
+        ) : (
+          <div className="flex-1">
+            <Select
+              value={group.environment}
+              onValueChange={(val) => onChangeEnvironment(index, val)}
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select environment" />
+              </SelectTrigger>
+              <SelectContent position="popper">
+                {environments.map((env) => (
+                  <SelectItem key={env.id} value={env.slug}>
+                    {env.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+        <IconButton variant="ghost-muted" size="xs" onClick={() => onRemoveGroup(index)}>
+          <Trash2 />
+        </IconButton>
       </div>
+
+      {group.secretPaths.map((sp, pathIndex) => (
+        <div key={sp} className="flex items-center gap-2 border-t border-border px-3 py-2.5">
+          <FolderIcon className="size-3.5 shrink-0 text-warning" />
+          <span className="flex-1 text-sm">{sp}</span>
+          <button
+            type="button"
+            className="text-muted transition-colors hover:text-foreground"
+            onClick={() => onRemovePath(index, pathIndex)}
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      ))}
+
+      {group.environment && (
+        <div className="border-t border-border px-3 py-2.5">
+          <PathAdder
+            environment={group.environment}
+            existingPaths={group.secretPaths}
+            onAdd={(path) => onAddPath(index, path)}
+          />
+        </div>
+      )}
     </div>
-    <div className="flex items-center gap-1">
-      <IconButton variant="ghost-muted" size="xs" onClick={onEdit}>
-        <Pencil />
-      </IconButton>
-      <IconButton variant="ghost-muted" size="xs" onClick={onRemove}>
-        <Trash2 />
-      </IconButton>
-    </div>
-  </div>
-);
+  );
+};
 
 type Props = {
   isOpen: boolean;
@@ -176,8 +201,7 @@ type Props = {
 
 export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => {
   const { currentProject } = useProject();
-  const [entries, setEntries] = useState<SourceEntry[]>([{ ...EMPTY_ENTRY }]);
-  const [editingIndex, setEditingIndex] = useState<number | null>(0);
+  const [groups, setGroups] = useState<EnvironmentGroup[]>([{ environment: "", secretPaths: [] }]);
   const [targetProjects, setTargetProjects] = useState<Project[]>([]);
 
   const queryClient = useQueryClient();
@@ -192,16 +216,19 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
     if (!isOpen) return;
 
     if (editData) {
-      const initialEntries: SourceEntry[] = editData.grants.map((g) => ({
-        environment: g.environmentSlug,
-        secretPath: g.secretPath
-      }));
-      setEntries(initialEntries.length > 0 ? initialEntries : [{ ...EMPTY_ENTRY }]);
-      setEditingIndex(null);
+      const groupMap = new Map<string, string[]>();
+      editData.grants.forEach((g) => {
+        const paths = groupMap.get(g.environmentSlug) ?? [];
+        paths.push(g.secretPath);
+        groupMap.set(g.environmentSlug, paths);
+      });
+      const initialGroups: EnvironmentGroup[] = Array.from(groupMap.entries()).map(
+        ([env, paths]) => ({ environment: env, secretPaths: paths })
+      );
+      setGroups(initialGroups.length > 0 ? initialGroups : [{ environment: "", secretPaths: [] }]);
       setTargetProjects([]);
     } else {
-      setEntries([{ ...EMPTY_ENTRY }]);
-      setEditingIndex(0);
+      setGroups([{ environment: "", secretPaths: [] }]);
       setTargetProjects([]);
     }
   }, [isOpen, editData]);
@@ -217,36 +244,40 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
 
   const availableProjects = projects.filter((p) => p.id !== currentProject.id);
 
-  const hasValidEntry = entries.some((e) => e.environment && e.secretPath);
+  const hasValidEntry = groups.some((g) => g.environment && g.secretPaths.length > 0);
 
-  const envNameBySlug = new Map(currentProject.environments.map((e) => [e.slug, e.name]));
-  const isEntryFilled = (entry: SourceEntry) => Boolean(entry.environment);
-
-  const compactEntries = entries
-    .map((entry, originalIndex) => ({ entry, originalIndex }))
-    .filter(({ entry, originalIndex }) => originalIndex !== editingIndex && isEntryFilled(entry));
-
-  const handleEntryChange = (index: number, updated: Partial<SourceEntry>) => {
-    setEntries((prev) => prev.map((e, i) => (i === index ? { ...e, ...updated } : e)));
+  const handleChangeEnvironment = (index: number, env: string) => {
+    setGroups((prev) =>
+      prev.map((g, i) => (i === index ? { ...g, environment: env, secretPaths: ["/"] } : g))
+    );
   };
 
-  const handleEntryRemove = (index: number) => {
-    setEntries((prev) => {
+  const handleAddPath = (index: number, path: string) => {
+    setGroups((prev) =>
+      prev.map((g, i) => (i === index ? { ...g, secretPaths: [...g.secretPaths, path] } : g))
+    );
+  };
+
+  const handleRemovePath = (groupIndex: number, pathIndex: number) => {
+    setGroups((prev) =>
+      prev.map((g, i) =>
+        i === groupIndex
+          ? { ...g, secretPaths: g.secretPaths.filter((_, pi) => pi !== pathIndex) }
+          : g
+      )
+    );
+  };
+
+  const handleRemoveGroup = (index: number) => {
+    setGroups((prev) => {
       const next = prev.filter((_, i) => i !== index);
-      if (next.length === 0) return [{ ...EMPTY_ENTRY }];
+      if (next.length === 0) return [{ environment: "", secretPaths: [] }];
       return next;
     });
-    setEditingIndex((prev) => {
-      if (prev === null) return null;
-      if (index < prev) return prev - 1;
-      if (index === prev) return null;
-      return prev;
-    });
   };
 
-  const handleAddEntry = () => {
-    setEntries((prev) => [...prev, { ...EMPTY_ENTRY }]);
-    setEditingIndex(entries.length);
+  const handleAddGroup = () => {
+    setGroups((prev) => [...prev, { environment: "", secretPaths: [] }]);
   };
 
   const postGrant = async (dto: TCreateProjectFolderGrantDTO) => {
@@ -271,7 +302,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
   };
 
   const handleSubmit = async () => {
-    const validEntries = entries.filter((e) => e.environment && e.secretPath);
+    const validEntries = flattenGroups(groups).filter((e) => e.environment && e.secretPath);
     if (validEntries.length === 0 || (!isEditMode && targetProjects.length === 0)) return;
 
     setIsSubmitting(true);
@@ -279,28 +310,20 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
       const operations: Promise<void>[] = [];
 
       if (editData) {
-        const currentKeys = new Set(validEntries.map(entryKey));
+        const currentKeys = new Set(validEntries.map((e) => entryKey(e.environment, e.secretPath)));
         const originalKeys = new Set(
-          editData.grants.map((g) =>
-            entryKey({
-              environment: g.environmentSlug,
-              secretPath: g.secretPath
-            })
-          )
+          editData.grants.map((g) => entryKey(g.environmentSlug, g.secretPath))
         );
 
         editData.grants.forEach((g) => {
-          const key = entryKey({
-            environment: g.environmentSlug,
-            secretPath: g.secretPath
-          });
+          const key = entryKey(g.environmentSlug, g.secretPath);
           if (!currentKeys.has(key)) {
             operations.push(removeGrant({ grantId: g.id, sourceProjectId: currentProject.id }));
           }
         });
 
         validEntries.forEach((entry) => {
-          if (!originalKeys.has(entryKey(entry))) {
+          if (!originalKeys.has(entryKey(entry.environment, entry.secretPath))) {
             operations.push(
               postGrant({
                 sourceProjectId: currentProject.id,
@@ -369,51 +392,52 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
 
         <div className="thin-scrollbar flex-1 overflow-y-auto px-4">
           <FieldGroup>
-            <p className="text-xs font-semibold tracking-widest text-muted uppercase">
-              From This Project
-            </p>
+            <div>
+              <p className="text-xs font-semibold tracking-widest text-muted uppercase">
+                Environments &amp; Folders
+              </p>
+              <p className="mt-1 text-xs text-muted">
+                Choose an environment, then pick which of its folders to share.
+              </p>
+            </div>
 
-            {compactEntries.length > 0 && (
-              <Card className="gap-0 divide-y divide-border p-0">
-                {compactEntries.map(({ entry, originalIndex }) => (
-                  <CompactEntryRow
-                    key={originalIndex}
-                    entry={entry}
-                    envName={envNameBySlug.get(entry.environment) ?? entry.environment}
-                    onEdit={() => setEditingIndex(originalIndex)}
-                    onRemove={() => handleEntryRemove(originalIndex)}
-                  />
-                ))}
-              </Card>
-            )}
+            <div className="flex flex-col gap-3">
+              {groups.map((group, index) => (
+                <EnvironmentGroupRow
+                  key={group.environment || `new-${String(index)}`}
+                  group={group}
+                  index={index}
+                  environments={currentProject.environments}
+                  onChangeEnvironment={handleChangeEnvironment}
+                  onAddPath={handleAddPath}
+                  onRemovePath={handleRemovePath}
+                  onRemoveGroup={handleRemoveGroup}
+                />
+              ))}
+            </div>
 
-            {editingIndex !== null && entries[editingIndex] && (
-              <SourceEntryRow
-                entry={entries[editingIndex]}
-                index={editingIndex}
-                environments={currentProject.environments}
-                onChange={handleEntryChange}
-              />
-            )}
-
-            <Button variant="outline" size="sm" className="w-fit" onClick={handleAddEntry}>
-              <Plus className="size-3.5" />
-              Add another path
+            <Button variant="outline" size="sm" className="w-fit" onClick={handleAddGroup}>
+              <Layers className="size-3.5" />
+              Add another environment
             </Button>
 
+            <div className="flex justify-center py-2">
+              <ArrowDown className="size-4 text-muted" />
+            </div>
+
             <div className="rounded-md border border-border p-4">
-              <p className="mb-4 text-xs font-semibold tracking-widest text-muted uppercase">
-                To Another Project
+              <p className="mb-1 text-xs font-semibold tracking-widest text-muted uppercase">
+                Share With Projects
+              </p>
+              <p className="mb-4 text-xs text-muted">
+                These projects get read access to the folders above.
               </p>
 
               <Field>
-                <FieldLabel>Target projects</FieldLabel>
                 {isEditMode ? (
                   <div className="flex items-center gap-2 rounded-md border border-border px-3 py-2">
-                    <Badge variant="project" className="gap-1.5">
-                      <Box className="size-3" />
-                      {editData!.targetProjectName}
-                    </Badge>
+                    <Box className="size-3 text-muted" />
+                    <span className="text-sm">{editData!.targetProjectName}</span>
                   </div>
                 ) : (
                   <FilterableSelect

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -1,17 +1,22 @@
 import { useState } from "react";
 import { MultiValue } from "react-select";
-import { TriangleAlert } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { ArrowRight, FolderIcon, Layers, Pencil, Plus, Trash2, TriangleAlert } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
   Alert,
   AlertDescription,
+  Badge,
   Button,
+  Card,
   Field,
   FieldDescription,
   FieldGroup,
   FieldLabel,
   FilterableSelect,
+  IconButton,
   SecretPathInput,
   Select,
   SelectContent,
@@ -26,15 +31,116 @@ import {
   SheetHeader,
   SheetTitle
 } from "@app/components/v3";
+import { apiRequest } from "@app/config/request";
 import { useProject } from "@app/context";
-import {
-  useCreateProjectFolderGrant,
-  useListProjectFolderGrants
-} from "@app/hooks/api/projectFolderGrants";
+import { projectFolderGrantKeys } from "@app/hooks/api/projectFolderGrants/queries";
+import { TCreateProjectFolderGrantDTO } from "@app/hooks/api/projectFolderGrants/types";
 import { useGetUserProjectsByType } from "@app/hooks/api/projects";
 import { Project, ProjectType } from "@app/hooks/api/projects/types";
-import { useGetProjectFolders } from "@app/hooks/api/secretFolders";
 import { useGetSecretImports } from "@app/hooks/api/secretImports";
+
+type SourceEntry = {
+  environment: string;
+  secretPath: string;
+};
+
+const EMPTY_ENTRY: SourceEntry = { environment: "", secretPath: "/" };
+
+type SourceEntryRowProps = {
+  entry: SourceEntry;
+  index: number;
+  environments: { id: string; slug: string; name: string }[];
+  onChange: (index: number, updated: Partial<SourceEntry>) => void;
+};
+
+const SourceEntryRow = ({ entry, index, environments, onChange }: SourceEntryRowProps) => {
+  const { currentProject } = useProject();
+  const { data: secretImports = [] } = useGetSecretImports({
+    projectId: currentProject.id,
+    environment: entry.environment,
+    path: entry.secretPath,
+    options: { enabled: Boolean(entry.environment) && Boolean(entry.secretPath) }
+  });
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Field>
+        <FieldLabel>Environment</FieldLabel>
+        <Select
+          value={entry.environment}
+          onValueChange={(val) => onChange(index, { environment: val, secretPath: "/" })}
+        >
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Select environment" />
+          </SelectTrigger>
+          <SelectContent position="popper">
+            {environments.map((env) => (
+              <SelectItem key={env.id} value={env.slug}>
+                {env.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Field>
+
+      <Field>
+        <FieldLabel>Folder path</FieldLabel>
+        <SecretPathInput
+          value={entry.secretPath}
+          onChange={(val) => onChange(index, { secretPath: val })}
+          environment={entry.environment}
+          placeholder="/"
+        />
+        <FieldDescription>
+          Secrets at this path become available to the target project.
+        </FieldDescription>
+      </Field>
+
+      {secretImports.length > 0 && (
+        <Alert variant="warning">
+          <TriangleAlert />
+          <AlertDescription>
+            This folder contains secret imports. Imports aren&apos;t re-shared across projects, so
+            only the folder&apos;s own static secrets will be shared with the target project.
+          </AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+};
+
+type CompactEntryRowProps = {
+  entry: SourceEntry;
+  envName: string;
+  onEdit: () => void;
+  onRemove: () => void;
+};
+
+const CompactEntryRow = ({ entry, envName, onEdit, onRemove }: CompactEntryRowProps) => (
+  <div className="flex items-center gap-2 px-3 py-2">
+    <div className="flex flex-1 items-center gap-2">
+      <Badge variant="neutral" className="gap-1.5">
+        <Layers className="size-3" />
+        {envName}
+      </Badge>
+      <ArrowRight className="size-3.5 shrink-0 text-muted" />
+      <div className="flex items-center gap-1.5">
+        <FolderIcon className="size-3.5 text-muted" />
+        <span className="text-sm text-muted">
+          {entry.secretPath === "/" ? "/" : entry.secretPath}
+        </span>
+      </div>
+    </div>
+    <div className="flex items-center gap-1">
+      <IconButton variant="ghost-muted" size="xs" onClick={onEdit}>
+        <Pencil />
+      </IconButton>
+      <IconButton variant="ghost-muted" size="xs" onClick={onRemove}>
+        <Trash2 />
+      </IconButton>
+    </div>
+  </div>
+);
 
 type Props = {
   isOpen: boolean;
@@ -43,71 +149,105 @@ type Props = {
 
 export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
   const { currentProject } = useProject();
-  const [environment, setEnvironment] = useState("");
-  const [folderPath, setFolderPath] = useState("/");
+  const [entries, setEntries] = useState<SourceEntry[]>([{ ...EMPTY_ENTRY }]);
+  const [editingIndex, setEditingIndex] = useState<number | null>(0);
   const [targetProjects, setTargetProjects] = useState<Project[]>([]);
 
+  const queryClient = useQueryClient();
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const { data: projects = [], isPending: isProjectsLoading } = useGetUserProjectsByType(
     ProjectType.SecretManager
   );
-  const { data: secretImports = [] } = useGetSecretImports({
-    projectId: currentProject.id,
-    environment,
-    path: folderPath,
-    options: { enabled: Boolean(environment) && Boolean(folderPath) }
-  });
-  const { data: existingGrants = [] } = useListProjectFolderGrants(currentProject.id);
-  const createGrant = useCreateProjectFolderGrant();
 
-  const pathSegments = folderPath.split("/").filter(Boolean);
-  const parentPath = pathSegments.length <= 1 ? "/" : `/${pathSegments.slice(0, -1).join("/")}`;
-  const leafName = pathSegments.at(-1) ?? "";
+  const availableProjects = projects.filter((p) => p.id !== currentProject.id);
 
-  const { data: parentFolders = [] } = useGetProjectFolders({
-    projectId: currentProject.id,
-    environment,
-    path: parentPath,
-    options: { enabled: Boolean(environment) && folderPath !== "/" }
-  });
+  const hasValidEntry = entries.some((e) => e.environment && e.secretPath);
 
-  const selectedFolderId = parentFolders.find((f) => f.name === leafName)?.id;
+  const envNameBySlug = new Map(currentProject.environments.map((e) => [e.slug, e.name]));
+  const isEntryFilled = (entry: SourceEntry) => Boolean(entry.environment);
 
-  const grantedProjectIds = new Set(
-    existingGrants
-      .filter((g) =>
-        selectedFolderId
-          ? g.sourceFolderId === selectedFolderId
-          : g.environmentSlug === environment && g.folderName === "root"
-      )
-      .map((g) => g.targetProjectId)
-  );
+  const compactEntries = entries
+    .map((entry, originalIndex) => ({ entry, originalIndex }))
+    .filter(({ entry, originalIndex }) => originalIndex !== editingIndex && isEntryFilled(entry));
 
-  const availableProjects = projects.filter(
-    (p) => p.id !== currentProject.id && !grantedProjectIds.has(p.id)
-  );
+  const handleEntryChange = (index: number, updated: Partial<SourceEntry>) => {
+    setEntries((prev) => prev.map((e, i) => (i === index ? { ...e, ...updated } : e)));
+  };
+
+  const handleEntryRemove = (index: number) => {
+    setEntries((prev) => {
+      const next = prev.filter((_, i) => i !== index);
+      if (next.length === 0) return [{ ...EMPTY_ENTRY }];
+      return next;
+    });
+    setEditingIndex((prev) => {
+      if (prev === null) return null;
+      if (index < prev) return prev - 1;
+      if (index === prev) return null;
+      return prev;
+    });
+  };
+
+  const handleAddEntry = () => {
+    setEntries((prev) => [...prev, { ...EMPTY_ENTRY }]);
+    setEditingIndex(entries.length);
+  };
+
+  const createGrant = async (dto: TCreateProjectFolderGrantDTO) => {
+    try {
+      await apiRequest.post("/api/v1/project-folder-grants", dto);
+    } catch (err) {
+      if (
+        axios.isAxiosError(err) &&
+        typeof err.response?.data?.message === "string" &&
+        (err.response.data.message as string).includes("already exists")
+      ) {
+        return;
+      }
+      throw err;
+    }
+  };
 
   const handleSubmit = async () => {
-    if (!environment || targetProjects.length === 0 || !folderPath) return;
+    const validEntries = entries.filter((e) => e.environment && e.secretPath);
+    if (validEntries.length === 0 || targetProjects.length === 0) return;
 
+    setIsSubmitting(true);
     try {
       await Promise.all(
-        targetProjects.map((project) =>
-          createGrant.mutateAsync({
-            sourceProjectId: currentProject.id,
-            environment,
-            secretPath: folderPath,
-            targetProjectId: project.id
+        validEntries.flatMap((entry) =>
+          targetProjects.map((project) =>
+            createGrant({
+              sourceProjectId: currentProject.id,
+              environment: entry.environment,
+              secretPath: entry.secretPath,
+              targetProjectId: project.id
+            })
+          )
+        )
+      );
+
+      await queryClient.invalidateQueries({
+        queryKey: projectFolderGrantKeys.listByProject(currentProject.id)
+      });
+      await Promise.all(
+        targetProjects.map((p) =>
+          queryClient.invalidateQueries({
+            queryKey: projectFolderGrantKeys.listReceived(p.id)
           })
         )
       );
+
       createNotification({ text: "Access granted successfully", type: "success" });
       onOpenChange(false);
-      setEnvironment("");
-      setFolderPath("/");
+      setEntries([{ ...EMPTY_ENTRY }]);
+      setEditingIndex(0);
       setTargetProjects([]);
     } catch (err) {
       console.error(err);
       createNotification({ text: "Failed to create grant", type: "error" });
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -127,54 +267,33 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
               From This Project
             </p>
 
-            <Field>
-              <FieldLabel>Environment</FieldLabel>
-              <Select
-                value={environment}
-                onValueChange={(val) => {
-                  setEnvironment(val);
-                  setTargetProjects([]);
-                }}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Select environment" />
-                </SelectTrigger>
-                <SelectContent position="popper">
-                  {currentProject.environments.map((env) => (
-                    <SelectItem key={env.id} value={env.slug}>
-                      {env.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-
-            <Field>
-              <FieldLabel>Folder path</FieldLabel>
-              <SecretPathInput
-                value={folderPath}
-                onChange={(val) => {
-                  setFolderPath(val);
-                  setTargetProjects([]);
-                }}
-                environment={environment}
-                placeholder="/"
-              />
-              <FieldDescription>
-                Secrets at this path become available to the target project.
-              </FieldDescription>
-            </Field>
-
-            {secretImports.length > 0 && (
-              <Alert variant="warning">
-                <TriangleAlert />
-                <AlertDescription>
-                  This folder contains secret imports. Imports aren&apos;t re-shared across
-                  projects, so only the folder&apos;s own static secrets will be shared with the
-                  target project.
-                </AlertDescription>
-              </Alert>
+            {compactEntries.length > 0 && (
+              <Card className="gap-0 divide-y divide-border p-0">
+                {compactEntries.map(({ entry, originalIndex }) => (
+                  <CompactEntryRow
+                    key={originalIndex}
+                    entry={entry}
+                    envName={envNameBySlug.get(entry.environment) ?? entry.environment}
+                    onEdit={() => setEditingIndex(originalIndex)}
+                    onRemove={() => handleEntryRemove(originalIndex)}
+                  />
+                ))}
+              </Card>
             )}
+
+            {editingIndex !== null && entries[editingIndex] && (
+              <SourceEntryRow
+                entry={entries[editingIndex]}
+                index={editingIndex}
+                environments={currentProject.environments}
+                onChange={handleEntryChange}
+              />
+            )}
+
+            <Button variant="outline" size="sm" className="w-fit" onClick={handleAddEntry}>
+              <Plus className="size-3.5" />
+              Add another path
+            </Button>
 
             <div className="rounded-md border border-border p-4">
               <p className="mb-4 text-xs font-semibold tracking-widest text-muted uppercase">
@@ -204,8 +323,8 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
           </SheetClose>
           <Button
             variant="project"
-            disabled={!environment || targetProjects.length === 0 || !folderPath}
-            isPending={createGrant.isPending}
+            disabled={!hasValidEntry || targetProjects.length === 0}
+            isPending={isSubmitting}
             onClick={handleSubmit}
           >
             Share

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -33,6 +33,7 @@ import {
 } from "@app/hooks/api/projectFolderGrants";
 import { useGetUserProjectsByType } from "@app/hooks/api/projects";
 import { Project, ProjectType } from "@app/hooks/api/projects/types";
+import { useGetProjectFolders } from "@app/hooks/api/secretFolders";
 import { useGetSecretImports } from "@app/hooks/api/secretImports";
 
 type Props = {
@@ -58,12 +59,26 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
   const { data: existingGrants = [] } = useListProjectFolderGrants(currentProject.id);
   const createGrant = useCreateProjectFolderGrant();
 
-  const expectedFolderName =
-    folderPath === "/" ? "root" : folderPath.split("/").filter(Boolean).pop() ?? "root";
+  const pathSegments = folderPath.split("/").filter(Boolean);
+  const parentPath = pathSegments.length <= 1 ? "/" : `/${pathSegments.slice(0, -1).join("/")}`;
+  const leafName = pathSegments.at(-1) ?? "";
+
+  const { data: parentFolders = [] } = useGetProjectFolders({
+    projectId: currentProject.id,
+    environment,
+    path: parentPath,
+    options: { enabled: Boolean(environment) && folderPath !== "/" }
+  });
+
+  const selectedFolderId = parentFolders.find((f) => f.name === leafName)?.id;
 
   const grantedProjectIds = new Set(
     existingGrants
-      .filter((g) => g.environmentSlug === environment && g.folderName === expectedFolderName)
+      .filter((g) =>
+        selectedFolderId
+          ? g.sourceFolderId === selectedFolderId
+          : g.environmentSlug === environment && g.folderName === "root"
+      )
       .map((g) => g.targetProjectId)
   );
 

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -262,7 +262,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
 
   const handleSubmit = async () => {
     const validEntries = entries.filter((e) => e.environment && e.secretPath);
-    if (validEntries.length === 0 || targetProjects.length === 0) return;
+    if (validEntries.length === 0 || (!isEditMode && targetProjects.length === 0)) return;
 
     setIsSubmitting(true);
     try {
@@ -321,10 +321,13 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
       await queryClient.invalidateQueries({
         queryKey: projectFolderGrantKeys.listByProject(currentProject.id)
       });
+      const targetProjectIds = isEditMode
+        ? [editData!.targetProjectId]
+        : targetProjects.map((p) => p.id);
       await Promise.all(
-        targetProjects.map((p) =>
+        targetProjectIds.map((id) =>
           queryClient.invalidateQueries({
-            queryKey: projectFolderGrantKeys.listReceived(p.id)
+            queryKey: projectFolderGrantKeys.listReceived(id)
           })
         )
       );
@@ -425,7 +428,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
           </SheetClose>
           <Button
             variant="project"
-            disabled={!hasValidEntry || targetProjects.length === 0}
+            disabled={!hasValidEntry || (!isEditMode && targetProjects.length === 0)}
             isPending={isSubmitting}
             onClick={handleSubmit}
           >

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -1,8 +1,17 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { MultiValue } from "react-select";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import { ArrowRight, FolderIcon, Layers, Pencil, Plus, Trash2, TriangleAlert } from "lucide-react";
+import {
+  ArrowRight,
+  Box,
+  FolderIcon,
+  Layers,
+  Pencil,
+  Plus,
+  Trash2,
+  TriangleAlert
+} from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -33,8 +42,12 @@ import {
 } from "@app/components/v3";
 import { apiRequest } from "@app/config/request";
 import { useProject } from "@app/context";
+import { TProjectFolderGrant } from "@app/hooks/api/projectFolderGrants";
 import { projectFolderGrantKeys } from "@app/hooks/api/projectFolderGrants/queries";
-import { TCreateProjectFolderGrantDTO } from "@app/hooks/api/projectFolderGrants/types";
+import {
+  TCreateProjectFolderGrantDTO,
+  TDeleteProjectFolderGrantDTO
+} from "@app/hooks/api/projectFolderGrants/types";
 import { useGetUserProjectsByType } from "@app/hooks/api/projects";
 import { Project, ProjectType } from "@app/hooks/api/projects/types";
 import { useGetSecretImports } from "@app/hooks/api/secretImports";
@@ -45,6 +58,14 @@ type SourceEntry = {
 };
 
 const EMPTY_ENTRY: SourceEntry = { environment: "", secretPath: "/" };
+
+const entryKey = (e: SourceEntry) => `${e.environment}:${e.secretPath}`;
+
+export type ShareSecretsEditData = {
+  targetProjectId: string;
+  targetProjectName: string;
+  grants: TProjectFolderGrant[];
+};
 
 type SourceEntryRowProps = {
   entry: SourceEntry;
@@ -145,9 +166,10 @@ const CompactEntryRow = ({ entry, envName, onEdit, onRemove }: CompactEntryRowPr
 type Props = {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
+  editData?: ShareSecretsEditData | null;
 };
 
-export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
+export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => {
   const { currentProject } = useProject();
   const [entries, setEntries] = useState<SourceEntry[]>([{ ...EMPTY_ENTRY }]);
   const [editingIndex, setEditingIndex] = useState<number | null>(0);
@@ -158,6 +180,30 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
   const { data: projects = [], isPending: isProjectsLoading } = useGetUserProjectsByType(
     ProjectType.SecretManager
   );
+
+  const isEditMode = Boolean(editData);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    if (editData) {
+      const initialEntries: SourceEntry[] = editData.grants.map((g) => ({
+        environment: g.environmentSlug,
+        secretPath: g.folderName === "root" ? "/" : `/${g.folderName}`
+      }));
+      setEntries(initialEntries.length > 0 ? initialEntries : [{ ...EMPTY_ENTRY }]);
+      setEditingIndex(null);
+
+      const matchingProject = projects.find((p) => p.id === editData.targetProjectId);
+      if (matchingProject) {
+        setTargetProjects([matchingProject]);
+      }
+    } else {
+      setEntries([{ ...EMPTY_ENTRY }]);
+      setEditingIndex(0);
+      setTargetProjects([]);
+    }
+  }, [isOpen, editData, projects]);
 
   const availableProjects = projects.filter((p) => p.id !== currentProject.id);
 
@@ -193,7 +239,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
     setEditingIndex(entries.length);
   };
 
-  const createGrant = async (dto: TCreateProjectFolderGrantDTO) => {
+  const postGrant = async (dto: TCreateProjectFolderGrantDTO) => {
     try {
       await apiRequest.post("/api/v1/project-folder-grants", dto);
     } catch (err) {
@@ -208,24 +254,69 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
     }
   };
 
+  const removeGrant = async (dto: TDeleteProjectFolderGrantDTO) => {
+    await apiRequest.delete(`/api/v1/project-folder-grants/${dto.grantId}`, {
+      params: { sourceProjectId: dto.sourceProjectId }
+    });
+  };
+
   const handleSubmit = async () => {
     const validEntries = entries.filter((e) => e.environment && e.secretPath);
     if (validEntries.length === 0 || targetProjects.length === 0) return;
 
     setIsSubmitting(true);
     try {
-      await Promise.all(
-        validEntries.flatMap((entry) =>
-          targetProjects.map((project) =>
-            createGrant({
-              sourceProjectId: currentProject.id,
-              environment: entry.environment,
-              secretPath: entry.secretPath,
-              targetProjectId: project.id
+      const operations: Promise<void>[] = [];
+
+      if (editData) {
+        const currentKeys = new Set(validEntries.map(entryKey));
+        const originalKeys = new Set(
+          editData.grants.map((g) =>
+            entryKey({
+              environment: g.environmentSlug,
+              secretPath: g.folderName === "root" ? "/" : `/${g.folderName}`
             })
           )
-        )
-      );
+        );
+
+        editData.grants.forEach((g) => {
+          const key = entryKey({
+            environment: g.environmentSlug,
+            secretPath: g.folderName === "root" ? "/" : `/${g.folderName}`
+          });
+          if (!currentKeys.has(key)) {
+            operations.push(removeGrant({ grantId: g.id, sourceProjectId: currentProject.id }));
+          }
+        });
+
+        validEntries.forEach((entry) => {
+          if (!originalKeys.has(entryKey(entry))) {
+            operations.push(
+              postGrant({
+                sourceProjectId: currentProject.id,
+                environment: entry.environment,
+                secretPath: entry.secretPath,
+                targetProjectId: editData.targetProjectId
+              })
+            );
+          }
+        });
+      } else {
+        validEntries.forEach((entry) => {
+          targetProjects.forEach((project) => {
+            operations.push(
+              postGrant({
+                sourceProjectId: currentProject.id,
+                environment: entry.environment,
+                secretPath: entry.secretPath,
+                targetProjectId: project.id
+              })
+            );
+          });
+        });
+      }
+
+      await Promise.all(operations);
 
       await queryClient.invalidateQueries({
         queryKey: projectFolderGrantKeys.listByProject(currentProject.id)
@@ -238,14 +329,14 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
         )
       );
 
-      createNotification({ text: "Access granted successfully", type: "success" });
+      createNotification({
+        text: isEditMode ? "Grants updated successfully" : "Access granted successfully",
+        type: "success"
+      });
       onOpenChange(false);
-      setEntries([{ ...EMPTY_ENTRY }]);
-      setEditingIndex(0);
-      setTargetProjects([]);
     } catch (err) {
       console.error(err);
-      createNotification({ text: "Failed to create grant", type: "error" });
+      createNotification({ text: "Failed to save grants", type: "error" });
     } finally {
       setIsSubmitting(false);
     }
@@ -255,9 +346,11 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetContent>
         <SheetHeader className="border-b">
-          <SheetTitle>Share Secrets</SheetTitle>
+          <SheetTitle>{isEditMode ? "Edit Shared Secrets" : "Share Secrets"}</SheetTitle>
           <SheetDescription>
-            Select which project receives read access and optionally scope what they can see.
+            {isEditMode
+              ? "Add or remove environment and folder combinations shared with this project."
+              : "Select which project receives read access and optionally scope what they can see."}
           </SheetDescription>
         </SheetHeader>
 
@@ -302,16 +395,25 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
 
               <Field>
                 <FieldLabel>Target projects</FieldLabel>
-                <FilterableSelect
-                  isMulti
-                  value={targetProjects}
-                  onChange={(options) => setTargetProjects([...(options as MultiValue<Project>)])}
-                  isLoading={isProjectsLoading}
-                  options={availableProjects}
-                  placeholder="Search projects..."
-                  getOptionLabel={(option) => option.name}
-                  getOptionValue={(option) => option.id}
-                />
+                {isEditMode ? (
+                  <div className="flex items-center gap-2 rounded-md border border-border px-3 py-2">
+                    <Badge variant="project" className="gap-1.5">
+                      <Box className="size-3" />
+                      {editData!.targetProjectName}
+                    </Badge>
+                  </div>
+                ) : (
+                  <FilterableSelect
+                    isMulti
+                    value={targetProjects}
+                    onChange={(options) => setTargetProjects([...(options as MultiValue<Project>)])}
+                    isLoading={isProjectsLoading}
+                    options={availableProjects}
+                    placeholder="Search projects..."
+                    getOptionLabel={(option) => option.name}
+                    getOptionValue={(option) => option.id}
+                  />
+                )}
               </Field>
             </div>
           </FieldGroup>
@@ -327,7 +429,7 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange }: Props) => {
             isPending={isSubmitting}
             onClick={handleSubmit}
           >
-            Share
+            {isEditMode ? "Save" : "Share"}
           </Button>
         </SheetFooter>
       </SheetContent>

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react";
 import { MultiValue } from "react-select";
-import { useQueryClient } from "@tanstack/react-query";
-import axios from "axios";
 import { ArrowDown, Box, FolderIcon, Layers, Plus, Trash2, X } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
@@ -25,14 +23,12 @@ import {
   SheetHeader,
   SheetTitle
 } from "@app/components/v3";
-import { apiRequest } from "@app/config/request";
 import { useProject } from "@app/context";
-import { TProjectFolderGrant } from "@app/hooks/api/projectFolderGrants";
-import { projectFolderGrantKeys } from "@app/hooks/api/projectFolderGrants/queries";
 import {
-  TCreateProjectFolderGrantDTO,
-  TDeleteProjectFolderGrantDTO
-} from "@app/hooks/api/projectFolderGrants/types";
+  TProjectFolderGrant,
+  useCreateProjectFolderGrant,
+  useDeleteProjectFolderGrant
+} from "@app/hooks/api/projectFolderGrants";
 import { useGetUserProjectsByType } from "@app/hooks/api/projects";
 import { Project, ProjectType } from "@app/hooks/api/projects/types";
 import { useGetProjectFolders } from "@app/hooks/api/secretFolders/queries";
@@ -197,15 +193,17 @@ type Props = {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
   editData?: ShareSecretsEditData | null;
+  existingGrants?: TProjectFolderGrant[];
 };
 
-export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => {
+export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData, existingGrants = [] }: Props) => {
   const { currentProject } = useProject();
   const [groups, setGroups] = useState<EnvironmentGroup[]>([{ environment: "", secretPaths: [] }]);
   const [targetProjects, setTargetProjects] = useState<Project[]>([]);
 
-  const queryClient = useQueryClient();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const createGrant = useCreateProjectFolderGrant();
+  const deleteGrant = useDeleteProjectFolderGrant();
   const { data: projects = [], isPending: isProjectsLoading } = useGetUserProjectsByType(
     ProjectType.SecretManager
   );
@@ -280,34 +278,17 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
     setGroups((prev) => [...prev, { environment: "", secretPaths: [] }]);
   };
 
-  const postGrant = async (dto: TCreateProjectFolderGrantDTO) => {
-    try {
-      await apiRequest.post("/api/v1/project-folder-grants", dto);
-    } catch (err) {
-      if (
-        axios.isAxiosError(err) &&
-        typeof err.response?.data?.message === "string" &&
-        (err.response.data.message as string).includes("already exists")
-      ) {
-        return;
-      }
-      throw err;
-    }
-  };
-
-  const removeGrant = async (dto: TDeleteProjectFolderGrantDTO) => {
-    await apiRequest.delete(`/api/v1/project-folder-grants/${dto.grantId}`, {
-      params: { sourceProjectId: dto.sourceProjectId }
-    });
-  };
-
   const handleSubmit = async () => {
     const validEntries = flattenGroups(groups).filter((e) => e.environment && e.secretPath);
     if (validEntries.length === 0 || (!isEditMode && targetProjects.length === 0)) return;
 
+    const existingGrantKeys = new Set(
+      existingGrants.map((g) => `${g.targetProjectId}:${g.environmentSlug}:${g.secretPath}`)
+    );
+
     setIsSubmitting(true);
     try {
-      const operations: Promise<void>[] = [];
+      const operations: Promise<unknown>[] = [];
 
       if (editData) {
         const currentKeys = new Set(validEntries.map((e) => entryKey(e.environment, e.secretPath)));
@@ -318,14 +299,16 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
         editData.grants.forEach((g) => {
           const key = entryKey(g.environmentSlug, g.secretPath);
           if (!currentKeys.has(key)) {
-            operations.push(removeGrant({ grantId: g.id, sourceProjectId: currentProject.id }));
+            operations.push(
+              deleteGrant.mutateAsync({ grantId: g.id, sourceProjectId: currentProject.id })
+            );
           }
         });
 
         validEntries.forEach((entry) => {
           if (!originalKeys.has(entryKey(entry.environment, entry.secretPath))) {
             operations.push(
-              postGrant({
+              createGrant.mutateAsync({
                 sourceProjectId: currentProject.id,
                 environment: entry.environment,
                 secretPath: entry.secretPath,
@@ -337,8 +320,11 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
       } else {
         validEntries.forEach((entry) => {
           targetProjects.forEach((project) => {
+            const grantKey = `${project.id}:${entry.environment}:${entry.secretPath}`;
+            if (existingGrantKeys.has(grantKey)) return;
+
             operations.push(
-              postGrant({
+              createGrant.mutateAsync({
                 sourceProjectId: currentProject.id,
                 environment: entry.environment,
                 secretPath: entry.secretPath,
@@ -350,20 +336,6 @@ export const ShareSecretsSheet = ({ isOpen, onOpenChange, editData }: Props) => 
       }
 
       await Promise.all(operations);
-
-      await queryClient.invalidateQueries({
-        queryKey: projectFolderGrantKeys.listByProject(currentProject.id)
-      });
-      const targetProjectIds = isEditMode
-        ? [editData!.targetProjectId]
-        : targetProjects.map((p) => p.id);
-      await Promise.all(
-        targetProjectIds.map((id) =>
-          queryClient.invalidateQueries({
-            queryKey: projectFolderGrantKeys.listReceived(id)
-          })
-        )
-      );
 
       createNotification({
         text: isEditMode ? "Grants updated successfully" : "Access granted successfully",

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateSecretImportForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateSecretImportForm.tsx
@@ -369,7 +369,7 @@ export const CreateSecretImportForm = ({
               </ItemTitle>
               <ItemDescription>
                 {selectedGrant.sourceProjectName} &middot; {selectedGrant.environmentName} &middot;{" "}
-                {selectedGrant.folderName === "root" ? "/" : `/${selectedGrant.folderName}`}
+                {selectedGrant.secretPath}
               </ItemDescription>
             </ItemContent>
           </Item>
@@ -394,7 +394,7 @@ export const CreateSecretImportForm = ({
                   import: {
                     sourceProjectId: selectedGrant.sourceProjectId,
                     environment: selectedGrant.environmentSlug,
-                    path: selectedGrant.folderName === "root" ? "/" : `/${selectedGrant.folderName}`
+                    path: selectedGrant.secretPath
                   }
                 });
                 handleClose();


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

We got some feedback that it would be useful if it would be possible to select multiple envs and projects at once instead of one by one. 

Important to notice that this will ignore duplicate grants (will not add them again), but this will not error out in the UI. The main reason is because we error out in that scenario it becomes annoying to select multiple envs/paths and multiple projects, especially if a grant already exists for any of the env/path/project combinations. 

So it makes UX better to ignore those errors and make them no-op instead.

## Screenshots

<img width="1411" height="557" alt="CleanShot 2026-07-14 at 15 00 47" src="https://github.com/user-attachments/assets/49f5a222-e625-427a-a7b0-55053e32ea0a" />

<img width="448" height="864" alt="CleanShot 2026-07-14 at 21 10 42" src="https://github.com/user-attachments/assets/ba43b28d-ecd0-479f-a6b2-96c5ea8b79e1" />




<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)