### PR TITLE
fix(ui): show grant-privileges action for org custom roles

### DIFF
--- a/frontend/src/pages/organization/ProductSettingsPage/project-templates/EditProjectTemplateSection/components/ProjectTemplateEditRoleForm.tsx
+++ b/frontend/src/pages/organization/ProductSettingsPage/project-templates/EditProjectTemplateSection/components/ProjectTemplateEditRoleForm.tsx
@@ -13,6 +13,7 @@ import { slugSchema } from "@app/lib/schemas";
 import { AddPoliciesButton } from "@app/pages/project/RoleDetailsBySlugPage/components/AddPoliciesButton";
 import {
   GeneralPermissionPolicies,
+  PermissionScope,
   TPermissionAction
 } from "@app/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies";
 import { PermissionEmptyState } from "@app/pages/project/RoleDetailsBySlugPage/components/PermissionEmptyState";
@@ -195,6 +196,7 @@ export const ProjectTemplateEditRoleForm = ({
                   (subject) => (
                     <GeneralPermissionPolicies
                       subject={subject}
+                      subjectScope={PermissionScope.Project}
                       actions={PROJECT_PERMISSION_OBJECT[subject].actions as TPermissionAction[]}
                       title={PROJECT_PERMISSION_OBJECT[subject].title}
                       description={PROJECT_PERMISSION_OBJECT[subject].description}

--- a/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
+++ b/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
@@ -619,7 +619,11 @@ export const ORG_PERMISSION_OBJECT: Record<string, TOrgPermissionConfig> = {
         label: "Delete Identities",
         description: "Delete machine identities"
       },
-      { value: OrgPermissionIdentityActions.GrantPrivileges, label: "Grant Privileges" },
+      {
+        value: OrgPermissionIdentityActions.GrantPrivileges,
+        label: "Grant Privileges",
+        description: "Assign roles and additional privileges to machine identities"
+      },
       {
         value: OrgPermissionIdentityActions.RevokeAuth,
         label: "Revoke Auth",
@@ -666,7 +670,11 @@ export const ORG_PERMISSION_OBJECT: Record<string, TOrgPermissionConfig> = {
         label: "Delete Groups",
         description: "Delete groups"
       },
-      { value: OrgPermissionGroupActions.GrantPrivileges, label: "Grant Privileges" },
+      {
+        value: OrgPermissionGroupActions.GrantPrivileges,
+        label: "Grant Privileges",
+        description: "Assign roles and additional privileges to groups"
+      },
       {
         value: OrgPermissionGroupActions.AddMembers,
         label: "Add Members",

--- a/frontend/src/pages/organization/RoleByIDPage/components/RolePermissionsSection/RolePermissionsSection.tsx
+++ b/frontend/src/pages/organization/RoleByIDPage/components/RolePermissionsSection/RolePermissionsSection.tsx
@@ -14,7 +14,10 @@ import {
 } from "@app/components/v3";
 import { OrgPermissionSubjects, useOrganization } from "@app/context";
 import { useGetOrgRole, useUpdateOrgRole } from "@app/hooks/api";
-import { GeneralPermissionPolicies } from "@app/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies";
+import {
+  GeneralPermissionPolicies,
+  PermissionScope
+} from "@app/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies";
 
 import {
   formRolePermission2API,
@@ -156,6 +159,7 @@ export const RolePermissionsSection = ({ roleId }: Props) => {
                   <GeneralPermissionPolicies
                     key={`org-role-${roleId}-permission-${subject}`}
                     subject={subject as OrgPermissionSubjects}
+                    subjectScope={PermissionScope.Organization}
                     title={config.title}
                     description={config.description}
                     actions={config.actions}

--- a/frontend/src/pages/organization/SettingsPage/components/ProjectTemplatesTab/components/EditProjectTemplateSection/components/ProjectTemplateEditRoleForm.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/ProjectTemplatesTab/components/EditProjectTemplateSection/components/ProjectTemplateEditRoleForm.tsx
@@ -14,6 +14,7 @@ import { slugSchema } from "@app/lib/schemas";
 import { AddPoliciesButton } from "@app/pages/project/RoleDetailsBySlugPage/components/AddPoliciesButton";
 import {
   GeneralPermissionPolicies,
+  PermissionScope,
   TPermissionAction
 } from "@app/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies";
 import { PermissionEmptyState } from "@app/pages/project/RoleDetailsBySlugPage/components/PermissionEmptyState";
@@ -204,6 +205,7 @@ export const ProjectTemplateEditRoleForm = ({
               {(Object.keys(PROJECT_PERMISSION_OBJECT) as ProjectPermissionSub[]).map((subject) => (
                 <GeneralPermissionPolicies
                   subject={subject}
+                  subjectScope={PermissionScope.Project}
                   actions={PROJECT_PERMISSION_OBJECT[subject].actions as TPermissionAction[]}
                   title={PROJECT_PERMISSION_OBJECT[subject].title}
                   description={PROJECT_PERMISSION_OBJECT[subject].description}

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityProjectAdditionalPrivilegeSection/IdentityProjectAdditionalPrivilegeModifySection.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityProjectAdditionalPrivilegeSection/IdentityProjectAdditionalPrivilegeModifySection.tsx
@@ -43,7 +43,10 @@ import {
   getIdentityAssignPrivilegesConditions
 } from "@app/lib/fn/permission";
 import { AddPoliciesButton } from "@app/pages/project/RoleDetailsBySlugPage/components/AddPoliciesButton";
-import { GeneralPermissionPolicies } from "@app/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies";
+import {
+  GeneralPermissionPolicies,
+  PermissionScope
+} from "@app/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies";
 import { PermissionEmptyState } from "@app/pages/project/RoleDetailsBySlugPage/components/PermissionEmptyState";
 import {
   formRolePermission2API,
@@ -442,6 +445,7 @@ export const IdentityProjectAdditionalPrivilegeModifySection = ({
                       return (
                         <GeneralPermissionPolicies
                           subject={permissionSubject}
+                          subjectScope={PermissionScope.Project}
                           actions={filteredActions}
                           title={PROJECT_PERMISSION_OBJECT[permissionSubject].title}
                           description={PROJECT_PERMISSION_OBJECT[permissionSubject].description}

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberProjectAdditionalPrivilegeSection/MembershipProjectAdditionalPrivilegeModifySection.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberProjectAdditionalPrivilegeSection/MembershipProjectAdditionalPrivilegeModifySection.tsx
@@ -42,7 +42,10 @@ import {
   getMemberAssignPrivilegesConditions
 } from "@app/lib/fn/permission";
 import { AddPoliciesButton } from "@app/pages/project/RoleDetailsBySlugPage/components/AddPoliciesButton";
-import { GeneralPermissionPolicies } from "@app/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies";
+import {
+  GeneralPermissionPolicies,
+  PermissionScope
+} from "@app/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies";
 import { PermissionEmptyState } from "@app/pages/project/RoleDetailsBySlugPage/components/PermissionEmptyState";
 import {
   formRolePermission2API,
@@ -438,6 +441,7 @@ export const MembershipProjectAdditionalPrivilegeModifySection = ({
                       return (
                         <GeneralPermissionPolicies
                           subject={permissionSubject}
+                          subjectScope={PermissionScope.Project}
                           actions={filteredActions}
                           title={PROJECT_PERMISSION_OBJECT[permissionSubject].title}
                           description={PROJECT_PERMISSION_OBJECT[permissionSubject].description}

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
@@ -43,6 +43,11 @@ export type TPermissionAction = {
 
 type AnyPermissionSubject = ProjectPermissionSub | OrgPermissionSubjects;
 
+export enum PermissionScope {
+  Project = "project",
+  Organization = "org"
+}
+
 type Props<T extends AnyPermissionSubject> = {
   title: string;
   description: string;
@@ -55,6 +60,7 @@ type Props<T extends AnyPermissionSubject> = {
   isOpen?: boolean;
   onShowAccessTree?: (subject: string) => void;
   menuPortalContainerRef?: RefObject<HTMLElement | null>;
+  subjectScope: PermissionScope;
 };
 
 type ActionsMultiSelectProps = {
@@ -65,6 +71,7 @@ type ActionsMultiSelectProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<any>;
   menuPortalContainerRef?: RefObject<HTMLElement | null>;
+  subjectScope: PermissionScope;
 };
 
 const ActionsMultiSelect = ({
@@ -73,7 +80,8 @@ const ActionsMultiSelect = ({
   actions,
   isDisabled,
   control,
-  menuPortalContainerRef
+  menuPortalContainerRef,
+  subjectScope
 }: ActionsMultiSelectProps) => {
   const { setValue, trigger } = useFormContext();
 
@@ -123,12 +131,14 @@ const ActionsMultiSelect = ({
           return legacyActionsState.memberGrantPrivileges;
         }
         if (
+          subjectScope === PermissionScope.Project &&
           subject === ProjectPermissionSub.Identity &&
           value === ProjectPermissionIdentityActions.GrantPrivileges
         ) {
           return legacyActionsState.identityGrantPrivileges;
         }
         if (
+          subjectScope === PermissionScope.Project &&
           subject === ProjectPermissionSub.Groups &&
           value === ProjectPermissionGroupActions.GrantPrivileges
         ) {
@@ -137,7 +147,7 @@ const ActionsMultiSelect = ({
 
         return true;
       }),
-    [actions, subject, legacyActionsState]
+    [actions, subject, legacyActionsState, subjectScope]
   );
 
   const actionOptions = useMemo(
@@ -203,7 +213,8 @@ export const GeneralPermissionPolicies = <T extends AnyPermissionSubject>({
   isDisabled,
   isOpen = false,
   onShowAccessTree,
-  menuPortalContainerRef
+  menuPortalContainerRef,
+  subjectScope
 }: Props<T>) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const { control, watch, trigger } = useFormContext<any>();
@@ -339,6 +350,7 @@ export const GeneralPermissionPolicies = <T extends AnyPermissionSubject>({
                         isDisabled={isDisabled}
                         control={control}
                         menuPortalContainerRef={menuPortalContainerRef}
+                        subjectScope={subjectScope}
                       />
                     </div>
                     {!isDisabled && (fields.length > 1 || isConditional || !!onRemoveLastRule) && (

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/RolePermissionsSection.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/RolePermissionsSection.tsx
@@ -23,7 +23,11 @@ import { CertificatePolicyPermissionConditions } from "./CertificatePolicyPermis
 import { CertificateProfilePermissionConditions } from "./CertificateProfilePermissionConditions";
 import { DynamicSecretPermissionConditions } from "./DynamicSecretPermissionConditions";
 import { GeneralPermissionConditions } from "./GeneralPermissionConditions";
-import { GeneralPermissionPolicies, TPermissionAction } from "./GeneralPermissionPolicies";
+import {
+  GeneralPermissionPolicies,
+  PermissionScope,
+  TPermissionAction
+} from "./GeneralPermissionPolicies";
 import { GroupPermissionConditions } from "./GroupPermissionConditions";
 import { IdentityManagementPermissionConditions } from "./IdentityManagementPermissionConditions";
 import { McpEndpointPermissionConditions } from "./McpEndpointPermissionConditions";
@@ -288,6 +292,7 @@ export const RolePermissionsSection = ({ roleSlug, isDisabled }: Props) => {
                     .map((subject) => (
                       <GeneralPermissionPolicies
                         subject={subject}
+                        subjectScope={PermissionScope.Project}
                         actions={PROJECT_PERMISSION_OBJECT[subject].actions as TPermissionAction[]}
                         title={PROJECT_PERMISSION_OBJECT[subject].title}
                         description={PROJECT_PERMISSION_OBJECT[subject].description}


### PR DESCRIPTION
## Context

Custom org roles couldn't grant the **Grant Privileges** action for **Machine Identity Management** or **Group Management** from the UI, even though the API accepted it just fine.

The issue was that the org role builder reuses `GeneralPermissionPolicies`, a component originally built for project roles. That component hides the `grant-privileges` action because it's deprecated at the project level (it was replaced by `assign-role` / `assign-additional-privileges`).

The problem is that org and project permissions use the same string values (`"identity"`, `"groups"`, `"grant-privileges"`), so the project-specific "hide deprecated actions" logic was also running for org roles. As a result, the UI was hiding a valid permission that the backend still supports and requires.

At the organization level, `grant-privileges` is **not** deprecated. It's still the permission the backend checks when assigning roles to org identities and groups, and there's no replacement, so it should always be visible.

## Screenshots

<!-- Add before/after screenshots of the Machine Identity Management and Group Management action dropdowns in the org custom role builder. -->

## Steps to verify

1. In the UI, go to **Organization Access Control → Roles** and create or edit a custom role.
2. Add a **Machine Identity Management** policy and open the actions dropdown. Verify that **Grant Privileges** is available.
3. Repeat the same for **Group Management** and verify that **Grant Privileges** is available there as well.
4. Save the role, reopen it, and confirm the permission was persisted.
5. Verify project roles still behave correctly by opening a project custom role and confirming the deprecated **Grant Privileges (Legacy)** and **Secrets Read** actions remain hidden unless the role already contains them.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format (`type(scope): short description`).
- [x] Tested locally.
- [ ] Updated docs (if needed).
- [ ] Updated `CLAUDE.md` files (if needed).
- [ ] Read the contributing guide.