### PR TITLE
fix(telemetry): extend aggregated events cron interval and timeout

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -199,7 +199,7 @@ export const KeyStoreTtls = {
   StepUpMfaAttemptWindowInSeconds: 300, // 5 minutes - rolling window for counting failed step-up attempts
   StepUpMfaLockoutInSeconds: 300, // 5 minutes - temporary lockout after too many failed step-up attempts
   TelemetryGroupIdentifyInSeconds: 3600, // 1 hour
-  TelemetryAggregatedEventInSeconds: 600, // 10 minutes
+  TelemetryAggregatedEventInSeconds: 1800, // 30 minutes
   SecretEtagInSeconds: 900, // 15 minutes
   PkiAcmeNonceInSeconds: 300, // 5 minutes
   GatewayRelayCredentialInSeconds: 600, // 10 minutes - TURN credential lifetime

--- a/backend/src/services/telemetry/telemetry-queue.ts
+++ b/backend/src/services/telemetry/telemetry-queue.ts
@@ -14,6 +14,8 @@ import {
 } from "./telemetry-service";
 import { PostHogEventTypes } from "./telemetry-types";
 
+const AGGREGATED_EVENTS_HANDLER_TIMEOUT_MS = 8 * 60 * 1000;
+
 type TTelemetryQueueServiceFactoryDep = {
   cronJob: TCronJobFactory;
   keyStore: Pick<TKeyStoreFactory, "getItem" | "deleteItem">;
@@ -75,8 +77,10 @@ export const telemetryQueueServiceFactory = ({
 
     cronJob.register({
       name: CronJobName.TelemetryAggregatedEvents,
-      pattern: "*/5 * * * *",
+      pattern: "*/10 * * * *",
       runHashTtlS: 60 * 60,
+      handlerTimeoutMs: AGGREGATED_EVENTS_HANDLER_TIMEOUT_MS,
+      leaseDurationMs: AGGREGATED_EVENTS_HANDLER_TIMEOUT_MS,
       handler: async () => {
         await telemetryService.processAggregatedEvents();
       }


### PR DESCRIPTION
## Context

`telemetry-aggregated-events` ran every 5 minutes with default 5-minute `handlerTimeoutMs` and `leaseDurationMs` — interval, timeout, and lease were all equal, so slow runs (~5–8 min) hit terminal timeouts and retries could never fit before the next fire.

This PR:
- Changes cron interval from `*/5` to `*/10`
- Sets per-job `handlerTimeoutMs` / `leaseDurationMs` to 8 minutes
- Raises `TelemetryAggregatedEventInSeconds` from 10 → 30 minutes so buffered events aren’t expired before the sweep runs

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)