### PR TITLE
fix(db): index six nullable FK columns added by pam-revamp

### DIFF
--- a/backend/src/db/migrations/20260715060344_add-fk-indexes-pam-revamp.ts
+++ b/backend/src/db/migrations/20260715060344_add-fk-indexes-pam-revamp.ts
@@ -1,0 +1,74 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+// The pam-revamp migration (20260612142201) added six nullable FK columns without covering
+// indexes. Postgres does not auto-index FK columns, so a delete on any parent (gateways_v2,
+// gateway_pools, app_connections) fires a per-row referential-integrity trigger that
+// seq-scans the child table on every row.
+//
+// All six are nullable and expected to be mostly NULL (they only carry a value when the
+// account/template overrides the default gateway/pool or opts into a recording connection),
+// so a partial `WHERE col IS NOT NULL` index is the right shape: it serves the RI lookup
+// at a fraction of the size and write cost of a full index.
+const FK_INDEXES = [
+  {
+    table: TableName.PamAccountTemplate,
+    column: "gatewayId",
+    name: "pam_account_templates_gateway_id_idx"
+  },
+  {
+    table: TableName.PamAccountTemplate,
+    column: "gatewayPoolId",
+    name: "pam_account_templates_gateway_pool_id_idx"
+  },
+  {
+    table: TableName.PamAccountTemplate,
+    column: "recordingConnectionId",
+    name: "pam_account_templates_recording_connection_id_idx"
+  },
+  {
+    table: TableName.PamAccount,
+    column: "gatewayId",
+    name: "pam_accounts_gateway_id_idx"
+  },
+  {
+    table: TableName.PamAccount,
+    column: "gatewayPoolId",
+    name: "pam_accounts_gateway_pool_id_idx"
+  },
+  {
+    table: TableName.PamAccount,
+    column: "recordingConnectionId",
+    name: "pam_accounts_recording_connection_id_idx"
+  }
+];
+
+const indexExists = async (knex: Knex, indexName: string): Promise<boolean> => {
+  const result = await knex.raw(`SELECT 1 FROM pg_indexes WHERE indexname = ?`, [indexName]);
+  return result.rows.length > 0;
+};
+
+export async function up(knex: Knex): Promise<void> {
+  for await (const idx of FK_INDEXES) {
+    if (
+      (await knex.schema.hasTable(idx.table)) &&
+      (await knex.schema.hasColumn(idx.table, idx.column)) &&
+      !(await indexExists(knex, idx.name))
+    ) {
+      await knex.schema.alterTable(idx.table, (t) => {
+        t.index([idx.column], idx.name, { predicate: knex.whereNotNull(idx.column) });
+      });
+    }
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for await (const idx of FK_INDEXES) {
+    if ((await knex.schema.hasTable(idx.table)) && (await indexExists(knex, idx.name))) {
+      await knex.schema.alterTable(idx.table, (t) => {
+        t.dropIndex([idx.column], idx.name);
+      });
+    }
+  }
+}

--- a/backend/src/db/migrations/20260715060344_add-fk-indexes-pam-revamp.ts
+++ b/backend/src/db/migrations/20260715060344_add-fk-indexes-pam-revamp.ts
@@ -51,6 +51,22 @@ const FK_INDEXES = [
 const MIGRATION_TIMEOUT = 60 * 60 * 1000; // 60 minutes
 const MIGRATION_LOCK_TIMEOUT = 30 * 1000; // 30 seconds
 
+// An interrupted CREATE INDEX CONCURRENTLY (deploy cancel, statement_timeout, lost connection)
+// leaves the index row in pg_class with indisvalid=false. A rerun with IF NOT EXISTS then no-ops,
+// so the migration "succeeds" without producing a usable index. Drop any such invalid index
+// before recreating.
+const dropIfInvalid = async (knex: Knex, indexName: string): Promise<void> => {
+  const result = await knex.raw(
+    `SELECT 1 FROM pg_class c
+     JOIN pg_index i ON i.indexrelid = c.oid
+     WHERE c.relname = ? AND c.relkind = 'i' AND i.indisvalid = false`,
+    [indexName]
+  );
+  if (result.rows.length > 0) {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "${indexName}"`);
+  }
+};
+
 export async function up(knex: Knex): Promise<void> {
   const stmtResult = await knex.raw("SHOW statement_timeout");
   const originalStatementTimeout = stmtResult.rows[0].statement_timeout;
@@ -63,6 +79,7 @@ export async function up(knex: Knex): Promise<void> {
 
     for await (const idx of FK_INDEXES) {
       if ((await knex.schema.hasTable(idx.table)) && (await knex.schema.hasColumn(idx.table, idx.column))) {
+        await dropIfInvalid(knex, idx.name);
         await knex.raw(`
           CREATE INDEX CONCURRENTLY IF NOT EXISTS "${idx.name}"
           ON ${idx.table} ("${idx.column}")

--- a/backend/src/db/migrations/20260715060344_add-fk-indexes-pam-revamp.ts
+++ b/backend/src/db/migrations/20260715060344_add-fk-indexes-pam-revamp.ts
@@ -11,6 +11,10 @@ import { TableName } from "../schemas";
 // account/template overrides the default gateway/pool or opts into a recording connection),
 // so a partial `WHERE col IS NOT NULL` index is the right shape: it serves the RI lookup
 // at a fraction of the size and write cost of a full index.
+//
+// Built CONCURRENTLY so the deploy doesn't take a write-blocking lock on production
+// pam_accounts / pam_account_templates while each index is created — pattern mirrors
+// 20260602100000_add-secret-versions-v2-envid-index.ts.
 const FK_INDEXES = [
   {
     table: TableName.PamAccountTemplate,
@@ -44,31 +48,39 @@ const FK_INDEXES = [
   }
 ];
 
-const indexExists = async (knex: Knex, indexName: string): Promise<boolean> => {
-  const result = await knex.raw(`SELECT 1 FROM pg_indexes WHERE indexname = ?`, [indexName]);
-  return result.rows.length > 0;
-};
+const MIGRATION_TIMEOUT = 60 * 60 * 1000; // 60 minutes
+const MIGRATION_LOCK_TIMEOUT = 30 * 1000; // 30 seconds
 
 export async function up(knex: Knex): Promise<void> {
-  for await (const idx of FK_INDEXES) {
-    if (
-      (await knex.schema.hasTable(idx.table)) &&
-      (await knex.schema.hasColumn(idx.table, idx.column)) &&
-      !(await indexExists(knex, idx.name))
-    ) {
-      await knex.schema.alterTable(idx.table, (t) => {
-        t.index([idx.column], idx.name, { predicate: knex.whereNotNull(idx.column) });
-      });
+  const stmtResult = await knex.raw("SHOW statement_timeout");
+  const originalStatementTimeout = stmtResult.rows[0].statement_timeout;
+  const lockResult = await knex.raw("SHOW lock_timeout");
+  const originalLockTimeout = lockResult.rows[0].lock_timeout;
+
+  try {
+    await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+    await knex.raw(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT}`);
+
+    for await (const idx of FK_INDEXES) {
+      if ((await knex.schema.hasTable(idx.table)) && (await knex.schema.hasColumn(idx.table, idx.column))) {
+        await knex.raw(`
+          CREATE INDEX CONCURRENTLY IF NOT EXISTS "${idx.name}"
+          ON ${idx.table} ("${idx.column}")
+          WHERE "${idx.column}" IS NOT NULL
+        `);
+      }
     }
+  } finally {
+    await knex.raw(`SET statement_timeout = '${originalStatementTimeout}'`);
+    await knex.raw(`SET lock_timeout = '${originalLockTimeout}'`);
   }
 }
 
 export async function down(knex: Knex): Promise<void> {
   for await (const idx of FK_INDEXES) {
-    if ((await knex.schema.hasTable(idx.table)) && (await indexExists(knex, idx.name))) {
-      await knex.schema.alterTable(idx.table, (t) => {
-        t.dropIndex([idx.column], idx.name);
-      });
-    }
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "${idx.name}"`);
   }
 }
+
+const config = { transaction: false };
+export { config };


### PR DESCRIPTION
## Context

The pam-revamp migration (`20260612142201`) added six FK columns without covering indexes:

- `pam_account_templates.gatewayId` → gateways_v2 (SET NULL)
- `pam_account_templates.gatewayPoolId` → gateway_pools (SET NULL)
- `pam_account_templates.recordingConnectionId` → app_connections (SET NULL)
- `pam_accounts.gatewayId` → gateways_v2 (SET NULL)
- `pam_accounts.gatewayPoolId` → gateway_pools (SET NULL)
- `pam_accounts.recordingConnectionId` → app_connections (SET NULL)

Postgres doesn't auto-index FK columns. When a parent (gateway, gateway pool, or app connection) gets deleted the SET NULL RI trigger runs per row and seq-scans the child table for each deleted parent — cheap today, but blows past `statement_timeout` as PAM adoption grows.

All six columns are nullable and expected to be mostly NULL (they only carry a value when the account/template opts into a specific gateway or recording connection), so a partial `WHERE col IS NOT NULL` index is the right shape per backend/CLAUDE.md — same pattern used in `dynamic_secrets.gatewayPoolId` and `pam_sessions.gatewayId` (my earlier PR #7000).

## Changes

- New migration `20260715060344_add-fk-indexes-pam-revamp.ts` that adds six partial indexes idempotently (checks `pg_indexes` first). Down migration drops them.

## Test plan

- [ ] `npm run migration:latest-dev` from `backend/`
- [ ] Verify indexes exist:
  ```sql
  SELECT indexname FROM pg_indexes
  WHERE indexname LIKE 'pam_account%_id_idx'
  ORDER BY indexname;
  ```
- [ ] `npm run migration:rollback-dev` — indexes drop cleanly
- [ ] Re-apply — still idempotent
