### PR TITLE
docs: surface Docker CLI usage in quickstart, embed Docker video

### DIFF
--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -85,6 +85,39 @@ The CLI is designed for a variety of secret management applications ranging from
 
   </Tab>
 
+  <Tab title="Docker containers">
+    Install the Infisical CLI into your Docker image and start your application with it to inject secrets at runtime.
+
+    <Steps>
+      <Step title="Install the Infisical CLI in your Dockerfile">
+        Install the CLI with the package manager of your base image. The example below targets Alpine; find the commands for other distributions [here](/cli/overview).
+
+        ```dockerfile
+        RUN apk add --no-cache bash wget && \
+            wget -qO- 'https://artifacts-cli.infisical.com/setup.apk.sh' | sh && \
+            apk update && apk add infisical
+        ```
+      </Step>
+      <Step title="Start your application with the CLI">
+        Set your container start command to run your application through `infisical run`. The CLI fetches your secrets from Infisical and injects them as environment variables.
+
+        ```dockerfile
+        CMD ["infisical", "run", "--projectId", "<your-project-id>", "--env", "prod", "--", "npm", "run", "start"]
+        ```
+      </Step>
+      <Step title="Authenticate the container">
+        Create a [machine identity](/documentation/platform/identities/machine-identities) and pass its access token to the container through the `INFISICAL_TOKEN` environment variable.
+
+        ```bash
+        docker run --env INFISICAL_TOKEN=$INFISICAL_TOKEN <your-image>
+        ```
+      </Step>
+    </Steps>
+
+    For Docker Compose and `--env-file` workflows, see the [Docker guides](/integrations/platforms/docker-intro).
+
+  </Tab>
+
   <Tab title="Staging, production & all other use cases">
     In the following steps, we explore how to use the Infisical CLI in a non-local development scenario
     to fetch back environment variables and export them to a file.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -664,6 +664,15 @@
                   {
                     "group": "Infrastructure",
                     "pages": [
+                      {
+                        "group": "Docker",
+                        "pages": [
+                          "integrations/platforms/docker-intro",
+                          "integrations/platforms/docker",
+                          "integrations/platforms/docker-pass-envs",
+                          "integrations/platforms/docker-compose"
+                        ]
+                      },
                       "integrations/platforms/ansible",
                       "integrations/platforms/apache-airflow",
                       {
@@ -676,15 +685,6 @@
                         "pages": [
                           "integrations/platforms/infisical-agent",
                           "integrations/platforms/ecs-with-agent"
-                        ]
-                      },
-                      {
-                        "group": "Docker",
-                        "pages": [
-                          "integrations/platforms/docker-intro",
-                          "integrations/platforms/docker",
-                          "integrations/platforms/docker-pass-envs",
-                          "integrations/platforms/docker-compose"
                         ]
                       },
                       "integrations/frameworks/packer",

--- a/docs/integrations/platforms/docker-intro.mdx
+++ b/docs/integrations/platforms/docker-intro.mdx
@@ -5,6 +5,22 @@ description: "Learn how to feed secrets from Infisical into your Docker applicat
 There are many methods to inject Infisical secrets into Docker-based applications. 
 Regardless of the method you choose, they all inject secrets from Infisical as environment variables into your Docker container.
 
+Watch the video below for an overview of managing environment variables in Docker, covering Docker Compose, Docker secrets, and injection with the Infisical CLI.
+
+<br />
+
+<div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", maxWidth: "100%" }}>
+  <iframe
+    src="https://www.youtube.com/embed/oU2nNBwlOTA"
+    title="YouTube video player"
+    style={{ position: "absolute", top: 0, left: 0, width: "100%", height: "100%", border: 0 }}
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+  ></iframe>
+</div>
+
+<br />
+
 <Card title="Docker Entrypoint" color="#ea5a0c" href="./docker">
   Install and run your app start command with Infisical CLI
 </Card>


### PR DESCRIPTION
## Context

The Docker guides live at Products > Infrastructure Integrations > Docker, four levels deep in the sidebar, while the CLI Quickstart (where developers actually start) never mentions Docker. This makes "how do I use the CLI in a container" needlessly hard to find.

This PR:
- Adds a "Docker containers" tab to the CLI Quickstart (`docs/cli/usage.mdx`): install the CLI in the Dockerfile, start the app through `infisical run`, authenticate with a machine identity token. Links onward to the full Docker guides for Compose and `--env-file` workflows.
- Embeds the new video "The Best Way to Manage .env Variables in Docker" on the Docker hub page (`docs/integrations/platforms/docker-intro.mdx`), using the same responsive iframe pattern as other video pages.
- Reorders the Infrastructure integrations nav in `docs/docs.json` so Docker is listed first instead of sixth.

## Steps to verify the change

- Open the docs preview deployment
- Visit CLI > Quickstart and check the new "Docker containers" tab
- Visit Integrations > Infrastructure > Docker and check the embedded video plays

## Type

- [x] Docs

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
