### PR TITLE
improvement(secret-v2-bridge): cache permission fingerprint for ETag path

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -124,6 +124,8 @@ export const KeyStorePrefixes = {
   TelemetryGroupIdentify: (orgId: string) => `telemetry-group-identify:${orgId}` as const,
   TelemetryIdentify: (distinctId: string) => `telemetry-identify:${distinctId}` as const,
   SecretEtag: (projectId: string, dayStamp: string) => `secret-etag:${projectId}:${dayStamp}` as const,
+  SecretPermissionFingerprint: (projectId: string, actorType: string, actorId: string) =>
+    `secret-perm-fingerprint:${projectId}:${actorType}:${actorId}` as const,
 
   PamAwsIamAccessKeyId: (sessionId: string) => `pam-aws-iam-access-key-id:${sessionId}` as const,
   PamDefaultProject: (orgId: string) => `pam-default-project:${orgId}` as const,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -30,6 +30,7 @@ import { TSecretApprovalRequestSecretDALFactory } from "@app/ee/services/secret-
 import { scanSecretPolicyViolations } from "@app/ee/services/secret-scanning-v2/secret-scanning-v2-fns";
 import { TSecretSnapshotServiceFactory } from "@app/ee/services/secret-snapshot/secret-snapshot-service";
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
+import { withCache } from "@app/lib/cache/with-cache";
 import { generateCacheKeyFromBuffer, generateCacheKeyFromData } from "@app/lib/crypto/cache";
 import { utcDayStamp } from "@app/lib/dates";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
@@ -1264,11 +1265,19 @@ export const secretV2BridgeServiceFactory = ({
     let permissionFingerprint = "";
 
     if (actor === ActorType.USER || actor === ActorType.IDENTITY) {
-      permissionFingerprint = await permissionDAL.getPermissionFingerprint({
-        projectId,
-        orgId: actorOrgId,
-        actorId,
-        actorType: actor
+      // Cache the fingerprint for the marker window so repeated polls
+      // skip the per-request DB query. Same 10s TTL as getProjectPermission's marker, so no new staleness.
+      permissionFingerprint = await withCache({
+        keyStore,
+        key: KeyStorePrefixes.SecretPermissionFingerprint(projectId, actor, actorId),
+        ttlSeconds: KeyStoreTtls.ProjectPermissionMarkerTtlSeconds,
+        fetcher: () =>
+          permissionDAL.getPermissionFingerprint({
+            projectId,
+            orgId: actorOrgId,
+            actorId,
+            actorType: actor
+          })
       });
     }
 

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1267,6 +1267,7 @@ export const secretV2BridgeServiceFactory = ({
     if (actor === ActorType.USER || actor === ActorType.IDENTITY) {
       // Cache the fingerprint for the marker window so repeated polls
       // skip the per-request DB query. Same 10s TTL as getProjectPermission's marker, so no new staleness.
+      // This gates only the Etag cache, the real permission check is still done on the getProjectPermission call.
       permissionFingerprint = await withCache({
         keyStore,
         key: KeyStorePrefixes.SecretPermissionFingerprint(projectId, actor, actorId),


### PR DESCRIPTION
## Context

Repeated `GET /api/v4/secrets` polls (e.g. k8s operator resync timers) call `getPermissionFingerprint` on every request to build the ETag hash field, even when permissions haven't changed.

This wraps the fingerprint in a short-lived Redis cache (`withCache`, 10s TTL — same as `ProjectPermissionMarkerTtlSeconds`). The new key prefix is `secret-perm-fingerprint:{projectId}:{actorType}:{actorId}`.

`getProjectPermission` still runs on every request; this only avoids the extra fingerprint DB read for the ETag/304 path. No new staleness window beyond what the permission marker cache already accepts; `filterTemporary` still runs per request for timed-access revocation.

## Steps to verify the change

1. Authenticate as a user or machine identity (Universal Auth or JWT).
2. Call `GET /api/v4/secrets` twice within 10s with the same `projectId`, `environment`, and `secretPath`.
3. Confirm Redis key `secret-perm-fingerprint:{projectId}:{actorType}:{actorId}` is set after the first call and reused on the second.
4. Optional: send `If-None-Match` with the returned `ETag` and confirm `304` on unchanged data.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)