### PR TITLE
feat: return secretPath in imported secrets

### DIFF
--- a/backend/src/server/routes/v4/secret-router.ts
+++ b/backend/src/server/routes/v4/secret-router.ts
@@ -173,7 +173,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
                 .omit({ createdAt: true, updatedAt: true })
                 .extend({
                   secretValueHidden: z.boolean(),
-                  secretPath: z.string(),
+                  secretPath: z.string().optional(),
                   secretMetadata: ResourceMetadataWithEncryptionSchema.optional()
                 })
                 .array()

--- a/backend/src/server/routes/v4/secret-router.ts
+++ b/backend/src/server/routes/v4/secret-router.ts
@@ -173,6 +173,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
                 .omit({ createdAt: true, updatedAt: true })
                 .extend({
                   secretValueHidden: z.boolean(),
+                  secretPath: z.string(),
                   secretMetadata: ResourceMetadataWithEncryptionSchema.optional()
                 })
                 .array()

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -476,6 +476,7 @@ export const fnSecretsV2FromImports = async ({
           secretTags: item.tags,
           secretComment: activeDecryptor(item.encryptedComment),
           environment: importEnv.slug,
+          secretPath: importAccessScopeByFolderId?.get(folderId)?.secretPath ?? importPath,
           workspace: "", // This field should not be used, it's only here to keep the older Python SDK versions backwards compatible with the new Postgres backend.
           _id: item.id // The old Python SDK depends on the _id field being returned. We return this to keep the older Python SDK versions backwards compatible with the new Postgres backend.
         }));

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -477,7 +477,7 @@ export const fnSecretsV2FromImports = async ({
           secretTags: item.tags,
           secretComment: activeDecryptor(item.encryptedComment),
           environment: importEnv.slug,
-          secretPath: importAccessScopeByFolderId?.get(folderId)?.secretPath ?? inheritedSecretPath ?? '',
+          secretPath: importAccessScopeByFolderId?.get(folderId)?.secretPath ?? inheritedSecretPath ?? "",
           workspace: "", // This field should not be used, it's only here to keep the older Python SDK versions backwards compatible with the new Postgres backend.
           _id: item.id // The old Python SDK depends on the _id field being returned. We return this to keep the older Python SDK versions backwards compatible with the new Postgres backend.
         }));

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -476,7 +476,7 @@ export const fnSecretsV2FromImports = async ({
           secretTags: item.tags,
           secretComment: activeDecryptor(item.encryptedComment),
           environment: importEnv.slug,
-          secretPath: importAccessScopeByFolderId?.get(folderId)?.secretPath ?? importPath,
+          secretPath: importAccessScopeByFolderId?.get(folderId)?.secretPath ?? '',
           workspace: "", // This field should not be used, it's only here to keep the older Python SDK versions backwards compatible with the new Postgres backend.
           _id: item.id // The old Python SDK depends on the _id field being returned. We return this to keep the older Python SDK versions backwards compatible with the new Postgres backend.
         }));

--- a/backend/src/services/secret-import/secret-import-fns.ts
+++ b/backend/src/services/secret-import/secret-import-fns.ts
@@ -301,6 +301,7 @@ export const fnSecretsV2FromImports = async ({
       secretValueHidden: boolean;
       secretTags: { slug: string; name: string; id: string; color?: string | null }[];
     })[];
+    inheritedSecretPath?: string;
   }[] = [{ secretImports: rootSecretImports, depth: 0, parentImportedSecrets: [] }];
 
   const processedImports: TSecretImportSecretsV2[] = [];
@@ -311,7 +312,7 @@ export const fnSecretsV2FromImports = async ({
   type TImportedSecret = Omit<Awaited<ReturnType<typeof secretDAL.find>>[number], "projectId">;
 
   while (stack.length) {
-    const { secretImports, depth, parentImportedSecrets } = stack.pop()!;
+    const { secretImports, depth, parentImportedSecrets, inheritedSecretPath } = stack.pop()!;
 
     if (depth > LEVEL_BREAK) continue;
     const sanitizedImports = secretImports.filter(
@@ -476,7 +477,7 @@ export const fnSecretsV2FromImports = async ({
           secretTags: item.tags,
           secretComment: activeDecryptor(item.encryptedComment),
           environment: importEnv.slug,
-          secretPath: importAccessScopeByFolderId?.get(folderId)?.secretPath ?? '',
+          secretPath: importAccessScopeByFolderId?.get(folderId)?.secretPath ?? inheritedSecretPath ?? '',
           workspace: "", // This field should not be used, it's only here to keep the older Python SDK versions backwards compatible with the new Postgres backend.
           _id: item.id // The old Python SDK depends on the _id field being returned. We return this to keep the older Python SDK versions backwards compatible with the new Postgres backend.
         }));
@@ -485,10 +486,12 @@ export const fnSecretsV2FromImports = async ({
         const deeperImportsForFolder = deeperImportsGroupByFolderId[sourceImportFolder?.id || ""];
 
         if (deeperImportsForFolder.length > 0) {
+          const resolvedSecretPath = importAccessScopeByFolderId?.get(folderId)?.secretPath ?? inheritedSecretPath;
           stack.push({
             secretImports: deeperImportsForFolder,
             depth: depth + 1,
-            parentImportedSecrets: secretsWithDuplicate
+            parentImportedSecrets: secretsWithDuplicate,
+            inheritedSecretPath: resolvedSecretPath
           });
         }
       }


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

For `recursive` secret list calls, imports don't carry any information on where they are located. This adds `secretPath` to imported secrets.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)