### PR TITLE
fix(audit-log): skip Postgres prune and query ClickHouse in reports when enabled

### DIFF
--- a/backend/src/ee/services/audit-report/audit-report-generators.ts
+++ b/backend/src/ee/services/audit-report/audit-report-generators.ts
@@ -1,9 +1,11 @@
 import picomatch from "picomatch";
 import { z } from "zod";
 
+import { TClickHouseAuditLogDALFactory } from "@app/ee/services/audit-log/audit-log-clickhouse-dal";
 import { TAuditLogDALFactory } from "@app/ee/services/audit-log/audit-log-dal";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { TSecretRotationV2DALFactory } from "@app/ee/services/secret-rotation-v2/secret-rotation-v2-dal";
+import { getConfig } from "@app/lib/config/env";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TReminderDALFactory } from "@app/services/reminder/reminder-dal";
@@ -27,6 +29,7 @@ export type TAuditReportGeneratorDALs = {
   secretRotationV2DAL: Pick<TSecretRotationV2DALFactory, "findByProjectAndDateRange" | "findByProject">;
   reminderDAL: Pick<TReminderDALFactory, "findByProjectAndDateRange">;
   auditLogDAL: Pick<TAuditLogDALFactory, "find">;
+  clickhouseAuditLogDAL?: Pick<TClickHouseAuditLogDALFactory, "find">;
   secretValidationRuleDAL: Pick<TSecretValidationRuleDALFactory, "find">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
 };
@@ -385,7 +388,7 @@ const secretAccessLogReport: TReportDefinition = {
   inputsSchema: SecretAccessLogInputsSchema,
   run: async ({ projectId, orgId, dal }, rawInputs) => {
     const { fromDate, toDate } = SecretAccessLogInputsSchema.parse(rawInputs ?? {});
-    const logs = await dal.auditLogDAL.find({
+    const findArgs = {
       orgId,
       projectId,
       eventType: SECRET_ACCESS_EVENT_TYPES,
@@ -393,7 +396,13 @@ const secretAccessLogReport: TReportDefinition = {
       endDate: toDate.toISOString(),
       offset: 0,
       limit: MAX_AUDIT_REPORT_ROWS + 1
-    });
+    };
+
+    const appCfg = getConfig();
+    const clickhouseAuditLogDAL = appCfg.CLICKHOUSE_AUDIT_LOG_ENABLED ? dal.clickhouseAuditLogDAL : undefined;
+    const logs = clickhouseAuditLogDAL
+      ? await clickhouseAuditLogDAL.find(findArgs)
+      : await dal.auditLogDAL.find(findArgs);
     const { items, truncated } = applyRowCap(logs);
 
     return {

--- a/backend/src/ee/services/audit-report/audit-report-queue.ts
+++ b/backend/src/ee/services/audit-report/audit-report-queue.ts
@@ -35,6 +35,7 @@ export const auditReportQueueServiceFactory = ({
   secretRotationV2DAL,
   reminderDAL,
   auditLogDAL,
+  clickhouseAuditLogDAL,
   secretValidationRuleDAL,
   kmsService
 }: TAuditReportQueueServiceFactoryDep) => {
@@ -44,6 +45,7 @@ export const auditReportQueueServiceFactory = ({
     secretRotationV2DAL,
     reminderDAL,
     auditLogDAL,
+    clickhouseAuditLogDAL,
     secretValidationRuleDAL,
     kmsService
   };

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -3101,6 +3101,7 @@ export const registerRoutes = async (
     secretRotationV2DAL,
     reminderDAL,
     auditLogDAL,
+    clickhouseAuditLogDAL,
     secretValidationRuleDAL,
     kmsService
   });

--- a/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
+++ b/backend/src/services/resource-cleanup/resource-cleanup-queue.ts
@@ -81,6 +81,7 @@ export const dailyResourceCleanUpQueueServiceFactory = ({
     const lightCleanupTimeoutMs = devMode ? 5 * 60_000 : 15 * 60_000;
     const dailyNotificationTimeoutMs = devMode ? 5 * 60_000 : 15 * 60_000;
     const frequentCleanupTimeoutMs = devMode ? 5 * 60_000 : 10 * 60_000;
+    const isClickHouseAuditLogEnabled = appCfg.isClickHouseConfigured && appCfg.CLICKHOUSE_AUDIT_LOG_ENABLED;
 
     cronJob.register({
       name: CronJobName.DailyResourceCleanup,
@@ -136,7 +137,7 @@ export const dailyResourceCleanUpQueueServiceFactory = ({
       runHashTtlS: 3 * 24 * 60 * 60,
       handlerTimeoutMs: heavyCleanupTimeoutMs,
       leaseDurationMs: heavyCleanupTimeoutMs,
-      enabled: !appCfg.isSecondaryInstance,
+      enabled: !appCfg.isSecondaryInstance && !isClickHouseAuditLogEnabled,
       handler: async () => {
         logger.info(`cron[${CronJobName.DailyAuditLogCleanup}]: task started`);
         await auditLogDAL.pruneAuditLog();


### PR DESCRIPTION
## Context

When ClickHouse audit logging is enabled, Postgres is no longer the source of truth for audit data — the audit log API already reads from ClickHouse in that mode. Two gaps remained:

1. **Daily Postgres prune still ran** — `DailyAuditLogCleanup` called `auditLogDAL.pruneAuditLog()` regardless of ClickHouse config, which could delete Postgres rows while ClickHouse holds the authoritative history (or while Postgres storage is intentionally disabled).
2. **Secret Access Log reports always queried Postgres** — the `SecretAccessLog` audit report generator used `auditLogDAL.find()` only, so reports could be empty or stale when audit logs live in ClickHouse.

This PR disables the Postgres audit-log prune cron when ClickHouse is configured and enabled (`isClickHouseConfigured && CLICKHOUSE_AUDIT_LOG_ENABLED`), and routes the Secret Access Log report through `clickhouseAuditLogDAL.find()` when `CLICKHOUSE_AUDIT_LOG_ENABLED` is set (with fallback to Postgres if the DAL is unavailable). Wiring passes `clickhouseAuditLogDAL` from `routes/index.ts` into the audit report queue service.

## Steps to verify the change

1. **Postgres prune disabled with ClickHouse on** — Set `CLICKHOUSE_AUDIT_LOG_ENABLED=true` with a valid ClickHouse connection. Restart backend and confirm `DailyAuditLogCleanup` is not enabled (no `cron[daily-audit-log-cleanup]: task started` in logs at the scheduled time, or inspect cron registration).
2. **Postgres prune still runs without ClickHouse** — Set `CLICKHOUSE_AUDIT_LOG_ENABLED=false` (or leave ClickHouse unconfigured). Confirm `DailyAuditLogCleanup` still fires and calls `pruneAuditLog`.
3. **Secret Access Log report uses ClickHouse** — With ClickHouse enabled, trigger a Secret Access Log audit report for a project/date range that has secret-access events. Confirm returned rows match the audit log UI/API for the same filters.
4. **Fallback to Postgres** — With `CLICKHOUSE_AUDIT_LOG_ENABLED=false`, generate the same report and confirm rows come from Postgres as before.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)