### PR TITLE
fix(helm): avoid duplicate DB_CONNECTION_URI env when using existing secret

### DIFF
--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -76,7 +76,7 @@ spec:
               name: {{ .Values.postgresql.useExistingPostgresSecret.existingConnectionStringSecret.name }}
               key: {{ .Values.postgresql.useExistingPostgresSecret.existingConnectionStringSecret.key }}
         {{- end }}
-        {{- if .Values.postgresql.enabled }}
+        {{- if and .Values.postgresql.enabled (not .Values.postgresql.useExistingPostgresSecret.enabled) }}
         - name: DB_CONNECTION_URI
           value: {{ include "infisical.postgresDBConnectionString" . }}
         {{- end }}


### PR DESCRIPTION
The infisical container rendered DB_CONNECTION_URI twice whenever postgresql.enabled and postgresql.useExistingPostgresSecret.enabled were both true (once from the existing-secret ref, once from the inline bundled connection-string helper). Client-side apply tolerated the duplicate (last-wins), but Kubernetes Server-Side Apply treats container env as a map keyed by name and rejects the duplicate key, failing the sync:

  failed to create typed patch object ... env: duplicate entries for
  key [name="DB_CONNECTION_URI"]

Only emit the inline helper URI when no existing connection-string secret is provided.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)