### PR TITLE
fix: consider mode when creating approval commits in /batch

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1882,8 +1882,15 @@ export const secretApprovalRequestServiceFactory = ({
         }
 
         if (updateMode === SecretUpdateMode.Upsert) {
+          const createdKeys = new Set(commits.filter((c) => c.op === SecretOperations.Create).map((c) => c.key));
+
+          // Make sure secrets in the update list are not present in the create list as well
+          // This prevents a commit from having the same secret being created twice and causing
+          // conflicts.
+          const upsertSecrets = missingSecrets.filter((s) => !createdKeys.has(s.secretKey));
+
           commits.push(
-            ...missingSecrets.map((secret) => ({
+            ...upsertSecrets.map((secret) => ({
               op: SecretOperations.Create as const,
               version: 1,
               encryptedComment: setKnexStringValue(
@@ -1907,7 +1914,7 @@ export const secretApprovalRequestServiceFactory = ({
               type: SecretType.Shared
             }))
           );
-          missingSecrets.forEach(({ tagIds, secretKey }) => {
+          upsertSecrets.forEach(({ tagIds, secretKey }) => {
             if (tagIds?.length) commitTagIds[secretKey] = tagIds;
           });
         }

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1754,7 +1754,7 @@ export const secretApprovalRequestServiceFactory = ({
     secretPath,
     environment,
     commitMessage,
-    updateMode,
+    updateMode = SecretUpdateMode.FailOnNotFound,
     trx: providedTx
   }: TGenerateSecretApprovalRequestV2BridgeDTO & { trx?: Knex }) => {
     if (actor === ActorType.SERVICE || actor === ActorType.IDENTITY)
@@ -1875,7 +1875,7 @@ export const secretApprovalRequestServiceFactory = ({
       const missingSecrets = secretsToUpdate.filter((el) => !existingKeys.has(el.secretKey));
 
       if (missingSecrets.length) {
-        if (!updateMode || updateMode === SecretUpdateMode.FailOnNotFound) {
+        if (updateMode === SecretUpdateMode.FailOnNotFound) {
           throw new NotFoundError({
             message: `Secret does not exist: ${missingSecrets.map((el) => el.secretKey).join(", ")}`
           });

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1887,9 +1887,7 @@ export const secretApprovalRequestServiceFactory = ({
           // Make sure we don't create 2 Create operations for the same key
           const upsertSecrets = [
             ...new Map(
-              missingSecrets
-                .filter((s) => !createdKeys.has(s.secretKey))
-                .map((s) => [s.secretKey, s] as const)
+              missingSecrets.filter((s) => !createdKeys.has(s.secretKey)).map((s) => [s.secretKey, s] as const)
             ).values()
           ];
 

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -64,6 +64,7 @@ import {
   fnUpdateMovedSecretReferences,
   fnUpdateSecretLinkedReferences
 } from "@app/services/secret-v2-bridge/secret-v2-bridge-fns";
+import { SecretUpdateMode } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
 import { TSecretVersionV2DALFactory } from "@app/services/secret-v2-bridge/secret-version-dal";
 import { TSecretVersionV2TagDALFactory } from "@app/services/secret-v2-bridge/secret-version-tag-dal";
 import { TProjectSlackConfigDALFactory } from "@app/services/slack/project-slack-config-dal";
@@ -1753,6 +1754,7 @@ export const secretApprovalRequestServiceFactory = ({
     secretPath,
     environment,
     commitMessage,
+    updateMode,
     trx: providedTx
   }: TGenerateSecretApprovalRequestV2BridgeDTO & { trx?: Knex }) => {
     if (actor === ActorType.SERVICE || actor === ActorType.IDENTITY)
@@ -1855,7 +1857,6 @@ export const secretApprovalRequestServiceFactory = ({
         if (tagIds?.length) commitTagIds[secretKey] = tagIds;
       });
     }
-    // not secret approval for update operations
     const secretsToUpdate = data[SecretOperations.Update];
     if (secretsToUpdate && secretsToUpdate?.length) {
       const secretsToUpdateStoredInDB = await secretV2BridgeDAL.findBySecretKeys(
@@ -1870,14 +1871,51 @@ export const secretApprovalRequestServiceFactory = ({
         if (el.tags?.length) existingTagIds[el.key] = el.tags.map((i) => i.id);
       });
 
-      if (secretsToUpdateStoredInDB.length !== secretsToUpdate.length)
-        throw new NotFoundError({
-          message: `Secret does not exist: ${secretsToUpdateStoredInDB.map((el) => el.key).join(",")}`
-        });
+      const existingKeys = new Set(secretsToUpdateStoredInDB.map((el) => el.key));
+      const missingSecrets = secretsToUpdate.filter((el) => !existingKeys.has(el.secretKey));
 
-      // now find any secret that needs to update its name
-      // same process as above
-      const secretsWithNewName = secretsToUpdate.filter(({ newSecretName }) => Boolean(newSecretName));
+      if (missingSecrets.length) {
+        if (!updateMode || updateMode === SecretUpdateMode.FailOnNotFound) {
+          throw new NotFoundError({
+            message: `Secret does not exist: ${missingSecrets.map((el) => el.secretKey).join(", ")}`
+          });
+        }
+
+        if (updateMode === SecretUpdateMode.Upsert) {
+          commits.push(
+            ...missingSecrets.map((secret) => ({
+              op: SecretOperations.Create as const,
+              version: 1,
+              encryptedComment: setKnexStringValue(
+                secret.secretComment,
+                (value) => secretManagerEncryptor({ plainText: Buffer.from(value) }).cipherTextBlob
+              ),
+              encryptedValue: setKnexStringValue(
+                secret.secretValue,
+                (value) => secretManagerEncryptor({ plainText: Buffer.from(value) }).cipherTextBlob
+              ),
+              skipMultilineEncoding: secret.skipMultilineEncoding,
+              key: secret.secretKey,
+              secretMetadata: JSON.stringify(
+                (secret.secretMetadata || [])?.map((meta) => ({
+                  key: meta.key,
+                  [meta.isEncrypted ? "encryptedValue" : "value"]: meta.isEncrypted
+                    ? secretManagerEncryptor({ plainText: Buffer.from(meta.value) }).cipherTextBlob.toString("base64")
+                    : meta.value
+                }))
+              ),
+              type: SecretType.Shared
+            }))
+          );
+          missingSecrets.forEach(({ tagIds, secretKey }) => {
+            if (tagIds?.length) commitTagIds[secretKey] = tagIds;
+          });
+        }
+      }
+
+      const actualSecretsToUpdate = secretsToUpdate.filter((el) => existingKeys.has(el.secretKey));
+
+      const secretsWithNewName = actualSecretsToUpdate.filter(({ newSecretName }) => Boolean(newSecretName));
       if (secretsWithNewName.length) {
         const secrets = await secretV2BridgeDAL.findBySecretKeys(
           folderId,
@@ -1899,7 +1937,7 @@ export const secretApprovalRequestServiceFactory = ({
         secretsToUpdateStoredInDB.map(({ id }) => id)
       );
       commits.push(
-        ...secretsToUpdate.map(
+        ...actualSecretsToUpdate.map(
           ({
             newSecretName,
             secretKey,

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1884,10 +1884,14 @@ export const secretApprovalRequestServiceFactory = ({
         if (updateMode === SecretUpdateMode.Upsert) {
           const createdKeys = new Set(commits.filter((c) => c.op === SecretOperations.Create).map((c) => c.key));
 
-          // Make sure secrets in the update list are not present in the create list as well
-          // This prevents a commit from having the same secret being created twice and causing
-          // conflicts.
-          const upsertSecrets = missingSecrets.filter((s) => !createdKeys.has(s.secretKey));
+          // Make sure we don't create 2 Create operations for the same key
+          const upsertSecrets = [
+            ...new Map(
+              missingSecrets
+                .filter((s) => !createdKeys.has(s.secretKey))
+                .map((s) => [s.secretKey, s] as const)
+            ).values()
+          ];
 
           commits.push(
             ...upsertSecrets.map((secret) => ({

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-types.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-types.ts
@@ -2,6 +2,7 @@ import { TImmutableDBKeys, TSecretApprovalPolicies, TSecretApprovalRequestsSecre
 import { TProjectPermission } from "@app/lib/types";
 import { ResourceMetadataWithEncryptionDTO } from "@app/services/resource-metadata/resource-metadata-schema";
 import { SecretOperations } from "@app/services/secret/secret-types";
+import { SecretUpdateMode } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
 
 export enum RequestState {
   Open = "open",
@@ -62,6 +63,7 @@ export type TGenerateSecretApprovalRequestV2BridgeDTO = {
   secretPath: string;
   commitMessage?: string;
   policy: TSecretApprovalPolicies;
+  updateMode?: SecretUpdateMode;
   data: {
     [SecretOperations.Create]?: TApprovalCreateSecretV2Bridge[];
     [SecretOperations.Update]?: TApprovalUpdateSecretV2Bridge[];

--- a/backend/src/server/routes/v3/deprecated-secret-router.ts
+++ b/backend/src/server/routes/v3/deprecated-secret-router.ts
@@ -2366,8 +2366,29 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         inputSecrets.map(({ secretKey, secretMetadata }) => [secretKey, secretMetadata])
       );
 
+      // updateManySecretsRaw can return an empty list of secrets
+      // if mode=ignore, a change policy exists and all secrets
+      // do not exist in the DB, so we have to resolve the projectId
+      // for the auditLog and posthog events
+      let projectId = req.body.workspaceId;
+      if (!projectId) {
+        if (secrets.length > 0) {
+          projectId = secrets[0].workspace;
+        } else {
+          const extractedProjectId = await server.services.project.extractProjectIdFromSlug({
+            projectSlug,
+            actorId: req.permission.id,
+            actor: req.permission.type,
+            actorAuthMethod: req.permission.authMethod,
+            actorOrgId: req.permission.orgId,
+          });
+
+          projectId = extractedProjectId;
+        }
+      }
+
       await server.services.auditLog.createAuditLog({
-        projectId: secrets[0].workspace,
+        projectId,
         ...req.auditLogInfo,
         event: {
           type: EventType.UPDATE_SECRETS,

--- a/backend/src/server/routes/v3/deprecated-secret-router.ts
+++ b/backend/src/server/routes/v3/deprecated-secret-router.ts
@@ -2380,7 +2380,7 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
             actorId: req.permission.id,
             actor: req.permission.type,
             actorAuthMethod: req.permission.authMethod,
-            actorOrgId: req.permission.orgId,
+            actorOrgId: req.permission.orgId
           });
 
           projectId = extractedProjectId;

--- a/backend/src/server/routes/v3/deprecated-secret-router.ts
+++ b/backend/src/server/routes/v3/deprecated-secret-router.ts
@@ -2415,7 +2415,7 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
       const createdSecrets = secrets.filter((el) => el.version === 1);
       if (createdSecrets.length) {
         await server.services.auditLog.createAuditLog({
-          projectId: secrets[0].workspace,
+          projectId,
           ...req.auditLogInfo,
           event: {
             type: EventType.CREATE_SECRETS,
@@ -2445,7 +2445,7 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         organizationId: req.permission.orgId,
         properties: {
           numberOfSecrets: secrets.length,
-          projectId: secrets[0].workspace,
+          projectId,
           environment: req.body.environment,
           secretPath: req.body.secretPath,
           channel: getUserAgentType(req.headers["user-agent"]),

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -2400,6 +2400,7 @@ export const secretServiceFactory = ({
           actorId,
           actorOrgId,
           actorAuthMethod,
+          updateMode: mode,
           data: {
             [SecretOperations.Update]: inputSecrets.map((el) => ({
               tagIds: el.tagIds,

--- a/backend/src/services/secret/secret-service.ts
+++ b/backend/src/services/secret/secret-service.ts
@@ -2391,28 +2391,38 @@ export const secretServiceFactory = ({
       }
 
       if (policy) {
-        const approval = await secretApprovalRequestService.generateSecretApprovalRequestV2Bridge({
-          policy,
-          secretPath,
-          environment,
-          projectId,
-          actor,
-          actorId,
-          actorOrgId,
-          actorAuthMethod,
-          updateMode: mode,
-          data: {
-            [SecretOperations.Update]: inputSecrets.map((el) => ({
-              tagIds: el.tagIds,
-              secretValue: el.secretValue,
-              secretComment: el.secretComment,
-              skipMultilineEncoding: el.skipMultilineEncoding,
-              secretKey: el.secretKey,
-              secretMetadata: el.secretMetadata
-            }))
+        try {
+          const approval = await secretApprovalRequestService.generateSecretApprovalRequestV2Bridge({
+            policy,
+            secretPath,
+            environment,
+            projectId,
+            actor,
+            actorId,
+            actorOrgId,
+            actorAuthMethod,
+            updateMode: mode,
+            data: {
+              [SecretOperations.Update]: inputSecrets.map((el) => ({
+                tagIds: el.tagIds,
+                secretValue: el.secretValue,
+                secretComment: el.secretComment,
+                skipMultilineEncoding: el.skipMultilineEncoding,
+                secretKey: el.secretKey,
+                secretMetadata: el.secretMetadata
+              }))
+            }
+          });
+          return { type: SecretProtectionType.Approval as const, approval };
+        } catch (e) {
+          // If mode is ignore and an update where all secrets do not exist, this can cause the
+          // "empty commits" error. But since mode is to ignore, we swallow that error and return
+          // as it was a no-op operation.
+          if (mode === SecretUpdateMode.Ignore && e instanceof BadRequestError && e.message === "Empty commits") {
+            return { type: SecretProtectionType.Direct as const, secrets: [] };
           }
-        });
-        return { type: SecretProtectionType.Approval as const, approval };
+          throw e;
+        }
       }
       const secrets = await secretV2BridgeService.updateManySecret({
         secretPath,


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

When generating secret approval requests, we never considered that `mode` could be provided. But if user uses their own user token to call the API using the `/v4/secrets/batch` endpoint, they will face a 404 error if one of the secrets don't exist yet. This only happens if there's an approval policy in place.

Now,  it considers `FailOnNotFound`as the default behavior, but it also allows the caller to override that to be `upsert`/`ignore`.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)