### PR TITLE
fix(project): let org admins break-glass into projects they only belong to via a group

### DIFF
--- a/backend/src/ee/services/group/user-group-membership-dal.ts
+++ b/backend/src/ee/services/group/user-group-membership-dal.ts
@@ -57,9 +57,14 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
 
   /**
    * Given a set of [userIds], returns the subset that have access to project [projectId]
-   * through a (non-pending) group membership, i.e. they belong to a group that is itself
-   * a member of the project. Used to validate approvers/bypassers who are project members
-   * via a group rather than directly.
+   * through a group membership, i.e. they belong to a group that is itself
+   * a member of the project.
+   *
+   * Note: this intentionally does NOT filter on `isPending`. The permission engine
+   * (`permission-dal.getPermission`) grants project access purely by group membership
+   * without considering `isPending`, and the flag is no longer cleared for accepted
+   * users (the un-pend transition was removed with the signup-flow simplification).
+   * Filtering it here would diverge from what actually grants access.
    */
   const findUserGroupMembershipsInProjectByUserIds = async (userIds: string[], projectId: string, tx?: Knex) => {
     try {
@@ -69,7 +74,6 @@ export const userGroupMembershipDALFactory = (db: TDbClient) => {
         .join(TableName.Membership, `${TableName.UserGroupMembership}.groupId`, `${TableName.Membership}.actorGroupId`)
         .where(`${TableName.Membership}.scope`, AccessScope.Project)
         .where(`${TableName.Membership}.scopeProjectId`, projectId)
-        .where(`${TableName.UserGroupMembership}.isPending`, false)
         .whereIn(`${TableName.UserGroupMembership}.userId`, userIds)
         .distinct(`${TableName.UserGroupMembership}.userId`)
         .pluck(`${TableName.UserGroupMembership}.userId`);

--- a/backend/src/server/routes/v1/deprecated-project-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-router.ts
@@ -717,7 +717,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
       }),
       response: {
         200: z.object({
-          projects: SanitizedProjectSchema.extend({ isMember: z.boolean() }).array(),
+          projects: SanitizedProjectSchema.extend({ isMember: z.boolean(), isDirectMember: z.boolean() }).array(),
           totalCount: z.number()
         })
       }

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -1175,7 +1175,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
       }),
       response: {
         200: z.object({
-          projects: SanitizedProjectSchema.extend({ isMember: z.boolean() }).array(),
+          projects: SanitizedProjectSchema.extend({ isMember: z.boolean(), isDirectMember: z.boolean() }).array(),
           totalCount: z.number()
         })
       }

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -445,8 +445,7 @@ export const projectMembershipServiceFactory = ({
       );
       if (groupMembership) {
         throw new BadRequestError({
-          message:
-            "You have access to this project through a group rather than a direct membership, so there is no membership to leave."
+          message: "You have access to this project through a group rather than a direct membership."
         });
       }
       throw new BadRequestError({ message: "You are not a member of this project" });

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -439,6 +439,16 @@ export const projectMembershipServiceFactory = ({
 
     const actorMembership = projectMembers.find((member) => member.userId === actorId);
     if (!actorMembership) {
+      const [groupMembership] = await userGroupMembershipDAL.findUserGroupMembershipsInProjectByUserIds(
+        [actorId],
+        project.id
+      );
+      if (groupMembership) {
+        throw new BadRequestError({
+          message:
+            "You have access to this project through a group rather than a direct membership, so there is no membership to leave."
+        });
+      }
       throw new BadRequestError({ message: "You are not a member of this project" });
     }
 

--- a/backend/src/services/project/project-dal.ts
+++ b/backend/src/services/project/project-dal.ts
@@ -848,9 +848,7 @@ export const projectDALFactory = (db: TDbClient) => {
                   END as "isMember"
                 `,
           [db.raw(membershipSQL)]
-        )
-      )
-      .select(
+        ),
         db.raw(
           `
                   CASE

--- a/backend/src/services/project/project-dal.ts
+++ b/backend/src/services/project/project-dal.ts
@@ -819,8 +819,19 @@ export const projectDALFactory = (db: TDbClient) => {
       })
       .select("scopeProjectId");
 
+    const directMembershipSubQuery = db(TableName.Membership)
+      .where(`${TableName.Membership}.scope`, AccessScope.Project)
+      .where(
+        dto.actor === ActorType.IDENTITY
+          ? `${TableName.Membership}.actorIdentityId`
+          : `${TableName.Membership}.actorUserId`,
+        dto.actorId
+      )
+      .select("scopeProjectId");
+
     // Get the SQL strings for the subqueries
     const membershipSQL = membershipSubQuery.toQuery();
+    const directMembershipSQL = directMembershipSubQuery.toQuery();
 
     const query = db
       .replicaNode()(TableName.Project)
@@ -828,7 +839,7 @@ export const projectDALFactory = (db: TDbClient) => {
       .whereNull(`${TableName.Project}.deleteAfter`)
       .select(selectAllTableCols(TableName.Project))
       .select(db.raw("COUNT(*) OVER() AS count"))
-      .select<(TProjects & { isMember: boolean; count: number })[]>(
+      .select<(TProjects & { isMember: boolean; isDirectMember: boolean; count: number })[]>(
         db.raw(
           `
                   CASE
@@ -837,6 +848,17 @@ export const projectDALFactory = (db: TDbClient) => {
                   END as "isMember"
                 `,
           [db.raw(membershipSQL)]
+        )
+      )
+      .select(
+        db.raw(
+          `
+                  CASE
+                    WHEN ${TableName.Project}.id IN (?) THEN TRUE
+                    ELSE FALSE
+                  END as "isDirectMember"
+                `,
+          [db.raw(directMembershipSQL)]
         )
       )
       .limit(limit)

--- a/frontend/src/hooks/api/projects/queries.tsx
+++ b/frontend/src/hooks/api/projects/queries.tsx
@@ -153,7 +153,7 @@ export const useSearchProjects = ({ options, ...dto }: TSearchProjectsDTO) =>
     queryKey: projectKeys.searchProject(dto),
     queryFn: async () => {
       const { data } = await apiRequest.post<{
-        projects: (Project & { isMember: boolean })[];
+        projects: (Project & { isMember: boolean; isDirectMember: boolean })[];
         totalCount: number;
       }>("/api/v1/projects/search", dto);
 

--- a/frontend/src/pages/organization/ProjectsPage/ProjectTypePage/ProjectTypePage.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/ProjectTypePage/ProjectTypePage.tsx
@@ -799,37 +799,51 @@ const AllProjectsForType = ({
                 </TableCell>
                 <TableCell className="w-0 pr-3 text-right">
                   {(() => {
+                    const joinedBadge = (
+                      <Badge variant="info">
+                        <CheckIcon />
+                        Joined
+                      </Badge>
+                    );
+                    const adminAccessButton = (label: string) => (
+                      <Button
+                        size="xs"
+                        variant="outline"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          e.preventDefault();
+                          handleAccessProject(
+                            workspace.type,
+                            workspace.id,
+                            workspace.environments,
+                            workspace.orgId
+                          );
+                        }}
+                        isDisabled={
+                          orgAdminAccessProject.variables?.projectId === workspace.id &&
+                          orgAdminAccessProject.isPending
+                        }
+                      >
+                        {label}
+                      </Button>
+                    );
+
+                    if (workspace.isDirectMember) {
+                      return joinedBadge;
+                    }
                     if (workspace.isMember) {
+                      if (!canAccessAllProjects) {
+                        return joinedBadge;
+                      }
                       return (
-                        <Badge variant="info">
-                          <CheckIcon />
-                          Joined
-                        </Badge>
+                        <div className="flex items-center justify-end gap-2">
+                          {joinedBadge}
+                          {adminAccessButton("Grant Admin")}
+                        </div>
                       );
                     }
                     if (canAccessAllProjects) {
-                      return (
-                        <Button
-                          size="xs"
-                          variant="outline"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            e.preventDefault();
-                            handleAccessProject(
-                              workspace.type,
-                              workspace.id,
-                              workspace.environments,
-                              workspace.orgId
-                            );
-                          }}
-                          isDisabled={
-                            orgAdminAccessProject.variables?.projectId === workspace.id &&
-                            orgAdminAccessProject.isPending
-                          }
-                        >
-                          Join as Admin
-                        </Button>
-                      );
+                      return adminAccessButton("Join as Admin");
                     }
                     const requestedAt = pendingAccessRequestByProjectId?.get(workspace.id);
                     if (requestedAt) {

--- a/frontend/src/pages/organization/ProjectsPage/ProjectTypePage/ProjectTypePage.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/ProjectTypePage/ProjectTypePage.tsx
@@ -838,7 +838,14 @@ const AllProjectsForType = ({
                       return (
                         <div className="flex items-center justify-end gap-2">
                           {joinedBadge}
-                          {adminAccessButton("Grant Admin")}
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              {adminAccessButton("Become Admin")}
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              You have access through a group. Become a direct admin.
+                            </TooltipContent>
+                          </Tooltip>
                         </div>
                       );
                     }

--- a/frontend/src/pages/project/SettingsPage/components/DeleteProjectSection/DeleteProjectSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/DeleteProjectSection/DeleteProjectSection.tsx
@@ -2,13 +2,14 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { Button, DeleteActionModal } from "@app/components/v2";
+import { Button, DeleteActionModal, Tooltip } from "@app/components/v2";
 import { LeaveProjectModal } from "@app/components/v2/LeaveProjectModal";
 import {
   ProjectPermissionActions,
   ProjectPermissionSub,
   useOrganization,
-  useProject
+  useProject,
+  useProjectPermission
 } from "@app/context";
 import { useToggle } from "@app/hooks";
 import { useDeleteWorkspace, useLeaveProject } from "@app/hooks/api";
@@ -24,6 +25,8 @@ export const DeleteProjectSection = () => {
 
   const { currentOrg } = useOrganization();
   const { currentProject } = useProject();
+  const { memberships } = useProjectPermission();
+  const isDirectMember = Boolean(memberships?.some((membership) => !membership.actorGroupId));
   const [isDeleting, setIsDeleting] = useToggle();
   const [isLeaving, setIsLeaving] = useToggle();
   const deleteWorkspace = useDeleteWorkspace();
@@ -90,15 +93,23 @@ export const DeleteProjectSection = () => {
             </Button>
           )}
         </ProjectPermissionCan>
-        <Button
-          isLoading={isLeaving}
-          colorSchema="danger"
-          variant="outline_bg"
-          type="submit"
-          onClick={() => handlePopUpOpen("leaveWorkspace")}
+        <Tooltip
+          content="You're a member through a group. Leave the group to remove access."
+          isDisabled={isDirectMember}
         >
-          {`Leave ${currentProject?.name}`}
-        </Button>
+          <span>
+            <Button
+              isLoading={isLeaving}
+              isDisabled={!isDirectMember}
+              colorSchema="danger"
+              variant="outline_bg"
+              type="submit"
+              onClick={() => handlePopUpOpen("leaveWorkspace")}
+            >
+              {`Leave ${currentProject?.name}`}
+            </Button>
+          </span>
+        </Tooltip>
       </div>
 
       <DeleteActionModal


### PR DESCRIPTION
## Context

An org admin with `organization-admin-console` + `access-all-projects` couldn't grant themselves admin access to a project if they were already a project member **through a group**.

This happened because of two issues:

1. **The "Grant Admin" button never showed up.** The All Projects page was checking `isMember`, which includes both direct and group membership. So if you only had access through a group, the UI treated you as already joined and hid the button, even though you didn't have a direct role.
2. **Leaving the project didn't work either.** `leaveProject` only checks direct project members, so group-only members got the confusing error: `"You are not a member of this project"`.

**This PR changes that:**

- `searchProjects` now returns both `isMember` and `isDirectMember`. The UI now uses `isDirectMember` to decide whether to show the `Grant Admin` button.
  - Group-only members with `access-all-projects` will now see both the `Joined` badge and the `Grant Admin` button.
  - Direct members will just see `Joined`.
  - Users with no access will still see `Join as Admin`.
- `leaveProject` now returns a proper error for group-only members, explaining that their access comes from a group and needs to be removed there instead.

## Screenshots

<img width="1183" height="248" alt="image" src="https://github.com/user-attachments/assets/50204eb1-c234-46ba-84e2-6e36139f3acf" />

<img width="799" height="550" alt="Screenshot 2026-07-23 at 16 23 16" src="https://github.com/user-attachments/assets/1d019b11-4611-4039-9080-d539f2a51a2f" />


## Steps to verify

1. Log in as an org admin.
2. Create a group (**Organization → Access Control → Groups**) and add a second test user to it.
3. Create a project and add the group under **Project → Access Control → Groups** with the **Member** role.
4. Log in as the group-only test user:
   - **Without** `access-all-projects`: the project shows as `Joined`, and trying to leave returns the new group-access error.
   - **With** `access-all-projects`: the project shows `Joined` + `Grant Admin`. Clicking `Grant Admin` gives the user a direct Admin role, and the row updates to just `Joined`.
5. Verify a real non-member (no direct or group access) still sees `Join as Admin`, and the deprecated leave flow still returns `"You are not a member of this project"`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format.
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)