### PR TITLE
improvement(frontend): migrate encryption project settings to v3

### DIFF
--- a/frontend/src/components/v3/generic/Empty/Empty.stories.tsx
+++ b/frontend/src/components/v3/generic/Empty/Empty.stories.tsx
@@ -29,11 +29,14 @@ import {
  * so the empty state reads as visually distinct from its container.
  *
  * **`frame` prop** — an alternate, SVG-drawn frame for surfaces that want a more
- * pronounced dashed (or solid) boundary than the CSS border gives — e.g. a
- * drag-and-drop target. `stroke-dasharray` allows a longer dash/gap than
- * `border-style: dashed` supports, without losing the rounded corners the way
- * `border-image` would. Opt-in and independent from `className="border"`; existing
- * consumers are unaffected. Recolor with `frameClassName` (defaults to `text-border`).
+ * deliberate dashed (or solid) boundary than the CSS border gives — e.g. a
+ * drag-and-drop target. `stroke-dasharray` allows precise control over dash and
+ * gap length, something `border-style: dashed` doesn't offer, without losing the
+ * rounded corners the way `border-image` would. Opt-in and independent from
+ * `className="border"`; `frame="none"` consumers render byte-for-byte unchanged.
+ * Recolor with `frameClassName` (defaults to `text-border`). The framed variant
+ * also adds a small outer margin and a hover tint, since it's meant for
+ * interactive surfaces (see `FileDropzone`) rather than static empty states.
  */
 const meta = {
   title: "Generic/Empty",
@@ -241,18 +244,18 @@ export const InsideCard: Story = {
   )
 };
 
-export const WithSvgFrame: Story = {
-  name: "Variant: SVG Frame (Dashed / Solid)",
+export const WithFrame: Story = {
+  name: "Variant: Frame (Dashed / Solid)",
   parameters: {
     docs: {
       description: {
         story:
-          'Pass `frame="dashed"` or `frame="solid"` for the SVG-drawn boundary — used by `FileDropzone` for its passive (dashed) and drag-active (solid, recolored via `frameClassName`) states. Prefer this over `className="border"` when the dash proportions need to stand out, such as an interactive drop target.'
+          'Pass `frame="dashed"` or `frame="solid"` for an SVG-drawn frame — used by `FileDropzone` for its passive (dashed) and drag-active (solid, recolored via `frameClassName`) states. Prefer this over `className="border"` when the dash proportions need to stand out, such as an interactive drop target.'
       }
     }
   },
   render: () => (
-    <div className="flex gap-4">
+    <div className="flex flex-wrap gap-4">
       <Empty frame="dashed" className="w-72">
         <EmptyHeader>
           <EmptyMedia variant="icon">

--- a/frontend/src/components/v3/generic/Empty/Empty.stories.tsx
+++ b/frontend/src/components/v3/generic/Empty/Empty.stories.tsx
@@ -27,6 +27,13 @@ import {
  * at the page level the frame-less look is intentional. When nesting `Empty` inside a
  * `Card`, `Sheet`, or `Dialog`, add `className="border"` to activate the dashed frame
  * so the empty state reads as visually distinct from its container.
+ *
+ * **`frame` prop** — an alternate, SVG-drawn frame for surfaces that want a more
+ * pronounced dashed (or solid) boundary than the CSS border gives — e.g. a
+ * drag-and-drop target. `stroke-dasharray` allows a longer dash/gap than
+ * `border-style: dashed` supports, without losing the rounded corners the way
+ * `border-image` would. Opt-in and independent from `className="border"`; existing
+ * consumers are unaffected. Recolor with `frameClassName` (defaults to `text-border`).
  */
 const meta = {
   title: "Generic/Empty",
@@ -231,5 +238,41 @@ export const InsideCard: Story = {
         </Empty>
       </CardContent>
     </Card>
+  )
+};
+
+export const WithSvgFrame: Story = {
+  name: "Variant: SVG Frame (Dashed / Solid)",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pass `frame="dashed"` or `frame="solid"` for the SVG-drawn boundary — used by `FileDropzone` for its passive (dashed) and drag-active (solid, recolored via `frameClassName`) states. Prefer this over `className="border"` when the dash proportions need to stand out, such as an interactive drop target.'
+      }
+    }
+  },
+  render: () => (
+    <div className="flex gap-4">
+      <Empty frame="dashed" className="w-72">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <UploadIcon />
+          </EmptyMedia>
+          <EmptyTitle>Dashed frame</EmptyTitle>
+          <EmptyDescription>frame=&quot;dashed&quot;</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+      <Empty frame="solid" frameClassName="text-info" className="w-72 bg-info/10">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <UploadIcon />
+          </EmptyMedia>
+          <EmptyTitle>Solid frame</EmptyTitle>
+          <EmptyDescription>
+            frame=&quot;solid&quot; frameClassName=&quot;text-info&quot;
+          </EmptyDescription>
+        </EmptyHeader>
+      </Empty>
+    </div>
   )
 };

--- a/frontend/src/components/v3/generic/Empty/Empty.tsx
+++ b/frontend/src/components/v3/generic/Empty/Empty.tsx
@@ -3,16 +3,44 @@ import { cva, VariantProps } from "cva";
 import { cn } from "../../utils";
 
 type EmptyFrameProps = {
-  // Draws the dashed/solid frame with an SVG rect instead of a CSS border.
-  // CSS `border-style: dashed` has no dash-length control; `stroke-dasharray`
-  // does, and unlike `border-image` it still respects the rounded corners.
-  // Opt-in and off by default so existing `className="border"` consumers
-  // (the CSS-border convention documented in this file's stories) render
-  // unchanged — this is a distinct, additive frame for new call sites.
+  // SVG-drawn dashed/solid frame — `stroke-dasharray` controls dash proportions
+  // in a way `border-style: dashed` can't. Opt-in and independent from the
+  // `className="border"` CSS-border convention; frame="none" consumers are
+  // byte-for-byte unchanged (no wrapper, no hover, no extra padding).
   frame?: "none" | "dashed" | "solid";
-  // Merged onto the frame's default `text-border` (e.g. to recolor on drag-active)
+  // Stroke color via `currentColor` (e.g. `text-info` on drag-active)
   frameClassName?: string;
 };
+
+const FRAME = { stroke: 2, dash: "4 2", radius: 6 } as const;
+
+function EmptyFrameSvg({ dashed, className }: { dashed: boolean; className?: string }) {
+  const inset = FRAME.stroke / 2;
+
+  return (
+    <svg
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute inset-0 size-full text-border transition-colors duration-75",
+        className
+      )}
+    >
+      <rect
+        x={inset}
+        y={inset}
+        rx={FRAME.radius}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={FRAME.stroke}
+        strokeDasharray={dashed ? FRAME.dash : undefined}
+        style={{
+          width: `calc(100% - ${FRAME.stroke}px)`,
+          height: `calc(100% - ${FRAME.stroke}px)`
+        }}
+      />
+    </svg>
+  );
+}
 
 function Empty({
   className,
@@ -21,43 +49,27 @@ function Empty({
   children,
   ...props
 }: React.ComponentProps<"div"> & EmptyFrameProps) {
+  const hasFrame = frame !== "none";
+
   const box = (
     <div
       data-slot="empty"
       className={cn(
-        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-md border-dashed border-border bg-container p-6 text-center text-balance text-foreground shadow-inner md:p-12",
-        frame !== "none" && "relative",
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-md bg-container p-6 text-center text-balance text-foreground shadow-inner md:p-12",
+        frame === "none" && "border-dashed border-border",
+        hasFrame && "relative transition-colors duration-200 hover:bg-container-hover",
         className
       )}
       {...props}
     >
-      {frame !== "none" && (
-        <svg
-          aria-hidden="true"
-          className={cn(
-            "pointer-events-none absolute inset-0 size-full text-border transition-colors duration-75",
-            frameClassName
-          )}
-        >
-          <rect
-            x="1"
-            y="1"
-            rx="4"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeDasharray={frame === "dashed" ? "10 6" : undefined}
-            style={{ width: "calc(100% - 2px)", height: "calc(100% - 2px)" }}
-          />
-        </svg>
-      )}
+      {hasFrame && <EmptyFrameSvg dashed={frame === "dashed"} className={frameClassName} />}
       {children}
     </div>
   );
 
   // Only the SVG-framed variant gets outer breathing room — the plain CSS-border
   // convention (className="border") keeps its existing flush layout untouched.
-  if (frame === "none") return box;
+  if (!hasFrame) return box;
 
   return <div className="p-0.5">{box}</div>;
 }

--- a/frontend/src/components/v3/generic/Empty/Empty.tsx
+++ b/frontend/src/components/v3/generic/Empty/Empty.tsx
@@ -2,17 +2,64 @@ import { cva, VariantProps } from "cva";
 
 import { cn } from "../../utils";
 
-function Empty({ className, ...props }: React.ComponentProps<"div">) {
-  return (
+type EmptyFrameProps = {
+  // Draws the dashed/solid frame with an SVG rect instead of a CSS border.
+  // CSS `border-style: dashed` has no dash-length control; `stroke-dasharray`
+  // does, and unlike `border-image` it still respects the rounded corners.
+  // Opt-in and off by default so existing `className="border"` consumers
+  // (the CSS-border convention documented in this file's stories) render
+  // unchanged — this is a distinct, additive frame for new call sites.
+  frame?: "none" | "dashed" | "solid";
+  // Merged onto the frame's default `text-border` (e.g. to recolor on drag-active)
+  frameClassName?: string;
+};
+
+function Empty({
+  className,
+  frame = "none",
+  frameClassName,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & EmptyFrameProps) {
+  const box = (
     <div
       data-slot="empty"
       className={cn(
         "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-md border-dashed border-border bg-container p-6 text-center text-balance text-foreground shadow-inner md:p-12",
+        frame !== "none" && "relative",
         className
       )}
       {...props}
-    />
+    >
+      {frame !== "none" && (
+        <svg
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-0 size-full text-border transition-colors duration-75",
+            frameClassName
+          )}
+        >
+          <rect
+            x="1"
+            y="1"
+            rx="4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeDasharray={frame === "dashed" ? "10 6" : undefined}
+            style={{ width: "calc(100% - 2px)", height: "calc(100% - 2px)" }}
+          />
+        </svg>
+      )}
+      {children}
+    </div>
   );
+
+  // Only the SVG-framed variant gets outer breathing room — the plain CSS-border
+  // convention (className="border") keeps its existing flush layout untouched.
+  if (frame === "none") return box;
+
+  return <div className="p-0.5">{box}</div>;
 }
 
 function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {

--- a/frontend/src/components/v3/generic/FileDropzone/FileDropzone.stories.tsx
+++ b/frontend/src/components/v3/generic/FileDropzone/FileDropzone.stories.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FileDropzone } from "./FileDropzone";
+
+/**
+ * FileDropzone is the standard file-upload surface: a dashed drop target that
+ * doubles as a click-to-browse button, with an accented "Choose file" affordance
+ * and an optional accepted-types line. While a file is dragged over it, the
+ * frame highlights with the info tint and the title swaps to a drop prompt.
+ *
+ * Selection is delivered through `onFilesSelect` with the files chosen in that
+ * interaction — an empty array signals an invalid drop (e.g. a file dragged out
+ * of VS Code), so callers can raise their own error. Single-file by default;
+ * pass `multiple` to allow several files per interaction.
+ *
+ * The component does not own the selected-file state. Pass `files` to render
+ * the selected files as rows (icon, truncating name with the extension always
+ * visible, size), and `onFileRemove` to expose a remove action on each row.
+ * Omit `files` when selection immediately advances to another step, as in the
+ * secrets import dialog.
+ */
+const meta = {
+  title: "Generic/FileDropzone",
+  component: FileDropzone,
+  parameters: {
+    layout: "centered"
+  },
+  tags: ["autodocs"],
+  args: {
+    className: "w-[480px]",
+    onFilesSelect: () => {}
+  },
+  argTypes: {
+    className: {
+      table: {
+        disable: true
+      }
+    }
+  }
+} satisfies Meta<typeof FileDropzone>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: "Example: Default",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Single-file dropzone with an accepted-types description. Selecting or dropping a file replaces the previous selection."
+      }
+    }
+  },
+  render: (args) => {
+    const [files, setFiles] = useState<File[]>([]);
+    return (
+      <FileDropzone
+        {...args}
+        accept=".env,.json,.yml"
+        description=".env, .json, or .yml"
+        files={files}
+        onFilesSelect={(selected) => setFiles(selected.slice(0, 1))}
+        onFileRemove={(_, index) => setFiles((prev) => prev.filter((__, i) => i !== index))}
+      />
+    );
+  }
+};
+
+export const Multiple: Story = {
+  name: "Variant: Multiple",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pass `multiple` to accept several files per interaction. The caller owns the list, so append incoming files to keep prior selections."
+      }
+    }
+  },
+  render: (args) => {
+    const [files, setFiles] = useState<File[]>([]);
+    return (
+      <FileDropzone
+        {...args}
+        multiple
+        description="Any file type"
+        files={files}
+        onFilesSelect={(selected) => setFiles((prev) => [...prev, ...selected])}
+        onFileRemove={(_, index) => setFiles((prev) => prev.filter((__, i) => i !== index))}
+      />
+    );
+  }
+};
+
+export const WithFile: Story = {
+  name: "Example: With Selected File",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A selected file renders as a row with icon, truncating name (extension always visible), size, and a remove action when `onFileRemove` is provided."
+      }
+    }
+  },
+  render: (args) => {
+    const [files, setFiles] = useState<File[]>([
+      new File(["x".repeat(4096)], "kms-backup-acme-example-project-secretManager.infisical.txt", {
+        type: "text/plain"
+      })
+    ]);
+    return (
+      <FileDropzone
+        {...args}
+        accept=".txt"
+        description=".infisical.txt backup file"
+        files={files}
+        onFilesSelect={(selected) => setFiles(selected.slice(0, 1))}
+        onFileRemove={(_, index) => setFiles((prev) => prev.filter((__, i) => i !== index))}
+      />
+    );
+  }
+};
+
+export const Disabled: Story = {
+  name: "Variant: Disabled",
+  parameters: {
+    docs: {
+      description: {
+        story: "Disabled surfaces dim and ignore both clicks and drops — use for permission gates."
+      }
+    }
+  },
+  render: (args) => <FileDropzone {...args} isDisabled description="Any file type" />
+};

