### PR TITLE
fix: updates DIGICERT_SERVICES_API_URL_EU to new endpoint

### DIFF
--- a/backend/src/services/integration-auth/integration-list.ts
+++ b/backend/src/services/integration-auth/integration-list.ts
@@ -102,7 +102,7 @@ export enum IntegrationUrls {
   CAMUNDA_API_URL = "https://api.cloud.camunda.io",
   DEVIN_API_URL = "https://api.devin.ai",
   DIGICERT_SERVICES_API_URL = "https://www.digicert.com/services/v2",
-  DIGICERT_SERVICES_API_URL_EU = "https://api-eu.digicert.com/services/v2",
+  DIGICERT_SERVICES_API_URL_EU = "https://certcentral.digicert.eu/services/v2",
 
   GODADDY_API_URL = "https://api.godaddy.com",
 


### PR DESCRIPTION
## Context

This pull request updates the European Digicert API endpoint in the `IntegrationUrls` enum to use the correct URL.

* Integration URL correction:
  * Updated the value of `DIGICERT_SERVICES_API_URL_EU` in `integration-list.ts` to `https://certcentral.digicert.eu/services/v2`

FYI I'm not sure where this URL came from, looks to be a hallucination. ([Ref1](https://github.com/search?q=%2Fapi-eu.digicert.com%2F&type=code) [Ref2](https://crt.sh/?q=api-eu.digicert.com) [Ref3](https://crt.sh/?q=digicert.com))


## Steps to verify the change

https://dev.digicert.com/certcentral-apis/services-api.html#:~:text=URL&text=API&text=API

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)