### PR TITLE
improvement(migration): add FK indexes for permission query joins

### DIFF
--- a/backend/src/db/migrations/20260720120000_add-permission-query-fk-indexes.ts
+++ b/backend/src/db/migrations/20260720120000_add-permission-query-fk-indexes.ts
@@ -27,53 +27,80 @@ const ADDITIONAL_PRIVILEGE_INDEXES = [
   { name: "idx_additional_privileges_org_id", column: "orgId", partial: true }
 ] as const;
 
+const INDEX_GROUPS = [
+  { table: TableName.IdentityMetadata, indexes: IDENTITY_METADATA_INDEXES },
+  { table: TableName.AdditionalPrivilege, indexes: ADDITIONAL_PRIVILEGE_INDEXES }
+] as const;
+
+const ALL_INDEXES = [...IDENTITY_METADATA_INDEXES, ...ADDITIONAL_PRIVILEGE_INDEXES];
+
 export async function up(knex: Knex): Promise<void> {
-  const stmtResult = await knex.raw("SHOW statement_timeout");
+  // Pin everything to one acquired connection.
+  const connection = await knex.client.acquireConnection();
+  const raw = (sql: string) => knex.raw(sql).connection(connection);
+  const hasTable = async (table: string) => {
+    const res = await raw(`SELECT to_regclass('${table}') IS NOT NULL AS present`);
+    return Boolean(res.rows[0]?.present);
+  };
+  const hasColumn = async (table: string, column: string) => {
+    const res = await raw(
+      `SELECT 1 FROM information_schema.columns WHERE table_name = '${table}' AND column_name = '${column}'`
+    );
+    return res.rows.length > 0;
+  };
+
+  const stmtResult = await raw("SHOW statement_timeout");
   const originalStatementTimeout = stmtResult.rows[0].statement_timeout;
-  const lockResult = await knex.raw("SHOW lock_timeout");
+  const lockResult = await raw("SHOW lock_timeout");
   const originalLockTimeout = lockResult.rows[0].lock_timeout;
 
   try {
-    await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
-    await knex.raw(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT}`);
+    await raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+    await raw(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT}`);
 
-    if (await knex.schema.hasTable(TableName.IdentityMetadata)) {
-      for (const { name, column, partial } of IDENTITY_METADATA_INDEXES) {
-        // eslint-disable-next-line no-await-in-loop
-        if (await knex.schema.hasColumn(TableName.IdentityMetadata, column)) {
-          // eslint-disable-next-line no-await-in-loop
-          await knex.raw(
-            `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${name}" ON ${TableName.IdentityMetadata} ("${column}")${
-              partial ? ` WHERE "${column}" IS NOT NULL` : ""
-            }`
-          );
-        }
+    for (const { table, indexes } of INDEX_GROUPS) {
+      // eslint-disable-next-line no-await-in-loop
+      if (!(await hasTable(table))) {
+        // eslint-disable-next-line no-continue
+        continue;
       }
-    }
 
-    if (await knex.schema.hasTable(TableName.AdditionalPrivilege)) {
-      for (const { name, column, partial } of ADDITIONAL_PRIVILEGE_INDEXES) {
+      for (const { name, column, partial } of indexes) {
         // eslint-disable-next-line no-await-in-loop
-        if (await knex.schema.hasColumn(TableName.AdditionalPrivilege, column)) {
-          // eslint-disable-next-line no-await-in-loop
-          await knex.raw(
-            `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${name}" ON ${TableName.AdditionalPrivilege} ("${column}")${
-              partial ? ` WHERE "${column}" IS NOT NULL` : ""
-            }`
-          );
+        if (!(await hasColumn(table, column))) {
+          // eslint-disable-next-line no-continue
+          continue;
         }
+
+        // A cancelled or failed CREATE INDEX CONCURRENTLY leaves behind an INVALID index.
+        // eslint-disable-next-line no-await-in-loop
+        const invalid = await raw(
+          `SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = '${name}' AND NOT i.indisvalid`
+        );
+        if (invalid.rows.length > 0) {
+          // eslint-disable-next-line no-await-in-loop
+          await raw(`DROP INDEX CONCURRENTLY IF EXISTS "${name}"`);
+        }
+
+        // eslint-disable-next-line no-await-in-loop
+        await raw(
+          `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${name}" ON ${table} ("${column}")${
+            partial ? ` WHERE "${column}" IS NOT NULL` : ""
+          }`
+        );
       }
     }
   } finally {
-    await knex.raw(`SET statement_timeout = '${originalStatementTimeout}'`);
-    await knex.raw(`SET lock_timeout = '${originalLockTimeout}'`);
+    await raw(`SET statement_timeout = '${originalStatementTimeout}'`);
+    await raw(`SET lock_timeout = '${originalLockTimeout}'`);
+    await knex.client.releaseConnection(connection);
   }
 }
 
 export async function down(knex: Knex): Promise<void> {
-  for (const { name } of [...IDENTITY_METADATA_INDEXES, ...ADDITIONAL_PRIVILEGE_INDEXES]) {
+  for (const { name } of ALL_INDEXES) {
     // eslint-disable-next-line no-await-in-loop
-    await knex.raw(`DROP INDEX IF EXISTS "${name}"`);
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "${name}"`);
   }
 }
 

--- a/backend/src/db/migrations/20260720120000_add-permission-query-fk-indexes.ts
+++ b/backend/src/db/migrations/20260720120000_add-permission-query-fk-indexes.ts
@@ -35,19 +35,8 @@ const INDEX_GROUPS = [
 const ALL_INDEXES = [...IDENTITY_METADATA_INDEXES, ...ADDITIONAL_PRIVILEGE_INDEXES];
 
 export async function up(knex: Knex): Promise<void> {
-  // Pin everything to one acquired connection.
   const connection = await knex.client.acquireConnection();
   const raw = (sql: string) => knex.raw(sql).connection(connection);
-  const hasTable = async (table: string) => {
-    const res = await raw(`SELECT to_regclass('${table}') IS NOT NULL AS present`);
-    return Boolean(res.rows[0]?.present);
-  };
-  const hasColumn = async (table: string, column: string) => {
-    const res = await raw(
-      `SELECT 1 FROM information_schema.columns WHERE table_name = '${table}' AND column_name = '${column}'`
-    );
-    return res.rows.length > 0;
-  };
 
   try {
     const stmtResult = await raw("SHOW statement_timeout");
@@ -61,14 +50,14 @@ export async function up(knex: Knex): Promise<void> {
 
       for (const { table, indexes } of INDEX_GROUPS) {
         // eslint-disable-next-line no-await-in-loop
-        if (!(await hasTable(table))) {
+        if (!(await knex.schema.hasTable(table))) {
           // eslint-disable-next-line no-continue
           continue;
         }
 
         for (const { name, column, partial } of indexes) {
           // eslint-disable-next-line no-await-in-loop
-          if (!(await hasColumn(table, column))) {
+          if (!(await knex.schema.hasColumn(table, column))) {
             // eslint-disable-next-line no-continue
             continue;
           }

--- a/backend/src/db/migrations/20260720120000_add-permission-query-fk-indexes.ts
+++ b/backend/src/db/migrations/20260720120000_add-permission-query-fk-indexes.ts
@@ -49,50 +49,53 @@ export async function up(knex: Knex): Promise<void> {
     return res.rows.length > 0;
   };
 
-  const stmtResult = await raw("SHOW statement_timeout");
-  const originalStatementTimeout = stmtResult.rows[0].statement_timeout;
-  const lockResult = await raw("SHOW lock_timeout");
-  const originalLockTimeout = lockResult.rows[0].lock_timeout;
-
   try {
-    await raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
-    await raw(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT}`);
+    const stmtResult = await raw("SHOW statement_timeout");
+    const originalStatementTimeout = stmtResult.rows[0].statement_timeout;
+    const lockResult = await raw("SHOW lock_timeout");
+    const originalLockTimeout = lockResult.rows[0].lock_timeout;
 
-    for (const { table, indexes } of INDEX_GROUPS) {
-      // eslint-disable-next-line no-await-in-loop
-      if (!(await hasTable(table))) {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
+    try {
+      await raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+      await raw(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT}`);
 
-      for (const { name, column, partial } of indexes) {
+      for (const { table, indexes } of INDEX_GROUPS) {
         // eslint-disable-next-line no-await-in-loop
-        if (!(await hasColumn(table, column))) {
+        if (!(await hasTable(table))) {
           // eslint-disable-next-line no-continue
           continue;
         }
 
-        // A cancelled or failed CREATE INDEX CONCURRENTLY leaves behind an INVALID index.
-        // eslint-disable-next-line no-await-in-loop
-        const invalid = await raw(
-          `SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = '${name}' AND NOT i.indisvalid`
-        );
-        if (invalid.rows.length > 0) {
+        for (const { name, column, partial } of indexes) {
           // eslint-disable-next-line no-await-in-loop
-          await raw(`DROP INDEX CONCURRENTLY IF EXISTS "${name}"`);
-        }
+          if (!(await hasColumn(table, column))) {
+            // eslint-disable-next-line no-continue
+            continue;
+          }
 
-        // eslint-disable-next-line no-await-in-loop
-        await raw(
-          `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${name}" ON ${table} ("${column}")${
-            partial ? ` WHERE "${column}" IS NOT NULL` : ""
-          }`
-        );
+          // A cancelled or failed CREATE INDEX CONCURRENTLY leaves behind an INVALID index.
+          // eslint-disable-next-line no-await-in-loop
+          const invalid = await raw(
+            `SELECT 1 FROM pg_class c JOIN pg_index i ON i.indexrelid = c.oid WHERE c.relname = '${name}' AND NOT i.indisvalid`
+          );
+          if (invalid.rows.length > 0) {
+            // eslint-disable-next-line no-await-in-loop
+            await raw(`DROP INDEX CONCURRENTLY IF EXISTS "${name}"`);
+          }
+
+          // eslint-disable-next-line no-await-in-loop
+          await raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${name}" ON ${table} ("${column}")${
+              partial ? ` WHERE "${column}" IS NOT NULL` : ""
+            }`
+          );
+        }
       }
+    } finally {
+      await raw(`SET statement_timeout = '${originalStatementTimeout}'`);
+      await raw(`SET lock_timeout = '${originalLockTimeout}'`);
     }
   } finally {
-    await raw(`SET statement_timeout = '${originalStatementTimeout}'`);
-    await raw(`SET lock_timeout = '${originalLockTimeout}'`);
     await knex.client.releaseConnection(connection);
   }
 }

--- a/backend/src/db/migrations/20260720120000_add-permission-query-fk-indexes.ts
+++ b/backend/src/db/migrations/20260720120000_add-permission-query-fk-indexes.ts
@@ -1,0 +1,81 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+// getPermissionFingerprint (and its siblings getPermission / getProjectUserPermissions /
+// getProjectIdentityPermissions) LEFT JOIN identity_metadata and additional_privileges on their
+// FK columns. Postgres does not auto-index FK columns, and neither table has ever had an index on
+// any of them, so each join degrades to a seq scan.
+//
+// Nullable FK columns get a partial index (WHERE col IS NOT NULL): the actor/scope xor check
+// constraints guarantee only one actor column and one scope column is set per row, so a partial
+// index is a fraction of the size and write cost of a full one.
+
+const MIGRATION_TIMEOUT = 60 * 60 * 1000; // 60 minutes
+const MIGRATION_LOCK_TIMEOUT = 30 * 1000; // 30 seconds
+
+const IDENTITY_METADATA_INDEXES = [
+  { name: "idx_identity_metadata_identity_id", column: "identityId", partial: true },
+  { name: "idx_identity_metadata_user_id", column: "userId", partial: true },
+  { name: "idx_identity_metadata_org_id", column: "orgId", partial: false }
+] as const;
+
+const ADDITIONAL_PRIVILEGE_INDEXES = [
+  { name: "idx_additional_privileges_actor_identity_id", column: "actorIdentityId", partial: true },
+  { name: "idx_additional_privileges_actor_user_id", column: "actorUserId", partial: true },
+  { name: "idx_additional_privileges_project_id", column: "projectId", partial: true },
+  { name: "idx_additional_privileges_org_id", column: "orgId", partial: true }
+] as const;
+
+export async function up(knex: Knex): Promise<void> {
+  const stmtResult = await knex.raw("SHOW statement_timeout");
+  const originalStatementTimeout = stmtResult.rows[0].statement_timeout;
+  const lockResult = await knex.raw("SHOW lock_timeout");
+  const originalLockTimeout = lockResult.rows[0].lock_timeout;
+
+  try {
+    await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+    await knex.raw(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT}`);
+
+    if (await knex.schema.hasTable(TableName.IdentityMetadata)) {
+      for (const { name, column, partial } of IDENTITY_METADATA_INDEXES) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await knex.schema.hasColumn(TableName.IdentityMetadata, column)) {
+          // eslint-disable-next-line no-await-in-loop
+          await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${name}" ON ${TableName.IdentityMetadata} ("${column}")${
+              partial ? ` WHERE "${column}" IS NOT NULL` : ""
+            }`
+          );
+        }
+      }
+    }
+
+    if (await knex.schema.hasTable(TableName.AdditionalPrivilege)) {
+      for (const { name, column, partial } of ADDITIONAL_PRIVILEGE_INDEXES) {
+        // eslint-disable-next-line no-await-in-loop
+        if (await knex.schema.hasColumn(TableName.AdditionalPrivilege, column)) {
+          // eslint-disable-next-line no-await-in-loop
+          await knex.raw(
+            `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${name}" ON ${TableName.AdditionalPrivilege} ("${column}")${
+              partial ? ` WHERE "${column}" IS NOT NULL` : ""
+            }`
+          );
+        }
+      }
+    }
+  } finally {
+    await knex.raw(`SET statement_timeout = '${originalStatementTimeout}'`);
+    await knex.raw(`SET lock_timeout = '${originalLockTimeout}'`);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for (const { name } of [...IDENTITY_METADATA_INDEXES, ...ADDITIONAL_PRIVILEGE_INDEXES]) {
+    // eslint-disable-next-line no-await-in-loop
+    await knex.raw(`DROP INDEX IF EXISTS "${name}"`);
+  }
+}
+
+const config = { transaction: false };
+export { config };


### PR DESCRIPTION
## Context

Permission resolution (`getPermissionFingerprint`, `getPermission`, and related paths) `LEFT JOIN`s `identity_metadata` and `additional_privileges` on FK columns that were never indexed. On large deployments those joins can fall back to sequential scans.

This adds a migration that creates **7 indexes** (`CREATE INDEX CONCURRENTLY`) on the join/filter columns:

- **`identity_metadata`:** `identityId`, `userId`, `orgId`
- **`additional_privileges`:** `actorIdentityId`, `actorUserId`, `projectId`, `orgId`

Nullable FK columns use **partial indexes** (`WHERE col IS NOT NULL`) to keep size and write cost down, matching the table XOR constraints.

The migration runs outside a transaction, pins a single DB connection (so timeout settings don’t leak via the pool), raises `statement_timeout`/`lock_timeout` for the build, drops any **invalid** leftover indexes from a failed concurrent build, and drops indexes concurrently on rollback.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)