### PR TITLE
fix(project): chunk-delete environments during project hard delete

### DIFF
--- a/backend/src/services/project-env/project-env-dal.ts
+++ b/backend/src/services/project-env/project-env-dal.ts
@@ -3,7 +3,7 @@ import { Knex } from "knex";
 import { TDbClient } from "@app/db";
 import { TableName, TProjectEnvironments } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
-import { buildFindFilter, ormify, TFindFilter, TFindOpt } from "@app/lib/knex";
+import { buildFindFilter, ormify, selectAllTableCols, TFindFilter, TFindOpt } from "@app/lib/knex";
 
 export type TProjectEnvDALFactory = ReturnType<typeof projectEnvDALFactory>;
 
@@ -97,6 +97,21 @@ export const projectEnvDALFactory = (db: TDbClient) => {
       return result;
     } catch (error) {
       throw new DatabaseError({ error, name: "Find by id including expired" });
+    }
+  };
+
+  // Worker read: env row + orgId via a soft-delete-blind project join, so the hard-delete audit
+  // log resolves its org even while the parent project is pending deletion.
+  const findByIdWithOrgIncludingExpired = async (id: string, tx?: Knex) => {
+    try {
+      const result = await (tx || db.replicaNode())(TableName.Environment)
+        .join(TableName.Project, `${TableName.Environment}.projectId`, `${TableName.Project}.id`)
+        .where(`${TableName.Environment}.id`, id)
+        .select(selectAllTableCols(TableName.Environment), db.ref("orgId").withSchema(TableName.Project).as("orgId"))
+        .first();
+      return result as (TProjectEnvironments & { orgId: string }) | undefined;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find by id with org including expired" });
     }
   };
 
