### PR TITLE
fix: frontend issues about cross project secret sharing

### DIFF
--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import { format, formatDistanceToNow } from "date-fns";
+import { format, formatDistanceToNowStrict } from "date-fns";
 import {
   Box,
   ChevronRight,
@@ -304,10 +304,9 @@ export const CrossProjectSharingSection = () => {
                 </AccordionTrigger>
                 <AccordionContent>
                   <div className="rounded-md border border-mineshaft-600">
-                    <div className="grid grid-cols-[1fr_auto_auto] items-center gap-4 border-b border-mineshaft-600 px-4 py-2 text-xs text-muted">
+                    <div className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-mineshaft-600 px-4 py-2 text-xs text-muted">
                       <span>Shared location in this project</span>
                       <span className="w-24 text-right">Secrets shared</span>
-                      <span className="w-32 text-right">Shared</span>
                     </div>
                     {projectGroup.grants
                       .sort((a, b) => {
@@ -318,32 +317,31 @@ export const CrossProjectSharingSection = () => {
                       .map((grant) => (
                         <div
                           key={grant.id}
-                          className="grid grid-cols-[1fr_auto_auto] items-center gap-4 border-b border-mineshaft-600 px-4 py-2.5 last:border-b-0"
+                          className="grid grid-cols-[1fr_auto] items-center gap-4 border-b border-mineshaft-600 px-4 py-2.5 last:border-b-0"
                         >
-                          <div className="flex items-center gap-2 text-sm">
-                            <Badge variant="neutral" className="gap-1.5">
-                              <Layers className="size-3" />
-                              {grant.environmentName}
-                            </Badge>
-                            <ChevronRight className="size-3.5 text-muted" />
-                            <FolderIcon className="size-3.5 text-muted" />
-                            <span>{grant.secretPath}</span>
-                          </div>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div className="flex w-fit items-center gap-2 text-sm">
+                                <Badge variant="neutral" className="gap-1.5">
+                                  <Layers className="size-3" />
+                                  {grant.environmentName}
+                                </Badge>
+                                <ChevronRight className="size-3.5 text-muted" />
+                                <FolderIcon className="size-3.5 text-muted" />
+                                <span>{grant.secretPath}</span>
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              Shared{" "}
+                              {formatDistanceToNowStrict(new Date(grant.createdAt), {
+                                addSuffix: true
+                              })}{" "}
+                              ({format(new Date(grant.createdAt), "MMM d, yyyy 'at' h:mm a")})
+                            </TooltipContent>
+                          </Tooltip>
                           <span className="w-24 text-right text-sm tabular-nums">
                             {grant.secretCount}
                           </span>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <span className="w-32 text-right text-sm whitespace-nowrap text-muted">
-                                {formatDistanceToNow(new Date(grant.createdAt), {
-                                  addSuffix: true
-                                }).replace(/^about /, "")}
-                              </span>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              {format(new Date(grant.createdAt), "MMM d, yyyy 'at' h:mm a")}
-                            </TooltipContent>
-                          </Tooltip>
                         </div>
                       ))}
                   </div>

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -296,7 +296,7 @@ export const CrossProjectSharingSection = () => {
                 <AccordionContent>
                   <div className="rounded-md border border-mineshaft-600">
                     <div className="flex items-center justify-between border-b border-mineshaft-600 px-4 py-2 text-xs text-muted">
-                      <span>Shared location in this project</span>
+                      <span>Shared locations in this project</span>
                       <span>Secrets shared</span>
                     </div>
                     {projectGroup.grants

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { format } from "date-fns";
-import { Box, Check, FolderIcon, Minus, Pencil, Plus, Trash2 } from "lucide-react";
+import { Box, ChevronRight, FolderIcon, Layers, Pencil, Plus, Trash2 } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -30,13 +30,7 @@ import {
   EmptyHeader,
   EmptyTitle,
   IconButton,
-  Input,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
+  Input
 } from "@app/components/v3";
 import { apiRequest } from "@app/config/request";
 import { useProject } from "@app/context";
@@ -52,8 +46,6 @@ type ProjectGroup = {
   targetProjectId: string;
   targetProjectName: string;
   totalSecrets: number;
-  folders: string[];
-  grantMatrix: Map<string, TProjectFolderGrant>;
   oldestGrantDate: string;
   grants: TProjectFolderGrant[];
 };
@@ -67,14 +59,8 @@ const groupGrantsByProject = (grants: TProjectFolderGrant[]): ProjectGroup[] => 
   }, new Map<string, TProjectFolderGrant[]>());
 
   return Array.from(byProject.entries()).map(([targetProjectId, projectGrants]) => {
-    const folderSet = new Set<string>();
-    const grantMatrix = new Map<string, TProjectFolderGrant>();
     let oldestDate = projectGrants[0].createdAt;
-
     projectGrants.forEach((g) => {
-      const folder = g.secretPath;
-      folderSet.add(folder);
-      grantMatrix.set(`${folder}:${g.environmentSlug}`, g);
       if (g.createdAt < oldestDate) oldestDate = g.createdAt;
     });
 
@@ -82,8 +68,6 @@ const groupGrantsByProject = (grants: TProjectFolderGrant[]): ProjectGroup[] => 
       targetProjectId,
       targetProjectName: projectGrants[0].targetProjectName,
       totalSecrets: projectGrants.reduce((sum, g) => sum + g.secretCount, 0),
-      folders: Array.from(folderSet).sort(),
-      grantMatrix,
       oldestGrantDate: oldestDate,
       grants: projectGrants
     };
@@ -310,51 +294,38 @@ export const CrossProjectSharingSection = () => {
                   </div>
                 </AccordionTrigger>
                 <AccordionContent>
-                  {(() => {
-                    const grantedSlugs = new Set(projectGroup.grants.map((g) => g.environmentSlug));
-                    const visibleEnvs = currentProject.environments.filter((env) =>
-                      grantedSlugs.has(env.slug)
-                    );
-
-                    return (
-                      <Table>
-                        <TableHeader>
-                          <TableRow>
-                            <TableHead>Folder</TableHead>
-                            {visibleEnvs.map((env) => (
-                              <TableHead key={env.slug} className="text-center">
-                                {env.name}
-                              </TableHead>
-                            ))}
-                          </TableRow>
-                        </TableHeader>
-                        <TableBody>
-                          {projectGroup.folders.map((folder) => (
-                            <TableRow key={folder}>
-                              <TableCell>
-                                <div className="flex items-center gap-1.5">
-                                  <FolderIcon className="size-3.5 text-muted" />
-                                  <span className="text-sm">{folder}</span>
-                                </div>
-                              </TableCell>
-                              {visibleEnvs.map((env) => {
-                                const grant = projectGroup.grantMatrix.get(`${folder}:${env.slug}`);
-                                return (
-                                  <TableCell key={env.slug} className="text-center">
-                                    {grant ? (
-                                      <Check className="mx-auto size-4 text-success" />
-                                    ) : (
-                                      <Minus className="mx-auto size-4 text-muted" />
-                                    )}
-                                  </TableCell>
-                                );
-                              })}
-                            </TableRow>
-                          ))}
-                        </TableBody>
-                      </Table>
-                    );
-                  })()}
+                  <div className="rounded-md border border-mineshaft-600">
+                    <div className="flex items-center justify-between border-b border-mineshaft-600 px-4 py-2 text-xs text-muted">
+                      <span>Shared location in this project</span>
+                      <span>Secrets shared</span>
+                    </div>
+                    {projectGroup.grants
+                      .sort((a, b) => {
+                        const envOrder =
+                          a.environmentName.localeCompare(b.environmentName);
+                        if (envOrder !== 0) return envOrder;
+                        return a.secretPath.localeCompare(b.secretPath);
+                      })
+                      .map((grant) => (
+                        <div
+                          key={grant.id}
+                          className="flex items-center justify-between border-b border-mineshaft-600 px-4 py-2.5 last:border-b-0"
+                        >
+                          <div className="flex items-center gap-2 text-sm">
+                            <Badge variant="neutral" className="gap-1.5">
+                              <Layers className="size-3" />
+                              {grant.environmentName}
+                            </Badge>
+                            <ChevronRight className="size-3.5 text-muted" />
+                            <FolderIcon className="size-3.5 text-muted" />
+                            <span>{grant.secretPath}</span>
+                          </div>
+                          <span className="text-sm tabular-nums">
+                            {grant.secretCount}
+                          </span>
+                        </div>
+                      ))}
+                  </div>
                 </AccordionContent>
               </AccordionItem>
             ))}

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -1,8 +1,17 @@
 import { useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
-import { format } from "date-fns";
-import { Box, ChevronRight, FolderIcon, Layers, Pencil, Plus, Trash2 } from "lucide-react";
+import { format, formatDistanceToNow } from "date-fns";
+import {
+  Box,
+  ChevronRight,
+  EllipsisVerticalIcon,
+  FolderIcon,
+  Layers,
+  PencilIcon,
+  Plus,
+  TrashIcon
+} from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -25,12 +34,19 @@ import {
   CardHeader,
   CardTitle,
   DocumentationLinkBadge,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyTitle,
   IconButton,
-  Input
+  Input,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
 } from "@app/components/v3";
 import { apiRequest } from "@app/config/request";
 import { useProject } from "@app/context";
@@ -46,7 +62,6 @@ type ProjectGroup = {
   targetProjectId: string;
   targetProjectName: string;
   totalSecrets: number;
-  oldestGrantDate: string;
   grants: TProjectFolderGrant[];
 };
 
@@ -58,20 +73,12 @@ const groupGrantsByProject = (grants: TProjectFolderGrant[]): ProjectGroup[] => 
     return map;
   }, new Map<string, TProjectFolderGrant[]>());
 
-  return Array.from(byProject.entries()).map(([targetProjectId, projectGrants]) => {
-    let oldestDate = projectGrants[0].createdAt;
-    projectGrants.forEach((g) => {
-      if (g.createdAt < oldestDate) oldestDate = g.createdAt;
-    });
-
-    return {
-      targetProjectId,
-      targetProjectName: projectGrants[0].targetProjectName,
-      totalSecrets: projectGrants.reduce((sum, g) => sum + g.secretCount, 0),
-      oldestGrantDate: oldestDate,
-      grants: projectGrants
-    };
-  });
+  return Array.from(byProject.entries()).map(([targetProjectId, projectGrants]) => ({
+    targetProjectId,
+    targetProjectName: projectGrants[0].targetProjectName,
+    totalSecrets: projectGrants.reduce((sum, g) => sum + g.secretCount, 0),
+    grants: projectGrants
+  }));
 };
 
 type DeleteProjectGrantsDialogProps = {
@@ -267,37 +274,40 @@ export const CrossProjectSharingSection = () => {
                       {projectGroup.totalSecrets === 1 ? "secret" : "secrets"} shared
                     </span>
                   </div>
-                  <div className="flex items-center gap-2 pr-2">
-                    <span className="text-xs text-muted">
-                      {format(new Date(projectGroup.oldestGrantDate), "MMM d, yyyy")}
-                    </span>
-                    <IconButton
-                      variant="ghost-muted"
-                      size="xs"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleEdit(projectGroup);
-                      }}
-                    >
-                      <Pencil />
-                    </IconButton>
-                    <IconButton
-                      variant="ghost-muted"
-                      size="xs"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setDeleteTarget(projectGroup);
-                      }}
-                    >
-                      <Trash2 />
-                    </IconButton>
+                  <div
+                    className="pr-2"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    role="presentation"
+                  >
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <IconButton aria-label="Actions" variant="ghost-muted" size="xs">
+                          <EllipsisVerticalIcon className="size-4" />
+                        </IconButton>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => handleEdit(projectGroup)}>
+                          <PencilIcon className="mr-2 size-4" />
+                          Edit
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          variant="danger"
+                          onClick={() => setDeleteTarget(projectGroup)}
+                        >
+                          <TrashIcon className="mr-2 size-4" />
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </div>
                 </AccordionTrigger>
                 <AccordionContent>
                   <div className="rounded-md border border-mineshaft-600">
