### PR TITLE
feat: azure auto rotate app connection credentials

### DIFF
--- a/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-fns.ts
+++ b/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-fns.ts
@@ -103,10 +103,11 @@ export const validateAzureAppConfigurationConnectionCredentials = async (
       };
 
     case AzureAppConfigurationConnectionMethod.ClientSecret:
-      const { tenantId, clientId, clientSecret } = inputCredentials as {
+      const { tenantId, clientId, clientSecret, clientSecretKeyId } = inputCredentials as {
         tenantId: string;
         clientId: string;
         clientSecret: string;
+        clientSecretKeyId?: string;
       };
 
       try {
@@ -125,7 +126,8 @@ export const validateAzureAppConfigurationConnectionCredentials = async (
           accessToken: clientData.access_token,
           expiresAt: Date.now() + clientData.expires_in * 1000,
           clientId,
-          clientSecret
+          clientSecret,
+          clientSecretKeyId
         };
       } catch (e: unknown) {
         if (e instanceof AxiosError) {

--- a/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
@@ -50,6 +50,7 @@ export const AzureAppConfigurationConnectionClientSecretOutputCredentialsSchema 
   clientId: z.string(),
   clientSecret: z.string(),
   tenantId: z.string(),
+  clientSecretKeyId: z.string().optional(),
   accessToken: z.string(),
   expiresAt: z.number()
 });

--- a/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
@@ -74,11 +74,21 @@ export const ValidateAzureAppConfigurationConnectionCredentialsSchema = z.discri
   })
 ]);
 
-export const CreateAzureAppConfigurationConnectionSchema = ValidateAzureAppConfigurationConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration, {
-    supportsCredentialRotation: true
-  })
-);
+export const CreateAzureAppConfigurationConnectionSchema = ValidateAzureAppConfigurationConnectionCredentialsSchema
+  .and(
+    GenericCreateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration, {
+      supportsCredentialRotation: true
+    })
+  )
+  .superRefine((data, ctx) => {
+    if (data.method !== AzureAppConfigurationConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Credential rotation is only supported for the client-secret method",
+        path: ["isAutoRotationEnabled"]
+      });
+    }
+  });
 
 export const UpdateAzureAppConfigurationConnectionSchema = z
   .object({

--- a/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
@@ -74,13 +74,12 @@ export const ValidateAzureAppConfigurationConnectionCredentialsSchema = z.discri
   })
 ]);
 
-export const CreateAzureAppConfigurationConnectionSchema = ValidateAzureAppConfigurationConnectionCredentialsSchema
-  .and(
+export const CreateAzureAppConfigurationConnectionSchema =
+  ValidateAzureAppConfigurationConnectionCredentialsSchema.and(
     GenericCreateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration, {
       supportsCredentialRotation: true
     })
-  )
-  .superRefine((data, ctx) => {
+  ).superRefine((data, ctx) => {
     if (data.method !== AzureAppConfigurationConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
@@ -74,20 +74,19 @@ export const ValidateAzureAppConfigurationConnectionCredentialsSchema = z.discri
   })
 ]);
 
-export const CreateAzureAppConfigurationConnectionSchema =
-  ValidateAzureAppConfigurationConnectionCredentialsSchema.and(
-    GenericCreateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration, {
-      supportsCredentialRotation: true
-    })
-  ).superRefine((data, ctx) => {
-    if (data.method !== AzureAppConfigurationConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Credential rotation is only supported for the client-secret method",
-        path: ["isAutoRotationEnabled"]
-      });
-    }
-  });
+export const CreateAzureAppConfigurationConnectionSchema = ValidateAzureAppConfigurationConnectionCredentialsSchema.and(
+  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration, {
+    supportsCredentialRotation: true
+  })
+).superRefine((data, ctx) => {
+  if (data.method !== AzureAppConfigurationConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Credential rotation is only supported for the client-secret method",
+      path: ["isAutoRotationEnabled"]
+    });
+  }
+});
 
 export const UpdateAzureAppConfigurationConnectionSchema = z
   .object({

--- a/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-app-configuration/azure-app-configuration-connection-schemas.ts
@@ -35,7 +35,15 @@ export const AzureAppConfigurationConnectionClientSecretInputCredentialsSchema =
     .trim()
     .min(1, "Client Secret required")
     .max(50, "Client Secret must be at most 50 characters long"),
-  tenantId: z.string().uuid().trim().min(1, "Tenant ID required")
+  tenantId: z.string().uuid().trim().min(1, "Tenant ID required"),
+  clientSecretKeyId: z
+    .string()
+    .uuid()
+    .trim()
+    .optional()
+    .describe(
+      "The Key ID of the client secret in Azure AD. Required when enabling credential rotation so the original secret can be revoked."
+    )
 });
 
 export const AzureAppConfigurationConnectionClientSecretOutputCredentialsSchema = z.object({
@@ -66,7 +74,9 @@ export const ValidateAzureAppConfigurationConnectionCredentialsSchema = z.discri
 ]);
 
 export const CreateAzureAppConfigurationConnectionSchema = ValidateAzureAppConfigurationConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration)
+  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration, {
+    supportsCredentialRotation: true
+  })
 );
 
 export const UpdateAzureAppConfigurationConnectionSchema = z
@@ -79,7 +89,11 @@ export const UpdateAzureAppConfigurationConnectionSchema = z
       .optional()
       .describe(AppConnections.UPDATE(AppConnection.AzureAppConfiguration).credentials)
   })
