### PR TITLE
fix(pam): aws iam role arn validation

### DIFF
--- a/backend/e2e-test/routes/v1/pam-account.spec.ts
+++ b/backend/e2e-test/routes/v1/pam-account.spec.ts
@@ -39,7 +39,8 @@ describe("PAM AWS IAM Account Router - roleArn validation", () => {
     "arn:aws:iam::123456789012:role/my-role",
     "arn:aws:iam::123456789012:role/service-role/my-role",
     "arn:aws-us-gov:iam::123456789012:role/gov-role",
-    "arn:aws-cn:iam::123456789012:role/cn-role"
+    "arn:aws-cn:iam::123456789012:role/cn-role",
+    "arn:aws-iso-b:iam::123456789012:role/iso-b-role"
   ])("accepts well-formed role ARN (passes format validation): %s", async (roleArn) => {
     const res = await createAwsIamAccount(roleArn);
     // The ARN format check passes; the request then fails downstream on the dummy

--- a/backend/e2e-test/routes/v1/pam-account.spec.ts
+++ b/backend/e2e-test/routes/v1/pam-account.spec.ts
@@ -1,0 +1,51 @@
+// Exercises the AWS IAM PAM account roleArn format validation (pam-account-schemas.ts)
+// through the real HTTP route with JWT auth, so a malformed ARN is rejected up front
+// (422 ValidationFailure) instead of only failing later at AssumeRole time.
+
+// Valid-format UUIDs that intentionally don't reference real rows, so the only body-level
+// validation issue is the roleArn itself.
+const DUMMY_UUID = "00000000-0000-4000-8000-000000000000";
+
+const createAwsIamAccount = (roleArn: string) =>
+  testServer.inject({
+    method: "POST",
+    url: "/api/v1/pam/accounts/aws-iam",
+    headers: {
+      authorization: `Bearer ${jwtAuthToken}`
+    },
+    body: {
+      name: "arn-validation-test",
+      folderId: DUMMY_UUID,
+      templateId: DUMMY_UUID,
+      connectionDetails: { roleArn },
+      credentials: {}
+    }
+  });
+
+describe("PAM AWS IAM Account Router - roleArn validation", () => {
+  test.each([
+    "not-an-arn",
+    "arn:aws:iam::123456789012:user/my-user", // user, not role
+    "arn:aws:iam::12345:role/my-role", // account id not 12 digits
+    "arn:aws:s3:::my-bucket", // wrong service
+    "arn:aws:iam::123456789012:role/" // empty role name
+  ])("rejects malformed role ARN: %s", async (roleArn) => {
+    const res = await createAwsIamAccount(roleArn);
+    expect(res.statusCode).toBe(422);
+    expect(res.payload).toContain("valid IAM role ARN");
+  });
+
+  test.each([
+    "arn:aws:iam::123456789012:role/my-role",
+    "arn:aws:iam::123456789012:role/service-role/my-role",
+    "arn:aws-us-gov:iam::123456789012:role/gov-role",
+    "arn:aws-cn:iam::123456789012:role/cn-role"
+  ])("accepts well-formed role ARN (passes format validation): %s", async (roleArn) => {
+    const res = await createAwsIamAccount(roleArn);
+    // The ARN format check passes; the request then fails downstream on the dummy
+    // folder/template lookup, NOT on ARN validation. So it must not be a 422 that
+    // references the ARN rule.
+    expect(res.statusCode).not.toBe(422);
+    expect(res.payload).not.toContain("valid IAM role ARN");
+  });
+});

--- a/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
@@ -8,7 +8,8 @@ import {
   isCredentialConfigured,
   PamAccountAccessibilityIssue,
   PamAccountTypeMetadataSchema,
-  PamFieldDescriptorSchema
+  PamFieldDescriptorSchema,
+  validateConnectionDetails
 } from "./pam-account-schemas";
 
 // These assertions exercise the Zod-introspection path (buildPamAccountTypeMetadata reads schema internals to derive field descriptors)
@@ -206,6 +207,41 @@ describe("isCredentialConfigured", () => {
     expect(isCredentialConfigured(PamAccountType.SSH, { authMethod: "public-key" })).toBe(false);
 
     expect(isCredentialConfigured(PamAccountType.SSH, { authMethod: "certificate" })).toBe(true);
+  });
+});
+
+describe("validateConnectionDetails (AWS IAM roleArn)", () => {
+  test("accepts valid role ARNs across partitions and paths", () => {
+    const valid = [
+      "arn:aws:iam::123456789012:role/my-role",
+      "arn:aws:iam::123456789012:role/service-role/my-role",
+      "arn:aws:iam::123456789012:role/team.dev/deploy@svc+build",
+      "arn:aws-us-gov:iam::123456789012:role/gov-role",
+      "arn:aws-cn:iam::123456789012:role/cn-role"
+    ];
+    valid.forEach((roleArn) => {
+      expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn })).not.toThrow();
+    });
+  });
+
+  test("trims surrounding whitespace before validating", () => {
+    const result = validateConnectionDetails(PamAccountType.AwsIam, {
+      roleArn: "  arn:aws:iam::123456789012:role/my-role  "
+    });
+    expect(result).toEqual({ roleArn: "arn:aws:iam::123456789012:role/my-role" });
+  });
+
+  test("rejects malformed ARNs", () => {
+    const invalid = [
+      "not-an-arn",
+      "arn:aws:iam::123456789012:user/my-user", // user, not role
+      "arn:aws:iam::12345:role/my-role", // account id not 12 digits
+      "arn:aws:s3:::my-bucket", // wrong service
+      "arn:aws:iam::123456789012:role/" // empty role name
+    ];
+    invalid.forEach((roleArn) => {
+      expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn })).toThrow();
+    });
   });
 });
 

