### PR TITLE
improvement(agent-proxy): remove agent and agent-proxy default roles

### DIFF
--- a/backend/src/db/schemas/models.ts
+++ b/backend/src/db/schemas/models.ts
@@ -374,10 +374,7 @@ export enum ProjectMembershipRole {
   // ssh
   SshHostBootstrapper = "ssh-host-bootstrapper",
   // kms
-  KmsCryptographicOperator = "cryptographic-operator",
-  // secrets brokering (agent proxy)
-  Agent = "agent",
-  AgentProxy = "agent-proxy"
+  KmsCryptographicOperator = "cryptographic-operator"
 }
 
 export enum ResourceMembershipRole {

--- a/backend/src/ee/services/permission/default-roles.ts
+++ b/backend/src/ee/services/permission/default-roles.ts
@@ -813,25 +813,6 @@ const buildCryptographicOperatorPermissionRules = () => {
   return rules;
 };
 
-const buildAgentPermissionRules = () => {
-  const { can, rules } = new AbilityBuilder<MongoAbility<ProjectPermissionSet>>(createMongoAbility);
-
-  can(ProjectPermissionProxiedServiceActions.Proxy, ProjectPermissionSub.ProxiedServices);
-
-  return rules;
-};
-
-const buildAgentProxyPermissionRules = () => {
-  const { can, rules } = new AbilityBuilder<MongoAbility<ProjectPermissionSet>>(createMongoAbility);
-
-  can(
-    [ProjectPermissionSecretActions.DescribeSecret, ProjectPermissionSecretActions.ReadValue],
-    ProjectPermissionSub.Secrets
-  );
-
-  return rules;
-};
-
 // General
 export const projectAdminPermissions = buildAdminPermissionRules();
 export const projectMemberPermissions = buildMemberPermissionRules();
@@ -843,10 +824,6 @@ export const sshHostBootstrapPermissions = buildSshHostBootstrapPermissionRules(
 
 // KMS
 export const cryptographicOperatorPermissions = buildCryptographicOperatorPermissionRules();
-
-// Secrets Brokering (Agent Proxy)
-export const agentPermissions = buildAgentPermissionRules();
-export const agentProxyPermissions = buildAgentProxyPermissionRules();
 
 const buildApplicationAdminPermissionRules = () => {
   const { can, rules } = new AbilityBuilder<MongoAbility<ResourcePermissionSet>>(createMongoAbility);

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -16,8 +16,6 @@ import {
 import { TGroupDALFactory } from "@app/ee/services/group/group-dal";
 import { PamResourceRole } from "@app/ee/services/pam/pam-enums";
 import {
-  agentPermissions,
-  agentProxyPermissions,
   applicationAdminPermissions,
   applicationAuditorPermissions,
   applicationOperatorPermissions,
@@ -139,10 +137,6 @@ const buildProjectPermissionRules = (projectUserRoles: TBuildProjectPermissionDT
             return sshHostBootstrapPermissions;
           case ProjectMembershipRole.KmsCryptographicOperator:
             return cryptographicOperatorPermissions;
-          case ProjectMembershipRole.Agent:
-            return agentPermissions;
-          case ProjectMembershipRole.AgentProxy:
-            return agentProxyPermissions;
           case ProjectMembershipRole.Custom: {
             return unpackRules<RawRuleOf<MongoAbility<ProjectPermissionSet>>>(
               permissions as PackRule<RawRuleOf<MongoAbility<ProjectPermissionSet>>>[]

--- a/backend/src/services/project-role/project-role-fns.ts
+++ b/backend/src/services/project-role/project-role-fns.ts
@@ -2,8 +2,6 @@ import { v4 as uuidv4 } from "uuid";
 
 import { ProjectMembershipRole, ProjectType } from "@app/db/schemas";
 import {
-  agentPermissions,
-  agentProxyPermissions,
   cryptographicOperatorPermissions,
   projectAdminPermissions,
   projectMemberPermissions,
@@ -56,28 +54,6 @@ export const getPredefinedRoles = ({ projectId, projectType, roleFilter }: TGetP
       createdAt: new Date(),
       updatedAt: new Date(),
       type: ProjectType.KMS
-    },
-    {
-      id: uuidv4(),
-      projectId,
-      name: "Agent",
-      slug: ProjectMembershipRole.Agent,
-      permissions: agentPermissions,
-      description: "Proxy traffic through all proxied services in a project",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      type: ProjectType.SecretManager
-    },
-    {
-      id: uuidv4(),
-      projectId,
-      name: "Agent Proxy",
-      slug: ProjectMembershipRole.AgentProxy,
-      permissions: agentProxyPermissions,
-      description: "Read all secret values in a project. Intended for the agent proxy",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      type: ProjectType.SecretManager
     },
     {
       id: uuidv4(),

--- a/backend/src/services/role/project/project-role-factory.ts
+++ b/backend/src/services/role/project/project-role-factory.ts
@@ -3,8 +3,6 @@ import { v4 as uuidv4 } from "uuid";
 
 import { AccessScope, ActionProjectType, ProjectMembershipRole, ProjectType } from "@app/db/schemas";
 import {
-  agentPermissions,
-  agentProxyPermissions,
   cryptographicOperatorPermissions,
   projectAdminPermissions,
   projectMemberPermissions,
@@ -171,28 +169,6 @@ export const newProjectRoleFactory = ({
         updatedAt: new Date(),
         projectId,
         type: ProjectType.KMS
-      },
-      {
-        id: uuidv4(),
-        name: "Agent",
-        slug: ProjectMembershipRole.Agent,
-        permissions: agentPermissions,
-        description: "Proxy traffic through all proxied services in a project",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        projectId,
-        type: ProjectType.SecretManager
-      },
-      {
-        id: uuidv4(),
-        name: "Agent Proxy",
-        slug: ProjectMembershipRole.AgentProxy,
-        permissions: agentProxyPermissions,
-        description: "Read all secret values in a project. Intended for the agent proxy",
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        projectId,
-        type: ProjectType.SecretManager
       },
       {
         id: uuidv4(),

--- a/docs/cli/commands/agent-proxy.mdx
+++ b/docs/cli/commands/agent-proxy.mdx
@@ -29,12 +29,12 @@ description: "Run the Infisical Agent Proxy and connect agents to it"
 
 Run the [Infisical Agent Proxy](/documentation/platform/agent-proxy/overview): `start` launches the proxy that brokers real credentials onto agent traffic on the wire, and `connect` launches an agent behind it with the proxy routing, CA trust, and dummy placeholder credentials already set up.
 
-Both subcommands authenticate with a [machine identity](/documentation/platform/identities/machine-identities) via [Universal Auth](/documentation/platform/identities/universal-auth). Use separate identities for the proxy and for each agent; see the [Quickstart](/documentation/platform/agent-proxy/quickstart) for the recommended roles.
+Both subcommands authenticate with a [machine identity](/documentation/platform/identities/machine-identities) via [Universal Auth](/documentation/platform/identities/universal-auth). Use separate identities for the proxy and for each agent; see the [Quickstart](/documentation/platform/agent-proxy/quickstart) for the recommended permissions.
 
 ## Subcommands & flags
 
 <Accordion title="infisical secrets agent-proxy start" defaultOpen="true">
-  Start the agent proxy, an HTTP(S) forward proxy that brokers credentials for the agents that connect to it. Requires machine identity credentials with read access to the secrets your proxied services reference (the built-in **Agent Proxy** role).
+  Start the agent proxy, an HTTP(S) forward proxy that brokers credentials for the agents that connect to it. Requires machine identity credentials with read access to the secrets your proxied services reference.
 
   Agents reach HTTPS services through standard `CONNECT` tunnels and plain-HTTP services through regular forward-proxy requests; credentials are brokered on both. Requests for `https://` URLs sent as plain forward-proxy requests (rather than `CONNECT`) are rejected so the proxy can never be used to downgrade TLS.
 
@@ -121,7 +121,7 @@ $ infisical secrets agent-proxy start --port 17322 --unmatched-host=block
   - `HTTPS_PROXY` / `HTTP_PROXY` pointing at the agent proxy, plus `NO_PROXY` (always includes `localhost,127.0.0.1`, merged with any `NO_PROXY` already in your environment and the `--no-proxy` flag).
   - The organization's root CA written to `~/.infisical/agent-proxy/mitm-ca.pem` and trusted via `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, and `DENO_CERT`.
   - Dummy placeholder environment variables for credential-substitution services the agent has **Proxy** access to.
-  - Real values for regular secrets the agent has **Read Value** on in the scoped folder, including secrets imported into it (similar to `infisical run`). This is opt-in; the built-in Agent role grants no read access, and brokered credentials never appear in the agent's environment. If the agent can read a secret that a proxied service brokers to it, `connect` refuses to start, since the agent would receive the real value directly and bypass the proxy; fix the permissions or pass `--allow-readable-brokered-secrets` to override.
+  - Real values for regular secrets the agent has **Read Value** on in the scoped folder, including secrets imported into it (similar to `infisical run`). This is opt-in; an agent identity scoped to just the proxy permission has no read access, and brokered credentials never appear in the agent's environment. If the agent can read a secret that a proxied service brokers to it, `connect` refuses to start, since the agent would receive the real value directly and bypass the proxy; fix the permissions or pass `--allow-readable-brokered-secrets` to override.
   - `INFISICAL_TOKEN` set to the agent's access token, so the agent can run Infisical CLI commands itself.
 
   The client ID and client secret used to authenticate are stripped from the child environment. The wrapper forwards signals to the agent process and exits with its exit code.

--- a/docs/documentation/platform/agent-proxy/quickstart.mdx
+++ b/docs/documentation/platform/agent-proxy/quickstart.mdx
@@ -32,8 +32,8 @@ This guide walks through brokering a credential end to end: you will create a pr
   <Step title="Create two machine identities">
     Create two [machine identities](/documentation/platform/identities/machine-identities) with [Universal Auth](/documentation/platform/identities/universal-auth) and add both to your project:
 
-    1. **Agent proxy identity**: it fetches the real credential values, so give it read access (describe and read value) to the referenced secrets.
-    2. **Agent identity**: it routes traffic through proxied services but should not read any secret values, so give it only the proxy permission on proxied services.
+    1. **Agent proxy identity**: it fetches the real credential values, so grant it `Read Value` and `Describe Secret` on the **Secrets** its services reference.
+    2. **Agent identity**: it routes traffic through proxied services but should not read any secret values, so grant it only `Proxy` on **Proxied Services**.
 
     <Note>
       Grant these permissions with a [custom role](/documentation/platform/access-controls/role-based-access-controls) or an [additional privilege](/documentation/platform/access-controls/additional-privileges) on each identity, scoped to the specific environments and paths you need. Running more than one agent? See [how many machine identities you need](/documentation/platform/agent-proxy/security#how-many-machine-identities-do-you-need).

--- a/docs/documentation/platform/agent-proxy/quickstart.mdx
+++ b/docs/documentation/platform/agent-proxy/quickstart.mdx
@@ -32,11 +32,11 @@ This guide walks through brokering a credential end to end: you will create a pr
   <Step title="Create two machine identities">
     Create two [machine identities](/documentation/platform/identities/machine-identities) with [Universal Auth](/documentation/platform/identities/universal-auth) and add both to your project:
 
-    1. **Agent proxy identity**: assign it the built-in **Agent Proxy** role. It fetches the real credential values, so it needs read access to the referenced secrets.
-    2. **Agent identity**: assign it the built-in **Agent** role. It can route traffic through proxied services but cannot read any secret values.
+    1. **Agent proxy identity**: it fetches the real credential values, so give it read access (describe and read value) to the referenced secrets.
+    2. **Agent identity**: it routes traffic through proxied services but should not read any secret values, so give it only the proxy permission on proxied services.
 
     <Note>
-      The built-in roles grant broad access across all environments and paths for a quick start. For production, consider [custom roles](/documentation/platform/access-controls/role-based-access-controls) scoped to specific environments and paths. Running more than one agent? See [how many machine identities you need](/documentation/platform/agent-proxy/security#how-many-machine-identities-do-you-need).
+      Grant these permissions with a [custom role](/documentation/platform/access-controls/role-based-access-controls) or an [additional privilege](/documentation/platform/access-controls/additional-privileges) on each identity, scoped to the specific environments and paths you need. Running more than one agent? See [how many machine identities you need](/documentation/platform/agent-proxy/security#how-many-machine-identities-do-you-need).
     </Note>
   </Step>
   <Step title="Start the agent proxy">
@@ -92,7 +92,7 @@ This guide walks through brokering a credential end to end: you will create a pr
     - Sets environment variables with real values for regular secrets the agent identity has **Read Value** on in the folder (including secrets imported into it), similar to `infisical run`.
 
     <Note>
-      Real values in the agent's environment are deliberate and opt-in. The built-in Agent role grants no secret read access, so nothing real lands in the environment unless an admin explicitly grants **Read Value** on specific secrets. Brokered credentials never appear in the agent's environment; the proxy only attaches them on the wire.
+      Real values in the agent's environment are deliberate and opt-in. When the agent identity has only the proxy permission and no secret read access, nothing real lands in the environment unless an admin explicitly grants **Read Value** on specific secrets. Brokered credentials never appear in the agent's environment; the proxy only attaches them on the wire.
     </Note>
 
     The project can also be set via `INFISICAL_PROJECT_ID` or an `.infisical.json` file (created by `infisical init`) instead of `--projectId`.

--- a/docs/documentation/platform/agent-proxy/security.mdx
+++ b/docs/documentation/platform/agent-proxy/security.mdx
@@ -72,27 +72,18 @@ Proxied services have their own project-level permission subject, with five acti
 
 **Proxy** is meant for agent machine identities: an identity with Proxy gets a service's secrets applied to its traffic without ever being able to read the values.
 
-### Built-in Roles
+### Roles
 
-Two built-in project roles make setup quick. Both grant broad access across all environments and paths; create a [custom role](/documentation/platform/access-controls/role-based-access-controls) instead if you need tighter scoping.
-
-| Role | Slug | Intended for | What it grants |
-| --- | --- | --- | --- |
-| **Agent** | `agent` | The agent machine identity | Proxy on all proxied services. No secret read access. |
-| **Agent Proxy** | `agent-proxy` | The agent proxy machine identity | Read access to all secret values, so it can fetch the real credentials it applies. No proxied service permissions. |
-
-<Note>
-  The Agent role intentionally has no secret read access. If an agent also needs real values in its environment, grant its identity **Read Value** on those specific secrets. Avoid granting folder-wide read access to an agent identity: that would also expose the brokered secrets and defeat the purpose of brokering them.
-</Note>
-
-### Custom Roles
-
-The built-in roles grant the right permissions but across all environments and paths. To scope tighter, build a [custom role](/documentation/platform/access-controls/role-based-access-controls) instead. This is the minimum each identity needs:
+Grant each identity the minimum permissions it needs with a [custom role](/documentation/platform/access-controls/role-based-access-controls) or an [additional privilege](/documentation/platform/access-controls/additional-privileges), scoped to the environments and paths its services live in. This is the minimum each identity needs:
 
 | Identity | Minimum permissions | Notes |
 | --- | --- | --- |
 | **Agent** | `Proxy` on **Proxied Services**, scoped to the environments and paths where its services live | This alone lets it route traffic and have credentials applied. It does not need to read any secret. Add `Read Value` on **Secrets** only for values the agent uses directly (not brokered ones). |
 | **Agent Proxy** | `Read Value` and `Describe Secret` on **Secrets**, covering every secret the services reference | This is the identity that actually fetches the real values. Both actions are required: `Describe Secret` determines whether a secret is visible to the identity at all, and `Read Value` reveals its value. It needs no proxied-service permission. |
+
+<Note>
+  An agent identity should be scoped to just the proxy permission, with no secret read access. If an agent also needs real values in its environment, grant its identity **Read Value** on those specific secrets. Avoid granting folder-wide read access to an agent identity: that would also expose the brokered secrets and defeat the purpose of brokering them.
+</Note>
 
 The key thing to get right for the agent proxy: it needs **Read Value on every secret referenced by every service any of its agents use**, across the relevant environments and paths. If a referenced secret comes from a [secret import](/documentation/platform/agent-proxy/proxied-services#using-secrets), the read permission has to cover the secret's real location (the import source), not just the folder it is imported into. If a grant is missing, that credential is skipped.
 

--- a/frontend/src/helpers/roles.ts
+++ b/frontend/src/helpers/roles.ts
@@ -33,10 +33,6 @@ export const formatProjectRoleName = (role: string, customRoleName?: string) => 
       return "SSH Host Bootstrapper";
     case ProjectMembershipRole.KmsCryptographicOperator:
       return "Cryptographic Operator";
-    case ProjectMembershipRole.Agent:
-      return "Agent";
-    case ProjectMembershipRole.AgentProxy:
-      return "Agent Proxy";
     default:
       return role;
   }

--- a/frontend/src/hooks/api/roles/types.ts
+++ b/frontend/src/hooks/api/roles/types.ts
@@ -5,9 +5,7 @@ export enum ProjectMembershipRole {
   Viewer = "viewer",
   NoAccess = "no-access",
   SshHostBootstrapper = "ssh-host-bootstrapper",
-  KmsCryptographicOperator = "cryptographic-operator",
-  Agent = "agent",
-  AgentProxy = "agent-proxy"
+  KmsCryptographicOperator = "cryptographic-operator"
 }
 
 export type TGetProjectRolesDTO = {


### PR DESCRIPTION
## Context

The secrets brokering feature shipped two default project roles, `agent` and `agent-proxy`. The slugs are generic enough that they collide with custom roles customers may already have (`agent` especially), and since reserved roles take precedence over custom ones, a self-hosted user with an existing `agent` role would silently have it shadowed by the default. They were only ever meant as a low-friction starting point, not something scoped enough for real use, so we're pulling them before they're in production for good. The rest of the brokering feature stays untouched: users grant the equivalent access with a custom role or an additional privilege (proxy on proxied services for the agent, read value + describe secret for the proxy identity).

No migration is needed since these roles are defined at runtime and never persisted to the DB.

**Permissions:** removed the `agent` / `agent-proxy` permission builders and their exports, and the two switch arms that mapped the slugs to them. The `ProxiedServices` permission subject and the proxied-service grants on the admin/member/viewer roles stay.

**Predefined roles:** removed the two role objects from both `getPredefinedRoles` lists (`project-role-fns.ts` and the newer `project-role-factory.ts`).

**Frontend:** dropped the two slugs from the `ProjectMembershipRole` enum and their `formatProjectRoleName` cases; the slugs now fall through and render as custom roles, which is the correct post-removal behavior.

**Docs:** reworded the agent-proxy quickstart, security, and CLI pages that told users to assign the built-in roles, pointing them to custom roles / additional privileges with the same minimum permissions instead.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
