### PR TITLE
improvement(dynamic-secret-gcp): validate that the email being used can only be used inside the same org

### DIFF
--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -642,9 +642,18 @@ export const dynamicSecretServiceFactory = ({
       secretManagerDecryptor({ cipherTextBlob: dynamicSecretCfg.encryptedInput }).toString()
     ) as object;
     const selectedProvider = dynamicSecretProviders[dynamicSecretCfg.type as DynamicSecretProviders];
-    const providerInputs = (await selectedProvider.validateProviderInputs(decryptedStoredInput, {
-      projectId
-    })) as object;
+    let providerInputs: object;
+    try {
+      providerInputs = (await selectedProvider.validateProviderInputs(decryptedStoredInput, {
+        projectId
+      })) as object;
+    } catch (error) {
+      if (error instanceof GcpIamServiceAccountSuffixError) {
+        providerInputs = decryptedStoredInput;
+      } else {
+        throw error;
+      }
+    }
 
     return {
       ...dynamicSecretCfg,

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -26,6 +26,7 @@ import { OrgPermissionGatewayActions, OrgPermissionSubjects } from "../permissio
 import { TDynamicSecretDALFactory } from "./dynamic-secret-dal";
 import { DynamicSecretStatus, TDynamicSecretServiceFactory } from "./dynamic-secret-types";
 import { AzureEntraIDProvider } from "./providers/azure-entra-id";
+import { GcpIamServiceAccountSuffixError } from "./providers/gcp-iam";
 import { IbmApiConnectProvider } from "./providers/ibm-api-connect";
 import { DynamicSecretProviders, SshStoredSchema, TDynamicProviderFns } from "./providers/models";
 
@@ -358,7 +359,16 @@ export const dynamicSecretServiceFactory = ({
       else if ((inputs as Record<string, unknown>).gatewayPoolId)
         (newInput as Record<string, unknown>).gatewayId = undefined;
     }
-    const oldInput = await selectedProvider.validateProviderInputs(decryptedStoredInput, { projectId });
+    let oldInput: unknown;
+    try {
+      oldInput = await selectedProvider.validateProviderInputs(decryptedStoredInput, { projectId });
+    } catch (error) {
+      if (error instanceof GcpIamServiceAccountSuffixError) {
+        oldInput = decryptedStoredInput;
+      } else {
+        throw error;
+      }
+    }
     const updatedInput = await selectedProvider.validateProviderInputs(newInput, { projectId });
 
     const updatedFields = getUpdatedFieldPaths(

--- a/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
@@ -13,6 +13,12 @@ import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { DynamicSecretGcpIamSchema, TDynamicProviderFns } from "./models";
 
+export class GcpIamServiceAccountSuffixError extends BadRequestError {
+  constructor({ message }: { message: string }) {
+    super({ message, name: "GcpIamServiceAccountSuffixError" });
+  }
+}
+
 type TGcpIamProviderDTO = {
   projectDAL: Pick<TProjectDALFactory, "findById">;
 };
@@ -38,7 +44,7 @@ export const GcpIamProvider = ({ projectDAL }: TGcpIamProviderDTO): TDynamicProv
     const serviceAccountId = providerInputs.serviceAccountEmail.split("@")[0];
 
     if (!serviceAccountId.endsWith(expectedAccountIdSuffix)) {
-      throw new BadRequestError({
+      throw new GcpIamServiceAccountSuffixError({
         message: `GCP service account ID must have a suffix of "${expectedAccountIdSuffix}"`
       });
     }

--- a/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
@@ -2,17 +2,41 @@ import { gaxios, Impersonated } from "google-auth-library";
 import { GetAccessTokenResponse } from "google-auth-library/build/src/auth/oauth2client";
 
 import { getConfig } from "@app/lib/config/env";
-import { BadRequestError, InternalServerError } from "@app/lib/errors";
+import { BadRequestError, InternalServerError, NotFoundError } from "@app/lib/errors";
 import { sanitizeString } from "@app/lib/fn";
 import { logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { buildGcpSourceCredential } from "@app/services/app-connection/gcp/gcp-connection-fns";
+import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { DynamicSecretGcpIamSchema, TDynamicProviderFns } from "./models";
 
-export const GcpIamProvider = (): TDynamicProviderFns => {
-  const validateProviderInputs = async (inputs: unknown) => {
+type TGcpIamProviderDTO = {
+  projectDAL: Pick<TProjectDALFactory, "findById">;
+};
+
+export const GcpIamProvider = ({ projectDAL }: TGcpIamProviderDTO): TDynamicProviderFns => {
+  const validateProviderInputs = async (inputs: unknown, metadata: { projectId: string }) => {
     const providerInputs = await DynamicSecretGcpIamSchema.parseAsync(inputs);
+
+    // Check if provided service account email suffix matches organization ID.
+    // We do this to mitigate confused deputy attacks in multi-tenant instances
+    const project = await requestMemoize(requestMemoKeys.projectFindById(metadata.projectId), () =>
+      projectDAL.findById(metadata.projectId)
+    );
+    if (!project) throw new NotFoundError({ message: `Project with ID '${metadata.projectId}' not found` });
+
+    const expectedAccountIdSuffix = project.orgId.split("-").slice(0, 2).join("-");
+    const serviceAccountId = providerInputs.serviceAccountEmail.split("@")[0];
+
+    if (!serviceAccountId.endsWith(expectedAccountIdSuffix)) {
+      throw new BadRequestError({
+        message: `GCP service account ID must have a suffix of "${expectedAccountIdSuffix}"`
+      });
+    }
+
     return providerInputs;
   };
 
@@ -57,8 +81,8 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
     return tokenResponse.token;
   };
 
-  const validateConnection = async (inputs: unknown) => {
-    const providerInputs = await validateProviderInputs(inputs);
+  const validateConnection = async (inputs: unknown, metadata: { projectId: string }) => {
+    const providerInputs = await validateProviderInputs(inputs, metadata);
     try {
       await $getToken(providerInputs.serviceAccountEmail, 10, providerInputs.tokenScopes);
       return true;
@@ -73,10 +97,10 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
     }
   };
 
-  const create = async (data: { inputs: unknown; expireAt: number }) => {
-    const { inputs, expireAt } = data;
+  const create = async (data: { inputs: unknown; expireAt: number; metadata: { projectId: string } }) => {
+    const { inputs, expireAt, metadata } = data;
 
-    const providerInputs = await validateProviderInputs(inputs);
+    const providerInputs = await validateProviderInputs(inputs, metadata);
 
     try {
       const now = Math.floor(Date.now() / 1000);
@@ -102,14 +126,14 @@ export const GcpIamProvider = (): TDynamicProviderFns => {
     return { entityId };
   };
 
-  const renew = async (inputs: unknown, entityId: string, expireAt: number) => {
+  const renew = async (inputs: unknown, entityId: string, expireAt: number, metadata: { projectId: string }) => {
     try {
       // To renew a token it must be re-created
-      const data = await create({ inputs, expireAt });
+      const data = await create({ inputs, expireAt, metadata });
 
       return { ...data, entityId };
     } catch (err) {
-      const providerInputs = await validateProviderInputs(inputs);
+      const providerInputs = await validateProviderInputs(inputs, metadata);
       const sanitizedErrorMessage = sanitizeString({
         unsanitizedString: (err as Error)?.message,
         tokens: [providerInputs.serviceAccountEmail]

--- a/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/gcp-iam.ts
@@ -18,6 +18,12 @@ type TGcpIamProviderDTO = {
 };
 
 export const GcpIamProvider = ({ projectDAL }: TGcpIamProviderDTO): TDynamicProviderFns => {
+  // used to keep backwards compatibility with existing provider inputs that didn't enforce the org id suffix
+  const validateExistingProviderInputs = async (inputs: unknown) => {
+    const providerInputs = await DynamicSecretGcpIamSchema.parseAsync(inputs);
+    return providerInputs;
+  };
+
   const validateProviderInputs = async (inputs: unknown, metadata: { projectId: string }) => {
     const providerInputs = await DynamicSecretGcpIamSchema.parseAsync(inputs);
 
@@ -98,9 +104,9 @@ export const GcpIamProvider = ({ projectDAL }: TGcpIamProviderDTO): TDynamicProv
   };
 
   const create = async (data: { inputs: unknown; expireAt: number; metadata: { projectId: string } }) => {
-    const { inputs, expireAt, metadata } = data;
+    const { inputs, expireAt } = data;
 
-    const providerInputs = await validateProviderInputs(inputs, metadata);
+    const providerInputs = await validateExistingProviderInputs(inputs);
 
     try {
       const now = Math.floor(Date.now() / 1000);
@@ -133,7 +139,7 @@ export const GcpIamProvider = ({ projectDAL }: TGcpIamProviderDTO): TDynamicProv
 
       return { ...data, entityId };
     } catch (err) {
-      const providerInputs = await validateProviderInputs(inputs, metadata);
+      const providerInputs = await validateExistingProviderInputs(inputs);
       const sanitizedErrorMessage = sanitizeString({
         unsanitizedString: (err as Error)?.message,
         tokens: [providerInputs.serviceAccountEmail]

--- a/backend/src/ee/services/dynamic-secret/providers/index.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/index.ts
@@ -1,4 +1,5 @@
 import { SnowflakeProvider } from "@app/ee/services/dynamic-secret/providers/snowflake";
+import { TProjectDALFactory } from "@app/services/project/project-dal";
 
 import { TGatewayServiceFactory } from "../../gateway/gateway-service";
 import { TGatewayPoolServiceFactory } from "../../gateway-pool/gateway-pool-service";
@@ -34,12 +35,14 @@ type TBuildDynamicSecretProviderDTO = {
   gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
   gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
+  projectDAL: Pick<TProjectDALFactory, "findById">;
 };
 
 export const buildDynamicSecretProviders = ({
   gatewayService,
   gatewayV2Service,
-  gatewayPoolService
+  gatewayPoolService,
+  projectDAL
 }: TBuildDynamicSecretProviderDTO): Record<DynamicSecretProviders, TDynamicProviderFns> => ({
   [DynamicSecretProviders.SqlDatabase]: SqlDatabaseProvider({ gatewayService, gatewayV2Service, gatewayPoolService }),
   [DynamicSecretProviders.Clickhouse]: ClickhouseProvider({ gatewayService, gatewayV2Service, gatewayPoolService }),
@@ -65,7 +68,7 @@ export const buildDynamicSecretProviders = ({
   [DynamicSecretProviders.SapAse]: SapAseProvider(),
   [DynamicSecretProviders.Kubernetes]: KubernetesProvider({ gatewayService, gatewayV2Service, gatewayPoolService }),
   [DynamicSecretProviders.Vertica]: VerticaProvider({ gatewayService, gatewayV2Service, gatewayPoolService }),
-  [DynamicSecretProviders.GcpIam]: GcpIamProvider(),
+  [DynamicSecretProviders.GcpIam]: GcpIamProvider({ projectDAL }),
   [DynamicSecretProviders.Github]: GithubProvider(),
   [DynamicSecretProviders.Couchbase]: CouchbaseProvider(),
   [DynamicSecretProviders.Milvus]: MilvusProvider({ gatewayService, gatewayV2Service, gatewayPoolService }),

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2708,7 +2708,8 @@ export const registerRoutes = async (
   const dynamicSecretProviders = buildDynamicSecretProviders({
     gatewayService,
     gatewayV2Service,
-    gatewayPoolService
+    gatewayPoolService,
+    projectDAL
   });
 
   const dynamicSecretQueueService = dynamicSecretLeaseQueueServiceFactory({

--- a/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
+++ b/docs/documentation/platform/dynamic-secrets/gcp-iam.mdx
@@ -73,6 +73,14 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
         ![Service Account Page](/images/app-connections/gcp/service-account-overview.png)
     </Step>
     <Step title="Create Service Account">
+        Create a new service account with an ID that follows this requirement:
+
+        Your service account ID must end with the first two sections of your Infisical organization ID.
+
+        Example:
+        - Infisical organization ID: `df92581a-0fe9-42b5-b526-0a1e88ec8085`
+        - Required service account ID suffix: `df92581a-0fe9`
+
         ![Create Service Account](/images/app-connections/gcp/create-service-account.png)
     </Step>
     <Step title="Configure Service Account Permissions">
@@ -121,7 +129,7 @@ The Infisical GCP IAM dynamic secret allows you to generate GCP service account 
     		Maximum time-to-live for a generated secret
     	</ParamField>
     	<ParamField path="Service Account Email" type="string" required>
-       		The email tied to the service account created in earlier steps.
+       		The email tied to the service account created in earlier steps. The service account ID (the part of the email before `@`) must end with the first two sections of your Infisical organization ID, e.g. `my-service-account-df92581a-0fe9@my-project.iam.gserviceaccount.com` for organization ID `df92581a-0fe9-42b5-b526-0a1e88ec8085`.
     	</ParamField>
     	<ParamField path="Token Scopes" type="string[]" default="https://www.googleapis.com/auth/iam, https://www.googleapis.com/auth/cloud-platform">
        		The OAuth scopes granted to the generated access token. Defaults to `https://www.googleapis.com/auth/iam` and `https://www.googleapis.com/auth/cloud-platform` scopes. You can add additional scopes such as `https://www.googleapis.com/auth/drive`.

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/GcpIamInputForm.tsx
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { TtlFormLabel } from "@app/components/features";
 import { Button, FilterableSelect, FormControl, IconButton, Input } from "@app/components/v2";
+import { useOrganization } from "@app/context";
 import { useCreateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
 import { ProjectEnv } from "@app/hooks/api/types";
@@ -65,6 +66,9 @@ export const GcpIamInputForm = ({
   projectSlug,
   isSingleEnvironmentMode
 }: Props) => {
+  const { currentOrg } = useOrganization();
+  const expectedAccountIdSuffix = currentOrg.id.split("-").slice(0, 2).join("-");
+
   const {
     control,
     formState: { isSubmitting },
@@ -186,6 +190,7 @@ export const GcpIamInputForm = ({
                     className="grow"
                     isError={Boolean(error?.message)}
                     errorText={error?.message}
+                    tooltipText={`The service account ID (the part of the email before "@") must end with the first two sections of your organization ID: "${expectedAccountIdSuffix}". Example: my-service-account-${expectedAccountIdSuffix}@my-project.iam.gserviceaccount.com`}
                     helperText={
                       <span>
                         Don&apos;t know where to get this value?{" "}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretGcpIamForm.tsx
@@ -8,6 +8,7 @@ import { z } from "zod";
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import { Button, FormControl, IconButton, Input } from "@app/components/v2";
+import { useOrganization } from "@app/context";
 import { useUpdateDynamicSecret } from "@app/hooks/api";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 
@@ -61,6 +62,9 @@ export const EditDynamicSecretGcpIamForm = ({
   environment,
   projectSlug
 }: Props) => {
+  const { currentOrg } = useOrganization();
+  const expectedAccountIdSuffix = currentOrg.id.split("-").slice(0, 2).join("-");
+
   const {
     control,
     formState: { isSubmitting },
@@ -181,6 +185,7 @@ export const EditDynamicSecretGcpIamForm = ({
                   className="grow"
                   isError={Boolean(error?.message)}
                   errorText={error?.message}
+                  tooltipText={`The service account ID (the part of the email before "@") must end with the first two sections of your organization ID: "${expectedAccountIdSuffix}". Example: my-service-account-${expectedAccountIdSuffix}@my-project.iam.gserviceaccount.com`}
                 >
                   <Input {...field} />
                 </FormControl>


### PR DESCRIPTION
## Context
Add a validation that makes that the email being used can only be validated by the same organization. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- create a new dynamic secret for GCP 
- make sure that if you use an email that does not end with the same two sections of the org id UUID it does not allow you to create a new dynamic secret

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)