--- a/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
@@ -210,23 +210,17 @@ describe("isCredentialConfigured", () => {
   });
 });
 
+// Exhaustive ARN accept/reject cases live in lib/validator/validate-aws-arn.test.ts. These assert the
+// schema is actually wired to that validator and applies its own trimming.
 describe("validateConnectionDetails (AWS IAM roleArn)", () => {
-  test("accepts valid role ARNs across partitions and paths", () => {
-    const valid = [
-      "arn:aws:iam::123456789012:role/my-role",
-      "arn:aws:iam::123456789012:role/service-role/my-role",
-      "arn:aws:iam::123456789012:role/team.dev/deploy@svc+build",
-      "arn:aws-us-gov:iam::123456789012:role/gov-role",
-      "arn:aws-cn:iam::123456789012:role/cn-role",
-      // future-proofing: ISO partitions and any hyphenated partition AWS may add
-      "arn:aws-iso:iam::123456789012:role/iso-role",
-      "arn:aws-iso-b:iam::123456789012:role/iso-b-role",
-      // IAM role paths allow the full printable-ASCII range, not just role-name characters
-      "arn:aws:iam::123456789012:role/odd!path$/role_name"
-    ];
-    valid.forEach((roleArn) => {
-      expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn })).not.toThrow();
-    });
+  test("accepts a valid role ARN", () => {
+    expect(() =>
+      validateConnectionDetails(PamAccountType.AwsIam, { roleArn: "arn:aws:iam::123456789012:role/my-role" })
+    ).not.toThrow();
+  });
+
+  test("rejects a malformed role ARN", () => {
+    expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn: "not-an-arn" })).toThrow();
   });
 
   test("trims surrounding whitespace before validating", () => {
@@ -234,21 +228,6 @@ describe("validateConnectionDetails (AWS IAM roleArn)", () => {
       roleArn: "  arn:aws:iam::123456789012:role/my-role  "
     });
     expect(result).toEqual({ roleArn: "arn:aws:iam::123456789012:role/my-role" });
-  });
-
-  test("rejects malformed ARNs", () => {
-    const invalid = [
-      "not-an-arn",
-      "arn:aws:iam::123456789012:user/my-user", // user, not role
-      "arn:aws:iam::12345:role/my-role", // account id not 12 digits
-      "arn:aws:s3:::my-bucket", // wrong service
-      "arn:aws:iam::123456789012:role/", // empty role name
-      "arn:awsx:iam::123456789012:role/my-role", // partition must be aws or aws-<segment>, not an arbitrary suffix
-      "arn:aws:iam::123456789012:role/has space" // resource may not contain spaces / control chars
-    ];
-    invalid.forEach((roleArn) => {
-      expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn })).toThrow();
-    });
   });
 });
 

