### PR TITLE
feat: allow region to be set for global scope in GCP sync

### DIFF
--- a/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
+++ b/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
@@ -16,6 +16,13 @@ import {
   TGcpSyncWithCredentials
 } from "./gcp-sync-types";
 
+const getGlobalReplication = (locationId?: string) => {
+  if (locationId) {
+    return { userManaged: { replicas: [{ location: locationId }] } };
+  }
+  return { automatic: {} };
+};
+
 const getProjectUrl = (secretSync: TGcpSyncWithCredentials) => {
   const { destinationConfig } = secretSync;
 
@@ -123,15 +130,7 @@ export const GcpSyncFns = {
             {
               replication:
                 destinationConfig.scope === GcpSyncScope.Global
-                  ? destinationConfig.locationId
-                    ? {
-                        userManaged: {
-                          replicas: [{ location: destinationConfig.locationId }]
-                        }
-                      }
-                    : {
-                        automatic: {}
-                      }
+                  ? getGlobalReplication(destinationConfig.locationId)
                   : undefined
             },
             {

--- a/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
+++ b/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
@@ -123,9 +123,15 @@ export const GcpSyncFns = {
             {
               replication:
                 destinationConfig.scope === GcpSyncScope.Global
-                  ? {
-                      automatic: {}
-                    }
+                  ? destinationConfig.locationId
+                    ? {
+                        userManaged: {
+                          replicas: [{ location: destinationConfig.locationId }]
+                        }
+                      }
+                    : {
+                        automatic: {}
+                      }
                   : undefined
             },
             {

--- a/backend/src/services/secret-sync/gcp/gcp-sync-schemas.ts
+++ b/backend/src/services/secret-sync/gcp/gcp-sync-schemas.ts
@@ -19,7 +19,11 @@ const GcpSyncDestinationConfigSchema = z.discriminatedUnion("scope", [
   z
     .object({
       scope: z.literal(GcpSyncScope.Global).describe(SecretSyncs.DESTINATION_CONFIG.GCP.scope),
-      projectId: z.string().min(1, "Project ID is required").describe(SecretSyncs.DESTINATION_CONFIG.GCP.projectId)
+      projectId: z.string().min(1, "Project ID is required").describe(SecretSyncs.DESTINATION_CONFIG.GCP.projectId),
+      locationId: z
+        .nativeEnum(GCPSecretManagerLocation)
+        .optional()
+        .describe(SecretSyncs.DESTINATION_CONFIG.GCP.locationId)
     })
     .describe(
       JSON.stringify({

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -1,6 +1,7 @@
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { buildAwsConnectionConfig, getAwsAccountId } from "@app/services/app-connection/aws/aws-connection-fns";
 import { TAwsConnection } from "@app/services/app-connection/aws/aws-connection-types";
+import { GcpSyncScope } from "@app/services/secret-sync/gcp/gcp-sync-enums";
 import { SecretSync, SecretSyncPlanType } from "@app/services/secret-sync/secret-sync-enums";
 import { DestinationDuplicateCheckFn } from "@app/services/secret-sync/secret-sync-types";
 
@@ -158,7 +159,7 @@ export const SECRET_SYNC_SKIP_FIELDS_MAP: Record<SecretSync, string[]> = {
   [SecretSync.AWSParameterStore]: [],
   [SecretSync.AWSSecretsManager]: ["mappingBehavior"],
   [SecretSync.GitHub]: [],
-  [SecretSync.GCPSecretManager]: ["locationId"],
+  [SecretSync.GCPSecretManager]: ["scope", "locationId"],
   [SecretSync.AzureKeyVault]: [],
   [SecretSync.AzureAppConfiguration]: ["label"],
   [SecretSync.AzureDevOps]: ["devopsProjectName"],
@@ -241,11 +242,24 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
   return existingAccountId === newAccountId;
 };
 
+const gcpDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, newSync }) => {
+  const existingConfig = existingSync.destinationConfig;
+  const newConfig = newSync.destinationConfig;
+
+  if (existingConfig.projectId !== newConfig.projectId) return false;
+
+  if (newConfig.scope === GcpSyncScope.Region) {
+    return existingConfig.scope === GcpSyncScope.Region && existingConfig.locationId === newConfig.locationId;
+  }
+
+  return existingConfig.scope === GcpSyncScope.Global;
+};
+
 export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDuplicateCheckFn> = {
   [SecretSync.AWSParameterStore]: awsDuplicateCheck,
   [SecretSync.AWSSecretsManager]: awsDuplicateCheck,
   [SecretSync.GitHub]: defaultDuplicateCheck,
-  [SecretSync.GCPSecretManager]: defaultDuplicateCheck,
+  [SecretSync.GCPSecretManager]: gcpDuplicateCheck,
   [SecretSync.AzureKeyVault]: defaultDuplicateCheck,
   [SecretSync.AzureAppConfiguration]: defaultDuplicateCheck,
   [SecretSync.AzureDevOps]: defaultDuplicateCheck,

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -158,7 +158,7 @@ export const SECRET_SYNC_SKIP_FIELDS_MAP: Record<SecretSync, string[]> = {
   [SecretSync.AWSParameterStore]: [],
   [SecretSync.AWSSecretsManager]: ["mappingBehavior"],
   [SecretSync.GitHub]: [],
-  [SecretSync.GCPSecretManager]: [],
+  [SecretSync.GCPSecretManager]: ["locationId"],
   [SecretSync.AzureKeyVault]: [],
   [SecretSync.AzureAppConfiguration]: ["label"],
   [SecretSync.AzureDevOps]: ["devopsProjectName"],

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
@@ -170,8 +170,8 @@ export const GcpSyncFields = () => {
                       <Info />
                     </TooltipTrigger>
                     <TooltipContent className="max-w-md">
-                      Optionally specify a region for user-managed replication. If not set, automatic
-                      replication will be used.
+                      Optionally specify a region for user-managed replication. If not set,
+                      automatic replication will be used.
                     </TooltipContent>
                   </Tooltip>
                 )}

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
@@ -156,23 +156,41 @@ export const GcpSyncFields = () => {
           </Field>
         )}
       />
-      {selectedScope === GcpSyncScope.Region && (
+      {(selectedScope === GcpSyncScope.Region || selectedScope === GcpSyncScope.Global) && (
         <Controller
           name="destinationConfig.locationId"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
             <Field>
-              <FieldLabel>Region</FieldLabel>
+              <FieldLabel>
+                Region
+                {selectedScope === GcpSyncScope.Global && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-md">
+                      Optionally specify a region for user-managed replication. If not set, automatic
+                      replication will be used.
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </FieldLabel>
               <FieldContent>
                 <FilterableSelect
                   isLoading={areLocationsPending && Boolean(projectId)}
                   isDisabled={!projectId}
+                  isClearable={selectedScope === GcpSyncScope.Global}
                   value={locations?.find((option) => option.locationId === value) ?? null}
                   onChange={(option) =>
-                    onChange((option as SingleValue<TGcpLocation>)?.locationId ?? null)
+                    onChange((option as SingleValue<TGcpLocation>)?.locationId ?? "")
                   }
                   options={locations}
-                  placeholder="Select a region..."
+                  placeholder={
+                    selectedScope === GcpSyncScope.Global
+                      ? "Automatic replication"
+                      : "Select a region..."
+                  }
                   getOptionValue={(option) => option.locationId}
                   formatOptionLabel={formatOptionLabel}
                 />

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
@@ -139,7 +139,14 @@ export const GcpSyncFields = () => {
               </Tooltip>
             </FieldLabel>
             <FieldContent>
-              <Select value={value} onValueChange={(val) => onChange(val)} disabled={!projectId}>
+              <Select
+                value={value}
+                onValueChange={(val) => {
+                  onChange(val);
+                  setValue("destinationConfig.locationId", "");
+                }}
+                disabled={!projectId}
+              >
                 <SelectTrigger className="w-full capitalize" isError={Boolean(error)}>
                   <SelectValue placeholder="Select a scope..." />
                 </SelectTrigger>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
@@ -270,10 +270,7 @@ export const SecretSyncOptionsFields = ({ hideInitialSync, children }: Props) =>
                   </AlertDialogHeader>
                   <AlertDialogFooter>
                     <AlertDialogCancel>Keep it enabled</AlertDialogCancel>
-                    <AlertDialogAction
-                      variant="project"
-                      onClick={() => onChange(false)}
-                    >
+                    <AlertDialogAction variant="project" onClick={() => onChange(false)}>
                       Disable
                     </AlertDialogAction>
                   </AlertDialogFooter>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncOptionsFields/SecretSyncOptionsFields.tsx
@@ -1,8 +1,17 @@
-import { ReactNode, useEffect } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { CircleHelp } from "lucide-react";
+import { AlertTriangleIcon, CircleHelp } from "lucide-react";
 
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogTitle,
   Field,
   FieldContent,
   FieldDescription,
@@ -44,6 +53,7 @@ type Props = {
 };
 
 export const SecretSyncOptionsFields = ({ hideInitialSync, children }: Props) => {
+  const [showDisableDeletionConfirm, setShowDisableDeletionConfirm] = useState(false);
   const { control, watch, setValue } = useFormContext<TSecretSyncForm>();
 
   const destination = watch("destination");
@@ -232,10 +242,43 @@ export const SecretSyncOptionsFields = ({ hideInitialSync, children }: Props) =>
                   id="disable-secret-deletion"
                   variant="project"
                   checked={value}
-                  onCheckedChange={onChange}
+                  onCheckedChange={(checked) => {
+                    if (checked) {
+                      onChange(true);
+                    } else {
+                      setShowDisableDeletionConfirm(true);
+                    }
+                  }}
                 />
               </Field>
               <FieldError errors={[error]} />
+              <AlertDialog
+                open={showDisableDeletionConfirm}
+                onOpenChange={setShowDisableDeletionConfirm}
+              >
+                <AlertDialogContent className="sm:max-w-lg!">
+                  <AlertDialogHeader>
+                    <AlertDialogMedia>
+                      <AlertTriangleIcon className="text-warning" />
+                    </AlertDialogMedia>
+                    <AlertDialogTitle>Disable Secret Deletion Protection</AlertDialogTitle>
+                    <AlertDialogDescription>
+                      Are you sure you want to disable secret deletion protection? This can lead to
+                      secrets being deleted from {destinationName} if they are not managed by
+                      Infisical.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Keep it enabled</AlertDialogCancel>
+                    <AlertDialogAction
+                      variant="project"
+                      onClick={() => onChange(false)}
+                    >
+                      Disable
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
             </Field>
           )}
         />

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/GcpSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/GcpSyncReviewFields.tsx
@@ -21,7 +21,8 @@ export const GcpSyncReviewFields = () => {
         <DetailLabel>Scope</DetailLabel>
         <DetailValue className="capitalize">{destinationConfig.scope}</DetailValue>
       </Detail>
-      {destinationConfig.scope === GcpSyncScope.Region && (
+      {(destinationConfig.scope === GcpSyncScope.Region ||
+        (destinationConfig.scope === GcpSyncScope.Global && destinationConfig.locationId)) && (
         <Detail>
           <DetailLabel>Region</DetailLabel>
           <DetailValue>{destinationConfig.locationId}</DetailValue>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
@@ -346,14 +346,14 @@ export const SecretSyncReviewFields = () => {
             )}
           </Detail>
           {AdditionalSyncOptionsFieldsComponent}
-          {disableSecretDeletion && (
-            <Detail>
-              <DetailLabel>Secret Deletion</DetailLabel>
-              <DetailValue>
-                <Badge variant="warning">Disabled</Badge>
-              </DetailValue>
-            </Detail>
-          )}
+          <Detail>
+            <DetailLabel>Secret Deletion Protection</DetailLabel>
+            <DetailValue>
+              <Badge variant={disableSecretDeletion ? "success" : "neutral"}>
+                {disableSecretDeletion ? "Enabled" : "Disabled"}
+              </Badge>
+            </DetailValue>
+          </Detail>
         </div>
       </DetailGroup>
 

--- a/frontend/src/components/secret-syncs/forms/schemas/gcp-sync-destination-schema.ts
+++ b/frontend/src/components/secret-syncs/forms/schemas/gcp-sync-destination-schema.ts
@@ -10,7 +10,11 @@ export const GcpSyncDestinationSchema = BaseSecretSyncSchema().merge(
     destinationConfig: z.discriminatedUnion("scope", [
       z.object({
         scope: z.literal(GcpSyncScope.Global),
-        projectId: z.string().min(1, "Project ID required")
+        projectId: z.string().min(1, "Project ID required"),
+        locationId: z
+          .string()
+          .optional()
+          .transform((val) => val || undefined)
       }),
       z.object({
         scope: z.literal(GcpSyncScope.Region),

--- a/frontend/src/hooks/api/secretSyncs/types/gcp-sync.ts
+++ b/frontend/src/hooks/api/secretSyncs/types/gcp-sync.ts
@@ -13,6 +13,7 @@ export type TGcpSync = TRootSecretSync & {
     | {
         scope: GcpSyncScope.Global;
         projectId: string;
+        locationId?: string;
       }
     | {
         scope: GcpSyncScope.Region;

--- a/frontend/src/pages/secret-manager/IntegrationsListPage/components/SecretSyncsTab/SecretSyncTable/helpers/index.ts
+++ b/frontend/src/pages/secret-manager/IntegrationsListPage/components/SecretSyncsTab/SecretSyncTable/helpers/index.ts
@@ -54,7 +54,11 @@ export const getSecretSyncDestinationColValues = (secretSync: TSecretSync) => {
     case SecretSync.GCPSecretManager:
       primaryText = destinationConfig.projectId;
       secondaryText =
-        destinationConfig.scope === GcpSyncScope.Global ? "Global" : destinationConfig.locationId;
+        destinationConfig.scope === GcpSyncScope.Global
+          ? destinationConfig.locationId
+            ? `Global - ${destinationConfig.locationId}`
+            : "Global"
+          : destinationConfig.locationId;
       break;
     case SecretSync.AzureKeyVault:
       primaryText = destinationConfig.vaultBaseUrl;

--- a/frontend/src/pages/secret-manager/IntegrationsListPage/components/SecretSyncsTab/SecretSyncTable/helpers/index.ts
+++ b/frontend/src/pages/secret-manager/IntegrationsListPage/components/SecretSyncsTab/SecretSyncTable/helpers/index.ts
@@ -53,12 +53,13 @@ export const getSecretSyncDestinationColValues = (secretSync: TSecretSync) => {
       break;
     case SecretSync.GCPSecretManager:
       primaryText = destinationConfig.projectId;
-      secondaryText =
-        destinationConfig.scope === GcpSyncScope.Global
-          ? destinationConfig.locationId
-            ? `Global - ${destinationConfig.locationId}`
-            : "Global"
-          : destinationConfig.locationId;
+      if (destinationConfig.scope === GcpSyncScope.Global) {
+        secondaryText = destinationConfig.locationId
+          ? `Global - ${destinationConfig.locationId}`
+          : "Global";
+      } else {
+        secondaryText = destinationConfig.locationId;
+      }
       break;
     case SecretSync.AzureKeyVault:
       primaryText = destinationConfig.vaultBaseUrl;

--- a/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncDestinationSection/GcpSyncDestinationSection.tsx
+++ b/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncDestinationSection/GcpSyncDestinationSection.tsx
@@ -18,7 +18,8 @@ export const GcpSyncDestinationSection = ({ secretSync }: Props) => {
         <DetailLabel>Scope</DetailLabel>
         <DetailValue>{destinationConfig.scope}</DetailValue>
       </Detail>
-      {destinationConfig.scope === GcpSyncScope.Region && (
+      {(destinationConfig.scope === GcpSyncScope.Region ||
+        (destinationConfig.scope === GcpSyncScope.Global && destinationConfig.locationId)) && (
         <Detail>
           <DetailLabel>Region</DetailLabel>
           <DetailValue>{destinationConfig.locationId}</DetailValue>

--- a/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncOptionsSection/SecretSyncOptionsSection.tsx
+++ b/frontend/src/pages/secret-manager/SecretSyncDetailsByIDPage/components/SecretSyncOptionsSection/SecretSyncOptionsSection.tsx
@@ -127,14 +127,14 @@ export const SecretSyncOptionsSection = ({ secretSync }: Props) => {
                 )}
               </Detail>
               {AdditionalSyncOptionsComponent}
-              {disableSecretDeletion && (
-                <Detail>
-                  <DetailLabel>Secret Deletion</DetailLabel>
-                  <DetailValue>
-                    <Badge variant="neutral">Disabled</Badge>
-                  </DetailValue>
-                </Detail>
-              )}
+              <Detail>
+                <DetailLabel>Secret Deletion Protection</DetailLabel>
+                <DetailValue>
+                  <Badge variant={disableSecretDeletion ? "success" : "neutral"}>
+                    {disableSecretDeletion ? "Enabled" : "Disabled"}
+                  </Badge>
+                </DetailValue>
+              </Detail>
             </DetailGroup>
           </AccordionContent>
         </AccordionItem>


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

GCP allow global secrets to have user defined regions, not just automatic replication. This allows them to select the region and if not set, use the automatic option from GCP.

This also improves the secret deletion protection UX for disabling it and places we show it's enabled/disabled.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="1913" height="871" alt="CleanShot 2026-07-15 at 13 38 44" src="https://github.com/user-attachments/assets/cc5bc4cd-0276-4e5e-8b5d-bb9189a2e804" />

<img width="1444" height="874" alt="CleanShot 2026-07-15 at 13 39 24" src="https://github.com/user-attachments/assets/b3bda172-33df-4336-9005-c3206c235a05" />


<img width="408" height="590" alt="CleanShot 2026-07-15 at 13 37 57" src="https://github.com/user-attachments/assets/9a46b24c-eaf9-471b-9217-6997f394fb2f" />

<img width="394" height="640" alt="CleanShot 2026-07-15 at 13 38 19" src="https://github.com/user-attachments/assets/ce40e329-3159-43f7-a069-b7412ec03d48" />


## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)