--- a/frontend/src/components/v3/generic/FileDropzone/FileDropzone.stories.tsx
+++ b/frontend/src/components/v3/generic/FileDropzone/FileDropzone.stories.tsx
@@ -19,6 +19,13 @@ import { FileDropzone } from "./FileDropzone";
  * visible, size), and `onFileRemove` to expose a remove action on each row.
  * Omit `files` when selection immediately advances to another step, as in the
  * secrets import dialog.
+ *
+ * Colors default to the `info` tint. When the surface belongs to a specific
+ * scope (e.g. a project-level dialog), override `accentClassName`,
+ * `activeFrameClassName`, and `activeEmptyClassName` with that scope's color
+ * (`text-project`, `bg-project/10`, etc.) per the design system's scope-color
+ * convention. `emptyClassName` and `frameClassName` are open escape hatches
+ * for anything else.
  */
 const meta = {
   title: "Generic/FileDropzone",
@@ -120,6 +127,28 @@ export const WithFile: Story = {
       />
     );
   }
+};
+
+export const ScopedAccent: Story = {
+  name: "Variant: Scoped Accent",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Override `accentClassName` / `activeFrameClassName` / `activeEmptyClassName` to match the surface's scope color instead of the `info` default — e.g. `text-project` for a project-settings dialog like the KMS backup upload."
+      }
+    }
+  },
+  render: (args) => (
+    <FileDropzone
+      {...args}
+      accept=".txt"
+      description=".infisical.txt backup file"
+      accentClassName="text-project"
+      activeFrameClassName="text-project"
+      activeEmptyClassName="bg-project/10"
+    />
+  )
 };
 
 export const Disabled: Story = {

--- a/frontend/src/components/v3/generic/FileDropzone/FileDropzone.tsx
+++ b/frontend/src/components/v3/generic/FileDropzone/FileDropzone.tsx
@@ -35,7 +35,18 @@ type FileDropzoneProps = {
   dropTitle?: ReactNode;
   description?: ReactNode;
   isDisabled?: boolean;
+  /** Layout/width on the outer dropzone wrapper */
   className?: string;
+  /** Merged onto the inner `Empty` surface (background, padding, etc.) */
+  emptyClassName?: string;
+  /** SVG frame stroke at rest — forwarded to `Empty`'s `frameClassName` */
+  frameClassName?: string;
+  /** Frame stroke while dragging — defaults to `text-info` */
+  activeFrameClassName?: string;
+  /** Surface tint while dragging — defaults to `bg-info/10` */
+  activeEmptyClassName?: string;
+  /** Accent on the default "Choose file" label — defaults to `text-info` */
+  accentClassName?: string;
 };
 
 function FileDropzone({
@@ -48,7 +59,12 @@ function FileDropzone({
   dropTitle,
   description,
   isDisabled,
-  className
+  className,
+  emptyClassName,
+  frameClassName,
+  activeFrameClassName = "text-info",
+  activeEmptyClassName = "bg-info/10",
+  accentClassName = "text-info"
 }: FileDropzoneProps) {
   const [isDragActive, setIsDragActive] = useState(false);
 
@@ -83,10 +99,11 @@ function FileDropzone({
     <div data-slot="file-dropzone" className={cn("flex min-w-0 flex-col gap-4", className)}>
       <Empty
         frame={isDragActive ? "solid" : "dashed"}
-        frameClassName={isDragActive ? "text-info" : undefined}
+        frameClassName={cn(frameClassName, isDragActive && activeFrameClassName)}
         className={cn(
-          "cursor-pointer bg-transparent transition-colors duration-75",
-          isDragActive && "bg-info/10",
+          "cursor-pointer bg-transparent",
+          emptyClassName,
+          isDragActive && activeEmptyClassName,
           isDisabled && "pointer-events-none opacity-50"
         )}
         onDragEnter={handleDrag}
@@ -103,7 +120,7 @@ function FileDropzone({
               ? (dropTitle ?? `Drop your file${multiple ? "s" : ""} here`)
               : (title ?? (
                   <>
-                    Drag & drop or <span className="text-info">Choose file</span> to upload
+                    Drag & drop or <span className={accentClassName}>Choose file</span> to upload
                   </>
                 ))}
           </EmptyTitle>

--- a/frontend/src/components/v3/generic/FileDropzone/FileDropzone.tsx
+++ b/frontend/src/components/v3/generic/FileDropzone/FileDropzone.tsx
@@ -1,0 +1,160 @@
+import { ChangeEvent, DragEvent, ReactNode, useState } from "react";
+import { FileTextIcon, UploadIcon, XIcon } from "lucide-react";
+
+import { cn } from "../../utils";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../Empty";
+import { IconButton } from "../IconButton";
+import { Item, ItemActions, ItemContent, ItemGroup, ItemMedia } from "../Item";
+
+// Split so the base name can truncate while the extension stays visible
+const splitFileName = (fileName: string) => {
+  const extIndex = fileName.lastIndexOf(".");
+  if (extIndex <= 0) return { base: fileName, ext: "" };
+  return { base: fileName.slice(0, extIndex), ext: fileName.slice(extIndex) };
+};
+
+const formatFileSize = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+type FileDropzoneProps = {
+  // Files chosen in this interaction (click or drop). Receives an empty array
+  // when a drop carries no real file (e.g. dragging out of VS Code), so
+  // callers can surface their own error message for that case.
+  onFilesSelect: (files: File[]) => void;
+  // Selected files to display as rows under the dropzone. Omit to render the
+  // surface alone (e.g. when selection immediately advances to another step).
+  files?: File[];
+  // Renders a remove action on each file row when provided
+  onFileRemove?: (file: File, index: number) => void;
+  multiple?: boolean;
+  accept?: string;
+  title?: ReactNode;
+  dropTitle?: ReactNode;
+  description?: ReactNode;
+  isDisabled?: boolean;
+  className?: string;
+};
+
+function FileDropzone({
+  onFilesSelect,
+  files,
+  onFileRemove,
+  multiple = false,
+  accept,
+  title,
+  dropTitle,
+  description,
+  isDisabled,
+  className
+}: FileDropzoneProps) {
+  const [isDragActive, setIsDragActive] = useState(false);
+
+  const handleDrag = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isDisabled) return;
+    if (e.type === "dragenter" || e.type === "dragover") {
+      setIsDragActive(true);
+    } else if (e.type === "dragleave") {
+      setIsDragActive(false);
+    }
+  };
+
+  const handleDrop = (e: DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isDisabled || !e.dataTransfer) return;
+    e.dataTransfer.dropEffect = "copy";
+    setIsDragActive(false);
+    const dropped = Array.from(e.dataTransfer.files);
+    onFilesSelect(multiple ? dropped : dropped.slice(0, 1));
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault();
+    onFilesSelect(Array.from(e.target.files ?? []));
+    e.target.value = "";
+  };
+
+  return (
+    <div data-slot="file-dropzone" className={cn("flex min-w-0 flex-col gap-4", className)}>
+      <Empty
+        frame={isDragActive ? "solid" : "dashed"}
+        frameClassName={isDragActive ? "text-info" : undefined}
+        className={cn(
+          "cursor-pointer bg-transparent transition-colors duration-75",
+          isDragActive && "bg-info/10",
+          isDisabled && "pointer-events-none opacity-50"
+        )}
+        onDragEnter={handleDrag}
+        onDragLeave={handleDrag}
+        onDragOver={handleDrag}
+        onDrop={handleDrop}
+      >
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <UploadIcon />
+          </EmptyMedia>
+          <EmptyTitle>
+            {isDragActive
+              ? (dropTitle ?? `Drop your file${multiple ? "s" : ""} here`)
+              : (title ?? (
+                  <>
+                    Drag & drop or <span className="text-info">Choose file</span> to upload
+                  </>
+                ))}
+          </EmptyTitle>
+          {description && <EmptyDescription>{description}</EmptyDescription>}
+        </EmptyHeader>
+        <input
+          type="file"
+          disabled={isDisabled}
+          multiple={multiple}
+          className="absolute top-0 left-0 h-full w-full cursor-pointer opacity-0"
+          accept={accept}
+          onChange={handleChange}
+        />
+      </Empty>
+      {!!files?.length && (
+        <ItemGroup>
+          {files.map((file, index) => {
+            const { base, ext } = splitFileName(file.name);
+            return (
+              // eslint-disable-next-line react/no-array-index-key
+              <Item key={`${file.name}-${index}`} variant="outline" size="xs" role="listitem">
+                <ItemMedia variant="icon">
+                  <FileTextIcon />
+                </ItemMedia>
+                <ItemContent className="min-w-0">
+                  <div className="flex max-w-full min-w-0 items-baseline text-sm text-foreground">
+                    <span className="min-w-0 truncate">{base}</span>
+                    <span className="shrink-0">{ext}</span>
+                  </div>
+                  <span className="text-xs text-muted">{formatFileSize(file.size)}</span>
+                </ItemContent>
+                {onFileRemove && (
+                  <ItemActions>
+                    <IconButton
+                      variant="ghost"
+                      size="xs"
+                      aria-label={`Remove ${file.name}`}
+                      onClick={() => onFileRemove(file, index)}
+                    >
+                      <XIcon />
+                    </IconButton>
+                  </ItemActions>
+                )}
+              </Item>
+            );
+          })}
+        </ItemGroup>
+      )}
+    </div>
+  );
+}
+
+export { FileDropzone };
+export type { FileDropzoneProps };

--- a/frontend/src/components/v3/generic/FileDropzone/index.ts
+++ b/frontend/src/components/v3/generic/FileDropzone/index.ts
@@ -1,0 +1,1 @@
+export * from "./FileDropzone";

--- a/frontend/src/components/v3/generic/index.ts
+++ b/frontend/src/components/v3/generic/index.ts
@@ -17,6 +17,7 @@ export * from "./Dialog";
 export * from "./Dropdown";
 export * from "./Empty";
 export * from "./Field";
+export * from "./FileDropzone";
 export * from "./HoverCard";
 export * from "./IconButton";
 export * from "./Input";

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/ImportSecretsModal.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretDropzone/ImportSecretsModal.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, DragEvent, useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import { subject } from "@casl/ability";
 import {
   ClipboardPasteIcon,
@@ -8,10 +8,8 @@ import {
   InfoIcon,
   MessageSquareIcon,
   TagsIcon,
-  UploadIcon,
   WrapTextIcon
 } from "lucide-react";
-import { twMerge } from "tailwind-merge";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
@@ -23,14 +21,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  Empty,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
   Field,
   FieldContent,
   FieldLabel,
+  FileDropzone,
   IconButton,
   Input,
   Switch,
@@ -88,7 +82,6 @@ const ImportSecretsContent = ({
   const { permission } = useProjectPermission();
   const [parsedSecrets, setParsedSecrets] = useState<TParsedEnv | null>(null);
   const [selectedEnvs, setSelectedEnvs] = useState<{ name: string; slug: string }[]>([]);
-  const [isDragActive, setDragActive] = useToggle();
   const [isImporting, setIsImporting] = useToggle();
   const [isPasteOpen, setIsPasteOpen] = useState(false);
   const [csvData, setCsvData] = useState<CsvData | null>(null);
@@ -156,31 +149,6 @@ const ImportSecretsContent = ({
     },
     [handleParsedSecrets]
   );
-
-  const handleDrag = (e: DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (e.type === "dragenter" || e.type === "dragover") {
-      setDragActive.on();
-    } else if (e.type === "dragleave") {
-      setDragActive.off();
-    }
-  };
-
-  const handleDrop = (e: DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (!e.dataTransfer) return;
-    e.dataTransfer.dropEffect = "copy";
-    setDragActive.off();
-    parseFile(e.dataTransfer.files[0]);
-  };
-
-  const handleFileUpload = (e: ChangeEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    parseFile(e.target?.files?.[0]);
-    e.target.value = "";
-  };
 
   const handleImport = async () => {
     if (!activeSecrets || !selectedEnvs.length) return;
@@ -449,36 +417,12 @@ const ImportSecretsContent = ({
             })}
           >
             {(isAllowed) => (
-              <Empty
-                className={twMerge(
-                  "relative cursor-pointer border transition-colors duration-75",
-                  isDragActive && "bg-container-hover"
-                )}
-                onDragEnter={handleDrag}
-                onDragLeave={handleDrag}
-                onDragOver={handleDrag}
-                onDrop={handleDrop}
-              >
-                <EmptyHeader>
-                  <EmptyMedia variant="icon">
-                    <UploadIcon />
-                  </EmptyMedia>
-                  <EmptyTitle>
-                    {isDragActive ? "Drop your file here" : "Upload your secrets"}
-                  </EmptyTitle>
-                  <EmptyDescription>
-                    Drag and drop your .env, .json, .yml, .csv, .pfx, .pem, or .crt files here, or
-                    click to browse
-                  </EmptyDescription>
-                </EmptyHeader>
-                <input
-                  type="file"
-                  disabled={!isAllowed}
-                  className="absolute top-0 left-0 h-full w-full cursor-pointer opacity-0"
-                  accept=".txt,.env,.yml,.yaml,.json,.csv,.pfx,.pem,.crt"
-                  onChange={handleFileUpload}
-                />
-              </Empty>
+              <FileDropzone
+                isDisabled={!isAllowed}
+                accept=".txt,.env,.yml,.yaml,.json,.csv,.pfx,.pem,.crt"
+                description=".env, .json, .yml, .csv, .pfx, .pem, or .crt"
+                onFilesSelect={(files) => parseFile(files[0])}
+              />
             )}
           </ProjectPermissionCan>
 

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
@@ -1,8 +1,7 @@
-import { ChangeEvent, useRef, useState } from "react";
+import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import FileSaver from "file-saver";
-import { UploadIcon } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
@@ -23,6 +22,7 @@ import {
   Field,
   FieldError,
   FieldLabel,
+  FileDropzone,
   Select,
   SelectContent,
   SelectItem,
@@ -131,10 +131,9 @@ const LoadBackupModal = ({
   org?: Organization;
   workspace: Project;
 }) => {
-  const fileUploadRef = useRef<HTMLInputElement>(null);
   const { mutateAsync: loadKmsBackup, isPending } = useLoadProjectKmsBackup(project.id);
   const [backupContent, setBackupContent] = useState("");
-  const [backupFileName, setBackupFileName] = useState("");
+  const [backupFiles, setBackupFiles] = useState<File[]>([]);
 
   const handleOpenChange = (state: boolean) => {
     // Clear on every open-change (open and close), not only close: a FileReader
@@ -142,7 +141,7 @@ const LoadBackupModal = ({
     // clearing on reopen recovers from that stale state (Continue would otherwise
     // be enabled with no filename shown).
     setBackupContent("");
-    setBackupFileName("");
+    setBackupFiles([]);
     onOpenChange(state);
   };
 
@@ -183,12 +182,6 @@ const LoadBackupModal = ({
     }
   };
 
-  const handleFileUpload = (e: ChangeEvent<HTMLInputElement>) => {
-    e.preventDefault();
-    parseFile(e.target?.files?.[0]);
-    setBackupFileName(e.target?.files?.[0]?.name || "");
-  };
-
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-lg">
@@ -199,31 +192,20 @@ const LoadBackupModal = ({
             KMS.
           </DialogDescription>
         </DialogHeader>
-        <input
-          id="fileSelect"
-          className="hidden"
-          type="file"
+        <FileDropzone
           accept=".txt"
-          onChange={handleFileUpload}
-          ref={fileUploadRef}
+          description=".infisical.txt backup file"
+          files={backupFiles}
+          onFilesSelect={(files) => {
+            const file = files[0];
+            parseFile(file);
+            setBackupFiles(file ? [file] : []);
+          }}
+          onFileRemove={() => {
+            setBackupFiles([]);
+            setBackupContent("");
+          }}
         />
-        <div className="flex flex-col items-center gap-2 py-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              fileUploadRef?.current?.click();
-            }}
-          >
-            <UploadIcon className="size-4" />
-            Choose Backup File
-          </Button>
-          {backupFileName && (
-            <span className="max-w-full truncate px-4 text-center text-sm text-muted">
-              {backupFileName}
-            </span>
-          )}
-        </div>
         <DialogFooter>
           <Button variant="outline" onClick={() => handleOpenChange(false)}>
             Cancel

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
@@ -137,10 +137,12 @@ const LoadBackupModal = ({
   const [backupFileName, setBackupFileName] = useState("");
 
   const handleOpenChange = (state: boolean) => {
-    if (!state) {
-      setBackupContent("");
-      setBackupFileName("");
-    }
+    // Clear on every open-change (open and close), not only close: a FileReader
+    // read can finish after the dialog closes and repopulate backupContent, so
+    // clearing on reopen recovers from that stale state (Continue would otherwise
+    // be enabled with no filename shown).
+    setBackupContent("");
+    setBackupFileName("");
     onOpenChange(state);
   };
 

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
@@ -196,6 +196,9 @@ const LoadBackupModal = ({
           accept=".txt"
           description=".infisical.txt backup file"
           files={backupFiles}
+          accentClassName="text-project"
+          activeFrameClassName="text-project"
+          activeEmptyClassName="bg-project/10"
           onFilesSelect={(files) => {
             const file = files[0];
             parseFile(file);

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
@@ -216,7 +216,7 @@ const LoadBackupModal = ({
             }}
           >
             <UploadIcon className="size-4" />
-            Choose backup file
+            Choose Backup File
           </Button>
           {backupFileName && (
             <span className="max-w-full truncate px-4 text-center text-sm text-muted">
@@ -296,13 +296,13 @@ export const EncryptionTab = () => {
             {kmsKeyId !== INTERNAL_KMS_KEY_ID && (
               <div className="flex gap-2">
                 <Button variant="outline" onClick={() => handlePopUpOpen("loadBackup")}>
-                  Load backup
+                  Load Backup
                 </Button>
                 <Button
                   variant="outline"
                   onClick={() => handlePopUpOpen("createBackupConfirmation")}
                 >
-                  Create backup
+                  Create Backup
                 </Button>
               </div>
             )}
@@ -317,7 +317,7 @@ export const EncryptionTab = () => {
                   name="kmsKeyId"
                   render={({ field: { onChange, value }, fieldState: { error } }) => (
                     <Field className="max-w-md">
-                      <FieldLabel htmlFor="kmsKeyId">Key management system</FieldLabel>
+                      <FieldLabel htmlFor="kmsKeyId">Key Management System</FieldLabel>
                       <Select
                         value={value}
                         onValueChange={onChange}
@@ -326,7 +326,7 @@ export const EncryptionTab = () => {
                         <SelectTrigger
                           id="kmsKeyId"
                           className="w-full"
-                          aria-label="Key management system"
+                          aria-label="Key Management System"
                         >
                           <SelectValue placeholder="Select a KMS" />
                         </SelectTrigger>

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
@@ -9,6 +9,7 @@ import { ProjectPermissionCan } from "@app/components/permissions";
 import {
   Button,
   Card,
+  CardAction,
   CardContent,
   CardDescription,
   CardHeader,
@@ -271,27 +272,20 @@ export const EncryptionTab = () => {
     <>
       <Card className="mb-6">
         <CardHeader>
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <CardTitle>Key Management</CardTitle>
-              <CardDescription>
-                Select which Key Management System to use for encrypting your project data
-              </CardDescription>
-            </div>
-            {kmsKeyId !== INTERNAL_KMS_KEY_ID && (
-              <div className="flex gap-2">
-                <Button variant="outline" onClick={() => handlePopUpOpen("loadBackup")}>
-                  Load Backup
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => handlePopUpOpen("createBackupConfirmation")}
-                >
-                  Create Backup
-                </Button>
-              </div>
-            )}
-          </div>
+          <CardTitle>Key Management</CardTitle>
+          <CardDescription>
+            Select which Key Management System to use for encrypting your project data
+          </CardDescription>
+          {kmsKeyId !== INTERNAL_KMS_KEY_ID && (
+            <CardAction className="flex gap-2">
+              <Button variant="outline" onClick={() => handlePopUpOpen("loadBackup")}>
+                Load Backup
+              </Button>
+              <Button variant="outline" onClick={() => handlePopUpOpen("createBackupConfirmation")}>
+                Create Backup
+              </Button>
+            </CardAction>
+          )}
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit(onUpdateProjectKms)}>

--- a/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/EncryptionTab/EncryptionTab.tsx
@@ -1,22 +1,34 @@
 import { ChangeEvent, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { faUpload } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import FileSaver from "file-saver";
+import { UploadIcon } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
 import {
   Button,
-  FormControl,
-  IconButton,
-  Modal,
-  ModalContent,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
   Select,
-  SelectItem
-} from "@app/components/v2";
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@app/components/v3";
 import {
   ProjectPermissionActions,
   ProjectPermissionSub,
@@ -81,25 +93,30 @@ const BackupConfirmationModal = ({
   };
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent title="Create KMS backup">
-        <p className="mb-6 text-bunker-300">
-          In case of interruptions with your configured external KMS, you can load a backup to set
-          the project&apos;s KMS back to the default Infisical KMS.
-        </p>
-        <Button onClick={downloadKmsBackup} isLoading={isGeneratingBackup}>
-          Generate
-        </Button>
-        <Button
-          onClick={() => onOpenChange(false)}
-          colorSchema="secondary"
-          variant="plain"
-          className="ml-4"
-        >
-          Cancel
-        </Button>
-      </ModalContent>
-    </Modal>
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Create KMS Backup</DialogTitle>
+          <DialogDescription>
+            In case of interruptions with your configured external KMS, you can load a backup to set
+            the project&apos;s KMS back to the default Infisical KMS.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="project"
+            onClick={downloadKmsBackup}
+            isPending={isGeneratingBackup}
+            isDisabled={isGeneratingBackup}
+          >
+            Generate
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 
@@ -119,6 +136,14 @@ const LoadBackupModal = ({
   const [backupContent, setBackupContent] = useState("");
   const [backupFileName, setBackupFileName] = useState("");
 
+  const handleOpenChange = (state: boolean) => {
+    if (!state) {
+      setBackupContent("");
+      setBackupFileName("");
+    }
+    onOpenChange(state);
+  };
+
   const uploadKmsBackup = async () => {
     if (!project || !org) {
       return;
@@ -130,7 +155,7 @@ const LoadBackupModal = ({
       type: "success"
     });
 
-    onOpenChange(false);
+    handleOpenChange(false);
   };
 
   const parseFile = (file?: File) => {
@@ -163,53 +188,55 @@ const LoadBackupModal = ({
   };
 
   return (
-    <Modal
-      isOpen={isOpen}
-      onOpenChange={(state: boolean) => {
-        setBackupContent("");
-        setBackupFileName("");
-        onOpenChange(state);
-      }}
-    >
-      <ModalContent title="Load KMS backup">
-        <p className="mb-6 text-bunker-300">
-          By loading a backup, the project&apos;s KMS will be switched to the default Infisical KMS.
-        </p>
-        <div className="flex justify-center">
-          <input
-            id="fileSelect"
-            className="hidden"
-            type="file"
-            accept=".txt"
-            onChange={handleFileUpload}
-            ref={fileUploadRef}
-          />
-          <IconButton
-            className="p-10"
-            ariaLabel="upload-backup"
-            colorSchema="secondary"
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Load KMS Backup</DialogTitle>
+          <DialogDescription>
+            By loading a backup, the project&apos;s KMS will be switched to the default Infisical
+            KMS.
+          </DialogDescription>
+        </DialogHeader>
+        <input
+          id="fileSelect"
+          className="hidden"
+          type="file"
+          accept=".txt"
+          onChange={handleFileUpload}
+          ref={fileUploadRef}
+        />
+        <div className="flex flex-col items-center gap-2 py-2">
+          <Button
+            type="button"
+            variant="outline"
             onClick={() => {
               fileUploadRef?.current?.click();
             }}
           >
-            <FontAwesomeIcon icon={faUpload} size="3x" />
-          </IconButton>
+            <UploadIcon className="size-4" />
+            Choose backup file
+          </Button>
+          {backupFileName && (
+            <span className="max-w-full truncate px-4 text-center text-sm text-muted">
+              {backupFileName}
+            </span>
+          )}
         </div>
-        {backupFileName && (
-          <div className="mt-2 flex justify-center px-4 text-center">{backupFileName}</div>
-        )}
-        {backupContent && (
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            Cancel
+          </Button>
           <Button
+            variant="project"
             onClick={uploadKmsBackup}
-            className="mt-10 w-fit"
-            disabled={isPending}
-            isLoading={isPending}
+            isPending={isPending}
+            isDisabled={!backupContent || isPending}
           >
             Continue
           </Button>
-        )}
-      </ModalContent>
-    </Modal>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };
 
@@ -254,73 +281,89 @@ export const EncryptionTab = () => {
   };
 
   return (
-    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-      <div className="flex justify-between">
-        <h2 className="mb-2 flex-1 text-xl font-medium text-mineshaft-100">Key Management</h2>
-        {kmsKeyId !== INTERNAL_KMS_KEY_ID && (
-          <div className="space-x-2">
-            <Button colorSchema="secondary" onClick={() => handlePopUpOpen("loadBackup")}>
-              Load Backup
-            </Button>
-            <Button
-              colorSchema="secondary"
-              onClick={() => {
-                handlePopUpOpen("createBackupConfirmation");
-              }}
-            >
-              Create Backup
-            </Button>
+    <>
+      <Card className="mb-6">
+        <CardHeader>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <CardTitle>Key Management</CardTitle>
+              <CardDescription>
+                Select which Key Management System to use for encrypting your project data
+              </CardDescription>
+            </div>
+            {kmsKeyId !== INTERNAL_KMS_KEY_ID && (
+              <div className="flex gap-2">
+                <Button variant="outline" onClick={() => handlePopUpOpen("loadBackup")}>
+                  Load backup
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => handlePopUpOpen("createBackupConfirmation")}
+                >
+                  Create backup
+                </Button>
+              </div>
+            )}
           </div>
-        )}
-      </div>
-
-      <p className="mb-4 text-gray-400">
-        Select which Key Management System to use for encrypting your project data
-      </p>
-      <div className="mb-6 max-w-md">
-        <form onSubmit={handleSubmit(onUpdateProjectKms)}>
-          <ProjectPermissionCan I={ProjectPermissionActions.Edit} a={ProjectPermissionSub.Kms}>
-            {(isAllowed) => (
-              <Controller
-                render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                  <FormControl errorText={error?.message} isError={Boolean(error)}>
-                    <Select
-                      {...field}
-                      isDisabled={!isAllowed || isUpdatingProjectKms}
-                      onValueChange={onChange}
-                      isLoading={isUpdatingProjectKms}
-                      className="w-3/4 bg-mineshaft-600"
-                    >
-                      <SelectItem value={INTERNAL_KMS_KEY_ID} key="kms-internal">
-                        Default Infisical KMS
-                      </SelectItem>
-                      {externalKmsList?.map((kms) => (
-                        <SelectItem value={kms.id} key={`kms-${kms.id}`}>
-                          {kms.name}
-                        </SelectItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                )}
-                control={control}
-                name="kmsKeyId"
-              />
-            )}
-          </ProjectPermissionCan>
-          <ProjectPermissionCan I={ProjectPermissionActions.Edit} a={ProjectPermissionSub.Project}>
-            {(isAllowed) => (
-              <Button
-                colorSchema="secondary"
-                type="submit"
-                isDisabled={!isAllowed || isSubmitting || !isDirty}
-                isLoading={isSubmitting}
-              >
-                Save
-              </Button>
-            )}
-          </ProjectPermissionCan>
-        </form>
-      </div>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onUpdateProjectKms)}>
+            <ProjectPermissionCan I={ProjectPermissionActions.Edit} a={ProjectPermissionSub.Kms}>
+              {(isAllowed) => (
+                <Controller
+                  control={control}
+                  name="kmsKeyId"
+                  render={({ field: { onChange, value }, fieldState: { error } }) => (
+                    <Field className="max-w-md">
+                      <FieldLabel htmlFor="kmsKeyId">Key management system</FieldLabel>
+                      <Select
+                        value={value}
+                        onValueChange={onChange}
+                        disabled={!isAllowed || isUpdatingProjectKms}
+                      >
+                        <SelectTrigger
+                          id="kmsKeyId"
+                          className="w-full"
+                          aria-label="Key management system"
+                        >
+                          <SelectValue placeholder="Select a KMS" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value={INTERNAL_KMS_KEY_ID} key="kms-internal">
+                            Default Infisical KMS
+                          </SelectItem>
+                          {externalKmsList?.map((kms) => (
+                            <SelectItem value={kms.id} key={`kms-${kms.id}`}>
+                              {kms.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FieldError>{error?.message}</FieldError>
+                    </Field>
+                  )}
+                />
+              )}
+            </ProjectPermissionCan>
+            <ProjectPermissionCan
+              I={ProjectPermissionActions.Edit}
+              a={ProjectPermissionSub.Project}
+            >
+              {(isAllowed) => (
+                <Button
+                  className="mt-4"
+                  variant="project"
+                  type="submit"
+                  isDisabled={!isAllowed || isSubmitting || !isDirty}
+                  isPending={isSubmitting}
+                >
+                  Save
+                </Button>
+              )}
+            </ProjectPermissionCan>
+          </form>
+        </CardContent>
+      </Card>
       <BackupConfirmationModal
         isOpen={popUp.createBackupConfirmation.isOpen}
         onOpenChange={(state: boolean) => handlePopUpToggle("createBackupConfirmation", state)}
@@ -333,6 +376,6 @@ export const EncryptionTab = () => {
         org={currentOrg}
         workspace={currentProject}
       />
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
## Context

The Secrets Management project **Encryption** settings tab (Key Management / KMS selection plus the Create Backup and Load Backup modals) was still built on the legacy **v2** component system.

This PR migrates it to **v3**:

- `Card` layout in place of the hand-rolled bordered container.
- Radix v3 `Select` (`SelectTrigger` / `SelectValue` / `SelectContent` / `SelectItem`) bound via react-hook-form, wrapped in `Field` / `FieldLabel` / `FieldError` with an accessible name.
- Both backup modals moved to v3 `Dialog` + `DialogFooter` (the default close button is retained).
- v3 `Button` props (`variant="project"`, `isPending` / `isDisabled`) replacing v2 `isLoading` / `colorSchema`; the FontAwesome upload icon replaced with Lucide.
- Content/casing pass per the design contract: Title Case dialog titles, sentence-case actions and labels.
- Load-backup modal now resets its file state on every close path (including the new Cancel), not just Escape / X / outside-click.

Behavior is preserved: KMS select + save, backup download, backup upload/parse, permission gating, and external-KMS-only backup buttons.

Resolves [PLATFOR-555](https://linear.app/infisical/issue/PLATFOR-555/migrate-encryption-project-settings-sm-to-v3).

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Open a v3 Secrets Management project → **Settings → Encryption**.
2. Confirm the section renders as a v3 `Card` ("Key Management") with the KMS `Select` and a Save button.
3. Choose a KMS and click **Save** — a success toast should appear.
4. With an external KMS active, open **Create backup** / **Load backup** — both should render as v3 dialogs. In Load backup, choose a file, click **Cancel**, then reopen — the filename should be cleared (no stale selection).

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
