### PR TITLE
fix(webauthn): support hardware security keys on FIPS instances

### DIFF
--- a/backend/src/server/routes/v1/user-router.ts
+++ b/backend/src/server/routes/v1/user-router.ts
@@ -381,6 +381,7 @@ export const registerUserRouter = async (server: FastifyZodProvider) => {
       operationId: "getUserWebAuthnCredentials",
       response: {
         200: z.object({
+          fipsEnabled: z.boolean(),
           credentials: z.array(
             z.object({
               id: z.string(),
@@ -396,10 +397,9 @@ export const registerUserRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
-      const credentials = await server.services.webAuthn.getUserWebAuthnCredentials({
+      return server.services.webAuthn.getUserWebAuthnCredentials({
         userId: req.permission.id
       });
-      return { credentials };
     }
   });
 

--- a/backend/src/server/routes/v2/mfa-router.ts
+++ b/backend/src/server/routes/v2/mfa-router.ts
@@ -214,7 +214,7 @@ export const registerMfaRouter = async (server: FastifyZodProvider) => {
     },
     handler: async (req) => {
       try {
-        const credentials = await server.services.webAuthn.getUserWebAuthnCredentials({
+        const { credentials } = await server.services.webAuthn.getUserWebAuthnCredentials({
           userId: req.mfa.userId
         });
 

--- a/backend/src/services/webauthn/webauthn-service.ts
+++ b/backend/src/services/webauthn/webauthn-service.ts
@@ -91,7 +91,7 @@ export const webAuthnServiceFactory = ({
       // cannot be verified under FIPS mode (OpenSSL FIPS provider rejects the key
       // import with "Invalid keyData"), so the credential enrolls and then always
       // fails MFA. ES256 is mandatory for FIDO2 authenticators, so nothing is
-      // excluded in practice;
+      // excluded in practice
       supportedAlgorithmIDs: [-7, -257],
       excludeCredentials: existingCredentials.map((cred) => ({
         id: cred.credentialId,

--- a/backend/src/services/webauthn/webauthn-service.ts
+++ b/backend/src/services/webauthn/webauthn-service.ts
@@ -63,6 +63,13 @@ export const webAuthnServiceFactory = ({
   const RP_NAME = "Infisical";
   const RP_ID = new URL(appCfg.SITE_URL || "http://localhost:8080").hostname;
   const ORIGIN = appCfg.SITE_URL || "http://localhost:8080";
+  // ES256/RS256 only. The library default also offers/accepts EdDSA (-8), which
+  // Ed25519-capable authenticators (e.g. modern YubiKeys) pick first, but Ed25519
+  // cannot be verified under FIPS mode (the OpenSSL FIPS provider rejects the key
+  // import with "Invalid keyData"), so such a credential enrolls and then always
+  // fails MFA. ES256 is mandatory for FIDO2 authenticators, so nothing is excluded
+  // in practice.
+  const SUPPORTED_COSE_ALGORITHM_IDS = [-7, -257];
   /**
    * Generate registration options for a new passkey
    * This is the first step in passkey registration
@@ -86,13 +93,7 @@ export const webAuthnServiceFactory = ({
       userName: user.email || "",
       userDisplayName: user.email || "",
       attestationType: "none",
-      // ES256/RS256 only. The library default also offers EdDSA (-8) first, which
-      // Ed25519-capable authenticators (e.g. modern YubiKeys) will pick, but Ed25519
-      // cannot be verified under FIPS mode (OpenSSL FIPS provider rejects the key
-      // import with "Invalid keyData"), so the credential enrolls and then always
-      // fails MFA. ES256 is mandatory for FIDO2 authenticators, so nothing is
-      // excluded in practice
-      supportedAlgorithmIDs: [-7, -257],
+      supportedAlgorithmIDs: SUPPORTED_COSE_ALGORITHM_IDS,
       excludeCredentials: existingCredentials.map((cred) => ({
         id: cred.credentialId,
         transports: cred.transports as AuthenticatorTransportFuture[]
@@ -142,7 +143,8 @@ export const webAuthnServiceFactory = ({
         expectedChallenge,
         expectedOrigin: ORIGIN,
         expectedRPID: RP_ID,
-        requireUserVerification: true
+        requireUserVerification: true,
+        supportedAlgorithmIDs: SUPPORTED_COSE_ALGORITHM_IDS
       });
     } catch (error: unknown) {
       await clearChallenge(userId);

--- a/backend/src/services/webauthn/webauthn-service.ts
+++ b/backend/src/services/webauthn/webauthn-service.ts
@@ -10,6 +10,7 @@ import {
 
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
+import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 
 import { MfaMethod } from "../auth/auth-type";
@@ -318,15 +319,18 @@ export const webAuthnServiceFactory = ({
   const getUserWebAuthnCredentials = async ({ userId }: TGetUserWebAuthnCredentialsDTO) => {
     const credentials = await webAuthnCredentialDAL.find({ userId });
 
-    // Don't return sensitive data like public keys
-    return credentials.map((cred) => ({
-      id: cred.id,
-      credentialId: cred.credentialId,
-      name: cred.name,
-      transports: cred.transports,
-      createdAt: cred.createdAt,
-      lastUsedAt: cred.lastUsedAt
-    }));
+    return {
+      fipsEnabled: crypto.isFipsModeEnabled(),
+      // Don't return sensitive data like public keys
+      credentials: credentials.map((cred) => ({
+        id: cred.id,
+        credentialId: cred.credentialId,
+        name: cred.name,
+        transports: cred.transports,
+        createdAt: cred.createdAt,
+        lastUsedAt: cred.lastUsedAt
+      }))
+    };
   };
 
   /**

--- a/backend/src/services/webauthn/webauthn-service.ts
+++ b/backend/src/services/webauthn/webauthn-service.ts
@@ -86,6 +86,13 @@ export const webAuthnServiceFactory = ({
       userName: user.email || "",
       userDisplayName: user.email || "",
       attestationType: "none",
+      // ES256/RS256 only. The library default also offers EdDSA (-8) first, which
+      // Ed25519-capable authenticators (e.g. modern YubiKeys) will pick, but Ed25519
+      // cannot be verified under FIPS mode (OpenSSL FIPS provider rejects the key
+      // import with "Invalid keyData"), so the credential enrolls and then always
+      // fails MFA. ES256 is mandatory for FIDO2 authenticators, so nothing is
+      // excluded in practice;
+      supportedAlgorithmIDs: [-7, -257],
       excludeCredentials: existingCredentials.map((cred) => ({
         id: cred.credentialId,
         transports: cred.transports as AuthenticatorTransportFuture[]

--- a/frontend/src/hooks/api/webauthn/queries.tsx
+++ b/frontend/src/hooks/api/webauthn/queries.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
 
-import { TWebAuthnCredential } from "./types";
+import { TGetWebAuthnCredentialsResponse } from "./types";
 
 export const webAuthnKeys = {
   credentials: ["webauthn-credentials"] as const,
@@ -14,9 +14,9 @@ export const useGetWebAuthnCredentials = () =>
   useQuery({
     queryKey: webAuthnKeys.credentials,
     queryFn: async () => {
-      const { data } = await apiRequest.get<{ credentials: TWebAuthnCredential[] }>(
+      const { data } = await apiRequest.get<TGetWebAuthnCredentialsResponse>(
         "/api/v1/user/me/webauthn"
       );
-      return data.credentials;
+      return data;
     }
   });

--- a/frontend/src/hooks/api/webauthn/types.ts
+++ b/frontend/src/hooks/api/webauthn/types.ts
@@ -14,6 +14,11 @@ export type TWebAuthnCredential = {
   lastUsedAt?: Date | null;
 };
 
+export type TGetWebAuthnCredentialsResponse = {
+  fipsEnabled: boolean;
+  credentials: TWebAuthnCredential[];
+};
+
 export type TGenerateRegistrationOptionsResponse = PublicKeyCredentialCreationOptionsJSON;
 
 export type TVerifyRegistrationDTO = {

--- a/frontend/src/hooks/api/webauthn/useRegisterPasskey.tsx
+++ b/frontend/src/hooks/api/webauthn/useRegisterPasskey.tsx
@@ -21,21 +21,8 @@ export const useRegisterPasskey = () => {
   const [isRegistering, setIsRegistering] = useState(false);
 
   const registerPasskey = async (name?: string, verify?: VerifyAttestation): Promise<boolean> => {
-    if (
-      !window.PublicKeyCredential ||
-      !window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable
-    ) {
+    if (!window.PublicKeyCredential) {
       createNotification({ text: "WebAuthn is not supported on this browser", type: "error" });
-      return false;
-    }
-
-    const isAuthenticatorAvailable =
-      await window.PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
-    if (!isAuthenticatorAvailable) {
-      createNotification({
-        text: "No passkey-compatible authenticator found on this device",
-        type: "error"
-      });
       return false;
     }
 

--- a/frontend/src/pages/user/PersonalSettingsPage/components/SecuritySection/MFASection.tsx
+++ b/frontend/src/pages/user/PersonalSettingsPage/components/SecuritySection/MFASection.tsx
@@ -47,7 +47,8 @@ export const MFASection = () => {
   const { isBusy: isEnabling, enableMfa } = useEnableMfa();
   const { isBusy: isDisabling, disableMfa } = useDisableMfa();
   const { data: totpConfiguration } = useGetUserTotpConfiguration();
-  const { data: webAuthnCredentials = [] } = useGetWebAuthnCredentials();
+  const { data: webAuthnData } = useGetWebAuthnCredentials();
+  const webAuthnCredentials = webAuthnData?.credentials ?? [];
   const { data: organizations = [] } = useGetOrganizations();
   const { data: serverDetails } = useFetchServerStatus();
 

--- a/frontend/src/pages/user/PersonalSettingsPage/components/SecuritySection/MfaMethodsCard.tsx
+++ b/frontend/src/pages/user/PersonalSettingsPage/components/SecuritySection/MfaMethodsCard.tsx
@@ -52,7 +52,8 @@ const MethodRow = ({ icon: Icon, title, description, badge, action }: MethodRowP
 export const MfaMethodsCard = () => {
   const queryClient = useQueryClient();
   const { data: totpConfiguration } = useGetUserTotpConfiguration();
-  const { data: webAuthnCredentials = [] } = useGetWebAuthnCredentials();
+  const { data: webAuthnData } = useGetWebAuthnCredentials();
+  const webAuthnCredentials = webAuthnData?.credentials ?? [];
   const { data: serverDetails } = useFetchServerStatus();
   const { removeTotp, isBusy: isRemovingTotp } = useRemoveTotp();
 

--- a/frontend/src/pages/user/PersonalSettingsPage/components/SecuritySection/PasskeyManagerDialog.tsx
+++ b/frontend/src/pages/user/PersonalSettingsPage/components/SecuritySection/PasskeyManagerDialog.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
-import { FingerprintIcon, PlusIcon, TrashIcon } from "lucide-react";
+import { FingerprintIcon, PlusIcon, TrashIcon, TriangleAlertIcon } from "lucide-react";
 
 import { ContentLoader } from "@app/components/v2";
 import {
+  Alert,
+  AlertDescription,
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -11,6 +13,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  AlertTitle,
   Button,
   Input,
   Sheet,
@@ -44,6 +47,17 @@ export const PasskeyManagerDialog = ({ isOpen, onOpenChange }: Props) => {
     }
   };
 
+  // Hardware security keys registered before the server pinned ES256/RS256 may hold an
+  // EdDSA credential that some instances (FIPS mode) cannot verify at sign-in. We can't
+  // inspect the credential's algorithm client-side, so surface a soft notice whenever a
+  // security-key credential is present. Platform and phone passkeys always report
+  // "internal"/"hybrid" transports and are unaffected.
+  const hasSecurityKeyCredential = credentials.some(
+    (credential) =>
+      !credential.transports?.length ||
+      !credential.transports.some((transport) => transport === "internal" || transport === "hybrid")
+  );
+
   // Removing weakens a login second factor, so it goes through the step-up MFA
   // challenge; the confirm dialog stays open until the challenge completes and the
   // removal succeeds.
@@ -76,6 +90,20 @@ export const PasskeyManagerDialog = ({ isOpen, onOpenChange }: Props) => {
                 <PlusIcon /> Add
               </Button>
             </div>
+
+            {hasSecurityKeyCredential && (
+              <Alert variant="warning">
+                <TriangleAlertIcon />
+                <AlertTitle>Using a hardware security key?</AlertTitle>
+                <AlertDescription>
+                  <p>
+                    Previously added security keys (like YubiKey) may use a signing algorithm that
+                    fails two-factor authentication on some instances. If signing in with your
+                    security key fails, remove it here and add it again.
+                  </p>
+                </AlertDescription>
+              </Alert>
+            )}
 
             {isPending ? (
               <ContentLoader />

--- a/frontend/src/pages/user/PersonalSettingsPage/components/SecuritySection/PasskeyManagerDialog.tsx
+++ b/frontend/src/pages/user/PersonalSettingsPage/components/SecuritySection/PasskeyManagerDialog.tsx
@@ -32,7 +32,8 @@ type Props = {
 };
 
 export const PasskeyManagerDialog = ({ isOpen, onOpenChange }: Props) => {
-  const { data: credentials = [], isPending } = useGetWebAuthnCredentials();
+  const { data, isPending } = useGetWebAuthnCredentials();
+  const credentials = data?.credentials ?? [];
   const { registerPasskey, isRegistering } = useRegisterPasskey();
   const { removePasskey, isBusy: isRemoving } = useRemovePasskey();
 
@@ -48,15 +49,20 @@ export const PasskeyManagerDialog = ({ isOpen, onOpenChange }: Props) => {
   };
 
   // Hardware security keys registered before the server pinned ES256/RS256 may hold an
-  // EdDSA credential that some instances (FIPS mode) cannot verify at sign-in. We can't
-  // inspect the credential's algorithm client-side, so surface a soft notice whenever a
-  // security-key credential is present. Platform and phone passkeys always report
-  // "internal"/"hybrid" transports and are unaffected.
-  const hasSecurityKeyCredential = credentials.some(
-    (credential) =>
-      !credential.transports?.length ||
-      !credential.transports.some((transport) => transport === "internal" || transport === "hybrid")
-  );
+  // EdDSA credential that FIPS instances cannot verify at sign-in. We can't inspect the
+  // credential's algorithm client-side, so on FIPS instances surface a soft notice
+  // whenever a security-key credential is present. Platform and phone passkeys always
+  // report "internal"/"hybrid" transports and are unaffected, and non-FIPS instances
+  // verify EdDSA fine.
+  const hasSecurityKeyCredential =
+    Boolean(data?.fipsEnabled) &&
+    credentials.some(
+      (credential) =>
+        !credential.transports?.length ||
+        !credential.transports.some(
+          (transport) => transport === "internal" || transport === "hybrid"
+        )
+    );
 
   // Removing weakens a login second factor, so it goes through the step-up MFA
   // challenge; the confirm dialog stays open until the challenge completes and the


### PR DESCRIPTION
## Context

Hardware security keys (e.g. YubiKey) could be registered as passkeys but then fail at MFA sign-in on FIPS-enabled instances. `@simplewebauthn/server` defaults to offering EdDSA (`-8`) first; Ed25519-capable keys pick it, but OpenSSL's FIPS provider rejects Ed25519 verification (`Invalid keyData`). Registration succeeds; authentication does not.

This PR:
- Pins registration to **ES256 (`-7`) and RS256 (`-257`)** only — both FIPS-compatible and mandatory for FIDO2 authenticators
- **Removes the platform-authenticator pre-check** that blocked hardware keys from registering
- **Adds a warning** in the passkey manager for existing security-key credentials that may need re-registration

## Steps to verify the change

- [ ] Register a new YubiKey/hardware security key on a FIPS instance — enrollment and MFA sign-in both succeed
- [ ] Register a platform passkey (Touch ID / Windows Hello) — still works
- [ ] Open passkey manager with an existing hardware key — warning is shown
- [ ] Re-register an affected security key after removing the old credential — MFA works

You can use chrome tools to generate a key:

<img width="687" height="774" alt="image" src="https://github.com/user-attachments/assets/05f56dce-2f66-425d-89ab-ff8ea191b23c" />

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)