-  .and(GenericUpdateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration));
+  .and(
+    GenericUpdateAppConnectionFieldsSchema(AppConnection.AzureAppConfiguration, {
+      supportsCredentialRotation: true
+    })
+  );
 
 const BaseAzureAppConfigurationConnectionSchema = BaseAppConnectionSchema.extend({
   app: z.literal(AppConnection.AzureAppConfiguration)

--- a/backend/src/services/app-connection/azure-client-secrets/azure-client-secrets-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-client-secrets/azure-client-secrets-connection-schemas.ts
@@ -126,9 +126,19 @@ export const ValidateAzureClientSecretsConnectionCredentialsSchema = z.discrimin
   })
 ]);
 
-export const CreateAzureClientSecretsConnectionSchema = ValidateAzureClientSecretsConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureClientSecrets, { supportsCredentialRotation: true })
-);
+export const CreateAzureClientSecretsConnectionSchema = ValidateAzureClientSecretsConnectionCredentialsSchema
+  .and(
+    GenericCreateAppConnectionFieldsSchema(AppConnection.AzureClientSecrets, { supportsCredentialRotation: true })
+  )
+  .superRefine((data, ctx) => {
+    if (data.method !== AzureClientSecretsConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Credential rotation is only supported for the client-secret method",
+        path: ["isAutoRotationEnabled"]
+      });
+    }
+  });
 
 export const UpdateAzureClientSecretsConnectionSchema = z
   .object({

--- a/backend/src/services/app-connection/azure-client-secrets/azure-client-secrets-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-client-secrets/azure-client-secrets-connection-schemas.ts
@@ -126,11 +126,10 @@ export const ValidateAzureClientSecretsConnectionCredentialsSchema = z.discrimin
   })
 ]);
 
-export const CreateAzureClientSecretsConnectionSchema = ValidateAzureClientSecretsConnectionCredentialsSchema
-  .and(
+export const CreateAzureClientSecretsConnectionSchema =
+  ValidateAzureClientSecretsConnectionCredentialsSchema.and(
     GenericCreateAppConnectionFieldsSchema(AppConnection.AzureClientSecrets, { supportsCredentialRotation: true })
-  )
-  .superRefine((data, ctx) => {
+  ).superRefine((data, ctx) => {
     if (data.method !== AzureClientSecretsConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/backend/src/services/app-connection/azure-client-secrets/azure-client-secrets-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-client-secrets/azure-client-secrets-connection-schemas.ts
@@ -126,18 +126,17 @@ export const ValidateAzureClientSecretsConnectionCredentialsSchema = z.discrimin
   })
 ]);
 
-export const CreateAzureClientSecretsConnectionSchema =
-  ValidateAzureClientSecretsConnectionCredentialsSchema.and(
-    GenericCreateAppConnectionFieldsSchema(AppConnection.AzureClientSecrets, { supportsCredentialRotation: true })
-  ).superRefine((data, ctx) => {
-    if (data.method !== AzureClientSecretsConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Credential rotation is only supported for the client-secret method",
-        path: ["isAutoRotationEnabled"]
-      });
-    }
-  });
+export const CreateAzureClientSecretsConnectionSchema = ValidateAzureClientSecretsConnectionCredentialsSchema.and(
+  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureClientSecrets, { supportsCredentialRotation: true })
+).superRefine((data, ctx) => {
+  if (data.method !== AzureClientSecretsConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Credential rotation is only supported for the client-secret method",
+      path: ["isAutoRotationEnabled"]
+    });
+  }
+});
 
 export const UpdateAzureClientSecretsConnectionSchema = z
   .object({

--- a/backend/src/services/app-connection/azure-devops/azure-devops-fns.ts
+++ b/backend/src/services/app-connection/azure-devops/azure-devops-fns.ts
@@ -317,11 +317,12 @@ export const validateAzureDevOpsConnectionCredentials = async (config: TAzureDev
       }
 
     case AzureDevOpsConnectionMethod.ClientSecret:
-      const { tenantId, clientId, clientSecret, orgName } = inputCredentials as {
+      const { tenantId, clientId, clientSecret, orgName, clientSecretKeyId } = inputCredentials as {
         tenantId: string;
         clientId: string;
         clientSecret: string;
         orgName: string;
+        clientSecretKeyId?: string;
       };
 
       try {
@@ -357,6 +358,7 @@ export const validateAzureDevOpsConnectionCredentials = async (config: TAzureDev
           clientId,
           clientSecret,
           orgName,
+          clientSecretKeyId,
           accessToken: clientData.access_token,
           expiresAt: Date.now() + clientData.expires_in * 1000
         };

--- a/backend/src/services/app-connection/azure-devops/azure-devops-schemas.ts
+++ b/backend/src/services/app-connection/azure-devops/azure-devops-schemas.ts
@@ -79,6 +79,7 @@ export const AzureDevOpsConnectionClientSecretOutputCredentialsSchema = z.object
   clientSecret: z.string(),
   tenantId: z.string(),
   orgName: z.string(),
+  clientSecretKeyId: z.string().optional(),
   accessToken: z.string(),
   expiresAt: z.number()
 });
@@ -110,11 +111,21 @@ export const ValidateAzureDevOpsConnectionCredentialsSchema = z.discriminatedUni
   })
 ]);
 
-export const CreateAzureDevOpsConnectionSchema = ValidateAzureDevOpsConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDevOps, {
-    supportsCredentialRotation: true
-  })
-);
+export const CreateAzureDevOpsConnectionSchema = ValidateAzureDevOpsConnectionCredentialsSchema
+  .and(
+    GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDevOps, {
+      supportsCredentialRotation: true
+    })
+  )
+  .superRefine((data, ctx) => {
+    if (data.method !== AzureDevOpsConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Credential rotation is only supported for the client-secret method",
+        path: ["isAutoRotationEnabled"]
+      });
+    }
+  });
 
 export const UpdateAzureDevOpsConnectionSchema = z
   .object({

--- a/backend/src/services/app-connection/azure-devops/azure-devops-schemas.ts
+++ b/backend/src/services/app-connection/azure-devops/azure-devops-schemas.ts
@@ -111,13 +111,12 @@ export const ValidateAzureDevOpsConnectionCredentialsSchema = z.discriminatedUni
   })
 ]);
 