-                    <div className="flex items-center justify-between border-b border-mineshaft-600 px-4 py-2 text-xs text-muted">
-                      <span>Shared locations in this project</span>
-                      <span>Secrets shared</span>
+                    <div className="grid grid-cols-[1fr_auto_auto] items-center gap-4 border-b border-mineshaft-600 px-4 py-2 text-xs text-muted">
+                      <span>Shared location in this project</span>
+                      <span className="w-24 text-right">Secrets shared</span>
+                      <span className="w-32 text-right">Shared</span>
                     </div>
                     {projectGroup.grants
                       .sort((a, b) => {
@@ -308,7 +318,7 @@ export const CrossProjectSharingSection = () => {
                       .map((grant) => (
                         <div
                           key={grant.id}
-                          className="flex items-center justify-between border-b border-mineshaft-600 px-4 py-2.5 last:border-b-0"
+                          className="grid grid-cols-[1fr_auto_auto] items-center gap-4 border-b border-mineshaft-600 px-4 py-2.5 last:border-b-0"
                         >
                           <div className="flex items-center gap-2 text-sm">
                             <Badge variant="neutral" className="gap-1.5">
@@ -319,7 +329,21 @@ export const CrossProjectSharingSection = () => {
                             <FolderIcon className="size-3.5 text-muted" />
                             <span>{grant.secretPath}</span>
                           </div>
-                          <span className="text-sm tabular-nums">{grant.secretCount}</span>
+                          <span className="w-24 text-right text-sm tabular-nums">
+                            {grant.secretCount}
+                          </span>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="w-32 text-right text-sm whitespace-nowrap text-muted">
+                                {formatDistanceToNow(new Date(grant.createdAt), {
+                                  addSuffix: true
+                                }).replace(/^about /, "")}
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {format(new Date(grant.createdAt), "MMM d, yyyy 'at' h:mm a")}
+                            </TooltipContent>
+                          </Tooltip>
                         </div>
                       ))}
                   </div>

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -301,8 +301,7 @@ export const CrossProjectSharingSection = () => {
                     </div>
                     {projectGroup.grants
                       .sort((a, b) => {
-                        const envOrder =
-                          a.environmentName.localeCompare(b.environmentName);
+                        const envOrder = a.environmentName.localeCompare(b.environmentName);
                         if (envOrder !== 0) return envOrder;
                         return a.secretPath.localeCompare(b.secretPath);
                       })
@@ -320,9 +319,7 @@ export const CrossProjectSharingSection = () => {
                             <FolderIcon className="size-3.5 text-muted" />
                             <span>{grant.secretPath}</span>
                           </div>
-                          <span className="text-sm tabular-nums">
-                            {grant.secretCount}
-                          </span>
+                          <span className="text-sm tabular-nums">{grant.secretCount}</span>
                         </div>
                       ))}
                   </div>

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -104,9 +104,10 @@ const PathAdder = ({ environment, existingPaths, onAdd }: PathAdderProps) => {
           }}
         />
       </div>
-      <IconButton variant="ghost-muted" size="sm" onClick={handleAdd} isDisabled={!canAdd}>
+      <Button variant="project" size="sm" onClick={handleAdd} isDisabled={!canAdd}>
         <Plus />
-      </IconButton>
+        Add
+      </Button>
     </div>
   );
 };
@@ -137,7 +138,14 @@ const EnvironmentGroupRow = ({
       <div className="flex items-center gap-2 px-3 py-2.5">
         <Layers className="size-4 shrink-0 text-muted" />
         {group.environment ? (
-          <span className="flex-1 text-sm font-medium">{envName ?? group.environment}</span>
+          <span className="flex-1 text-sm font-medium">
+            {envName ?? group.environment}
+            <span className="ml-2 text-xs font-normal text-muted">
+              {group.secretPaths.length === 0
+                ? "No paths selected"
+                : `${String(group.secretPaths.length)} path${group.secretPaths.length === 1 ? "" : "s"}`}
+            </span>
+          </span>
         ) : (
           <div className="flex-1">
             <Select
@@ -251,7 +259,7 @@ export const ShareSecretsSheet = ({
 
   const handleChangeEnvironment = (index: number, env: string) => {
     setGroups((prev) =>
-      prev.map((g, i) => (i === index ? { ...g, environment: env, secretPaths: ["/"] } : g))
+      prev.map((g, i) => (i === index ? { ...g, environment: env, secretPaths: [] } : g))
     );
   };
 

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/ShareSecretsSheet.tsx
@@ -116,6 +116,7 @@ type EnvironmentGroupRowProps = {
   group: EnvironmentGroup;
   index: number;
   environments: { id: string; slug: string; name: string }[];
+  usedEnvironments: Set<string>;
   onChangeEnvironment: (index: number, env: string) => void;
   onAddPath: (index: number, path: string) => void;
   onRemovePath: (index: number, pathIndex: number) => void;
@@ -126,6 +127,7 @@ const EnvironmentGroupRow = ({
   group,
   index,
   environments,
+  usedEnvironments,
   onChangeEnvironment,
   onAddPath,
   onRemovePath,
@@ -156,11 +158,13 @@ const EnvironmentGroupRow = ({
                 <SelectValue placeholder="Select environment" />
               </SelectTrigger>
               <SelectContent position="popper">
-                {environments.map((env) => (
-                  <SelectItem key={env.id} value={env.slug}>
-                    {env.name}
-                  </SelectItem>
-                ))}
+                {environments
+                  .filter((env) => !usedEnvironments.has(env.slug))
+                  .map((env) => (
+                    <SelectItem key={env.id} value={env.slug}>
+                      {env.name}
+                    </SelectItem>
+                  ))}
               </SelectContent>
             </Select>
           </div>
@@ -255,7 +259,10 @@ export const ShareSecretsSheet = ({
 
   const availableProjects = projects.filter((p) => p.id !== currentProject.id);
 
-  const hasValidEntry = groups.some((g) => g.environment && g.secretPaths.length > 0);
+  const usedEnvironments = new Set(groups.map((g) => g.environment).filter(Boolean));
+
+  const hasValidEntry =
+    groups.length > 0 && groups.every((g) => g.environment && g.secretPaths.length > 0);
 
   const handleChangeEnvironment = (index: number, env: string) => {
     setGroups((prev) =>
@@ -393,6 +400,7 @@ export const ShareSecretsSheet = ({
                   group={group}
                   index={index}
                   environments={currentProject.environments}
+                  usedEnvironments={usedEnvironments}
                   onChangeEnvironment={handleChangeEnvironment}
                   onAddPath={handleAddPath}
                   onRemovePath={handleRemovePath}
@@ -401,10 +409,12 @@ export const ShareSecretsSheet = ({
               ))}
             </div>
 
-            <Button variant="outline" size="sm" className="w-fit" onClick={handleAddGroup}>
-              <Layers className="size-3.5" />
-              Add another environment
-            </Button>
+            {groups.length < currentProject.environments.length && (
+              <Button variant="outline" size="sm" className="w-fit" onClick={handleAddGroup}>
+                <Layers className="size-3.5" />
+                Add another environment
+              </Button>
+            )}
 
             <div className="flex justify-center py-2">
               <ArrowDown className="size-4 text-muted" />

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -3222,6 +3222,7 @@ const OverviewPageContent = () => {
                                   handlePopUpOpen("deleteSecretImport", secretImport)
                                 }
                                 importedSecrets={importedSecretsFlat}
+                                isVisible={isSingleEnvSecretsVisible}
                               />
                             ))}
                           {!isSingleEnvView &&
@@ -3243,6 +3244,7 @@ const OverviewPageContent = () => {
                                     handlePopUpOpen("deleteSecretImport", secretImport)
                                   }
                                   importedSecrets={importedSecretsFlat}
+                                  isVisible={isSingleEnvSecretsVisible}
                                 />
                               )
                             )}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretImportTableRow/SecretImportSecretRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretImportTableRow/SecretImportSecretRow.tsx
@@ -10,6 +10,7 @@ type Props = {
   secretPath?: string;
   isEmpty?: boolean;
   missingFromEnvs?: string[];
+  isVisible?: boolean;
 };
 
 export const SecretImportSecretRow = ({
@@ -17,7 +18,8 @@ export const SecretImportSecretRow = ({
   environment,
   secretPath = "/",
   isEmpty,
-  missingFromEnvs
+  missingFromEnvs,
+  isVisible
 }: Props) => {
   return (
     <TableRow className="group">
@@ -40,6 +42,7 @@ export const SecretImportSecretRow = ({
           environment={environment}
           secretPath={secretPath}
           isEmpty={isEmpty}
+          isVisible={isVisible}
         />
       </TableCell>
     </TableRow>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretImportTableRow/SecretImportSecretValueCell.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretImportTableRow/SecretImportSecretValueCell.tsx
@@ -14,13 +14,15 @@ type Props = {
   environment: string;
   secretPath?: string;
   isEmpty?: boolean;
+  isVisible?: boolean;
 };
 
 export const SecretImportSecretValueCell = ({
   secretKey,
   environment,
   secretPath = "/",
-  isEmpty
+  isEmpty,
+  isVisible
 }: Props) => {
   const [isFieldFocused, setIsFieldFocused] = useToggle();
   const [isCopied, , setIsCopied] = useTimedReset<boolean>({ initialState: false });
@@ -41,7 +43,7 @@ export const SecretImportSecretValueCell = ({
       projectId: currentProject.id
     },
     {
-      enabled: isFieldFocused && canFetchSecretValue
+      enabled: (isFieldFocused || isVisible) && canFetchSecretValue
     }
   );
 
@@ -81,6 +83,7 @@ export const SecretImportSecretValueCell = ({
       <div className="flex-1">
         <SecretInput
           value={getValue()}
+          isVisible={isVisible}
           onFocus={() => setIsFieldFocused.on()}
           onBlur={() => setIsFieldFocused.off()}
           isReadOnly

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretImportTableRow/SecretImportTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretImportTableRow/SecretImportTableRow.tsx
@@ -77,6 +77,7 @@ type Props = {
   importedSecrets: ImportedSecretData[];
   index: number;
   secretImport?: TSecretImport;
+  isVisible?: boolean;
 };
 
 export const SecretImportTableRow = ({
@@ -92,7 +93,8 @@ export const SecretImportTableRow = ({
   onDelete,
   importedSecrets,
   index,
-  secretImport
+  secretImport,
+  isVisible
 }: Props) => {
   const [isExpanded, setIsExpanded] = useToggle(false);
   const [selectedReplicationEnv, setSelectedReplicationEnv] = useState<string>("");
@@ -536,6 +538,7 @@ export const SecretImportTableRow = ({
                   }
                   secretPath={getImportedSecretPath(selectedImport)}
                   isEmpty={secret.isEmpty}
+                  isVisible={isVisible}
                 />
               ))}
             </TableBody>
@@ -599,6 +602,7 @@ export const SecretImportTableRow = ({
                   }
                   isEmpty={secret.isEmpty}
                   missingFromEnvs={missingEnvNames}
+                  isVisible={isVisible}
                 />
               );
             })}
@@ -657,6 +661,7 @@ export const SecretImportTableRow = ({
               }
               secretPath={getImportedSecretPath(singleEnvImport)}
               isEmpty={secret.isEmpty}
+              isVisible={isVisible}
             />
           ))}
         </TableBody>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateSecretImportForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateSecretImportForm.tsx
@@ -103,7 +103,7 @@ export const CreateSecretImportForm = ({
 
   const [selectedSourceProjectId, setSelectedSourceProjectId] = useState<string | null>(null);
   const [selectedEnvironmentSlug, setSelectedEnvironmentSlug] = useState<string | null>(null);
-  const [selectedFolderName, setSelectedFolderName] = useState<string | null>(null);
+  const [selectedSecretPath, setSelectedSecretPath] = useState<string | null>(null);
 
   const uniqueSourceProjects = useMemo(() => {
     const seen = new Set<string>();
@@ -134,8 +134,8 @@ export const CreateSecretImportForm = ({
   );
 
   const selectedGrant = useMemo(
-    () => grantsForSelectedEnv.find((g) => g.folderName === selectedFolderName) ?? null,
-    [grantsForSelectedEnv, selectedFolderName]
+    () => grantsForSelectedEnv.find((g) => g.secretPath === selectedSecretPath) ?? null,
+    [grantsForSelectedEnv, selectedSecretPath]
   );
 
   const handleClose = () => {
@@ -143,7 +143,7 @@ export const CreateSecretImportForm = ({
     setImportSource("this-project");
     setSelectedSourceProjectId(null);
     setSelectedEnvironmentSlug(null);
-    setSelectedFolderName(null);
+    setSelectedSecretPath(null);
     onClose();
   };
 
@@ -283,8 +283,8 @@ export const CreateSecretImportForm = ({
     }));
 
     const folderOptions = grantsForSelectedEnv.map((g) => ({
-      label: g.folderName === "root" ? "/" : `/${g.folderName}`,
-      value: g.folderName
+      label: g.secretPath,
+      value: g.secretPath
     }));
 
     return (
@@ -306,7 +306,7 @@ export const CreateSecretImportForm = ({
                 const single = Array.isArray(newValue) ? newValue[0] : newValue;
                 setSelectedSourceProjectId(single && "value" in single ? single.value : null);
                 setSelectedEnvironmentSlug(null);
-                setSelectedFolderName(null);
+                setSelectedSecretPath(null);
               }}
             />
           </FieldContent>
@@ -329,7 +329,7 @@ export const CreateSecretImportForm = ({
               onChange={(newValue) => {
                 const single = Array.isArray(newValue) ? newValue[0] : newValue;
                 setSelectedEnvironmentSlug(single && "value" in single ? single.value : null);
-                setSelectedFolderName(null);
+                setSelectedSecretPath(null);
               }}
             />
           </FieldContent>
@@ -345,13 +345,13 @@ export const CreateSecretImportForm = ({
               placeholder="Select folder..."
               isDisabled={!selectedEnvironmentSlug}
               value={
-                selectedFolderName
-                  ? (folderOptions.find((o) => o.value === selectedFolderName) ?? null)
+                selectedSecretPath
+                  ? (folderOptions.find((o) => o.value === selectedSecretPath) ?? null)
                   : null
               }
               onChange={(newValue) => {
                 const single = Array.isArray(newValue) ? newValue[0] : newValue;
-                setSelectedFolderName(single && "value" in single ? single.value : null);
+                setSelectedSecretPath(single && "value" in single ? single.value : null);
               }}
             />
           </FieldContent>
@@ -434,7 +434,7 @@ export const CreateSecretImportForm = ({
               setImportSource(val as ImportSource);
               setSelectedSourceProjectId(null);
               setSelectedEnvironmentSlug(null);
-              setSelectedFolderName(null);
+              setSelectedSecretPath(null);
             }}
           >
             <div className="mx-auto flex items-center gap-2">

--- a/frontend/src/pages/secret-manager/SettingsPage/components/PoliciesTab/PoliciesTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/PoliciesTab/PoliciesTab.tsx
@@ -12,8 +12,8 @@ export const PoliciesTab = () => {
 
   return (
     <div>
-      <SecretValidationRulesSection />
       <PreferencesSection />
+      <SecretValidationRulesSection />
       {config.isCrossProjectSecretSharingEnabled && currentOrg.allowCrossProjectSecretSharing && (
         <CrossProjectSharingSection />
       )}


### PR DESCRIPTION
## Context

Fixes cross-secret import paths to display the full path, also makes Reveal values to render the values of imported secrets, and small UX changes to the project grant sheet.

Now the "+" button is project variant and "+ Add". We also show the number of selected paths from the environment

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="445" height="689" alt="CleanShot 2026-07-17 at 10 54 43" src="https://github.com/user-attachments/assets/ece6b265-0d24-4c7a-8142-d48cd0842d1c" />


## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)