### PR TITLE
fix: update upgrade plan modal link

### DIFF
--- a/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
+++ b/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
@@ -44,7 +44,7 @@ export const UpgradePlanModal = ({
       return "https://infisical.com/talk-to-us";
     }
 
-    return "/organization/billing" as const;
+    return `/organizations/${currentOrg?.id}/billing` as const;
   };
 
   const link = getLink();

--- a/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
+++ b/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
@@ -44,7 +44,8 @@ export const UpgradePlanModal = ({
       return "https://infisical.com/talk-to-us";
     }
 
-    return `/organizations/${currentOrg?.id}/billing` as const;
+    const billingUri = `/organizations/${currentOrg?.rootOrgId ?? currentOrg?.id}/billing`;
+    return billingUri;
   };
 
   const link = getLink();


### PR DESCRIPTION
## Context

- Clicking Upgrade Plan in the UpgradePlanModal navigated to `/organization/billing`, which is not a valid route (the actual route is `/organizations/$orgId/billing`). Users landed on a 404 page instead of billing.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)