### PR TITLE
improvement(ui): add Agent Proxy and Agent policy templates

### DIFF
--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
@@ -4047,7 +4047,38 @@ export const RoleTemplates: Record<ProjectType, RoleTemplate[]> = {
         subject: ProjectPermissionSub.Webhooks,
         actions: Object.values(ProjectPermissionActions)
       }
-    ])
+    ]),
+    {
+      id: "agent-proxy",
+      name: "Agent Proxy Policies",
+      description:
+        "For the Agent Proxy identity: reads brokered secret values and mints dynamic-secret leases",
+      permissions: [
+        {
+          subject: ProjectPermissionSub.Secrets,
+          actions: [
+            ProjectPermissionSecretActions.DescribeSecret,
+            ProjectPermissionSecretActions.ReadValue
+          ]
+        },
+        {
+          subject: ProjectPermissionSub.DynamicSecrets,
+          actions: [ProjectPermissionDynamicSecretActions.Lease]
+        }
+      ]
+    },
+    {
+      id: "agent",
+      name: "Agent Policies",
+      description:
+        "For an agent identity: routes traffic through proxied services without reading secrets",
+      permissions: [
+        {
+          subject: ProjectPermissionSub.ProxiedServices,
+          actions: [ProjectPermissionProxiedServiceActions.Proxy]
+        }
+      ]
+    }
   ],
   [ProjectType.PAM]: [projectManagerTemplate()],
   [ProjectType.AI]: [projectManagerTemplate()]


### PR DESCRIPTION
## Context

Adds two policy templates for the Agent Proxy under Secrets Management: **Agent Proxy Policies** (`Read Value` + `Describe Secret` on secrets, and `Manage Leases` on dynamic secrets) and **Agent Policies** (`Proxy` on proxied services). These match the two least-privilege identities the Agent Proxy uses: the proxy identity that fetches secret values and mints dynamic-secret leases, and the agent identity that only routes traffic and never reads secrets.

The existing Secret Manager templates all bundle `proxy` together with broad secret read/write, which is the opposite of what the agent identity should hold, so none of them expressed the split cleanly. The two new templates live in the shared `RoleTemplates` map, so they show up wherever policies are applied: custom roles, machine identity and member additional privileges, and project templates.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
