### PR TITLE
fix(audit-log): skip Postgres cleanup cron when ClickHouse audit logs are enabled

### DIFF
--- a/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
+++ b/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
@@ -82,6 +82,14 @@ export const dailyResourceCleanUpQueueServiceFactory = ({
     const dailyNotificationTimeoutMs = devMode ? 5 * 60_000 : 15 * 60_000;
     const frequentCleanupTimeoutMs = devMode ? 5 * 60_000 : 10 * 60_000;
 
+    // When audit logs are written to ClickHouse, Postgres audit logs stop growing and are no
+    // longer read, so the Postgres prune cron has nothing to do — and cannot drain the frozen
+    // pre-cutover backlog within its timeout, causing a nightly terminal failure. Skip it here
+    // (Postgres cleanup is handled out-of-band by dropping old partitions). This mirrors the
+    // write-path condition in audit-log-queue.ts so pruning stays enabled if ClickHouse inserts
+    // are turned off while CLICKHOUSE_URL is still set.
+    const isClickHouseAuditLogEnabled = appCfg.isClickHouseConfigured && appCfg.CLICKHOUSE_AUDIT_LOG_ENABLED;
+
     cronJob.register({
       name: CronJobName.DailyResourceCleanup,
       pattern: devMode ? "*/5 * * * *" : "30 0 * * *",
@@ -136,7 +144,7 @@ export const dailyResourceCleanUpQueueServiceFactory = ({
       runHashTtlS: 3 * 24 * 60 * 60,
       handlerTimeoutMs: heavyCleanupTimeoutMs,
       leaseDurationMs: heavyCleanupTimeoutMs,
-      enabled: !appCfg.isSecondaryInstance,
+      enabled: !appCfg.isSecondaryInstance && !isClickHouseAuditLogEnabled,
       handler: async () => {
         logger.info(`cron[${CronJobName.DailyAuditLogCleanup}]: task started`);
         await auditLogDAL.pruneAuditLog();


### PR DESCRIPTION
## Problem

The `daily-audit-log-cleanup` cron is **not gated by ClickHouse**. Enabling ClickHouse only redirects audit-log writes and reads; the cron still unconditionally row-prunes the Postgres `audit_logs` table (its only gate is `!appCfg.isSecondaryInstance`).

On a deployment that has cut over to ClickHouse, the Postgres `audit_logs` table becomes a large frozen pre-cutover backlog. The nightly prune tries to row-delete it in 10k batches but cannot finish within the 45-minute handler timeout, so the cron reaches a terminal failure **every night**.

Observed on EU prod: the `infisical-prod-eu-redis-cron-terminal-failure-daily-audit-log-cleanup` alarm has gone OK→ALARM daily since it was created. Logs show `03:30:03 task started` → `04:15:03 attempt 1 timed out (no retry, wait for next fire)` — exactly the 45-minute timeout.

## Fix

Gate the cron so it is skipped precisely when Postgres audit logs are no longer being written — i.e. when the ClickHouse write path is active. This mirrors the write-path condition in `audit-log-queue.ts` (`Boolean(clickhouseClient && CLICKHOUSE_AUDIT_LOG_ENABLED)`):

```ts
const isClickHouseAuditLogEnabled = appCfg.isClickHouseConfigured && appCfg.CLICKHOUSE_AUDIT_LOG_ENABLED;
// ...
enabled: !appCfg.isSecondaryInstance && !isClickHouseAuditLogEnabled,
```

If `CLICKHOUSE_AUDIT_LOG_ENABLED` is false while `CLICKHOUSE_URL` is still set, Postgres remains the write target, so pruning stays enabled.

## Scope / follow-up

This stops the pointless nightly grind and the terminal-failure alarm. It does **not** reclaim the frozen Postgres `audit_logs` data already on disk — that is handled out-of-band by dropping the old monthly partitions (and the `intermediate_audit_logs` catch-all). See `docs/documentation/platform/audit-logs-clickhouse-setup.mdx` (Phase 3: Postgres cleanup).

## Testing

- `npm run type:check` passes.
- On a ClickHouse-enabled deployment, the cron is no longer registered (no `cron[daily-audit-log-cleanup]: task started` on boot); on a Postgres-only deployment it still runs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)