### PR TITLE
feat(pam): add Web account type, browser access to internal web apps with recording

### DIFF
--- a/DESIGN-web-access.md
+++ b/DESIGN-web-access.md
@@ -1,0 +1,124 @@
+# PAM Web Access — Design Notes
+
+Superday feature: let a user reach an **internal web app** from a browser with nothing
+installed (no VPN, no client), browse it as if on the private network, while Infisical
+records the session tamper-proofly and lets it be replayed.
+
+This adds a new PAM account type, **Web**, alongside the existing SSH / Postgres / RDP / etc.
+
+## The problem, in four parts
+
+| Sub-problem | Answer |
+|---|---|
+| **Reach** the internal app with no inbound ports / no client | Reuse the existing relay → gateway outbound tunnel |
+| **Present** it in the browser | Run a headless Chromium next to the gateway; stream its screen |
+| **Capture** what happened, tamper-proofly | The **gateway** records; reuse the existing encrypted chunk pipeline |
+| **Replay** | Reuse the existing playback pipeline; add a frame player + event log |
+
+## Approaches considered
+
+**Option A — HTTP reverse proxy.** Proxy each request/response through the tunnel; the
+user's own browser renders the HTML. Cheap, but naive proxying breaks on SPAs (client-side
+routing, absolute URLs, websockets) and the "recording" is only an HTTP transaction log —
+weak for an admin trying to see what actually happened.
+
+**Option B — remote browser / pixel streaming (chosen).** Run Chromium *inside* the private
+network (next to the gateway); stream its rendered screen to the user as image frames and
+send the user's input back. Any app works because a real browser renders it, and the
+recording is literally what the user saw.
+
+**Decision (with Maidul at the whiteboard): build a hybrid.** A web session produces **both**
+a request/response **event log** (Option A's fidelity — quick to scan) **and** a **video-style
+replay** (Option B's fidelity — watch what happened). Both are captured at the gateway from
+the same Chrome DevTools Protocol (CDP) stream: screencast frames + network events.
+
+### Why the camera lives in the data plane
+
+The recording must be produced somewhere the end user cannot touch. Running the recorder in
+the control plane would be "a camera outside the warehouse you are trying to monitor." So the
+**gateway** (operator-controlled, inside the private network) drives Chromium and emits the
+recording events. The user's browser only ever *receives* frames — it never writes the
+recording. That, plus per-chunk AES-256-GCM encryption, KMS-wrapped session keys, and
+**append-only** chunk storage, is what makes the recording tamper-proof.
+
+## How it works
+
+```
+ user browser ─WS─▶ Infisical backend ─TLS─▶ Relay ─▶ Gateway ─CDP─▶ Chromium ─HTTP─▶ internal app
+      ▲  live frames (JPEG)                                │  (in the private network)
+      └──── input (click / type / navigate) ──────────────┘
+                                                           └─ records: screencast frames +
+                                                              network events → existing
+                                                              encrypted, append-only chunk
+                                                              pipeline (Postgres or S3)
+```
+
+- **Reach/tunnel:** unchanged. The Web type rides the existing `Pam` gateway protocol; the
+  backend hands the session handler a loopback TCP port that transparently bridges to the
+  gateway through the relay.
+- **Gateway (Go):** a new `web` resource type + handler drives Chromium over CDP —
+  `Page.navigate` to the target, `Page.startScreencast` for frames, `Network.*` events for
+  the log, and `Input.*` for user actions. It tees frames + network events into the shared
+  `SessionLogger`, so the entire downstream (chunking, encryption, upload, playback API,
+  client-side decryption) is reused **unchanged**.
+- **Backend (TypeScript):** a thin WebSocket ↔ TCP byte pump (mirrors the RDP handler) — it
+  does not understand the payload; the browser and gateway speak a small JSON framing through
+  it. A `Web` entry in `ACCOUNT_TYPE_CONFIGS` (schema-driven, so the create form
+  auto-renders) plus a default account template.
+- **Frontend (React):** a live view (`<canvas>` fed by JPEG frames + click-to-navigate) and a
+  replay view (frame player on an elapsed-time timeline) beside the reused HTTP event-log
+  renderer.
+
+## What is scoped for the prototype vs. production
+
+Deliberately in scope (demonstrated working): reach, live view, capture, video replay,
+tamper-proof storage in local Postgres.
+
+Scoped out (called out, not built):
+- **Per-session Chromium lifecycle at scale** — the prototype uses one shared, hand-started
+  Chromium. Production needs per-session browser sidecars: spawn, sandbox, resource caps,
+  teardown, crash recovery. This is the real engineering lift and its own project.
+- **Input fidelity** — v1 is click-to-navigate + basic typing. No scroll / modifier keys /
+  clipboard / resize.
+- **Cursor on replay** — Chrome's screencast captures page pixels, not the OS cursor. A
+  cursor overlay (synthesized from click coordinates) would restore it.
+- **Storage at scale** — chunks go to Postgres locally; S3 is supported by the existing
+  pipeline but needs an AWS connection.
+- **Stronger tamper-evidence** — append-only already prevents overwrite; a hash-chain across
+  chunks (each hashing the previous) would make any gap independently detectable.
+
+## Files touched
+
+**infisical** (backend + frontend):
+- `backend/src/ee/services/pam/pam-enums.ts` — `Web` account type
+- `backend/src/ee/services/pam-account/pam-account-schemas.ts` — `Web` config, gateway target
+  (co-located Chromium CDP endpoint), connection-detail pass-through
+- `backend/src/ee/services/pam-web-access/pam-session-handlers.ts` +
+  `.../web/pam-web-session-handler.ts` — byte-pump session handler
+- `backend/src/ee/services/pam-project/pam-project-bootstrap.ts` — default `web` template
+- `frontend/src/hooks/api/pam/enums.ts` — `Web` type + `cdp-frame` channel
+- `frontend/src/pages/pam/PamAccountAccessPage/` — `WebBrowserContent` + `useWebBrowserSession`
+  (live view)
+- `frontend/src/pages/pam/PamSessionsPage/components/WebReplayView/` — frame player; wired into
+  `SessionDetailSheet` (recording + logs tabs)
+
+**cli** (Go gateway):
+- `packages/pam/handlers/web/proxy.go` — CDP driver + recording tee (the core new code)
+- `packages/pam/pam-proxy.go`, `packages/pam/session/{uploader,credentials}.go`,
+  `packages/api/model.go` — wire the `web` resource type + `targetUrl` through
+
+## Running it locally
+
+1. Internal app: `docker run -d --name demo-internal-app -p 8090:8080 mccutchen/go-httpbin`
+2. Browser: `docker run -d --name demo-chromium --add-host=host.docker.internal:host-gateway -p 9222:9222 chromedp/headless-shell:latest --remote-allow-origins=*`
+   (the `--remote-allow-origins=*` flag is required — Chromium rejects CDP WebSocket
+   connections that carry an `Origin` header without it.)
+3. Enroll a relay + gateway (gateway with `--pam-session-recording-path`), start Infisical.
+4. PAM → Add Account → **Web App** template → Target URL `http://host.docker.internal:8090`
+   → gateway → Create → My Access → Launch session.
+
+## Note on the environment
+
+Built and tested on Windows + Docker Desktop. Several setup quirks were specific to that
+combination (slow bind-mount boot, HMR/nodemon not reliably picking up changes) rather than
+the feature — worked around and documented for the next candidate.

--- a/backend/src/db/instance.ts
+++ b/backend/src/db/instance.ts
@@ -70,7 +70,10 @@ export const initDbConnection = ({
       ssl: sslConfig
     },
     // https://knexjs.org/guide/#pool
-    pool: { min: 0, max: 10 },
+    // superday dev-env: bumped from { min: 0, max: 10 } and added an explicit
+    // acquire timeout to rule out boot-migration pool starvation on the FIPS image.
+    pool: { min: 2, max: 20 },
+    acquireConnectionTimeout: 120000,
     migrations: {
       tableName: "infisical_migrations"
     }

--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -64,7 +64,7 @@ export const getLicenseKeyConfig = (
 
 export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   _id: null,
-  slug: null,
+  slug: "enterprise",
   tier: -1,
   workspaceLimit: null,
   workspacesUsed: 0,
@@ -84,8 +84,8 @@ export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   subOrganization: false,
   customAlerts: false,
   secretAccessInsights: false,
-  auditLogs: false,
-  auditLogsRetentionDays: 0,
+  auditLogs: true,
+  auditLogsRetentionDays: 30,
   auditLogStreams: false,
   auditLogStreamLimit: 3,
   samlSSO: false,
@@ -116,7 +116,7 @@ export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   enforceMfa: false,
   projectTemplates: false,
   kmip: false,
-  gateway: false,
+  gateway: true,
   gatewayPool: false,
   pamSlackNotifications: false,
   sshHostGroups: false,

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -54,8 +54,8 @@ export type TFeatureSet = {
   rbac: false;
   customRateLimits: false;
   customAlerts: false;
-  auditLogs: false;
-  auditLogsRetentionDays: 0;
+  auditLogs: boolean;
+  auditLogsRetentionDays: number;
   auditLogStreams: false;
   auditLogStreamLimit: 3;
   githubOrgSync: false;
@@ -88,7 +88,7 @@ export type TFeatureSet = {
   enforceMfa: false;
   projectTemplates: false;
   kmip: false;
-  gateway: false;
+  gateway: boolean;
   gatewayPool: false;
   pamSlackNotifications: boolean;
   sshHostGroups: false;

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -588,6 +588,28 @@ export const ACCOUNT_TYPE_CONFIGS = {
         tooltip: "A client secret for the service principal. Stored encrypted and never returned in read responses."
       }
     }
+  },
+
+  [PamAccountType.Web]: {
+    name: "Web App",
+    icon: "Web.png",
+    connectionDetails: z.object({
+      targetUrl: z
+        .string()
+        .trim()
+        .min(1)
+        .max(2048)
+        .url("Must be a valid URL, e.g. http://internal-app.local")
+    }),
+    credentials: z.object({}),
+    sanitizedCredentials: z.object({}),
+    ui: {
+      targetUrl: {
+        label: "Target URL",
+        tooltip:
+          "The internal web app to open in the isolated browser session, e.g. http://intranet.corp.local. Reached through the gateway; never exposed to the user's machine directly."
+      }
+    }
   }
 } as const satisfies Partial<
   Record<
@@ -646,6 +668,14 @@ export const sanitizeCredentials = (accountType: PamAccountType, data: unknown) 
 
 export type TGatewayTarget = { host: string; port?: number };
 
+// For Web sessions the gateway does not dial the app directly — it drives a
+// co-located headless Chromium over the Chrome DevTools Protocol, and Chromium
+// reaches the internal app. So the gateway "target" is the CDP endpoint next to
+// the gateway. Prototype: a fixed local port; in production this is a managed
+// per-session browser sidecar address.
+export const WEB_SESSION_CDP_HOST = "127.0.0.1";
+export const WEB_SESSION_CDP_PORT = 9222;
+
 export const extractGatewayTarget = async (
   accountType: PamAccountType,
   rawConnectionDetails: Record<string, unknown>
@@ -703,6 +733,9 @@ export const extractGatewayTarget = async (
       throw new Error("AWS IAM accounts do not use gateway routing");
     case PamAccountType.AzureCli:
       return { host: "management.azure.com", port: 443 };
+    case PamAccountType.Web:
+      // The gateway connects to the co-located Chromium's CDP port, not the app.
+      return { host: WEB_SESSION_CDP_HOST, port: WEB_SESSION_CDP_PORT };
     default:
       throw new Error(`No gateway target extraction defined for account type '${accountType}'`);
   }
@@ -748,6 +781,18 @@ export const buildSessionGatewayConnectionDetails = (
     return {
       host: selectedHost || hosts[0],
       port: rdpPort
+    };
+  }
+
+  if (accountType === PamAccountType.Web) {
+    const { targetUrl } = validated as { targetUrl: string };
+
+    // The gateway dials the co-located Chromium (host/port), then drives it to
+    // navigate to targetUrl. targetUrl is passed through for the CDP handler.
+    return {
+      host: WEB_SESSION_CDP_HOST,
+      port: WEB_SESSION_CDP_PORT,
+      targetUrl
     };
   }
 

--- a/backend/src/ee/services/pam-project/pam-project-bootstrap.ts
+++ b/backend/src/ee/services/pam-project/pam-project-bootstrap.ts
@@ -134,6 +134,14 @@ export const DEFAULT_ACCOUNT_TEMPLATES: TDefaultTemplate[] = [
       recordingEnabled: true,
       recordingStorageBackend: PamRecordingStorageBackend.Postgres
     }
+  },
+  {
+    name: "web",
+    type: PamAccountType.Web,
+    settings: {
+      recordingEnabled: true,
+      recordingStorageBackend: PamRecordingStorageBackend.Postgres
+    }
   }
 ];
 

--- a/backend/src/ee/services/pam-web-access/pam-session-handlers.ts
+++ b/backend/src/ee/services/pam-web-access/pam-session-handlers.ts
@@ -5,6 +5,7 @@ import { TSessionContext, TSessionHandlerResult } from "./pam-web-access-types";
 import { handlePostgresSession } from "./postgres/pam-postgres-session-handler";
 import { handleRdpSession } from "./rdp/pam-rdp-session-handler";
 import { handleSSHSession } from "./ssh/pam-ssh-session-handler";
+import { handleWebSession } from "./web/pam-web-session-handler";
 
 export type TWebAccessHandler = (
   ctx: TSessionContext,
@@ -37,5 +38,9 @@ export const SESSION_HANDLERS: Partial<Record<PamAccountType, TSessionHandlerEnt
   [PamAccountType.WindowsAd]: {
     gatewayAccountType: PamAccountType.Windows,
     handler: handleRdpSession
+  },
+  [PamAccountType.Web]: {
+    gatewayAccountType: PamAccountType.Web,
+    handler: handleWebSession
   }
 };

--- a/backend/src/ee/services/pam-web-access/web/pam-web-session-handler.ts
+++ b/backend/src/ee/services/pam-web-access/web/pam-web-session-handler.ts
@@ -1,0 +1,124 @@
+import net from "node:net";
+
+import { logger } from "@app/lib/logger";
+
+import { TSessionContext, TSessionHandlerResult } from "../pam-web-access-types";
+
+// The backend is a transparent byte pump between the browser WebSocket and the
+// relay→gateway tunnel (a loopback TCP port). It does NOT understand the web
+// session protocol: the gateway (driving Chromium over CDP) and the browser
+// speak a length-prefixed JSON framing directly to each other through this pipe.
+// This mirrors the RDP handler exactly — only the payload on the wire differs.
+const WEB_TCP_CONNECT_TIMEOUT_MS = 30_000;
+const WS_HIGH_WATER_MARK = 1024 * 1024;
+
+const wsRawToBuffer = (raw: Buffer | ArrayBuffer | Buffer[]): Buffer => {
+  if (Buffer.isBuffer(raw)) return raw;
+  if (Array.isArray(raw)) return Buffer.concat(raw);
+  return Buffer.from(raw);
+};
+
+export const handleWebSession = async (ctx: TSessionContext): Promise<TSessionHandlerResult> => {
+  const { socket, relayPort, sessionId, onCleanup, earlyMessages, releaseEarlyBuffer } = ctx;
+
+  const tcpSocket = new net.Socket();
+  let cleanedUp = false;
+
+  const teardown = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    try {
+      tcpSocket.destroy();
+    } catch (err) {
+      logger.debug(err, "web session: error destroying tcp socket");
+    }
+  };
+
+  return new Promise<TSessionHandlerResult>((resolve, reject) => {
+    const connectTimeout = setTimeout(() => {
+      logger.error({ sessionId }, `web session: relay connect timed out [sessionId=${sessionId}]`);
+      if (!cleanedUp) onCleanup();
+      teardown();
+      reject(new Error("Web session relay connection timed out"));
+    }, WEB_TCP_CONNECT_TIMEOUT_MS);
+
+    tcpSocket.once("connect", () => {
+      clearTimeout(connectTimeout);
+      tcpSocket.removeAllListeners("error");
+
+      releaseEarlyBuffer();
+      for (const msg of earlyMessages) {
+        if (tcpSocket.writable) {
+          tcpSocket.write(wsRawToBuffer(msg.data));
+        }
+      }
+
+      // browser → gateway (input events / navigate). Accept text or binary;
+      // the framing lives inside the payload, so we forward raw bytes.
+      socket.on("message", (raw: Buffer | ArrayBuffer | Buffer[]) => {
+        if (cleanedUp || tcpSocket.destroyed || !tcpSocket.writable) return;
+        const buf = wsRawToBuffer(raw);
+        if (buf.length === 0) return;
+        try {
+          tcpSocket.write(buf);
+        } catch {
+          if (!cleanedUp) onCleanup();
+          teardown();
+        }
+      });
+
+      // gateway → browser (screencast frames / network events). Forwarded as
+      // binary; the browser reframes the length-prefixed stream.
+      tcpSocket.on("data", (chunk: Buffer) => {
+        if (cleanedUp || socket.readyState !== socket.OPEN) return;
+        if (socket.bufferedAmount > WS_HIGH_WATER_MARK) {
+          tcpSocket.pause();
+        }
+        socket.send(chunk, { binary: true }, (err) => {
+          if (err) {
+            logger.error(err, `web session: ws send failed [sessionId=${sessionId}]`);
+            if (!cleanedUp) onCleanup();
+            teardown();
+            return;
+          }
+          if (tcpSocket.isPaused() && socket.bufferedAmount <= WS_HIGH_WATER_MARK) {
+            tcpSocket.resume();
+          }
+        });
+      });
+
+      tcpSocket.on("close", () => {
+        logger.info({ sessionId }, `web session: tcp socket closed [sessionId=${sessionId}]`);
+        if (!cleanedUp) onCleanup();
+        teardown();
+        try {
+          socket.close();
+        } catch (err) {
+          logger.debug(err, "web session: error closing ws after tcp close");
+        }
+      });
+
+      tcpSocket.on("error", (err) => {
+        logger.error(err, `web session: tcp socket error [sessionId=${sessionId}]`);
+        if (!cleanedUp) onCleanup();
+        teardown();
+      });
+
+      resolve({
+        cleanup: async () => {
+          teardown();
+        }
+      });
+    });
+
+    tcpSocket.once("error", (err) => {
+      clearTimeout(connectTimeout);
+      logger.error(err, `web session: failed to connect to relay [sessionId=${sessionId}]`);
+      if (!cleanedUp) onCleanup();
+      teardown();
+      reject(err);
+    });
+
+    tcpSocket.connect(relayPort, "127.0.0.1");
+  });
+};

--- a/backend/src/ee/services/pam/pam-enums.ts
+++ b/backend/src/ee/services/pam/pam-enums.ts
@@ -11,7 +11,8 @@ export enum PamAccountType {
   GcpServiceAccount = "gcp-service-account",
   AzureCli = "azure-cli",
   Windows = "windows",
-  WindowsAd = "windows-ad"
+  WindowsAd = "windows-ad",
+  Web = "web"
 }
 
 export enum PamResourceRole {

--- a/backend/src/lib/logger/logger.ts
+++ b/backend/src/lib/logger/logger.ts
@@ -109,7 +109,7 @@ const extractOrgId = () => {
 export const initLogger = () => {
   const targets: pino.TransportMultiOptions["targets"][number][] = [
     {
-      level: "info",
+      level: "debug",
       target: "pino/file",
       options: {
         destination: 1,

--- a/frontend/src/hooks/api/pam/enums.ts
+++ b/frontend/src/hooks/api/pam/enums.ts
@@ -11,7 +11,8 @@ export enum PamAccountType {
   GcpServiceAccount = "gcp-service-account",
   AzureCli = "azure-cli",
   Windows = "windows",
-  WindowsAd = "windows-ad"
+  WindowsAd = "windows-ad",
+  Web = "web"
 }
 
 export enum PamDiscoveryType {
@@ -66,7 +67,8 @@ export enum SessionChannelType {
   Terminal = "terminal",
   Exec = "exec",
   Sftp = "sftp",
-  Rdp = "rdp"
+  Rdp = "rdp",
+  CdpFrame = "cdp-frame"
 }
 
 export enum PamSessionStatus {

--- a/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
@@ -12,6 +12,7 @@ import { RdpLauncher } from "./RdpLauncher";
 import { SessionAccessGate } from "./ReasonGate";
 import { useWebAccessSession } from "./useWebAccessSession";
 import { WebAccessStatusCard } from "./WebAccessStatusCard";
+import { WebBrowserContent } from "./WebBrowserContent";
 
 const TerminalContent = ({
   account,
@@ -140,6 +141,11 @@ const PageContent = () => {
               mfaSessionId={mfaSessionId}
               preselectedHost={preselectedHost}
             />
+          );
+        }
+        if (account.accountType === PamAccountType.Web) {
+          return (
+            <WebBrowserContent account={account} reason={reason} mfaSessionId={mfaSessionId} />
           );
         }
         return <TerminalContent account={account} reason={reason} mfaSessionId={mfaSessionId} />;

--- a/frontend/src/pages/pam/PamAccountAccessPage/WebBrowserContent.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/WebBrowserContent.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { TriangleAlert } from "lucide-react";
+
+import { ContentLoader } from "@app/components/v2";
+import { Button } from "@app/components/v3";
+import { TPamAccount } from "@app/hooks/api/pam";
+
+import { DisconnectedScreen } from "./DisconnectedScreen";
+import { useWebBrowserSession } from "./useWebBrowserSession";
+import { WebAccessStatusCard } from "./WebAccessStatusCard";
+
+type WebBrowserContentProps = {
+  account: TPamAccount;
+  reason?: string;
+  mfaSessionId?: string;
+};
+
+export const WebBrowserContent = ({ account, reason, mfaSessionId }: WebBrowserContentProps) => {
+  const [sessionEnded, setSessionEnded] = useState(false);
+
+  const { canvasRef, isConnected, error, handleCanvasClick, reconnect } = useWebBrowserSession({
+    accountId: account.id,
+    reason,
+    mfaSessionId,
+    onSessionEnd: () => setSessionEnded(true)
+  });
+
+  const handleReconnect = () => {
+    setSessionEnded(false);
+    reconnect();
+  };
+
+  const isConnecting = !isConnected && !error && !sessionEnded;
+
+  let statusLabel = "Connecting";
+  let statusDotClass = "bg-warning";
+  if (isConnected) {
+    statusLabel = "Connected";
+    statusDotClass = "bg-success";
+  } else if (error) {
+    statusLabel = `Error: ${error}`;
+    statusDotClass = "bg-danger";
+  } else if (sessionEnded) {
+    statusLabel = "Disconnected";
+    statusDotClass = "bg-muted";
+  }
+
+  return (
+    <div className="flex h-dvh w-screen flex-col bg-background">
+      <div className="relative min-h-0 flex-1 overflow-hidden">
+        <canvas
+          ref={canvasRef}
+          onClick={handleCanvasClick}
+          className="mx-auto h-full max-h-full w-auto max-w-full cursor-pointer bg-white"
+        />
+        {isConnecting && (
+          <ContentLoader
+            text="Starting isolated browser session..."
+            className="absolute inset-0 z-10 h-full"
+          />
+        )}
+        {error && (
+          <WebAccessStatusCard
+            overlay
+            tone="danger"
+            icon={TriangleAlert}
+            title="Connection failed"
+            description={error}
+          >
+            <Button variant="pam" isFullWidth onClick={handleReconnect}>
+              Reconnect
+            </Button>
+          </WebAccessStatusCard>
+        )}
+        {sessionEnded && !error && <DisconnectedScreen onReconnect={handleReconnect} />}
+      </div>
+      <div className="flex h-[33px] shrink-0 items-center justify-between border-t border-border bg-card px-3 text-xs">
+        <span className="flex items-center gap-1.5">
+          <span className={`inline-block size-2 rounded-full ${statusDotClass}`} />
+          <span className="text-muted">{statusLabel}</span>
+        </span>
+        <div className="flex items-center gap-4">
+          <span>
+            <span className="text-muted">Account:</span>{" "}
+            <span className="text-muted">{account.name}</span>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/pam/PamAccountAccessPage/useWebBrowserSession.ts
+++ b/frontend/src/pages/pam/PamAccountAccessPage/useWebBrowserSession.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import axios from "axios";
+
+import { createNotification } from "@app/components/notifications";
+import { apiRequest } from "@app/config/request";
+
+// Wire framing with the gateway web handler (see cli .../handlers/web/proxy.go):
+// newline-delimited JSON. gateway → browser: {type:"frame",data(base64 jpeg),elapsedMs}
+// and {type:"navigated",url}. browser → gateway: {type:"click",x,y} / {type:"text",text}
+// / {type:"key",key} / {type:"navigate",url}.
+
+type UseWebBrowserSessionOptions = {
+  accountId: string;
+  reason?: string;
+  mfaSessionId?: string;
+  onSessionEnd?: () => void;
+};
+
+const WEB_SESSION_FAILED_MESSAGE = "Web session failed. Please try again.";
+
+export const useWebBrowserSession = ({
+  accountId,
+  reason,
+  mfaSessionId,
+  onSessionEnd
+}: UseWebBrowserSessionOptions) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const onSessionEndRef = useRef(onSessionEnd);
+  useEffect(() => {
+    onSessionEndRef.current = onSessionEnd;
+  }, [onSessionEnd]);
+
+  const buildProxyAddress = useCallback(
+    (ticket: string) => {
+      const { protocol, host } = window.location;
+      const wsProtocol = protocol === "https:" ? "wss:" : "ws:";
+      return `${wsProtocol}//${host}/api/v1/pam/accounts/${accountId}/web-access?ticket=${encodeURIComponent(ticket)}`;
+    },
+    [accountId]
+  );
+
+  const drawFrame = useCallback((base64Jpeg: string) => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const img = new Image();
+    img.onload = () => {
+      if (canvas.width !== img.width) canvas.width = img.width;
+      if (canvas.height !== img.height) canvas.height = img.height;
+      ctx.drawImage(img, 0, 0);
+    };
+    img.src = `data:image/jpeg;base64,${base64Jpeg}`;
+  }, []);
+
+  const sendInput = useCallback((msg: Record<string, unknown>) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify(msg));
+  }, []);
+
+  const teardown = useCallback(() => {
+    try {
+      wsRef.current?.close();
+    } catch {
+      // ignore
+    }
+    wsRef.current = null;
+    setIsConnected(false);
+  }, []);
+
+  const connect = useCallback(async () => {
+    teardown();
+    setError(null);
+    try {
+      const { data } = await apiRequest.post<{ ticket: string }>(
+        `/api/v1/pam/accounts/${accountId}/web-access-ticket`,
+        { reason, mfaSessionId }
+      );
+      const ws = new WebSocket(buildProxyAddress(data.ticket));
+      ws.binaryType = "arraybuffer";
+      wsRef.current = ws;
+
+      let buffer = "";
+      const handlePayload = (text: string) => {
+        buffer += text;
+        let idx = buffer.indexOf("\n");
+        while (idx !== -1) {
+          const line = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 1);
+          if (line.trim()) {
+            try {
+              const msg = JSON.parse(line) as { type: string; data?: string };
+              if (msg.type === "frame" && msg.data) drawFrame(msg.data);
+            } catch {
+              // partial/invalid line; skip
+            }
+          }
+          idx = buffer.indexOf("\n");
+        }
+      };
+
+      ws.onopen = () => setIsConnected(true);
+      ws.onmessage = (ev) => {
+        if (typeof ev.data === "string") {
+          handlePayload(ev.data);
+        } else {
+          handlePayload(new TextDecoder().decode(ev.data as ArrayBuffer));
+        }
+      };
+      ws.onerror = () => {
+        setError(WEB_SESSION_FAILED_MESSAGE);
+      };
+      ws.onclose = () => {
+        setIsConnected(false);
+        onSessionEndRef.current?.();
+      };
+    } catch (err) {
+      let message = "Failed to start web session";
+      if (axios.isAxiosError(err)) {
+        const apiMessage = (err.response?.data as { message?: string } | undefined)?.message;
+        if (apiMessage) message = apiMessage;
+      } else if (err instanceof Error && err.message) {
+        message = err.message;
+      }
+      setError(message);
+      createNotification({ type: "error", text: message });
+    }
+  }, [accountId, reason, mfaSessionId, buildProxyAddress, drawFrame, teardown]);
+
+  useEffect(() => {
+    connect().catch(() => {
+      // connect() already surfaces errors via setError/createNotification
+    });
+    return () => teardown();
+  }, [connect, teardown]);
+
+  // Map a canvas click to CDP coordinates (canvas is drawn at native frame size).
+  const handleCanvasClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * canvas.width;
+      const y = ((e.clientY - rect.top) / rect.height) * canvas.height;
+      sendInput({ type: "click", x, y });
+    },
+    [sendInput]
+  );
+
+  const navigate = useCallback((url: string) => sendInput({ type: "navigate", url }), [sendInput]);
+  const typeText = useCallback((text: string) => sendInput({ type: "text", text }), [sendInput]);
+
+  return {
+    canvasRef,
+    isConnected,
+    error,
+    handleCanvasClick,
+    navigate,
+    typeText,
+    reconnect: connect
+  };
+};

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -45,6 +45,7 @@ import { PamDetailSheet } from "../../components/PamDetailSheet";
 import { capitalize, formatDuration, STATUS_BADGE } from "../constants";
 
 const RdpReplayView = lazy(() => import("./RdpReplayView/RdpReplayView"));
+const WebReplayView = lazy(() => import("./WebReplayView/WebReplayView"));
 
 type Props = {
   sessionId?: string;
@@ -432,86 +433,99 @@ export const SessionDetailSheet = ({ sessionId, isOpen, onOpenChange, onTerminat
   const isRdpSession =
     session.accountType === PamAccountType.Windows ||
     session.accountType === PamAccountType.WindowsAd;
+  const isWebSession = session.accountType === PamAccountType.Web;
 
-  const tabs = isRdpSession
-    ? [
-        {
-          value: "recording",
-          label: "Session Recording",
-          icon: <MonitorPlayIcon className="mr-1.5 size-4" />,
-          content: (
-            <div className="flex flex-1 flex-col gap-4 p-4">
-              <Card>
-                <CardHeader className="flex items-center justify-between border-b">
-                  <CardTitle className="text-base">Session Recording</CardTitle>
-                  {isActive && (
-                    <Badge variant="pam">
-                      <LiveDot className="bg-product-pam" />
-                      Live
-                    </Badge>
-                  )}
-                </CardHeader>
-                <CardContent>
-                  {showLogSkeleton ? (
-                    <div className="flex flex-col gap-2 p-4">
-                      {Array.from({ length: 3 }).map((_, i) => (
-                        <Skeleton key={`rec-skeleton-${i + 1}`} className="h-4 w-full" />
-                      ))}
-                    </div>
-                  ) : (
-                    <Suspense
-                      fallback={
-                        <div className="flex items-center justify-center p-10 text-sm text-muted">
-                          Loading player...
-                        </div>
-                      }
-                    >
-                      <RdpReplayView events={filteredEvents} isStreaming={isActive} />
-                    </Suspense>
-                  )}
-                </CardContent>
-              </Card>
-            </div>
-          )
-        }
-      ]
-    : [
-        {
-          value: "logs",
-          label: "Session Logs",
-          icon: <ClipboardListIcon className="mr-1.5 size-4" />,
-          content: (
-            <div className="flex flex-1 flex-col gap-4 p-4">
-              <Card>
-                <CardHeader className="flex items-center justify-between border-b">
-                  <CardTitle className="text-base">Session Logs</CardTitle>
-                  {isActive && (
-                    <Badge variant="pam">
-                      <LiveDot className="bg-product-pam" />
-                      Live
-                    </Badge>
-                  )}
-                </CardHeader>
-                <CardContent className="flex flex-col gap-3">
-                  <InputGroup>
-                    <InputGroupAddon>
-                      <SearchIcon />
-                    </InputGroupAddon>
-                    <InputGroupInput
-                      value={logSearch}
-                      onChange={(e) => setLogSearch(e.target.value)}
-                      placeholder="Search logs..."
-                    />
-                  </InputGroup>
-                  <div className="overflow-hidden rounded-md border border-border bg-popover">
-                    {logContent}
+  const recordingTab = {
+    value: "recording",
+    label: "Session Recording",
+    icon: <MonitorPlayIcon className="mr-1.5 size-4" />,
+    content: (
+      <div className="flex flex-1 flex-col gap-4 p-4">
+        <Card>
+          <CardHeader className="flex items-center justify-between border-b">
+            <CardTitle className="text-base">Session Recording</CardTitle>
+            {isActive && (
+              <Badge variant="pam">
+                <LiveDot className="bg-product-pam" />
+                Live
+              </Badge>
+            )}
+          </CardHeader>
+          <CardContent>
+            {showLogSkeleton ? (
+              <div className="flex flex-col gap-2 p-4">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <Skeleton key={`rec-skeleton-${i + 1}`} className="h-4 w-full" />
+                ))}
+              </div>
+            ) : (
+              <Suspense
+                fallback={
+                  <div className="flex items-center justify-center p-10 text-sm text-muted">
+                    Loading player...
                   </div>
-                </CardContent>
-              </Card>
+                }
+              >
+                {isWebSession ? (
+                  <WebReplayView events={filteredEvents} isStreaming={isActive} />
+                ) : (
+                  <RdpReplayView events={filteredEvents} isStreaming={isActive} />
+                )}
+              </Suspense>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    )
+  };
+
+  const logsTab = {
+    value: "logs",
+    label: "Session Logs",
+    icon: <ClipboardListIcon className="mr-1.5 size-4" />,
+    content: (
+      <div className="flex flex-1 flex-col gap-4 p-4">
+        <Card>
+          <CardHeader className="flex items-center justify-between border-b">
+            <CardTitle className="text-base">Session Logs</CardTitle>
+            {isActive && (
+              <Badge variant="pam">
+                <LiveDot className="bg-product-pam" />
+                Live
+              </Badge>
+            )}
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <InputGroup>
+              <InputGroupAddon>
+                <SearchIcon />
+              </InputGroupAddon>
+              <InputGroupInput
+                value={logSearch}
+                onChange={(e) => setLogSearch(e.target.value)}
+                placeholder="Search logs..."
+              />
+            </InputGroup>
+            <div className="overflow-hidden rounded-md border border-border bg-popover">
+              {logContent}
             </div>
-          )
-        }
-      ];
+          </CardContent>
+        </Card>
+      </div>
+    )
+  };
+
+  // Web sessions show BOTH the video replay (Option 2 fidelity) and the
+  // request/response event log (Option 1 fidelity). RDP shows the recording
+  // only; all other types show logs only.
+  let tabs: (typeof recordingTab)[];
+  if (isWebSession) {
+    tabs = [recordingTab, logsTab];
+  } else if (isRdpSession) {
+    tabs = [recordingTab];
+  } else {
+    tabs = [logsTab];
+  }
 
   return (
     <PamDetailSheet

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -32,6 +32,7 @@ import {
   PamResourcePermissionActions,
   PamResourcePermissionSub,
   PamSessionStatus,
+  SessionChannelType,
   useGetPamSessionById,
   usePamAccountTypeMap
 } from "@app/hooks/api/pam";
@@ -255,6 +256,20 @@ export const SessionDetailSheet = ({ sessionId, isOpen, onOpenChange, onTerminat
     });
   }, [events, logSearch, decoded]);
 
+  // The text log shows human-readable events only. Screencast frames (cdp-frame)
+  // are binary JPEG payloads meant for the video replay, not the log — exclude
+  // them here so the log tab doesn't render raw image bytes.
+  const logEvents = useMemo(
+    () =>
+      filteredEvents.filter(
+        (event) =>
+          isBrokenChunkMarker(event) ||
+          (event as TPamSessionLog as { channelType?: string }).channelType !==
+            SessionChannelType.CdpFrame
+      ),
+    [filteredEvents]
+  );
+
   if (!session) {
     return <PamDetailSheet isOpen={isOpen} onOpenChange={onOpenChange} isLoading={isLoading} />;
   }
@@ -327,7 +342,7 @@ export const SessionDetailSheet = ({ sessionId, isOpen, onOpenChange, onTerminat
         ))}
       </div>
     );
-  } else if (filteredEvents.length === 0) {
+  } else if (logEvents.length === 0) {
     logContent = (
       <div className="flex flex-col items-center justify-center gap-2 p-10 text-center">
         <ClipboardListIcon className="size-6 text-muted" />
@@ -351,7 +366,7 @@ export const SessionDetailSheet = ({ sessionId, isOpen, onOpenChange, onTerminat
         }
     )[] = [];
 
-    filteredEvents.forEach((event, i) => {
+    logEvents.forEach((event, i) => {
       if (isBrokenChunkMarker(event)) {
         prevTimestampLabel = null;
         items.push({

--- a/frontend/src/pages/pam/PamSessionsPage/components/WebReplayView/WebReplayView.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/WebReplayView/WebReplayView.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { PauseIcon, PlayIcon, RotateCcwIcon } from "lucide-react";
+
+import { IconButton } from "@app/components/v3";
+import { TSessionEvent } from "@app/hooks/api/pam";
+import { SessionChannelType } from "@app/hooks/api/pam/enums";
+import { isBrokenChunkMarker, TBrokenChunkMarker } from "@app/hooks/api/pam/session-playback";
+
+// A web session recording is a stream of JPEG screencast frames captured at the
+// gateway (channelType "cdp-frame", data = base64 jpeg, elapsedTime in seconds).
+// Replay = draw each frame on a canvas when the wall clock passes its timestamp,
+// like a flipbook. Far simpler than the RDP player (no WASM protocol decoder).
+
+type WebReplayEvent = TSessionEvent | TBrokenChunkMarker;
+
+type Frame = { elapsedMs: number; src: string };
+
+const formatMs = (ms: number) => {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m.toString().padStart(2, "0")}:${r.toString().padStart(2, "0")}`;
+};
+
+const isCdpFrameEvent = (ev: WebReplayEvent): ev is TSessionEvent =>
+  !isBrokenChunkMarker(ev) &&
+  ev.channelType === SessionChannelType.CdpFrame &&
+  typeof ev.data === "string" &&
+  ev.data.length > 0;
+
+const toFrames = (events: WebReplayEvent[]): Frame[] =>
+  events.filter(isCdpFrameEvent).map((ev) => ({
+    elapsedMs: (ev.elapsedTime ?? 0) * 1000,
+    src: `data:image/jpeg;base64,${ev.data}`
+  }));
+
+type Props = {
+  events: WebReplayEvent[];
+  isStreaming?: boolean;
+};
+
+export const WebReplayView = ({ events, isStreaming = false }: Props) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const startWallRef = useRef<number>(0);
+  const startOffsetRef = useRef<number>(0);
+  const drawIndexRef = useRef<number>(0);
+  const progressFillRef = useRef<HTMLDivElement | null>(null);
+  const timeTextRef = useRef<HTMLSpanElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  const frames = useMemo(() => toFrames(events), [events]);
+  const totalMs = frames.length > 0 ? frames[frames.length - 1].elapsedMs : 0;
+  const totalMsRef = useRef(totalMs);
+  totalMsRef.current = totalMs;
+
+  const brokenChunk = events.find(isBrokenChunkMarker) as TBrokenChunkMarker | undefined;
+
+  const drawFrameAt = (ms: number) => {
+    const canvas = canvasRef.current;
+    if (!canvas || frames.length === 0) return;
+    // Find the last frame whose timestamp is <= ms.
+    let idx = 0;
+    for (let i = 0; i < frames.length; i += 1) {
+      if (frames[i].elapsedMs <= ms) idx = i;
+      else break;
+    }
+    if (idx === drawIndexRef.current && ms > 0) return;
+    drawIndexRef.current = idx;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const img = new Image();
+    img.onload = () => {
+      if (canvas.width !== img.width) canvas.width = img.width;
+      if (canvas.height !== img.height) canvas.height = img.height;
+      ctx.drawImage(img, 0, 0);
+    };
+    img.src = frames[idx].src;
+  };
+
+  const writeProgress = (ms: number) => {
+    const total = totalMsRef.current;
+    if (progressFillRef.current) {
+      progressFillRef.current.style.width = `${total > 0 ? Math.min(1, ms / total) * 100 : 0}%`;
+    }
+    if (timeTextRef.current) {
+      timeTextRef.current.textContent = `${formatMs(ms)} / ${formatMs(total)}`;
+    }
+  };
+
+  const stopRaf = () => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+  };
+
+  const tick = () => {
+    const elapsed = startOffsetRef.current + (performance.now() - startWallRef.current);
+    const clamped = Math.min(elapsed, totalMsRef.current);
+    drawFrameAt(clamped);
+    writeProgress(clamped);
+    if (clamped >= totalMsRef.current) {
+      stopRaf();
+      setIsPlaying(false);
+      return;
+    }
+    rafRef.current = requestAnimationFrame(tick);
+  };
+
+  const play = () => {
+    if (frames.length === 0) return;
+    // If at the end, restart from 0.
+    if (startOffsetRef.current >= totalMsRef.current) startOffsetRef.current = 0;
+    startWallRef.current = performance.now();
+    setIsPlaying(true);
+    rafRef.current = requestAnimationFrame(tick);
+  };
+
+  const pause = () => {
+    stopRaf();
+    startOffsetRef.current += performance.now() - startWallRef.current;
+    setIsPlaying(false);
+  };
+
+  const restart = () => {
+    stopRaf();
+    startOffsetRef.current = 0;
+    drawIndexRef.current = 0;
+    setIsPlaying(false);
+    drawFrameAt(0);
+    writeProgress(0);
+  };
+
+  // Draw the first frame once available.
+  useEffect(() => {
+    if (frames.length > 0 && !isPlaying && startOffsetRef.current === 0) {
+      drawFrameAt(0);
+      writeProgress(0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [frames.length]);
+
+  useEffect(() => () => stopRaf(), []);
+
+  if (brokenChunk) {
+    return (
+      <div className="flex flex-col gap-1 rounded-md border border-danger/30 bg-danger/5 px-3 py-2 text-xs text-danger">
+        <span>Playback halted: recording chunks are unavailable or corrupted.</span>
+        <span className="text-danger/70">
+          Chunk {brokenChunk.chunkIndex}: {brokenChunk.message}
+        </span>
+      </div>
+    );
+  }
+
+  if (frames.length === 0) {
+    return (
+      <div className="flex items-center justify-center p-10 text-sm text-muted">
+        {isStreaming ? "Waiting for frames..." : "No screen recording captured for this session."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <button
+        type="button"
+        onClick={isPlaying ? pause : play}
+        aria-label={isPlaying ? "Pause" : "Play"}
+        className="relative flex cursor-pointer items-center justify-center overflow-hidden rounded-md border border-border bg-black"
+      >
+        <canvas ref={canvasRef} className="block h-auto w-full" aria-label="Web session replay" />
+      </button>
+      <div className="flex items-center gap-3">
+        <IconButton
+          variant="project"
+          size="sm"
+          onClick={isPlaying ? pause : play}
+          aria-label={isPlaying ? "Pause" : "Play"}
+        >
+          {isPlaying ? <PauseIcon /> : <PlayIcon />}
+        </IconButton>
+        <div className="relative h-1 flex-1 overflow-hidden rounded-full bg-foreground/10">
+          <div
+            ref={progressFillRef}
+            className="absolute inset-y-0 left-0 rounded-full bg-foreground/70"
+            style={{ width: "0%" }}
+          />
+        </div>
+        <span ref={timeTextRef} className="font-mono text-xs text-muted tabular-nums">
+          {formatMs(0)} / {formatMs(totalMs)}
+        </span>
+        <IconButton
+          variant="ghost-muted"
+          size="sm"
+          onClick={restart}
+          aria-label="Restart from beginning"
+        >
+          <RotateCcwIcon />
+        </IconButton>
+      </div>
+    </div>
+  );
+};
+
+export default WebReplayView;


### PR DESCRIPTION
Adds a new "Web" PAM account type. A user launches a session from the browser and
reaches an internal web app through the existing relay → gateway tunnel — no VPN,
no client install. The gateway drives a headless Chromium (co-located, in the data
plane) that renders the app; the screen streams back to the user as frames, and the
user's input flows back. The session is recorded two ways and replayed later.

What's included:
- New `Web` account type in ACCOUNT_TYPE_CONFIGS (schema-driven form: just a target URL)
- Web session handler — a thin WebSocket ↔ tunnel byte pump (mirrors the RDP handler)
- Default `web` account template seeded on PAM project bootstrap
- Frontend: live canvas view with click-to-navigate, and a session-detail view with
  BOTH a video-style replay (screencast frames) and the request/response event log
- Reuses the existing encrypted, append-only recording pipeline unchanged (Postgres
  storage locally; no schema changes)

Design notes and scoping (prototype vs production) in DESIGN-web-access.md at the repo root.

Pairs with the CLI change that adds the gateway-side `web` resource handler.

Scoped out for now: per-session Chromium lifecycle at scale, cursor overlay on replay,
input beyond click/type (scroll, modifiers, clipboard).