-export const CreateAzureDevOpsConnectionSchema = ValidateAzureDevOpsConnectionCredentialsSchema
-  .and(
+export const CreateAzureDevOpsConnectionSchema =
+  ValidateAzureDevOpsConnectionCredentialsSchema.and(
     GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDevOps, {
       supportsCredentialRotation: true
     })
-  )
-  .superRefine((data, ctx) => {
+  ).superRefine((data, ctx) => {
     if (data.method !== AzureDevOpsConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/backend/src/services/app-connection/azure-devops/azure-devops-schemas.ts
+++ b/backend/src/services/app-connection/azure-devops/azure-devops-schemas.ts
@@ -63,7 +63,15 @@ export const AzureDevOpsConnectionClientSecretInputCredentialsSchema = z.object(
     .string()
     .trim()
     .min(1, "Organization name required")
-    .describe(AppConnections.CREDENTIALS.AZURE_DEVOPS.orgName)
+    .describe(AppConnections.CREDENTIALS.AZURE_DEVOPS.orgName),
+  clientSecretKeyId: z
+    .string()
+    .uuid()
+    .trim()
+    .optional()
+    .describe(
+      "The Key ID of the client secret in Azure AD. Required when enabling credential rotation so the original secret can be revoked."
+    )
 });
 
 export const AzureDevOpsConnectionClientSecretOutputCredentialsSchema = z.object({
@@ -103,7 +111,9 @@ export const ValidateAzureDevOpsConnectionCredentialsSchema = z.discriminatedUni
 ]);
 
 export const CreateAzureDevOpsConnectionSchema = ValidateAzureDevOpsConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDevOps)
+  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDevOps, {
+    supportsCredentialRotation: true
+  })
 );
 
 export const UpdateAzureDevOpsConnectionSchema = z
@@ -117,7 +127,11 @@ export const UpdateAzureDevOpsConnectionSchema = z
       .optional()
       .describe(AppConnections.UPDATE(AppConnection.AzureDevOps).credentials)
   })
-  .and(GenericUpdateAppConnectionFieldsSchema(AppConnection.AzureDevOps));
+  .and(
+    GenericUpdateAppConnectionFieldsSchema(AppConnection.AzureDevOps, {
+      supportsCredentialRotation: true
+    })
+  );
 
 const BaseAzureDevOpsConnectionSchema = BaseAppConnectionSchema.extend({
   app: z.literal(AppConnection.AzureDevOps)

--- a/backend/src/services/app-connection/azure-devops/azure-devops-schemas.ts
+++ b/backend/src/services/app-connection/azure-devops/azure-devops-schemas.ts
@@ -111,20 +111,19 @@ export const ValidateAzureDevOpsConnectionCredentialsSchema = z.discriminatedUni
   })
 ]);
 
-export const CreateAzureDevOpsConnectionSchema =
-  ValidateAzureDevOpsConnectionCredentialsSchema.and(
-    GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDevOps, {
-      supportsCredentialRotation: true
-    })
-  ).superRefine((data, ctx) => {
-    if (data.method !== AzureDevOpsConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Credential rotation is only supported for the client-secret method",
-        path: ["isAutoRotationEnabled"]
-      });
-    }
-  });
+export const CreateAzureDevOpsConnectionSchema = ValidateAzureDevOpsConnectionCredentialsSchema.and(
+  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDevOps, {
+    supportsCredentialRotation: true
+  })
+).superRefine((data, ctx) => {
+  if (data.method !== AzureDevOpsConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Credential rotation is only supported for the client-secret method",
+      path: ["isAutoRotationEnabled"]
+    });
+  }
+});
 
 export const UpdateAzureDevOpsConnectionSchema = z
   .object({

--- a/backend/src/services/app-connection/azure-dns/azure-dns-connection-schema.ts
+++ b/backend/src/services/app-connection/azure-dns/azure-dns-connection-schema.ts
@@ -26,7 +26,15 @@ export const AzureDnsConnectionClientSecretCredentialsSchema = z.object({
     .trim()
     .min(1, "Client secret required")
     .max(256, "Client secret cannot exceed 256 characters"),
-  subscriptionId: azureGuidSchema.describe("Subscription ID must be a valid GUID")
+  subscriptionId: azureGuidSchema.describe("Subscription ID must be a valid GUID"),
+  clientSecretKeyId: z
+    .string()
+    .trim()
+    .refine((val) => AZURE_GUID_REGEX.test(val), { message: "Invalid GUID format" })
+    .optional()
+    .describe(
+      "The Key ID of the client secret in Azure AD. Required when enabling credential rotation so the original secret can be revoked."
+    )
 });
 
 const BaseAzureDnsConnectionSchema = BaseAppConnectionSchema.extend({
@@ -57,7 +65,9 @@ export const ValidateAzureDnsConnectionCredentialsSchema = z.discriminatedUnion(
 ]);
 
 export const CreateAzureDnsConnectionSchema = ValidateAzureDnsConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDNS)
+  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureDNS, {
+    supportsCredentialRotation: true
+  })
 );
 
 export const UpdateAzureDnsConnectionSchema = z
@@ -66,7 +76,11 @@ export const UpdateAzureDnsConnectionSchema = z
       AppConnections.UPDATE(AppConnection.AzureDNS).credentials
     )
   })
