### PR TITLE
fix(ui): close mobile sidebar after navigation

### DIFF
--- a/frontend/src/components/v3/generic/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/v3/generic/Sidebar/Sidebar.tsx
@@ -663,6 +663,7 @@ const sidebarMenuButtonVariants = cva(
 
 function SidebarMenuButton({
   asChild = false,
+  closeOnMobile = false,
   isActive = false,
   variant = "default",
   size = "default",
@@ -673,6 +674,7 @@ function SidebarMenuButton({
   ...props
 }: React.ComponentProps<"button"> & {
   asChild?: boolean;
+  closeOnMobile?: boolean;
   isActive?: boolean;
   tooltip?: string | React.ComponentProps<typeof TooltipContent>;
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
@@ -690,7 +692,7 @@ function SidebarMenuButton({
       className={cn(sidebarMenuButtonVariants({ variant, size, scope }), className)}
       onClick={(event) => {
         onClick?.(event);
-        if (asChild && isMobile) {
+        if (closeOnMobile && isMobile) {
           setOpenMobile(false);
         }
       }}

--- a/frontend/src/components/v3/generic/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/v3/generic/Sidebar/Sidebar.tsx
@@ -669,6 +669,7 @@ function SidebarMenuButton({
   scope: scopeProp,
   tooltip,
   className,
+  onClick,
   ...props
 }: React.ComponentProps<"button"> & {
   asChild?: boolean;
@@ -676,7 +677,7 @@ function SidebarMenuButton({
   tooltip?: string | React.ComponentProps<typeof TooltipContent>;
 } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const Comp = asChild ? Slot : "button";
-  const { isMobile, state } = useSidebar();
+  const { isMobile, setOpenMobile, state } = useSidebar();
   const contextScope = useSidebarScope();
   const scope = scopeProp ?? contextScope;
 
@@ -687,6 +688,12 @@ function SidebarMenuButton({
       data-size={size}
       data-active={isActive || undefined}
       className={cn(sidebarMenuButtonVariants({ variant, size, scope }), className)}
+      onClick={(event) => {
+        onClick?.(event);
+        if (asChild && isMobile) {
+          setOpenMobile(false);
+        }
+      }}
       {...props}
     />
   );

--- a/frontend/src/layouts/AdminLayout/AdminSidebar.tsx
+++ b/frontend/src/layouts/AdminLayout/AdminSidebar.tsx
@@ -102,7 +102,13 @@ const AdminSubmenuView = ({ submenu, onBack }: { submenu: AdminSubmenu; onBack: 
 
           return (
             <SidebarMenuItem key={sub.label}>
-              <SidebarMenuButton size="lg" asChild isActive={isActive} tooltip={sub.label}>
+              <SidebarMenuButton
+                size="lg"
+                asChild
+                closeOnMobile
+                isActive={isActive}
+                tooltip={sub.label}
+              >
                 <Link to={submenu.link} search={{ selectedTab: sub.tab }}>
                   <sub.icon className="size-4" />
                   <span>{sub.label}</span>
@@ -143,7 +149,13 @@ const AdminNav = ({ onSubmenuOpen }: { onSubmenuOpen: (submenu: AdminSubmenu) =>
 
         return (
           <SidebarMenuItem key={item.link}>
-            <SidebarMenuButton asChild isActive={isActive} size="lg" tooltip={item.label}>
+            <SidebarMenuButton
+              asChild
+              closeOnMobile
+              isActive={isActive}
+              size="lg"
+              tooltip={item.label}
+            >
               <Link to={item.link}>
                 <item.icon className="size-4" />
                 <span>{item.label}</span>

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNavLink.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNavLink.tsx
@@ -45,7 +45,13 @@ export const OrgNavLink = ({
 
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton asChild isActive={isActive} size="lg" tooltip={item.label}>
+      <SidebarMenuButton
+        asChild
+        closeOnMobile
+        isActive={isActive}
+        size="lg"
+        tooltip={item.label}
+      >
         <Link
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           to={`/organizations/$orgId/${item.pathSuffix}` as any}

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNavLink.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNavLink.tsx
@@ -45,13 +45,7 @@ export const OrgNavLink = ({
 
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton
-        asChild
-        closeOnMobile
-        isActive={isActive}
-        size="lg"
-        tooltip={item.label}
-      >
+      <SidebarMenuButton asChild closeOnMobile isActive={isActive} size="lg" tooltip={item.label}>
         <Link
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           to={`/organizations/$orgId/${item.pathSuffix}` as any}

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNavLink.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNavLink.tsx
@@ -82,6 +82,7 @@ export const ProjectNavLink = ({
         size="lg"
         scope={sidebarScope}
         asChild
+        closeOnMobile
         isActive={isActive}
         tooltip={item.label}
       >

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectTypeNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectTypeNav.tsx
@@ -55,6 +55,7 @@ export const ProjectTypeNav = () => {
             size="lg"
             scope="project"
             asChild
+            closeOnMobile
             isActive={
               !isOnKmipServers && !isOnSecretSharing && !isOnSecretManagementProductSettings
             }
@@ -75,6 +76,7 @@ export const ProjectTypeNav = () => {
               size="lg"
               scope="project"
               asChild
+              closeOnMobile
               isActive={isOnKmipServers}
               tooltip="KMIP Servers"
             >
@@ -94,6 +96,7 @@ export const ProjectTypeNav = () => {
               size="lg"
               scope="project"
               asChild
+              closeOnMobile
               isActive={isOnSecretSharing}
               tooltip="Secret Sharing"
             >
@@ -113,6 +116,7 @@ export const ProjectTypeNav = () => {
               size="lg"
               scope="project"
               asChild
+              closeOnMobile
               isActive={isOnSecretManagementProductSettings}
               tooltip="Product Settings"
             >

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/SubmenuViews.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/SubmenuViews.tsx
@@ -67,6 +67,7 @@ export const ProjectSubmenuView = ({
                 size="lg"
                 scope={sidebarScope}
                 asChild
+                closeOnMobile
                 isActive={isActive}
                 tooltip={sub.label}
               >


### PR DESCRIPTION
## Context

Fixes [ENG-5412](https://linear.app/infisical/issue/ENG-5412/settings-sheet-not-closing-after-navigation).

On narrow viewports, selecting a navigation destination from the organization settings sidebar changed the underlying route but left the mobile sidebar sheet open. Navigation links now explicitly opt into closing the mobile sidebar after selection.

The behavior is owned by an explicit `closeOnMobile` prop on `SidebarMenuButton`. This avoids inferring navigation semantics from Radix's `asChild` composition mechanism and applies consistently to organization, project, and admin navigation links while leaving submenu-opening buttons unchanged.

## Screenshots

The Linear ticket contains the original screen recording. No current screenshot is attached; the reported organization settings flow was exercised against the local preview before the final contract refactor.

## Steps to verify the change

1. Open the app at a viewport narrower than 1024px.
2. Open the organization sidebar and select **Settings**; confirm the settings submenu remains open.
3. Select **OAuth Applications** or **SSO & Provisioning**; confirm the route changes and the mobile sidebar closes.
4. Repeat with an organization main-navigation link, a project navigation link, and an admin navigation link.
5. Confirm desktop sidebar behavior is unchanged.
6. Run the frontend lint and TypeScript checks.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)