### PR TITLE
improvement(identity-access-token): cache org membership in revocation verdict

### DIFF
--- a/backend/e2e-test/routes/v1/identity-access-token-redesign.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-access-token-redesign.spec.ts
@@ -131,8 +131,7 @@ const deleteOrgIdentityMembership = async (identityId: string) => {
   // The real removal paths (membershipIdentityService.deleteMembership,
   // identityV1.deleteIdentity sub-org branch) bump the identity's revocation
   // version so cached "allow" verdicts are rechecked once against Postgres. This
-  // helper mutates the row directly, so mirror that bump here — otherwise the
-  // cache-gated membership check keeps serving the stale allow until the TTL.
+  // helper mutates the row directly, so mirror that bump here.
   await testRedis.incr(KeyStorePrefixes.IdentityRevocationVersion(identityId));
 };
 

--- a/backend/e2e-test/routes/v1/identity-access-token-redesign.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-access-token-redesign.spec.ts
@@ -16,6 +16,7 @@ import jwt from "jsonwebtoken";
 
 import { AccessScope, IdentityAuthMethod, OrgMembershipRole, TableName } from "@app/db/schemas";
 import { seedData1 } from "@app/db/seed-data";
+import { KeyStorePrefixes } from "@app/keystore/keystore";
 import { AuthTokenType } from "@app/services/auth/auth-type";
 
 // ---------------------------------------------------------------------------
@@ -126,6 +127,13 @@ const deleteOrgIdentityMembership = async (identityId: string) => {
 
   await testDb(TableName.MembershipRole).where({ membershipId: membership.id }).delete();
   await testDb(TableName.Membership).where({ id: membership.id }).delete();
+
+  // The real removal paths (membershipIdentityService.deleteMembership,
+  // identityV1.deleteIdentity sub-org branch) bump the identity's revocation
+  // version so cached "allow" verdicts are rechecked once against Postgres. This
+  // helper mutates the row directly, so mirror that bump here — otherwise the
+  // cache-gated membership check keeps serving the stale allow until the TTL.
+  await testRedis.incr(KeyStorePrefixes.IdentityRevocationVersion(identityId));
 };
 
 const waitForRevocationRow = async (tokenId: string) => {

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -17,6 +17,7 @@ import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TGenericPermission } from "@app/lib/types";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
+import { TIdentityAccessTokenServiceFactory } from "@app/services/identity-access-token/identity-access-token-service";
 import { PamIdentities, SecretIdentities } from "@app/services/license-client";
 import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage";
 import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
@@ -93,6 +94,7 @@ type TGroupServiceFactoryDep = {
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   oidcConfigDAL: Pick<TOidcConfigDALFactory, "findOne">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
+  identityAccessTokenService: Pick<TIdentityAccessTokenServiceFactory, "bumpIdentityRevocationVersion">;
 };
 
 export type TGroupServiceFactory = ReturnType<typeof groupServiceFactory>;
@@ -113,7 +115,8 @@ export const groupServiceFactory = ({
   oidcConfigDAL,
   membershipGroupDAL,
   membershipRoleDAL,
-  usageMeteringService
+  usageMeteringService,
+  identityAccessTokenService
 }: TGroupServiceFactoryDep) => {
   const createGroup = async ({ name, slug, role, actor, actorId, actorAuthMethod, actorOrgId }: TCreateGroupDTO) => {
     if (!actorOrgId) throw new UnauthorizedError({ message: "No organization ID provided in request" });
@@ -1227,6 +1230,9 @@ export const groupServiceFactory = ({
       userIds: [],
       identityIds: [identityId]
     });
+
+    // Losing a group can remove the identity's effective org access.
+    await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId });
 
     // The identity may have left a secret-manager or PAM project it only reached through this group.
     usageMeteringService.emit(actorOrgId, SecretIdentities.key);

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -2,7 +2,14 @@ import { ForbiddenError } from "@casl/ability";
 import slugify from "@sindresorhus/slugify";
 import { Knex } from "knex";
 
-import { AccessScope, OrganizationActionScope, OrgMembershipRole, TGroups, TRoles } from "@app/db/schemas";
+import {
+  AccessScope,
+  OrganizationActionScope,
+  OrgMembershipRole,
+  OrgMembershipStatus,
+  TGroups,
+  TRoles
+} from "@app/db/schemas";
 import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import {
@@ -969,6 +976,28 @@ export const groupServiceFactory = ({
     return { user: users[0], group: groupMembership.group };
   };
 
+  // Joining/leaving this group changes the identity's effective org
+  // access only in orgs where the group holds a membership row and the identity
+  // has no direct access.
+  const groupMembershipAffectsIdentityOrgAccess = async (groupId: string, identityId: string) => {
+    const groupOrgMemberships = await membershipDAL.find({
+      scope: AccessScope.Organization,
+      actorGroupId: groupId
+    });
+    if (groupOrgMemberships.length === 0) return false;
+
+    const identityDirectMemberships = await membershipDAL.find({
+      scope: AccessScope.Organization,
+      actorIdentityId: identityId
+    });
+    const directOrgIds = new Set(
+      identityDirectMemberships
+        .filter((membership) => !membership.status || membership.status === OrgMembershipStatus.Accepted)
+        .map((membership) => membership.scopeOrgId)
+    );
+    return groupOrgMemberships.some((membership) => !directOrgIds.has(membership.scopeOrgId));
+  };
+
   const addMachineIdentityToGroup = async ({
     id,
     identityId,
@@ -1046,6 +1075,13 @@ export const groupServiceFactory = ({
       membershipDAL,
       identityGroupMembershipDAL
     });
+
+    // Gaining a group can restore the identity's effective org access, so cached
+    // membership denies must re-check. Skipped when the group grants no org the
+    // identity lacks directly.
+    if (await groupMembershipAffectsIdentityOrgAccess(id, identityId)) {
+      await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId });
+    }
 
     // The identity may now be in a secret-manager or PAM project through this group.
     usageMeteringService.emit(actorOrgId, SecretIdentities.key);
@@ -1231,8 +1267,11 @@ export const groupServiceFactory = ({
       identityIds: [identityId]
     });
 
-    // Losing a group can remove the identity's effective org access.
-    await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId });
+    // Losing a group can remove the identity's effective org access. Skipped when
+    // the group granted no org the identity lacks directly
+    if (await groupMembershipAffectsIdentityOrgAccess(id, identityId)) {
+      await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId });
+    }
 
     // The identity may have left a secret-manager or PAM project it only reached through this group.
     usageMeteringService.emit(actorOrgId, SecretIdentities.key);

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -908,6 +908,14 @@ export const registerRoutes = async (
     usageMeteringService
   });
 
+  const identityAccessTokenService = identityAccessTokenServiceFactory({
+    identityAccessTokenDAL,
+    identityAccessTokenRevocationDAL,
+    identityDAL,
+    orgDAL,
+    keyStore
+  });
+
   const membershipIdentityService = membershipIdentityServiceFactory({
     identityDAL,
     membershipIdentityDAL,
@@ -920,7 +928,8 @@ export const registerRoutes = async (
     applicationMembershipCleanupService,
     projectDAL,
     keyStore,
-    usageMeteringService
+    usageMeteringService,
+    identityAccessTokenService
   });
 
   const membershipGroupService = membershipGroupServiceFactory({
@@ -2466,14 +2475,6 @@ export const registerRoutes = async (
     membershipIdentityDAL,
     membershipRoleDAL,
     usageMeteringService
-  });
-
-  const identityAccessTokenService = identityAccessTokenServiceFactory({
-    identityAccessTokenDAL,
-    identityAccessTokenRevocationDAL,
-    identityDAL,
-    orgDAL,
-    keyStore
   });
 
   const identityV2Service = identityV2ServiceFactory({

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2475,7 +2475,8 @@ export const registerRoutes = async (
     orgDAL,
     membershipIdentityDAL,
     membershipRoleDAL,
-    usageMeteringService
+    usageMeteringService,
+    identityAccessTokenService
   });
 
   const identityV2Service = identityV2ServiceFactory({

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1086,7 +1086,8 @@ export const registerRoutes = async (
     oidcConfigDAL,
     membershipGroupDAL,
     membershipRoleDAL,
-    usageMeteringService
+    usageMeteringService,
+    identityAccessTokenService
   });
   const groupProjectService = groupProjectServiceFactory({
     groupDAL,

--- a/backend/src/services/identity-access-token/identity-access-token-fns.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-fns.test.ts
@@ -327,4 +327,29 @@ describe("evaluateRevocationMarkers", () => {
       })
     ).toBe("auth-method");
   });
+
+  test("denies org-scoped membership markers only for matching orgId", () => {
+    const revokedAt = new Date((NOW + 10) * 1000);
+    expect(
+      evaluateRevocationMarkers({
+        ...base,
+        orgId: "org-id",
+        markers: [{ id: "uuid", identityId: "identity-id", createdAt: revokedAt, revokedAt, scope: "org-id" }]
+      })
+    ).toBe("org-membership");
+    expect(
+      evaluateRevocationMarkers({
+        ...base,
+        orgId: "other-org",
+        markers: [{ id: "uuid", identityId: "identity-id", createdAt: revokedAt, revokedAt, scope: "org-id" }]
+      })
+    ).toBeNull();
+    expect(
+      evaluateRevocationMarkers({
+        ...base,
+        orgId: "org-id",
+        markers: [{ id: "uuid", identityId: "identity-id", createdAt: new Date((NOW - 10) * 1000), scope: "org-id" }]
+      })
+    ).toBeNull();
+  });
 });

--- a/backend/src/services/identity-access-token/identity-access-token-fns.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-fns.test.ts
@@ -8,7 +8,8 @@ import {
   computeTokenAuthRevokeMarkerExpiry,
   evaluateRevocationMarkers,
   hasLegacyTokenWithoutExpExceededMaxAge,
-  IDENTITY_REVOCATION_MARKER_SKEW_SECONDS
+  IDENTITY_REVOCATION_MARKER_SKEW_SECONDS,
+  isMembershipDenyReason
 } from "./identity-access-token-fns";
 
 const MAX_AGE = 7_776_000;
@@ -351,5 +352,16 @@ describe("evaluateRevocationMarkers", () => {
         markers: [{ id: "uuid", identityId: "identity-id", createdAt: new Date((NOW - 10) * 1000), scope: "org-id" }]
       })
     ).toBeNull();
