### PR TITLE
fix(pki): base certificate renewal eligibility on the certificate's enrollment method

### DIFF
--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -2329,55 +2329,6 @@ describe("CertificateV3Service", () => {
       ).rejects.toThrow("Certificate is not eligible for auto-renewal: certificate has already been renewed");
     });
 
-    it("should reject update when Infisical does not hold the private key", async () => {
-      const mockCert = {
-        id: "cert-123",
-        profileId: "profile-123",
-        renewedByCertificateId: null,
-        notBefore: new Date(),
-        notAfter: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
-        projectId: "project-123",
-        status: CertStatus.ACTIVE,
-        revokedAt: null
-      };
-
-      const mockProfile = {
-        id: "profile-123",
-        enrollmentType: EnrollmentType.ACME,
-        issuerType: IssuerType.CA,
-        projectId: "project-123"
-      };
-
-      vi.mocked(mockCertificateDAL.findById).mockResolvedValue(mockCert as any);
-      vi.mocked(mockCertificateProfileDAL.findByIdWithConfigs).mockResolvedValue(mockProfile as any);
-      vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(EnrollmentType.API);
-      vi.mocked(mockCertificateSecretDAL.findOne).mockResolvedValue(undefined as any);
-
-      await expect(
-        service.updateRenewalConfig({
-          actor: ActorType.USER,
-          actorId: "user-123",
-          actorAuthMethod: AuthMethod.EMAIL,
-          actorOrgId: "org-123",
-          certificateId: "cert-123",
-          renewBeforeDays: 7
-        })
-      ).rejects.toThrow(ForbiddenRequestError);
-
-      await expect(
-        service.updateRenewalConfig({
-          actor: ActorType.USER,
-          actorId: "user-123",
-          actorAuthMethod: AuthMethod.EMAIL,
-          actorOrgId: "org-123",
-          certificateId: "cert-123",
-          renewBeforeDays: 7
-        })
-      ).rejects.toThrow(
-        "Certificate is not eligible for auto-renewal: certificates issued from CSR (external private key) cannot be auto-renewed"
-      );
-    });
-
     it("should allow update for an API-issued certificate under a legacy ACME-labeled profile", async () => {
       const mockCert = {
         id: "cert-123",

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -63,8 +63,6 @@ describe("CertificateV3Service", () => {
     findOne: vi.fn(),
     findById: vi.fn(),
     updateById: vi.fn(),
-    // Cert's actual enrollment method (from its request row). Defaults to null (no explicit signal → defer
-    // to the private-key check); enrollment-gated tests override this per-case.
     getRequestEnrollmentTypeByCertId: vi.fn().mockResolvedValue(null),
     create: vi.fn().mockResolvedValue({
       id: "new-cert-id",
@@ -163,7 +161,6 @@ describe("CertificateV3Service", () => {
       const mockTx = {};
       return callback(mockTx);
     });
-    // No explicit enrollment signal by default → defer to the private-key check; overridden per enrollment-gated test.
     vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(null);
 
     // Mock ForbiddenError.from static method
@@ -2332,8 +2329,6 @@ describe("CertificateV3Service", () => {
 
       vi.mocked(mockCertificateDAL.findById).mockResolvedValue(mockCert as any);
       vi.mocked(mockCertificateProfileDAL.findByIdWithConfigs).mockResolvedValue(mockProfile as any);
-      // API-enrolled, so it clears the enrollment guard; the rejection comes from the missing private key
-      // (e.g. issued from an externally-held CSR).
       vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(EnrollmentType.API);
       vi.mocked(mockCertificateSecretDAL.findOne).mockResolvedValue(undefined as any);
 
@@ -2363,9 +2358,6 @@ describe("CertificateV3Service", () => {
     });
 
     it("should allow update for an API-issued certificate under a legacy ACME-labeled profile", async () => {
-      // Regression: pre-application profiles retain a stale enrollmentType (e.g. "acme"). A certificate issued
-      // via API under such a profile records "api" on its own request row and has an Infisical-held key, so it
-      // IS renewable. Eligibility is judged by the certificate's own enrollment record, not the profile's label.
       const mockCert = {
         id: "cert-123",
         profileId: "profile-123",
@@ -2387,7 +2379,6 @@ describe("CertificateV3Service", () => {
 
       vi.mocked(mockCertificateDAL.findById).mockResolvedValue(mockCert as any);
       vi.mocked(mockCertificateProfileDAL.findByIdWithConfigs).mockResolvedValue(mockProfile as any);
-      // The certificate's OWN enrollment record is "api", despite the profile's stale "acme" label.
       vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(EnrollmentType.API);
       vi.mocked(mockCertificateSecretDAL.findOne).mockResolvedValue({ id: "secret-123", certId: "cert-123" } as any);
       vi.mocked(mockCertificateDAL.updateById).mockResolvedValue(mockCert as any);
@@ -2410,9 +2401,6 @@ describe("CertificateV3Service", () => {
     });
 
     it("should reject update for a protocol-enrolled certificate regardless of key presence", async () => {
-      // Fail-closed guard: a certificate whose own enrollment record is a protocol method (ACME/EST/SCEP) is
-      // never auto-renewable, even if a private key were present. This keeps the check safe if a future
-      // enrollment method ever stored a key server-side, it would be blocked by enrollment, not silently renewed.
       const mockCert = {
         id: "cert-123",
         profileId: "profile-123",
@@ -2434,7 +2422,6 @@ describe("CertificateV3Service", () => {
       vi.mocked(mockCertificateDAL.findById).mockResolvedValue(mockCert as any);
       vi.mocked(mockCertificateProfileDAL.findByIdWithConfigs).mockResolvedValue(mockProfile as any);
       vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(EnrollmentType.ACME);
-      // Key present on purpose: the enrollment guard must reject before/independent of the key check.
       vi.mocked(mockCertificateSecretDAL.findOne).mockResolvedValue({ id: "secret-123", certId: "cert-123" } as any);
 
       await expect(

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -1969,6 +1969,27 @@ describe("CertificateV3Service", () => {
       ).rejects.toThrow("certificates issued from CSR (external private key) cannot be renewed");
     });
 
+    it("should reject renewal for a protocol-enrolled certificate", async () => {
+      vi.mocked(mockCertificateDAL.findById).mockResolvedValue(mockOriginalCert);
+      vi.mocked(mockCertificateProfileDAL.findByIdWithConfigs).mockResolvedValue(mockProfile);
+      vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(EnrollmentType.ACME);
+      vi.mocked(mockCertificateSecretDAL.findOne).mockResolvedValue({ id: "secret-123", certId: "cert-123" } as any);
+
+      await expect(
+        service.renewCertificate({
+          certificateId: "cert-123",
+          ...mockActor
+        })
+      ).rejects.toThrow(ForbiddenRequestError);
+
+      await expect(
+        service.renewCertificate({
+          certificateId: "cert-123",
+          ...mockActor
+        })
+      ).rejects.toThrow("Certificate is not eligible for renewal: ACME certificates cannot be renewed");
+    });
+
     it("should reject renewal if certificate is already renewed", async () => {
       const alreadyRenewedCert = { ...mockOriginalCert, renewedByCertificateId: "cert-456" };
       vi.mocked(mockCertificateDAL.findById).mockResolvedValue(alreadyRenewedCert);

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -58,11 +58,14 @@ describe("CertificateV3Service", () => {
 
   const mockCertificateDAL: Pick<
     TCertificateDALFactory,
-    "findOne" | "findById" | "updateById" | "transaction" | "create" | "find"
+    "findOne" | "findById" | "updateById" | "transaction" | "create" | "find" | "getRequestEnrollmentTypeByCertId"
   > = {
     findOne: vi.fn(),
     findById: vi.fn(),
     updateById: vi.fn(),
+    // Cert's actual enrollment method (from its request row). Defaults to null (no explicit signal → defer
+    // to the private-key check); enrollment-gated tests override this per-case.
+    getRequestEnrollmentTypeByCertId: vi.fn().mockResolvedValue(null),
     create: vi.fn().mockResolvedValue({
       id: "new-cert-id",
       serialNumber: "123456789",
@@ -160,6 +163,8 @@ describe("CertificateV3Service", () => {
       const mockTx = {};
       return callback(mockTx);
     });
+    // No explicit enrollment signal by default → defer to the private-key check; overridden per enrollment-gated test.
+    vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(null);
 
     // Mock ForbiddenError.from static method
     vi.spyOn(ForbiddenError, "from").mockReturnValue({
@@ -2306,7 +2311,7 @@ describe("CertificateV3Service", () => {
       ).rejects.toThrow("Certificate is not eligible for auto-renewal: certificate has already been renewed");
     });
 
-    it("should reject update with accurate enrollment type when profile is ACME", async () => {
+    it("should reject update when Infisical does not hold the private key", async () => {
       const mockCert = {
         id: "cert-123",
         profileId: "profile-123",
@@ -2327,6 +2332,10 @@ describe("CertificateV3Service", () => {
 
       vi.mocked(mockCertificateDAL.findById).mockResolvedValue(mockCert as any);
       vi.mocked(mockCertificateProfileDAL.findByIdWithConfigs).mockResolvedValue(mockProfile as any);
+      // API-enrolled, so it clears the enrollment guard; the rejection comes from the missing private key
+      // (e.g. issued from an externally-held CSR).
+      vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(EnrollmentType.API);
+      vi.mocked(mockCertificateSecretDAL.findOne).mockResolvedValue(undefined as any);
 
       await expect(
         service.updateRenewalConfig({
@@ -2338,6 +2347,95 @@ describe("CertificateV3Service", () => {
           renewBeforeDays: 7
         })
       ).rejects.toThrow(ForbiddenRequestError);
+
+      await expect(
+        service.updateRenewalConfig({
+          actor: ActorType.USER,
+          actorId: "user-123",
+          actorAuthMethod: AuthMethod.EMAIL,
+          actorOrgId: "org-123",
+          certificateId: "cert-123",
+          renewBeforeDays: 7
+        })
+      ).rejects.toThrow(
+        "Certificate is not eligible for auto-renewal: certificates issued from CSR (external private key) cannot be auto-renewed"
+      );
+    });
+
+    it("should allow update for an API-issued certificate under a legacy ACME-labeled profile", async () => {
+      // Regression: pre-application profiles retain a stale enrollmentType (e.g. "acme"). A certificate issued
+      // via API under such a profile records "api" on its own request row and has an Infisical-held key, so it
+      // IS renewable. Eligibility is judged by the certificate's own enrollment record, not the profile's label.
+      const mockCert = {
+        id: "cert-123",
+        profileId: "profile-123",
+        renewedByCertificateId: null,
+        notBefore: new Date(),
+        notAfter: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
+        projectId: "project-123",
+        status: CertStatus.ACTIVE,
+        revokedAt: null,
+        commonName: ""
+      };
+
+      const mockProfile = {
+        id: "profile-123",
+        enrollmentType: EnrollmentType.ACME,
+        issuerType: IssuerType.CA,
+        projectId: "project-123"
+      };
+
+      vi.mocked(mockCertificateDAL.findById).mockResolvedValue(mockCert as any);
+      vi.mocked(mockCertificateProfileDAL.findByIdWithConfigs).mockResolvedValue(mockProfile as any);
+      // The certificate's OWN enrollment record is "api", despite the profile's stale "acme" label.
+      vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(EnrollmentType.API);
+      vi.mocked(mockCertificateSecretDAL.findOne).mockResolvedValue({ id: "secret-123", certId: "cert-123" } as any);
+      vi.mocked(mockCertificateDAL.updateById).mockResolvedValue(mockCert as any);
+
+      const result = await service.updateRenewalConfig({
+        actor: ActorType.USER,
+        actorId: "user-123",
+        actorAuthMethod: AuthMethod.EMAIL,
+        actorOrgId: "org-123",
+        certificateId: "cert-123",
+        renewBeforeDays: 7
+      });
+
+      expect(result).toEqual({
+        projectId: "project-123",
+        renewBeforeDays: 7,
+        commonName: ""
+      });
+      expect(mockCertificateDAL.updateById).toHaveBeenCalledWith("cert-123", { renewBeforeDays: 7 }, expect.anything());
+    });
+
+    it("should reject update for a protocol-enrolled certificate regardless of key presence", async () => {
+      // Fail-closed guard: a certificate whose own enrollment record is a protocol method (ACME/EST/SCEP) is
+      // never auto-renewable, even if a private key were present. This keeps the check safe if a future
+      // enrollment method ever stored a key server-side, it would be blocked by enrollment, not silently renewed.
+      const mockCert = {
+        id: "cert-123",
+        profileId: "profile-123",
+        renewedByCertificateId: null,
+        notBefore: new Date(),
+        notAfter: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30),
+        projectId: "project-123",
+        status: CertStatus.ACTIVE,
+        revokedAt: null
+      };
+
+      const mockProfile = {
+        id: "profile-123",
+        enrollmentType: EnrollmentType.API,
+        issuerType: IssuerType.CA,
+        projectId: "project-123"
+      };
+
+      vi.mocked(mockCertificateDAL.findById).mockResolvedValue(mockCert as any);
+      vi.mocked(mockCertificateProfileDAL.findByIdWithConfigs).mockResolvedValue(mockProfile as any);
+      vi.mocked(mockCertificateDAL.getRequestEnrollmentTypeByCertId).mockResolvedValue(EnrollmentType.ACME);
+      // Key present on purpose: the enrollment guard must reject before/independent of the key check.
+      vi.mocked(mockCertificateSecretDAL.findOne).mockResolvedValue({ id: "secret-123", certId: "cert-123" } as any);
 
       await expect(
         service.updateRenewalConfig({

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2301,10 +2301,7 @@ export const certificateV3ServiceFactory = ({
     });
   };
 
-  // Blocks renewal for certificates enrolled via an external/protocol method (ACME/EST/SCEP), where the client
-  // owns the private key and drives its own renewal. Judged by the certificate's OWN enrollment record, never the
-  // profile's enrollmentType (a legacy label that drifts under the application flow). Only an explicit non-API
-  // value blocks; a missing signal defers to the stored-private-key check, so older certs are not wrongly blocked.
+  // Only an explicit non-API enrollment blocks; a missing signal defers to the key-presence check.
   const $assertCertificateEnrollmentRenewable = async (
     certId: string,
     { context, tx }: { context: "renewal" | "auto-renewal"; tx?: Knex }

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -1,5 +1,6 @@
 import { ForbiddenError, subject } from "@casl/ability";
 import { randomUUID } from "crypto";
+import { Knex } from "knex";
 import RE2 from "re2";
 
 import { ActionProjectType, ResourceType, TCertificates } from "@app/db/schemas";
@@ -129,7 +130,7 @@ import {
 type TCertificateV3ServiceFactoryDep = {
   certificateDAL: Pick<
     TCertificateDALFactory,
-    "findOne" | "findById" | "updateById" | "transaction" | "create" | "find"
+    "findOne" | "findById" | "updateById" | "transaction" | "create" | "find" | "getRequestEnrollmentTypeByCertId"
   >;
   certificateBodyDAL: Pick<TCertificateBodyDALFactory, "create">;
   certificateSecretDAL: Pick<TCertificateSecretDALFactory, "findOne" | "create">;
@@ -2300,6 +2301,23 @@ export const certificateV3ServiceFactory = ({
     });
   };
 
+  // Blocks renewal for certificates enrolled via an external/protocol method (ACME/EST/SCEP), where the client
+  // owns the private key and drives its own renewal. Judged by the certificate's OWN enrollment record, never the
+  // profile's enrollmentType (a legacy label that drifts under the application flow). Only an explicit non-API
+  // value blocks; a missing signal defers to the stored-private-key check, so older certs are not wrongly blocked.
+  const $assertCertificateEnrollmentRenewable = async (
+    certId: string,
+    { context, tx }: { context: "renewal" | "auto-renewal"; tx?: Knex }
+  ) => {
+    const enrollmentType = await certificateDAL.getRequestEnrollmentTypeByCertId(certId, tx);
+    if (enrollmentType && enrollmentType !== EnrollmentType.API) {
+      const verb = context === "renewal" ? "renewed" : "auto-renewed";
+      throw new ForbiddenRequestError({
+        message: `Certificate is not eligible for ${context}: ${enrollmentType.toUpperCase()} certificates cannot be ${verb}`
+      });
+    }
+  };
+
   const renewCertificate = async ({
     certificateId,
     actor,
@@ -2355,14 +2373,9 @@ export const certificateV3ServiceFactory = ({
         if (!profile) {
           throw new NotFoundError({ message: "Certificate profile not found" });
         }
-
-        if (profile.enrollmentType !== EnrollmentType.API) {
-          throw new ForbiddenRequestError({
-            message:
-              "Certificate is not eligible for renewal: Only certificates issued from an API enrollment profile can be renewed through this endpoint"
-          });
-        }
       }
+
+      await $assertCertificateEnrollmentRenewable(originalCert.id, { context: "renewal", tx });
 
       const certificateSecret = await certificateSecretDAL.findOne({ certId: originalCert.id }, tx);
       if (!certificateSecret) {
@@ -2957,11 +2970,7 @@ export const certificateV3ServiceFactory = ({
       throw new NotFoundError({ message: "Certificate profile not found" });
     }
 
-    if (profile.enrollmentType !== EnrollmentType.API) {
-      throw new ForbiddenRequestError({
-        message: `Certificate is not eligible for auto-renewal: ${profile.enrollmentType.toUpperCase()} certificates cannot be auto-renewed`
-      });
-    }
+    await $assertCertificateEnrollmentRenewable(certificate.id, { context: "auto-renewal" });
 
     const certificateSecret = await certificateSecretDAL.findOne({ certId: certificate.id });
     if (!certificateSecret) {
@@ -3088,12 +3097,6 @@ export const certificateV3ServiceFactory = ({
     const profile = await certificateProfileDAL.findByIdWithConfigs(certificate.profileId);
     if (!profile) {
       throw new NotFoundError({ message: "Certificate profile not found" });
-    }
-
-    if (profile.enrollmentType !== EnrollmentType.API) {
-      throw new ForbiddenRequestError({
-        message: `Certificate is not eligible for auto-renewal: ${profile.enrollmentType.toUpperCase()} certificates cannot be auto-renewed`
-      });
     }
 
     await certificateDAL.transaction(async (tx) => {

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -2301,7 +2301,6 @@ export const certificateV3ServiceFactory = ({
     });
   };
 
-  // Only an explicit non-API enrollment blocks; a missing signal defers to the key-presence check.
   const $assertCertificateEnrollmentRenewable = async (
     certId: string,
     { context, tx }: { context: "renewal" | "auto-renewal"; tx?: Knex }

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -1,6 +1,5 @@
 import { ForbiddenError, subject } from "@casl/ability";
 import { randomUUID } from "crypto";
-import { Knex } from "knex";
 import RE2 from "re2";
 
 import { ActionProjectType, ResourceType, TCertificates } from "@app/db/schemas";
@@ -2301,19 +2300,6 @@ export const certificateV3ServiceFactory = ({
     });
   };
 
-  const $assertCertificateEnrollmentRenewable = async (
-    certId: string,
-    { context, tx }: { context: "renewal" | "auto-renewal"; tx?: Knex }
-  ) => {
-    const enrollmentType = await certificateDAL.getRequestEnrollmentTypeByCertId(certId, tx);
-    if (enrollmentType && enrollmentType !== EnrollmentType.API) {
-      const verb = context === "renewal" ? "renewed" : "auto-renewed";
-      throw new ForbiddenRequestError({
-        message: `Certificate is not eligible for ${context}: ${enrollmentType.toUpperCase()} certificates cannot be ${verb}`
-      });
-    }
-  };
-
   const renewCertificate = async ({
     certificateId,
     actor,
@@ -2371,7 +2357,12 @@ export const certificateV3ServiceFactory = ({
         }
       }
 
-      await $assertCertificateEnrollmentRenewable(originalCert.id, { context: "renewal", tx });
+      const enrollmentType = await certificateDAL.getRequestEnrollmentTypeByCertId(originalCert.id, tx);
+      if (enrollmentType && enrollmentType !== EnrollmentType.API) {
+        throw new ForbiddenRequestError({
+          message: `Certificate is not eligible for renewal: ${enrollmentType.toUpperCase()} certificates cannot be renewed`
+        });
+      }
 
       const certificateSecret = await certificateSecretDAL.findOne({ certId: originalCert.id }, tx);
       if (!certificateSecret) {
@@ -2966,7 +2957,12 @@ export const certificateV3ServiceFactory = ({
       throw new NotFoundError({ message: "Certificate profile not found" });
     }
 
-    await $assertCertificateEnrollmentRenewable(certificate.id, { context: "auto-renewal" });
+    const enrollmentType = await certificateDAL.getRequestEnrollmentTypeByCertId(certificate.id);
+    if (enrollmentType && enrollmentType !== EnrollmentType.API) {
+      throw new ForbiddenRequestError({
+        message: `Certificate is not eligible for auto-renewal: ${enrollmentType.toUpperCase()} certificates cannot be auto-renewed`
+      });
+    }
 
     const certificateSecret = await certificateSecretDAL.findOne({ certId: certificate.id });
     if (!certificateSecret) {

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -555,15 +555,11 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
-  // Returns how THIS certificate was actually enrolled, read from its originating certificate_requests row
-  // (earliest wins). Deliberately does NOT fall back to the profile's enrollmentType: that field is a legacy
-  // per-profile label that drifts under the application flow (a profile created as "acme" can still issue API
-  // certs), which is exactly what misjudges renewability. Returns null when there is no request row, so callers
-  // can defer to another signal (the stored-private-key check) rather than block on a stale label.
+  // Enrollment method from the cert's own request row, not the profile's enrollmentType (a legacy label that
+  // drifts under applications). null = no request row, so callers defer to the private-key check.
   const getRequestEnrollmentTypeByCertId = async (certId: string, tx?: Knex): Promise<string | null> => {
     try {
-      // Read from primary (not the replica): this feeds a renewal eligibility guard, and a replica miss on a
-      // freshly-attached request row would turn into a null and let the guard defer, so consistency wins here.
+      // Primary, not replica: a lagged miss on a fresh request row would wrongly defer the renewal guard.
       const row = (await (tx || db)(TableName.CertificateRequests)
         .where(`${TableName.CertificateRequests}.certificateId`, certId)
         .orderBy(`${TableName.CertificateRequests}.createdAt`, "asc")

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -555,6 +555,25 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
+  // Returns how THIS certificate was actually enrolled, read from its originating certificate_requests row
+  // (earliest wins). Deliberately does NOT fall back to the profile's enrollmentType: that field is a legacy
+  // per-profile label that drifts under the application flow (a profile created as "acme" can still issue API
+  // certs), which is exactly what misjudges renewability. Returns null when there is no request row, so callers
+  // can defer to another signal (the stored-private-key check) rather than block on a stale label.
+  const getRequestEnrollmentTypeByCertId = async (certId: string, tx?: Knex): Promise<string | null> => {
+    try {
+      const row = (await (tx || db.replicaNode())(TableName.CertificateRequests)
+        .where(`${TableName.CertificateRequests}.certificateId`, certId)
+        .orderBy(`${TableName.CertificateRequests}.createdAt`, "asc")
+        .select(`${TableName.CertificateRequests}.enrollmentType`)
+        .first()) as { enrollmentType?: string | null } | undefined;
+
+      return row?.enrollmentType ?? null;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Get request enrollment type by cert id" });
+    }
+  };
+
   type TCertificateWithInventoryFields = TCertificates & {
     hasPrivateKey: boolean;
     caName?: string | null;
@@ -1164,6 +1183,7 @@ export const certificateDALFactory = (db: TDbClient) => {
     findActiveCertificatesByIds,
     findActiveCertificatesForSync,
     findCertificatesEligibleForRenewal,
+    getRequestEnrollmentTypeByCertId,
     findWithPrivateKeyInfo,
     findWithFullDetails,
     getDashboardStats,

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -562,7 +562,9 @@ export const certificateDALFactory = (db: TDbClient) => {
   // can defer to another signal (the stored-private-key check) rather than block on a stale label.
   const getRequestEnrollmentTypeByCertId = async (certId: string, tx?: Knex): Promise<string | null> => {
     try {
-      const row = (await (tx || db.replicaNode())(TableName.CertificateRequests)
+      // Read from primary (not the replica): this feeds a renewal eligibility guard, and a replica miss on a
+      // freshly-attached request row would turn into a null and let the guard defer, so consistency wins here.
+      const row = (await (tx || db)(TableName.CertificateRequests)
         .where(`${TableName.CertificateRequests}.certificateId`, certId)
         .orderBy(`${TableName.CertificateRequests}.createdAt`, "asc")
         .select(`${TableName.CertificateRequests}.enrollmentType`)

--- a/backend/src/services/certificate/certificate-dal.ts
+++ b/backend/src/services/certificate/certificate-dal.ts
@@ -555,11 +555,9 @@ export const certificateDALFactory = (db: TDbClient) => {
     }
   };
 
-  // Enrollment method from the cert's own request row, not the profile's enrollmentType (a legacy label that
-  // drifts under applications). null = no request row, so callers defer to the private-key check.
   const getRequestEnrollmentTypeByCertId = async (certId: string, tx?: Knex): Promise<string | null> => {
     try {
-      // Primary, not replica: a lagged miss on a fresh request row would wrongly defer the renewal guard.
+      // Primary, not replica: eligibility checks must not miss a recently-issued request row.
       const row = (await (tx || db)(TableName.CertificateRequests)
         .where(`${TableName.CertificateRequests}.certificateId`, certId)
         .orderBy(`${TableName.CertificateRequests}.createdAt`, "asc")


### PR DESCRIPTION
## Context

Renewal and auto-renewal eligibility were gated on the certificate **profile's** `enrollmentType`. Under the applications flow a single profile can expose multiple enrollment methods (e.g. API + ACME), so that field no longer reflects how a given certificate was actually issued. An API-issued cert under a profile labeled `acme`/`est`/`scep` was wrongly rejected (`ACME certificates cannot be auto-renewed`) even though Infisical holds its private key and can renew it.

Eligibility is now judged per-certificate: the enrollment method recorded on the cert's own `certificate_request`, combined with the existing "Infisical holds the private key" check. Protocol-enrolled certs (where the client owns the key) stay correctly blocked, and disabling auto-renewal is now allowed regardless of enrollment method.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