--- a/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
@@ -217,7 +217,10 @@ describe("validateConnectionDetails (AWS IAM roleArn)", () => {
       "arn:aws:iam::123456789012:role/service-role/my-role",
       "arn:aws:iam::123456789012:role/team.dev/deploy@svc+build",
       "arn:aws-us-gov:iam::123456789012:role/gov-role",
-      "arn:aws-cn:iam::123456789012:role/cn-role"
+      "arn:aws-cn:iam::123456789012:role/cn-role",
+      // future-proofing: ISO partitions and any hyphenated partition AWS may add
+      "arn:aws-iso:iam::123456789012:role/iso-role",
+      "arn:aws-iso-b:iam::123456789012:role/iso-b-role"
     ];
     valid.forEach((roleArn) => {
       expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn })).not.toThrow();
@@ -237,7 +240,8 @@ describe("validateConnectionDetails (AWS IAM roleArn)", () => {
       "arn:aws:iam::123456789012:user/my-user", // user, not role
       "arn:aws:iam::12345:role/my-role", // account id not 12 digits
       "arn:aws:s3:::my-bucket", // wrong service
-      "arn:aws:iam::123456789012:role/" // empty role name
+      "arn:aws:iam::123456789012:role/", // empty role name
+      "arn:awsx:iam::123456789012:role/my-role" // partition must be aws or aws-<segment>, not an arbitrary suffix
     ];
     invalid.forEach((roleArn) => {
       expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn })).toThrow();

--- a/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
@@ -220,7 +220,9 @@ describe("validateConnectionDetails (AWS IAM roleArn)", () => {
       "arn:aws-cn:iam::123456789012:role/cn-role",
       // future-proofing: ISO partitions and any hyphenated partition AWS may add
       "arn:aws-iso:iam::123456789012:role/iso-role",
-      "arn:aws-iso-b:iam::123456789012:role/iso-b-role"
+      "arn:aws-iso-b:iam::123456789012:role/iso-b-role",
+      // IAM role paths allow the full printable-ASCII range, not just role-name characters
+      "arn:aws:iam::123456789012:role/odd!path$/role_name"
     ];
     valid.forEach((roleArn) => {
       expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn })).not.toThrow();