+  });
+});
+
+describe("isMembershipDenyReason", () => {
+  test("marks only the membership-derived reasons as reversible", () => {
+    expect(isMembershipDenyReason("org-membership")).toBe(true);
+    expect(isMembershipDenyReason("org-membership-inactive")).toBe(true);
+    expect(isMembershipDenyReason("token")).toBe(false);
+    expect(isMembershipDenyReason("identity")).toBe(false);
+    expect(isMembershipDenyReason("client-secret")).toBe(false);
+    expect(isMembershipDenyReason("auth-method")).toBe(false);
   });
 });

--- a/backend/src/services/identity-access-token/identity-access-token-fns.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-fns.ts
@@ -303,6 +303,11 @@ export const evaluateRevocationMarkers = ({
   return null;
 };
 
+// Membership-derived denies are reversible (the identity can be re-added to the
+// org, reactivated, or regain access through a group)
+export const isMembershipDenyReason = (reason: TRevocationDenyReason): boolean =>
+  reason === "org-membership" || reason === "org-membership-inactive";
+
 export const revocationDenyReasonToMessage = (
   reason: TRevocationDenyReason,
   messagePrefix: "Failed to authorize" | "Cannot renew"

--- a/backend/src/services/identity-access-token/identity-access-token-fns.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-fns.ts
@@ -259,7 +259,8 @@ export const evaluateRevocationMarkers = ({
   identityId,
   issuedAtMs,
   clientSecretId,
-  authMethod
+  authMethod,
+  orgId
 }: {
   markers: TRevocationMarker[];
   tokenId: string;
@@ -267,6 +268,7 @@ export const evaluateRevocationMarkers = ({
   issuedAtMs: number;
   clientSecretId?: string;
   authMethod?: string;
+  orgId?: string;
 }): TRevocationDenyReason | null => {
   for (const revocation of markers) {
     // A record with no scope either targets this exact token, or (when the whole
@@ -283,7 +285,7 @@ export const evaluateRevocationMarkers = ({
       }
     } else {
       // A scoped record blocks every token issued before the revocation whose
-      // client secret or login method matches the scope.
+      // client secret, login method, or org membership matches the scope.
       const revokedAtMs = (revocation.revokedAt ?? revocation.createdAt).getTime();
       if (issuedAtMs < revokedAtMs) {
         if (clientSecretId && revocation.scope === clientSecretId) {
@@ -291,6 +293,9 @@ export const evaluateRevocationMarkers = ({
         }
         if (authMethod && revocation.scope === authMethod) {
           return "auth-method";
+        }
+        if (orgId && revocation.scope === orgId) {
+          return "org-membership";
         }
       }
     }
@@ -309,6 +314,10 @@ export const revocationDenyReasonToMessage = (
       return `${messagePrefix}: identity tokens have been revoked`;
     case "client-secret":
       return `${messagePrefix}: client secret has been revoked`;
+    case "org-membership":
+      return `${messagePrefix}: Identity is not a member of the organization`;
+    case "org-membership-inactive":
+      return `${messagePrefix}: Identity organization membership is inactive`;
     case "auth-method":
     default:
       return `${messagePrefix}: auth method has been revoked`;

--- a/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
@@ -46,6 +46,19 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
     }
   };
 
+  // Scoped markers are the only reversible kind (org membership can be restored),
+  // so they are the only ones with a delete path.
+  const deleteRevocationsByScope = async ({ identityId, scope }: { identityId: string; scope: string }, tx?: Knex) => {
+    try {
+      await (tx ?? db)(TableName.IdentityAccessTokenRevocation)
+        .where("identityId", identityId)
+        .where("scope", scope)
+        .del();
+    } catch (error) {
+      throw new DatabaseError({ error, name: "IdentityAccessTokenRevocationDeleteByScope" });
+    }
+  };
+
   const findActiveRevocationsForToken = async ({
     tokenId,
     identityId,
@@ -148,6 +161,7 @@ export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
 
   return {
     insertRevocation,
+    deleteRevocationsByScope,
     findActiveRevocationsForToken,
     removeExpiredRevocations
   };

--- a/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
@@ -11,8 +11,9 @@ export type TIdentityAccessTokenRevocationDALFactory = ReturnType<typeof identit
 // revoke-all sentinels, random UUID for scoped markers. `revokedAt` is populated
 // for every marker except per-token revocations so runtime validation can compare
 // the JWT iat against the exact revocation time. `scope` is null for legacy
-// (per-token / identity-wide) markers and holds the scope key (clientSecretId or
-// IdentityAuthMethod string) for scoped markers.
+// (per-token / identity-wide) markers and holds the scope key (clientSecretId,
+// IdentityAuthMethod string, or orgId for membership deactivate/removal) for
+// scoped markers.
 type TInsertRevocationInput = {
   id: string;
   identityId: string;

--- a/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-revocation-dal.ts
@@ -1,3 +1,5 @@
+import { Knex } from "knex";
+
 import { TDbClient } from "@app/db";
 import { TableName, TIdentityAccessTokenRevocations } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
@@ -27,9 +29,9 @@ const REVOCATION_PRUNE_BATCH_SIZE = 10000;
 const MAX_RETRY_ON_FAILURE = 3;
 
 export const identityAccessTokenRevocationDALFactory = (db: TDbClient) => {
-  const insertRevocation = async (row: TInsertRevocationInput) => {
+  const insertRevocation = async (row: TInsertRevocationInput, tx?: Knex) => {
     try {
-      await db(TableName.IdentityAccessTokenRevocation)
+      await (tx ?? db)(TableName.IdentityAccessTokenRevocation)
         .insert(row)
         .onConflict(["id"])
         .merge({

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -235,12 +235,34 @@ describe("identityAccessTokenServiceFactory", () => {
 
     await service.revokeAllTokensForIdentity("identity-id");
 
-    expect(identityAccessTokenRevocationDAL.insertRevocation).toHaveBeenCalledWith({
-      id: "identity-id",
-      identityId: "identity-id",
-      revokedAt: new Date(NOW_SECONDS * 1000),
-      expiresAt: new Date((NOW_SECONDS + MAX_AGE) * 1000)
-    });
+    expect(identityAccessTokenRevocationDAL.insertRevocation).toHaveBeenCalledWith(
+      {
+        id: "identity-id",
+        identityId: "identity-id",
+        revokedAt: new Date(NOW_SECONDS * 1000),
+        expiresAt: new Date((NOW_SECONDS + MAX_AGE) * 1000)
+      },
+      undefined
+    );
+  });
+
+  test("insertIdentityWideRevocationMarker writes the sentinel in the caller tx without bumping", async () => {
+    const { service, identityAccessTokenRevocationDAL, keyStore } = createService();
+    const tx = {} as unknown as Parameters<typeof service.insertIdentityWideRevocationMarker>[0]["tx"];
+
+    await service.insertIdentityWideRevocationMarker({ identityId: "identity-id", tx });
+
+    expect(identityAccessTokenRevocationDAL.insertRevocation).toHaveBeenCalledWith(
+      {
+        id: "identity-id",
+        identityId: "identity-id",
+        revokedAt: new Date(NOW_SECONDS * 1000),
+        expiresAt: new Date((NOW_SECONDS + MAX_AGE) * 1000)
+      },
+      tx
+    );
+    // The bump runs post-commit in the caller, never inside the marker insert.
+    expect(keyStore.incrementSeededWithExpiry).not.toHaveBeenCalled();
   });
 
   test("writes per-token revocation to PG for exact legacy tokens", async () => {

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -743,8 +743,8 @@ describe("identityAccessTokenServiceFactory", () => {
     );
   });
 
-  test("serves a cached allow verdict without hitting the revocation DAL", async () => {
-    const { service, keyStore, identityAccessTokenRevocationDAL } = createService();
+  test("serves a cached allow verdict without hitting the revocation DAL or membership", async () => {
+    const { service, keyStore, identityAccessTokenRevocationDAL, orgDAL } = createService();
     keyStore.getItem.mockImplementation(async (key: string) => {
       if (key.startsWith("identity-revocation-version:")) return "5";
       if (key.startsWith("identity-revocation-verdict:")) return JSON.stringify({ v: 5 });
@@ -755,6 +755,7 @@ describe("identityAccessTokenServiceFactory", () => {
       identityId: "identity-id"
     });
     expect(identityAccessTokenRevocationDAL.findActiveRevocationsForToken).not.toHaveBeenCalled();
+    expect(orgDAL.findEffectiveOrgMembership).not.toHaveBeenCalled();
   });
 
   test("serves a cached deny verdict without hitting the revocation DAL", async () => {
@@ -772,7 +773,7 @@ describe("identityAccessTokenServiceFactory", () => {
   });
 
   test("re-queries the primary when the cached allow version is stale", async () => {
-    const { service, keyStore, identityAccessTokenRevocationDAL } = createService();
+    const { service, keyStore, identityAccessTokenRevocationDAL, orgDAL } = createService();
     // Live version advanced past the version the cached allow was stamped with.
     keyStore.getItem.mockImplementation(async (key: string) => {
       if (key.startsWith("identity-revocation-version:")) return "6";
@@ -784,11 +785,48 @@ describe("identityAccessTokenServiceFactory", () => {
       identityId: "identity-id"
     });
     expect(identityAccessTokenRevocationDAL.findActiveRevocationsForToken).toHaveBeenCalledTimes(1);
+    expect(identityAccessTokenRevocationDAL.findActiveRevocationsForToken).toHaveBeenCalledWith(
+      expect.objectContaining({ scopes: expect.arrayContaining(["org-id"]) as unknown as string[] })
+    );
+    expect(orgDAL.findEffectiveOrgMembership).toHaveBeenCalled();
     // Re-stamp the allow with the current live version.
     expect(keyStore.setItemWithExpiry).toHaveBeenCalledWith(
       expect.stringContaining("identity-revocation-verdict:identity-id:"),
       expect.any(Number),
       JSON.stringify({ v: 6 })
+    );
+  });
+
+  test("denies via org-scoped membership marker without a membership re-read when cached", async () => {
+    const { service, keyStore, orgDAL } = createService();
+    keyStore.getItem.mockImplementation(async (key: string) => {
+      if (key.startsWith("identity-revocation-version:")) return "5";
+      if (key.startsWith("identity-revocation-verdict:")) return JSON.stringify({ deny: "org-membership" });
+      return null;
+    });
+
+    await expect(service.fnValidateIdentityAccessTokenFast(createTokenClaims(), "10.0.0.1")).rejects.toThrow(
+      "not a member"
+    );
+    expect(orgDAL.findEffectiveOrgMembership).not.toHaveBeenCalled();
+  });
+
+  test("revokeTokensForIdentityOrgMembership inserts an org-scoped marker and bumps version", async () => {
+    const { service, identityAccessTokenRevocationDAL, keyStore } = createService();
+
+    await service.revokeTokensForIdentityOrgMembership({ identityId: "identity-id", orgId: "org-id" });
+
+    expect(identityAccessTokenRevocationDAL.insertRevocation).toHaveBeenCalledWith({
+      id: expect.any(String) as unknown as string,
+      identityId: "identity-id",
+      scope: "org-id",
+      revokedAt: new Date(NOW_SECONDS * 1000),
+      expiresAt: new Date((NOW_SECONDS + MAX_AGE) * 1000)
+    });
+    expect(keyStore.incrementSeededWithExpiry).toHaveBeenCalledWith(
+      "identity-revocation-version:identity-id",
+      expect.any(Number),
+      expect.any(Number)
     );
   });
 

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -811,18 +811,32 @@ describe("identityAccessTokenServiceFactory", () => {
     expect(orgDAL.findEffectiveOrgMembership).not.toHaveBeenCalled();
   });
 
-  test("revokeTokensForIdentityOrgMembership inserts an org-scoped marker and bumps version", async () => {
+  test("insertOrgMembershipRevocationMarker writes an org-scoped marker in the caller tx without bumping", async () => {
+    const { service, identityAccessTokenRevocationDAL, keyStore } = createService();
+    const tx = {} as unknown as Parameters<typeof service.insertOrgMembershipRevocationMarker>[0]["tx"];
+
+    await service.insertOrgMembershipRevocationMarker({ identityId: "identity-id", orgId: "org-id", tx });
+
+    expect(identityAccessTokenRevocationDAL.insertRevocation).toHaveBeenCalledWith(
+      {
+        id: expect.any(String) as unknown as string,
+        identityId: "identity-id",
+        scope: "org-id",
+        revokedAt: new Date(NOW_SECONDS * 1000),
+        expiresAt: new Date((NOW_SECONDS + MAX_AGE) * 1000)
+      },
+      tx
+    );
+    // The bump is a separate post-commit step, never triggered by the marker insert.
+    expect(keyStore.incrementSeededWithExpiry).not.toHaveBeenCalled();
+  });
+
+  test("bumpIdentityRevocationVersion bumps the identity version without writing a marker", async () => {
     const { service, identityAccessTokenRevocationDAL, keyStore } = createService();
 
-    await service.revokeTokensForIdentityOrgMembership({ identityId: "identity-id", orgId: "org-id" });
+    await service.bumpIdentityRevocationVersion({ identityId: "identity-id" });
 
-    expect(identityAccessTokenRevocationDAL.insertRevocation).toHaveBeenCalledWith({
-      id: expect.any(String) as unknown as string,
-      identityId: "identity-id",
-      scope: "org-id",
-      revokedAt: new Date(NOW_SECONDS * 1000),
-      expiresAt: new Date((NOW_SECONDS + MAX_AGE) * 1000)
-    });
+    expect(identityAccessTokenRevocationDAL.insertRevocation).not.toHaveBeenCalled();
     expect(keyStore.incrementSeededWithExpiry).toHaveBeenCalledWith(
       "identity-revocation-version:identity-id",
       expect.any(Number),

--- a/backend/src/services/identity-access-token/identity-access-token-service.test.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.test.ts
@@ -66,7 +66,8 @@ const createService = ({
   );
   const identityAccessTokenRevocationDAL = {
     findActiveRevocationsForToken: vi.fn().mockResolvedValue(activeRevocations),
-    insertRevocation: vi.fn()
+    insertRevocation: vi.fn(),
+    deleteRevocationsByScope: vi.fn()
   };
   const identityDAL = {
     getTrustedIpsByAuthMethod: vi.fn().mockResolvedValue(trustedIps),
@@ -797,11 +798,11 @@ describe("identityAccessTokenServiceFactory", () => {
     );
   });
 
-  test("denies via org-scoped membership marker without a membership re-read when cached", async () => {
+  test("denies via a version-current cached membership deny without a membership re-read", async () => {
     const { service, keyStore, orgDAL } = createService();
     keyStore.getItem.mockImplementation(async (key: string) => {
       if (key.startsWith("identity-revocation-version:")) return "5";
-      if (key.startsWith("identity-revocation-verdict:")) return JSON.stringify({ deny: "org-membership" });
+      if (key.startsWith("identity-revocation-verdict:")) return JSON.stringify({ deny: "org-membership", v: 5 });
       return null;
     });
 
@@ -809,6 +810,86 @@ describe("identityAccessTokenServiceFactory", () => {
       "not a member"
     );
     expect(orgDAL.findEffectiveOrgMembership).not.toHaveBeenCalled();
+  });
+
+  test("caches a cold-path membership deny stamped with the live version", async () => {
+    const { service, keyStore } = createService({ membership: null });
+    keyStore.getItem.mockImplementation(async (key: string) => {
+      if (key.startsWith("identity-revocation-version:")) return "7";
+      return null;
+    });
+
+    await expect(service.fnValidateIdentityAccessTokenFast(createTokenClaims(), "10.0.0.1")).rejects.toThrow(
+      "not a member"
+    );
+    expect(keyStore.setItemWithExpiry).toHaveBeenCalledWith(
+      expect.stringContaining("identity-revocation-verdict:identity-id:"),
+      expect.any(Number),
+      JSON.stringify({ deny: "org-membership", v: 7 })
+    );
+  });
+
+  test("re-checks a stale cached membership deny and allows once membership is restored", async () => {
+    // Deny was stamped at v5; restoring the membership bumped the version to 6.
+    const { service, keyStore, orgDAL } = createService();
+    keyStore.getItem.mockImplementation(async (key: string) => {
+      if (key.startsWith("identity-revocation-version:")) return "6";
+      if (key.startsWith("identity-revocation-verdict:")) return JSON.stringify({ deny: "org-membership", v: 5 });
+      return null;
+    });
+
+    await expect(service.fnValidateIdentityAccessTokenFast(createTokenClaims(), "10.0.0.1")).resolves.toMatchObject({
+      identityId: "identity-id"
+    });
+    expect(orgDAL.findEffectiveOrgMembership).toHaveBeenCalled();
+    // Re-stamped as an allow under the live version.
+    expect(keyStore.setItemWithExpiry).toHaveBeenCalledWith(
+      expect.stringContaining("identity-revocation-verdict:identity-id:"),
+      expect.any(Number),
+      JSON.stringify({ v: 6 })
+    );
+  });
+
+  test("re-checks an unstamped legacy cached membership deny instead of trusting it", async () => {
+    const { service, keyStore, orgDAL } = createService();
+    keyStore.getItem.mockImplementation(async (key: string) => {
+      if (key.startsWith("identity-revocation-version:")) return "5";
+      if (key.startsWith("identity-revocation-verdict:")) return JSON.stringify({ deny: "org-membership" });
+      return null;
+    });
+
+    await expect(service.fnValidateIdentityAccessTokenFast(createTokenClaims(), "10.0.0.1")).resolves.toMatchObject({
+      identityId: "identity-id"
+    });
+    expect(orgDAL.findEffectiveOrgMembership).toHaveBeenCalled();
+  });
+
+  test("serves a cached revocation deny regardless of a version mismatch", async () => {
+    const { service, keyStore, identityAccessTokenRevocationDAL } = createService();
+    keyStore.getItem.mockImplementation(async (key: string) => {
+      if (key.startsWith("identity-revocation-version:")) return "9";
+      if (key.startsWith("identity-revocation-verdict:")) return JSON.stringify({ deny: "auth-method", v: 5 });
+      return null;
+    });
+
+    await expect(service.fnValidateIdentityAccessTokenFast(createTokenClaims(), "10.0.0.1")).rejects.toThrow(
+      "auth method has been revoked"
+    );
+    expect(identityAccessTokenRevocationDAL.findActiveRevocationsForToken).not.toHaveBeenCalled();
+  });
+
+  test("removeOrgMembershipRevocationMarkers deletes the org-scoped markers in the caller tx without bumping", async () => {
+    const { service, identityAccessTokenRevocationDAL, keyStore } = createService();
+    const tx = {} as unknown as Parameters<typeof service.removeOrgMembershipRevocationMarkers>[0]["tx"];
+
+    await service.removeOrgMembershipRevocationMarkers({ identityId: "identity-id", orgId: "org-id", tx });
+
+    expect(identityAccessTokenRevocationDAL.deleteRevocationsByScope).toHaveBeenCalledWith(
+      { identityId: "identity-id", scope: "org-id" },
+      tx
+    );
+    // The bump is a separate post-commit step, never triggered by the marker removal.
+    expect(keyStore.incrementSeededWithExpiry).not.toHaveBeenCalled();
   });
 
   test("insertOrgMembershipRevocationMarker writes an org-scoped marker in the caller tx without bumping", async () => {

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -689,18 +689,25 @@ export const identityAccessTokenServiceFactory = ({
     await bumpRevocationVersion(identityId);
   };
 
-  // Identity-wide revoke: any JWT with iat < this epoch is rejected on auth.
-  // Uses the 90d fallback since it is one marker per deleted identity.
-  const revokeAllTokensForIdentity = async (identityId: string) => {
+  // Identity-wide revoke marker: any JWT with iat < this epoch is rejected on
+  // auth. Uses the 90d fallback since it is one marker per deleted identity.
+  const insertIdentityWideRevocationMarker = async ({ identityId, tx }: { identityId: string; tx?: Knex }) => {
     const appCfg = getConfig();
     const revokedAt = new Date();
 
-    await identityAccessTokenRevocationDAL.insertRevocation({
-      id: identityId,
-      identityId,
-      revokedAt,
-      expiresAt: new Date(revokedAt.getTime() + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000)
-    });
+    await identityAccessTokenRevocationDAL.insertRevocation(
+      {
+        id: identityId,
+        identityId,
+        revokedAt,
+        expiresAt: new Date(revokedAt.getTime() + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000)
+      },
+      tx
+    );
+  };
+
+  const revokeAllTokensForIdentity = async (identityId: string) => {
+    await insertIdentityWideRevocationMarker({ identityId });
     await bumpRevocationVersion(identityId);
   };
 
@@ -802,6 +809,7 @@ export const identityAccessTokenServiceFactory = ({
   return {
     issueIdentityAccessToken,
     renewAccessToken,
+    insertIdentityWideRevocationMarker,
     revokeAccessToken,
     revokeAllTokensForIdentity,
     revokeAllTokensForClientSecret,

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -24,6 +24,7 @@ import {
   hasFullRenewClaims,
   hasLegacyTokenWithoutExpExceededMaxAge,
   hasNonWildcardTrustedIps,
+  isMembershipDenyReason,
   parseUsesRemaining,
   resolveTtlInputs,
   revocationDenyReasonToMessage,
@@ -140,12 +141,15 @@ export const identityAccessTokenServiceFactory = ({
 
   // A cached "allowed" answer is only trusted while the identity's version
   // number still matches, so a revoke instantly invalidates it without ever
-  // storing the set of revocation records. A cached "denied"
-  // answer needs no version check and stands for its whole lifetime, because a
-  // revocation record always outlives any token it can block.
+  // storing the set of revocation records. A cached "denied" answer from a
+  // revocation needs no version check and stands for its whole lifetime,
+  // because a revocation record always outlives any token it can block.
   //
   // Org membership is folded into this path: on a cache miss / version change we
   // re-check membership in Postgres; on a stamped allow hit we skip that query.
+  // Membership denies are reversible (re-add / reactivate), so they are
+  // version-stamped like allows and only trusted while the version matches;
+  // restoring membership bumps the version to force an immediate re-check.
   const assertTokenIsNotRevoked = async ({
     tokenId,
     identityId,
@@ -199,7 +203,14 @@ export const identityAccessTokenServiceFactory = ({
       }
 
       if (parsed?.deny) {
-        throw new UnauthorizedError({ message: revocationDenyReasonToMessage(parsed.deny, messagePrefix) });
+        // A membership deny is only honored while its stamped version matches the
+        // live one; a stale one falls through to the cold path and re-checks.
+        const denyIsCurrent =
+          !isMembershipDenyReason(parsed.deny) ||
+          (typeof parsed.v === "number" && cachedVersion !== null && parsed.v === cachedVersion);
+        if (denyIsCurrent) {
+          throw new UnauthorizedError({ message: revocationDenyReasonToMessage(parsed.deny, messagePrefix) });
+        }
       }
       // An allow only holds while the stamped version still matches the live one.
       if (parsed && typeof parsed.v === "number" && cachedVersion !== null && parsed.v === cachedVersion) {
@@ -258,8 +269,13 @@ export const identityAccessTokenServiceFactory = ({
           KeyStoreTtls.IdentityRevocationVerdictBaseInSeconds,
           KeyStoreTtls.IdentityRevocationVerdictJitterInSeconds
         );
-        if (denyReason) {
+        if (denyReason && !isMembershipDenyReason(denyReason)) {
           await keyStore.setItemWithExpiry(verdictKey, ttl, JSON.stringify({ deny: denyReason }));
+        } else if (denyReason) {
+          // Version-stamped so restoring membership (bump) invalidates it instantly.
+          if (versionForStamp !== null) {
+            await keyStore.setItemWithExpiry(verdictKey, ttl, JSON.stringify({ deny: denyReason, v: versionForStamp }));
+          }
         } else if (versionForStamp !== null) {
           await keyStore.setItemWithExpiry(verdictKey, ttl, JSON.stringify({ v: versionForStamp }));
         }
@@ -763,6 +779,19 @@ export const identityAccessTokenServiceFactory = ({
     );
   };
 
+  // Inverse of insertOrgMembershipRevocationMarker, for restoring org access (membership re-added or reactivated)
+  const removeOrgMembershipRevocationMarkers = async ({
+    identityId,
+    orgId,
+    tx
+  }: {
+    identityId: string;
+    orgId: string;
+    tx?: Knex;
+  }) => {
+    await identityAccessTokenRevocationDAL.deleteRevocationsByScope({ identityId, scope: orgId }, tx);
+  };
+
   // Best-effort cache accelerator: bumps the version so cached allow verdicts are
   // rechecked once. A failed bump only defers enforcement to the verdict TTL, since the committed
   // membership row (and marker) remain the durable deny that the cold path reads.
@@ -778,6 +807,7 @@ export const identityAccessTokenServiceFactory = ({
     revokeAllTokensForClientSecret,
     revokeTokensForIdentityAuthMethod,
     insertOrgMembershipRevocationMarker,
+    removeOrgMembershipRevocationMarkers,
     bumpIdentityRevocationVersion,
     markPerTokenRevocation,
     fnValidateIdentityAccessTokenFast

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -112,11 +112,8 @@ export const identityAccessTokenServiceFactory = ({
   // old version.
   const bumpRevocationVersion = async (identityId: string) => {
     try {
-      await keyStore.incrementSeededWithExpiry(
-        KeyStorePrefixes.IdentityRevocationVersion(identityId),
-        Date.now(),
-        KeyStoreTtls.IdentityRevocationVersionInSeconds
-      );
+      const versionKey = KeyStorePrefixes.IdentityRevocationVersion(identityId);
+      await keyStore.incrementSeededWithExpiry(versionKey, Date.now(), KeyStoreTtls.IdentityRevocationVersionInSeconds);
     } catch (error) {
       logger.warn(error, `identity-revocation: failed to bump version [identityId=${identityId}]`);
     }
@@ -146,12 +143,16 @@ export const identityAccessTokenServiceFactory = ({
   // storing the set of revocation records. A cached "denied"
   // answer needs no version check and stands for its whole lifetime, because a
   // revocation record always outlives any token it can block.
+  //
+  // Org membership is folded into this path: on a cache miss / version change we
+  // re-check membership in Postgres; on a stamped allow hit we skip that query.
   const assertTokenIsNotRevoked = async ({
     tokenId,
     identityId,
     issuedAtMs,
     clientSecretId,
     authMethod,
+    orgId,
     messagePrefix = "Failed to authorize"
   }: {
     tokenId: string;
@@ -159,11 +160,13 @@ export const identityAccessTokenServiceFactory = ({
     issuedAtMs: number;
     clientSecretId?: string;
     authMethod?: string;
+    orgId?: string;
     messagePrefix?: "Failed to authorize" | "Cannot renew";
   }) => {
     const scopes: string[] = [];
     if (clientSecretId) scopes.push(clientSecretId);
     if (authMethod) scopes.push(authMethod);
+    if (orgId) scopes.push(orgId);
 
     const fingerprint = computeRevocationVerdictFingerprint({ tokenId, issuedAtMs, clientSecretId, authMethod });
     const verdictKey = KeyStorePrefixes.IdentityRevocationVerdict(identityId, fingerprint);
@@ -222,14 +225,32 @@ export const identityAccessTokenServiceFactory = ({
       scopes
     });
 
-    const denyReason = evaluateRevocationMarkers({
+    let denyReason = evaluateRevocationMarkers({
       markers: activeRevocations,
       tokenId,
       identityId,
       issuedAtMs,
       clientSecretId,
-      authMethod
+      authMethod,
+      orgId
     });
+
+    // Cold-path membership check. Skipped on a stamped allow hit above; after a
+    // version bump every live token rechecks once, and only org-scoped markers
+    // deny (other orgs re-allow and re-cache).
+    if (!denyReason && orgId) {
+      const orgMembership = await orgDAL.findEffectiveOrgMembership({
+        actorType: ActorType.IDENTITY,
+        actorId: identityId,
+        orgId,
+        status: OrgMembershipStatus.Accepted
+      });
+      if (!orgMembership) {
+        denyReason = "org-membership";
+      } else if (!orgMembership.isActive) {
+        denyReason = "org-membership-inactive";
+      }
+    }
 
     if (cacheAvailable) {
       try {
@@ -416,7 +437,8 @@ export const identityAccessTokenServiceFactory = ({
         identityId: token.identityId,
         issuedAtMs,
         clientSecretId: source.clientSecretId,
-        authMethod: source.authMethod
+        authMethod: source.authMethod,
+        orgId: source.orgId
       }),
       keyStore.getItem(KeyStorePrefixes.IdentityTokenUsesRemaining(token.identityId, tokenId))
     ]);
@@ -453,19 +475,6 @@ export const identityAccessTokenServiceFactory = ({
           trustedIps: trustedIps as TIp[]
         });
       }
-    }
-
-    const orgMembership = await orgDAL.findEffectiveOrgMembership({
-      actorType: ActorType.IDENTITY,
-      actorId: token.identityId,
-      orgId: source.orgId,
-      status: OrgMembershipStatus.Accepted
-    });
-    if (!orgMembership) {
-      throw new UnauthorizedError({ message: "Identity is not a member of the organization" });
-    }
-    if (!orgMembership.isActive) {
-      throw new UnauthorizedError({ message: "Identity organization membership is inactive" });
     }
 
     return {
@@ -522,6 +531,7 @@ export const identityAccessTokenServiceFactory = ({
         issuedAtMs: decodedToken.iat * 1000,
         clientSecretId: source.clientSecretId,
         authMethod: source.authMethod,
+        orgId: source.orgId,
         messagePrefix: "Cannot renew"
       }),
       keyStore.getItem(KeyStorePrefixes.IdentityTokenUsesRemaining(decodedToken.identityId, tokenId))
@@ -724,6 +734,24 @@ export const identityAccessTokenServiceFactory = ({
     await bumpRevocationVersion(identityId);
   };
 
+  // Org-scoped revoke for membership deactivate / remove-from-org: rejects every
+  // JWT for this identity whose orgId claim matches, with iat < revokedAt.
+  // Tokens scoped to other orgs (sub-org hierarchy) stay valid. Bumps the global
+  // version so cached allows are rechecked once; only this org's tokens deny.
+  const revokeTokensForIdentityOrgMembership = async ({ identityId, orgId }: { identityId: string; orgId: string }) => {
+    const appCfg = getConfig();
+    const revokedAt = new Date();
+
+    await identityAccessTokenRevocationDAL.insertRevocation({
+      id: crypto.nativeCrypto.randomUUID(),
+      identityId,
+      scope: orgId,
+      revokedAt,
+      expiresAt: new Date(revokedAt.getTime() + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000)
+    });
+    await bumpRevocationVersion(identityId);
+  };
+
   return {
     issueIdentityAccessToken,
     renewAccessToken,
@@ -731,6 +759,7 @@ export const identityAccessTokenServiceFactory = ({
     revokeAllTokensForIdentity,
     revokeAllTokensForClientSecret,
     revokeTokensForIdentityAuthMethod,
+    revokeTokensForIdentityOrgMembership,
     markPerTokenRevocation,
     fnValidateIdentityAccessTokenFast
   };

--- a/backend/src/services/identity-access-token/identity-access-token-service.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-service.ts
@@ -734,21 +734,39 @@ export const identityAccessTokenServiceFactory = ({
     await bumpRevocationVersion(identityId);
   };
 
-  // Org-scoped revoke for membership deactivate / remove-from-org: rejects every
-  // JWT for this identity whose orgId claim matches, with iat < revokedAt.
-  // Tokens scoped to other orgs (sub-org hierarchy) stay valid. Bumps the global
-  // version so cached allows are rechecked once; only this org's tokens deny.
-  const revokeTokensForIdentityOrgMembership = async ({ identityId, orgId }: { identityId: string; orgId: string }) => {
+  // Org-scoped revoke marker for membership deactivate / remove-from-org: rejects
+  // every JWT for this identity whose orgId claim matches, with iat < revokedAt.
+  // Tokens scoped to other orgs (sub-org hierarchy) stay valid. Accepts the caller's
+  // tx so the marker commits atomically with the membership mutation, making it the
+  // durable source of truth for the deny (see bumpIdentityRevocationVersion).
+  const insertOrgMembershipRevocationMarker = async ({
+    identityId,
+    orgId,
+    tx
+  }: {
+    identityId: string;
+    orgId: string;
+    tx?: Knex;
+  }) => {
     const appCfg = getConfig();
     const revokedAt = new Date();
 
-    await identityAccessTokenRevocationDAL.insertRevocation({
-      id: crypto.nativeCrypto.randomUUID(),
-      identityId,
-      scope: orgId,
-      revokedAt,
-      expiresAt: new Date(revokedAt.getTime() + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000)
-    });
+    await identityAccessTokenRevocationDAL.insertRevocation(
+      {
+        id: crypto.nativeCrypto.randomUUID(),
+        identityId,
+        scope: orgId,
+        revokedAt,
+        expiresAt: new Date(revokedAt.getTime() + appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE * 1000)
+      },
+      tx
+    );
+  };
+
+  // Best-effort cache accelerator: bumps the version so cached allow verdicts are
+  // rechecked once. A failed bump only defers enforcement to the verdict TTL, since the committed
+  // membership row (and marker) remain the durable deny that the cold path reads.
+  const bumpIdentityRevocationVersion = async ({ identityId }: { identityId: string }) => {
     await bumpRevocationVersion(identityId);
   };
 
@@ -759,7 +777,8 @@ export const identityAccessTokenServiceFactory = ({
     revokeAllTokensForIdentity,
     revokeAllTokensForClientSecret,
     revokeTokensForIdentityAuthMethod,
-    revokeTokensForIdentityOrgMembership,
+    insertOrgMembershipRevocationMarker,
+    bumpIdentityRevocationVersion,
     markPerTokenRevocation,
     fnValidateIdentityAccessTokenFast
   };

--- a/backend/src/services/identity-access-token/identity-access-token-types.ts
+++ b/backend/src/services/identity-access-token/identity-access-token-types.ts
@@ -155,4 +155,10 @@ export type TRevocationMarker = {
 };
 
 // Reason a token is denied. Cached so a hit can build the error without hitting PG.
-export type TRevocationDenyReason = "token" | "identity" | "client-secret" | "auth-method";
+export type TRevocationDenyReason =
+  | "token"
+  | "identity"
+  | "client-secret"
+  | "auth-method"
+  | "org-membership"
+  | "org-membership-inactive";

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -66,7 +66,10 @@ type TScopedIdentityV2ServiceFactoryDep = {
   membershipIdentityDAL: TMembershipIdentityDALFactory;
   membershipRoleDAL: TMembershipRoleDALFactory;
   identityMetadataDAL: TIdentityMetadataDALFactory;
-  identityAccessTokenService: Pick<TIdentityAccessTokenServiceFactory, "revokeAllTokensForIdentity">;
+  identityAccessTokenService: Pick<
+    TIdentityAccessTokenServiceFactory,
+    "insertIdentityWideRevocationMarker" | "bumpIdentityRevocationVersion"
+  >;
   keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
   projectDAL: Pick<TProjectDALFactory, "findActorAccessibleProjectIds" | "findOrgProjectIds" | "findById">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
@@ -377,11 +380,13 @@ export const identityV2ServiceFactory = ({
       throw new BadRequestError({ message: "Cannot delete identity while delete protection is enabled" });
     }
 
-    // Set the identity-wide PG revocation epoch before removing the row so
-    // any JWT issued for this identity (with iat < now) is rejected.
-    await identityAccessTokenService.revokeAllTokensForIdentity(dto.selector.identityId);
-
-    const deletedIdentity = await identityDAL.deleteById(dto.selector.identityId);
+    // Set the identity-wide PG revocation epoch atomically with the row delete
+    // so any JWT issued for this identity (with iat < now) is rejected.
+    const deletedIdentity = await identityDAL.transaction(async (tx) => {
+      await identityAccessTokenService.insertIdentityWideRevocationMarker({ identityId: dto.selector.identityId, tx });
+      return identityDAL.deleteById(dto.selector.identityId, tx);
+    });
+    await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId: dto.selector.identityId });
 
     await licenseService.updateSubscriptionOrgMemberCount(scopeData.orgId);
 

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -54,7 +54,7 @@ type TIdentityServiceFactoryDep = {
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "revokeAllTokensForIdentity" | "insertOrgMembershipRevocationMarker" | "bumpIdentityRevocationVersion"
+    "insertIdentityWideRevocationMarker" | "insertOrgMembershipRevocationMarker" | "bumpIdentityRevocationVersion"
   >;
 };
 
@@ -382,9 +382,11 @@ export const identityServiceFactory = ({
       if (identityOrgMembership.identity.hasDeleteProtection)
         throw new BadRequestError({ message: "Identity has delete protection" });
 
-      await identityAccessTokenService.revokeAllTokensForIdentity(id);
-
-      const deletedIdentity = await identityDAL.deleteById(id);
+      const deletedIdentity = await identityDAL.transaction(async (tx) => {
+        await identityAccessTokenService.insertIdentityWideRevocationMarker({ identityId: id, tx });
+        return identityDAL.deleteById(id, tx);
+      });
+      await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId: id });
       await licenseService.updateSubscriptionOrgMemberCount(identityOrgMembership.scopeOrgId);
       usageMeteringService.emit(identityOrgMembership.scopeOrgId, IdentitiesMeter.key);
       usageMeteringService.emit(identityOrgMembership.scopeOrgId, SecretIdentities.key);

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -19,6 +19,7 @@ import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage
 
 import { TAdditionalPrivilegeDALFactory } from "../additional-privilege/additional-privilege-dal";
 import { ActorType } from "../auth/auth-type";
+import { TIdentityAccessTokenServiceFactory } from "../identity-access-token/identity-access-token-service";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipIdentityDALFactory } from "../membership-identity/membership-identity-dal";
 import { TOrgDALFactory } from "../org/org-dal";
@@ -51,6 +52,10 @@ type TIdentityServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById" | "findEffectiveOrgMembership">;
   additionalPrivilegeDAL: Pick<TAdditionalPrivilegeDALFactory, "delete">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
+  identityAccessTokenService: Pick<
+    TIdentityAccessTokenServiceFactory,
+    "revokeAllTokensForIdentity" | "insertOrgMembershipRevocationMarker" | "bumpIdentityRevocationVersion"
+  >;
 };
 
 export type TIdentityServiceFactory = ReturnType<typeof identityServiceFactory>;
@@ -68,7 +73,8 @@ export const identityServiceFactory = ({
   membershipIdentityDAL,
   membershipRoleDAL,
   additionalPrivilegeDAL,
-  usageMeteringService
+  usageMeteringService,
+  identityAccessTokenService
 }: TIdentityServiceFactoryDep) => {
   const createIdentity = async ({
     name,
@@ -376,6 +382,8 @@ export const identityServiceFactory = ({
       if (identityOrgMembership.identity.hasDeleteProtection)
         throw new BadRequestError({ message: "Identity has delete protection" });
 
+      await identityAccessTokenService.revokeAllTokensForIdentity(id);
+
       const deletedIdentity = await identityDAL.deleteById(id);
       await licenseService.updateSubscriptionOrgMemberCount(identityOrgMembership.scopeOrgId);
       usageMeteringService.emit(identityOrgMembership.scopeOrgId, IdentitiesMeter.key);
@@ -410,8 +418,13 @@ export const identityServiceFactory = ({
         tx
       );
       const doc = await membershipIdentityDAL.delete({ actorIdentityId: id, scopeOrgId: actorOrgId }, tx);
+
+      await identityAccessTokenService.insertOrgMembershipRevocationMarker({ identityId: id, orgId: actorOrgId, tx });
+
       return doc;
     });
+
+    await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId: id });
 
     const deletedIdentity = await requestMemoize(requestMemoKeys.identityFindById(id), () => identityDAL.findById(id));
     usageMeteringService.emit(identityOrgMembership.scopeOrgId, IdentitiesMeter.key);

--- a/backend/src/services/membership-identity/membership-identity-dal.ts
+++ b/backend/src/services/membership-identity/membership-identity-dal.ts
@@ -493,5 +493,16 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
     }
   };
 
-  return { ...orm, findIdentities, getIdentityById, listAvailableIdentities };
+  // Row-locked read for transactions that must decide on the membership's
+  // current state before mutating it (e.g. the isActive revoke/restore hooks)
+  const findByIdForUpdate = async (id: string, tx: Knex) => {
+    try {
+      const doc = await tx(TableName.Membership).where({ id }).forUpdate().first();
+      return doc ? MembershipsSchema.parse(doc) : undefined;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "FindByIdForUpdate" });
+    }
+  };
+
+  return { ...orm, findIdentities, getIdentityById, listAvailableIdentities, findByIdForUpdate };
 };

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -1,0 +1,105 @@
+import { createMongoAbility } from "@casl/ability";
+import { Knex } from "knex";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { AccessScope } from "@app/db/schemas";
+
+import { membershipIdentityServiceFactory } from "./membership-identity-service";
+import { TDeleteMembershipIdentityDTO } from "./membership-identity-types";
+
+vi.mock("@app/lib/config/env", () => ({
+  getConfig: () => ({})
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}));
+
+const ROOT_ORG_ID = "root-org";
+const SUB_ORG_ID = "sub-org";
+const IDENTITY_ID = "identity-1";
+const MEMBERSHIP_ID = "membership-1";
+
+// The org-membership delete guard only permits removing a sub-org membership of an
+// identity that lives in the parent org, so root/sub/identity orgs must differ.
+const buildDto = (): TDeleteMembershipIdentityDTO => ({
+  permission: {
+    type: "user",
+    id: "actor-1",
+    authMethod: null,
+    orgId: SUB_ORG_ID,
+    rootOrgId: ROOT_ORG_ID,
+    parentOrgId: ROOT_ORG_ID
+  } as unknown as TDeleteMembershipIdentityDTO["permission"],
+  scopeData: { scope: AccessScope.Organization, orgId: SUB_ORG_ID },
+  selector: { identityId: IDENTITY_ID }
+});
+
+const createService = () => {
+  const bumpIdentityRevocationVersion = vi.fn().mockResolvedValue(undefined);
+  const insertOrgMembershipRevocationMarker = vi.fn().mockResolvedValue(undefined);
+
+  const membershipIdentityDAL = {
+    findOne: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID }),
+    deleteById: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID }),
+    transaction: vi.fn(async (cb: (tx: Knex) => Promise<unknown>) => cb({} as Knex))
+  };
+
+  const service = membershipIdentityServiceFactory({
+    membershipIdentityDAL: membershipIdentityDAL as never,
+    roleDAL: { find: vi.fn() } as never,
+    membershipRoleDAL: { delete: vi.fn().mockResolvedValue(undefined), insertMany: vi.fn() } as never,
+    permissionService: {
+      getOrgPermission: vi
+        .fn()
+        .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) })
+    } as never,
+    orgDAL: { findById: vi.fn(), findEffectiveOrgMembership: vi.fn() } as never,
+    additionalPrivilegeDAL: { delete: vi.fn().mockResolvedValue(undefined) } as never,
+    identityDAL: {
+      findById: vi.fn().mockResolvedValue({ orgId: ROOT_ORG_ID, projectId: null })
+    } as never,
+    licenseService: { getPlan: vi.fn() } as never,
+    applicationMembershipCleanupService: { cleanupActorApplicationMemberships: vi.fn() } as never,
+    projectDAL: { findById: vi.fn() } as never,
+    keyStore: { getKeysByPattern: vi.fn(), getItem: vi.fn() } as never,
+    usageMeteringService: { emit: vi.fn(), emitForProject: vi.fn() } as never,
+    identityAccessTokenService: {
+      insertOrgMembershipRevocationMarker,
+      bumpIdentityRevocationVersion
+    } as never
+  });
+
+  return { service, membershipIdentityDAL, bumpIdentityRevocationVersion, insertOrgMembershipRevocationMarker };
+};
+
+describe("deleteMembership org revocation bump ordering", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("bumps the revocation version after committing its own transaction", async () => {
+    const { service, membershipIdentityDAL, bumpIdentityRevocationVersion, insertOrgMembershipRevocationMarker } =
+      createService();
+
+    const result = await service.deleteMembership(buildDto());
+
+    expect(membershipIdentityDAL.transaction).toHaveBeenCalledTimes(1);
+    expect(insertOrgMembershipRevocationMarker).toHaveBeenCalledTimes(1);
+    // The marker is written inside the service-owned transaction, the bump runs after it.
+    expect(bumpIdentityRevocationVersion).toHaveBeenCalledTimes(1);
+    expect(bumpIdentityRevocationVersion).toHaveBeenCalledWith({ identityId: IDENTITY_ID });
+    expect(result).not.toHaveProperty("revocationBumpPending");
+  });
+
+  test("defers the bump to the caller when an external transaction is supplied", async () => {
+    const { service, membershipIdentityDAL, bumpIdentityRevocationVersion, insertOrgMembershipRevocationMarker } =
+      createService();
+
+    const result = await service.deleteMembership(buildDto(), {} as Knex);
+
+    // The caller owns the tx, so we cannot know when it commits: never bump inline.
+    expect(membershipIdentityDAL.transaction).not.toHaveBeenCalled();
+    expect(insertOrgMembershipRevocationMarker).toHaveBeenCalledTimes(1);
+    expect(bumpIdentityRevocationVersion).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ revocationBumpPending: { identityId: IDENTITY_ID } });
+  });
+});

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -5,7 +5,11 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { AccessScope } from "@app/db/schemas";
 
 import { membershipIdentityServiceFactory } from "./membership-identity-service";
-import { TDeleteMembershipIdentityDTO } from "./membership-identity-types";
+import {
+  TCreateMembershipIdentityDTO,
+  TDeleteMembershipIdentityDTO,
+  TUpdateMembershipIdentityDTO
+} from "./membership-identity-types";
 
 vi.mock("@app/lib/config/env", () => ({
   getConfig: () => ({})
@@ -35,26 +39,36 @@ const buildDto = (): TDeleteMembershipIdentityDTO => ({
   selector: { identityId: IDENTITY_ID }
 });
 
-const createService = () => {
+const createService = ({
+  existingMembership = { id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID }
+}: { existingMembership?: Record<string, unknown> | null } = {}) => {
   const bumpIdentityRevocationVersion = vi.fn().mockResolvedValue(undefined);
   const insertOrgMembershipRevocationMarker = vi.fn().mockResolvedValue(undefined);
+  const removeOrgMembershipRevocationMarkers = vi.fn().mockResolvedValue(undefined);
 
   const membershipIdentityDAL = {
-    findOne: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID }),
+    findOne: vi.fn().mockResolvedValue(existingMembership),
+    create: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID }),
+    updateById: vi.fn().mockImplementation(async (id: string, data: Record<string, unknown>) => ({ id, ...data })),
     deleteById: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID }),
     transaction: vi.fn(async (cb: (tx: Knex) => Promise<unknown>) => cb({} as Knex))
   };
 
   const service = membershipIdentityServiceFactory({
     membershipIdentityDAL: membershipIdentityDAL as never,
-    roleDAL: { find: vi.fn() } as never,
-    membershipRoleDAL: { delete: vi.fn().mockResolvedValue(undefined), insertMany: vi.fn() } as never,
+    roleDAL: { find: vi.fn().mockResolvedValue([]) } as never,
+    membershipRoleDAL: {
+      delete: vi.fn().mockResolvedValue(undefined),
+      insertMany: vi.fn().mockResolvedValue([])
+    } as never,
     permissionService: {
       getOrgPermission: vi
         .fn()
-        .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) })
+        .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) }),
+      // Role name "no-access" skips the privilege-boundary comparison in the guards.
+      getOrgPermissionByRoles: vi.fn().mockResolvedValue([{ role: { name: "no-access" }, permission: null }])
     } as never,
-    orgDAL: { findById: vi.fn(), findEffectiveOrgMembership: vi.fn() } as never,
+    orgDAL: { findById: vi.fn().mockResolvedValue({}), findEffectiveOrgMembership: vi.fn() } as never,
     additionalPrivilegeDAL: { delete: vi.fn().mockResolvedValue(undefined) } as never,
     identityDAL: {
       findById: vi.fn().mockResolvedValue({ orgId: ROOT_ORG_ID, projectId: null })
@@ -66,11 +80,18 @@ const createService = () => {
     usageMeteringService: { emit: vi.fn(), emitForProject: vi.fn() } as never,
     identityAccessTokenService: {
       insertOrgMembershipRevocationMarker,
+      removeOrgMembershipRevocationMarkers,
       bumpIdentityRevocationVersion
     } as never
   });
 
-  return { service, membershipIdentityDAL, bumpIdentityRevocationVersion, insertOrgMembershipRevocationMarker };
+  return {
+    service,
+    membershipIdentityDAL,
+    bumpIdentityRevocationVersion,
+    insertOrgMembershipRevocationMarker,
+    removeOrgMembershipRevocationMarkers
+  };
 };
 
 describe("deleteMembership org revocation bump ordering", () => {
@@ -101,5 +122,93 @@ describe("deleteMembership org revocation bump ordering", () => {
     expect(insertOrgMembershipRevocationMarker).toHaveBeenCalledTimes(1);
     expect(bumpIdentityRevocationVersion).not.toHaveBeenCalled();
     expect(result).toMatchObject({ revocationBumpPending: { identityId: IDENTITY_ID } });
+  });
+});
+
+const buildCreateDto = (): TCreateMembershipIdentityDTO => ({
+  permission: buildDto().permission,
+  scopeData: { scope: AccessScope.Organization, orgId: SUB_ORG_ID },
+  data: { identityId: IDENTITY_ID, roles: [{ role: "member", isTemporary: false }] }
+});
+
+const buildUpdateDto = (isActive?: boolean): TUpdateMembershipIdentityDTO => ({
+  permission: buildDto().permission,
+  scopeData: { scope: AccessScope.Organization, orgId: SUB_ORG_ID },
+  selector: { identityId: IDENTITY_ID },
+  data: { isActive, roles: [{ role: "member", isTemporary: false }] }
+});
+
+describe("createMembership org revocation restore", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("removes org-scoped markers in the transaction and bumps after commit on re-add", async () => {
+    const { service, membershipIdentityDAL, bumpIdentityRevocationVersion, removeOrgMembershipRevocationMarkers } =
+      createService({ existingMembership: null });
+
+    await service.createMembership(buildCreateDto());
+
+    expect(membershipIdentityDAL.transaction).toHaveBeenCalledTimes(1);
+    expect(removeOrgMembershipRevocationMarkers).toHaveBeenCalledTimes(1);
+    expect(removeOrgMembershipRevocationMarkers).toHaveBeenCalledWith({
+      identityId: IDENTITY_ID,
+      orgId: SUB_ORG_ID,
+      tx: expect.anything() as Knex
+    });
+    expect(bumpIdentityRevocationVersion).toHaveBeenCalledTimes(1);
+    expect(bumpIdentityRevocationVersion).toHaveBeenCalledWith({ identityId: IDENTITY_ID });
+  });
+});
+
+describe("updateMembership org revocation restore", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("reactivating an inactive membership removes markers and bumps, never inserts one", async () => {
+    const {
+      service,
+      bumpIdentityRevocationVersion,
+      insertOrgMembershipRevocationMarker,
+      removeOrgMembershipRevocationMarkers
+    } = createService({ existingMembership: { id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID, isActive: false } });
+
+    await service.updateMembership(buildUpdateDto(true));
+
+    expect(insertOrgMembershipRevocationMarker).not.toHaveBeenCalled();
+    expect(removeOrgMembershipRevocationMarkers).toHaveBeenCalledTimes(1);
+    expect(removeOrgMembershipRevocationMarkers).toHaveBeenCalledWith({
+      identityId: IDENTITY_ID,
+      orgId: SUB_ORG_ID,
+      tx: expect.anything() as Knex
+    });
+    expect(bumpIdentityRevocationVersion).toHaveBeenCalledTimes(1);
+  });
+
+  test("deactivating an active membership inserts a marker and bumps, never removes markers", async () => {
+    const {
+      service,
+      bumpIdentityRevocationVersion,
+      insertOrgMembershipRevocationMarker,
+      removeOrgMembershipRevocationMarkers
+    } = createService({ existingMembership: { id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID, isActive: true } });
+
+    await service.updateMembership(buildUpdateDto(false));
+
+    expect(insertOrgMembershipRevocationMarker).toHaveBeenCalledTimes(1);
+    expect(removeOrgMembershipRevocationMarkers).not.toHaveBeenCalled();
+    expect(bumpIdentityRevocationVersion).toHaveBeenCalledTimes(1);
+  });
+
+  test("an already-active membership updated without an isActive change touches nothing", async () => {
+    const {
+      service,
+      bumpIdentityRevocationVersion,
+      insertOrgMembershipRevocationMarker,
+      removeOrgMembershipRevocationMarkers
+    } = createService({ existingMembership: { id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID, isActive: true } });
+
+    await service.updateMembership(buildUpdateDto(undefined));
+
+    expect(insertOrgMembershipRevocationMarker).not.toHaveBeenCalled();
+    expect(removeOrgMembershipRevocationMarkers).not.toHaveBeenCalled();
+    expect(bumpIdentityRevocationVersion).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -48,6 +48,7 @@ const createService = ({
 
   const membershipIdentityDAL = {
     findOne: vi.fn().mockResolvedValue(existingMembership),
+    findByIdForUpdate: vi.fn().mockResolvedValue(existingMembership),
     create: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID }),
     updateById: vi.fn().mockImplementation(async (id: string, data: Record<string, unknown>) => ({ id, ...data })),
     deleteById: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID }),
@@ -210,5 +211,29 @@ describe("updateMembership org revocation restore", () => {
     expect(insertOrgMembershipRevocationMarker).not.toHaveBeenCalled();
     expect(removeOrgMembershipRevocationMarkers).not.toHaveBeenCalled();
     expect(bumpIdentityRevocationVersion).not.toHaveBeenCalled();
+  });
+
+  test("decides revoke/restore from the row-locked in-transaction read, not the stale pre-read", async () => {
+    // Pre-transaction read says active; by the time the tx locks the row a
+    // concurrent update deactivated it. Reactivating must follow the locked
+    // read (restore), not the stale snapshot (no-op).
+    const {
+      service,
+      membershipIdentityDAL,
+      bumpIdentityRevocationVersion,
+      insertOrgMembershipRevocationMarker,
+      removeOrgMembershipRevocationMarkers
+    } = createService({ existingMembership: { id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID, isActive: true } });
+    membershipIdentityDAL.findByIdForUpdate.mockResolvedValue({
+      id: MEMBERSHIP_ID,
+      actorIdentityId: IDENTITY_ID,
+      isActive: false
+    });
+
+    await service.updateMembership(buildUpdateDto(true));
+
+    expect(removeOrgMembershipRevocationMarkers).toHaveBeenCalledTimes(1);
+    expect(insertOrgMembershipRevocationMarker).not.toHaveBeenCalled();
+    expect(bumpIdentityRevocationVersion).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -418,7 +418,11 @@ export const membershipIdentityServiceFactory = ({
       ? await performDelete(externalTx)
       : await membershipIdentityDAL.transaction(performDelete);
 
-    if (scopeData.scope === AccessScope.Organization) {
+    // The version bump must run after the delete commits. When we own the tx it
+    // has already committed here; when the caller owns externalTx we cannot know when
+    // it commits, so we return the pending bump for the caller to run post-commit.
+    const needsRevocationBump = scopeData.scope === AccessScope.Organization;
+    if (needsRevocationBump && !externalTx) {
       await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId: dto.selector.identityId });
     }
 
@@ -430,6 +434,13 @@ export const membershipIdentityServiceFactory = ({
     } else {
       usageMeteringService.emit(scopeData.orgId, SecretIdentities.key);
       usageMeteringService.emit(scopeData.orgId, PamIdentities.key);
+    }
+
+    if (needsRevocationBump && externalTx) {
+      return {
+        membership: membershipDoc,
+        revocationBumpPending: { identityId: dto.selector.identityId }
+      };
     }
     return { membership: membershipDoc };
   };

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -52,7 +52,10 @@ type TMembershipIdentityServiceFactoryDep = {
   projectDAL: Pick<TProjectDALFactory, "findById">;
   keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit" | "emitForProject">;
-  identityAccessTokenService: Pick<TIdentityAccessTokenServiceFactory, "revokeTokensForIdentityOrgMembership">;
+  identityAccessTokenService: Pick<
+    TIdentityAccessTokenServiceFactory,
+    "insertOrgMembershipRevocationMarker" | "bumpIdentityRevocationVersion"
+  >;
 };
 
 export type TMembershipIdentityServiceFactory = ReturnType<typeof membershipIdentityServiceFactory>;
@@ -281,6 +284,9 @@ export const membershipIdentityServiceFactory = ({
 
     const customRolesGroupBySlug = groupBy(customRoles, ({ slug }) => slug);
 
+    const shouldRevokeOrgTokens =
+      scopeData.scope === AccessScope.Organization && data.isActive === false && existingMembership.isActive !== false;
+
     const membershipDoc = await membershipIdentityDAL.transaction(async (tx) => {
       const doc =
         typeof data.isActive === "undefined"
@@ -329,18 +335,20 @@ export const membershipIdentityServiceFactory = ({
         tx
       );
       const insertedRoleDocs = await membershipRoleDAL.insertMany(roleDocs, tx);
+
+      if (shouldRevokeOrgTokens) {
+        await identityAccessTokenService.insertOrgMembershipRevocationMarker({
+          identityId: dto.selector.identityId,
+          orgId: scopeData.orgId,
+          tx
+        });
+      }
+
       return { ...doc, roles: insertedRoleDocs };
     });
 
-    if (
-      scopeData.scope === AccessScope.Organization &&
-      data.isActive === false &&
-      existingMembership.isActive !== false
-    ) {
-      await identityAccessTokenService.revokeTokensForIdentityOrgMembership({
-        identityId: dto.selector.identityId,
-        orgId: scopeData.orgId
-      });
+    if (shouldRevokeOrgTokens) {
+      await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId: dto.selector.identityId });
     }
 
     return { membership: membershipDoc };
@@ -394,6 +402,15 @@ export const membershipIdentityServiceFactory = ({
         }
       }
 
+      // Durable deny atomic with the org-membership removal.
+      if (scopeData.scope === AccessScope.Organization) {
+        await identityAccessTokenService.insertOrgMembershipRevocationMarker({
+          identityId: dto.selector.identityId,
+          orgId: scopeData.orgId,
+          tx
+        });
+      }
+
       return doc;
     };
 
@@ -402,10 +419,7 @@ export const membershipIdentityServiceFactory = ({
       : await membershipIdentityDAL.transaction(performDelete);
 
     if (scopeData.scope === AccessScope.Organization) {
-      await identityAccessTokenService.revokeTokensForIdentityOrgMembership({
-        identityId: dto.selector.identityId,
-        orgId: scopeData.orgId
-      });
+      await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId: dto.selector.identityId });
     }
 
     // Removing an identity from a project drops a direct member; removing it from the org cascades its

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -54,7 +54,7 @@ type TMembershipIdentityServiceFactoryDep = {
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit" | "emitForProject">;
   identityAccessTokenService: Pick<
     TIdentityAccessTokenServiceFactory,
-    "insertOrgMembershipRevocationMarker" | "bumpIdentityRevocationVersion"
+    "insertOrgMembershipRevocationMarker" | "removeOrgMembershipRevocationMarkers" | "bumpIdentityRevocationVersion"
   >;
 };
 
@@ -203,8 +203,24 @@ export const membershipIdentityServiceFactory = ({
         }
       });
       await membershipRoleDAL.insertMany(roleDocs, tx);
+
+      // Re-adding an identity that was previously removed must lift the org-scoped
+      // token revocation, atomically with the membership insert.
+      if (scopeData.scope === AccessScope.Organization) {
+        await identityAccessTokenService.removeOrgMembershipRevocationMarkers({
+          identityId: dto.data.identityId,
+          orgId: scopeData.orgId,
+          tx
+        });
+      }
+
       return doc;
     });
+
+    if (scopeData.scope === AccessScope.Organization) {
+      // Post-commit, so cached membership denies re-check against the restored state.
+      await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId: dto.data.identityId });
+    }
 
     // Adding an identity to a project changes the secret-manager and PAM identity meters (a direct member).
     if (scopeData.scope === AccessScope.Project) {
@@ -286,6 +302,8 @@ export const membershipIdentityServiceFactory = ({
 
     const shouldRevokeOrgTokens =
       scopeData.scope === AccessScope.Organization && data.isActive === false && existingMembership.isActive !== false;
+    const shouldRestoreOrgTokens =
+      scopeData.scope === AccessScope.Organization && data.isActive === true && existingMembership.isActive === false;
 
     const membershipDoc = await membershipIdentityDAL.transaction(async (tx) => {
       const doc =
@@ -344,10 +362,18 @@ export const membershipIdentityServiceFactory = ({
         });
       }
 
+      if (shouldRestoreOrgTokens) {
+        await identityAccessTokenService.removeOrgMembershipRevocationMarkers({
+          identityId: dto.selector.identityId,
+          orgId: scopeData.orgId,
+          tx
+        });
+      }
+
       return { ...doc, roles: insertedRoleDocs };
     });
 
-    if (shouldRevokeOrgTokens) {
+    if (shouldRevokeOrgTokens || shouldRestoreOrgTokens) {
       await identityAccessTokenService.bumpIdentityRevocationVersion({ identityId: dto.selector.identityId });
     }
 

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -300,15 +300,22 @@ export const membershipIdentityServiceFactory = ({
 
     const customRolesGroupBySlug = groupBy(customRoles, ({ slug }) => slug);
 
-    const shouldRevokeOrgTokens =
-      scopeData.scope === AccessScope.Organization && data.isActive === false && existingMembership.isActive !== false;
-    const shouldRestoreOrgTokens =
-      scopeData.scope === AccessScope.Organization && data.isActive === true && existingMembership.isActive === false;
+    let shouldRevokeOrgTokens = false;
+    let shouldRestoreOrgTokens = false;
 
     const membershipDoc = await membershipIdentityDAL.transaction(async (tx) => {
+      const currentMembership = await membershipIdentityDAL.findByIdForUpdate(existingMembership.id, tx);
+      if (!currentMembership) {
+        throw new BadRequestError({ message: "Identity doesn't have membership" });
+      }
+      shouldRevokeOrgTokens =
+        scopeData.scope === AccessScope.Organization && data.isActive === false && currentMembership.isActive !== false;
+      shouldRestoreOrgTokens =
+        scopeData.scope === AccessScope.Organization && data.isActive === true && currentMembership.isActive === false;
+
       const doc =
         typeof data.isActive === "undefined"
-          ? existingMembership
+          ? currentMembership
           : await membershipIdentityDAL.updateById(
               existingMembership.id,
               {

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -14,6 +14,7 @@ import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage
 
 import { TAdditionalPrivilegeDALFactory } from "../additional-privilege/additional-privilege-dal";
 import { TIdentityDALFactory } from "../identity/identity-dal";
+import { TIdentityAccessTokenServiceFactory } from "../identity-access-token/identity-access-token-service";
 import { TApplicationMembershipCleanupServiceFactory } from "../membership/application-membership-cleanup-service";
 import { assertSecretsTemporaryAccessAllowed } from "../membership/membership-fns";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
@@ -51,6 +52,7 @@ type TMembershipIdentityServiceFactoryDep = {
   projectDAL: Pick<TProjectDALFactory, "findById">;
   keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit" | "emitForProject">;
+  identityAccessTokenService: Pick<TIdentityAccessTokenServiceFactory, "revokeTokensForIdentityOrgMembership">;
 };
 
 export type TMembershipIdentityServiceFactory = ReturnType<typeof membershipIdentityServiceFactory>;
@@ -67,7 +69,8 @@ export const membershipIdentityServiceFactory = ({
   applicationMembershipCleanupService,
   projectDAL,
   keyStore,
-  usageMeteringService
+  usageMeteringService,
+  identityAccessTokenService
 }: TMembershipIdentityServiceFactoryDep) => {
   const scopeFactory = {
     [AccessScope.Organization]: newOrgMembershipIdentityFactory({
@@ -329,6 +332,17 @@ export const membershipIdentityServiceFactory = ({
       return { ...doc, roles: insertedRoleDocs };
     });
 
+    if (
+      scopeData.scope === AccessScope.Organization &&
+      data.isActive === false &&
+      existingMembership.isActive !== false
+    ) {
+      await identityAccessTokenService.revokeTokensForIdentityOrgMembership({
+        identityId: dto.selector.identityId,
+        orgId: scopeData.orgId
+      });
+    }
+
     return { membership: membershipDoc };
   };
 
@@ -386,6 +400,13 @@ export const membershipIdentityServiceFactory = ({
     const membershipDoc = externalTx
       ? await performDelete(externalTx)
       : await membershipIdentityDAL.transaction(performDelete);
+
+    if (scopeData.scope === AccessScope.Organization) {
+      await identityAccessTokenService.revokeTokensForIdentityOrgMembership({
+        identityId: dto.selector.identityId,
+        orgId: scopeData.orgId
+      });
+    }
 
     // Removing an identity from a project drops a direct member; removing it from the org cascades its
     // project + group memberships. Either way the secret-manager and PAM identity meters change.

--- a/backend/src/services/org/org-dal.ts
+++ b/backend/src/services/org/org-dal.ts
@@ -837,14 +837,39 @@ export const orgDALFactory = (db: TDbClient) => {
     acceptAnyStatus?: boolean;
     tx?: Knex;
   }): Promise<TMemberships | null> => {
-    const list = await findEffectiveOrgMemberships(dto);
-    const directMembership = list.find((membership) =>
-      dto.actorType === ActorType.USER
-        ? membership.actorUserId === dto.actorId
-        : membership.actorIdentityId === dto.actorId
-    );
+    try {
+      const conn = dto.tx ?? db.replicaNode();
+      const status = dto.status ?? OrgMembershipStatus.Accepted;
+      const anyStatus = dto.acceptAnyStatus === true;
+      const actorColumn =
+        dto.actorType === ActorType.USER
+          ? (`${TableName.Membership}.actorUserId` as const)
+          : (`${TableName.Membership}.actorIdentityId` as const);
 
-    return directMembership ?? list[0] ?? null;
+      const directQuery = conn(TableName.Membership)
+        .where(`${TableName.Membership}.scope`, AccessScope.Organization)
+        .where(`${TableName.Membership}.scopeOrgId`, dto.orgId)
+        .where(actorColumn, dto.actorId)
+        .select(selectAllTableCols(TableName.Membership))
+        .first();
+
+      if (!anyStatus) {
+        void directQuery.where((qb) => {
+          void qb.where(`${TableName.Membership}.status`, status).orWhereNull(`${TableName.Membership}.status`);
+        });
+      }
+
+      const direct = (await directQuery) as TMemberships | undefined;
+      if (direct) {
+        return direct;
+      }
+
+      // Direct miss: fall back to group membership.
+      const list = await findEffectiveOrgMemberships(dto);
+      return list[0] ?? null;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Find effective org membership" });
+    }
   };
 
   const findMembershipWithScimFilter = async (


### PR DESCRIPTION
## Context

Every identity access token validation previously called `orgDAL.findEffectiveOrgMembership` after the revocation check, adding a Postgres read to a high-frequency auth path. Revocation verdicts were already cached in Redis (`identity-revocation-verdict:{identityId}:{fingerprint}`, ~10 min TTL with jitter), but membership was re-queried on every request regardless.

This PR folds org membership into the revocation verdict path. On a cache miss (or stale version), `assertTokenIsNotRevoked` now checks revocation markers **and** membership, then caches the result as allow or deny. Stamped allow hits skip both the revocation DAL and the membership query. New org-scoped revocation markers (`scope: orgId`) reject tokens issued before deactivate/remove for that org only — tokens scoped to other orgs in a hierarchy stay valid. `membershipIdentityService` calls `revokeTokensForIdentityOrgMembership` when an identity org membership is deactivated or deleted, bumping `identity-revocation-version:{identityId}` so cached allows are invalidated.

`findEffectiveOrgMembership` is also optimized to try a direct membership row lookup first before falling back to the group-membership path, reducing cost on the cold-path recheck.

## Steps to verify the change

1. Authenticate with a machine identity token twice in quick succession; confirm the second request does not call `findEffectiveOrgMembership` (cached allow at `identity-revocation-verdict:{identityId}:{fingerprint}`).
2. Deactivate an identity's org membership (`isActive: false`); confirm existing tokens for that org are rejected and `identity-revocation-version:{identityId}` increments.
3. Remove an identity from an org; confirm the same org-scoped rejection behavior.
4. In a sub-org hierarchy, confirm tokens whose JWT `orgId` differs from the revoked org still authenticate.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)