### PR TITLE
fix: allow spaces and special characters in project search name validation

### DIFF
--- a/backend/src/server/routes/v1/deprecated-project-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-router.ts
@@ -707,9 +707,20 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         name: z
           .string()
           .trim()
-          .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
-            message: "Invalid pattern: only alphanumeric characters, - are allowed."
-          })
+          .refine(
+            (val) =>
+              characterValidator([
+                CharacterType.UnicodeLettersAndDigits,
+                CharacterType.Hyphen,
+                CharacterType.Spaces,
+                CharacterType.Underscore,
+                CharacterType.Period
+              ])(val),
+            {
+              message:
+                "Invalid pattern: only alphanumeric/unicode characters, spaces, hyphens, underscores, and periods are allowed."
+            }
+          )
           .optional()
       }),
       response: {

--- a/backend/src/server/routes/v1/deprecated-project-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-router.ts
@@ -707,20 +707,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         name: z
           .string()
           .trim()
-          .refine(
-            (val) =>
-              characterValidator([
-                CharacterType.UnicodeLettersAndDigits,
-                CharacterType.Hyphen,
-                CharacterType.Spaces,
-                CharacterType.Underscore,
-                CharacterType.Period
-              ])(val),
-            {
-              message:
-                "Invalid pattern: only alphanumeric/unicode characters, spaces, hyphens, underscores, and periods are allowed."
-            }
-          )
+          .transform((val) => val.normalize("NFC"))
           .optional()
       }),
       response: {

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -1165,9 +1165,20 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         name: z
           .string()
           .trim()
-          .refine((val) => characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen])(val), {
-            message: "Invalid pattern: only alphanumeric characters, - are allowed."
-          })
+          .refine(
+            (val) =>
+              characterValidator([
+                CharacterType.UnicodeLettersAndDigits,
+                CharacterType.Hyphen,
+                CharacterType.Spaces,
+                CharacterType.Underscore,
+                CharacterType.Period
+              ])(val),
+            {
+              message:
+                "Invalid pattern: only alphanumeric/unicode characters, spaces, hyphens, underscores, and periods are allowed."
+            }
+          )
           .optional()
       }),
       response: {

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -1165,20 +1165,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         name: z
           .string()
           .trim()
-          .refine(
-            (val) =>
-              characterValidator([
-                CharacterType.UnicodeLettersAndDigits,
-                CharacterType.Hyphen,
-                CharacterType.Spaces,
-                CharacterType.Underscore,
-                CharacterType.Period
-              ])(val),
-            {
-              message:
-                "Invalid pattern: only alphanumeric/unicode characters, spaces, hyphens, underscores, and periods are allowed."
-            }
-          )
+          .transform((val) => val.normalize("NFC"))
           .optional()
       }),
       response: {


### PR DESCRIPTION
## Summary
This PR fixes a bug in the "All Projects" page search where searching for project names containing spaces, underscores, periods, symbols, or Unicode characters failed due to overly strict backend validation.

## Context
When users searched for projects under **Organization > Projects > All Projects**, any query containing spaces (e.g., `"My Project"`) or other standard name characters was rejected by the backend. 
The backend schema for the search query's `name` parameter only allowed alphanumeric characters and hyphens (`[CharacterType.AlphaNumeric, CharacterType.Hyphen]`). This was too restrictive, as project names in Infisical can contain spaces, underscores, periods, and non-English (Unicode) characters.

This issue is reported in #5813.

## Changes
- Completely relaxed the `name` search query parameter validation in both `project-router.ts` and `deprecated-project-router.ts` to allow any valid string, matching the behavior of the project creation/update schemas.
- Added Unicode normalization (`NFC`) via Zod's `.transform()` to ensure that Unicode strings with combining marks (e.g., `e\u0301` instead of `é`) are correctly normalized before being processed.
- Ensured consistency across both the modern and deprecated/legacy project routers.

### Key Implementation Details
Rather than arbitrarily restricting search queries with an artificial character safelist, we aligned the search input schema with the actual characters allowed in project names (which have no character validation on creation, only a length limit of 64). 

The database layer is 100% secure: the search query parameter is fully parameterized by Knex (`whereILike`) and LIKE wildcards are properly escaped via `sanitizeSqlLikeString`, eliminating any risk of SQL injection.

By removing the restrictive regex-based `characterValidator` on search, we successfully:
1. Resolved the issue for multi-word project names (spaces).
2. Resolved issues for projects containing symbols allowed by the creation API (e.g., `Acme & Co`, `R&D (Prod)`).
3. Correctly normalized Unicode inputs to NFC to prevent validation/matching mismatches on accented characters.
4. Simplified the codebase and removed unnecessary validation complexity.

## Use Cases
- Searching for a project named `"My Infisical Project"` (contains spaces)
- Searching for a project named `"api-service_v2.0"` (contains hyphens, underscores, and periods)
- Searching for a project named `"R&D (Prod)"` (contains symbols)
- Searching for a project with non-English/Unicode characters in its name (e.g., `"Projet de Sécurité"`)

## Testing
1. Run unit tests to verify string validation continues to function as expected:
   ```bash
   npx vitest run src/lib/validator/validate-string.test.ts
   ```
2. Manually test the search endpoint using curl:
   ```bash
   curl -X GET "http://localhost:8080/api/v1/workspace?name=My%20Project" \
     -H "Authorization: Bearer <token>"
   ```
   Verify that it no longer returns a `400 Bad Request` validation error.

## Links
- Closes #5813
