### PR TITLE
improvement: use product color for product activation button and add icon

### DIFF
--- a/frontend/src/components/v3/generic/Button/Button.tsx
+++ b/frontend/src/components/v3/generic/Button/Button.tsx
@@ -35,7 +35,11 @@ const buttonVariants = cva(
           "border-warning/25 bg-warning/10 text-foreground hover:bg-warning/15 hover:border-warning/30 data-[state=open]:bg-warning/15 data-[state=open]:border-warning/30",
         danger:
           "border-danger/25 bg-danger/10 text-foreground hover:bg-danger/15 hover:border-danger/30 data-[state=open]:bg-danger/15 data-[state=open]:border-danger/30",
-        pam: "border-product-pam/30 bg-product-pam/25 text-foreground hover:bg-product-pam/30 hover:border-product-pam/35 data-[state=open]:bg-product-pam/30 data-[state=open]:border-product-pam/35"
+        pam: "border-product-pam/30 bg-product-pam/25 text-foreground hover:bg-product-pam/30 hover:border-product-pam/35 data-[state=open]:bg-product-pam/30 data-[state=open]:border-product-pam/35",
+        // Tinted from --product-color, which the caller must set inline (e.g. a billing catalog
+        // product's color) since the palette isn't knowable at build time.
+        product:
+          "border-(--product-color)/30 bg-(--product-color)/25 text-foreground hover:bg-(--product-color)/30 hover:border-(--product-color)/35 data-[state=open]:bg-(--product-color)/30 data-[state=open]:border-(--product-color)/35"
       },
       size: {
         xs: "h-7 gap-2 rounded-sm px-2 text-xs [&>svg]:size-3",

--- a/frontend/src/pages/organization/BillingV2Page/components/cards/ProductsCard.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/cards/ProductsCard.tsx
@@ -1,5 +1,5 @@
-import { ReactNode } from "react";
-import { DollarSign, Package, RefreshCw } from "lucide-react";
+import { CSSProperties, ReactNode } from "react";
+import { ArrowBigUpDashIcon, DollarSign, Package, RefreshCw } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -217,7 +217,13 @@ const AvailableProductTile = ({
   if (!readOnly) {
     if (selfServe) {
       action = (
-        <Button variant="org" size="sm" onClick={() => onManage(prod.id)}>
+        <Button
+          variant="product"
+          size="sm"
+          style={{ "--product-color": prod.color } as CSSProperties}
+          onClick={() => onManage(prod.id)}
+        >
+          <ArrowBigUpDashIcon />
           Activate
         </Button>
       );


### PR DESCRIPTION
## Context

This PR updates the billing page to use the product color for the product activation button

## Screenshots

<img width="3456" height="1928" alt="CleanShot 2026-07-23 at 19 02 29@2x" src="https://github.com/user-attachments/assets/2ea1c659-5ed7-49a0-a818-1cc6e65ae081" />

## Steps to verify the change

look

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)