@@ -241,7 +243,8 @@ describe("validateConnectionDetails (AWS IAM roleArn)", () => {
       "arn:aws:iam::12345:role/my-role", // account id not 12 digits
       "arn:aws:s3:::my-bucket", // wrong service
       "arn:aws:iam::123456789012:role/", // empty role name
-      "arn:awsx:iam::123456789012:role/my-role" // partition must be aws or aws-<segment>, not an arbitrary suffix
+      "arn:awsx:iam::123456789012:role/my-role", // partition must be aws or aws-<segment>, not an arbitrary suffix
+      "arn:aws:iam::123456789012:role/has space" // resource may not contain spaces / control chars
     ];
     invalid.forEach((roleArn) => {
       expect(() => validateConnectionDetails(PamAccountType.AwsIam, { roleArn })).toThrow();

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -534,12 +534,13 @@ export const ACCOUNT_TYPE_CONFIGS = {
         .trim()
         .min(1)
         .max(2048)
-        // Partition is matched as `aws` plus optional hyphenated segments so this stays valid for
-        // every current partition (aws, aws-cn, aws-us-gov, the aws-iso* family) and any AWS adds
-        // later, without re-touching this regex. Structure is still enforced: IAM service, empty
-        // region, 12-digit account, and a role resource.
+        // Matches every valid IAM role ARN without enumerating specifics that can grow:
+        //  - partition: `aws` plus optional hyphenated segments (aws, aws-cn, aws-us-gov, aws-iso*, future)
+        //  - service is always `iam`, region is always empty, account id is 12 digits
+        //  - resource is `role/` + path/name, whose characters AWS defines as printable ASCII
+        //    (0x21 to 0x7F); using that full range keeps unusual-but-valid role paths from being rejected
         .regex(
-          new RE2(/^arn:aws(-[a-z]+)*:iam::\d{12}:role\/[\w+=,.@/-]+$/),
+          new RE2(/^arn:aws(-[a-z]+)*:iam::\d{12}:role\/[\x21-\x7F]+$/),
           "Must be a valid IAM role ARN (e.g. arn:aws:iam::123456789012:role/my-role)"
         )
     }),

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -534,8 +534,12 @@ export const ACCOUNT_TYPE_CONFIGS = {
         .trim()
         .min(1)
         .max(2048)
+        // Partition is matched as `aws` plus optional hyphenated segments so this stays valid for
+        // every current partition (aws, aws-cn, aws-us-gov, the aws-iso* family) and any AWS adds
+        // later, without re-touching this regex. Structure is still enforced: IAM service, empty
+        // region, 12-digit account, and a role resource.
         .regex(
-          new RE2(/^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/[\w+=,.@/-]+$/),
+          new RE2(/^arn:aws(-[a-z]+)*:iam::\d{12}:role\/[\w+=,.@/-]+$/),
           "Must be a valid IAM role ARN (e.g. arn:aws:iam::123456789012:role/my-role)"
         )
     }),

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -529,7 +529,15 @@ export const ACCOUNT_TYPE_CONFIGS = {
     icon: "Amazon Web Services.png",
     requiresGateway: false,
     connectionDetails: z.object({
-      roleArn: z.string().trim().min(1).max(2048)
+      roleArn: z
+        .string()
+        .trim()
+        .min(1)
+        .max(2048)
+        .regex(
+          new RE2(/^arn:aws(-cn|-us-gov)?:iam::\d{12}:role\/[\w+=,.@/-]+$/),
+          "Must be a valid IAM role ARN (e.g. arn:aws:iam::123456789012:role/my-role)"
+        )
     }),
     credentials: z.object({}),
     sanitizedCredentials: z.object({}),

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -6,6 +6,7 @@ import { promisify } from "util";
 import { z } from "zod";
 
 import { BadRequestError } from "@app/lib/errors";
+import { isAwsIamRoleArn } from "@app/lib/validator";
 
 import { GcpServiceAccountAuthMethod, PamAccountType, PamSshAuthMethod } from "../pam/pam-enums";
 import { getApplicablePolicies, PamPolicyDescriptorSchema } from "../pam/pam-policies";
@@ -534,15 +535,7 @@ export const ACCOUNT_TYPE_CONFIGS = {
         .trim()
         .min(1)
         .max(2048)
-        // Matches every valid IAM role ARN without enumerating specifics that can grow:
-        //  - partition: `aws` plus optional hyphenated segments (aws, aws-cn, aws-us-gov, aws-iso*, future)
-        //  - service is always `iam`, region is always empty, account id is 12 digits
-        //  - resource is `role/` + path/name, whose characters AWS defines as printable ASCII
-        //    (0x21 to 0x7F); using that full range keeps unusual-but-valid role paths from being rejected
-        .regex(
-          new RE2(/^arn:aws(-[a-z]+)*:iam::\d{12}:role\/[\x21-\x7F]+$/),
-          "Must be a valid IAM role ARN (e.g. arn:aws:iam::123456789012:role/my-role)"
-        )
+        .refine(isAwsIamRoleArn, "Must be a valid IAM role ARN (e.g. arn:aws:iam::123456789012:role/my-role)")
     }),
     credentials: z.object({}),
     sanitizedCredentials: z.object({}),

--- a/backend/src/lib/validator/index.ts
+++ b/backend/src/lib/validator/index.ts
@@ -1,6 +1,7 @@
 export { matchesAllowedEmailDomain } from "./email-domain-matcher";
 export type { TValidatedHost } from "./safe-request";
 export { buildSsrfSafeAgent, safeRequest } from "./safe-request";
+export { isAwsIamRoleArn } from "./validate-aws-arn";
 export { isDisposableEmail, isValidEmailDomain, sanitizeEmail, validateEmail } from "./validate-email";
 export { isValidFolderName, isValidSecretPath } from "./validate-folder-name";
 export {

--- a/backend/src/lib/validator/validate-aws-arn.test.ts
+++ b/backend/src/lib/validator/validate-aws-arn.test.ts
@@ -10,8 +10,9 @@ describe("isAwsIamRoleArn", () => {
     "arn:aws-cn:iam::123456789012:role/cn-role",
     "arn:aws-iso:iam::123456789012:role/iso-role",
     "arn:aws-iso-b:iam::123456789012:role/iso-b-role",
-    // IAM role paths allow the full printable-ASCII range, not just role-name characters
+    // resource is matched permissively (any non-whitespace) so unusual-but-valid role paths/names pass
     "arn:aws:iam::123456789012:role/odd!path$/role_name",
+    "arn:aws:iam::123456789012:role/team#svc|role~name",
     "arn:aws:iam::123456789012:role/aws-service-role/elasticbeanstalk.amazonaws.com/AWSServiceRoleForElasticBeanstalk"
   ])("accepts valid role ARN: %s", (arn) => {
     expect(isAwsIamRoleArn(arn)).toBe(true);

--- a/backend/src/lib/validator/validate-aws-arn.test.ts
+++ b/backend/src/lib/validator/validate-aws-arn.test.ts
@@ -10,9 +10,8 @@ describe("isAwsIamRoleArn", () => {
     "arn:aws-cn:iam::123456789012:role/cn-role",
     "arn:aws-iso:iam::123456789012:role/iso-role",
     "arn:aws-iso-b:iam::123456789012:role/iso-b-role",
-    // resource is matched permissively (any non-whitespace) so unusual-but-valid role paths/names pass
+    // path may use AWS's broad path charset (here `!` and `$`), while the final name stays valid
     "arn:aws:iam::123456789012:role/odd!path$/role_name",
-    "arn:aws:iam::123456789012:role/team#svc|role~name",
     "arn:aws:iam::123456789012:role/aws-service-role/elasticbeanstalk.amazonaws.com/AWSServiceRoleForElasticBeanstalk"
   ])("accepts valid role ARN: %s", (arn) => {
     expect(isAwsIamRoleArn(arn)).toBe(true);
@@ -26,7 +25,9 @@ describe("isAwsIamRoleArn", () => {
     "arn:aws:iam:us-east-1:123456789012:role/regional", // IAM ARNs have no region
     "arn:aws:iam::123456789012:role/", // empty role name
     "arn:awsx:iam::123456789012:role/my-role", // partition must be aws or aws-<segment>
-    "arn:aws:iam::123456789012:role/has space" // resource may not contain spaces / control chars
+    "arn:aws:iam::123456789012:role/has space", // resource may not contain spaces / control chars
+    "arn:aws:iam::123456789012:role/team#svc|role~name", // invalid characters in role name
+    "arn:aws:iam::123456789012:role/service-role/foo#bar" // invalid character in name segment (after a valid path)
   ])("rejects invalid role ARN: %s", (arn) => {
     expect(isAwsIamRoleArn(arn)).toBe(false);
   });

--- a/backend/src/lib/validator/validate-aws-arn.test.ts
+++ b/backend/src/lib/validator/validate-aws-arn.test.ts
@@ -1,0 +1,32 @@
+import { isAwsIamRoleArn } from "./validate-aws-arn";
+
+describe("isAwsIamRoleArn", () => {
+  test.each([
+    "arn:aws:iam::123456789012:role/my-role",
+    "arn:aws:iam::123456789012:role/service-role/my-role",
+    "arn:aws:iam::123456789012:role/team.dev/deploy@svc+build",
+    // partitions: standard, GovCloud, China, ISO family, and any future hyphenated partition
+    "arn:aws-us-gov:iam::123456789012:role/gov-role",
+    "arn:aws-cn:iam::123456789012:role/cn-role",
+    "arn:aws-iso:iam::123456789012:role/iso-role",
+    "arn:aws-iso-b:iam::123456789012:role/iso-b-role",
+    // IAM role paths allow the full printable-ASCII range, not just role-name characters
+    "arn:aws:iam::123456789012:role/odd!path$/role_name",
+    "arn:aws:iam::123456789012:role/aws-service-role/elasticbeanstalk.amazonaws.com/AWSServiceRoleForElasticBeanstalk"
+  ])("accepts valid role ARN: %s", (arn) => {
+    expect(isAwsIamRoleArn(arn)).toBe(true);
+  });
+
+  test.each([
+    "not-an-arn",
+    "arn:aws:iam::123456789012:user/my-user", // user, not role
+    "arn:aws:iam::12345:role/my-role", // account id not 12 digits
+    "arn:aws:s3:::my-bucket", // wrong service
+    "arn:aws:iam:us-east-1:123456789012:role/regional", // IAM ARNs have no region
+    "arn:aws:iam::123456789012:role/", // empty role name
+    "arn:awsx:iam::123456789012:role/my-role", // partition must be aws or aws-<segment>
+    "arn:aws:iam::123456789012:role/has space" // resource may not contain spaces / control chars
+  ])("rejects invalid role ARN: %s", (arn) => {
+    expect(isAwsIamRoleArn(arn)).toBe(false);
+  });
+});

--- a/backend/src/lib/validator/validate-aws-arn.ts
+++ b/backend/src/lib/validator/validate-aws-arn.ts
@@ -1,12 +1,12 @@
 import RE2 from "re2";
 
-// Validates the STRUCTURE of an AWS IAM role ARN while staying permissive about the parts that vary, so a
-// legitimate role name/path is never rejected. Being slightly over-permissive on the resource is intentional;
-// the value is in the structural anchors:
+// Validates the structure of an AWS IAM role ARN, matching each segment to what AWS actually allows so a
+// legitimate role is never rejected:
 //  - partition: `aws` plus optional hyphenated segments (aws, aws-cn, aws-us-gov, aws-iso*, and any AWS adds later)
 //  - service is always `iam`, region is always empty, account id is 12 digits
-//  - resource: `role/` followed by any non-whitespace path/name. AWS's documented charset (role names
-//    [\w+=,.@-], paths ASCII 0x21-0x7E) is a subset of non-whitespace, so \S+ accepts every valid value.
-const AWS_IAM_ROLE_ARN_PATTERN = new RE2(/^arn:aws(-[a-z0-9]+)*:iam::\d{12}:role\/\S+$/);
+//  - resource: `role/`, an optional path (AWS's broad path charset, ASCII 0x21-0x7E, may include slashes),
+//    then the role name. The name uses AWS's RoleName charset ([\w+=,.@-]), so an invalid name is caught here
+//    instead of passing through to a later AssumeRole failure.
+const AWS_IAM_ROLE_ARN_PATTERN = new RE2(/^arn:aws(-[a-z0-9]+)*:iam::\d{12}:role\/([\x21-\x7e]*\/)?[\w+=,.@-]+$/);
 
 export const isAwsIamRoleArn = (value: string) => AWS_IAM_ROLE_ARN_PATTERN.test(value);

--- a/backend/src/lib/validator/validate-aws-arn.ts
+++ b/backend/src/lib/validator/validate-aws-arn.ts
@@ -1,0 +1,10 @@
+import RE2 from "re2";
+
+// Matches every valid AWS IAM role ARN without enumerating parts that can grow:
+//  - partition: `aws` plus optional hyphenated segments (aws, aws-cn, aws-us-gov, aws-iso*, and any AWS adds later)
+//  - service is always `iam`, region is always empty, account id is 12 digits
+//  - resource is `role/` + path/name, matched against the printable-ASCII range AWS documents for
+//    IAM paths (0x21 to 0x7F), so unusual-but-valid role paths (e.g. service-linked role paths) are not rejected
+const AWS_IAM_ROLE_ARN_PATTERN = new RE2(/^arn:aws(-[a-z]+)*:iam::\d{12}:role\/[\x21-\x7F]+$/);
+
+export const isAwsIamRoleArn = (value: string) => AWS_IAM_ROLE_ARN_PATTERN.test(value);

--- a/backend/src/lib/validator/validate-aws-arn.ts
+++ b/backend/src/lib/validator/validate-aws-arn.ts
@@ -1,10 +1,12 @@
 import RE2 from "re2";
 
-// Matches every valid AWS IAM role ARN without enumerating parts that can grow:
+// Validates the STRUCTURE of an AWS IAM role ARN while staying permissive about the parts that vary, so a
+// legitimate role name/path is never rejected. Being slightly over-permissive on the resource is intentional;
+// the value is in the structural anchors:
 //  - partition: `aws` plus optional hyphenated segments (aws, aws-cn, aws-us-gov, aws-iso*, and any AWS adds later)
 //  - service is always `iam`, region is always empty, account id is 12 digits
-//  - resource is `role/` + path/name, matched against the printable-ASCII range AWS documents for
-//    IAM paths (0x21 to 0x7F), so unusual-but-valid role paths (e.g. service-linked role paths) are not rejected
-const AWS_IAM_ROLE_ARN_PATTERN = new RE2(/^arn:aws(-[a-z]+)*:iam::\d{12}:role\/[\x21-\x7F]+$/);
+//  - resource: `role/` followed by any non-whitespace path/name. AWS's documented charset (role names
+//    [\w+=,.@-], paths ASCII 0x21-0x7E) is a subset of non-whitespace, so \S+ accepts every valid value.
+const AWS_IAM_ROLE_ARN_PATTERN = new RE2(/^arn:aws(-[a-z0-9]+)*:iam::\d{12}:role\/\S+$/);
 
 export const isAwsIamRoleArn = (value: string) => AWS_IAM_ROLE_ARN_PATTERN.test(value);


### PR DESCRIPTION
## Context

When creating or updating an AWS IAM PAM account, the `roleArn` connection detail was only validated
for presence and length (`z.string().trim().min(1).max(2048)`), with no format check. A malformed value
(a typo, a non-role ARN, a wrong account id) was accepted at input time and only surfaced later as a
failed AssumeRole with a less clear error.

This adds a format check on `roleArn` so the value is validated at input with a clear message. The check
keeps the fixed parts of the ARN strict and the parts that vary permissive, so it accepts every valid IAM
role ARN and rejects only clearly malformed input:

- Partition is `aws` plus optional hyphenated segments, so it stays valid for `aws`, `aws-cn`,
  `aws-us-gov`, the `aws-iso*` family, and any partition AWS adds later.
- Service must be `iam`, region must be empty (IAM is global), and the account id must be 12 digits.
- The resource must be `role/`, an optional path (AWS's broad path charset), then the role name. The name
  uses AWS's `RoleName` charset (`[\w+=,.@-]`), so an invalid name is caught here rather than passing
  through to a later AssumeRole failure, while unusual-but-valid paths (such as service-linked roles) still
  pass.

Before: any non-empty string up to 2048 chars was accepted, and bad ARNs failed later at AssumeRole.
After: the ARN structure is checked at create and update with a clear message, and malformed values are
rejected right away.

Scope note: this change is limited to the PAM AWS IAM account field. Other AWS role ARN inputs (app
connection, dynamic secrets, external KMS) have the same length-only pattern and can be handled separately.

Changed files:

- `backend/src/lib/validator/validate-aws-arn.ts`: new reusable `isAwsIamRoleArn` helper (RE2), following
  the existing validator pattern (`isUuidV4`, `validateEmail`).
- `backend/src/lib/validator/validate-aws-arn.test.ts`: accept and reject coverage for the helper
  (partitions, paths, unusual resource characters, and malformed input).
- `backend/src/lib/validator/index.ts`: export the helper from the barrel.
- `backend/src/ee/services/pam-account/pam-account-schemas.ts`: refine the AWS IAM `roleArn` connection
  detail through `isAwsIamRoleArn`.
- `backend/src/ee/services/pam-account/pam-account-schemas.test.ts`: schema-level wiring and trim assertions.
- `backend/e2e-test/routes/v1/pam-account.spec.ts`: e2e coverage through the authenticated
  `POST /api/v1/pam/accounts/aws-iam` route.

## Screenshots

<!-- Not applicable (no UI change; backend input validation only). -->

## Steps to verify the change

- Manual: in Privileged Access Management, add an AWS IAM account and enter a malformed Role ARN (for
  example `not-an-arn` or `arn:aws:iam::12345:role/x`). The request is rejected with "Must be a valid IAM
  role ARN (e.g. arn:aws:iam::123456789012:role/my-role)". A well-formed ARN (for example
  `arn:aws:iam::123456789012:role/my-role`) passes and proceeds as before.
- Automated (unit): `cd backend && npm run test:unit`. `validate-aws-arn.test.ts` covers accepted ARNs
  (standard, GovCloud, China, ISO partitions, multi-segment paths, unusual path characters) and rejected
  input (non-role, wrong service, wrong account id, regional, empty role name, invalid role-name
  characters, whitespace).
  `pam-account-schemas.test.ts` checks that the schema uses the helper and trims input.
- Automated (e2e): `cd backend && npm run test:e2e -- pam-account` hits the authenticated route and checks
  that malformed ARNs return 422 and well-formed ARNs pass the format check.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
