### PR TITLE
improvement(telemetry): label secret cache ETag misses and fix k8-operator UA detection

### DIFF
--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -328,10 +328,10 @@ export enum SecretCacheAccessResult {
   MISS = "miss"
 }
 
-// Why an If-None-Match request did not 304.
+// What the server observed when an If-None-Match request did not 304 (cause is inferred downstream).
 export enum SecretEtagMissReason {
-  FIELD_ABSENT = "field_absent", // no stored ETag field: churned or expired
-  VALUE_DIFFERS = "value_differs" // field exists, content hash differs: secrets changed
+  FIELD_ABSENT = "field_absent", // no stored ETag for this (actor, fingerprint, params) key
+  VALUE_DIFFERS = "value_differs" // a stored ETag exists but differs from the client's If-None-Match
 }
 
 export const secretCacheAccessCounter = infisicalCoreMeter.createCounter("infisical.secret.cache.access.count", {

--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -328,8 +328,14 @@ export enum SecretCacheAccessResult {
   MISS = "miss"
 }
 
+// Why an If-None-Match request did not 304.
+export enum SecretEtagMissReason {
+  FIELD_ABSENT = "field_absent", // no stored ETag field: churned or expired
+  VALUE_DIFFERS = "value_differs" // field exists, content hash differs: secrets changed
+}
+
 export const secretCacheAccessCounter = infisicalCoreMeter.createCounter("infisical.secret.cache.access.count", {
-  description: "Secret service-layer cache accesses by outcome (304 not-modified / hit / miss)",
+  description: "Secret cache accesses, labeled by result, whether If-None-Match was sent, and why it missed the 304.",
   unit: "{access}"
 });
 
@@ -346,9 +352,15 @@ export const secretCacheOversizeSkipCounter = infisicalCoreMeter.createCounter(
   }
 );
 
-export const recordSecretCacheAccessMetric = (result: SecretCacheAccessResult) => {
+export const recordSecretCacheAccessMetric = (
+  result: SecretCacheAccessResult,
+  opts?: { hasIfNoneMatch?: boolean; etagMissReason?: SecretEtagMissReason }
+) => {
   if (!isTelemetryEnabled()) return;
-  secretCacheAccessCounter.add(1, { "cache.result": result });
+  const attributes: Record<string, string> = { "cache.result": result };
+  if (opts?.hasIfNoneMatch !== undefined) attributes["cache.if_none_match"] = opts.hasIfNoneMatch ? "true" : "false";
+  if (opts?.etagMissReason) attributes["cache.etag_miss_reason"] = opts.etagMissReason;
+  secretCacheAccessCounter.add(1, attributes);
 };
 
 export const recordSecretCacheWriteMetric = (params: { bytes: number; stored: boolean }) => {

--- a/backend/src/lib/telemetry/telemetry-attributes.ts
+++ b/backend/src/lib/telemetry/telemetry-attributes.ts
@@ -26,6 +26,8 @@ export const INFISICAL_CORE_METER_ATTRIBUTES = [
   "sso.action",
   "db.pool.state",
   "cache.result",
+  "cache.if_none_match",
+  "cache.etag_miss_reason",
   "rate_limit.bucket",
   "provider",
   "destination",

--- a/backend/src/server/plugins/audit-log.ts
+++ b/backend/src/server/plugins/audit-log.ts
@@ -13,7 +13,8 @@ export const getUserAgentType = (userAgent: string | undefined) => {
   if (userAgent === UserAgentType.CLI) {
     return UserAgentType.CLI;
   }
-  if (userAgent === UserAgentType.K8_OPERATOR) {
+  // also match the versioned UA, e.g. "k8-operator/0.11.4"
+  if (userAgent === UserAgentType.K8_OPERATOR || userAgent.startsWith(`${UserAgentType.K8_OPERATOR}/`)) {
     return UserAgentType.K8_OPERATOR;
   }
   if (userAgent === UserAgentType.TERRAFORM) {

--- a/backend/src/server/routes/v3/deprecated-secret-router.ts
+++ b/backend/src/server/routes/v3/deprecated-secret-router.ts
@@ -1069,7 +1069,8 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
       // }
 
       const shouldCapture =
-        req.query.workspaceId !== "650e71fbae3e6c8572f436d4" && req.headers["user-agent"] !== "k8-operator";
+        req.query.workspaceId !== "650e71fbae3e6c8572f436d4" &&
+        getUserAgentType(req.headers["user-agent"]) !== UserAgentType.K8_OPERATOR;
       if (shouldCapture) {
         await server.services.telemetry.sendPostHogEvents({
           event: PostHogEventTypes.SecretPulled,

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -45,7 +45,8 @@ import {
   recordSecretOperationDuration,
   recordSecretReadMetric,
   recordSecretWriteMetric,
-  SecretCacheAccessResult
+  SecretCacheAccessResult,
+  SecretEtagMissReason
 } from "@app/lib/telemetry/metrics";
 
 import { ActorType } from "../auth/auth-type";
@@ -1292,12 +1293,16 @@ export const secretV2BridgeServiceFactory = ({
     });
     const etagField = `${actorId}:${permissionFingerprint}:${requestParamsHash}`;
 
+    const hasIfNoneMatch = Boolean(ifNoneMatch);
+    let etagMissReason: SecretEtagMissReason | undefined;
+
     if (ifNoneMatch) {
       const storedEtag = await keyStore.hashGet(etagRedisKey, etagField);
       if (storedEtag && storedEtag === ifNoneMatch) {
-        recordSecretCacheAccessMetric(SecretCacheAccessResult.NOT_MODIFIED);
+        recordSecretCacheAccessMetric(SecretCacheAccessResult.NOT_MODIFIED, { hasIfNoneMatch: true });
         return { notModified: true, etag: ifNoneMatch, secrets: [], imports: [] };
       }
+      etagMissReason = storedEtag ? SecretEtagMissReason.VALUE_DIFFERS : SecretEtagMissReason.FIELD_ABSENT;
     }
 
     const { permission } = await permissionService.getProjectPermission({
@@ -1357,7 +1362,7 @@ export const secretV2BridgeServiceFactory = ({
         const payload = { secrets, imports };
         await keyStore.hashSet(etagRedisKey, etagField, cachedEtag);
         await keyStore.setExpiry(etagRedisKey, KeyStoreTtls.SecretEtagInSeconds);
-        recordSecretCacheAccessMetric(SecretCacheAccessResult.HIT);
+        recordSecretCacheAccessMetric(SecretCacheAccessResult.HIT, { hasIfNoneMatch, etagMissReason });
         return { ...payload, etag: cachedEtag };
       } catch (err) {
         logger.error(err, "Secret service layer cache miss");
@@ -1617,7 +1622,7 @@ export const secretV2BridgeServiceFactory = ({
         await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL(), encryptedUpdatedCachedSecrets.toString("base64"));
       }
       recordSecretCacheWriteMetric({ bytes: cacheBytes, stored });
-      recordSecretCacheAccessMetric(SecretCacheAccessResult.MISS);
+      recordSecretCacheAccessMetric(SecretCacheAccessResult.MISS, { hasIfNoneMatch, etagMissReason });
       await keyStore.hashSet(etagRedisKey, etagField, computedEtag);
       await keyStore.setExpiry(etagRedisKey, KeyStoreTtls.SecretEtagInSeconds);
       return { ...payload, etag: computedEtag };
@@ -1708,7 +1713,7 @@ export const secretV2BridgeServiceFactory = ({
       await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL(), encryptedUpdatedCachedSecrets.toString("base64"));
     }
     recordSecretCacheWriteMetric({ bytes: cacheBytes, stored });
-    recordSecretCacheAccessMetric(SecretCacheAccessResult.MISS);
+    recordSecretCacheAccessMetric(SecretCacheAccessResult.MISS, { hasIfNoneMatch, etagMissReason });
     await keyStore.hashSet(etagRedisKey, etagField, computedEtag);
     await keyStore.setExpiry(etagRedisKey, KeyStoreTtls.SecretEtagInSeconds);
     return { ...payload, etag: computedEtag };

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1293,7 +1293,7 @@ export const secretV2BridgeServiceFactory = ({
     });
     const etagField = `${actorId}:${permissionFingerprint}:${requestParamsHash}`;
 
-    const hasIfNoneMatch = Boolean(ifNoneMatch);
+    const hasIfNoneMatch = ifNoneMatch !== undefined;
     let etagMissReason: SecretEtagMissReason | undefined;
 
     if (ifNoneMatch) {


### PR DESCRIPTION
## Context

Secret cache metrics (`infisical.secret.cache.access.count`) only recorded `hit` / `miss` / `not_modified`, so it was hard to tell why `If-None-Match` requests returned 200 instead of 304, expired/missing ETag hash vs actual content change.

This adds bounded labels: `cache.if_none_match` and `cache.etag_miss_reason` (`field_absent` | `value_differs`), wired through `getSecrets` on all cache outcomes. New attributes are allowlisted on the InfisicalCore meter.

Also fixes k8-operator detection for versioned user agents (e.g. `k8-operator/0.11.4`) in `getUserAgentType`, and applies the same check in the v3 deprecated secret router PostHog skip path.

## Steps to verify the change

1. `GET /api/v4/secrets` without `If-None-Match` — metric with `cache.if_none_match=false`.
2. Repeat with `If-None-Match: "<etag>"` (quotes included) on unchanged data — `cache.result=not_modified`, `cache.if_none_match=true`.
3. Send a stale/wrong ETag — `cache.result=hit|miss` with `cache.etag_miss_reason=field_absent` or `value_differs`.
4. Call with `User-Agent: k8-operator/0.11.4` and confirm it is classified as k8-operator (PostHog `SecretPulled` skipped on v3/v4).

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)