### PR TITLE
improvement(identity-access-token): cache trusted IP allowlists in Redis

### DIFF
--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -73,6 +73,8 @@ export const KeyStorePrefixes = {
   IdentityRevocationVersion: (identityId: string) => `identity-revocation-version:${identityId}` as const,
   IdentityRevocationVerdict: (identityId: string, fingerprint: string) =>
     `identity-revocation-verdict:${identityId}:${fingerprint}` as const,
+  IdentityTrustedIps: (identityId: string, authMethod: string) =>
+    `identity-trusted-ips:${identityId}:${authMethod}` as const,
   IdentityUaClientSecretUsageDebounce: (clientSecretId: string) =>
     `identity-ua-client-secret-usage-debounce:${clientSecretId}` as const,
   ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`,
@@ -169,6 +171,7 @@ export const KeyStoreTtls = {
   IdentityRevocationVerdictBaseInSeconds: 600, // 10 minutes
   IdentityRevocationVerdictJitterInSeconds: 120, // +/- 2 minutes
   IdentityRevocationVersionInSeconds: 604800, // 7 days
+  IdentityTrustedIpsInSeconds: 300, // 5 minutes
   ProjectPermissionMarkerTtlSeconds: 10, // 10 seconds - short-lived marker for fingerprint validation
   ProjectPermissionDataTtlSeconds: 600, // 10 minutes - longer-lived data payload
 

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -57,7 +57,8 @@ const createService = ({
     incrementBy: vi.fn(),
     setItemWithExpiry: vi.fn(),
     setItemWithExpiryNX: vi.fn().mockResolvedValue("OK"),
-    incrementSeededWithExpiry: vi.fn().mockResolvedValue(1)
+    incrementSeededWithExpiry: vi.fn().mockResolvedValue(1),
+    deleteItem: vi.fn().mockResolvedValue(1)
   };
   // getItemPrimary shares the getItem mock so tests that stub getItem by key also
   // cover the primary-pinned version reads.
@@ -340,8 +341,17 @@ describe("identityAccessTokenServiceFactory", () => {
     await expect(service.fnValidateIdentityAccessTokenFast(createTokenClaims(), "10.0.0.1")).resolves.toMatchObject({
       identityId: "identity-id"
     });
-    expect(keyStore.setItemWithExpiry).not.toHaveBeenCalled();
+    expect(keyStore.setItemWithExpiry).not.toHaveBeenCalledWith(
+      expect.stringContaining("identity-token-uses-remaining:"),
+      expect.anything(),
+      expect.anything()
+    );
     expect(keyStore.incrementBy).not.toHaveBeenCalled();
+    expect(keyStore.setItemWithExpiry).toHaveBeenCalledWith(
+      "identity-trusted-ips:identity-id:universal-auth",
+      300,
+      expect.any(String)
+    );
   });
 
   test("rejects exhausted Redis usage counters", async () => {

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -6,6 +6,7 @@ import { withCache } from "@app/lib/cache/with-cache";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
 import { applyJitter } from "@app/lib/dates";
+import { delay } from "@app/lib/delay";
 import { UnauthorizedError } from "@app/lib/errors";
 import { checkIPAgainstBlocklist, TIp } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
@@ -111,12 +112,23 @@ export const identityAccessTokenServiceFactory = ({
     );
   };
 
+  // Delayed re-delete: a request that missed cache before this delete can still
+  // write a stale allowlist back. Second delete ~1s later clears that race.
+  const TRUSTED_IPS_CACHE_REDELETE_DELAY_MS = 1000;
+
   const invalidateTrustedIpsCache = async (identityId: string, authMethod: IdentityAuthMethod | string) => {
+    const key = KeyStorePrefixes.IdentityTrustedIps(identityId, authMethod);
     try {
-      await keyStore.deleteItem(KeyStorePrefixes.IdentityTrustedIps(identityId, authMethod));
+      await keyStore.deleteItem(key);
     } catch (error) {
       logger.warn(error, `identity-trusted-ips: failed to invalidate cache [identityId=${identityId}]`);
     }
+
+    void delay(TRUSTED_IPS_CACHE_REDELETE_DELAY_MS)
+      .then(() => keyStore.deleteItem(key))
+      .catch((error) => {
+        logger.warn(error, `identity-trusted-ips: failed delayed re-delete [identityId=${identityId}]`);
+      });
   };
 
   // On revoke, bump this identity's version number. Every cached "allowed" answer

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -2,6 +2,7 @@ import { Knex } from "knex";
 
 import { IdentityAuthMethod, OrgMembershipStatus, TableName, TIdentityAccessTokens } from "@app/db/schemas";
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
+import { withCache } from "@app/lib/cache/with-cache";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
 import { applyJitter } from "@app/lib/dates";
@@ -85,7 +86,12 @@ type TIdentityAccessTokenServiceFactoryDep = {
     | "setItemWithExpiry"
     | "setItemWithExpiryNX"
     | "incrementSeededWithExpiry"
+    | "deleteItem"
   >;
+};
+
+type TTrustedIpsCachePayload = {
+  accessTokenTrustedIps: TIp[] | null;
 };
 
 export type TIdentityAccessTokenServiceFactory = ReturnType<typeof identityAccessTokenServiceFactory>;
@@ -103,6 +109,14 @@ export const identityAccessTokenServiceFactory = ({
       ttlSeconds,
       usesRemaining
     );
+  };
+
+  const invalidateTrustedIpsCache = async (identityId: string, authMethod: IdentityAuthMethod | string) => {
+    try {
+      await keyStore.deleteItem(KeyStorePrefixes.IdentityTrustedIps(identityId, authMethod));
+    } catch (error) {
+      logger.warn(error, `identity-trusted-ips: failed to invalidate cache [identityId=${identityId}]`);
+    }
   };
 
   // On revoke, bump this identity's version number. Every cached "allowed" answer
@@ -446,8 +460,16 @@ export const identityAccessTokenServiceFactory = ({
     }
 
     if (ipAddress) {
-      const trustedIps = await identityDAL.getTrustedIpsByAuthMethod(token.identityId, source.authMethod);
-      if (hasNonWildcardTrustedIps(trustedIps as TIp[] | null | undefined)) {
+      const { accessTokenTrustedIps: trustedIps } = await withCache<TTrustedIpsCachePayload>({
+        keyStore,
+        key: KeyStorePrefixes.IdentityTrustedIps(token.identityId, source.authMethod),
+        ttlSeconds: KeyStoreTtls.IdentityTrustedIpsInSeconds,
+        fetcher: async () => {
+          const ips = await identityDAL.getTrustedIpsByAuthMethod(token.identityId, source.authMethod);
+          return { accessTokenTrustedIps: (ips as TIp[] | null | undefined) ?? null };
+        }
+      });
+      if (hasNonWildcardTrustedIps(trustedIps)) {
         checkIPAgainstBlocklist({
           ipAddress,
           trustedIps: trustedIps as TIp[]
@@ -732,6 +754,7 @@ export const identityAccessTokenServiceFactory = ({
     revokeAllTokensForClientSecret,
     revokeTokensForIdentityAuthMethod,
     markPerTokenRevocation,
+    invalidateTrustedIpsCache,
     fnValidateIdentityAccessTokenFast
   };
 };

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -113,7 +113,7 @@ export const identityAccessTokenServiceFactory = ({
   };
 
   // Delayed re-delete: a request that missed cache before this delete can still
-  // write a stale allowlist back. Second delete ~1s later clears that race.
+  // write a stale allowlist back. Second delete ~1s later helps with race conditions, but still best effort.
   const TRUSTED_IPS_CACHE_REDELETE_DELAY_MS = 1000;
 
   const invalidateTrustedIpsCache = async (identityId: string, authMethod: IdentityAuthMethod | string) => {

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -473,7 +473,11 @@ export const identityAccessTokenServiceFactory = ({
 
     if (ipAddress) {
       const { accessTokenTrustedIps: trustedIps } = await withCache<TTrustedIpsCachePayload>({
-        keyStore,
+        // A Redis read replica can lag behind the primary's DEL on invalidation and serve a stale allowlist
+        keyStore: {
+          getItem: (key, prefix) => keyStore.getItemPrimary(key, prefix),
+          setItemWithExpiry: keyStore.setItemWithExpiry
+        },
         key: KeyStorePrefixes.IdentityTrustedIps(token.identityId, source.authMethod),
         ttlSeconds: KeyStoreTtls.IdentityTrustedIpsInSeconds,
         fetcher: async () => {

--- a/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
+++ b/backend/src/services/identity-alicloud-auth/identity-alicloud-auth-service.ts
@@ -63,7 +63,7 @@ type TIdentityAliCloudAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -357,6 +357,7 @@ export const identityAliCloudAuthServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.ALICLOUD_AUTH);
     return { ...identityAliCloudAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -453,6 +454,7 @@ export const identityAliCloudAuthServiceFactory = ({
         : undefined
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.ALICLOUD_AUTH);
     return { ...updatedAliCloudAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -600,6 +602,7 @@ export const identityAliCloudAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.ALICLOUD_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.ALICLOUD_AUTH);
 
     return revokedIdentityAliCloudAuth;
   };

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -63,7 +63,7 @@ type TIdentityAwsAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -457,6 +457,7 @@ export const identityAwsAuthServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.AWS_AUTH);
     return { ...identityAwsAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -556,6 +557,7 @@ export const identityAwsAuthServiceFactory = ({
         : undefined
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.AWS_AUTH);
     return { ...updatedAwsAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -702,6 +704,7 @@ export const identityAwsAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.AWS_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.AWS_AUTH);
 
     return revokedIdentityAwsAuth;
   };

--- a/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
+++ b/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
@@ -59,7 +59,7 @@ type TIdentityAzureAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -358,6 +358,7 @@ export const identityAzureAuthServiceFactory = ({
 
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.AZURE_AUTH);
     return { ...identityAzureAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -456,6 +457,7 @@ export const identityAzureAuthServiceFactory = ({
         : undefined
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.AZURE_AUTH);
     return {
       ...updatedAzureAuth,
       orgId: identityMembershipOrg.scopeOrgId
@@ -603,6 +605,7 @@ export const identityAzureAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.AZURE_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.AZURE_AUTH);
 
     return revokedIdentityAzureAuth;
   };

--- a/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
+++ b/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
@@ -57,7 +57,7 @@ type TIdentityGcpAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -403,6 +403,7 @@ export const identityGcpAuthServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.GCP_AUTH);
     return { ...identityGcpAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -504,6 +505,7 @@ export const identityGcpAuthServiceFactory = ({
         : undefined
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.GCP_AUTH);
     return {
       ...updatedGcpAuth,
       orgId: identityMembershipOrg.scopeOrgId
@@ -652,6 +654,7 @@ export const identityGcpAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.GCP_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.GCP_AUTH);
 
     return revokedIdentityGcpAuth;
   };

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -72,7 +72,7 @@ type TIdentityJwtAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -546,6 +546,7 @@ export const identityJwtAuthServiceFactory = ({
 
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.JWT_AUTH);
     return { ...identityJwtAuth, orgId: identityMembershipOrg.scopeOrgId, jwksCaCert, publicKeys };
   };
 
@@ -686,6 +687,7 @@ export const identityJwtAuthServiceFactory = ({
       .toString()
       .split(",");
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.JWT_AUTH);
     return {
       ...updatedJwtAuth,
       orgId: identityMembershipOrg.scopeOrgId,
@@ -851,6 +853,7 @@ export const identityJwtAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.JWT_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.JWT_AUTH);
 
     return revokedIdentityJwtAuth;
   };

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -104,7 +104,7 @@ type TIdentityKubernetesAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -1042,6 +1042,7 @@ export const identityKubernetesAuthServiceFactory = ({
       return doc;
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.KUBERNETES_AUTH);
     return {
       ...identityKubernetesAuth,
       caCert: caCert ?? "",
@@ -1395,6 +1396,7 @@ export const identityKubernetesAuthServiceFactory = ({
         }).toString()
       : "";
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.KUBERNETES_AUTH);
     return {
       ...updatedKubernetesAuth,
       orgId: identityMembershipOrg.scopeOrgId,
@@ -1577,6 +1579,7 @@ export const identityKubernetesAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.KUBERNETES_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.KUBERNETES_AUTH);
 
     return revokedIdentityKubernetesAuth;
   };

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -81,7 +81,7 @@ type TIdentityLdapAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -519,6 +519,7 @@ export const identityLdapAuthServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.LDAP_AUTH);
     return { ...identityLdapAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -732,6 +733,7 @@ export const identityLdapAuthServiceFactory = ({
       lockoutCounterResetSeconds
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.LDAP_AUTH);
     return { ...updatedLdapAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -892,6 +894,7 @@ export const identityLdapAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.LDAP_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.LDAP_AUTH);
 
     return revokedIdentityLdapAuth;
   };

--- a/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
+++ b/backend/src/services/identity-oci-auth/identity-oci-auth-service.ts
@@ -61,7 +61,7 @@ type TIdentityOciAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -371,6 +371,7 @@ export const identityOciAuthServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.OCI_AUTH);
     return { ...identityOciAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -469,6 +470,7 @@ export const identityOciAuthServiceFactory = ({
         : undefined
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.OCI_AUTH);
     return { ...updatedOciAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -616,6 +618,7 @@ export const identityOciAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.OCI_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.OCI_AUTH);
 
     return revokedIdentityOciAuth;
   };

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -73,7 +73,7 @@ type TIdentityOidcAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -708,6 +708,7 @@ export const identityOidcAuthServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.OIDC_AUTH);
     return { ...identityOidcAuth, orgId: identityMembershipOrg.scopeOrgId, caCert };
   };
 
@@ -834,6 +835,7 @@ export const identityOidcAuthServiceFactory = ({
       ? decryptor({ cipherTextBlob: updatedOidcAuth.encryptedCaCertificate }).toString()
       : "";
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.OIDC_AUTH);
     return {
       ...updatedOidcAuth,
       orgId: identityMembershipOrg.scopeOrgId,
@@ -994,6 +996,7 @@ export const identityOidcAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.OIDC_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.OIDC_AUTH);
 
     return revokedIdentityOidcAuth;
   };

--- a/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
+++ b/backend/src/services/identity-spiffe-auth/identity-spiffe-auth-service.ts
@@ -78,7 +78,7 @@ type TIdentitySpiffeAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -625,6 +625,7 @@ export const identitySpiffeAuthServiceFactory = ({
       return doc;
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.SPIFFE_AUTH);
     return {
       ...identitySpiffeAuth,
       orgId: identityMembershipOrg.scopeOrgId,
@@ -769,6 +770,7 @@ export const identitySpiffeAuthServiceFactory = ({
       ? orgDataKeyDecryptor({ cipherTextBlob: updatedSpiffeAuth.encryptedBundleEndpointCaCert }).toString()
       : "";
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.SPIFFE_AUTH);
     return {
       ...updatedSpiffeAuth,
       orgId: identityMembershipOrg.scopeOrgId,
@@ -946,6 +948,7 @@ export const identitySpiffeAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.SPIFFE_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.SPIFFE_AUTH);
 
     const { decryptor: orgDataKeyDecryptor } = await kmsService.createCipherPairWithDataKey({
       type: KmsDataKey.Organization,

--- a/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
+++ b/backend/src/services/identity-tls-cert-auth/identity-tls-cert-auth-service.ts
@@ -64,7 +64,7 @@ type TIdentityTlsCertAuthServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod"
+    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "invalidateTrustedIpsCache"
   >;
 };
 
@@ -450,6 +450,7 @@ export const identityTlsCertAuthServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.TLS_CERT_AUTH);
     return { ...identityTlsCertAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -557,6 +558,7 @@ export const identityTlsCertAuthServiceFactory = ({
         : undefined
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.TLS_CERT_AUTH);
     return { ...updatedTlsCertAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -717,6 +719,7 @@ export const identityTlsCertAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.TLS_CERT_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.TLS_CERT_AUTH);
 
     return revokedIdentityTlsCertAuth;
   };

--- a/backend/src/services/identity-token-auth/identity-token-auth-service.ts
+++ b/backend/src/services/identity-token-auth/identity-token-auth-service.ts
@@ -58,7 +58,10 @@ type TIdentityTokenAuthServiceFactoryDep = {
   >;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "markPerTokenRevocation"
+    | "issueIdentityAccessToken"
+    | "revokeTokensForIdentityAuthMethod"
+    | "markPerTokenRevocation"
+    | "invalidateTrustedIpsCache"
   >;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission" | "getProjectPermission">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
@@ -172,6 +175,7 @@ export const identityTokenAuthServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.TOKEN_AUTH);
     return { ...identityTokenAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -270,6 +274,7 @@ export const identityTokenAuthServiceFactory = ({
         : undefined
     });
 
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.TOKEN_AUTH);
     return {
       ...updatedTokenAuth,
       orgId: identityMembershipOrg.scopeOrgId
@@ -428,6 +433,7 @@ export const identityTokenAuthServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.TOKEN_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.TOKEN_AUTH);
 
     return revokedIdentityTokenAuth;
   };

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -64,7 +64,10 @@ type TIdentityUaServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "issueIdentityAccessToken" | "revokeTokensForIdentityAuthMethod" | "revokeAllTokensForClientSecret"
+    | "issueIdentityAccessToken"
+    | "revokeTokensForIdentityAuthMethod"
+    | "revokeAllTokensForClientSecret"
+    | "invalidateTrustedIpsCache"
   >;
   keyStore: Pick<
     TKeyStoreFactory,
@@ -551,6 +554,10 @@ export const identityUaServiceFactory = ({
       );
       return doc;
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(
+      identityMembershipOrg.identity.id,
+      IdentityAuthMethod.UNIVERSAL_AUTH
+    );
     return { ...identityUa, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -678,6 +685,7 @@ export const identityUaServiceFactory = ({
       lockoutDurationSeconds,
       lockoutCounterResetSeconds
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.UNIVERSAL_AUTH);
     return { ...updatedUaAuth, orgId: identityMembershipOrg.scopeOrgId };
   };
 
@@ -825,6 +833,7 @@ export const identityUaServiceFactory = ({
       identityId,
       authMethod: IdentityAuthMethod.UNIVERSAL_AUTH
     });
+    await identityAccessTokenService.invalidateTrustedIpsCache(identityId, IdentityAuthMethod.UNIVERSAL_AUTH);
 
     return revokedIdentityUniversalAuth;
   };

--- a/backend/src/services/identity/identity-dal.ts
+++ b/backend/src/services/identity/identity-dal.ts
@@ -27,7 +27,9 @@ export const identityDALFactory = (db: TDbClient) => {
     } as const;
     const tableName = authMethodToTableName[authMethod];
     if (!tableName) return;
-    const data = await db.replicaNode()(tableName).where({ identityId }).first();
+    // Authorization read: must observe the latest committed allowlist. Read from
+    // the primary, never a replica.
+    const data = await db(tableName).where({ identityId }).first();
     if (!data) return;
     return data.accessTokenTrustedIps;
   };


### PR DESCRIPTION
## Context

Every authenticated machine identity request runs `fnValidateIdentityAccessTokenFast`, which previously called `identityDAL.getTrustedIpsByAuthMethod` on each validation when an IP address was present and a non-wildcard allowlist was configured. That added a Postgres read to a high-frequency auth path.

This PR caches trusted IP allowlists in Redis via `withCache` (5-minute TTL, key `identity-trusted-ips:{identityId}:{authMethod}`). Cache misses still fetch from Postgres; wildcard-only allowlists skip the check as before. A new `invalidateTrustedIpsCache` helper deletes the key immediately and again after ~1s (delayed re-delete) to reduce races where a concurrent request repopulates stale data after invalidation. All identity auth method services (Universal Auth, AWS, GCP, K8s, OIDC, etc.) call invalidation on attach, update, and revoke.

Invalidation is explicit on config changes, so tightened IP restrictions take effect immediately in the normal case. If invalidation fails, allowlist data can be stale for up to the 5-minute TTL — same tradeoff as other cache-aside paths.

## Steps to verify the change

1. Configure an identity auth method with a non-wildcard IP allowlist (e.g. Universal Auth with `10.0.0.0/8`).
2. Authenticate twice in quick succession with a valid token from an allowed IP; confirm Redis key `identity-trusted-ips:{identityId}:{authMethod}` is set with TTL ~300s and the second validation does not hit Postgres for trusted IPs.
3. Update the allowlist to remove the caller's IP; confirm the Redis key is deleted (and a second delete fires ~1s later).
4. Retry auth from the now-blocked IP — request should be rejected without waiting for TTL expiry.


## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)