### PR TITLE
fix: use standard upgrade plan modal for gateway pools gate

### DIFF
--- a/frontend/src/hooks/api/gateway-pools/queries.tsx
+++ b/frontend/src/hooks/api/gateway-pools/queries.tsx
@@ -27,10 +27,11 @@ export const gatewayPoolsQueryKeys = {
   })
 };
 
-export const useListGatewayPools = (options?: { refetchInterval?: number }) => {
+export const useListGatewayPools = (options?: { refetchInterval?: number; enabled?: boolean }) => {
   return useQuery({
     ...gatewayPoolsQueryKeys.list(),
-    refetchInterval: options?.refetchInterval
+    refetchInterval: options?.refetchInterval,
+    enabled: options?.enabled
   });
 };
 

--- a/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/GatewayTab.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/GatewayTab.tsx
@@ -14,6 +14,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { PlusIcon, SearchIcon } from "lucide-react";
 
+import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
@@ -87,7 +88,7 @@ export const GatewayTab = withPermission(
       ...gatewaysQueryKeys.listWithTokens(),
       refetchInterval: 15_000
     });
-    const { data: pools } = useListGatewayPools();
+    const { data: pools } = useListGatewayPools({ enabled: Boolean(showPoolsTab) });
 
     // Build reverse map: gatewayId -> pool names
     const gatewayPoolMap = new Map<string, string[]>();
@@ -105,7 +106,8 @@ export const GatewayTab = withPermission(
       "deployGateway",
       "deleteGateway",
       "editDetails",
-      "createPool"
+      "createPool",
+      "upgradePlan"
     ] as const);
 
     const deleteGatewayById = useDeleteGatewayById();
@@ -175,23 +177,27 @@ export const GatewayTab = withPermission(
                 )}
               </OrgPermissionCan>
             ) : (
-              showPoolsTab && (
-                <OrgPermissionCan
-                  I={OrgGatewayPoolPermissionActions.CreateGatewayPools}
-                  a={OrgPermissionSubjects.GatewayPool}
-                >
-                  {(isAllowed: boolean) => (
-                    <Button
-                      variant="org"
-                      onClick={() => handlePopUpOpen("createPool")}
-                      isDisabled={!isAllowed}
-                    >
-                      <PlusIcon />
-                      Create Pool
-                    </Button>
-                  )}
-                </OrgPermissionCan>
-              )
+              <OrgPermissionCan
+                I={OrgGatewayPoolPermissionActions.CreateGatewayPools}
+                a={OrgPermissionSubjects.GatewayPool}
+              >
+                {(isAllowed: boolean) => (
+                  <Button
+                    variant="org"
+                    onClick={() => {
+                      if (!subscription?.gatewayPool) {
+                        handlePopUpOpen("upgradePlan");
+                        return;
+                      }
+                      handlePopUpOpen("createPool");
+                    }}
+                    isDisabled={!isAllowed}
+                  >
+                    <PlusIcon />
+                    Create Pool
+                  </Button>
+                )}
+              </OrgPermissionCan>
             )}
           </CardAction>
         </CardHeader>
@@ -218,18 +224,16 @@ export const GatewayTab = withPermission(
                 />
               </InputGroup>
             ) : (
-              showPoolsTab && (
-                <InputGroup className="w-1/2 min-w-64">
-                  <InputGroupAddon align="inline-start">
-                    <SearchIcon />
-                  </InputGroupAddon>
-                  <InputGroupInput
-                    value={poolSearch}
-                    onChange={(e) => setPoolSearch(e.target.value)}
-                    placeholder="Search pool..."
-                  />
-                </InputGroup>
-              )
+              <InputGroup className="w-1/2 min-w-64">
+                <InputGroupAddon align="inline-start">
+                  <SearchIcon />
+                </InputGroupAddon>
+                <InputGroupInput
+                  value={poolSearch}
+                  onChange={(e) => setPoolSearch(e.target.value)}
+                  placeholder="Search pool..."
+                />
+              </InputGroup>
             )}
           </div>
           {activeSubTab === "gateway-pools" ? (
@@ -429,6 +433,12 @@ export const GatewayTab = withPermission(
         <CreateGatewayPoolModal
           isOpen={popUp.createPool.isOpen}
           onToggle={(isOpen) => handlePopUpToggle("createPool", isOpen)}
+        />
+        <UpgradePlanModal
+          isOpen={popUp.upgradePlan.isOpen}
+          onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
+          text="Your current plan does not include access to gateway pools. To unlock this feature, please upgrade to Infisical Enterprise plan."
+          isEnterpriseFeature
         />
       </Card>
     );

--- a/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/components/GatewayPoolsContent.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/components/GatewayPoolsContent.tsx
@@ -2,10 +2,8 @@ import { useState } from "react";
 import { faEllipsisV, faPen, faTrash } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
-import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import {
-  Button,
   DeleteActionModal,
   DropdownMenu,
   DropdownMenuContent,
@@ -41,15 +39,15 @@ export const GatewayPoolsContent = ({ search }: Props) => {
   const isEnterprise = subscription?.gatewayPool;
   const [selectedPoolId, setSelectedPoolId] = useState<string | null>(null);
   const [resourcesPool, setResourcesPool] = useState<{ id: string; name: string } | null>(null);
-  const { data: pools, isPending: isPoolsLoading } = useListGatewayPools({
-    refetchInterval: 15_000
+  const { data: pools, isLoading: isPoolsLoading } = useListGatewayPools({
+    refetchInterval: 15_000,
+    enabled: Boolean(isEnterprise)
   });
   const deletePool = useDeleteGatewayPool();
 
   const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp([
     "editPool",
-    "deletePool",
-    "upgradePlan"
+    "deletePool"
   ] as const);
 
   const filteredPools = pools?.filter((p) => p.name.toLowerCase().includes(search.toLowerCase()));
@@ -69,29 +67,6 @@ export const GatewayPoolsContent = ({ search }: Props) => {
       createNotification({ type: "error", text: message });
     }
   };
-
-  if (!isEnterprise) {
-    return (
-      <div>
-        <div className="rounded-md border border-yellow-500/30 bg-yellow-500/5 p-8 text-center">
-          <div className="mb-3 text-2xl">&#x1f6e1;&#xfe0f;</div>
-          <h4 className="mb-2 text-lg font-medium text-mineshaft-100">Enterprise Feature</h4>
-          <p className="mx-auto mb-4 max-w-md text-sm text-mineshaft-300">
-            Gateway Pools provide high availability and automatic failover. When a gateway goes
-            down, the platform automatically routes through a healthy member of the pool.
-          </p>
-          <Button colorSchema="primary" onClick={() => handlePopUpOpen("upgradePlan")}>
-            Upgrade to Enterprise
-          </Button>
-        </div>
-        <UpgradePlanModal
-          isOpen={popUp.upgradePlan.isOpen}
-          onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
-          text="To use gateway pools, upgrade to Infisical's Enterprise plan."
-        />
-      </div>
-    );
-  }
 
   return (
     <div>
@@ -166,7 +141,7 @@ export const GatewayPoolsContent = ({ search }: Props) => {
                 </Td>
               </Tr>
             ))}
-            {!isPoolsLoading && filteredPools?.length === 0 && (
+            {!isPoolsLoading && !filteredPools?.length && (
               <Tr>
                 <Td colSpan={4}>
                   <EmptyState title="No gateway pools found" />


### PR DESCRIPTION
Replaces the custom yellow enterprise banner on the Gateway Pools tab with the standard UpgradePlanModal pattern used by other gated features (button always visible, modal on click, list query skipped when unlicensed).