### PR TITLE
feat: add a instance version update check and display

### DIFF
--- a/backend/src/@types/fastify.d.ts
+++ b/backend/src/@types/fastify.d.ts
@@ -180,6 +180,7 @@ import { TSlackServiceFactory } from "@app/services/slack/slack-service";
 import { TSuperAdminServiceFactory } from "@app/services/super-admin/super-admin-service";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 import { TTotpServiceFactory } from "@app/services/totp/totp-service";
+import { TUpdateCheckServiceFactory } from "@app/services/update-check/update-check-queue";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserServiceFactory } from "@app/services/user/user-service";
 import { TUserActivationServiceFactory } from "@app/services/user-activation/user-activation-service";
@@ -385,6 +386,7 @@ declare module "fastify" {
       trustedIp: TTrustedIpServiceFactory;
       secretBlindIndex: TSecretBlindIndexServiceFactory;
       telemetry: TTelemetryServiceFactory;
+      updateCheck: TUpdateCheckServiceFactory;
       dynamicSecret: TDynamicSecretServiceFactory;
       dynamicSecretLease: TDynamicSecretLeaseServiceFactory;
       emailDomain: TEmailDomainServiceFactory;

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -140,6 +140,7 @@ export const KeyStorePrefixes = {
   InsightsCache: (projectId: string, endpoint: string) => `insights-cache:${projectId}:${endpoint}` as const,
 
   AdminConfig: "infisical-admin-cfg",
+  UpdateCheckLatestVersion: "update-check-latest-version",
   InvalidatingCache: "invalidating-cache",
   SecretManagerCachePattern: "secret-manager:*",
   AuditLogMigrationAlert: "audit-log-migration-alert-last-row-count",
@@ -186,6 +187,7 @@ export const KeyStoreTtls = {
   InsightsCacheInSeconds: 300, // 5 minutes
   InsightsDuplicationCacheInSeconds: 3600, // 1 hour
   AdminConfigInSeconds: 60,
+  UpdateCheckLatestVersionInSeconds: 1209600, // 14 days (survives one missed weekly check)
   InvalidatingCacheInSeconds: 1800, // 30 minutes max lock for cache invalidation job
   AuditLogMigrationAlertInSeconds: 604800, // 7 days
   LicenseCloudPlanInSeconds: 300, // 5 minutes

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -55,6 +55,7 @@ const envSchema = z
       .default("false")
       .transform((el) => el === "true"),
     DISABLE_PUBLIC_SECRET_SHARING: zodStrBool.default("false"),
+    DISABLE_UPDATE_CHECK: zodStrBool.default("false"),
     REDIS_URL: zpStr(z.string().optional()),
     REDIS_USERNAME: zpStr(z.string().optional()),
     REDIS_PASSWORD: zpStr(z.string().optional()),

--- a/backend/src/lib/cron/cron-job.ts
+++ b/backend/src/lib/cron/cron-job.ts
@@ -42,7 +42,8 @@ export const CronJobName = {
   AuditLogStreamOutboxStaleClaimSweeper: "audit-log-stream-outbox-stale-claim-sweeper",
   AuditLogStreamOutboxCleanup: "audit-log-stream-outbox-cleanup",
   LicenseUsageFlush: "license-usage-flush",
-  PamCredentialRotationQueueRotations: "pam-credential-rotation-queue-rotations"
+  PamCredentialRotationQueueRotations: "pam-credential-rotation-queue-rotations",
+  InstanceUpdateCheck: "instance-update-check"
 } as const;
 
 // ── tuning constants ──────────────────────────────────────────────────────────

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -523,6 +523,7 @@ import { telemetryQueueServiceFactory } from "@app/services/telemetry/telemetry-
 import { telemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 import { totpConfigDALFactory } from "@app/services/totp/totp-config-dal";
 import { totpServiceFactory } from "@app/services/totp/totp-service";
+import { updateCheckServiceFactory } from "@app/services/update-check/update-check-queue";
 import { userDALFactory } from "@app/services/user/user-dal";
 import { userServiceFactory } from "@app/services/user/user-service";
 import { userActivationDALFactory } from "@app/services/user-activation/user-activation-dal";
@@ -1131,6 +1132,10 @@ export const registerRoutes = async (
     telemetryDAL,
     cronJob,
     telemetryService
+  });
+  const updateCheckService = updateCheckServiceFactory({
+    cronJob,
+    keyStore
   });
 
   const scimService = scimServiceFactory({
@@ -3833,6 +3838,7 @@ export const registerRoutes = async (
   // Register all cron jobs (synchronous registrations) before starting the scheduler
   telemetryQueue.startTelemetryCheck();
   telemetryQueue.startAggregatedEventsJob();
+  updateCheckService.init();
   dailyResourceCleanUp.init();
   projectEnvQueue.init();
   projectCleanupQueue.init();
@@ -3980,6 +3986,7 @@ export const registerRoutes = async (
     scim: scimService,
     secretBlindIndex: secretBlindIndexService,
     telemetry: telemetryService,
+    updateCheck: updateCheckService,
     secretSharing: secretSharingService,
     userActivation: userActivationService,
     userEngagement: userEngagementService,

--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -42,6 +42,8 @@ const SanitizedSuperAdminSchema = z.object({
   enabledLoginMethods: z.string().array().nullable().optional(),
   authConsentContent: z.string().nullable().optional(),
   pageFrameContent: z.string().nullable().optional(),
+  // Populated on self-hosted instances when a newer release than the running version exists
+  latestAvailableVersion: z.string().nullable().optional(),
   // Super admin-only fields (omitted for non-super-admin callers)
   instanceId: z.string().uuid().optional(),
   createdAt: z.date().optional(),
@@ -89,6 +91,8 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
       const isSuperAdminUser = req.auth && isSuperAdmin(req.auth);
       const orgId = req.auth?.orgId ?? "";
 
+      const latestAvailableVersion = await server.services.updateCheck.getAvailableUpdateVersion();
+
       if (!isSuperAdminUser) {
         // Only return fields the frontend needs before authentication
         return {
@@ -106,7 +110,8 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
             pageFrameContent: config.pageFrameContent,
             isPublicSecretSharingDisabled: serverEnvs.DISABLE_PUBLIC_SECRET_SHARING,
             licenseServerV2Enabled: serverEnvs.LICENSE_SERVER_V2_MODE === "on",
-            isCrossProjectSecretSharingEnabled: canUseCrossProjectSecretSharing(orgId)
+            isCrossProjectSecretSharingEnabled: canUseCrossProjectSecretSharing(orgId),
+            latestAvailableVersion
           }
         };
       }
@@ -122,7 +127,8 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
           kubernetesAutoFetchServiceAccountToken: serverEnvs.KUBERNETES_AUTO_FETCH_SERVICE_ACCOUNT_TOKEN,
           paramsFolderSecretDetectionEnabled: serverEnvs.PARAMS_FOLDER_SECRET_DETECTION_ENABLED,
           isOfflineUsageReportsEnabled: hasOfflineLicense,
-          isCrossProjectSecretSharingEnabled: canUseCrossProjectSecretSharing(orgId)
+          isCrossProjectSecretSharingEnabled: canUseCrossProjectSecretSharing(orgId),
+          latestAvailableVersion
         }
       };
     }

--- a/backend/src/services/update-check/update-check-fns.test.ts
+++ b/backend/src/services/update-check/update-check-fns.test.ts
@@ -1,4 +1,10 @@
-import { isVersionNewer, parseSemanticVersion, TSemanticVersion } from "./update-check-fns";
+import {
+  isUpdateCheckEnabled,
+  isVersionNewer,
+  parseSemanticVersion,
+  TSemanticVersion,
+  TUpdateCheckGateInput
+} from "./update-check-fns";
 
 const version = (value: string): TSemanticVersion => {
   const parsed = parseSemanticVersion(value);
@@ -54,5 +60,38 @@ describe("isVersionNewer", () => {
   test("compares numerically, not lexicographically", () => {
     expect(isVersionNewer(version("0.10.0"), version("0.9.0"))).toBe(true);
     expect(isVersionNewer(version("0.100.0"), version("0.99.0"))).toBe(true);
+  });
+});
+
+describe("isUpdateCheckEnabled", () => {
+  const connectedSelfHosted: TUpdateCheckGateInput = {
+    isInfisicalCloud: false,
+    isCloud: false,
+    isUpdateCheckDisabled: false,
+    hasOfflineLicense: false,
+    platformVersion: "0.162.10"
+  };
+
+  test("enabled for a standard self-hosted instance with a semver version", () => {
+    expect(isUpdateCheckEnabled(connectedSelfHosted)).toBe(true);
+  });
+
+  test("disabled on cloud instances", () => {
+    expect(isUpdateCheckEnabled({ ...connectedSelfHosted, isInfisicalCloud: true })).toBe(false);
+    expect(isUpdateCheckEnabled({ ...connectedSelfHosted, isCloud: true })).toBe(false);
+  });
+
+  test("disabled by the DISABLE_UPDATE_CHECK flag", () => {
+    expect(isUpdateCheckEnabled({ ...connectedSelfHosted, isUpdateCheckDisabled: true })).toBe(false);
+  });
+
+  test("disabled when an offline license is configured", () => {
+    expect(isUpdateCheckEnabled({ ...connectedSelfHosted, hasOfflineLicense: true })).toBe(false);
+  });
+
+  test("disabled without a comparable platform version", () => {
+    expect(isUpdateCheckEnabled({ ...connectedSelfHosted, platformVersion: undefined })).toBe(false);
+    // dedicated instances use commit hash versions
+    expect(isUpdateCheckEnabled({ ...connectedSelfHosted, platformVersion: "a1b2c3d" })).toBe(false);
   });
 });

--- a/backend/src/services/update-check/update-check-fns.test.ts
+++ b/backend/src/services/update-check/update-check-fns.test.ts
@@ -1,0 +1,58 @@
+import { isVersionNewer, parseSemanticVersion, TSemanticVersion } from "./update-check-fns";
+
+const version = (value: string): TSemanticVersion => {
+  const parsed = parseSemanticVersion(value);
+  if (!parsed) throw new Error(`Invalid test version: ${value}`);
+  return parsed;
+};
+
+describe("parseSemanticVersion", () => {
+  test("parses plain semantic versions", () => {
+    expect(parseSemanticVersion("0.162.10")).toEqual({ major: 0, minor: 162, patch: 10 });
+  });
+
+  test("parses versions with a leading v", () => {
+    expect(parseSemanticVersion("v0.162.10")).toEqual({ major: 0, minor: 162, patch: 10 });
+    expect(parseSemanticVersion("V0.162.10")).toEqual({ major: 0, minor: 162, patch: 10 });
+  });
+
+  test("parses nightly/prerelease versions to their base version", () => {
+    expect(parseSemanticVersion("0.163.0-nightly-20260721")).toEqual({ major: 0, minor: 163, patch: 0 });
+    expect(parseSemanticVersion("v0.163.0-nightly-20260721.1")).toEqual({ major: 0, minor: 163, patch: 0 });
+  });
+
+  test("returns null for values that are not semver-shaped", () => {
+    expect(parseSemanticVersion(undefined)).toBeNull();
+    expect(parseSemanticVersion("")).toBeNull();
+    // dedicated instances use commit hash versions
+    expect(parseSemanticVersion("a1b2c3d")).toBeNull();
+    expect(parseSemanticVersion("0.162")).toBeNull();
+    expect(parseSemanticVersion("0.162.10.1")).toBeNull();
+    expect(parseSemanticVersion("latest")).toBeNull();
+  });
+});
+
+describe("isVersionNewer", () => {
+  test("returns false for equal versions", () => {
+    expect(isVersionNewer(version("0.162.10"), version("0.162.10"))).toBe(false);
+  });
+
+  test("compares patch versions", () => {
+    expect(isVersionNewer(version("0.162.11"), version("0.162.10"))).toBe(true);
+    expect(isVersionNewer(version("0.162.9"), version("0.162.10"))).toBe(false);
+  });
+
+  test("a minor bump outranks a higher patch", () => {
+    expect(isVersionNewer(version("0.163.0"), version("0.162.10"))).toBe(true);
+    expect(isVersionNewer(version("0.162.10"), version("0.163.0"))).toBe(false);
+  });
+
+  test("a major bump outranks a higher minor", () => {
+    expect(isVersionNewer(version("1.0.0"), version("0.999.999"))).toBe(true);
+  });
+
+  test("compares numerically, not lexicographically", () => {
+    expect(isVersionNewer(version("0.10.0"), version("0.9.0"))).toBe(true);
+    expect(isVersionNewer(version("0.100.0"), version("0.99.0"))).toBe(true);
+  });
+});

--- a/backend/src/services/update-check/update-check-fns.ts
+++ b/backend/src/services/update-check/update-check-fns.ts
@@ -1,0 +1,19 @@
+// Parses release tags / platform versions like "v0.162.10", "0.162.10" or
+// "0.162.10-nightly-20260721" (the base version is used). Returns null for anything
+// that is not semver-shaped (dev mode, dedicated instance hash versions, etc.)
+export const parseSemanticVersion = (version?: string) => {
+  if (!version) return null;
+
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/i.exec(version.trim());
+  if (!match) return null;
+
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+};
+
+export type TSemanticVersion = NonNullable<ReturnType<typeof parseSemanticVersion>>;
+
+export const isVersionNewer = (candidate: TSemanticVersion, current: TSemanticVersion) => {
+  if (candidate.major !== current.major) return candidate.major > current.major;
+  if (candidate.minor !== current.minor) return candidate.minor > current.minor;
+  return candidate.patch > current.patch;
+};

--- a/backend/src/services/update-check/update-check-fns.ts
+++ b/backend/src/services/update-check/update-check-fns.ts
@@ -17,3 +17,21 @@ export const isVersionNewer = (candidate: TSemanticVersion, current: TSemanticVe
   if (candidate.minor !== current.minor) return candidate.minor > current.minor;
   return candidate.patch > current.patch;
 };
+
+export type TUpdateCheckGateInput = {
+  isInfisicalCloud: boolean;
+  isCloud: boolean;
+  isUpdateCheckDisabled: boolean;
+  hasOfflineLicense: boolean;
+  platformVersion?: string;
+};
+
+// The update check only applies to standard self-hosted instances: cloud deploys
+// continuously, dedicated instances use hash versions that cannot be compared, and
+// an offline license explicitly signals an intentionally air-gapped instance.
+export const isUpdateCheckEnabled = (input: TUpdateCheckGateInput) =>
+  !input.isInfisicalCloud &&
+  !input.isCloud &&
+  !input.isUpdateCheckDisabled &&
+  !input.hasOfflineLicense &&
+  Boolean(parseSemanticVersion(input.platformVersion));

--- a/backend/src/services/update-check/update-check-queue.ts
+++ b/backend/src/services/update-check/update-check-queue.ts
@@ -59,14 +59,15 @@ export const updateCheckServiceFactory = ({ cronJob, keyStore }: TUpdateCheckSer
   };
 
   const init = () => {
-    if (!isEnabled) return;
-
     cronJob.register({
       name: CronJobName.InstanceUpdateCheck,
       pattern: "0 0 * * 0", // weekly on Sunday at midnight UTC
       runHashTtlS: 3 * 24 * 60 * 60,
+      enabled: isEnabled,
       handler: refreshLatestVersion
     });
+
+    if (!isEnabled) return;
 
     // also refresh once at boot so a fresh instance is not blind until the next Sunday fire
     void keyStore

--- a/backend/src/services/update-check/update-check-queue.ts
+++ b/backend/src/services/update-check/update-check-queue.ts
@@ -1,0 +1,97 @@
+import { getLicenseKeyConfig } from "@app/ee/services/license/license-fns";
+import { LicenseType } from "@app/ee/services/license/license-types";
+import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
+import { getConfig } from "@app/lib/config/env";
+import { request } from "@app/lib/config/request";
+import { CronJobName, TCronJobFactory } from "@app/lib/cron/cron-job";
+import { logger } from "@app/lib/logger";
+
+import { isVersionNewer, parseSemanticVersion } from "./update-check-fns";
+
+const GITHUB_LATEST_RELEASE_URL = "https://api.github.com/repos/Infisical/infisical/releases/latest";
+
+type TUpdateCheckServiceFactoryDep = {
+  cronJob: TCronJobFactory;
+  keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry">;
+};
+
+export type TUpdateCheckServiceFactory = ReturnType<typeof updateCheckServiceFactory>;
+
+export const updateCheckServiceFactory = ({ cronJob, keyStore }: TUpdateCheckServiceFactoryDep) => {
+  const appCfg = getConfig();
+
+  const licenseKeyConfig = getLicenseKeyConfig();
+  const hasOfflineLicense = licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Offline;
+
+  // The update check only applies to standard self-hosted instances: cloud deploys
+  // continuously, dedicated instances use hash versions that cannot be compared, and
+  // an offline license explicitly signals an intentionally air-gapped instance.
+  const isEnabled =
+    !appCfg.INFISICAL_CLOUD &&
+    !appCfg.isCloud &&
+    !appCfg.DISABLE_UPDATE_CHECK &&
+    !hasOfflineLicense &&
+    Boolean(parseSemanticVersion(appCfg.INFISICAL_PLATFORM_VERSION));
+
+  const refreshLatestVersion = async () => {
+    try {
+      const { data } = await request.get<{ tag_name?: unknown }>(GITHUB_LATEST_RELEASE_URL, {
+        headers: { Accept: "application/vnd.github+json" },
+        timeout: 10_000
+      });
+
+      const tagName = data.tag_name;
+      const latestVersion = typeof tagName === "string" ? tagName.replace(/^v/i, "") : null;
+      if (!latestVersion || !parseSemanticVersion(latestVersion)) {
+        logger.warn(`update-check: could not interpret latest release tag [tagName=${String(tagName)}]`);
+        return;
+      }
+
+      await keyStore.setItemWithExpiry(
+        KeyStorePrefixes.UpdateCheckLatestVersion,
+        KeyStoreTtls.UpdateCheckLatestVersionInSeconds,
+        latestVersion
+      );
+      logger.info(`update-check: refreshed latest platform version [latestVersion=${latestVersion}]`);
+    } catch (err) {
+      // best effort: air-gapped instances cannot reach GitHub, and a missed refresh
+      // only delays the nudge until the next weekly fire, so failures stay quiet
+      // instead of surfacing as failed cron runs
+      logger.debug(err, "update-check: failed to refresh latest platform version");
+    }
+  };
+
+  const init = () => {
+    if (!isEnabled) return;
+
+    cronJob.register({
+      name: CronJobName.InstanceUpdateCheck,
+      pattern: "0 0 * * 0", // weekly on Sunday at midnight UTC
+      runHashTtlS: 3 * 24 * 60 * 60,
+      handler: refreshLatestVersion
+    });
+
+    // also refresh once at boot so a fresh instance is not blind until the next Sunday fire
+    void keyStore
+      .getItem(KeyStorePrefixes.UpdateCheckLatestVersion)
+      .then((cached) => (cached ? undefined : refreshLatestVersion()))
+      .catch((err) => logger.debug(err, "update-check: failed to refresh latest platform version at boot"));
+  };
+
+  // Returns the latest release version when it is newer than the running instance,
+  // null otherwise (up to date, check disabled, or no data fetched yet).
+  const getAvailableUpdateVersion = async () => {
+    if (!isEnabled) return null;
+
+    const latestVersion = await keyStore.getItem(KeyStorePrefixes.UpdateCheckLatestVersion);
+    if (!latestVersion) return null;
+
+    const latest = parseSemanticVersion(latestVersion);
+    const current = parseSemanticVersion(appCfg.INFISICAL_PLATFORM_VERSION);
+    if (!latest || !current) return null;
+
+    return isVersionNewer(latest, current) ? latestVersion : null;
+  };
+
+  return { init, getAvailableUpdateVersion };
+};

--- a/backend/src/services/update-check/update-check-queue.ts
+++ b/backend/src/services/update-check/update-check-queue.ts
@@ -6,7 +6,7 @@ import { request } from "@app/lib/config/request";
 import { CronJobName, TCronJobFactory } from "@app/lib/cron/cron-job";
 import { logger } from "@app/lib/logger";
 
-import { isVersionNewer, parseSemanticVersion } from "./update-check-fns";
+import { isUpdateCheckEnabled, isVersionNewer, parseSemanticVersion } from "./update-check-fns";
 
 const GITHUB_LATEST_RELEASE_URL = "https://api.github.com/repos/Infisical/infisical/releases/latest";
 
@@ -21,17 +21,14 @@ export const updateCheckServiceFactory = ({ cronJob, keyStore }: TUpdateCheckSer
   const appCfg = getConfig();
 
   const licenseKeyConfig = getLicenseKeyConfig();
-  const hasOfflineLicense = licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Offline;
 
-  // The update check only applies to standard self-hosted instances: cloud deploys
-  // continuously, dedicated instances use hash versions that cannot be compared, and
-  // an offline license explicitly signals an intentionally air-gapped instance.
-  const isEnabled =
-    !appCfg.INFISICAL_CLOUD &&
-    !appCfg.isCloud &&
-    !appCfg.DISABLE_UPDATE_CHECK &&
-    !hasOfflineLicense &&
-    Boolean(parseSemanticVersion(appCfg.INFISICAL_PLATFORM_VERSION));
+  const isEnabled = isUpdateCheckEnabled({
+    isInfisicalCloud: appCfg.INFISICAL_CLOUD,
+    isCloud: appCfg.isCloud,
+    isUpdateCheckDisabled: appCfg.DISABLE_UPDATE_CHECK,
+    hasOfflineLicense: Boolean(licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Offline),
+    platformVersion: appCfg.INFISICAL_PLATFORM_VERSION
+  });
 
   const refreshLatestVersion = async () => {
     try {
@@ -78,12 +75,19 @@ export const updateCheckServiceFactory = ({ cronJob, keyStore }: TUpdateCheckSer
       .catch((err) => logger.debug(err, "update-check: failed to refresh latest platform version at boot"));
   };
 
-  // Returns the latest release version when it is newer than the running instance,
-  // null otherwise (up to date, check disabled, or no data fetched yet).
+  // Returns the latest release version when it is newer than the running instance, null
+  // otherwise (up to date, check disabled, no data fetched yet, or keystore unavailable).
+  // Never throws: the optional indicator must not be able to fail admin config reads.
   const getAvailableUpdateVersion = async () => {
     if (!isEnabled) return null;
 
-    const latestVersion = await keyStore.getItem(KeyStorePrefixes.UpdateCheckLatestVersion);
+    let latestVersion: string | null;
+    try {
+      latestVersion = await keyStore.getItem(KeyStorePrefixes.UpdateCheckLatestVersion);
+    } catch (err) {
+      logger.debug(err, "update-check: failed to read latest platform version from the keystore");
+      return null;
+    }
     if (!latestVersion) return null;
 
     const latest = parseSemanticVersion(latestVersion);

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -54,6 +54,17 @@ Example values:
   this to `false`.
 </ParamField>
 
+<ParamField query="DISABLE_UPDATE_CHECK" type="bool" default="false" optional>
+  Self-hosted instances check GitHub for the latest Infisical release once a week
+  (and once at startup) and show a subtle indicator in the UI when a newer version
+  is available. Set this to `true` to disable the check; no request is made to
+  GitHub when disabled.
+
+  Air-gapped deployments should set this to `true` to suppress the outbound
+  request entirely. Instances configured with an offline license disable the
+  check automatically.
+</ParamField>
+
 <ParamField
   query="ALLOW_INTERNAL_IP_CONNECTIONS"
   type="bool"

--- a/frontend/src/hooks/api/admin/types.ts
+++ b/frontend/src/hooks/api/admin/types.ts
@@ -67,6 +67,8 @@ export type TServerConfig = {
   isPublicSecretSharingDisabled?: boolean;
   licenseServerV2Enabled?: boolean;
   isCrossProjectSecretSharingEnabled?: boolean;
+  // populated on self-hosted instances when a newer release than the running version exists
+  latestAvailableVersion?: string | null;
   // Super admin-only fields (omitted for non-super-admin callers)
   instanceId?: string;
   createdAt?: string;

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -66,6 +66,7 @@ import {
   OrgPermissionActions,
   OrgPermissionSubjects,
   useOrganization,
+  useServerConfig,
   useSubscription,
   useUser
 } from "@app/context";
@@ -142,6 +143,7 @@ export const Navbar = () => {
   const { user } = useUser();
   const { subscription } = useSubscription();
   const { currentOrg, isSubOrganization } = useOrganization();
+  const { config: serverConfig } = useServerConfig();
 
   const [showAdminsModal, setShowAdminsModal] = useState(false);
   const [showSubOrgForm, setShowSubOrgForm] = useState(false);
@@ -595,6 +597,7 @@ export const Navbar = () => {
         )}
       </div>
 
+      <VersionBadge />
       {subscription &&
       subscription.slug === SubscriptionPlanTypes.Starter &&
       !subscription.has_used_trial ? (
@@ -624,7 +627,6 @@ export const Navbar = () => {
           {getSubscriptionPlanLabel(subscription)}
         </Badge>
       )}
-      <VersionBadge />
       {!location.pathname.startsWith("/admin") && user.superAdmin && (
         <Button variant="outline" size="xs" className="mt-px mr-2" asChild>
           <Link to="/admin" onClick={handleNavigateToAdminConsole}>
@@ -699,6 +701,16 @@ export const Navbar = () => {
                 <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-muted">
                   <Info className="size-3.5" />
                   Version: {envConfig.PLATFORM_VERSION}
+                  {serverConfig.latestAvailableVersion && (
+                    <a
+                      href="https://github.com/Infisical/infisical/releases"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-info hover:underline"
+                    >
+                      (v{serverConfig.latestAvailableVersion} available)
+                    </a>
+                  )}
                 </div>
               </>
             )}

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -703,7 +703,7 @@ export const Navbar = () => {
                   Version: {envConfig.PLATFORM_VERSION}
                   {serverConfig.latestAvailableVersion && (
                     <a
-                      href="https://github.com/Infisical/infisical/releases"
+                      href="https://upgrade.infisical.com/"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-info hover:underline"

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/VersionBadge.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/VersionBadge.tsx
@@ -22,7 +22,11 @@ export const VersionBadge = () => {
   const newerVersion = config.latestAvailableVersion;
 
   if (!newerVersion) {
-    return null;
+    return (
+      <span className="mt-1 mr-2 hidden items-center gap-x-1.5 text-xs text-muted transition-colors hover:text-accent md:inline-flex">
+        v{version}
+      </span>
+    );
   }
 
   return (

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/VersionBadge.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/VersionBadge.tsx
@@ -1,8 +1,10 @@
-import { Badge } from "@app/components/v3";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { envConfig } from "@app/config/env";
+import { useServerConfig } from "@app/context";
 import { isInfisicalCloud } from "@app/helpers/platform";
 
 export const VersionBadge = () => {
+  const { config } = useServerConfig();
   const version = envConfig.PLATFORM_VERSION;
 
   // We only display the version for on-premise instances, so we disable this
@@ -16,9 +18,29 @@ export const VersionBadge = () => {
 
   if (shouldNotDisplay) return null;
 
+  // only populated on self-hosted instances that are behind the latest release
+  const newerVersion = config.latestAvailableVersion;
+
+  if (!newerVersion) {
+    return null;
+  }
+
   return (
-    <Badge variant="neutral" className="mt-[3px] mr-2 hidden md:inline-flex">
-      {`v${version}`}
-    </Badge>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <a
+          href="https://github.com/Infisical/infisical/releases"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 mr-2 hidden items-center gap-x-1.5 text-xs text-muted transition-colors hover:text-accent md:inline-flex"
+        >
+          <span aria-hidden className="size-1.5 rounded-full bg-info" />
+          New version available
+        </a>
+      </TooltipTrigger>
+      <TooltipContent>
+        v{version} → v{newerVersion}
+      </TooltipContent>
+    </Tooltip>
   );
 };

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/VersionBadge.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/VersionBadge.tsx
@@ -33,7 +33,7 @@ export const VersionBadge = () => {
     <Tooltip>
       <TooltipTrigger asChild>
         <a
-          href="https://github.com/Infisical/infisical/releases"
+          href="https://upgrade.infisical.com/"
           target="_blank"
           rel="noopener noreferrer"
           className="mt-1 mr-2 hidden items-center gap-x-1.5 text-xs text-muted transition-colors hover:text-accent md:inline-flex"


### PR DESCRIPTION
## Context

This PR adds a cron to get the latest release version once a week to display an update in the UI for self-hosted instances that aren't airgapped

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-07-21 at 12 05 06@2x" src="https://github.com/user-attachments/assets/a095e665-d7c5-452b-8d41-afcd66ff90fe" />

## Steps to verify the change

**Setup** (make the dev stack look like an internet-connected self-hosted instance on an old version):

1. In root `.env`, add `INFISICAL_PLATFORM_VERSION=0.150.0` and `VITE_INFISICAL_PLATFORM_VERSION=v0.150.0`, and ensure `LICENSE_SERVER_KEY` / `LICENSE_SERVER_V2_SERVICE_KEY` are NOT set (they mark the instance as cloud, which disables the check).
2. `docker compose -f docker-compose.dev.yml up -d --force-recreate backend frontend`

**Backend**

3. `docker logs infisical-dev-api 2>&1 | grep update-check` shows `cron[instance-update-check]: registered (pattern="0 0 * * 0")` and, within ~30s, `refreshed latest platform version [latestVersion=<latest>]` (boot fetch; the cron also fires a catch-up run for the missed Sunday slot, so no need to wait for a real Sunday).
4. `docker exec infisical-dev-redis redis-cli GET update-check-latest-version` returns `<latest>`; `TTL` is ~1209600 (14 days).
5. `curl -s localhost:4000/api/v1/admin/config | jq .config.latestAvailableVersion` returns `"<latest>"` (comparison is server-side; the field is only set when newer than the running version).

**UI** (http://localhost:8080, any logged-in user)

6. Navbar, left of the plan badge: info dot + "New version available"; hover shows `v0.150.0 → v<latest>`; click opens the Infisical upgrade tool (https://upgrade.infisical.com/). Nothing is rendered when up to date.
7. Help dropdown (`?` icon): `Version: 0.150.0 (v<latest> available)`.

**Gating** (apply each to `.env`, recreate backend, observe)

8. `DISABLE_UPDATE_CHECK=true`: the only log line is `cron[instance-update-check]: disabled` (no outbound request at all), `latestAvailableVersion` null, indicator gone.
9. `INFISICAL_PLATFORM_VERSION=<latest>`: check still runs (logs appear) but the field is null and the indicator is gone, since the instance is up to date.
10. Remove `INFISICAL_PLATFORM_VERSION` (dev default): check fully disabled, no version UI anywhere.
11. Offline-license auto-disable: `LICENSE_KEY=$(printf '{"license":{},"signature":"x"}' | base64)` (offline keys are detected structurally, so a fake one drives the real path; a boot WARN "offline license verification failed" is expected). Confirm: the only update-check log line is `cron[instance-update-check]: disabled`, `latestAvailableVersion` null even with a previously cached Redis value, indicator gone.

**Tests**: `cd backend && npm run test:unit` covers semver parse/compare and the full gating matrix (cloud, flag, offline license, hash/missing version) in `update-check-fns.test.ts`.

Air-gapped failure mode: the fetch fails quietly (debug log only, no cron retries, no failed-run noise), the field stays null, and the UI shows nothing.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