-  .and(GenericUpdateAppConnectionFieldsSchema(AppConnection.AzureDNS));
+  .and(
+    GenericUpdateAppConnectionFieldsSchema(AppConnection.AzureDNS, {
+      supportsCredentialRotation: true
+    })
+  );
 
 export const AzureDnsConnectionListItemSchema = z
   .object({

--- a/backend/src/services/app-connection/azure-entra-id/azure-entra-id-connection-fns.ts
+++ b/backend/src/services/app-connection/azure-entra-id/azure-entra-id-connection-fns.ts
@@ -122,10 +122,11 @@ export const validateAzureEntraIdConnectionCredentials = async (config: TAzureEn
 
   switch (method) {
     case AzureEntraIdConnectionMethod.ClientSecret: {
-      const { tenantId, clientId, clientSecret } = inputCredentials as {
+      const { tenantId, clientId, clientSecret, clientSecretKeyId } = inputCredentials as {
         tenantId: string;
         clientId: string;
         clientSecret: string;
+        clientSecretKeyId?: string;
       };
 
       try {
@@ -144,7 +145,8 @@ export const validateAzureEntraIdConnectionCredentials = async (config: TAzureEn
           accessToken: clientData.access_token,
           expiresAt: Date.now() + clientData.expires_in * 1000,
           clientId,
-          clientSecret
+          clientSecret,
+          clientSecretKeyId
         };
       } catch (e: unknown) {
         if (e instanceof AxiosError) {

--- a/backend/src/services/app-connection/azure-entra-id/azure-entra-id-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-entra-id/azure-entra-id-connection-schemas.ts
@@ -19,7 +19,15 @@ export const AzureEntraIdConnectionClientSecretInputCredentialsSchema = z.object
     .min(1, "Client ID required")
     .max(50, "Client ID must be at most 50 characters long"),
   clientSecret: z.string().trim().min(1, "Client Secret required"),
-  tenantId: z.string().uuid().trim().min(1, "Tenant ID required")
+  tenantId: z.string().uuid().trim().min(1, "Tenant ID required"),
+  clientSecretKeyId: z
+    .string()
+    .uuid()
+    .trim()
+    .optional()
+    .describe(
+      "The Key ID of the client secret in Azure AD. Required when enabling credential rotation so the original secret can be revoked."
+    )
 });
 
 export const AzureEntraIdConnectionClientSecretOutputCredentialsSchema = z.object({
@@ -42,7 +50,9 @@ export const ValidateAzureEntraIdConnectionCredentialsSchema = z.discriminatedUn
 ]);
 
 export const CreateAzureEntraIdConnectionSchema = ValidateAzureEntraIdConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureEntraId)
+  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureEntraId, {
+    supportsCredentialRotation: true
+  })
 );
 
 export const UpdateAzureEntraIdConnectionSchema = z
@@ -51,7 +61,11 @@ export const UpdateAzureEntraIdConnectionSchema = z
       AppConnections.UPDATE(AppConnection.AzureEntraId).credentials
     )
   })
-  .and(GenericUpdateAppConnectionFieldsSchema(AppConnection.AzureEntraId));
+  .and(
+    GenericUpdateAppConnectionFieldsSchema(AppConnection.AzureEntraId, {
+      supportsCredentialRotation: true
+    })
+  );
 
 const BaseAzureEntraIdConnectionSchema = BaseAppConnectionSchema.extend({
   app: z.literal(AppConnection.AzureEntraId)

--- a/backend/src/services/app-connection/azure-entra-id/azure-entra-id-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-entra-id/azure-entra-id-connection-schemas.ts
@@ -34,6 +34,7 @@ export const AzureEntraIdConnectionClientSecretOutputCredentialsSchema = z.objec
   clientId: z.string(),
   clientSecret: z.string(),
   tenantId: z.string(),
+  clientSecretKeyId: z.string().optional(),
   accessToken: z.string(),
   expiresAt: z.number()
 });

--- a/backend/src/services/app-connection/azure-key-vault/azure-key-vault-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-key-vault/azure-key-vault-connection-schemas.ts
@@ -98,12 +98,22 @@ export const ValidateAzureKeyVaultConnectionCredentialsSchema = z.discriminatedU
   })
 ]);
 
-export const CreateAzureKeyVaultConnectionSchema = ValidateAzureKeyVaultConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureKeyVault, {
-    supportsCredentialRotation: true,
-    supportsGateways: true
-  })
-);
+export const CreateAzureKeyVaultConnectionSchema = ValidateAzureKeyVaultConnectionCredentialsSchema
+  .and(
+    GenericCreateAppConnectionFieldsSchema(AppConnection.AzureKeyVault, {
+      supportsCredentialRotation: true,
+      supportsGateways: true
+    })
+  )
+  .superRefine((data, ctx) => {
+    if (data.method !== AzureKeyVaultConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Credential rotation is only supported for the client-secret method",
+        path: ["isAutoRotationEnabled"]
+      });
+    }
+  });
 
 export const UpdateAzureKeyVaultConnectionSchema = z
   .object({

--- a/backend/src/services/app-connection/azure-key-vault/azure-key-vault-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-key-vault/azure-key-vault-connection-schemas.ts
@@ -98,14 +98,13 @@ export const ValidateAzureKeyVaultConnectionCredentialsSchema = z.discriminatedU
   })
 ]);
 
