### PR TITLE
improvement(agent-proxy): optional basic auth password + docs link on proxied service sheet

### DIFF
--- a/backend/src/ee/services/proxied-service/proxied-service-schemas.test.ts
+++ b/backend/src/ee/services/proxied-service/proxied-service-schemas.test.ts
@@ -1,4 +1,5 @@
-import { hostPatternSchema } from "./proxied-service-schemas";
+import { ProxiedServiceCredentialRole, ProxiedServiceHeaderPurpose } from "./proxied-service-enums";
+import { CredentialsArraySchema, hostPatternSchema } from "./proxied-service-schemas";
 
 // The host-pattern grammar mirrors the agent-proxy CLI matcher (packages/agentproxy/match.go);
 // keep these cases in sync with that matcher's expectations.
@@ -118,5 +119,42 @@ describe("hostPatternSchema", () => {
     it("invalid IPv6 address", () => {
       expect(firstError("[not-an-ip]")).toContain("is not a valid IPv6 address");
     });
+  });
+});
+
+describe("CredentialsArraySchema basic auth", () => {
+  const username = {
+    secretKey: "API_KEY",
+    role: ProxiedServiceCredentialRole.HeaderRewrite,
+    headerPurpose: ProxiedServiceHeaderPurpose.Username
+  };
+  const password = {
+    secretKey: "API_SECRET",
+    role: ProxiedServiceCredentialRole.HeaderRewrite,
+    headerPurpose: ProxiedServiceHeaderPurpose.Password
+  };
+
+  it("accepts a username without a password (username-only basic auth)", () => {
+    expect(CredentialsArraySchema.safeParse([username]).success).toBe(true);
+  });
+
+  it("accepts a username with a password", () => {
+    expect(CredentialsArraySchema.safeParse([username, password]).success).toBe(true);
+  });
+
+  it("rejects a password without a username", () => {
+    const result = CredentialsArraySchema.safeParse([password]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.message.includes("requires a username"))).toBe(true);
+    }
+  });
+
+  it("rejects two username credentials", () => {
+    const result = CredentialsArraySchema.safeParse([username, { ...username, secretKey: "OTHER" }]);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.message.includes("at most one"))).toBe(true);
+    }
   });
 });

--- a/backend/src/ee/services/proxied-service/proxied-service-schemas.ts
+++ b/backend/src/ee/services/proxied-service/proxied-service-schemas.ts
@@ -176,8 +176,6 @@ export const CredentialsArraySchema = CredentialInputSchema.array()
         message: "Basic auth allows at most one username and one password credential"
       });
     }
-    // Password is optional (username-only basic auth yields `base64(username:)`), but a lone
-    // password with no username is meaningless.
     if (passwordCount > 0 && usernameCount === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/backend/src/ee/services/proxied-service/proxied-service-schemas.ts
+++ b/backend/src/ee/services/proxied-service/proxied-service-schemas.ts
@@ -176,10 +176,12 @@ export const CredentialsArraySchema = CredentialInputSchema.array()
         message: "Basic auth allows at most one username and one password credential"
       });
     }
