### PR TITLE
improvement(frontend): polish external migrations modal flow

### DIFF
--- a/frontend/src/components/v3/generic/Dialog/Dialog.tsx
+++ b/frontend/src/components/v3/generic/Dialog/Dialog.tsx
@@ -30,7 +30,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -55,7 +55,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border bg-popover p-6 text-foreground shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-border bg-popover p-6 text-foreground shadow-lg duration-200 outline-none data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         onPointerDownOutside={(e) => {

--- a/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/EnvKeyPlatformModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/EnvKeyPlatformModal.tsx
@@ -99,7 +99,7 @@ export const EnvKeyPlatformModal = ({ onClose }: Props) => {
       <div className="flex items-center gap-2 pt-2">
         <Button
           type="submit"
-          variant="project"
+          variant="org"
           isPending={isLoading || isSubmitting}
           isDisabled={!isDirty || isSubmitting || isLoading || !isValid}
         >

--- a/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/SelectImportFromPlatformModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/SelectImportFromPlatformModal.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
 
 import {
   Dialog,
@@ -64,73 +63,47 @@ export const SelectImportFromPlatformModal = ({ isOpen, onToggle }: Props) => {
             <DialogDescription>Select a platform to import from</DialogDescription>
           )}
         </DialogHeader>
-        <AnimatePresence mode="wait">
-          {wizardStep === WizardSteps.SelectPlatform && (
-            <motion.div
-              key="select-type-step"
-              transition={{ duration: 0.1 }}
-              initial={{ opacity: 0, translateX: 30 }}
-              animate={{ opacity: 1, translateX: 0 }}
-              exit={{ opacity: 0, translateX: -30 }}
-            >
-              <div className="flex items-center space-x-4">
-                {PLATFORM_LIST.map((platform, idx) => (
-                  <div
-                    key={`platform-${idx + 1}`}
-                    className="flex h-28 w-32 cursor-pointer flex-col items-center justify-between rounded-sm border border-border bg-container p-6 py-5 transition-all hover:border-accent/40 hover:bg-foreground/5"
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => {
-                      setSelectedPlatform(platform);
-                      setWizardStep(WizardSteps.PlatformInputs);
-                    }}
-                    onKeyDown={(evt) => {
-                      if (evt.key === "Enter") {
-                        setSelectedPlatform(platform);
-                        setWizardStep(WizardSteps.PlatformInputs);
-                      }
-                    }}
-                  >
-                    <img
-                      src={platform.image}
-                      alt={`${platform.title} logo`}
-                      style={{ width: platform.size }}
-                    />
-                    <div className="text-center text-sm whitespace-pre-wrap text-foreground">
-                      {platform.title}
-                    </div>
-                  </div>
-                ))}
+        {wizardStep === WizardSteps.SelectPlatform && (
+          <div className="flex items-center space-x-4">
+            {PLATFORM_LIST.map((platform, idx) => (
+              <div
+                key={`platform-${idx + 1}`}
+                className="flex h-28 w-32 cursor-pointer flex-col items-center justify-between rounded-sm border border-border bg-container p-6 py-5 transition-all hover:border-accent/40 hover:bg-foreground/5"
+                role="button"
+                tabIndex={0}
+                onClick={() => {
+                  setSelectedPlatform(platform);
+                  setWizardStep(WizardSteps.PlatformInputs);
+                }}
+                onKeyDown={(evt) => {
+                  if (evt.key === "Enter") {
+                    setSelectedPlatform(platform);
+                    setWizardStep(WizardSteps.PlatformInputs);
+                  }
+                }}
+              >
+                <img
+                  src={platform.image}
+                  alt={`${platform.title} logo`}
+                  style={{ width: platform.size }}
+                />
+                <div className="text-center text-sm whitespace-pre-wrap text-foreground">
+                  {platform.title}
+                </div>
               </div>
-            </motion.div>
-          )}
-          {wizardStep === WizardSteps.PlatformInputs && (
-            <>
-              {selectedPlatform?.platform === "env-key" && (
-                <motion.div
-                  key="env-key-step"
-                  transition={{ duration: 0.1 }}
-                  initial={{ opacity: 0, translateX: 30 }}
-                  animate={{ opacity: 1, translateX: 0 }}
-                  exit={{ opacity: 0, translateX: -30 }}
-                >
-                  <EnvKeyPlatformModal onClose={() => handleOpenChange(false)} />
-                </motion.div>
-              )}
-              {selectedPlatform?.platform === "vault" && (
-                <motion.div
-                  key="vault-step"
-                  transition={{ duration: 0.1 }}
-                  initial={{ opacity: 0, translateX: 30 }}
-                  animate={{ opacity: 1, translateX: 0 }}
-                  exit={{ opacity: 0, translateX: -30 }}
-                >
-                  <VaultPlatformModal onClose={() => handleOpenChange(false)} />
-                </motion.div>
-              )}
-            </>
-          )}
-        </AnimatePresence>
+            ))}
+          </div>
+        )}
+        {wizardStep === WizardSteps.PlatformInputs && (
+          <>
+            {selectedPlatform?.platform === "env-key" && (
+              <EnvKeyPlatformModal onClose={() => handleOpenChange(false)} />
+            )}
+            {selectedPlatform?.platform === "vault" && (
+              <VaultPlatformModal onClose={() => handleOpenChange(false)} />
+            )}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ExternalMigrationsTab/components/VaultPlatformModal.tsx
@@ -314,7 +314,7 @@ export const VaultPlatformModal = ({ onClose }: Props) => {
                       className={twMerge(
                         "flex w-full cursor-pointer flex-col items-center gap-2 rounded-sm border border-border bg-container/50 p-4 opacity-75 transition-all",
                         field.value === el.value
-                          ? "border-project/50 bg-container opacity-100"
+                          ? "border-org/50 bg-container opacity-100"
                           : "hover:border-accent/30 hover:bg-foreground/5",
                         el.isCustom && "col-span-2",
                         el.isCustom &&
@@ -364,7 +364,7 @@ export const VaultPlatformModal = ({ onClose }: Props) => {
         <div className="flex items-center gap-2 pt-2">
           <Button
             type="submit"
-            variant="project"
+            variant="org"
             isPending={isLoading || isSubmitting}
             isDisabled={!isDirty || isSubmitting || isLoading || !isValid}
           >


### PR DESCRIPTION
## Context

The organization **External Migrations** import modal animated its wizard steps with a framer-motion slide/fade transition, and its inner import forms (EnvKey and HCP Vault) used **project**-scope styling — a `variant="project"` submit button and a `border-project` selection token — even though the entire flow lives under the org-scoped External Migrations tab.

This PR polishes that flow:

- Removes the framer-motion wizard-step transition; steps now render instantly (and the now-unused `framer-motion` import is dropped).
- Switches the EnvKey and Vault import forms to **org** scope — `variant="org"` submit buttons and the `border-org` selection token — so the whole flow matches the org-scoped tab it lives in.

It also includes a **shared-component** change: the v3 `Dialog` now **dismisses instantly on close** (the fade-out/zoom-out exit animation was removed from `DialogContent` and `DialogOverlay`). The open animation is unchanged.

> ⚠️ **Scope/risk:** this Dialog change affects **every v3 `Dialog` across the app**, not just this modal. Dropdown / Popover / Sheet / Tooltip are unaffected (they keep their own close animations).

Resolves [PLATFOR-553](https://linear.app/infisical/issue/PLATFOR-553/polish-external-migrations-modal-flow).

## Screenshots

https://github.com/user-attachments/assets/ab380319-086d-4682-82aa-c59355138f5b

## Steps to verify the change

1. Go to **Organization → Settings → External Migrations** and click **Import**.
2. Select a platform (EnvKey or HCP Vault) — the import form should appear **instantly**, with no slide/fade transition between steps.
3. Confirm the submit button ("Import data") uses the **org** color (matching the "Import" trigger button), not the previous project color.
4. In the Vault form, select a **Project Mapping** card — its selected-state border should be org-colored.
5. Close the dialog (X, Escape, or click outside) — it should dismiss **instantly**, with no fade-out. Spot-check a couple of other dialogs in the app to confirm the shared behavior.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
