### PR TITLE
fix(replica): preserve form body stream when forwarding writes to primary

### DIFF
--- a/backend/src/server/plugins/primary-forwarding-mode.ts
+++ b/backend/src/server/plugins/primary-forwarding-mode.ts
@@ -10,7 +10,9 @@ export const forwardWritesToPrimary = fp(async (server, opt: { primaryUrl: strin
   // stream so it can be piped to the primary byte-for-byte (e.g. SAML callback form posts).
   // Safe on replicas: all /api writes are forwarded, so no local route needs a parsed form body.
   server.removeContentTypeParser("application/x-www-form-urlencoded");
-  server.addContentTypeParser("application/x-www-form-urlencoded", (_req, payload, done) => done(null, payload));
+  server.addContentTypeParser("application/x-www-form-urlencoded", { parseAs: "buffer" }, (_req, payload, done) =>
+    done(null, payload)
+  );
 
   server.addHook("preValidation", async (request, reply) => {
     if (request.url.startsWith("/api") && ["POST", "PUT", "DELETE", "PATCH"].includes(request.method)) {

--- a/backend/src/server/plugins/primary-forwarding-mode.ts
+++ b/backend/src/server/plugins/primary-forwarding-mode.ts
@@ -6,6 +6,12 @@ export const forwardWritesToPrimary = fp(async (server, opt: { primaryUrl: strin
     base: opt.primaryUrl
   });
 
+  // reply-from only re-encodes parsed JSON bodies; every other content type must stay a raw
+  // stream so it can be piped to the primary byte-for-byte (e.g. SAML callback form posts).
+  // Safe on replicas: all /api writes are forwarded, so no local route needs a parsed form body.
+  server.removeContentTypeParser("application/x-www-form-urlencoded");
+  server.addContentTypeParser("application/x-www-form-urlencoded", (_req, payload, done) => done(null, payload));
+
   server.addHook("preValidation", async (request, reply) => {
     if (request.url.startsWith("/api") && ["POST", "PUT", "DELETE", "PATCH"].includes(request.method)) {
       return reply.from(request.url);


### PR DESCRIPTION
## Context

On secondary instances (`INFISICAL_PRIMARY_INSTANCE_URL` set), write requests are proxied to the primary via `reply.from()`. SAML ACS callbacks and OAuth token requests POST `application/x-www-form-urlencoded` bodies.

`@fastify/formbody` (registered globally in `app.ts`) parses those into objects. `@fastify/reply-from` only reliably re-encodes parsed JSON, so forwarded form POSTs could arrive at the primary corrupted or empty — breaking SAML login on replicas.

This PR replaces the form-urlencoded parser on secondaries with a pass-through that keeps the raw body stream for byte-for-byte forwarding to the primary.

## Steps to verify the change

1. Run a secondary with `INFISICAL_PRIMARY_INSTANCE_URL` pointing at a primary.
2. Complete a SAML SSO flow that hits the replica (IdP POST to `/api/v1/sso/saml2/...`).
3. Confirm login succeeds on the primary and the forwarded request body is intact (no empty/malformed `SAMLResponse`).
4. Smoke-test an OAuth token POST (`application/x-www-form-urlencoded`) through the replica.
5. On a primary (no `INFISICAL_PRIMARY_INSTANCE_URL`), confirm SAML/OAuth still work with normal formbody parsing.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)