-    if (usernameCount !== passwordCount) {
+    // Password is optional (username-only basic auth yields `base64(username:)`), but a lone
+    // password with no username is meaningless.
+    if (passwordCount > 0 && usernameCount === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "Basic auth requires both a username and a password credential"
+        message: "Basic auth password requires a username credential"
       });
     }
     if (usernameCount + passwordCount > 0 && headerNameCounts.size > 0) {

--- a/docs/documentation/platform/agent-proxy/proxied-services.mdx
+++ b/docs/documentation/platform/agent-proxy/proxied-services.mdx
@@ -61,8 +61,10 @@ Header rewriting adds or replaces an HTTP header on the outbound request. The ag
 | --- | --- | --- |
 | Bearer token | Header name `Authorization`, prefix `Bearer`, one secret | `Authorization: Bearer <secret>` |
 | API key header | Header name `x-api-key`, no prefix, one secret | `x-api-key: <secret>` |
-| Basic auth | Two secrets, one as **Username** and one as **Password** | `Authorization: Basic base64(username:password)` |
+| Basic auth | One secret as **Username**, and optionally a second as **Password** | `Authorization: Basic base64(username:password)` |
 | Custom | Any header name and optional prefix | `<name>: <prefix> <secret>` |
+
+The password is optional for basic auth. Many APIs pass an API key as the username with an empty password; omitting the password produces `Authorization: Basic base64(username:)`.
 
 A service can rewrite multiple distinct headers (for example, an API key header plus a tenant header), but each header name can only be set by one secret. To build one header value out of several secrets, or use a secret kept elsewhere, see [reusing secrets from other folders and environments](#reusing-secrets-from-other-folders-and-environments).
 

--- a/frontend/src/components/proxied-services/CreateProxiedServiceModal.tsx
+++ b/frontend/src/components/proxied-services/CreateProxiedServiceModal.tsx
@@ -1,16 +1,7 @@
-import {
-  DocumentationLinkBadge,
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle
-} from "@app/components/v3";
+import { Sheet, SheetContent, SheetHeader } from "@app/components/v3";
 
 import { ProxiedServiceForm } from "./forms";
-
-const QUICKSTART_DOCS_URL =
-  "https://infisical.com/docs/documentation/platform/agent-proxy/quickstart";
+import { ProxiedServiceModalHeader } from "./ProxiedServiceModalHeader";
 
 type Props = {
   isOpen: boolean;
@@ -31,13 +22,7 @@ export const CreateProxiedServiceModal = ({
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-4xl">
         <SheetHeader className="border-b">
-          <div className="flex items-center gap-x-2">
-            <SheetTitle>Create Proxied Service</SheetTitle>
-            <DocumentationLinkBadge href={QUICKSTART_DOCS_URL} />
-          </div>
-          <SheetDescription>
-            Define a service the agent proxy can broker secrets for.
-          </SheetDescription>
+          <ProxiedServiceModalHeader />
         </SheetHeader>
         <ProxiedServiceForm
           projectId={projectId}

--- a/frontend/src/components/proxied-services/CreateProxiedServiceModal.tsx
+++ b/frontend/src/components/proxied-services/CreateProxiedServiceModal.tsx
@@ -1,6 +1,16 @@
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@app/components/v3";
+import {
+  DocumentationLinkBadge,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@app/components/v3";
 
 import { ProxiedServiceForm } from "./forms";
+
+const QUICKSTART_DOCS_URL =
+  "https://infisical.com/docs/documentation/platform/agent-proxy/quickstart";
 
 type Props = {
   isOpen: boolean;
@@ -21,7 +31,10 @@ export const CreateProxiedServiceModal = ({
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-4xl">
         <SheetHeader className="border-b">
-          <SheetTitle>Create Proxied Service</SheetTitle>
+          <div className="flex items-center gap-x-2">
+            <SheetTitle>Create Proxied Service</SheetTitle>
+            <DocumentationLinkBadge href={QUICKSTART_DOCS_URL} />
+          </div>
           <SheetDescription>
             Define a service the agent proxy can broker secrets for.
           </SheetDescription>

--- a/frontend/src/components/proxied-services/EditProxiedServiceModal.tsx
+++ b/frontend/src/components/proxied-services/EditProxiedServiceModal.tsx
@@ -1,17 +1,8 @@
-import {
-  DocumentationLinkBadge,
-  Sheet,
-  SheetContent,
-  SheetDescription,
-  SheetHeader,
-  SheetTitle
-} from "@app/components/v3";
+import { Sheet, SheetContent, SheetHeader } from "@app/components/v3";
 import { TDashboardProxiedService } from "@app/hooks/api/proxiedServices/types";
 
 import { ProxiedServiceForm } from "./forms";
-
-const QUICKSTART_DOCS_URL =
-  "https://infisical.com/docs/documentation/platform/agent-proxy/quickstart";
+import { ProxiedServiceModalHeader } from "./ProxiedServiceModalHeader";
 
 type Props = {
   proxiedService?: TDashboardProxiedService;
@@ -32,11 +23,7 @@ export const EditProxiedServiceModal = ({
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-4xl">
         <SheetHeader className="border-b">
-          <div className="flex items-center gap-x-2">
-            <SheetTitle>Edit Proxied Service</SheetTitle>
-            <DocumentationLinkBadge href={QUICKSTART_DOCS_URL} />
-          </div>
-          <SheetDescription>Update how the agent proxy brokers this service.</SheetDescription>
+          <ProxiedServiceModalHeader isEdit />
         </SheetHeader>
         <ProxiedServiceForm
           projectId={projectId}

--- a/frontend/src/components/proxied-services/EditProxiedServiceModal.tsx
+++ b/frontend/src/components/proxied-services/EditProxiedServiceModal.tsx
@@ -1,7 +1,17 @@
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@app/components/v3";
+import {
+  DocumentationLinkBadge,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@app/components/v3";
 import { TDashboardProxiedService } from "@app/hooks/api/proxiedServices/types";
 
 import { ProxiedServiceForm } from "./forms";
+
+const QUICKSTART_DOCS_URL =
+  "https://infisical.com/docs/documentation/platform/agent-proxy/quickstart";
 
 type Props = {
   proxiedService?: TDashboardProxiedService;
@@ -22,7 +32,10 @@ export const EditProxiedServiceModal = ({
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetContent className="flex h-full flex-col gap-y-0 overflow-y-auto sm:max-w-4xl">
         <SheetHeader className="border-b">
-          <SheetTitle>Edit Proxied Service</SheetTitle>
+          <div className="flex items-center gap-x-2">
+            <SheetTitle>Edit Proxied Service</SheetTitle>
+            <DocumentationLinkBadge href={QUICKSTART_DOCS_URL} />
+          </div>
           <SheetDescription>Update how the agent proxy brokers this service.</SheetDescription>
         </SheetHeader>
         <ProxiedServiceForm

--- a/frontend/src/components/proxied-services/ProxiedServiceModalHeader.tsx
+++ b/frontend/src/components/proxied-services/ProxiedServiceModalHeader.tsx
@@ -1,0 +1,21 @@
+import { DocumentationLinkBadge, SheetDescription, SheetTitle } from "@app/components/v3";
+
+type Props = {
+  isEdit?: boolean;
+};
+
+export const ProxiedServiceModalHeader = ({ isEdit }: Props) => {
+  return (
+    <>
+      <div className="flex items-center gap-x-2">
+        <SheetTitle>{isEdit ? "Edit Proxied Service" : "Create Proxied Service"}</SheetTitle>
+        <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/agent-proxy/quickstart" />
+      </div>
+      <SheetDescription>
+        {isEdit
+          ? "Update how the agent proxy brokers this service."
+          : "Define a service the agent proxy can broker secrets for."}
+      </SheetDescription>
+    </>
+  );
+};

--- a/frontend/src/components/proxied-services/forms/ProxiedServiceForm.tsx
+++ b/frontend/src/components/proxied-services/forms/ProxiedServiceForm.tsx
@@ -407,7 +407,10 @@ export const ProxiedServiceForm = ({
                   </FieldContent>
                 </Field>
                 <Field className="flex-1">
-                  <FieldLabel>Password</FieldLabel>
+                  <FieldLabel>
+                    Password
+                    <span className="ml-1 font-normal text-muted">(optional)</span>
+                  </FieldLabel>
                   <FieldContent>
                     <Controller
                       control={control}

--- a/frontend/src/components/proxied-services/forms/schema.ts
+++ b/frontend/src/components/proxied-services/forms/schema.ts
@@ -61,7 +61,8 @@ const headerCredentialSchema = z.object({
 
 const basicAuthSchema = z.object({
   usernameSecretKey: z.string().trim(),
-  passwordSecretKey: z.string().trim()
+  // Optional: username-only basic auth is valid (yields `base64(username:)`).
+  passwordSecretKey: z.string().trim().optional()
 });
 
 const substitutionSchema = z.object({
@@ -139,13 +140,7 @@ export const proxiedServiceFormSchema = z
           path: ["basicAuth", "usernameSecretKey"]
         });
       }
-      if (!form.basicAuth?.passwordSecretKey) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Select a secret",
-          path: ["basicAuth", "passwordSecretKey"]
-        });
-      }
+      // Password is optional — username-only basic auth is allowed.
     }
 
     const seenPlaceholderKeys = new Map<string, number>();

--- a/frontend/src/components/proxied-services/forms/schema.ts
+++ b/frontend/src/components/proxied-services/forms/schema.ts
@@ -132,15 +132,13 @@ export const proxiedServiceFormSchema = z
           path: ["headers"]
         });
       }
-    } else {
-      if (!form.basicAuth?.usernameSecretKey) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Select a secret",
-          path: ["basicAuth", "usernameSecretKey"]
-        });
-      }
-      // Password is optional — username-only basic auth is allowed.
+      // Password is optional — username-only basic auth is allowed, so only the username is required.
+    } else if (!form.basicAuth?.usernameSecretKey) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Select a secret",
+        path: ["basicAuth", "usernameSecretKey"]
+      });
     }
 
     const seenPlaceholderKeys = new Map<string, number>();

--- a/frontend/src/components/proxied-services/forms/schema.ts
+++ b/frontend/src/components/proxied-services/forms/schema.ts
@@ -61,7 +61,6 @@ const headerCredentialSchema = z.object({
 
 const basicAuthSchema = z.object({
   usernameSecretKey: z.string().trim(),
-  // Optional: username-only basic auth is valid (yields `base64(username:)`).
   passwordSecretKey: z.string().trim().optional()
 });
 
@@ -132,7 +131,6 @@ export const proxiedServiceFormSchema = z
           path: ["headers"]
         });
       }
-      // Password is optional — username-only basic auth is allowed, so only the username is required.
     } else if (!form.basicAuth?.usernameSecretKey) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## Context

Feedback from trying out the agent proxy: Basic Auth on a proxied service was forcing both a username and a password, but plenty of APIs authenticate with just a username and an empty password (Ashby, and the common "API key as username" pattern), producing `Authorization: Basic base64(username:)`. Agent Vault already allows this, so this closes a parity gap. Also adds a documentation link to the create/edit proxied service sheet, which previously had no pointer to the docs anywhere.

**Backend:** credential validation required the username and password counts to match (`Basic auth requires both a username and a password credential`). Now the password is optional and only a lone password with no username is rejected. The "at most one of each" and "can't combine basic auth with other header rewrites" rules are unchanged.

**Frontend:** the Password field on the Basic Auth tab is marked `(optional)` and is no longer required by the form schema (`passwordSecretKey` is now optional on the object schema, not just skipped in the refine, so a username-only create doesn't silently fail Zod validation). Added a `Documentation` badge next to the title on both the create and edit sheets, linking to the agent proxy quickstart.

**Docs:** the basic auth row on the proxied services page notes the password is optional and that omitting it yields `base64(username:)`.

**CLI:** no code change needed. The proxy already emits `base64(username:)` when the password credential is absent; added a test there to lock it in. Companion PR: https://github.com/Infisical/cli/pull/316

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

Created a proxied service with only a Username credential (no password) pointing at a local echo server, connected an agent through the proxy, and confirmed the injected header was `Authorization: Basic base64("<secret>:")` (empty password segment). Before this change the create call was rejected with "Basic auth requires both a username and a password credential".

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