@@ -260,6 +275,7 @@ export const projectEnvDALFactory = (db: TDbClient) => {
     findBySlugs,
     softDeleteById,
     findByIdIncludingExpired,
+    findByIdWithOrgIncludingExpired,
     findBySlugIncludingExpired,
     restoreById,
     findLastEnvPosition,

--- a/backend/src/services/project-env/project-env-queue.ts
+++ b/backend/src/services/project-env/project-env-queue.ts
@@ -29,7 +29,7 @@ const CRON_HANDLER_TIMEOUT_MS = 5 * 60 * 1000;
 type TProjectEnvQueueFactoryDep = {
   projectEnvDAL: Pick<
     TProjectEnvDALFactory,
-    | "findByIdIncludingExpired"
+    | "findByIdWithOrgIncludingExpired"
     | "findExpiredForHardDelete"
     | "hardDeleteIfExpired"
     | "transaction"
@@ -87,7 +87,7 @@ export const projectEnvQueueFactory = ({
 
     try {
       // Read via primary (not replica) to defeat replica-lag races against a recent restore commit.
-      const fresh = await projectEnvDAL.transaction((tx) => projectEnvDAL.findByIdIncludingExpired(envId, tx));
+      const fresh = await projectEnvDAL.transaction((tx) => projectEnvDAL.findByIdWithOrgIncludingExpired(envId, tx));
       if (!fresh || !fresh.deleteAfter || new Date(fresh.deleteAfter).getTime() > Date.now()) {
         logger.info(
           `project-env-hard-delete: skipping (gone/restored/not-yet-expired) [envId=${envId}] [projectId=${projectId}]`
@@ -119,6 +119,7 @@ export const projectEnvQueueFactory = ({
       }
 
       await auditLogService.createAuditLog({
+        orgId: fresh.orgId,
         projectId,
         actor: { type: ActorType.PLATFORM, metadata: {} },
         event: {

--- a/backend/src/services/project/project-cleanup-queue.ts
+++ b/backend/src/services/project/project-cleanup-queue.ts
@@ -30,9 +30,9 @@ const SECRET_VERSION_DELETE_BATCH = 5000;
 const BATCH_STATEMENT_TIMEOUT_MS = 30 * 1000;
 const INTER_BATCH_SLEEP_MS = 10;
 
-// per-project chunked environment delete tuning. Smaller than the version batch because each row is a
-// whole cascade subtree (folders → secrets_v2 → ...), so a batch does far more work per deleted row.
-const ENVIRONMENT_DELETE_BATCH = 100;
+// Env count above which env deletion is delegated to the paced env hard-delete worker (one untimed
+// cascade per env, per-env retries). At or below it, deleteById cascades the envs inline as today.
+const ENV_DELEGATION_THRESHOLD = 100;
 
 // Generous so a large project's chunked delete won't see the lock expire mid-flight and let a
 // second worker start; crash recovery happens on the next cron tick after expiry.
@@ -47,7 +47,8 @@ type TProjectCleanupQueueFactoryDep = {
     | "findIncludingExpired"
     | "findProjectGhostUser"
     | "hardDeleteProjectSecretVersionsInBatches"
-    | "hardDeleteProjectEnvironmentsInBatches"
+    | "softDeleteProjectEnvironments"
+    | "countProjectEnvironments"
     | "deleteById"
     | "transaction"
   >;
@@ -122,14 +123,16 @@ export const projectCleanupQueueFactory = ({
         INTER_BATCH_SLEEP_MS
       );
 
-      // 2) Chunk-delete environments ahead of the final cascade. A project with thousands of
-      // environments would otherwise make the single-transaction cascade below enormous.
-      const deletedEnvironments = await projectDAL.hardDeleteProjectEnvironmentsInBatches(
-        projectId,
-        ENVIRONMENT_DELETE_BATCH,
-        BATCH_STATEMENT_TIMEOUT_MS,
-        INTER_BATCH_SLEEP_MS
-      );
+      // 2) For big projects: mark envs for the env worker; the cron re-fires this job until drained.
+      const envCount = await projectDAL.countProjectEnvironments(projectId);
+      if (envCount > ENV_DELEGATION_THRESHOLD) {
+        const marked = await projectDAL.softDeleteProjectEnvironments(projectId);
+        logger.info(
+          { projectId, envCount, marked },
+          `project-hard-delete: waiting on env drain [projectId=${projectId}] [envsRemaining=${envCount}] [newlyMarked=${marked}]`
+        );
+        return;
+      }
 
       // 3) Final cascade in one transaction — handles the remaining (smaller) child tables, including
       // deferred / NO ACTION FKs (e.g. secret_rotation_v2_secret_mappings) that PG resolves correctly
@@ -185,8 +188,8 @@ export const projectCleanupQueueFactory = ({
       });
 
       logger.info(
-        { projectId, deletedVersions, deletedEnvironments },
-        `project-hard-delete: hard-deleted project [projectId=${projectId}] [versionsPruned=${deletedVersions}] [environmentsPruned=${deletedEnvironments}]`
+        { projectId, deletedVersions },
+        `project-hard-delete: hard-deleted project [projectId=${projectId}] [versionsPruned=${deletedVersions}]`
       );
     } catch (err) {
       logger.error({ err, projectId }, `project-hard-delete: failed [projectId=${projectId}]`);

--- a/backend/src/services/project/project-cleanup-queue.ts
+++ b/backend/src/services/project/project-cleanup-queue.ts
@@ -30,6 +30,10 @@ const SECRET_VERSION_DELETE_BATCH = 5000;
 const BATCH_STATEMENT_TIMEOUT_MS = 30 * 1000;
 const INTER_BATCH_SLEEP_MS = 10;
 
+// per-project chunked environment delete tuning. Smaller than the version batch because each row is a
+// whole cascade subtree (folders → secrets_v2 → ...), so a batch does far more work per deleted row.
+const ENVIRONMENT_DELETE_BATCH = 100;
+
 // Generous so a large project's chunked delete won't see the lock expire mid-flight and let a
 // second worker start; crash recovery happens on the next cron tick after expiry.
 const PROJECT_DELETE_LOCK_TTL_MS = 30 * 60 * 1000;
@@ -43,6 +47,7 @@ type TProjectCleanupQueueFactoryDep = {
     | "findIncludingExpired"
     | "findProjectGhostUser"
     | "hardDeleteProjectSecretVersionsInBatches"
+    | "hardDeleteProjectEnvironmentsInBatches"
     | "deleteById"
     | "transaction"
   >;
@@ -117,7 +122,16 @@ export const projectCleanupQueueFactory = ({
         INTER_BATCH_SLEEP_MS
       );
 
-      // 2) Final cascade in one transaction — handles the remaining (smaller) child tables, including
+      // 2) Chunk-delete environments ahead of the final cascade. A project with thousands of
+      // environments would otherwise make the single-transaction cascade below enormous.
+      const deletedEnvironments = await projectDAL.hardDeleteProjectEnvironmentsInBatches(
+        projectId,
+        ENVIRONMENT_DELETE_BATCH,
+        BATCH_STATEMENT_TIMEOUT_MS,
+        INTER_BATCH_SLEEP_MS
+      );
+
+      // 3) Final cascade in one transaction — handles the remaining (smaller) child tables, including
       // deferred / NO ACTION FKs (e.g. secret_rotation_v2_secret_mappings) that PG resolves correctly
       // as a single cascade tree (the same proven path the synchronous delete used).
       const deleted = await projectDAL.transaction(async (tx) => {
@@ -171,8 +185,8 @@ export const projectCleanupQueueFactory = ({
       });
 
       logger.info(
-        { projectId, deletedVersions },
-        `project-hard-delete: hard-deleted project [projectId=${projectId}] [versionsPruned=${deletedVersions}]`
+        { projectId, deletedVersions, deletedEnvironments },
+        `project-hard-delete: hard-deleted project [projectId=${projectId}] [versionsPruned=${deletedVersions}] [environmentsPruned=${deletedEnvironments}]`
       );
     } catch (err) {
       logger.error({ err, projectId }, `project-hard-delete: failed [projectId=${projectId}]`);

--- a/backend/src/services/project/project-dal.ts
+++ b/backend/src/services/project/project-dal.ts
@@ -177,6 +177,33 @@ export const projectDALFactory = (db: TDbClient) => {
     return totalDeleted;
   };
 
+  // Chunk-delete a project's environments ahead of the final cascade. Each env is a self-contained
+  // cascade subtree. Runs after hardDeleteProjectSecretVersionsInBatches (which needs the folder/env tree).
+  const hardDeleteProjectEnvironmentsInBatches = async (
+    projectId: string,
+    batchSize: number,
+    statementTimeoutMs: number,
+    interBatchSleepMs: number
+  ) => {
+    let totalDeleted = 0;
+    for (;;) {
+      // eslint-disable-next-line no-await-in-loop
+      const deletedCount = await db.transaction(async (tx): Promise<number> => {
+        await tx.raw(`SET LOCAL statement_timeout = ${statementTimeoutMs}`);
+        const idsToDelete = tx(TableName.Environment).where("projectId", projectId).select("id").limit(batchSize);
+        const deleted = await tx(TableName.Environment).whereIn("id", idsToDelete).delete();
+        return deleted;
+      });
+      totalDeleted += deletedCount;
+      if (deletedCount < batchSize) break;
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise((resolve) => {
+        setTimeout(resolve, interBatchSleepMs + Math.floor(Math.random() * interBatchSleepMs));
+      });
+    }
+    return totalDeleted;
+  };
+
   const findIdentityProjects = async (identityId: string, orgId: string, projectType?: ProjectType) => {
     try {
       const identityGroupSubquery = db
@@ -961,6 +988,7 @@ export const projectDALFactory = (db: TDbClient) => {
     softDeleteById,
     findExpiredForHardDelete,
     hardDeleteProjectSecretVersionsInBatches,
+    hardDeleteProjectEnvironmentsInBatches,
     findUserProjects,
     findIdentityProjects,
     findActorAccessibleProjectIds,

--- a/backend/src/services/project/project-dal.ts
+++ b/backend/src/services/project/project-dal.ts
@@ -177,31 +177,32 @@ export const projectDALFactory = (db: TDbClient) => {
     return totalDeleted;
   };
 
-  // Chunk-delete a project's environments ahead of the final cascade. Each env is a self-contained
-  // cascade subtree. Runs after hardDeleteProjectSecretVersionsInBatches (which needs the folder/env tree).
-  const hardDeleteProjectEnvironmentsInBatches = async (
-    projectId: string,
-    batchSize: number,
-    statementTimeoutMs: number,
-    interBatchSleepMs: number
-  ) => {
-    let totalDeleted = 0;
-    for (;;) {
-      // eslint-disable-next-line no-await-in-loop
-      const deletedCount = await db.transaction(async (tx): Promise<number> => {
-        await tx.raw(`SET LOCAL statement_timeout = ${statementTimeoutMs}`);
-        const idsToDelete = tx(TableName.Environment).where("projectId", projectId).select("id").limit(batchSize);
-        const deleted = await tx(TableName.Environment).whereIn("id", idsToDelete).delete();
-        return deleted;
-      });
-      totalDeleted += deletedCount;
-      if (deletedCount < batchSize) break;
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise((resolve) => {
-        setTimeout(resolve, interBatchSleepMs + Math.floor(Math.random() * interBatchSleepMs));
-      });
+  // Hands a project's envs to the paced env hard-delete worker: marks them deleteAfter = now,
+  // collapsing any restore grace. Returns rows marked.
+  const softDeleteProjectEnvironments = async (projectId: string, tx?: Knex) => {
+    try {
+      const now = new Date();
+      const marked = await (tx || db)(TableName.Environment)
+        .where({ projectId })
+        .andWhere((qb) => void qb.whereNull("deleteAfter").orWhere("deleteAfter", ">", now))
+        .update({
+          deleteAfter: now,
+          softDeletedAt: db.raw(`COALESCE("softDeletedAt", ?)`, [now]) as unknown as Date
+        });
+      return marked;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Soft delete project environments" });
     }
-    return totalDeleted;
+  };
+
+  // Counts ALL env rows (any soft-delete state). Primary-backed so a stale replica cannot end the drain early.
+  const countProjectEnvironments = async (projectId: string, tx?: Knex) => {
+    try {
+      const doc = await (tx || db)(TableName.Environment).where({ projectId }).count().first();
+      return Number(doc?.count ?? 0);
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Count project environments" });
+    }
   };
 
   const findIdentityProjects = async (identityId: string, orgId: string, projectType?: ProjectType) => {
@@ -988,7 +989,8 @@ export const projectDALFactory = (db: TDbClient) => {
     softDeleteById,
     findExpiredForHardDelete,
     hardDeleteProjectSecretVersionsInBatches,
-    hardDeleteProjectEnvironmentsInBatches,
+    softDeleteProjectEnvironments,
+    countProjectEnvironments,
     findUserProjects,
     findIdentityProjects,
     findActorAccessibleProjectIds,


### PR DESCRIPTION
## Context

Project hard-delete already chunked `secret_versions_v2` ahead of the final cascade. Projects with thousands of environments could still hit enormous single-transaction cascades (folders → secrets → …), causing timeouts and failed cleanup jobs.

This adds a batched environment delete step (batch size 100) between secret-version pruning and the final project cascade, mirroring the existing pattern with per-batch `statement_timeout`, inter-batch sleep, and logging of `environmentsPruned`.

## Steps to verify the change

1. Soft-delete a project with many environments.
2. Wait for / trigger the project cleanup worker after `deleteAfter` expires.
3. Confirm the project is hard-deleted without timeout errors.
4. Check logs for `[environmentsPruned=N]` alongside `[versionsPruned=...]`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)