-export const CreateAzureKeyVaultConnectionSchema = ValidateAzureKeyVaultConnectionCredentialsSchema
-  .and(
+export const CreateAzureKeyVaultConnectionSchema =
+  ValidateAzureKeyVaultConnectionCredentialsSchema.and(
     GenericCreateAppConnectionFieldsSchema(AppConnection.AzureKeyVault, {
       supportsCredentialRotation: true,
       supportsGateways: true
     })
-  )
-  .superRefine((data, ctx) => {
+  ).superRefine((data, ctx) => {
     if (data.method !== AzureKeyVaultConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/backend/src/services/app-connection/azure-key-vault/azure-key-vault-connection-schemas.ts
+++ b/backend/src/services/app-connection/azure-key-vault/azure-key-vault-connection-schemas.ts
@@ -98,21 +98,20 @@ export const ValidateAzureKeyVaultConnectionCredentialsSchema = z.discriminatedU
   })
 ]);
 
-export const CreateAzureKeyVaultConnectionSchema =
-  ValidateAzureKeyVaultConnectionCredentialsSchema.and(
-    GenericCreateAppConnectionFieldsSchema(AppConnection.AzureKeyVault, {
-      supportsCredentialRotation: true,
-      supportsGateways: true
-    })
-  ).superRefine((data, ctx) => {
-    if (data.method !== AzureKeyVaultConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Credential rotation is only supported for the client-secret method",
-        path: ["isAutoRotationEnabled"]
-      });
-    }
-  });
+export const CreateAzureKeyVaultConnectionSchema = ValidateAzureKeyVaultConnectionCredentialsSchema.and(
+  GenericCreateAppConnectionFieldsSchema(AppConnection.AzureKeyVault, {
+    supportsCredentialRotation: true,
+    supportsGateways: true
+  })
+).superRefine((data, ctx) => {
+  if (data.method !== AzureKeyVaultConnectionMethod.ClientSecret && data.isAutoRotationEnabled) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Credential rotation is only supported for the client-secret method",
+      path: ["isAutoRotationEnabled"]
+    });
+  }
+});
 
 export const UpdateAzureKeyVaultConnectionSchema = z
   .object({

--- a/backend/src/services/app-connection/credential-rotation/app-connection-credential-rotation-service.ts
+++ b/backend/src/services/app-connection/credential-rotation/app-connection-credential-rotation-service.ts
@@ -15,8 +15,12 @@ import {
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 
 import { TAppConnection, TAppConnectionRaw } from "../app-connection-types";
-import { AzureClientSecretsConnectionMethod } from "../azure-client-secrets";
-import { AzureKeyVaultConnectionMethod } from "../azure-key-vault";
+import { AzureAppConfigurationConnectionMethod } from "../azure-app-configuration/azure-app-configuration-connection-enums";
+import { AzureClientSecretsConnectionMethod } from "../azure-client-secrets/azure-client-secrets-connection-enums";
+import { AzureDevOpsConnectionMethod } from "../azure-devops/azure-devops-enums";
+import { AzureDnsConnectionMethod } from "../azure-dns/azure-dns-connection-enums";
+import { AzureEntraIdConnectionMethod } from "../azure-entra-id/azure-entra-id-connection-enums";
+import { AzureKeyVaultConnectionMethod } from "../azure-key-vault/azure-key-vault-connection-enums";
 import { TAppConnectionCredentialRotationDALFactory } from "./app-connection-credential-rotation-dal";
 import {
   AppConnectionCredentialRotationStatus,
@@ -62,6 +66,22 @@ const STRATEGY_MAP: Record<
     {
       app: AppConnection.AzureClientSecrets,
       method: AzureClientSecretsConnectionMethod.ClientSecret
+    },
+    {
+      app: AppConnection.AzureAppConfiguration,
+      method: AzureAppConfigurationConnectionMethod.ClientSecret
+    },
+    {
+      app: AppConnection.AzureDevOps,
+      method: AzureDevOpsConnectionMethod.ClientSecret
+    },
+    {
+      app: AppConnection.AzureDNS,
+      method: AzureDnsConnectionMethod.ClientSecret
+    },
+    {
+      app: AppConnection.AzureEntraId,
+      method: AzureEntraIdConnectionMethod.ClientSecret
     }
   ]
 };

--- a/docs/integrations/app-connections/azure-app-configuration.mdx
+++ b/docs/integrations/app-connections/azure-app-configuration.mdx
@@ -36,8 +36,15 @@ Infisical currently only supports two methods for connecting to Azure, which are
 
       #### Azure App Configuration permissions
     
-      Set the API permissions of the Azure application to include the following Azure App Configuration permissions: `KeyValue.Delete`, `KeyValue.Read`, and `KeyValue.Write`.
-      ![Azure app config](../../images/integrations/azure-app-configuration/app-api-permissions.png)
+      Set the API permissions of the Azure application to include the following permissions:
+        - Microsoft Graph
+          - `Application.ReadWrite.All`
+          - `Application.ReadWrite.OwnedBy`
+          - `Application.ReadWrite.All` (Delegated)
+          - `Directory.ReadWrite.All` (Delegated)
+          - `User.Read` (Delegated)
+
+      ![Azure client secrets](/images/integrations/azure-client-secrets/app-api-permissions.png)
 
 
     </Step>
@@ -72,9 +79,15 @@ Infisical currently only supports two methods for connecting to Azure, which are
 
       #### Azure App Configuration permissions
     
-      Set the API permissions of your Azure service principal to include the following Azure App Configuration permissions: `KeyValue.Delete`, `KeyValue.Read`, and `KeyValue.Write`.
-      
-      ![Azure app config](../../images/integrations/azure-app-configuration/app-api-permissions.png)
+      Set the API permissions of the Azure application to include the following permissions:
+        - Microsoft Graph
+          - `Application.ReadWrite.All`
+          - `Application.ReadWrite.OwnedBy`
+          - `Application.ReadWrite.All` (Delegated)
+          - `Directory.ReadWrite.All` (Delegated)
+          - `User.Read` (Delegated)
+
+      ![Azure client secrets](/images/integrations/azure-client-secrets/app-api-permissions.png)
     </Step>
   </Steps>
 </Accordion>

--- a/docs/integrations/app-connections/azure-app-configuration.mdx
+++ b/docs/integrations/app-connections/azure-app-configuration.mdx
@@ -46,7 +46,6 @@ Infisical currently only supports two methods for connecting to Azure, which are
 
       ![Azure client secrets](/images/integrations/azure-client-secrets/app-api-permissions.png)
 
-
     </Step>
     <Step title="Add your application credentials to Infisical">
       Obtain the **Application (Client) ID** in Overview and generate a **Client Secret** in Certificate & secrets for your Azure application.
@@ -88,6 +87,8 @@ Infisical currently only supports two methods for connecting to Azure, which are
           - `User.Read` (Delegated)
 
       ![Azure client secrets](/images/integrations/azure-client-secrets/app-api-permissions.png)
+
+      <Note>If you want to configure automatic client secret rotation for this App Connection, you also need to grant either `Application.ReadWrite.OwnedBy` or `Application.ReadWrite.All` permissions.</Note>
     </Step>
   </Steps>
 </Accordion>

--- a/docs/integrations/app-connections/azure-client-secrets.mdx
+++ b/docs/integrations/app-connections/azure-client-secrets.mdx
@@ -46,7 +46,6 @@ Infisical currently only supports two methods for connecting to Azure, which are
 
       ![Azure client secrets](/images/integrations/azure-client-secrets/app-api-permissions.png)
 
-
     </Step>
     <Step title="Add your application credentials to Infisical">
       Obtain the **Application (Client) ID** and **Directory (Tenant) ID** (this will be used later in the Infisical connection) in Overview and generate a **Client Secret** in Certificate & secrets for your Azure application.
@@ -89,6 +88,8 @@ Infisical currently only supports two methods for connecting to Azure, which are
         - `User.Read` (Delegated)
 
         ![Azure client secrets](/images/integrations/azure-client-secrets/app-api-permissions.png)
+
+        <Note>If you want to configure automatic client secret rotation for this App Connection, you also need to grant either `Application.ReadWrite.OwnedBy` or `Application.ReadWrite.All` permissions.</Note>
       </Step>
     </Steps>
   </Accordion>

--- a/docs/integrations/app-connections/azure-devops.mdx
+++ b/docs/integrations/app-connections/azure-devops.mdx
@@ -45,7 +45,6 @@ Infisical currently supports three methods for connecting to Azure DevOps, which
 
       ![Azure devops](/images/integrations/azure-devops/app-api-permissions.png)
 
-
     </Step>
     <Step title="Add your application credentials to Infisical">
       Obtain the **Application (Client) ID** and **Directory (Tenant) ID** (this will be used later in the Infisical connection) in Overview and generate a **Client Secret** in Certificate & secrets for your Azure application.
@@ -109,6 +108,8 @@ Infisical currently supports three methods for connecting to Azure DevOps, which
           - `vso.variablegroups_write`
 
       ![Azure devops](/images/integrations/azure-devops/app-api-permissions.png)
+
+      <Note>If you want to configure automatic client secret rotation for this App Connection, you also need to grant either `Application.ReadWrite.OwnedBy` or `Application.ReadWrite.All` permissions.</Note>
     </Step>
   </Steps>
 </Accordion>

--- a/docs/integrations/app-connections/azure-dns.mdx
+++ b/docs/integrations/app-connections/azure-dns.mdx
@@ -8,6 +8,8 @@ Infisical supports connecting to Azure DNS using a Service Principal with Client
 <Accordion title="Client Secret Authentication">
   To use client secret authentication, ensure your Azure Service Principal has the required permissions to manage DNS records in your Azure DNS Zone.
 
+  <Note>If you want to configure automatic client secret rotation for this App Connection, you also need to grant either `Application.ReadWrite.OwnedBy` or `Application.ReadWrite.All` permissions.</Note>
+
   **Prerequisites:**
   - Set up Azure and have an existing DNS Zone.
   - An Azure Service Principal (App Registration) with a Client Secret.

--- a/docs/integrations/app-connections/azure-key-vault.mdx
+++ b/docs/integrations/app-connections/azure-key-vault.mdx
@@ -75,6 +75,8 @@ Infisical supports three methods for connecting to Azure Key Vault: OAuth, Clien
       Set the API permissions of your Azure service principal to include `user_impersonation` for the Key Vault API.
       ![Azure key vault](/images/app-connections/azure/keyvault-azure-permissions.png)
 
+      <Note>If you want to configure automatic client secret rotation for this App Connection, you also need to grant either `Application.ReadWrite.OwnedBy` or `Application.ReadWrite.All` permissions.</Note>
+
     </Step>
   </Steps>
 </Accordion>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureAppConfigurationConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureAppConfigurationConnectionForm.tsx
@@ -37,6 +37,7 @@ import {
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { AzureAppConfigurationFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
+import { CredentialRotationForm } from "./shared/CredentialRotationForm";
 import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
@@ -66,7 +67,8 @@ const clientSecretSchema = baseSchema.extend({
   credentials: z.object({
     clientSecret: z.string().trim().min(1, "Client Secret is required"),
     clientId: z.string().trim().min(1, "Client ID is required"),
-    tenantId: z.string().trim().min(1, "Tenant ID is required")
+    tenantId: z.string().trim().min(1, "Tenant ID is required"),
+    clientSecretKeyId: z.string().trim().optional()
   })
 });
 
@@ -74,11 +76,21 @@ const formSchema = z.discriminatedUnion("method", [oauthSchema, clientSecretSche
 
 type FormData = z.infer<typeof formSchema>;
 
+const defaultRotation = {
+  rotationInterval: 30,
+  rotateAtUtc: {
+    hours: 0,
+    minutes: 0
+  }
+};
+
 const getDefaultValues = (appConnection?: TAzureAppConfigurationConnection): Partial<FormData> => {
   if (!appConnection) {
     return {
       app: AppConnection.AzureAppConfiguration,
-      method: AzureAppConfigurationConnectionMethod.OAuth
+      method: AzureAppConfigurationConnectionMethod.OAuth,
+      isAutoRotationEnabled: false,
+      rotation: defaultRotation
     };
   }
 
@@ -86,7 +98,9 @@ const getDefaultValues = (appConnection?: TAzureAppConfigurationConnection): Par
     name: appConnection.name,
     description: appConnection.description,
     app: appConnection.app,
-    method: appConnection.method
+    method: appConnection.method,
+    isAutoRotationEnabled: appConnection.isAutoRotationEnabled,
+    rotation: appConnection.rotation ?? defaultRotation
   };
   const { credentials } = appConnection;
 
@@ -318,6 +332,36 @@ export const AzureAppConfigurationConnectionForm = ({
                 </Field>
               )}
             />
+            <CredentialRotationForm>
+              <Controller
+                name="credentials.clientSecretKeyId"
+                control={control}
+                render={({ field, fieldState: { error } }) => (
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="credentials.clientSecretKeyId">
+                      Client Secret Key ID
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-sm">
+                          The Key ID of the client secret provided above. Found in Azure Portal
+                          under App Registrations &gt; Certificates &amp; Secrets. Required so
+                          Infisical can revoke the original secret after rotation.
+                        </TooltipContent>
+                      </Tooltip>
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id="credentials.clientSecretKeyId"
+                      placeholder="00000000-0000-0000-0000-000000000000"
+                      isError={Boolean(error)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+            </CredentialRotationForm>
           </>
         )}
         <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDNSConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDNSConnectionForm.tsx
@@ -23,6 +23,7 @@ import { TAzureDNSConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { AzureDNSConnectionMethod } from "@app/hooks/api/appConnections/types/azure-dns-connection";
 
+import { CredentialRotationForm } from "./shared/CredentialRotationForm";
 import { AppConnectionFormFooter } from "./AppConnectionFormFooter";
 import {
   genericAppConnectionFieldsSchema,
@@ -45,28 +46,45 @@ const formSchema = z.discriminatedUnion("method", [
       tenantId: z.string().trim().min(1, "Tenant ID required"),
       clientId: z.string().trim().min(1, "Client ID required"),
       clientSecret: z.string().trim().min(1, "Client Secret required"),
-      subscriptionId: z.string().trim().min(1, "Subscription ID required")
+      subscriptionId: z.string().trim().min(1, "Subscription ID required"),
+      clientSecretKeyId: z.string().trim().optional()
     })
   })
 ]);
 
 type FormData = z.infer<typeof formSchema>;
 
+const defaultRotation = {
+  rotationInterval: 30,
+  rotateAtUtc: {
+    hours: 0,
+    minutes: 0
+  }
+};
+
 export const AzureDNSConnectionForm = ({ appConnection, onSubmit }: Props) => {
   const isUpdate = Boolean(appConnection);
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
-    defaultValues: appConnection ?? {
-      app: AppConnection.AzureDNS,
-      method: AzureDNSConnectionMethod.ClientSecret,
-      credentials: {
-        tenantId: "",
-        clientId: "",
-        clientSecret: "",
-        subscriptionId: ""
-      }
-    }
+    defaultValues: appConnection
+      ? {
+          ...appConnection,
+          isAutoRotationEnabled: appConnection.isAutoRotationEnabled,
+          rotation: appConnection.rotation ?? defaultRotation
+        }
+      : {
+          app: AppConnection.AzureDNS,
+          method: AzureDNSConnectionMethod.ClientSecret,
+          isAutoRotationEnabled: false,
+          rotation: defaultRotation,
+          credentials: {
+            tenantId: "",
+            clientId: "",
+            clientSecret: "",
+            subscriptionId: ""
+          }
+        }
   });
 
   const { handleSubmit, control } = form;
@@ -181,6 +199,37 @@ export const AzureDNSConnectionForm = ({ appConnection, onSubmit }: Props) => {
             </Field>
           )}
         />
+        <CredentialRotationForm>
+          <Controller
+            name="credentials.clientSecretKeyId"
+            control={control}
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <Field className="mb-4">
+                <FieldLabel htmlFor="credentials.clientSecretKeyId">
+                  Client Secret Key ID
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-sm">
+                      The Key ID of the client secret provided above. Found in Azure Portal under
+                      App Registrations &gt; Certificates &amp; Secrets. Required so Infisical can
+                      revoke the original secret after rotation.
+                    </TooltipContent>
+                  </Tooltip>
+                </FieldLabel>
+                <Input
+                  id="credentials.clientSecretKeyId"
+                  value={value}
+                  onChange={(e) => onChange(e.target.value)}
+                  placeholder="00000000-0000-0000-0000-000000000000"
+                  isError={Boolean(error)}
+                />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+        </CredentialRotationForm>
         <AppConnectionFormFooter
           submitLabel={isUpdate ? "Update Credentials" : "Connect to Azure DNS"}
         />

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDevOpsConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDevOpsConnectionForm.tsx
@@ -38,6 +38,7 @@ import {
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { AzureDevOpsFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
+import { CredentialRotationForm } from "./shared/CredentialRotationForm";
 import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
@@ -71,7 +72,8 @@ const clientSecretSchema = baseSchema.extend({
     clientSecret: z.string().trim().min(1, "Client Secret is required"),
     tenantId: z.string().trim().min(1, "Tenant ID is required"),
     clientId: z.string().trim().min(1, "Client ID is required"),
-    orgName: z.string().trim().min(1, "Organization name is required")
+    orgName: z.string().trim().min(1, "Organization name is required"),
+    clientSecretKeyId: z.string().trim().optional()
   })
 });
 
@@ -91,11 +93,21 @@ type Props = {
   projectId: string | undefined | null;
 };
 
+const defaultRotation = {
+  rotationInterval: 30,
+  rotateAtUtc: {
+    hours: 0,
+    minutes: 0
+  }
+};
+
 const getDefaultValues = (appConnection?: TAzureDevOpsConnection): Partial<FormData> => {
   if (!appConnection) {
     return {
       app: AppConnection.AzureDevOps,
-      method: AzureDevOpsConnectionMethod.OAuth
+      method: AzureDevOpsConnectionMethod.OAuth,
+      isAutoRotationEnabled: false,
+      rotation: defaultRotation
     };
   }
 
@@ -103,7 +115,9 @@ const getDefaultValues = (appConnection?: TAzureDevOpsConnection): Partial<FormD
     name: appConnection.name,
     description: appConnection.description,
     app: appConnection.app,
-    method: appConnection.method
+    method: appConnection.method,
+    isAutoRotationEnabled: appConnection.isAutoRotationEnabled,
+    rotation: appConnection.rotation ?? defaultRotation
   };
   const { credentials } = appConnection;
 
@@ -375,6 +389,36 @@ export const AzureDevOpsConnectionForm = ({ appConnection, onSubmit, projectId }
                 </Field>
               )}
             />
+            <CredentialRotationForm>
+              <Controller
+                name="credentials.clientSecretKeyId"
+                control={control}
+                render={({ field, fieldState: { error } }) => (
+                  <Field className="mb-4">
+                    <FieldLabel htmlFor="credentials.clientSecretKeyId">
+                      Client Secret Key ID
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-sm">
+                          The Key ID of the client secret provided above. Found in Azure Portal
+                          under App Registrations &gt; Certificates &amp; Secrets. Required so
+                          Infisical can revoke the original secret after rotation.
+                        </TooltipContent>
+                      </Tooltip>
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id="credentials.clientSecretKeyId"
+                      placeholder="00000000-0000-0000-0000-000000000000"
+                      isError={Boolean(error)}
+                    />
+                    <FieldError errors={[error]} />
+                  </Field>
+                )}
+              />
+            </CredentialRotationForm>
           </>
         )}
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureEntraIdConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureEntraIdConnectionForm.tsx
@@ -27,6 +27,7 @@ import {
   TAzureEntraIdConnection
 } from "@app/hooks/api/appConnections/types/azure-entra-id-connection";
 
