### PR TITLE
improvement: advance options secrets and bulk suggestions 

### DIFF
--- a/frontend/src/components/v3/generic/Alert/Alert.tsx
+++ b/frontend/src/components/v3/generic/Alert/Alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-foreground/5 text-foreground/75 border-border",
+        default: "bg-container text-foreground/75 border-border",
         info: "bg-info/5 text-info border-info/20",
         success: "bg-success/5 text-success border-success/20",
         warning: "bg-warning/5 text-warning border-warning/20",

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -3489,7 +3489,7 @@ const OverviewPageContent = () => {
             isBatchMode={isBatchModeActive}
             onSecretCreated={checkSecretsActivation}
             onUploadSecrets={(env) => {
-              if (env) setImportParsedSecrets(env);
+              setImportParsedSecrets(env ?? null);
               handlePopUpClose("addSecretsInAllEnvs");
               handlePopUpOpen("importSecrets");
             }}

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -3488,6 +3488,11 @@ const OverviewPageContent = () => {
             onClose={() => handlePopUpClose("addSecretsInAllEnvs")}
             isBatchMode={isBatchModeActive}
             onSecretCreated={checkSecretsActivation}
+            onUploadSecrets={(env) => {
+              if (env) setImportParsedSecrets(env);
+              handlePopUpClose("addSecretsInAllEnvs");
+              handlePopUpOpen("importSecrets");
+            }}
             onBatchSecretCreate={(params) => {
               addPendingChange(
                 {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -2,16 +2,27 @@ import { ClipboardEvent, KeyboardEvent, useMemo, useRef, useState } from "react"
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { subject } from "@casl/ability";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { AlertTriangleIcon, InfoIcon, PlusIcon, TrashIcon, TriangleAlertIcon } from "lucide-react";
+import {
+  AlertTriangleIcon,
+  InfoIcon,
+  PlusIcon,
+  TrashIcon,
+  TriangleAlertIcon,
+  UploadIcon
+} from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
+import { parseDotEnv } from "@app/components/utilities/parseSecrets";
 import {
   Accordion,
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Button,
   IconButton,
   InfisicalSecretInput,
@@ -76,6 +87,8 @@ const formSchema = z
 
 type TFormSchema = z.infer<typeof formSchema>;
 
+type TParsedEnv = Record<string, { value: string; comments: string[] }>;
+
 type Props = {
   secretPath?: string;
   defaultSelectedEnvs?: { name: string; slug: string }[];
@@ -93,6 +106,10 @@ type Props = {
   // Called after the user actually creates a secret (non-batch path) so the parent can run the
   // activation nudge. The parent owns the nudge hook + modal state, so this stays a callback.
   onSecretCreated?: () => void;
+  // Called when the user opts to bulk-upload secrets instead. The parent owns the import modal,
+  // so it swaps popups; when the user pasted multiple KEY=VALUE pairs, the parsed set is passed
+  // along so the modal can skip its upload step.
+  onUploadSecrets?: (env?: TParsedEnv) => void;
 };
 
 export const CreateSecretForm = ({
@@ -101,7 +118,8 @@ export const CreateSecretForm = ({
   onClose,
   isBatchMode,
   onBatchSecretCreate,
-  onSecretCreated
+  onSecretCreated,
+  onUploadSecrets
 }: Props) => {
   const { currentProject, projectId } = useProject();
   const { permission } = useProjectPermission();
@@ -159,6 +177,9 @@ export const CreateSecretForm = ({
   );
 
   const [createMore, setCreateMore] = useState(false);
+  // Set when a paste into the key field contained multiple KEY=VALUE pairs; drives the
+  // "upload them all instead" hint under the field.
+  const [pastedSecrets, setPastedSecrets] = useState<TParsedEnv | null>(null);
   const secretKeyInputRef = useRef<HTMLInputElement>(null);
   const secretKey = watch("key");
   const selectedEnvironments = watch("environments");
@@ -172,6 +193,7 @@ export const CreateSecretForm = ({
     tags,
     metadata
   }: TFormSchema) => {
+    setPastedSecrets(null);
     const filteredMetadata = metadata?.filter((m) => m.key && m.value);
 
     if (isBatchMode && onBatchSecretCreate) {
@@ -310,6 +332,22 @@ export const CreateSecretForm = ({
 
     if (!secretKey || isWholeKeyHighlighted) {
       e.preventDefault();
+
+      // If the paste holds multiple KEY=VALUE pairs (e.g. a whole .env file), keep the first
+      // pair in the form and offer to hand the full set to the bulk upload modal instead.
+      if (onUploadSecrets) {
+        const parsedEnv = parseDotEnv(pastedContent);
+        const parsedKeys = Object.keys(parsedEnv);
+        if (parsedKeys.length > 1) {
+          const firstKey = parsedKeys[0];
+          setValue("key", currentProject.autoCapitalization ? firstKey.toUpperCase() : firstKey);
+          setValue("value", parsedEnv[firstKey].value);
+          setPastedSecrets(parsedEnv);
+          return;
+        }
+      }
+
+      setPastedSecrets(null);
       const keyStr = currentProject.autoCapitalization ? key.toUpperCase() : key;
       setValue("key", keyStr);
       if (value) {
@@ -429,6 +467,24 @@ export const CreateSecretForm = ({
                   )}
                 </div>
                 <FieldError errors={[error]} />
+                {pastedSecrets && onUploadSecrets && (
+                  <FieldDescription>
+                    <span className="flex items-center gap-1.5">
+                      <UploadIcon className="size-3 shrink-0" />
+                      <span>
+                        Pasted {Object.keys(pastedSecrets).length} secrets, but only the first was
+                        kept.{" "}
+                        <button
+                          type="button"
+                          className="text-foreground/95 underline underline-offset-2 hover:text-foreground"
+                          onClick={() => onUploadSecrets(pastedSecrets)}
+                        >
+                          Upload all {Object.keys(pastedSecrets).length}
+                        </button>
+                      </span>
+                    </span>
+                  </FieldDescription>
+                )}
               </FieldContent>
             </Field>
           )}
@@ -652,6 +708,18 @@ export const CreateSecretForm = ({
           </AccordionItem>
         </Accordion>
       </div>
+      {onUploadSecrets && (
+        <Alert className="mx-4 w-auto">
+          <UploadIcon />
+          <AlertTitle>Adding more than one secret?</AlertTitle>
+          <AlertDescription>
+            <p>Upload a file or paste contents in .env, .json or .yml format instead.</p>
+            <Button variant="outline" size="xs" type="button" onClick={() => onUploadSecrets()}>
+              Upload Secrets
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
       <SheetFooter className="border-t">
         <Button isPending={isSubmitting} isDisabled={isSubmitting} variant="project" type="submit">
           Create Secret

--- a/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -714,7 +714,13 @@ export const CreateSecretForm = ({
           <AlertTitle>Adding more than one secret?</AlertTitle>
           <AlertDescription>
             <p>Upload a file or paste contents in .env, .json or .yml format instead.</p>
-            <Button variant="outline" size="xs" type="button" onClick={() => onUploadSecrets()}>
+            <Button
+              variant="outline"
+              size="xs"
+              className="mt-0.5"
+              type="button"
+              onClick={() => onUploadSecrets()}
+            >
               Upload Secrets
             </Button>
           </AlertDescription>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -89,12 +89,12 @@ type TFormSchema = z.infer<typeof formSchema>;
 
 type TParsedEnv = Record<string, { value: string; comments: string[] }>;
 
-// Parse pasted content as .env lines, dropping pairs without a real value so base64 padding
-// lines ("abc==") in a pasted PEM/private key don't register as KEY=VALUE pairs.
+// Parse pasted content as .env lines. Pastes containing a PEM block (certificate/key chains)
+// are excluded entirely: their base64 padding lines ("abc==") would otherwise register as
+// KEY=VALUE pairs, and such a paste is a single secret value, not a bulk paste. Entries with
+// empty values are kept since they are valid secrets in the import flows.
 const getParsedEnvPairs = (content: string): TParsedEnv =>
-  Object.fromEntries(
-    Object.entries(parseDotEnv(content)).filter(([, v]) => v.value && v.value !== "=")
-  );
+  content.includes("-----BEGIN") ? {} : parseDotEnv(content);
 
 type Props = {
   secretPath?: string;

--- a/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -89,6 +89,13 @@ type TFormSchema = z.infer<typeof formSchema>;
 
 type TParsedEnv = Record<string, { value: string; comments: string[] }>;
 
+// Parse pasted content as .env lines, dropping pairs without a real value so base64 padding
+// lines ("abc==") in a pasted PEM/private key don't register as KEY=VALUE pairs.
+const getParsedEnvPairs = (content: string): TParsedEnv =>
+  Object.fromEntries(
+    Object.entries(parseDotEnv(content)).filter(([, v]) => v.value && v.value !== "=")
+  );
+
 type Props = {
   secretPath?: string;
   defaultSelectedEnvs?: { name: string; slug: string }[];
@@ -177,9 +184,13 @@ export const CreateSecretForm = ({
   );
 
   const [createMore, setCreateMore] = useState(false);
-  // Set when a paste into the key field contained multiple KEY=VALUE pairs; drives the
-  // "upload them all instead" hint under the field.
-  const [pastedSecrets, setPastedSecrets] = useState<TParsedEnv | null>(null);
+  // Set when a paste into the key or value field contained multiple KEY=VALUE pairs; flips the
+  // upload alert above the footer into its "upload them all instead" state. keptFirst records
+  // whether the paste was reduced to its first pair (key field) or left untouched (value field).
+  const [pastedSecrets, setPastedSecrets] = useState<{
+    env: TParsedEnv;
+    keptFirst: boolean;
+  } | null>(null);
   const secretKeyInputRef = useRef<HTMLInputElement>(null);
   const secretKey = watch("key");
   const selectedEnvironments = watch("environments");
@@ -336,13 +347,13 @@ export const CreateSecretForm = ({
       // If the paste holds multiple KEY=VALUE pairs (e.g. a whole .env file), keep the first
       // pair in the form and offer to hand the full set to the bulk upload modal instead.
       if (onUploadSecrets) {
-        const parsedEnv = parseDotEnv(pastedContent);
+        const parsedEnv = getParsedEnvPairs(pastedContent);
         const parsedKeys = Object.keys(parsedEnv);
         if (parsedKeys.length > 1) {
           const firstKey = parsedKeys[0];
           setValue("key", currentProject.autoCapitalization ? firstKey.toUpperCase() : firstKey);
           setValue("value", parsedEnv[firstKey].value);
-          setPastedSecrets(parsedEnv);
+          setPastedSecrets({ env: parsedEnv, keptFirst: true });
           return;
         }
       }
@@ -354,6 +365,23 @@ export const CreateSecretForm = ({
         setValue("value", value);
       }
     }
+  };
+
+  const handleValuePaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!onUploadSecrets) return;
+
+    // Only consider pastes that replace the whole value. Pastes into an existing value are
+    // assumed to be assembling a legitimate multiline value.
+    const { value: currentValue, selectionStart, selectionEnd } = e.currentTarget;
+    const isReplacingWholeValue =
+      !currentValue || (selectionStart === 0 && selectionEnd === currentValue.length);
+    if (!isReplacingWholeValue) return;
+
+    // Leave the pasted content in place and just offer the bulk path if it looks like a .env file.
+    const parsedEnv = getParsedEnvPairs(e.clipboardData.getData("text"));
+    setPastedSecrets(
+      Object.keys(parsedEnv).length > 1 ? { env: parsedEnv, keptFirst: false } : null
+    );
   };
 
   const createWsTag = useCreateWsTag();
@@ -467,24 +495,6 @@ export const CreateSecretForm = ({
                   )}
                 </div>
                 <FieldError errors={[error]} />
-                {pastedSecrets && onUploadSecrets && (
-                  <FieldDescription>
-                    <span className="flex items-center gap-1.5">
-                      <UploadIcon className="size-3 shrink-0" />
-                      <span>
-                        Pasted {Object.keys(pastedSecrets).length} secrets, but only the first was
-                        kept.{" "}
-                        <button
-                          type="button"
-                          className="text-foreground/95 underline underline-offset-2 hover:text-foreground"
-                          onClick={() => onUploadSecrets(pastedSecrets)}
-                        >
-                          Upload all {Object.keys(pastedSecrets).length}
-                        </button>
-                      </span>
-                    </span>
-                  </FieldDescription>
-                )}
               </FieldContent>
             </Field>
           )}
@@ -514,6 +524,7 @@ export const CreateSecretForm = ({
                   <InfisicalSecretInput
                     value={field.value ?? ""}
                     onChange={field.onChange}
+                    onPaste={handleValuePaste}
                     placeholder="Enter secret value..."
                   />
                   <PasswordGenerator
@@ -708,24 +719,57 @@ export const CreateSecretForm = ({
           </AccordionItem>
         </Accordion>
       </div>
-      {onUploadSecrets && (
-        <Alert className="mx-4 w-auto">
-          <UploadIcon />
-          <AlertTitle>Adding more than one secret?</AlertTitle>
-          <AlertDescription>
-            <p>Upload a file or paste contents in .env, .json or .yml format instead.</p>
-            <Button
-              variant="outline"
-              size="xs"
-              className="mt-0.5"
-              type="button"
-              onClick={() => onUploadSecrets()}
-            >
-              Upload Secrets
-            </Button>
-          </AlertDescription>
-        </Alert>
-      )}
+      {onUploadSecrets &&
+        (pastedSecrets ? (
+          <Alert variant="project" className="mx-4 w-auto">
+            <UploadIcon />
+            <AlertTitle>
+              Found {Object.keys(pastedSecrets.env).length} secrets in your paste
+            </AlertTitle>
+            <AlertDescription>
+              <p>
+                {pastedSecrets.keptFirst
+                  ? "Only the first pair was kept in the form."
+                  : "It looks like you meant to add multiple secrets, not one value."}
+              </p>
+              <div className="mt-0.5 flex gap-2">
+                <Button
+                  variant="project"
+                  size="xs"
+                  type="button"
+                  onClick={() => onUploadSecrets(pastedSecrets.env)}
+                >
+                  Upload all {Object.keys(pastedSecrets.env).length}
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  type="button"
+                  onClick={() => setPastedSecrets(null)}
+                >
+                  Dismiss
+                </Button>
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : (
+          <Alert className="mx-4 w-auto">
+            <UploadIcon />
+            <AlertTitle>Adding more than one secret?</AlertTitle>
+            <AlertDescription>
+              <p>Upload a file or paste contents in .env, .json or .yml format instead.</p>
+              <Button
+                variant="outline"
+                size="xs"
+                className="mt-0.5"
+                type="button"
+                onClick={() => onUploadSecrets()}
+              >
+                Upload Secrets
+              </Button>
+            </AlertDescription>
+          </Alert>
+        ))}
       <SheetFooter className="border-t">
         <Button isPending={isSubmitting} isDisabled={isSubmitting} variant="project" type="submit">
           Create Secret

--- a/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/CreateSecretForm/CreateSecretForm.tsx
@@ -8,6 +8,10 @@ import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Button,
   IconButton,
   InfisicalSecretInput,
@@ -470,165 +474,183 @@ export const CreateSecretForm = ({
           )}
         />
 
-        <Controller
-          control={control}
-          name="comment"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel>Comment</FieldLabel>
-              <FieldContent>
-                <TextArea
-                  {...field}
-                  placeholder="Add a comment for this secret..."
-                  className="max-h-32 min-h-[60px] resize-y"
-                />
-              </FieldContent>
-            </Field>
-          )}
-        />
-
-        <Controller
-          control={control}
-          name="tags"
-          render={({ field }) => (
-            <Field>
-              <FieldLabel>Tags</FieldLabel>
-              <FieldContent>
-                {!canReadTags ? (
-                  <FieldDescription>
-                    <span className="flex items-center gap-1.5 text-warning">
-                      <TriangleAlertIcon className="size-3" />
-                      You do not have permission to read tags.
-                    </span>
-                  </FieldDescription>
-                ) : (
-                  <CreatableSelect
-                    isMulti
-                    className="w-full"
-                    placeholder="Select tags to assign to secret..."
-                    isValidNewOption={(v) => slugSchema().safeParse(v).success}
-                    name="tagIds"
-                    isDisabled={!canReadTags}
-                    isLoading={isTagsLoading && canReadTags}
-                    options={tagOptions}
-                    value={field.value}
-                    onChange={field.onChange}
-                    onCreateOption={createNewTag}
-                  />
-                )}
-              </FieldContent>
-            </Field>
-          )}
-        />
-
-        <Controller
-          control={control}
-          name="skipMultilineEncoding"
-          render={({ field }) => (
-            <Field orientation="horizontal">
-              <FieldLabel className="cursor-pointer">Enable Multiline Encoding</FieldLabel>
-              <Switch variant="project" checked={field.value} onCheckedChange={field.onChange} />
-            </Field>
-          )}
-        />
-
-        <div>
-          <div className="mb-1">
-            <p className="text-sm font-medium">Metadata</p>
-            <p className="mt-1 text-xs text-accent">
-              Encrypted Metadata will not be searchable via the UI or API.
-            </p>
-          </div>
-          <div className="flex max-h-64 thin-scrollbar flex-col gap-3 overflow-y-auto rounded-md border border-border bg-container/50 p-4">
-            {metadataFields.length === 0 && (
-              <p className="text-center text-sm text-muted">
-                No metadata entries. Click below to add.
-              </p>
-            )}
-            {metadataFields.map((metaField, index) => (
-              <div key={metaField.id} className="flex items-start gap-3">
-                <Field className="flex-1">
-                  {index === 0 && <FieldLabel className="text-xs">Key</FieldLabel>}
-                  <FieldContent>
-                    <Controller
-                      control={control}
-                      name={`metadata.${index}.key`}
-                      render={({ field: inputField, fieldState: { error } }) => (
-                        <>
-                          <Input {...inputField} placeholder="Enter key" className="h-8" />
-                          <FieldError errors={[error]} />
-                        </>
-                      )}
-                    />
-                  </FieldContent>
-                </Field>
-
-                <Field className="flex-1">
-                  {index === 0 && <FieldLabel className="text-xs">Value</FieldLabel>}
-                  <FieldContent>
-                    <Controller
-                      control={control}
-                      name={`metadata.${index}.value`}
-                      render={({ field: inputField, fieldState: { error } }) => (
-                        <>
-                          <Input {...inputField} placeholder="Enter value" className="h-8" />
-                          <FieldError errors={[error]} />
-                        </>
-                      )}
-                    />
-                  </FieldContent>
-                </Field>
-
-                <Field className="w-10">
-                  {index === 0 && <FieldLabel className="text-xs">Encrypt</FieldLabel>}
-                  <Controller
-                    control={control}
-                    name={`metadata.${index}.isEncrypted`}
-                    render={({ field: switchField }) => (
-                      <Switch
-                        className="mt-2"
-                        variant="project"
-                        size="default"
-                        checked={switchField.value}
-                        onCheckedChange={switchField.onChange}
-                      />
-                    )}
-                  />
-                </Field>
-
-                <IconButton
-                  variant="ghost"
-                  size="xs"
-                  type="button"
-                  className={twMerge(
-                    index === 0 ? "mt-6.5" : "mt-0.5",
-                    "transition-transform hover:text-danger"
+        <Accordion type="single" collapsible variant="ghost">
+          <AccordionItem value="advanced" className="border-b-0">
+            <AccordionTrigger>Advanced Options</AccordionTrigger>
+            <AccordionContent>
+              <div className="flex flex-col gap-4">
+                <Controller
+                  control={control}
+                  name="comment"
+                  render={({ field }) => (
+                    <Field>
+                      <FieldLabel>Comment</FieldLabel>
+                      <FieldContent>
+                        <TextArea
+                          {...field}
+                          placeholder="Add a comment for this secret..."
+                          className="max-h-32 min-h-[60px] resize-y"
+                        />
+                      </FieldContent>
+                    </Field>
                   )}
-                  onClick={() => removeMetadata(index)}
-                >
-                  <TrashIcon className="size-4" />
-                </IconButton>
-              </div>
-            ))}
-          </div>
+                />
 
-          <Button
-            variant="ghost"
-            size="xs"
-            type="button"
-            className="mt-2"
-            onClick={() =>
-              appendMetadata({
-                key: "",
-                value: "",
-                isEncrypted: currentProject?.enforceEncryptedSecretManagerSecretMetadata ?? false
-              })
-            }
-          >
-            <PlusIcon className="mr-1 size-4" />
-            Add Entry
-          </Button>
-        </div>
+                <Controller
+                  control={control}
+                  name="tags"
+                  render={({ field }) => (
+                    <Field>
+                      <FieldLabel>Tags</FieldLabel>
+                      <FieldContent>
+                        {!canReadTags ? (
+                          <FieldDescription>
+                            <span className="flex items-center gap-1.5 text-warning">
+                              <TriangleAlertIcon className="size-3" />
+                              You do not have permission to read tags.
+                            </span>
+                          </FieldDescription>
+                        ) : (
+                          <CreatableSelect
+                            isMulti
+                            className="w-full"
+                            placeholder="Select tags to assign to secret..."
+                            isValidNewOption={(v) => slugSchema().safeParse(v).success}
+                            name="tagIds"
+                            isDisabled={!canReadTags}
+                            isLoading={isTagsLoading && canReadTags}
+                            options={tagOptions}
+                            value={field.value}
+                            onChange={field.onChange}
+                            onCreateOption={createNewTag}
+                          />
+                        )}
+                      </FieldContent>
+                    </Field>
+                  )}
+                />
+
+                <Controller
+                  control={control}
+                  name="skipMultilineEncoding"
+                  render={({ field }) => (
+                    <Field orientation="horizontal">
+                      <FieldLabel className="cursor-pointer">Enable Multiline Encoding</FieldLabel>
+                      <Switch
+                        variant="project"
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </Field>
+                  )}
+                />
+
+                <div>
+                  <div className="mb-1">
+                    <p className="text-sm font-medium">Metadata</p>
+                    <p className="mt-1 text-xs text-accent">
+                      Encrypted Metadata will not be searchable via the UI or API.
+                    </p>
+                  </div>
+                  <div className="flex max-h-64 thin-scrollbar flex-col gap-3 overflow-y-auto rounded-md border border-border bg-container/50 p-4">
+                    {metadataFields.length === 0 && (
+                      <p className="text-center text-sm text-muted">
+                        No metadata entries. Click below to add.
+                      </p>
+                    )}
+                    {metadataFields.map((metaField, index) => (
+                      <div key={metaField.id} className="flex items-start gap-3">
+                        <Field className="flex-1">
+                          {index === 0 && <FieldLabel className="text-xs">Key</FieldLabel>}
+                          <FieldContent>
+                            <Controller
+                              control={control}
+                              name={`metadata.${index}.key`}
+                              render={({ field: inputField, fieldState: { error } }) => (
+                                <>
+                                  <Input {...inputField} placeholder="Enter key" className="h-8" />
+                                  <FieldError errors={[error]} />
+                                </>
+                              )}
+                            />
+                          </FieldContent>
+                        </Field>
+
+                        <Field className="flex-1">
+                          {index === 0 && <FieldLabel className="text-xs">Value</FieldLabel>}
+                          <FieldContent>
+                            <Controller
+                              control={control}
+                              name={`metadata.${index}.value`}
+                              render={({ field: inputField, fieldState: { error } }) => (
+                                <>
+                                  <Input
+                                    {...inputField}
+                                    placeholder="Enter value"
+                                    className="h-8"
+                                  />
+                                  <FieldError errors={[error]} />
+                                </>
+                              )}
+                            />
+                          </FieldContent>
+                        </Field>
+
+                        <Field className="w-10">
+                          {index === 0 && <FieldLabel className="text-xs">Encrypt</FieldLabel>}
+                          <Controller
+                            control={control}
+                            name={`metadata.${index}.isEncrypted`}
+                            render={({ field: switchField }) => (
+                              <Switch
+                                className="mt-2"
+                                variant="project"
+                                size="default"
+                                checked={switchField.value}
+                                onCheckedChange={switchField.onChange}
+                              />
+                            )}
+                          />
+                        </Field>
+
+                        <IconButton
+                          variant="ghost"
+                          size="xs"
+                          type="button"
+                          className={twMerge(
+                            index === 0 ? "mt-6.5" : "mt-0.5",
+                            "transition-transform hover:text-danger"
+                          )}
+                          onClick={() => removeMetadata(index)}
+                        >
+                          <TrashIcon className="size-4" />
+                        </IconButton>
+                      </div>
+                    ))}
+                  </div>
+
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    type="button"
+                    className="mt-2"
+                    onClick={() =>
+                      appendMetadata({
+                        key: "",
+                        value: "",
+                        isEncrypted:
+                          currentProject?.enforceEncryptedSecretManagerSecretMetadata ?? false
+                      })
+                    }
+                  >
+                    <PlusIcon className="mr-1 size-4" />
+                    Add Entry
+                  </Button>
+                </div>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </div>
       <SheetFooter className="border-t">
         <Button isPending={isSubmitting} isDisabled={isSubmitting} variant="project" type="submit">


### PR DESCRIPTION
## Context

This PR moves secret comments, metadata and tags to an advanced options section and adds an alert callout for refering users to uploading secrets for bulk actions

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-07-21 at 16 43 37@2x" src="https://github.com/user-attachments/assets/0d08feee-1369-44ca-a5eb-9b1da2153106" />

## Steps to verify the change

- [ ] test adding secret with advance options 
- [ ] click upload button link
- [ ] test pasting multiple values into value/key to test upload forward

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)