### PR TITLE
improvement(kms): cache project secret manager KMS material

### DIFF
--- a/backend/scripts/seed-gamma-fixtures.ts
+++ b/backend/scripts/seed-gamma-fixtures.ts
@@ -33,6 +33,7 @@ import promptSync from "prompt-sync";
 import { initializeHsmModule } from "@app/ee/services/hsm/hsm-fns";
 import { hsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
 import { SamlProviders } from "@app/ee/services/saml-config/saml-config-types";
+import { inMemoryKeyStore } from "@app/keystore/memory";
 import { getConfig, getHsmConfig, initEnvConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { initLogger, logger } from "@app/lib/logger";
@@ -157,6 +158,7 @@ const main = async () => {
     orgDAL,
     projectDAL,
     hsmService,
+    keyStore: inMemoryKeyStore(),
     envConfig
   });
   // Loads the decrypted root key into the service's in-memory buffer; the

--- a/backend/src/db/migrations/utils/services.ts
+++ b/backend/src/db/migrations/utils/services.ts
@@ -129,6 +129,7 @@ export const getMigrationEncryptionServices = async ({
     orgDAL,
     projectDAL,
     hsmService,
+    keyStore,
     envConfig
   });
 

--- a/backend/src/ee/services/kmip/kmip-operation-service.ts
+++ b/backend/src/ee/services/kmip/kmip-operation-service.ts
@@ -133,6 +133,9 @@ export const kmipOperationServiceFactory = ({
     }
 
     const completeKeyDetails = await kmsDAL.findByIdWithAssociatedKms(id);
+    if (!completeKeyDetails) {
+      throw new NotFoundError({ message: `Key with ID '${id}' not found` });
+    }
     if (!completeKeyDetails.internalKms) {
       throw new BadRequestError({
         message: "Cannot destroy external keys"
@@ -187,6 +190,9 @@ export const kmipOperationServiceFactory = ({
     }
 
     const completeKeyDetails = await kmsDAL.findByIdWithAssociatedKms(id);
+    if (!completeKeyDetails) {
+      throw new NotFoundError({ message: `Key with ID '${id}' not found` });
+    }
 
     if (!completeKeyDetails.internalKms) {
       throw new BadRequestError({
@@ -284,6 +290,9 @@ export const kmipOperationServiceFactory = ({
     }
 
     const completeKeyDetails = await kmsDAL.findByIdWithAssociatedKms(id);
+    if (!completeKeyDetails) {
+      throw new NotFoundError({ message: `Key with ID '${id}' not found` });
+    }
 
     if (!completeKeyDetails.internalKms) {
       throw new BadRequestError({
@@ -346,6 +355,9 @@ export const kmipOperationServiceFactory = ({
     }
 
     const completeKeyDetails = await kmsDAL.findByIdWithAssociatedKms(id);
+    if (!completeKeyDetails) {
+      throw new NotFoundError({ message: `Key with ID '${id}' not found` });
+    }
 
     if (!completeKeyDetails.internalKms) {
       throw new BadRequestError({

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -88,6 +88,8 @@ export const KeyStorePrefixes = {
   ProjectPermissionData: (projectId: string, actorType: string, actorId: string, actionProjectType: string) =>
     `project-permission-data:${projectId}:${actorType}:${actorId}:${actionProjectType}` as const,
 
+  KmsProjectSecretManagerMaterial: (projectId: string) => `kms-project-sm-material:${projectId}` as const,
+
   PkiAcmeNonce: (nonce: string) => `pki-acme-nonce:${nonce}` as const,
   MfaSession: (mfaSessionId: string) => `mfa-session:${mfaSessionId}` as const,
   MfaCodeResendCooldown: (userId: string) => `mfa-code-resend-cooldown:${userId}` as const,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -967,6 +967,7 @@ export const registerRoutes = async (
     orgDAL,
     projectDAL,
     hsmService,
+    keyStore,
     envConfig
   });
 

--- a/backend/src/services/kms/kms-key-dal.ts
+++ b/backend/src/services/kms/kms-key-dal.ts
@@ -62,6 +62,8 @@ export const kmskeyDALFactory = (db: TDbClient) => {
           db.ref("kmsEncryptedDataKey").withSchema(TableName.Organization).as("orgKmsEncryptedDataKey")
         );
 
+      if (!result) return undefined;
+
       const data = {
         ...KmsKeysSchema.parse(result),
         isExternal: Boolean(result?.externalKmsId),

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -22,6 +22,7 @@ import { crypto } from "@app/lib/crypto/cryptography";
 import { HmacAlgorithm, hmacService } from "@app/lib/crypto/hmac";
 import { detectPqcVariantFromDer } from "@app/lib/crypto/pqc/pqc-crypto";
 import { AsymmetricKeyAlgorithm, isPqcKeyAlgorithm, KMS_TO_OPENSSL_NAME, signingService } from "@app/lib/crypto/sign";
+import { delay } from "@app/lib/delay";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
@@ -273,6 +274,7 @@ export const kmsServiceFactory = ({
 
   const deleteInternalKms = async (kmsId: string, orgId: string, tx?: Knex) => {
     const kms = await kmsDAL.findByIdWithAssociatedKms(kmsId, tx);
+    if (!kms) return;
     if (kms.isExternal) return;
     if (kms.orgId !== orgId) throw new ForbiddenRequestError({ message: "KMS doesn't belong to organization" });
     return kmsDAL.deleteById(kmsId, tx);
@@ -972,13 +974,28 @@ export const kmsServiceFactory = ({
     return key.id;
   };
 
-  // Drops the cached KMS material for a project. Best-effort: a failed delete only shortens
-  // the window to the TTL, never corrupts data.
+  // Drops the cached KMS material for a project. Call after the writing transaction commits. Retries transient
+  // Redis failures; a final failure is safe to swallow: stale entries either degrade gracefully (creation,
+  // backup restore) or are recovered by the NotFound self-heal in $getProjectSecretManagerKmsDataKey (rotation).
   const $invalidateProjectSecretManagerKmsMaterialCache = async (projectId: string) => {
-    try {
-      await keyStore.deleteItem(KeyStorePrefixes.KmsProjectSecretManagerMaterial(projectId));
-    } catch (err) {
-      logger.warn({ err, projectId }, `Failed to invalidate project KMS material cache [projectId=${projectId}]`);
+    const cacheKey = KeyStorePrefixes.KmsProjectSecretManagerMaterial(projectId);
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        await keyStore.deleteItem(cacheKey);
+        return;
+      } catch (err) {
+        if (attempt === maxAttempts) {
+          logger.error(
+            { err, projectId },
+            `Failed to invalidate project KMS material cache after ${maxAttempts} attempts; stale reads self-heal on decrypt [projectId=${projectId}]`
+          );
+          return;
+        }
+        // eslint-disable-next-line no-await-in-loop
+        await delay(100 * attempt);
+      }
     }
   };
 
@@ -1014,9 +1031,9 @@ export const kmsServiceFactory = ({
   };
 
   /** Single project row read; reuses snapshot for data-key path to avoid duplicate findById. */
-  const $getProjectSecretManagerKmsKeyIdAndProject = async (projectId: string, trx?: Knex) => {
-    // Transactional callers (key/data-key creation, rotation, backup restore) must read fresh under their advisory lock.
-    if (!trx) {
+  const $getProjectSecretManagerKmsKeyIdAndProject = async (projectId: string, trx?: Knex, skipCache = false) => {
+    // Transactional callers (key/data-key creation, rotation, backup restore) must read fresh under their advisory lock
+    if (!trx && !skipCache) {
       const material = await $getCachedProjectSecretManagerKmsMaterial(projectId);
       if (material.kmsSecretManagerKeyId) {
         return { kmsKeyId: material.kmsSecretManagerKeyId, project: material };
@@ -1073,8 +1090,12 @@ export const kmsServiceFactory = ({
     return dataKey;
   };
 
-  const $getProjectSecretManagerKmsDataKey = async (projectId: string, trx?: Knex) => {
-    const { kmsKeyId, project: projectSnapshot } = await $getProjectSecretManagerKmsKeyIdAndProject(projectId, trx);
+  const $getProjectSecretManagerKmsDataKeyImpl = async (projectId: string, trx?: Knex, skipCache = false) => {
+    const { kmsKeyId, project: projectSnapshot } = await $getProjectSecretManagerKmsKeyIdAndProject(
+      projectId,
+      trx,
+      skipCache
+    );
     let project = projectSnapshot;
 
     if (!project.kmsSecretManagerEncryptedDataKey) {
@@ -1114,6 +1135,24 @@ export const kmsServiceFactory = ({
     return kmsDecryptor({
       cipherTextBlob: project.kmsSecretManagerEncryptedDataKey
     });
+  };
+
+  const $getProjectSecretManagerKmsDataKey = async (projectId: string, trx?: Knex) => {
+    try {
+      return await $getProjectSecretManagerKmsDataKeyImpl(projectId, trx);
+    } catch (err) {
+      // Self-heal: a NotFound here means the cached material points at a KMS key deleted by rotation
+      // (invalidation failed). Drop the entry and retry once bypassing the cache.
+      if (!trx && err instanceof NotFoundError) {
+        logger.warn(
+          { err, projectId },
+          `Project KMS material resolved from cache failed with NotFound; invalidating cache and retrying fresh [projectId=${projectId}]`
+        );
+        await $invalidateProjectSecretManagerKmsMaterialCache(projectId);
+        return await $getProjectSecretManagerKmsDataKeyImpl(projectId, undefined, true);
+      }
+      throw err;
+    }
   };
 
   const $getDataKey = async (dto: TEncryptWithKmsDataKeyDTO, trx?: Knex) => {
@@ -1217,7 +1256,8 @@ export const kmsServiceFactory = ({
   };
 
   const updateProjectSecretManagerKmsKey = async ({ projectId, kms }: TUpdateProjectSecretManagerKmsKeyDTO) => {
-    const kmsKeyId = await getProjectSecretManagerKmsKeyId(projectId);
+    // a stale cached id from a previous rotation whose invalidation failed would point at a deleted key row here.
+    const { kmsKeyId } = await $getProjectSecretManagerKmsKeyIdAndProject(projectId, undefined, true);
     const currentKms = await kmsDAL.findById(kmsKeyId);
 
     // case: internal kms -> internal kms. no change needed
@@ -1341,6 +1381,9 @@ export const kmsServiceFactory = ({
     }
 
     const kmsDoc = await kmsDAL.findByIdWithAssociatedKms(backupKmsKeyId);
+    if (!kmsDoc) {
+      throw new NotFoundError({ message: `KMS with ID '${backupKmsKeyId}' not found` });
+    }
     if (kmsDoc.orgId !== project.orgId)
       throw new ForbiddenRequestError({
         message: "Backup does not belong to project"
@@ -1369,7 +1412,12 @@ export const kmsServiceFactory = ({
         },
         tx
       );
-      return kmsDAL.findByIdWithAssociatedKms(key.id, tx);
+      const restoredKms = await kmsDAL.findByIdWithAssociatedKms(key.id, tx);
+      if (!restoredKms) {
+        // invariant: the key was created in this same transaction
+        throw new NotFoundError({ message: `KMS with ID '${key.id}' not found` });
+      }
+      return restoredKms;
     });
 
     // Backup restore re-pointed the project at a freshly generated KMS key + re-wrapped data key,
@@ -1384,7 +1432,7 @@ export const kmsServiceFactory = ({
   const getKmsById = async (kmsKeyId: string, tx?: Knex) => {
     const kms = await kmsDAL.findByIdWithAssociatedKms(kmsKeyId, tx);
 
-    if (!kms.id) {
+    if (!kms) {
       throw new NotFoundError({
         message: `KMS with ID '${kmsKeyId}' not found`
       });

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -999,6 +999,36 @@ export const kmsServiceFactory = ({
     }
   };
 
+  // Opportunistic cache repair for fresh (skipCache) readers: if a cached entry exists and disagrees with the
+  // project row just read from the DB, drop it so cached readers converge before the TTL expires.
+  const $repairProjectSecretManagerKmsMaterialCache = async (
+    projectId: string,
+    fresh: { kmsSecretManagerKeyId?: string | null; kmsSecretManagerEncryptedDataKey?: Buffer | null }
+  ) => {
+    try {
+      const raw = await keyStore.getItem(KeyStorePrefixes.KmsProjectSecretManagerMaterial(projectId));
+      if (!raw) return;
+      const cached = JSON.parse(raw) as TCachedProjectSmKmsMaterial;
+      const freshEncryptedDataKey = fresh.kmsSecretManagerEncryptedDataKey
+        ? Buffer.from(fresh.kmsSecretManagerEncryptedDataKey).toString("base64")
+        : null;
+      if (
+        cached.kmsSecretManagerKeyId === (fresh.kmsSecretManagerKeyId ?? null) &&
+        cached.kmsSecretManagerEncryptedDataKey === freshEncryptedDataKey
+      ) {
+        return;
+      }
+      logger.warn(
+        { projectId },
+        `Cached project KMS material disagrees with DB; dropping stale cache entry [projectId=${projectId}]`
+      );
+      await $invalidateProjectSecretManagerKmsMaterialCache(projectId);
+    } catch (err) {
+      // best-effort: the fresh read already succeeded, so a failed repair must never fail the request
+      logger.warn({ err, projectId }, `Failed to repair project KMS material cache [projectId=${projectId}]`);
+    }
+  };
+
   const $getCachedProjectSecretManagerKmsMaterial = async (projectId: string) => {
     const cached = await withCache<TCachedProjectSmKmsMaterial>({
       keyStore,
@@ -1046,6 +1076,10 @@ export const kmsServiceFactory = ({
       throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
     }
 
+    if (!trx && skipCache) {
+      await $repairProjectSecretManagerKmsMaterialCache(projectId, project);
+    }
+
     if (!project.kmsSecretManagerKeyId) {
       if (trx) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
@@ -1069,8 +1103,8 @@ export const kmsServiceFactory = ({
     return { kmsKeyId: project.kmsSecretManagerKeyId, project };
   };
 
-  const getProjectSecretManagerKmsKeyId = async (projectId: string, trx?: Knex) => {
-    const { kmsKeyId } = await $getProjectSecretManagerKmsKeyIdAndProject(projectId, trx);
+  const getProjectSecretManagerKmsKeyId = async (projectId: string, trx?: Knex, skipCache = false) => {
+    const { kmsKeyId } = await $getProjectSecretManagerKmsKeyIdAndProject(projectId, trx, skipCache);
     return kmsKeyId;
   };
 

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -13,7 +13,8 @@ import {
 } from "@app/ee/services/external-kms/providers/model";
 import { THsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
 import { THsmStatus } from "@app/ee/services/hsm/hsm-types";
-import { PgSqlLock } from "@app/keystore/keystore";
+import { KeyStorePrefixes, PgSqlLock, TKeyStoreFactory } from "@app/keystore/keystore";
+import { withCache } from "@app/lib/cache/with-cache";
 import { TEnvConfig } from "@app/lib/config/env";
 import { generateSecretValueBlindIndexFromKmsKey } from "@app/lib/crypto/blind-index";
 import { symmetricCipherService, SymmetricKeyAlgorithm } from "@app/lib/crypto/cipher";
@@ -70,10 +71,17 @@ type TKmsServiceFactoryDep = {
   internalKmsDAL: Pick<TInternalKmsDALFactory, "create" | "findByKmsKeyIdForUpdate" | "updateById">;
   internalKmsKeyVersionDAL: Pick<TInternalKmsKeyVersionDALFactory, "create" | "find">;
   hsmService: THsmServiceFactory;
+  keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry" | "deleteItem">;
   envConfig: Pick<TEnvConfig, "ENCRYPTION_KEY" | "ROOT_ENCRYPTION_KEY">;
 };
 
 export type TKmsServiceFactory = ReturnType<typeof kmsServiceFactory>;
+
+type TCachedProjectSmKmsMaterial = {
+  kmsSecretManagerKeyId: string | null;
+  kmsSecretManagerEncryptedDataKey: string | null;
+  orgId: string;
+};
 
 // akhilmhdh: Don't edit this value. This is measured for blob concatination in kms
 const KMS_VERSION = "v01";
@@ -87,6 +95,7 @@ const KMS_KEY_VERSION_BLOB_LENGTH = 4;
 // malformed/attacker input and must fall through to the legacy path rather than reading out of bounds.
 const MIN_AES_GCM_BLOB_LENGTH = 12 + 16;
 const MIN_V02_BLOB_LENGTH = MIN_AES_GCM_BLOB_LENGTH + KMS_KEY_VERSION_BLOB_LENGTH + KMS_VERSION_BLOB_LENGTH;
+const KMS_PROJECT_SM_MATERIAL_CACHE_TTL_SECONDS = 5 * 60; // 5 minutes
 
 // Single source of truth for the cipher-blob trailer so the encode side here and the decode side in
 // decryptWithKmsKey can never drift: v1 keys get the legacy 3-byte "v01" suffix (byte-identical to pre-rotation
@@ -112,7 +121,8 @@ export const kmsServiceFactory = ({
   internalKmsKeyVersionDAL,
   orgDAL,
   projectDAL,
-  hsmService
+  hsmService,
+  keyStore
 }: TKmsServiceFactoryDep) => {
   let ROOT_ENCRYPTION_KEY: Buffer = Buffer.alloc(0);
 
@@ -962,8 +972,58 @@ export const kmsServiceFactory = ({
     return key.id;
   };
 
+  // Drops the cached KMS material for a project. Best-effort: a failed delete only shortens
+  // the window to the TTL, never corrupts data.
+  const $invalidateProjectSecretManagerKmsMaterialCache = async (projectId: string) => {
+    try {
+      await keyStore.deleteItem(KeyStorePrefixes.KmsProjectSecretManagerMaterial(projectId));
+    } catch (err) {
+      logger.warn({ err, projectId }, `Failed to invalidate project KMS material cache [projectId=${projectId}]`);
+    }
+  };
+
+  const $getCachedProjectSecretManagerKmsMaterial = async (projectId: string) => {
+    const cached = await withCache<TCachedProjectSmKmsMaterial>({
+      keyStore,
+      key: KeyStorePrefixes.KmsProjectSecretManagerMaterial(projectId),
+      ttlSeconds: KMS_PROJECT_SM_MATERIAL_CACHE_TTL_SECONDS,
+      fetcher: async () => {
+        const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
+          projectDAL.findById(projectId)
+        );
+        if (!project) {
+          throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
+        }
+        return {
+          kmsSecretManagerKeyId: project.kmsSecretManagerKeyId ?? null,
+          kmsSecretManagerEncryptedDataKey: project.kmsSecretManagerEncryptedDataKey
+            ? Buffer.from(project.kmsSecretManagerEncryptedDataKey).toString("base64")
+            : null,
+          orgId: project.orgId
+        };
+      }
+    });
+
+    return {
+      kmsSecretManagerKeyId: cached.kmsSecretManagerKeyId,
+      kmsSecretManagerEncryptedDataKey: cached.kmsSecretManagerEncryptedDataKey
+        ? Buffer.from(cached.kmsSecretManagerEncryptedDataKey, "base64")
+        : null,
+      orgId: cached.orgId
+    };
+  };
+
   /** Single project row read; reuses snapshot for data-key path to avoid duplicate findById. */
   const $getProjectSecretManagerKmsKeyIdAndProject = async (projectId: string, trx?: Knex) => {
+    // Transactional callers (key/data-key creation, rotation, backup restore) must read fresh under their advisory lock.
+    if (!trx) {
+      const material = await $getCachedProjectSecretManagerKmsMaterial(projectId);
+      if (material.kmsSecretManagerKeyId) {
+        return { kmsKeyId: material.kmsSecretManagerKeyId, project: material };
+      }
+      // No key yet: fall through to first-use creation below, which invalidates the (miss-populated) cache entry.
+    }
+
     const project = await projectDAL.findById(projectId, trx);
     if (!project) {
       throw new NotFoundError({ message: `Project with ID '${projectId}' not found` });
@@ -982,6 +1042,9 @@ export const kmsServiceFactory = ({
         await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.KmsProjectKeyCreation(projectId)]);
         return $createProjectKmsKey(projectId, tx);
       });
+      // First-use key creation wrote kmsSecretManagerKeyId: drop the stale (keyId=null) cache entry the miss just
+      // wrote so the next read repopulates with the provisioned key.
+      await $invalidateProjectSecretManagerKmsMaterialCache(projectId);
 
       return { kmsKeyId, project };
     }
@@ -1027,6 +1090,9 @@ export const kmsServiceFactory = ({
           await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.KmsProjectDataKeyCreation(projectId)]);
           return $createProjectKmsDataKey(projectId, kmsKeyId, tx);
         });
+        // First-use data-key creation committed a new kmsSecretManagerEncryptedDataKey: drop the cache entry
+        // (which may still hold encryptedDataKey=null) so the next read repopulates with the new ciphertext.
+        await $invalidateProjectSecretManagerKmsMaterialCache(projectId);
       }
 
       if (projectDataKey) {
@@ -1181,7 +1247,7 @@ export const kmsServiceFactory = ({
     }
 
     const dataKey = await $getProjectSecretManagerKmsDataKey(projectId);
-    return kmsDAL.transaction(async (tx) => {
+    const rotatedKms = await kmsDAL.transaction(async (tx) => {
       const project = await projectDAL.findById(projectId, tx);
       let kmsId;
       if (kms.type === KmsType.Internal) {
@@ -1211,6 +1277,10 @@ export const kmsServiceFactory = ({
       const newKms = await kmsDAL.findById(kmsId, tx);
       return KmsSanitizedSchema.parseAsync({ isExternal: !currentKms.isReserved, ...newKms });
     });
+
+    await $invalidateProjectSecretManagerKmsMaterialCache(projectId);
+
+    return rotatedKms;
   };
 
   const getProjectKeyBackup = async (projectId: string) => {
@@ -1301,6 +1371,10 @@ export const kmsServiceFactory = ({
       );
       return kmsDAL.findByIdWithAssociatedKms(key.id, tx);
     });
+
+    // Backup restore re-pointed the project at a freshly generated KMS key + re-wrapped data key,
+    // so any cached material for this project is now stale.
+    await $invalidateProjectSecretManagerKmsMaterialCache(projectId);
 
     return {
       secretManagerKmsKey: newKms

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -1983,7 +1983,7 @@ export const projectServiceFactory = ({
       actionProjectType: ActionProjectType.Any
     });
 
-    const kmsKeyId = await kmsService.getProjectSecretManagerKmsKeyId(projectId);
+    const kmsKeyId = await kmsService.getProjectSecretManagerKmsKeyId(projectId, undefined, true);
     const kmsKey = await kmsService.getKmsById(kmsKeyId);
 
     return { secretManagerKmsKey: kmsKey };


### PR DESCRIPTION
## Context

Secret encrypt/decrypt paths call `$getProjectSecretManagerKmsKeyIdAndProject` on every operation, which hits Postgres for `kmsSecretManagerKeyId`, `kmsSecretManagerEncryptedDataKey`, and `orgId`.

This PR caches that material in Redis (`withCache`, 5-minute TTL, key `kms-project-sm-material:{projectId}`). Transactional callers and rotation reads bypass the cache; invalidation runs after commit on first-use key/data-key creation, KMS rotation, and backup restore (3 retries with backoff). If invalidation fails or stale material points at a deleted key, `$getProjectSecretManagerKmsDataKey` self-heals via NotFound → invalidate → one fresh retry.

Also hardens null handling where `findByIdWithAssociatedKms` can return undefined (`kms-key-dal`, `getKmsById`, KMIP destroy/activate paths, backup restore) so cache-related NotFound paths don't surface as parse crashes.

## Steps to verify the change

1. Encrypt or decrypt a secret; confirm Redis key `kms-project-sm-material:{projectId}` is populated.
2. Repeat within 5 minutes; confirm no second project-row read for KMS material on the hot path.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)