+import { CredentialRotationForm } from "./shared/CredentialRotationForm";
 import { useAppConnectionForm } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
@@ -39,7 +40,8 @@ const formSchema = genericAppConnectionFieldsSchema.extend({
   credentials: z.object({
     tenantId: z.string().trim().min(1, "Tenant ID is required"),
     clientId: z.string().trim().min(1, "Client ID is required"),
-    clientSecret: z.string().trim().min(1, "Client Secret is required")
+    clientSecret: z.string().trim().min(1, "Client Secret is required"),
+    clientSecretKeyId: z.string().trim().optional()
   })
 });
 
@@ -54,6 +56,14 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
   const isUpdate = Boolean(appConnection);
   const { onCancel } = useAppConnectionForm();
 
+  const defaultRotation = {
+    rotationInterval: 30,
+    rotateAtUtc: {
+      hours: 0,
+      minutes: 0
+    }
+  };
+
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: appConnection
@@ -62,6 +72,8 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
           description: appConnection.description,
           app: AppConnection.AzureEntraId,
           method: AzureEntraIdConnectionMethod.ClientSecret,
+          isAutoRotationEnabled: appConnection.isAutoRotationEnabled,
+          rotation: appConnection.rotation ?? defaultRotation,
           credentials: {
             tenantId: appConnection.credentials.tenantId,
             clientId: appConnection.credentials.clientId,
@@ -71,6 +83,8 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
       : {
           app: AppConnection.AzureEntraId,
           method: AzureEntraIdConnectionMethod.ClientSecret,
+          isAutoRotationEnabled: false,
+          rotation: defaultRotation,
           credentials: {
             tenantId: "",
             clientId: "",
@@ -210,6 +224,37 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
             </Field>
           )}
         />
+
+        <CredentialRotationForm>
+          <Controller
+            name="credentials.clientSecretKeyId"
+            control={control}
+            render={({ field, fieldState: { error } }) => (
+              <Field className="mb-4">
+                <FieldLabel htmlFor="credentials.clientSecretKeyId">
+                  Client Secret Key ID
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-sm">
+                      The Key ID of the client secret provided above. Found in Azure Portal under
+                      App Registrations &gt; Certificates &amp; Secrets. Required so Infisical can
+                      revoke the original secret after rotation.
+                    </TooltipContent>
+                  </Tooltip>
+                </FieldLabel>
+                <Input
+                  {...field}
+                  id="credentials.clientSecretKeyId"
+                  placeholder="00000000-0000-0000-0000-000000000000"
+                  isError={Boolean(error)}
+                />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+        </CredentialRotationForm>
 
         <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">
           <Button


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Add Vault App Connection credential rotations. This enable the credential rotation for the remaining 4 Azure App Connections. This is only valid for `client secret` auth method.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)