### PR TITLE
feat(admin): migrate server console to v3 components

### DIFF
--- a/frontend/src/components/v3/generic/AlertDialog/AlertDialog.tsx
+++ b/frontend/src/components/v3/generic/AlertDialog/AlertDialog.tsx
@@ -90,7 +90,7 @@ function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) 
     <div
       data-slot="alert-dialog-media"
       className={cn(
-        "mb-2 inline-flex size-10 items-center justify-center rounded-md border border-border bg-container sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-container sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
         className
       )}
       {...props}
@@ -122,7 +122,7 @@ function AlertDialogDescription({
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
       className={cn(
-        "text-sm text-balance text-label md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        "text-sm text-label md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
         className
       )}
       {...props}

--- a/frontend/src/components/v3/generic/Input/Input.tsx
+++ b/frontend/src/components/v3/generic/Input/Input.tsx
@@ -10,7 +10,7 @@ const Input = forwardRef<HTMLInputElement, React.ComponentProps<"input"> & { isE
         type={type}
         data-slot="input"
         className={cn(
-          "h-9 w-full min-w-0 rounded-md border border-border bg-transparent px-3 py-1 text-sm text-foreground shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+          "h-9 w-full min-w-0 rounded-md border border-border bg-transparent px-3 py-1 text-base text-foreground shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           "hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60",
           "aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60",
           "selection:bg-foreground selection:text-background",

--- a/frontend/src/components/v3/generic/Pagination/Pagination.tsx
+++ b/frontend/src/components/v3/generic/Pagination/Pagination.tsx
@@ -60,7 +60,7 @@ const Pagination = ({
         </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <IconButton variant="ghost" size="xs">
+            <IconButton variant="ghost" size="xs" aria-label="Select rows per page">
               <ChevronDownIcon />
             </IconButton>
           </DropdownMenuTrigger>
@@ -89,6 +89,7 @@ const Pagination = ({
         <IconButton
           variant="ghost"
           size="xs"
+          aria-label="Go to first page"
           onClick={() => onChangePage(1)}
           isDisabled={!canGoFirst}
         >
@@ -97,6 +98,7 @@ const Pagination = ({
         <IconButton
           variant="ghost"
           size="xs"
+          aria-label="Go to previous page"
           onClick={() => onChangePage(prevPageNumber)}
           isDisabled={!canGoPrev}
         >
@@ -105,6 +107,7 @@ const Pagination = ({
         <IconButton
           variant="ghost"
           size="xs"
+          aria-label="Go to next page"
           onClick={() => onChangePage(nextPageNumber)}
           isDisabled={!canGoNext}
         >
@@ -113,6 +116,7 @@ const Pagination = ({
         <IconButton
           variant="ghost"
           size="xs"
+          aria-label="Go to last page"
           onClick={() => onChangePage(upperLimit)}
           isDisabled={!canGoLast}
         >

--- a/frontend/src/layouts/AdminLayout/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout/AdminLayout.tsx
@@ -24,7 +24,7 @@ export const AdminLayout = () => {
     <>
       <Banner />
       <SidebarProvider
-        className={`dark ${containerHeight} flex !min-h-0 w-full flex-col overflow-hidden bg-bunker-800 transition-all`}
+        className={`dark ${containerHeight} flex !min-h-0 w-full flex-col overflow-hidden bg-background transition-all`}
       >
         <Navbar />
         {!isLoading && !serverDetails?.redisConfigured && <RedisBanner />}
@@ -33,7 +33,7 @@ export const AdminLayout = () => {
         {!window.isSecureContext && <InsecureConnectionBanner />}
         <div className="flex min-h-0 flex-1">
           <AdminSidebar />
-          <div className="min-h-0 flex-1 overflow-y-auto bg-bunker-800 px-12 pt-10 pb-4 dark:scheme-dark">
+          <div className="min-h-0 flex-1 overflow-y-auto bg-background px-4 pt-6 pb-4 text-foreground md:px-8 md:pt-8 xl:px-12 xl:pt-10 dark:scheme-dark">
             <SignupDisabledBanner />
             <Outlet />
           </div>

--- a/frontend/src/layouts/AdminLayout/AdminNavBar.tsx
+++ b/frontend/src/layouts/AdminLayout/AdminNavBar.tsx
@@ -13,7 +13,14 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link, useMatchRoute } from "@tanstack/react-router";
 import { motion } from "framer-motion";
 
-import { Tab, TabList, Tabs, Tooltip } from "@app/components/v2";
+import {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 
 const generalTabs = [
@@ -64,7 +71,7 @@ export const AdminNavBar = () => {
   const { currentOrg } = useOrganization();
 
   return (
-    <div className="border-b border-mineshaft-600 bg-mineshaft-900">
+    <div className="border-b border-border bg-card">
       <motion.div
         initial={{ x: -150 }}
         animate={{ x: 0 }}
@@ -74,25 +81,26 @@ export const AdminNavBar = () => {
       >
         <nav className="w-full">
           <Tabs value="selected">
-            <TabList className="border-b-0">
-              <Tooltip position="bottom" content="Back to organization">
-                <Link to="/organizations/$orgId/projects" params={{ orgId: currentOrg.id }}>
-                  <Tab value="back">
-                    <FontAwesomeIcon icon={faArrowLeft} />
-                  </Tab>
-                </Link>
+            <TabsList variant="admin">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <TabsTrigger value="back" asChild>
+                    <Link to="/organizations/$orgId/projects" params={{ orgId: currentOrg.id }}>
+                      <FontAwesomeIcon icon={faArrowLeft} />
+                    </Link>
+                  </TabsTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Back to organization</TooltipContent>
               </Tooltip>
               {generalTabs.map((tab) => {
                 const isActive = matchRoute({ to: tab.link, fuzzy: false });
                 return (
-                  <Link key={tab.link} to={tab.link}>
-                    <Tab variant="instance" value={isActive ? "selected" : ""}>
-                      {tab.label}
-                    </Tab>
-                  </Link>
+                  <TabsTrigger key={tab.link} value={isActive ? "selected" : ""} asChild>
+                    <Link to={tab.link}>{tab.label}</Link>
+                  </TabsTrigger>
                 );
               })}
-            </TabList>
+            </TabsList>
           </Tabs>
         </nav>
       </motion.div>

--- a/frontend/src/pages/admin/AccessManagementPage/AccessManagementPage.tsx
+++ b/frontend/src/pages/admin/AccessManagementPage/AccessManagementPage.tsx
@@ -9,11 +9,11 @@ export const AccessManagementPage = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="h-full bg-bunker-800">
+    <div className="h-full bg-background text-foreground">
       <Helmet>
         <title>{t("common.head-title", { title: "Access Control" })}</title>
       </Helmet>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+      <div className="mx-auto flex flex-col justify-between">
         <div className="mx-auto mb-6 w-full max-w-8xl">
           <PageHeader
             scope="instance"

--- a/frontend/src/pages/admin/AccessManagementPage/components/AddServerAdminModal.tsx
+++ b/frontend/src/pages/admin/AccessManagementPage/components/AddServerAdminModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -55,6 +55,7 @@ type FormData = z.infer<typeof AddServerAdminSchema>;
 
 const Content = ({ onClose }: ContentProps) => {
   const grantAdmin = useAdminGrantServerAdminAccess();
+  const userSelectId = useId();
 
   const {
     handleSubmit,
@@ -91,8 +92,9 @@ const Content = ({ onClose }: ContentProps) => {
       <Controller
         render={({ field, fieldState: { error } }) => (
           <Field>
-            <FieldLabel>User</FieldLabel>
+            <FieldLabel htmlFor={userSelectId}>User</FieldLabel>
             <FilterableSelect
+              inputId={userSelectId}
               isLoading={searchUserFilter !== debouncedSearchTerm || isPending}
               className="w-full"
               placeholder="Search users..."

--- a/frontend/src/pages/admin/AccessManagementPage/components/AddServerAdminModal.tsx
+++ b/frontend/src/pages/admin/AccessManagementPage/components/AddServerAdminModal.tsx
@@ -4,7 +4,19 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FilterableSelect, FormControl, Modal, ModalContent } from "@app/components/v2";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  FilterableSelect
+} from "@app/components/v3";
 import { useDebounce } from "@app/hooks";
 import { useAdminGetUsers, useAdminGrantServerAdminAccess } from "@app/hooks/api";
 import { User } from "@app/hooks/api/users/types";
@@ -75,10 +87,11 @@ const Content = ({ onClose }: ContentProps) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
       <Controller
         render={({ field, fieldState: { error } }) => (
-          <FormControl isError={Boolean(error)} errorText={error?.message} label="User">
+          <Field>
+            <FieldLabel>User</FieldLabel>
             <FilterableSelect
               isLoading={searchUserFilter !== debouncedSearchTerm || isPending}
               className="w-full"
@@ -93,38 +106,34 @@ const Content = ({ onClose }: ContentProps) => {
                 if (!value) setDebouncedSearchTerm("");
               }}
             />
-          </FormControl>
+            <FieldError>{error?.message}</FieldError>
+          </Field>
         )}
         control={control}
         name="user"
       />
-      <div className="flex w-full gap-4 pt-4">
-        <Button
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-          colorSchema="secondary"
-        >
-          Grant
-        </Button>
-        <Button onClick={() => onClose()} variant="plain" colorSchema="secondary">
+      <DialogFooter>
+        <Button variant="ghost" type="button" onClick={() => onClose()}>
           Cancel
         </Button>
-      </div>
+        <Button variant="neutral" type="submit" isPending={isSubmitting}>
+          Grant
+        </Button>
+      </DialogFooter>
     </form>
   );
 };
 
 export const AddServerAdminModal = ({ isOpen, onOpenChange }: Props) => {
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        bodyClassName="overflow-visible"
-        title="Grant Server Admin"
-        subTitle="Grant server admin status to a user"
-      >
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader className="text-left">
+          <DialogTitle>Grant Server Admin</DialogTitle>
+          <DialogDescription>Grant server admin status to a user.</DialogDescription>
+        </DialogHeader>
         <Content onClose={() => onOpenChange(false)} />
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/admin/AccessManagementPage/components/ServerAdminsTable.tsx
+++ b/frontend/src/pages/admin/AccessManagementPage/components/ServerAdminsTable.tsx
@@ -115,6 +115,7 @@ const ServerAdminsPanelTable = ({
     <>
       <div className="flex items-center gap-x-2">
         <Input
+          aria-label="Search server admins"
           value={searchUserFilter}
           onChange={(e) => setSearchUserFilter(e.target.value)}
           leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
@@ -136,6 +137,7 @@ const ServerAdminsPanelTable = ({
               <Tr>
                 <Th className="w-5">
                   <Checkbox
+                    aria-label="Select all server admins on this page"
                     id="member-page-select"
                     isChecked={isPageSelected || isPageIndeterminate}
                     isIndeterminate={isPageIndeterminate}
@@ -171,6 +173,7 @@ const ServerAdminsPanelTable = ({
                     <Tr key={`user-${id}`} className="w-full">
                       <Td>
                         <Checkbox
+                          aria-label={`Select user ${username || email}`}
                           id={`select-user-${id}`}
                           isChecked={isSelected}
                           onClick={(e) => {

--- a/frontend/src/pages/admin/AccessManagementPage/components/ServerAdminsTable.tsx
+++ b/frontend/src/pages/admin/AccessManagementPage/components/ServerAdminsTable.tsx
@@ -15,29 +15,7 @@ import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
-import {
-  Button,
-  Checkbox,
-  DeleteActionModal,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  EmptyState,
-  IconButton,
-  Input,
-  Pagination,
-  Table,
-  TableContainer,
-  TableSkeleton,
-  TBody,
-  Td,
-  Th,
-  THead,
-  Tooltip,
-  Tr
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, Pagination } from "@app/components/v3";
 import { useSubscription, useUser } from "@app/context";
 import {
   getUserTablePreference,
@@ -54,6 +32,29 @@ import {
 import { User } from "@app/hooks/api/users/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 import { AddServerAdminModal } from "@app/pages/admin/AccessManagementPage/components/AddServerAdminModal";
+import {
+  EmptyState,
+  Table,
+  TableContainer,
+  TableSkeleton,
+  TBody,
+  Td,
+  Th,
+  THead,
+  Tr
+} from "@app/pages/admin/components/AdminTable";
+import {
+  Button,
+  Checkbox,
+  DeleteActionModal,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  IconButton,
+  Input,
+  Tooltip
+} from "@app/pages/admin/components/AdminV3Adapters";
 
 const removeServerAdminUpgradePlanMessage = "Removing Server Admin permissions from user";
 
@@ -192,12 +193,7 @@ const ServerAdminsPanelTable = ({
                         <div className="flex justify-end">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <IconButton
-                                ariaLabel="Options"
-                                colorSchema="secondary"
-                                className="w-6"
-                                variant="plain"
-                              >
+                              <IconButton ariaLabel="Options" size="xs" variant="plain">
                                 <FontAwesomeIcon icon={faEllipsisV} />
                               </IconButton>
                             </DropdownMenuTrigger>
@@ -205,7 +201,10 @@ const ServerAdminsPanelTable = ({
                               <DropdownMenuItem
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  handlePopUpOpen("removeUser", { username, id });
+                                  handlePopUpOpen("removeUser", {
+                                    username,
+                                    id
+                                  });
                                 }}
                                 icon={<FontAwesomeIcon icon={faUserXmark} />}
                               >
@@ -232,7 +231,10 @@ const ServerAdminsPanelTable = ({
                                     });
                                     return;
                                   }
-                                  handlePopUpOpen("removeServerAdmin", { username, id });
+                                  handlePopUpOpen("removeServerAdmin", {
+                                    username,
+                                    id
+                                  });
                                 }}
                               >
                                 Remove Server Admin
@@ -314,7 +316,10 @@ export const ServerAdminsTable = () => {
   };
 
   const handleRemoveServerAdminAccess = async () => {
-    const { id } = popUp?.removeServerAdmin?.data as { id: string; username: string };
+    const { id } = popUp?.removeServerAdmin?.data as {
+      id: string;
+      username: string;
+    };
 
     await removeAdminAccess(id);
     createNotification({
@@ -370,7 +375,7 @@ export const ServerAdminsTable = () => {
           </Button>
         </div>
       </div>
-      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+      <div className="mb-6 rounded-lg border border-border bg-card p-5 text-foreground">
         <ServerAdminsPanelTable
           handlePopUpOpen={handlePopUpOpen}
           users={users}

--- a/frontend/src/pages/admin/AuthenticationPage/AuthenticationPage.tsx
+++ b/frontend/src/pages/admin/AuthenticationPage/AuthenticationPage.tsx
@@ -9,11 +9,11 @@ export const AuthenticationPage = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="h-full bg-bunker-800">
+    <div className="h-full bg-background text-foreground">
       <Helmet>
         <title>{t("common.head-title", { title: "Admin" })}</title>
       </Helmet>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+      <div className="mx-auto flex flex-col justify-between">
         <div className="mx-auto mb-6 w-full max-w-8xl">
           <PageHeader
             scope="instance"

--- a/frontend/src/pages/admin/AuthenticationPage/components/AuthenticationPageForm.tsx
+++ b/frontend/src/pages/admin/AuthenticationPage/components/AuthenticationPageForm.tsx
@@ -154,6 +154,7 @@ export const AuthenticationPageForm = () => {
                     </FieldContent>
                     <Switch
                       id={id}
+                      aria-label={label}
                       variant="neutral"
                       checked={field.value}
                       onCheckedChange={field.onChange}

--- a/frontend/src/pages/admin/AuthenticationPage/components/AuthenticationPageForm.tsx
+++ b/frontend/src/pages/admin/AuthenticationPage/components/AuthenticationPageForm.tsx
@@ -3,7 +3,21 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Switch } from "@app/components/v2";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldTitle,
+  Switch
+} from "@app/components/v3";
 import { useServerConfig } from "@app/context";
 import { useUpdateServerConfig } from "@app/hooks/api";
 import { LoginMethod } from "@app/hooks/api/admin/types";
@@ -19,6 +33,20 @@ const formSchema = z.object({
 });
 
 type TAuthForm = z.infer<typeof formSchema>;
+
+const loginMethods: Array<{
+  id: string;
+  label: string;
+  name: keyof TAuthForm;
+}> = [
+  { id: "email-enabled", label: "Email", name: "isEmailEnabled" },
+  { id: "google-enabled", label: "Google SSO", name: "isGoogleEnabled" },
+  { id: "enable-github", label: "GitHub SSO", name: "isGithubEnabled" },
+  { id: "enable-gitlab", label: "GitLab SSO", name: "isGitlabEnabled" },
+  { id: "enable-saml", label: "SAML SSO", name: "isSamlEnabled" },
+  { id: "enable-oidc", label: "OIDC SSO", name: "isOidcEnabled" },
+  { id: "enable-ldap", label: "LDAP", name: "isLdapEnabled" }
+];
 
 export const AuthenticationPageForm = () => {
   const { config } = useServerConfig();
@@ -102,143 +130,50 @@ export const AuthenticationPageForm = () => {
   };
 
   return (
-    <form
-      className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4"
-      onSubmit={handleSubmit(onAuthFormSubmit)}
-    >
-      <div className="flex flex-col justify-start">
-        <div className="mb-2 text-xl font-medium text-mineshaft-100">Login Methods</div>
-        <div className="mb-4 max-w-sm text-sm text-mineshaft-400">
-          Select the login methods you wish to allow for all users of this instance.
-        </div>
-        <Controller
-          control={control}
-          name="isEmailEnabled"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="email-enabled"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-24">Email</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-        <Controller
-          control={control}
-          name="isGoogleEnabled"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="google-enabled"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-24">Google SSO</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-        <Controller
-          control={control}
-          name="isGithubEnabled"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="enable-github"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-24">Github SSO</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-        <Controller
-          control={control}
-          name="isGitlabEnabled"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="enable-gitlab"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-24">Gitlab SSO</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-        <Controller
-          control={control}
-          name="isSamlEnabled"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="enable-saml"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-24">SAML SSO</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-        <Controller
-          control={control}
-          name="isOidcEnabled"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="enable-oidc"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-24">OIDC SSO</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-      </div>
-      <Controller
-        control={control}
-        name="isLdapEnabled"
-        render={({ field, fieldState: { error } }) => {
-          return (
-            <FormControl isError={Boolean(error)} errorText={error?.message}>
-              <Switch
-                id="enable-ldap"
-                onCheckedChange={(value) => field.onChange(value)}
-                isChecked={field.value}
-              >
-                <p className="w-24">LDAP</p>
-              </Switch>
-            </FormControl>
-          );
-        }}
-      />
-      <Button
-        className="mt-2"
-        type="submit"
-        isLoading={isSubmitting}
-        isDisabled={isSubmitting || !isDirty}
-      >
-        Save
-      </Button>
-    </form>
+    <Card>
+      <CardHeader>
+        <CardTitle>Login Methods</CardTitle>
+        <CardDescription>
+          Select the login methods available to all users of this instance.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(onAuthFormSubmit)}>
+          <FieldGroup>
+            {loginMethods.map(({ id, label, name }) => (
+              <Controller
+                key={name}
+                control={control}
+                name={name}
+                render={({ field, fieldState: { error } }) => (
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldTitle>{label}</FieldTitle>
+                      <FieldDescription>Allow users to authenticate with {label}.</FieldDescription>
+                      <FieldError>{error?.message}</FieldError>
+                    </FieldContent>
+                    <Switch
+                      id={id}
+                      variant="neutral"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </Field>
+                )}
+              />
+            ))}
+          </FieldGroup>
+          <Button
+            variant="neutral"
+            className="mt-6"
+            type="submit"
+            isPending={isSubmitting}
+            isDisabled={!isDirty}
+          >
+            Save
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
   );
 };

--- a/frontend/src/pages/admin/CachingPage/CachingPage.tsx
+++ b/frontend/src/pages/admin/CachingPage/CachingPage.tsx
@@ -9,11 +9,11 @@ export const CachingPage = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="h-full bg-bunker-800">
+    <div className="h-full bg-background text-foreground">
       <Helmet>
         <title>{t("common.head-title", { title: "Admin" })}</title>
       </Helmet>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+      <div className="mx-auto flex flex-col justify-between">
         <div className="mx-auto mb-6 w-full max-w-8xl">
           <PageHeader
             scope="instance"

--- a/frontend/src/pages/admin/CachingPage/components/CachingPageForm.tsx
+++ b/frontend/src/pages/admin/CachingPage/components/CachingPageForm.tsx
@@ -133,7 +133,7 @@ export const CachingPageForm = () => {
             className="contents"
             onSubmit={(event) => {
               event.preventDefault();
-              void handleInvalidateCacheSubmit();
+              handleInvalidateCacheSubmit().catch(() => undefined);
             }}
           >
             <AlertDialogHeader className="text-left">

--- a/frontend/src/pages/admin/CachingPage/components/CachingPageForm.tsx
+++ b/frontend/src/pages/admin/CachingPage/components/CachingPageForm.tsx
@@ -6,7 +6,6 @@ import {
   Alert,
   AlertDescription,
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -36,6 +35,7 @@ export const CachingPageForm = () => {
 
   const [type, setType] = useState<CacheType | null>(null);
   const [shouldPoll, setShouldPoll] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [confirmation, setConfirmation] = useState("");
   const confirmationInputId = useId();
 
@@ -44,7 +44,9 @@ export const CachingPageForm = () => {
     isFetching,
     refetch
   } = useGetInvalidatingCacheStatus(shouldPoll);
-  const isInvalidating = Boolean(shouldPoll && (isFetching || invalidationStatus));
+  const isInvalidating = Boolean(
+    isSubmitting || (shouldPoll && (isFetching || invalidationStatus))
+  );
 
   const { popUp, handlePopUpOpen, handlePopUpClose, handlePopUpToggle } = usePopUp([
     "invalidateCache"
@@ -53,14 +55,21 @@ export const CachingPageForm = () => {
   const handleInvalidateCacheSubmit = async () => {
     if (!type || isInvalidating) return;
 
-    await invalidateCache({ type });
-    createNotification({
-      text: `Began invalidating ${type} cache`,
-      type: "success"
-    });
-    setShouldPoll(true);
-    setConfirmation("");
-    handlePopUpClose("invalidateCache");
+    setIsSubmitting(true);
+    try {
+      await invalidateCache({ type });
+      createNotification({
+        text: `Began invalidating ${type} cache`,
+        type: "success"
+      });
+      setShouldPoll(true);
+      setConfirmation("");
+      handlePopUpClose("invalidateCache");
+    } catch {
+      // MutationCache reports request errors globally; keep the dialog and confirmation available.
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   useEffect(() => {
@@ -114,44 +123,55 @@ export const CachingPageForm = () => {
       <AlertDialog
         open={popUp.invalidateCache.isOpen}
         onOpenChange={(isOpen) => {
+          if (isSubmitting && !isOpen) return;
           handlePopUpToggle("invalidateCache", isOpen);
           if (!isOpen) setConfirmation("");
         }}
       >
         <AlertDialogContent>
-          <AlertDialogHeader className="text-left">
-            <AlertDialogTitle>Invalidate {type} cache?</AlertDialogTitle>
-            <AlertDialogDescription>
-              This action is permanent and may take several minutes to complete.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <Field>
-            <FieldLabel htmlFor={confirmationInputId}>Type confirm to continue</FieldLabel>
-            <Input
-              id={confirmationInputId}
-              name={confirmationInputId}
-              value={confirmation}
-              onChange={(event) => setConfirmation(event.target.value)}
-              autoComplete="new-password"
-              data-1p-ignore
-              data-lpignore="true"
-              spellCheck={false}
-            />
-          </Field>
-          <Alert variant="danger" className="items-center [&>svg]:translate-y-0">
-            <TriangleAlertIcon />
-            <AlertDescription className="text-current">This cannot be undone.</AlertDescription>
-          </Alert>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              variant="danger"
-              isDisabled={confirmation !== "confirm" || isInvalidating}
-              onClick={handleInvalidateCacheSubmit}
-            >
-              Invalidate cache
-            </AlertDialogAction>
-          </AlertDialogFooter>
+          <form
+            className="contents"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleInvalidateCacheSubmit();
+            }}
+          >
+            <AlertDialogHeader className="text-left">
+              <AlertDialogTitle>Invalidate {type} cache?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This action is permanent and may take several minutes to complete.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <Field>
+              <FieldLabel htmlFor={confirmationInputId}>Type confirm to continue</FieldLabel>
+              <Input
+                id={confirmationInputId}
+                name={confirmationInputId}
+                value={confirmation}
+                onChange={(event) => setConfirmation(event.target.value)}
+                autoComplete="new-password"
+                data-1p-ignore
+                data-lpignore="true"
+                spellCheck={false}
+              />
+            </Field>
+            <Alert variant="danger" className="items-center [&>svg]:translate-y-0">
+              <TriangleAlertIcon />
+              <AlertDescription className="text-current">This cannot be undone.</AlertDescription>
+            </Alert>
+            <AlertDialogFooter>
+              <AlertDialogCancel isDisabled={isSubmitting}>Cancel</AlertDialogCancel>
+              <Button
+                type="submit"
+                variant="danger"
+                size="sm"
+                isPending={isSubmitting}
+                isDisabled={confirmation !== "confirm" || isInvalidating}
+              >
+                Invalidate cache
+              </Button>
+            </AlertDialogFooter>
+          </form>
         </AlertDialogContent>
       </AlertDialog>
     </>

--- a/frontend/src/pages/admin/CachingPage/components/CachingPageForm.tsx
+++ b/frontend/src/pages/admin/CachingPage/components/CachingPageForm.tsx
@@ -1,9 +1,29 @@
-import { useEffect, useState } from "react";
-import { RefreshCwIcon } from "lucide-react";
+import { useEffect, useId, useState } from "react";
+import { RefreshCwIcon, TriangleAlertIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, DeleteActionModal } from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Badge,
+  Button,
+  Card,
+  CardAction,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
 import { useUser } from "@app/context";
 import { usePopUp } from "@app/hooks";
 import { useInvalidateCache } from "@app/hooks/api";
@@ -16,6 +36,8 @@ export const CachingPageForm = () => {
 
   const [type, setType] = useState<CacheType | null>(null);
   const [shouldPoll, setShouldPoll] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const confirmationInputId = useId();
 
   const {
     data: invalidationStatus,
@@ -32,8 +54,12 @@ export const CachingPageForm = () => {
     if (!type || isInvalidating) return;
 
     await invalidateCache({ type });
-    createNotification({ text: `Began invalidating ${type} cache`, type: "success" });
+    createNotification({
+      text: `Began invalidating ${type} cache`,
+      type: "success"
+    });
     setShouldPoll(true);
+    setConfirmation("");
     handlePopUpClose("invalidateCache");
   };
 
@@ -42,7 +68,10 @@ export const CachingPageForm = () => {
 
     if (shouldPoll) {
       setShouldPoll(false);
-      createNotification({ text: "Successfully invalidated cache", type: "success" });
+      createNotification({
+        text: "Successfully invalidated cache",
+        type: "success"
+      });
     }
   }, [isInvalidating, shouldPoll]);
 
@@ -52,42 +81,79 @@ export const CachingPageForm = () => {
 
   return (
     <>
-      <div className="mb-6 flex flex-wrap items-end justify-between gap-4 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-        <div className="flex flex-col">
-          <div className="mb-2 flex items-center gap-3">
-            <span className="text-xl font-medium text-mineshaft-100">Secrets Cache</span>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            Secrets Cache
             {isInvalidating && (
               <Badge variant="danger">
                 <RefreshCwIcon className="animate-spin" />
-                Invalidating Cache
+                Invalidating cache
               </Badge>
             )}
-          </div>
-          <span className="max-w-xl text-sm text-mineshaft-400">
+          </CardTitle>
+          <CardDescription className="max-w-xl">
             The encrypted secrets cache encompasses all secrets stored within the system and
             provides a temporary, secure storage location for frequently accessed credentials.
-          </span>
-        </div>
-
-        <Button
-          colorSchema="danger"
-          onClick={() => {
-            setType(CacheType.SECRETS);
-            handlePopUpOpen("invalidateCache");
-          }}
-          isDisabled={!user.superAdmin || isInvalidating}
-        >
-          Invalidate Secrets Cache
-        </Button>
-      </div>
-      <DeleteActionModal
-        isOpen={popUp.invalidateCache.isOpen}
-        title={`Are you sure you want to invalidate ${type} cache?`}
-        subTitle="This action is permanent and irreversible. The cache invalidation process may take several minutes to complete."
-        onChange={(isOpen) => handlePopUpToggle("invalidateCache", isOpen)}
-        deleteKey="confirm"
-        onDeleteApproved={handleInvalidateCacheSubmit}
-      />
+          </CardDescription>
+          <CardAction>
+            <Button
+              variant="danger"
+              onClick={() => {
+                setConfirmation("");
+                setType(CacheType.SECRETS);
+                handlePopUpOpen("invalidateCache");
+              }}
+              isDisabled={!user.superAdmin || isInvalidating}
+            >
+              Invalidate secrets cache
+            </Button>
+          </CardAction>
+        </CardHeader>
+      </Card>
+      <AlertDialog
+        open={popUp.invalidateCache.isOpen}
+        onOpenChange={(isOpen) => {
+          handlePopUpToggle("invalidateCache", isOpen);
+          if (!isOpen) setConfirmation("");
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader className="text-left">
+            <AlertDialogTitle>Invalidate {type} cache?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action is permanent and may take several minutes to complete.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Field>
+            <FieldLabel htmlFor={confirmationInputId}>Type confirm to continue</FieldLabel>
+            <Input
+              id={confirmationInputId}
+              name={confirmationInputId}
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+              autoComplete="new-password"
+              data-1p-ignore
+              data-lpignore="true"
+              spellCheck={false}
+            />
+          </Field>
+          <Alert variant="danger" className="items-center [&>svg]:translate-y-0">
+            <TriangleAlertIcon />
+            <AlertDescription className="text-current">This cannot be undone.</AlertDescription>
+          </Alert>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="danger"
+              isDisabled={confirmation !== "confirm" || isInvalidating}
+              onClick={handleInvalidateCacheSubmit}
+            >
+              Invalidate cache
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 };

--- a/frontend/src/pages/admin/EncryptionPage/EncryptionPage.tsx
+++ b/frontend/src/pages/admin/EncryptionPage/EncryptionPage.tsx
@@ -9,11 +9,11 @@ export const EncryptionPage = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="h-full bg-bunker-800">
+    <div className="h-full bg-background text-foreground">
       <Helmet>
         <title>{t("common.head-title", { title: "Admin" })}</title>
       </Helmet>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+      <div className="mx-auto flex flex-col justify-between">
         <div className="mx-auto mb-6 w-full max-w-8xl">
           <PageHeader
             scope="instance"

--- a/frontend/src/pages/admin/EncryptionPage/components/EncryptionPageForm.tsx
+++ b/frontend/src/pages/admin/EncryptionPage/components/EncryptionPageForm.tsx
@@ -6,8 +6,26 @@ import { z } from "zod";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Select, SelectItem, Tooltip } from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useServerConfig, useSubscription } from "@app/context";
 import { usePopUp } from "@app/hooks";
 import {
@@ -70,70 +88,75 @@ export const EncryptionPageForm = () => {
 
   return (
     <>
-      <form
-        className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4"
-        onSubmit={handleSubmit(onSubmit)}
-      >
-        <div className="flex flex-col justify-start">
-          <div className="flex w-full justify-between">
-            <div className="mb-2 text-xl font-medium text-mineshaft-100">
-              KMS Encryption Strategy
-            </div>
-          </div>
-          <div className="mb-4 max-w-sm text-sm text-mineshaft-400">
+      <Card>
+        <CardHeader>
+          <CardTitle>KMS Encryption Strategy</CardTitle>
+          <CardDescription>
             Select which type of encryption strategy you want to use for your KMS root key. HSM is
             supported on Enterprise plans.
-          </div>
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit(onSubmit)}>
+            {!!rootKmsDetails && (
+              <Controller
+                control={control}
+                name="encryptionStrategy"
+                render={({ field: { onChange, value }, fieldState: { error } }) => (
+                  <Field className="max-w-sm">
+                    <FieldLabel htmlFor="server-encryption-strategy">
+                      Encryption strategy
+                    </FieldLabel>
+                    <Select value={value} onValueChange={onChange}>
+                      <SelectTrigger
+                        id="server-encryption-strategy"
+                        isError={Boolean(error)}
+                        className="w-full"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {rootKmsDetails.strategies?.map((strategy) => (
+                          <SelectItem key={strategy.strategy} value={strategy.strategy}>
+                            {strategies[strategy.strategy]}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+            )}
 
-          {!!rootKmsDetails && (
-            <Controller
-              control={control}
-              name="encryptionStrategy"
-              render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                <FormControl
-                  className="max-w-sm"
-                  errorText={error?.message}
-                  isError={Boolean(error)}
-                >
-                  <Select
-                    className="w-full bg-mineshaft-700"
-                    dropdownContainerClassName="bg-mineshaft-800"
-                    defaultValue={field.value}
-                    onValueChange={(e) => onChange(e)}
-                    {...field}
-                  >
-                    {rootKmsDetails.strategies?.map((strategy) => (
-                      <SelectItem key={strategy.strategy} value={strategy.strategy}>
-                        {strategies[strategy.strategy]}
-                      </SelectItem>
-                    ))}
-                  </Select>
-                </FormControl>
+            <div className="mt-6 flex w-full items-center justify-between">
+              <Button
+                variant="neutral"
+                type="submit"
+                isPending={isSubmitting}
+                isDisabled={!isDirty}
+              >
+                Save
+              </Button>
+
+              {config.fipsEnabled && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge variant="info">
+                      FIPS mode enabled
+                      <InfoIcon />
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    FIPS mode is enabled. Cryptographic operations within the FIPS boundaries are
+                    validated as FIPS compliant.
+                  </TooltipContent>
+                </Tooltip>
               )}
-            />
-          )}
-        </div>
-
-        <div className="flex w-full items-center justify-between">
-          <Button
-            className="mt-2"
-            type="submit"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
-          >
-            Save
-          </Button>
-
-          {config.fipsEnabled && (
-            <Tooltip content="FIPS mode of operation is enabled for your instance. All cryptographic operations within the FIPS boundaries are validated to be FIPS compliant.">
-              <Badge variant="info">
-                FIPS Mode: Enabled
-                <InfoIcon />
-              </Badge>
-            </Tooltip>
-          )}
-        </div>
-      </form>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}

--- a/frontend/src/pages/admin/EnvironmentPage/EnvironmentPage.tsx
+++ b/frontend/src/pages/admin/EnvironmentPage/EnvironmentPage.tsx
@@ -9,11 +9,11 @@ export const EnvironmentPage = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="bg-bunker-800">
+    <div className="bg-background text-foreground">
       <Helmet>
         <title>{t("common.head-title", { title: "Admin" })}</title>
       </Helmet>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+      <div className="mx-auto flex flex-col justify-between">
         <div className="mx-auto mb-6 w-full max-w-8xl">
           <PageHeader
             scope="instance"

--- a/frontend/src/pages/admin/EnvironmentPage/components/EnvironmentPageForm.tsx
+++ b/frontend/src/pages/admin/EnvironmentPage/components/EnvironmentPageForm.tsx
@@ -1,18 +1,33 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Control, Controller, useForm, useWatch } from "react-hook-form";
-import {
-  faChevronRight,
-  faExclamationTriangle,
-  faMagnifyingGlass
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Search, TriangleAlert } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input, SecretInput, Tooltip } from "@app/components/v2";
 import { HighlightText } from "@app/components/v2/HighlightText";
-import { DocumentationLinkBadge } from "@app/components/v3";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  DocumentationLinkBadge,
+  Field,
+  FieldError,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  SecretInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useGetEnvOverrides, useUpdateServerConfig } from "@app/hooks/api";
 
 type TForm = Record<string, string>;
@@ -34,55 +49,34 @@ export const GroupContainer = ({
   control: Control<TForm, any, TForm>;
   search: string;
 }) => {
-  const [open, setOpen] = useState(false);
-
   return (
-    <div
-      key={group.name}
-      className="overflow-clip border border-b-0 border-mineshaft-600 bg-mineshaft-800 first:rounded-t-md last:rounded-b-md last:border-b"
-    >
-      <div
-        className="flex h-14 cursor-pointer items-center px-5 py-4 text-sm text-gray-300"
-        role="button"
-        tabIndex={0}
-        onClick={() => setOpen((o) => !o)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            setOpen((o) => !o);
-          }
-        }}
-      >
-        <FontAwesomeIcon
-          className={`mr-8 transition-transform duration-100 ${open || search ? "rotate-90" : ""}`}
-          icon={faChevronRight}
-        />
-
-        <div className="grow text-base select-none">{group.name}</div>
-      </div>
-
-      {(open || search) && (
-        <div className="flex flex-col">
+    <AccordionItem value={group.name}>
+      <AccordionTrigger>{group.name}</AccordionTrigger>
+      <AccordionContent>
+        <div className="flex flex-col divide-y divide-border">
           {group.fields.map((field) => (
             <div
               key={field.key}
-              className="flex items-center justify-between gap-4 border-t border-mineshaft-500 bg-mineshaft-700/50 p-4"
+              className="flex flex-col justify-between gap-4 py-4 first:pt-0 last:pb-0 md:flex-row md:items-center"
             >
               <div className="flex max-w-lg flex-col">
-                <span className="text-sm">
+                <span className="text-sm font-medium text-foreground">
                   <HighlightText text={field.key} highlight={search} />
                 </span>
-                <span className="text-sm text-mineshaft-400">
+                <span className="text-sm text-label">
                   <HighlightText text={field.description} highlight={search} />
                 </span>
               </div>
 
-              <div className="flex grow items-center justify-end gap-2">
+              <div className="flex grow items-center justify-end gap-3">
                 {field.hasEnvEntry && (
-                  <Tooltip
-                    content="Setting this value will override an existing environment variable"
-                    className="text-center"
-                  >
-                    <FontAwesomeIcon icon={faExclamationTriangle} className="text-yellow" />
+                  <Tooltip>
+                    <TooltipTrigger aria-label="Environment variable override warning">
+                      <TriangleAlert className="size-4 text-warning" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Setting this value overrides an existing environment variable.
+                    </TooltipContent>
                   </Tooltip>
                 )}
 
@@ -90,25 +84,18 @@ export const GroupContainer = ({
                   control={control}
                   name={field.key}
                   render={({ field: formGenField, fieldState: { error } }) => (
-                    <FormControl
-                      isError={Boolean(error)}
-                      errorText={error?.message}
-                      className="mb-0 w-full max-w-sm"
-                    >
-                      <SecretInput
-                        {...formGenField}
-                        autoComplete="off"
-                        containerClassName="text-bunker-300 hover:border-mineshaft-400 border border-mineshaft-600 bg-bunker-600 px-2 py-1.5"
-                      />
-                    </FormControl>
+                    <Field className="w-full max-w-sm">
+                      <SecretInput {...formGenField} autoComplete="off" aria-label={field.key} />
+                      <FieldError>{error?.message}</FieldError>
+                    </Field>
                   )}
                 />
               </div>
             </div>
           ))}
         </div>
-      )}
-    </div>
+      </AccordionContent>
+    </AccordionItem>
   );
 };
 
@@ -194,45 +181,44 @@ export const EnvironmentPageForm = () => {
   );
 
   return (
-    <form
-      className="flex flex-col gap-4 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4"
-      onSubmit={handleSubmit(onSubmit)}
-    >
-      <div className="flex w-full flex-row items-center justify-between">
-        <div>
-          <div className="flex items-center gap-x-2">
-            <p className="text-xl font-medium text-mineshaft-100">Overrides</p>
-            <DocumentationLinkBadge href="https://infisical.com/docs/self-hosting/configuration/envars#environment-variable-overrides" />
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          Overrides
+          <DocumentationLinkBadge href="https://infisical.com/docs/self-hosting/configuration/envars#environment-variable-overrides" />
+        </CardTitle>
+        <CardDescription>
+          Override specific environment variables. Saved values may take up to five minutes to
+          propagate to every container.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
+          <div className="flex justify-end">
+            <Button variant="neutral" type="submit" isPending={isSubmitting} isDisabled={!isDirty}>
+              Save
+            </Button>
           </div>
-          <p className="text-sm text-bunker-300">
-            Override specific environment variables. After saving, it may take up to 5 minutes for
-            variables to propagate throughout every container.
-          </p>
-        </div>
-
-        <div className="flex flex-row gap-2">
-          <Button
-            type="submit"
-            variant="outline_bg"
-            isLoading={isSubmitting}
-            isDisabled={isSubmitting || !isDirty}
+          <InputGroup>
+            <InputGroupAddon>
+              <Search />
+            </InputGroupAddon>
+            <InputGroupInput
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search keys and descriptions"
+            />
+          </InputGroup>
+          <Accordion
+            type="multiple"
+            value={search ? filteredData.map((group) => group!.name) : undefined}
           >
-            Save
-          </Button>
-        </div>
-      </div>
-      <Input
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-        leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
-        placeholder="Search for keys, descriptions, and values..."
-        className="flex-1"
-      />
-      <div className="flex flex-col">
-        {filteredData.map((group) => (
-          <GroupContainer group={group!} control={control} search={search} />
-        ))}
-      </div>
-    </form>
+            {filteredData.map((group) => (
+              <GroupContainer key={group!.name} group={group!} control={control} search={search} />
+            ))}
+          </Accordion>
+        </form>
+      </CardContent>
+    </Card>
   );
 };

--- a/frontend/src/pages/admin/EnvironmentPage/components/EnvironmentPageForm.tsx
+++ b/frontend/src/pages/admin/EnvironmentPage/components/EnvironmentPageForm.tsx
@@ -204,6 +204,7 @@ export const EnvironmentPageForm = () => {
               <Search />
             </InputGroupAddon>
             <InputGroupInput
+              aria-label="Search environment variables"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search keys and descriptions"

--- a/frontend/src/pages/admin/GeneralPage/GeneralPage.tsx
+++ b/frontend/src/pages/admin/GeneralPage/GeneralPage.tsx
@@ -11,11 +11,11 @@ export const GeneralPage = () => {
   const { data: serverConfig } = useGetServerConfig();
 
   return (
-    <div className="h-full bg-bunker-800">
+    <div className="h-full bg-background text-foreground">
       <Helmet>
         <title>{t("common.head-title", { title: "Admin" })}</title>
       </Helmet>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+      <div className="mx-auto flex flex-col justify-between">
         <div className="mx-auto mb-6 w-full max-w-8xl">
           <PageHeader
             scope="instance"

--- a/frontend/src/pages/admin/GeneralPage/components/GeneralPageForm.tsx
+++ b/frontend/src/pages/admin/GeneralPage/components/GeneralPageForm.tsx
@@ -236,6 +236,7 @@ export const GeneralPageForm = () => {
                     </FieldContent>
                     <Switch
                       id={`trust-${label.toLowerCase()}-emails`}
+                      aria-label={`Trust ${label} emails`}
                       variant="neutral"
                       checked={field.value}
                       onCheckedChange={field.onChange}

--- a/frontend/src/pages/admin/GeneralPage/components/GeneralPageForm.tsx
+++ b/frontend/src/pages/admin/GeneralPage/components/GeneralPageForm.tsx
@@ -1,20 +1,35 @@
 import { Controller, useForm } from "react-hook-form";
-import { faAt } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { AtSign } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
   Button,
-  FormControl,
-  Input,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldTitle,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
   Select,
-  SelectClear,
+  SelectContent,
   SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
   Switch,
   TextArea
-} from "@app/components/v2";
+} from "@app/components/v3";
 import { useServerConfig } from "@app/context";
 import { useGetOrganizations, useUpdateServerConfig } from "@app/hooks/api";
 
@@ -61,8 +76,6 @@ export const GeneralPageForm = () => {
   });
 
   const signUpMode = watch("signUpMode");
-  const defaultAuthOrgId = watch("defaultAuthOrgId");
-
   const { mutateAsync: updateServerConfig } = useUpdateServerConfig();
 
   const organizations = useGetOrganizations();
@@ -78,7 +91,7 @@ export const GeneralPageForm = () => {
     } = formData;
 
     await updateServerConfig({
-      defaultAuthOrgId: defaultAuthOrgId || null,
+      defaultAuthOrgId: formData.defaultAuthOrgId || null,
       allowSignUp: signUpMode !== SignUpModes.Disabled,
       allowedSignUpDomain: signUpMode === SignUpModes.Anyone ? allowedSignUpDomain : null,
       trustSamlEmails,
@@ -94,208 +107,195 @@ export const GeneralPageForm = () => {
   };
 
   return (
-    <form
-      className="space-y-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4"
-      onSubmit={handleSubmit(onFormSubmit)}
-    >
-      <div className="flex flex-col justify-start">
-        <div className="mb-2 text-xl font-medium text-mineshaft-100">Allow user signups</div>
-        <div className="mb-4 max-w-sm text-sm text-mineshaft-400">
-          Select if you want users to be able to signup freely into your Infisical instance.
-        </div>
-        <Controller
-          control={control}
-          name="signUpMode"
-          render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-            <FormControl className="max-w-sm" errorText={error?.message} isError={Boolean(error)}>
-              <Select
-                className="w-full bg-mineshaft-700"
-                dropdownContainerClassName="bg-mineshaft-800"
-                defaultValue={field.value}
-                onValueChange={(e) => onChange(e)}
-                {...field}
-              >
-                <SelectItem value={SignUpModes.Disabled}>Disabled</SelectItem>
-                <SelectItem value={SignUpModes.Anyone}>Anyone</SelectItem>
-              </Select>
-            </FormControl>
-          )}
-        />
-      </div>
-      {signUpMode === "anyone" && (
-        <div className="flex flex-col justify-start">
-          <div className="mb-4 text-xl font-medium text-mineshaft-100">
-            Restrict signup by email domain(s)
-          </div>
-          <Controller
-            control={control}
-            defaultValue=""
-            name="allowedSignUpDomain"
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                label="Leave blank to allow any email domains"
-                className="w-72"
-                isError={Boolean(error)}
-                errorText={error?.message}
-              >
-                <Input
-                  {...field}
-                  value={field.value || ""}
-                  placeholder="gmail.com, aws.com, redhat.com"
-                  leftIcon={<FontAwesomeIcon icon={faAt} />}
-                />
-              </FormControl>
+    <Card>
+      <CardHeader>
+        <CardTitle>Instance Settings</CardTitle>
+        <CardDescription>
+          Configure signups, authentication defaults, trusted identities, and instance notices.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit(onFormSubmit)}>
+          <FieldGroup>
+            <div>
+              <FieldTitle>Allow User Signups</FieldTitle>
+              <FieldDescription>
+                Choose whether users can sign up for this Infisical instance.
+              </FieldDescription>
+            </div>
+            <Controller
+              control={control}
+              name="signUpMode"
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <Field className="max-w-sm">
+                  <FieldLabel htmlFor="signup-mode">Signup mode</FieldLabel>
+                  <Select value={value} onValueChange={onChange}>
+                    <SelectTrigger id="signup-mode" className="w-full" isError={Boolean(error)}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={SignUpModes.Disabled}>Disabled</SelectItem>
+                      <SelectItem value={SignUpModes.Anyone}>Anyone</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
+              )}
+            />
+            {signUpMode === "anyone" && (
+              <Controller
+                control={control}
+                defaultValue=""
+                name="allowedSignUpDomain"
+                render={({ field, fieldState: { error } }) => (
+                  <Field className="max-w-sm">
+                    <FieldLabel htmlFor="allowed-signup-domains">Allowed email domains</FieldLabel>
+                    <InputGroup>
+                      <InputGroupAddon>
+                        <AtSign />
+                      </InputGroupAddon>
+                      <InputGroupInput
+                        id="allowed-signup-domains"
+                        {...field}
+                        value={field.value || ""}
+                        placeholder="gmail.com, aws.com, redhat.com"
+                      />
+                    </InputGroup>
+                    <FieldDescription>Leave blank to allow any email domain.</FieldDescription>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
             )}
-          />
-        </div>
-      )}
 
-      <div className="flex flex-col justify-start">
-        <div className="mb-2 text-xl font-medium text-mineshaft-100">Default organization</div>
-        <div className="mb-4 max-w-sm text-sm text-mineshaft-400">
-          Select the default organization you want to set for SAML/LDAP/OIDC/Github logins. When
-          selected, user logins will be automatically scoped to the selected organization.
-        </div>
-        <Controller
-          control={control}
-          name="defaultAuthOrgId"
-          render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-            <FormControl className="max-w-sm" errorText={error?.message} isError={Boolean(error)}>
-              <Select
-                placeholder="Allow all organizations"
-                className="w-full bg-mineshaft-700"
-                dropdownContainerClassName="bg-mineshaft-800"
-                defaultValue={field.value ?? " "}
-                onValueChange={(e) => onChange(e)}
-                {...field}
-              >
-                <SelectClear
-                  selectValue={defaultAuthOrgId}
-                  onClear={() => {
-                    onChange("");
-                  }}
-                >
-                  Allow all organizations
-                </SelectClear>
-                {organizations.data?.map((org) => (
-                  <SelectItem key={org.id} value={org.id}>
-                    {org.name}
-                  </SelectItem>
-                ))}
-              </Select>
-            </FormControl>
-          )}
-        />
-      </div>
+            <Separator />
+            <div>
+              <FieldTitle>Default Organization</FieldTitle>
+              <FieldDescription>
+                Select the default organization you want to set for SAML/LDAP/OIDC/Github logins.
+                When selected, user logins will be automatically scoped to the selected
+                organization.
+              </FieldDescription>
+            </div>
+            <Controller
+              control={control}
+              name="defaultAuthOrgId"
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <Field className="max-w-sm">
+                  <FieldLabel htmlFor="default-auth-org">Organization</FieldLabel>
+                  <Select
+                    value={value || "all"}
+                    onValueChange={(next) => onChange(next === "all" ? "" : next)}
+                  >
+                    <SelectTrigger
+                      id="default-auth-org"
+                      className="w-full"
+                      isError={Boolean(error)}
+                    >
+                      <SelectValue placeholder="Allow all organizations" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Allow all organizations</SelectItem>
+                      {organizations.data?.map((org) => (
+                        <SelectItem key={org.id} value={org.id}>
+                          {org.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
+              )}
+            />
 
-      <div className="flex flex-col justify-start">
-        <div className="mb-2 text-xl font-medium text-mineshaft-100">Trust emails</div>
-        <div className="mb-4 max-w-sm text-sm text-mineshaft-400">
-          Select if you want Infisical to trust external emails from SAML/LDAP/OIDC identity
-          providers. If set to false, then Infisical will prompt SAML/LDAP/OIDC provisioned users to
-          verify their email upon their first login.
-        </div>
-        <Controller
-          control={control}
-          name="trustSamlEmails"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="trust-saml-emails"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-full">Trust SAML emails</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-        <Controller
-          control={control}
-          name="trustLdapEmails"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="trust-ldap-emails"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-full">Trust LDAP emails</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-        <Controller
-          control={control}
-          name="trustOidcEmails"
-          render={({ field, fieldState: { error } }) => {
-            return (
-              <FormControl isError={Boolean(error)} errorText={error?.message}>
-                <Switch
-                  id="trust-oidc-emails"
-                  onCheckedChange={(value) => field.onChange(value)}
-                  isChecked={field.value}
-                >
-                  <p className="w-full">Trust OIDC emails</p>
-                </Switch>
-              </FormControl>
-            );
-          }}
-        />
-      </div>
-
-      <div className="flex flex-col justify-start">
-        <div className="mb-2 text-xl font-medium text-mineshaft-100">Notices</div>
-        <div className="mb-4 max-w-lg text-sm text-mineshaft-400">
-          Configure system-wide notification banners and security messages. These settings control
-          the text displayed to users during authentication and throughout their session
-        </div>
-        <Controller
-          render={({ field, fieldState: { error } }) => (
-            <FormControl
-              isError={Boolean(error)}
-              errorText={error?.message}
-              label="Auth Consent Content"
-              tooltipText="Formatting supported: HTML, Markdown, Plain text"
-            >
-              <TextArea
-                placeholder="**Auth Consent Message**"
-                {...field}
-                rows={3}
-                className="h-48 thin-scrollbar max-w-lg resize-none! bg-mineshaft-800"
+            <Separator />
+            <div>
+              <FieldTitle>Trust Emails</FieldTitle>
+              <FieldDescription>
+                Select if you want Infisical to trust external emails from SAML/LDAP/OIDC identity
+                providers. If set to false, then Infisical will prompt SAML/LDAP/OIDC provisioned
+                users to verify their email upon their first login.
+              </FieldDescription>
+            </div>
+            {(
+              [
+                ["trustSamlEmails", "SAML"],
+                ["trustLdapEmails", "LDAP"],
+                ["trustOidcEmails", "OIDC"]
+              ] as const
+            ).map(([name, label]) => (
+              <Controller
+                key={name}
+                control={control}
+                name={name}
+                render={({ field, fieldState: { error } }) => (
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldTitle>Trust {label} emails</FieldTitle>
+                      <FieldError>{error?.message}</FieldError>
+                    </FieldContent>
+                    <Switch
+                      id={`trust-${label.toLowerCase()}-emails`}
+                      variant="neutral"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </Field>
+                )}
               />
-            </FormControl>
-          )}
-          control={control}
-          name="authConsentContent"
-        />
-        <Controller
-          render={({ field, fieldState: { error } }) => (
-            <FormControl
-              isError={Boolean(error)}
-              errorText={error?.message}
-              label="Page Frame Content"
-              tooltipText="Formatting supported: HTML, Markdown, Plain text"
-            >
-              <TextArea
-                placeholder='<div style="background-color: red">TOP SECRET</div>'
-                {...field}
-                rows={3}
-                className="h-48 thin-scrollbar max-w-lg resize-none! bg-mineshaft-800"
-              />
-            </FormControl>
-          )}
-          control={control}
-          name="pageFrameContent"
-        />
-      </div>
-      <Button type="submit" isLoading={isSubmitting} isDisabled={isSubmitting || !isDirty}>
-        Save
-      </Button>
-    </form>
+            ))}
+
+            <Separator />
+            <div>
+              <FieldTitle>Notices</FieldTitle>
+              <FieldDescription>
+                Configure system-wide notification banners and security messages. These settings
+                control the text displayed during authentication and throughout a user&apos;s
+                session.
+              </FieldDescription>
+            </div>
+            <Controller
+              render={({ field, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="auth-consent-content">Auth consent content</FieldLabel>
+                  <TextArea
+                    id="auth-consent-content"
+                    placeholder="**Auth Consent Message**"
+                    {...field}
+                    rows={3}
+                    className="h-48 max-w-lg resize-none"
+                  />
+                  <FieldDescription>Supports HTML, Markdown, and plain text.</FieldDescription>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
+              )}
+              control={control}
+              name="authConsentContent"
+            />
+            <Controller
+              render={({ field, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="page-frame-content">Page frame content</FieldLabel>
+                  <TextArea
+                    id="page-frame-content"
+                    placeholder='<div style="background-color: red">TOP SECRET</div>'
+                    {...field}
+                    rows={3}
+                    className="h-48 max-w-lg resize-none"
+                  />
+                  <FieldDescription>Supports HTML, Markdown, and plain text.</FieldDescription>
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
+              )}
+              control={control}
+              name="pageFrameContent"
+            />
+            <Button variant="neutral" type="submit" isPending={isSubmitting} isDisabled={!isDirty}>
+              Save
+            </Button>
+          </FieldGroup>
+        </form>
+      </CardContent>
+    </Card>
   );
 };

--- a/frontend/src/pages/admin/GeneralPage/components/UsageReportSection.tsx
+++ b/frontend/src/pages/admin/GeneralPage/components/UsageReportSection.tsx
@@ -1,8 +1,15 @@
-import { faDownload, faFileAlt, faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { faDownload, faFileAlt } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, Card, CardTitle } from "@app/components/v2";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@app/components/v3";
 import { downloadFile } from "@app/helpers/download";
 import { useGenerateUsageReport } from "@app/hooks/api/admin/mutation";
 
@@ -22,24 +29,26 @@ export const UsageReportSection = () => {
   };
 
   return (
-    <Card className="p-6">
-      <CardTitle className="mb-4 flex items-center gap-3">
-        <FontAwesomeIcon icon={faFileAlt} />
-        Offline Usage Reports
-      </CardTitle>
-
-      <div className="mb-4 text-sm text-gray-400">
-        Generate secure usage reports for offline license compliance and billing verification.
-      </div>
-
-      <Button
-        onClick={handleGenerateReport}
-        className="w-fit"
-        isLoading={generateUsageReport.isPending}
-        leftIcon={<FontAwesomeIcon icon={generateUsageReport.isPending ? faSpinner : faDownload} />}
-      >
-        {generateUsageReport.isPending ? "Generating..." : "Generate Report"}
-      </Button>
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <FontAwesomeIcon icon={faFileAlt} />
+          Offline Usage Reports
+        </CardTitle>
+        <CardDescription>
+          Generate secure usage reports for offline license compliance and billing verification.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          variant="neutral"
+          onClick={handleGenerateReport}
+          isPending={generateUsageReport.isPending}
+        >
+          <FontAwesomeIcon icon={faDownload} />
+          Generate report
+        </Button>
+      </CardContent>
     </Card>
   );
 };

--- a/frontend/src/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/src/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -9,11 +9,11 @@ export const IntegrationsPage = () => {
   const { t } = useTranslation();
 
   return (
-    <div className="h-full bg-bunker-800">
+    <div className="h-full bg-background text-foreground">
       <Helmet>
         <title>{t("common.head-title", { title: "Admin" })}</title>
       </Helmet>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+      <div className="mx-auto flex flex-col justify-between">
         <div className="mx-auto mb-6 w-full max-w-8xl">
           <PageHeader
             scope="instance"

--- a/frontend/src/pages/admin/IntegrationsPage/components/IntegrationsPageForm.tsx
+++ b/frontend/src/pages/admin/IntegrationsPage/components/IntegrationsPageForm.tsx
@@ -1,6 +1,16 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 
-import { Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger
+} from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useGetAdminIntegrationsConfig } from "@app/hooks/api";
 import { AdminIntegrationsConfig } from "@app/hooks/api/admin/types";
@@ -51,27 +61,29 @@ export const IntegrationsPageForm = () => {
   ];
 
   return (
-    <div className="mb-6 min-h-64 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
-      <div className="mb-4">
-        <div className="text-xl font-medium text-mineshaft-100">Integrations</div>
-        <div className="text-sm text-mineshaft-300">
+    <Card className="min-h-64">
+      <CardHeader>
+        <CardTitle>Integrations</CardTitle>
+        <CardDescription>
           Configure your instance-wide settings to enable integration with third-party services.
-        </div>
-      </div>
-      <Tabs value={selectedTab} onValueChange={updateSelectedTab}>
-        <TabList>
-          {tabSections.map((section) => (
-            <Tab value={section.key} key={`integration-tab-${section.key}`}>
-              {section.label}
-            </Tab>
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Tabs value={selectedTab} onValueChange={updateSelectedTab}>
+          <TabsList variant="admin">
+            {tabSections.map((section) => (
+              <TabsTrigger value={section.key} key={`integration-tab-${section.key}`}>
+                {section.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+          {tabSections.map(({ key, component: Component }) => (
+            <TabsContent value={key} key={`integration-tab-panel-${key}`}>
+              <Component adminIntegrationsConfig={adminIntegrationsConfig!} />
+            </TabsContent>
           ))}
-        </TabList>
-        {tabSections.map(({ key, component: Component }) => (
-          <TabPanel value={key} key={`integration-tab-panel-${key}`}>
-            <Component adminIntegrationsConfig={adminIntegrationsConfig!} />
-          </TabPanel>
-        ))}
-      </Tabs>
-    </div>
+        </Tabs>
+      </CardContent>
+    </Card>
   );
 };

--- a/frontend/src/pages/admin/IntegrationsPage/components/MicrosoftTeamsIntegrationForm.tsx
+++ b/frontend/src/pages/admin/IntegrationsPage/components/MicrosoftTeamsIntegrationForm.tsx
@@ -11,10 +11,13 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
-  FormControl,
-  Input
-} from "@app/components/v2";
-import { useToggle } from "@app/hooks";
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  SecretInput
+} from "@app/components/v3";
 import { useUpdateServerConfig } from "@app/hooks/api";
 import { AdminIntegrationsConfig } from "@app/hooks/api/admin/types";
 
@@ -32,9 +35,6 @@ type Props = {
 
 export const MicrosoftTeamsIntegrationForm = ({ adminIntegrationsConfig }: Props) => {
   const { mutateAsync: updateAdminServerConfig } = useUpdateServerConfig();
-  const [isMicrosoftTeamsAppIdFocused, setIsMicrosoftTeamsAppIdFocused] = useToggle();
-  const [isMicrosoftTeamsClientSecretFocused, setIsMicrosoftTeamsClientSecretFocused] = useToggle();
-  const [isMicrosoftTeamsBotIdFocused, setIsMicrosoftTeamsBotIdFocused] = useToggle();
   const {
     control,
     handleSubmit,
@@ -72,28 +72,30 @@ export const MicrosoftTeamsIntegrationForm = ({ adminIntegrationsConfig }: Props
           value="microsoft-teams-integration"
           className="data-[state=open]:border-none"
         >
-          <AccordionTrigger className="flex h-fit w-full justify-start rounded-md border border-mineshaft-500 bg-mineshaft-700 px-4 py-6 text-sm transition-colors data-[state=open]:rounded-b-none">
-            <div className="text-md group order-1 ml-3 flex items-center gap-2">
-              <BsMicrosoftTeams className="text-lg group-hover:text-primary-400" />
+          <AccordionTrigger>
+            <div className="flex items-center gap-2">
+              <BsMicrosoftTeams className="text-lg" />
               <div className="text-[15px] font-medium">Microsoft Teams</div>
             </div>
           </AccordionTrigger>
-          <AccordionContent childrenClassName="px-0 py-0">
-            <div className="flex w-full flex-col justify-start rounded-md rounded-t-none border border-t-0 border-mineshaft-500 bg-mineshaft-700 px-4 py-4">
-              <div className="mb-2 max-w-lg text-sm text-mineshaft-300">
+          <AccordionContent>
+            <div className="flex w-full flex-col gap-4">
+              <div className="max-w-lg text-sm text-label">
                 Step 1: Create and configure Microsoft Teams bot and Azure Resources. Please refer
                 to the documentation below for more information.
               </div>
-              <div className="mb-6">
-                <a
-                  href="https://infisical.com/docs/documentation/platform/workflow-integrations/microsoft-teams-integration"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Button colorSchema="secondary">Documentation</Button>
-                </a>
+              <div>
+                <Button variant="neutral" asChild>
+                  <a
+                    href="https://infisical.com/docs/documentation/platform/workflow-integrations/microsoft-teams-integration"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Documentation
+                  </a>
+                </Button>
               </div>
-              <div className="mb-4 max-w-lg text-sm text-mineshaft-300">
+              <div className="max-w-lg text-sm text-label">
                 Step 2: Configure your instance-wide settings to enable integration with Microsoft
                 Teams. Copy the App ID and Client Secret from your Microsoft Teams bot&apos;s App
                 Registration page. The Client Secret is the password for the bot.
@@ -102,43 +104,37 @@ export const MicrosoftTeamsIntegrationForm = ({ adminIntegrationsConfig }: Props
                 control={control}
                 name="appId"
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    label="Application (Client) ID"
-                    className="w-96"
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                  >
+                  <Field className="max-w-96">
+                    <FieldLabel htmlFor="teams-app-client-id">Application (Client) ID</FieldLabel>
                     <Input
+                      id="teams-app-client-id"
                       {...field}
                       value={field.value || ""}
-                      type={isMicrosoftTeamsAppIdFocused ? "text" : "password"}
-                      onFocus={() => setIsMicrosoftTeamsAppIdFocused.on()}
-                      onBlur={() => setIsMicrosoftTeamsAppIdFocused.off()}
+                      isError={Boolean(error)}
                       onChange={(e) => field.onChange(e.target.value)}
                     />
-                  </FormControl>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
                 )}
               />
               <Controller
                 control={control}
                 name="clientSecret"
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    label="Client Secret"
-                    tooltipText="You can find your Client Secret in the Certificates & Secrets section of your Microsoft Teams bot's App Registration."
-                    className="w-96"
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                  >
-                    <Input
+                  <Field className="max-w-96">
+                    <FieldLabel htmlFor="teams-client-secret">Client secret</FieldLabel>
+                    <SecretInput
+                      id="teams-client-secret"
                       {...field}
                       value={field.value || ""}
-                      type={isMicrosoftTeamsClientSecretFocused ? "text" : "password"}
-                      onFocus={() => setIsMicrosoftTeamsClientSecretFocused.on()}
-                      onBlur={() => setIsMicrosoftTeamsClientSecretFocused.off()}
                       onChange={(e) => field.onChange(e.target.value)}
                     />
-                  </FormControl>
+                    <FieldDescription>
+                      Find this value under Certificates &amp; secrets in the bot&apos;s app
+                      registration.
+                    </FieldDescription>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
                 )}
               />
 
@@ -146,30 +142,28 @@ export const MicrosoftTeamsIntegrationForm = ({ adminIntegrationsConfig }: Props
                 control={control}
                 name="botId"
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    label="Microsoft Teams App ID"
-                    tooltipText="You can find the Microsoft Teams App ID in the overview of your Microsoft Teams App inside the Microsoft Teams Developer Portal."
-                    className="w-96"
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                  >
+                  <Field className="max-w-96">
+                    <FieldLabel htmlFor="teams-app-id">Microsoft Teams App ID</FieldLabel>
                     <Input
+                      id="teams-app-id"
                       {...field}
                       value={field.value || ""}
-                      type={isMicrosoftTeamsBotIdFocused ? "text" : "password"}
-                      onFocus={() => setIsMicrosoftTeamsBotIdFocused.on()}
-                      onBlur={() => setIsMicrosoftTeamsBotIdFocused.off()}
+                      isError={Boolean(error)}
                       onChange={(e) => field.onChange(e.target.value)}
                     />
-                  </FormControl>
+                    <FieldDescription>
+                      Find this value in the app overview in the Microsoft Teams Developer Portal.
+                    </FieldDescription>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
                 )}
               />
               <div>
                 <Button
-                  className="mt-2"
+                  variant="neutral"
                   type="submit"
-                  isLoading={isSubmitting}
-                  isDisabled={isSubmitting || !isDirty}
+                  isPending={isSubmitting}
+                  isDisabled={!isDirty}
                 >
                   Save
                 </Button>

--- a/frontend/src/pages/admin/IntegrationsPage/components/SlackIntegrationForm.tsx
+++ b/frontend/src/pages/admin/IntegrationsPage/components/SlackIntegrationForm.tsx
@@ -11,10 +11,12 @@ import {
   AccordionItem,
   AccordionTrigger,
   Button,
-  FormControl,
-  Input
-} from "@app/components/v2";
-import { useToggle } from "@app/hooks";
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  SecretInput
+} from "@app/components/v3";
 import { useUpdateServerConfig } from "@app/hooks/api";
 import { AdminIntegrationsConfig } from "@app/hooks/api/admin/types";
 
@@ -70,9 +72,6 @@ type Props = {
 
 export const SlackIntegrationForm = ({ adminIntegrationsConfig }: Props) => {
   const { mutateAsync: updateAdminServerConfig } = useUpdateServerConfig();
-  const [isSlackClientIdFocused, setIsSlackClientIdFocused] = useToggle();
-  const [isSlackClientSecretFocused, setIsSlackClientSecretFocused] = useToggle();
-
   const {
     control,
     handleSubmit,
@@ -105,26 +104,26 @@ export const SlackIntegrationForm = ({ adminIntegrationsConfig }: Props) => {
     <form onSubmit={handleSubmit(onSubmit)}>
       <Accordion type="single" collapsible className="w-full">
         <AccordionItem value="slack-integration" className="data-[state=open]:border-none">
-          <AccordionTrigger className="flex h-fit w-full justify-start rounded-md border border-mineshaft-500 bg-mineshaft-700 px-4 py-6 text-sm transition-colors data-[state=open]:rounded-b-none">
-            <div className="text-md group order-1 ml-3 flex items-center gap-2">
-              <BsSlack className="text-lg group-hover:text-primary-400" />
+          <AccordionTrigger>
+            <div className="flex items-center gap-2">
+              <BsSlack className="text-lg" />
               <div className="text-[15px] font-medium">Slack</div>
             </div>
           </AccordionTrigger>
-          <AccordionContent childrenClassName="px-0 py-0">
-            <div className="flex w-full flex-col justify-start rounded-md rounded-t-none border border-t-0 border-mineshaft-500 bg-mineshaft-700 px-4 py-4">
-              <div className="mb-4 max-w-lg text-sm text-mineshaft-300">
+          <AccordionContent>
+            <div className="flex w-full flex-col gap-4">
+              <div className="max-w-lg text-sm text-label">
                 Step 1: Create your Infisical Slack App
               </div>
-              <div className="mb-6">
+              <div>
                 <Button
-                  colorSchema="secondary"
+                  variant="neutral"
                   onClick={() => window.open(getCustomSlackAppCreationUrl())}
                 >
-                  Create Slack App
+                  Create Slack app
                 </Button>
               </div>
-              <div className="mb-4 max-w-lg text-sm text-mineshaft-300">
+              <div className="max-w-lg text-sm text-label">
                 Step 2: Configure your instance-wide settings to enable integration with Slack. Copy
                 the values from the App Credentials page of your custom Slack App.
               </div>
@@ -132,50 +131,41 @@ export const SlackIntegrationForm = ({ adminIntegrationsConfig }: Props) => {
                 control={control}
                 name="clientId"
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    label="Client ID"
-                    className="w-96"
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                  >
+                  <Field className="max-w-96">
+                    <FieldLabel htmlFor="slack-client-id">Client ID</FieldLabel>
                     <Input
+                      id="slack-client-id"
                       {...field}
                       value={field.value || ""}
-                      type={isSlackClientIdFocused ? "text" : "password"}
-                      onFocus={() => setIsSlackClientIdFocused.on()}
-                      onBlur={() => setIsSlackClientIdFocused.off()}
+                      isError={Boolean(error)}
                       onChange={(e) => field.onChange(e.target.value)}
                     />
-                  </FormControl>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
                 )}
               />
               <Controller
                 control={control}
                 name="clientSecret"
                 render={({ field, fieldState: { error } }) => (
-                  <FormControl
-                    label="Client Secret"
-                    className="w-96"
-                    isError={Boolean(error)}
-                    errorText={error?.message}
-                  >
-                    <Input
+                  <Field className="max-w-96">
+                    <FieldLabel htmlFor="slack-client-secret">Client secret</FieldLabel>
+                    <SecretInput
+                      id="slack-client-secret"
                       {...field}
                       value={field.value || ""}
-                      type={isSlackClientSecretFocused ? "text" : "password"}
-                      onFocus={() => setIsSlackClientSecretFocused.on()}
-                      onBlur={() => setIsSlackClientSecretFocused.off()}
                       onChange={(e) => field.onChange(e.target.value)}
                     />
-                  </FormControl>
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
                 )}
               />
               <div>
                 <Button
-                  className="mt-2"
+                  variant="neutral"
                   type="submit"
-                  isLoading={isSubmitting}
-                  isDisabled={isSubmitting || !isDirty}
+                  isPending={isSubmitting}
+                  isDisabled={!isDirty}
                 >
                   Save
                 </Button>

--- a/frontend/src/pages/admin/ResourceOverviewPage/ResourceOverviewPage.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/ResourceOverviewPage.tsx
@@ -20,11 +20,11 @@ export const ResourceOverviewPage = () => {
   const activeTab = selectedTab || "organizations";
 
   return (
-    <div className="h-full bg-bunker-800">
+    <div className="h-full bg-background text-foreground">
       <Helmet>
         <title>{t("common.head-title", { title: "Resource Overview" })}</title>
       </Helmet>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 text-white">
+      <div className="mx-auto flex flex-col justify-between">
         <div className="mx-auto mb-6 w-full max-w-8xl">
           <PageHeader
             scope="instance"

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/AddOrganizationModal.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/AddOrganizationModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -67,6 +67,7 @@ const AddOrgSchema = z.object({
 type FormData = z.infer<typeof AddOrgSchema>;
 
 const Content = ({ onClose }: ContentProps) => {
+  const adminSelectId = useId();
   const createOrg = useServerAdminCreateOrganization();
 
   const {
@@ -132,8 +133,9 @@ const Content = ({ onClose }: ContentProps) => {
       <Controller
         render={({ field, fieldState: { error } }) => (
           <Field>
-            <FieldLabel>Assign organization admins</FieldLabel>
+            <FieldLabel htmlFor={adminSelectId}>Assign organization admins</FieldLabel>
             <CreatableSelect
+              inputId={adminSelectId}
               /* eslint-disable-next-line react/no-unstable-nested-components */
               noOptionsMessage={() => (
                 <p>Invite new users to this organization by typing out their email address.</p>

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/AddOrganizationModal.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/AddOrganizationModal.tsx
@@ -4,8 +4,20 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input, Modal, ModalContent } from "@app/components/v2";
-import { CreatableSelect } from "@app/components/v2/CreatableSelect";
+import {
+  Button,
+  CreatableSelect,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
 import { useDebounce } from "@app/hooks";
 import { useAdminGetUsers, useServerAdminCreateOrganization } from "@app/hooks/api";
 import { User } from "@app/hooks/api/users/types";
@@ -98,30 +110,39 @@ const Content = ({ onClose }: ContentProps) => {
   const { append } = useFieldArray<FormData>({ control, name: "invitees" });
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
       <Controller
         render={({ field: { value, onChange }, fieldState: { error } }) => (
-          <FormControl isError={Boolean(error)} errorText={error?.message} label="Name">
-            <Input autoFocus value={value} onChange={onChange} placeholder="My Organization" />
-          </FormControl>
+          <Field>
+            <FieldLabel htmlFor="new-organization-name">Name</FieldLabel>
+            <Input
+              id="new-organization-name"
+              autoFocus
+              value={value}
+              onChange={onChange}
+              placeholder="My Organization"
+              isError={Boolean(error)}
+            />
+            <FieldError>{error?.message}</FieldError>
+          </Field>
         )}
         control={control}
         name="name"
       />
       <Controller
         render={({ field, fieldState: { error } }) => (
-          <FormControl
-            isError={Boolean(error)}
-            errorText={error?.message}
-            label="Assign Organization Admins"
-          >
+          <Field>
+            <FieldLabel>Assign organization admins</FieldLabel>
             <CreatableSelect
               /* eslint-disable-next-line react/no-unstable-nested-components */
               noOptionsMessage={() => (
                 <p>Invite new users to this organization by typing out their email address.</p>
               )}
               onCreateOption={(inputValue) =>
-                append({ id: `${inputValue}_${Math.random()}`, email: inputValue })
+                append({
+                  id: `${inputValue}_${Math.random()}`,
+                  email: inputValue
+                })
               }
               formatCreateLabel={(inputValue) => `Invite "${inputValue}"`}
               isValidNewOption={(input) =>
@@ -158,34 +179,36 @@ const Content = ({ onClose }: ContentProps) => {
                 if (!value) setDebouncedSearchTerm("");
               }}
             />
-          </FormControl>
+            <FieldError>{error?.message}</FieldError>
+          </Field>
         )}
         control={control}
         name="invitees"
       />
-      <div className="flex w-full gap-4 pt-4">
-        <Button
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-          colorSchema="secondary"
-        >
-          Add Organization
-        </Button>
-        <Button onClick={() => onClose()} variant="plain" colorSchema="secondary">
+      <DialogFooter>
+        <Button variant="ghost" type="button" onClick={() => onClose()}>
           Cancel
         </Button>
-      </div>
+        <Button variant="neutral" type="submit" isPending={isSubmitting}>
+          Add organization
+        </Button>
+      </DialogFooter>
     </form>
   );
 };
 
 export const AddOrganizationModal = ({ isOpen, onOpenChange }: Props) => {
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent bodyClassName="overflow-visible" title="Add Organization">
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader className="text-left">
+          <DialogTitle>Add Organization</DialogTitle>
+          <DialogDescription>
+            Create an organization and assign its initial admins.
+          </DialogDescription>
+        </DialogHeader>
         <Content onClose={() => onOpenChange(false)} />
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/EmailDomainsTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/EmailDomainsTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import {
   faEllipsisV,
@@ -71,6 +71,7 @@ type AddEmailDomainFormData = z.infer<typeof AddEmailDomainSchema>;
 
 const AddEmailDomainContent = ({ onClose }: { onClose: () => void }) => {
   const createEmailDomain = useAdminCreateEmailDomain();
+  const organizationSelectId = useId();
 
   const {
     handleSubmit,
@@ -116,8 +117,9 @@ const AddEmailDomainContent = ({ onClose }: { onClose: () => void }) => {
         name="organization"
         render={({ field, fieldState: { error } }) => (
           <Field>
-            <FieldLabel>Organization</FieldLabel>
+            <FieldLabel htmlFor={organizationSelectId}>Organization</FieldLabel>
             <FilterableSelect<OrganizationWithProjects>
+              inputId={organizationSelectId}
               isLoading={searchOrgFilter !== debouncedSearchTerm || isPending}
               placeholder="Search organizations..."
               options={organizations}
@@ -243,6 +245,7 @@ export const EmailDomainsTable = () => {
         </Button>
       </div>
       <Input
+        aria-label="Search email domains"
         value={searchFilter}
         onChange={(e) => setSearchFilter(e.target.value)}
         leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/EmailDomainsTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/EmailDomainsTable.tsx
@@ -13,30 +13,20 @@ import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
-  Button,
-  DeleteActionModal,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  EmptyState,
+  Badge,
+  Button as DialogButton,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
   FilterableSelect,
-  FormControl,
-  IconButton,
-  Input,
-  Modal,
-  ModalContent,
-  Pagination,
-  Table,
-  TableContainer,
-  TableSkeleton,
-  TBody,
-  Td,
-  Th,
-  THead,
-  Tr
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+  Input as DialogInput,
+  Pagination
+} from "@app/components/v3";
 import {
   getUserTablePreference,
   PreferenceKey,
@@ -50,6 +40,27 @@ import {
   useAdminGetOrganizations
 } from "@app/hooks/api";
 import { OrganizationWithProjects } from "@app/hooks/api/admin/types";
+import {
+  EmptyState,
+  Table,
+  TableContainer,
+  TableSkeleton,
+  TBody,
+  Td,
+  Th,
+  THead,
+  Tr
+} from "@app/pages/admin/components/AdminTable";
+import {
+  Button,
+  DeleteActionModal,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  IconButton,
+  Input
+} from "@app/pages/admin/components/AdminV3Adapters";
 
 const AddEmailDomainSchema = z.object({
   organization: z.object({ id: z.string(), name: z.string() }),
@@ -64,10 +75,12 @@ const AddEmailDomainContent = ({ onClose }: { onClose: () => void }) => {
   const {
     handleSubmit,
     control,
-    register,
     formState: { isSubmitting, errors }
   } = useForm<AddEmailDomainFormData>({
-    resolver: zodResolver(AddEmailDomainSchema)
+    resolver: zodResolver(AddEmailDomainSchema),
+    defaultValues: {
+      domain: ""
+    }
   });
 
   const [searchOrgFilter, setSearchOrgFilter] = useState("");
@@ -83,7 +96,10 @@ const AddEmailDomainContent = ({ onClose }: { onClose: () => void }) => {
   const onSubmit = async ({ organization, domain }: AddEmailDomainFormData) => {
     try {
       await createEmailDomain.mutateAsync({ orgId: organization.id, domain });
-      createNotification({ text: "Email domain added successfully", type: "success" });
+      createNotification({
+        text: "Email domain added successfully",
+        type: "success"
+      });
       onClose();
     } catch (err: any) {
       createNotification({
@@ -94,12 +110,13 @@ const AddEmailDomainContent = ({ onClose }: { onClose: () => void }) => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form className="flex flex-col gap-4" onSubmit={handleSubmit(onSubmit)}>
       <Controller
         control={control}
         name="organization"
         render={({ field, fieldState: { error } }) => (
-          <FormControl isError={Boolean(error)} errorText={error?.message} label="Organization">
+          <Field>
+            <FieldLabel>Organization</FieldLabel>
             <FilterableSelect<OrganizationWithProjects>
               isLoading={searchOrgFilter !== debouncedSearchTerm || isPending}
               placeholder="Search organizations..."
@@ -113,29 +130,34 @@ const AddEmailDomainContent = ({ onClose }: { onClose: () => void }) => {
                 if (!value) setDebouncedSearchTerm("");
               }}
             />
-          </FormControl>
+            <FieldError>{error?.message}</FieldError>
+          </Field>
         )}
       />
-      <FormControl
-        isError={Boolean(errors.domain)}
-        errorText={errors.domain?.message}
-        label="Domain"
-      >
-        <Input {...register("domain")} placeholder="company.com" />
-      </FormControl>
-      <div className="flex w-full gap-4 pt-4">
-        <Button
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-          colorSchema="secondary"
-        >
-          Add Domain
-        </Button>
-        <Button onClick={onClose} variant="plain" colorSchema="secondary">
+      <Controller
+        control={control}
+        name="domain"
+        render={({ field }) => (
+          <Field>
+            <FieldLabel htmlFor="verified-email-domain">Domain</FieldLabel>
+            <DialogInput
+              id="verified-email-domain"
+              placeholder="company.com"
+              isError={Boolean(errors.domain)}
+              {...field}
+            />
+            <FieldError>{errors.domain?.message}</FieldError>
+          </Field>
+        )}
+      />
+      <DialogFooter>
+        <DialogButton variant="ghost" type="button" onClick={onClose}>
           Cancel
-        </Button>
-      </div>
+        </DialogButton>
+        <DialogButton variant="neutral" type="submit" isPending={isSubmitting}>
+          Add domain
+        </DialogButton>
+      </DialogFooter>
     </form>
   );
 };
@@ -148,11 +170,14 @@ const AddEmailDomainModal = ({
   onOpenChange: (isOpen: boolean) => void;
 }) => {
   return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent bodyClassName="overflow-visible" title="Add Verified Email Domain">
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader className="text-left">
+          <DialogTitle>Add Verified Email Domain</DialogTitle>
+        </DialogHeader>
         <AddEmailDomainContent onClose={() => onOpenChange(false)} />
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };
 
@@ -192,14 +217,16 @@ export const EmailDomainsTable = () => {
   const { mutateAsync: deleteEmailDomain } = useAdminDeleteEmailDomain();
 
   const handleDelete = async () => {
-    const { emailDomainId } = popUp?.deleteEmailDomain?.data as { emailDomainId: string };
+    const { emailDomainId } = popUp?.deleteEmailDomain?.data as {
+      emailDomainId: string;
+    };
     await deleteEmailDomain(emailDomainId);
     createNotification({ text: "Email domain deleted", type: "success" });
     handlePopUpClose("deleteEmailDomain");
   };
 
   return (
-    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+    <div className="mb-6 rounded-lg border border-border bg-card p-5 text-foreground">
       <div className="mb-4 flex items-center justify-between">
         <div>
           <p className="text-xl font-medium text-mineshaft-100">Email Domains</p>
@@ -253,12 +280,7 @@ export const EmailDomainsTable = () => {
                       <div className="flex justify-end">
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
-                            <IconButton
-                              ariaLabel="Options"
-                              colorSchema="secondary"
-                              className="w-6"
-                              variant="plain"
-                            >
+                            <IconButton ariaLabel="Options" size="xs" variant="plain">
                               <FontAwesomeIcon icon={faEllipsisV} />
                             </IconButton>
                           </DropdownMenuTrigger>

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/MachineIdentitiesTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/MachineIdentitiesTable.tsx
@@ -180,8 +180,7 @@ export const MachineIdentitiesTable = () => {
     "removeServerAdmin"
   ] as const);
 
-  const { mutateAsync: deleteIdentitySuperAdminAccess } =
-    useAdminRemoveIdentitySuperAdminAccess();
+  const { mutateAsync: deleteIdentitySuperAdminAccess } = useAdminRemoveIdentitySuperAdminAccess();
 
   const handleRemoveServerAdmin = async () => {
     const { id } = popUp?.removeServerAdmin?.data as {

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/MachineIdentitiesTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/MachineIdentitiesTable.tsx
@@ -10,26 +10,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ServerCogIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
-import {
-  DeleteActionModal,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  EmptyState,
-  IconButton,
-  Input,
-  Pagination,
-  Table,
-  TableContainer,
-  TableSkeleton,
-  TBody,
-  Td,
-  Th,
-  THead,
-  Tr
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, Pagination } from "@app/components/v3";
 import {
   getUserTablePreference,
   PreferenceKey,
@@ -39,6 +20,26 @@ import { useDebounce, usePagination, usePopUp, useResetPageHelper } from "@app/h
 import { useAdminRemoveIdentitySuperAdminAccess } from "@app/hooks/api/admin";
 import { useAdminGetIdentities } from "@app/hooks/api/admin/queries";
 import { UsePopUpState } from "@app/hooks/usePopUp";
+import {
+  EmptyState,
+  Table,
+  TableContainer,
+  TableSkeleton,
+  TBody,
+  Td,
+  Th,
+  THead,
+  Tr
+} from "@app/pages/admin/components/AdminTable";
+import {
+  DeleteActionModal,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  IconButton,
+  Input
+} from "@app/pages/admin/components/AdminV3Adapters";
 
 const IdentityPanelTable = ({
   handlePopUpOpen
@@ -122,12 +123,7 @@ const IdentityPanelTable = ({
                         <div className="flex justify-end">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <IconButton
-                                ariaLabel="Options"
-                                colorSchema="secondary"
-                                className="w-6"
-                                variant="plain"
-                              >
+                              <IconButton ariaLabel="Options" size="xs" variant="plain">
                                 <FontAwesomeIcon icon={faEllipsisV} />
                               </IconButton>
                             </DropdownMenuTrigger>
@@ -135,7 +131,10 @@ const IdentityPanelTable = ({
                               <DropdownMenuItem
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  handlePopUpOpen("removeServerAdmin", { name, id });
+                                  handlePopUpOpen("removeServerAdmin", {
+                                    name,
+                                    id
+                                  });
                                 }}
                                 icon={
                                   <div className="relative">
@@ -183,7 +182,10 @@ export const MachineIdentitiesTable = () => {
   const { mutate: deleteIdentitySuperAdminAccess } = useAdminRemoveIdentitySuperAdminAccess();
 
   const handleRemoveServerAdmin = async () => {
-    const { id } = popUp?.removeServerAdmin?.data as { id: string; name: string };
+    const { id } = popUp?.removeServerAdmin?.data as {
+      id: string;
+      name: string;
+    };
 
     await deleteIdentitySuperAdminAccess(id);
     createNotification({
@@ -195,7 +197,7 @@ export const MachineIdentitiesTable = () => {
   };
 
   return (
-    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+    <div className="mb-6 rounded-lg border border-border bg-card p-5 text-foreground">
       <div className="mb-4 flex items-center justify-between">
         <div>
           <p className="text-xl font-medium text-mineshaft-100">Machine Identities</p>

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/MachineIdentitiesTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/MachineIdentitiesTable.tsx
@@ -88,6 +88,7 @@ const IdentityPanelTable = ({
     <>
       <div className="flex gap-2">
         <Input
+          aria-label="Search machine identities"
           value={searchIdentityFilter}
           onChange={(e) => setSearchIdentityFilter(e.target.value)}
           leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
@@ -179,7 +180,8 @@ export const MachineIdentitiesTable = () => {
     "removeServerAdmin"
   ] as const);
 
-  const { mutate: deleteIdentitySuperAdminAccess } = useAdminRemoveIdentitySuperAdminAccess();
+  const { mutateAsync: deleteIdentitySuperAdminAccess } =
+    useAdminRemoveIdentitySuperAdminAccess();
 
   const handleRemoveServerAdmin = async () => {
     const { id } = popUp?.removeServerAdmin?.data as {

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/OrganizationsTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/OrganizationsTable.tsx
@@ -188,6 +188,7 @@ const ViewMembersModalContent = ({
   return (
     <>
       <Input
+        aria-label="Search organization members"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
@@ -195,15 +196,15 @@ const ViewMembersModalContent = ({
       />
       <TableContainer
         className={twMerge(
-          "mt-4 flex flex-1 flex-col bg-mineshaft-700",
+          "mt-4 flex flex-1 flex-col bg-container",
           Boolean(filteredMembers.length) && "rounded-b-none"
         )}
       >
-        <Table className="overflow-y-auto bg-mineshaft-700">
+        <Table className="overflow-y-auto bg-container">
           <THead className="sticky top-0 z-50">
             <Tr>
-              <Th className="w-1/3 border-none bg-mineshaft-700 p-0">
-                <div className="flex h-12 w-full items-center border-b-2 border-mineshaft-500 px-3 py-2.5">
+              <Th className="w-1/3 border-none bg-container p-0">
+                <div className="flex h-12 w-full items-center border-b border-border px-3 py-2.5">
                   Name
                   <IconButton
                     variant="plain"
@@ -221,8 +222,8 @@ const ViewMembersModalContent = ({
                   </IconButton>
                 </div>
               </Th>
-              <Th className="w-1/3 border-none bg-mineshaft-700 p-0">
-                <div className="flex h-12 w-full items-center border-b-2 border-mineshaft-500 px-3 py-2.5">
+              <Th className="w-1/3 border-none bg-container p-0">
+                <div className="flex h-12 w-full items-center border-b border-border px-3 py-2.5">
                   Email
                   <IconButton
                     variant="plain"
@@ -240,13 +241,13 @@ const ViewMembersModalContent = ({
                   </IconButton>
                 </div>
               </Th>
-              <Th className="w-1/4 border-none bg-mineshaft-700 p-0">
-                <div className="flex h-12 w-full items-center border-b-2 border-mineshaft-500 px-3 py-2.5">
+              <Th className="w-1/4 border-none bg-container p-0">
+                <div className="flex h-12 w-full items-center border-b border-border px-3 py-2.5">
                   Role
                 </div>
               </Th>
-              <Th className="w-5 border-none bg-mineshaft-700 p-0">
-                <div className="flex h-12 w-full items-center border-b-2 border-mineshaft-500 px-3 py-2.5" />
+              <Th className="w-5 border-none bg-container p-0">
+                <div className="flex h-12 w-full items-center border-b border-border px-3 py-2.5" />
               </Th>
             </Tr>
           </THead>
@@ -261,7 +262,7 @@ const ViewMembersModalContent = ({
                   <Td className="max-w-0">
                     <div className="flex items-center">
                       <p className="truncate">
-                        {name ?? <span className="text-mineshaft-400">Not Set</span>}
+                        {name ?? <span className="text-muted">Not Set</span>}
                       </p>
                     </div>
                   </Td>
@@ -272,7 +273,7 @@ const ViewMembersModalContent = ({
                         status !== OrgMembershipStatus.Accepted && (
                           <Button
                             isDisabled={resendOrgInvite.isPending}
-                            className="ml-2 h-7 border-mineshaft-600 bg-mineshaft-800/50 font-normal"
+                            className="ml-2 font-normal"
                             colorSchema="primary"
                             variant="outline_bg"
                             size="xs"
@@ -345,7 +346,7 @@ const ViewMembersModalContent = ({
         </Table>
         {!filteredMembers.length && (
           <EmptyState
-            className="my-auto bg-mineshaft-700"
+            className="my-auto bg-container"
             title={
               members.length
                 ? "No organization users match search..."
@@ -357,7 +358,7 @@ const ViewMembersModalContent = ({
       </TableContainer>
       {Boolean(filteredMembers.length) && (
         <Pagination
-          className="rounded-b-md border border-t-0 bg-mineshaft-700"
+          className="rounded-b-md border border-t-0 border-border bg-container"
           count={filteredMembers.length}
           page={page}
           perPage={perPage}
@@ -489,6 +490,7 @@ const OrganizationsPanelTable = ({
   return (
     <>
       <Input
+        aria-label="Search organizations"
         value={searchOrganizationsFilter}
         onChange={(e) => setSearchOrganizationsFilter(e.target.value)}
         leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/OrganizationsTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/OrganizationsTable.tsx
@@ -22,30 +22,7 @@ import { CircleQuestionMarkIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 import { createNotification } from "@app/components/notifications";
-import {
-  Button,
-  DeleteActionModal,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  EmptyState,
-  IconButton,
-  Input,
-  Modal,
-  ModalContent,
-  Pagination,
-  Table,
-  TableContainer,
-  TableSkeleton,
-  TBody,
-  Td,
-  Th,
-  THead,
-  Tooltip,
-  Tr
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, Pagination } from "@app/components/v3";
 import { useUser } from "@app/context";
 import { OrgMembershipRole } from "@app/helpers/roles";
 import {
@@ -66,6 +43,30 @@ import { OrganizationWithProjects } from "@app/hooks/api/admin/types";
 import { OrderByDirection } from "@app/hooks/api/generic/types";
 import { OrgMembershipStatus } from "@app/hooks/api/organization/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
+import {
+  EmptyState,
+  Table,
+  TableContainer,
+  TableSkeleton,
+  TBody,
+  Td,
+  Th,
+  THead,
+  Tr
+} from "@app/pages/admin/components/AdminTable";
+import {
+  Button,
+  DeleteActionModal,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  IconButton,
+  Input,
+  Modal,
+  ModalContent,
+  Tooltip
+} from "@app/pages/admin/components/AdminV3Adapters";
 import { AddOrganizationModal } from "@app/pages/admin/ResourceOverviewPage/components/AddOrganizationModal";
 
 enum MembersOrderBy {
@@ -194,7 +195,7 @@ const ViewMembersModalContent = ({
       />
       <TableContainer
         className={twMerge(
-          "mt-4 flex flex-1 flex-col border border-mineshaft-500 bg-mineshaft-700",
+          "mt-4 flex flex-1 flex-col bg-mineshaft-700",
           Boolean(filteredMembers.length) && "rounded-b-none"
         )}
       >
@@ -305,12 +306,7 @@ const ViewMembersModalContent = ({
                     <div className="flex justify-end">
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
-                          <IconButton
-                            ariaLabel="Options"
-                            colorSchema="secondary"
-                            className="w-6"
-                            variant="plain"
-                          >
+                          <IconButton ariaLabel="Options" size="xs" variant="plain">
                             <FontAwesomeIcon icon={faEllipsisV} />
                           </IconButton>
                         </DropdownMenuTrigger>
@@ -331,7 +327,9 @@ const ViewMembersModalContent = ({
                           <DropdownMenuItem
                             icon={<FontAwesomeIcon icon={faUserXmark} />}
                             onClick={() =>
-                              handlePopUpOpen("deleteUser", { userId: member.user.id })
+                              handlePopUpOpen("deleteUser", {
+                                userId: member.user.id
+                              })
                             }
                           >
                             Delete User
@@ -393,8 +391,8 @@ const ViewMembersModal = ({
         }}
         title="Organization Members"
         subTitle="View the members of the organization."
-        className="h-full max-w-4xl"
-        bodyClassName="flex flex-col h-full"
+        className="max-h-[calc(100vh-2rem)] sm:max-w-4xl"
+        bodyClassName="flex flex-col overflow-hidden"
       >
         <ViewMembersModalContent popUp={popUp} handlePopUpOpen={handlePopUpOpen} />
       </ModalContent>
@@ -528,7 +526,11 @@ const OrganizationsPanelTable = ({
                       <Td className="w-1/3">
                         <button
                           type="button"
-                          onClick={() => handlePopUpOpen("viewMembers", { organization: org })}
+                          onClick={() =>
+                            handlePopUpOpen("viewMembers", {
+                              organization: org
+                            })
+                          }
                           className="flex items-center hover:underline"
                         >
                           <Tooltip className="text-center" content="View Members">
@@ -556,15 +558,15 @@ const OrganizationsPanelTable = ({
                         {org.projects.length} {org.projects.length === 1 ? "Project" : "Projects"}
                       </Td>
                       <Td>
-                        <div className="flex justify-end gap-x-1">
+                        <div className="flex items-center justify-end gap-1">
                           {isMember && (
                             <Tooltip
                               className="text-center"
                               content="You are a member of this organization"
                             >
-                              <div>
+                              <div className="flex size-7 items-center justify-center">
                                 <FontAwesomeIcon
-                                  className="text-mineshaft-400"
+                                  className="text-muted"
                                   icon={faUserCheck}
                                   size="sm"
                                 />
@@ -573,12 +575,7 @@ const OrganizationsPanelTable = ({
                           )}
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <IconButton
-                                ariaLabel="Options"
-                                colorSchema="secondary"
-                                className="w-6"
-                                variant="plain"
-                              >
+                              <IconButton ariaLabel="Options" size="xs" variant="plain">
                                 <FontAwesomeIcon icon={faEllipsisV} />
                               </IconButton>
                             </DropdownMenuTrigger>
@@ -700,7 +697,7 @@ export const OrganizationsTable = () => {
   };
 
   return (
-    <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+    <div className="mb-6 rounded-lg border border-border bg-card p-5 text-foreground">
       <div className="mb-4 flex items-center justify-between">
         <div>
           <p className="text-xl font-medium text-mineshaft-100">Organizations</p>

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/UserIdentitiesTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/UserIdentitiesTable.tsx
@@ -17,30 +17,7 @@ import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
-import {
-  Button,
-  Checkbox,
-  DeleteActionModal,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuTrigger,
-  EmptyState,
-  IconButton,
-  Input,
-  Pagination,
-  Table,
-  TableContainer,
-  TableSkeleton,
-  TBody,
-  Td,
-  Th,
-  THead,
-  Tooltip,
-  Tr
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, Button as V3Button, Pagination } from "@app/components/v3";
 import { useSubscription, useUser } from "@app/context";
 import {
   getUserTablePreference,
@@ -57,6 +34,30 @@ import {
 } from "@app/hooks/api";
 import { User } from "@app/hooks/api/users/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
+import {
+  EmptyState,
+  Table,
+  TableContainer,
+  TableSkeleton,
+  TBody,
+  Td,
+  Th,
+  THead,
+  Tr
+} from "@app/pages/admin/components/AdminTable";
+import {
+  Button,
+  Checkbox,
+  DeleteActionModal,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+  IconButton,
+  Input,
+  Tooltip
+} from "@app/pages/admin/components/AdminV3Adapters";
 
 const UserPanelTable = ({
   handlePopUpOpen,
@@ -128,17 +129,13 @@ const UserPanelTable = ({
         />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <IconButton
-              ariaLabel="Filter Users"
-              variant="plain"
-              size="sm"
-              className={twMerge(
-                "flex h-10 w-11 items-center justify-center overflow-hidden border border-mineshaft-600 bg-mineshaft-800 p-0 transition-all hover:border-primary/60 hover:bg-primary/10",
-                isTableFiltered && "border-primary/50 text-primary"
-              )}
+            <V3Button
+              aria-label="Filter Users"
+              variant="outline"
+              className={twMerge("px-3", isTableFiltered && "border-primary/50 text-primary")}
             >
               <FontAwesomeIcon icon={faFilter} />
-            </IconButton>
+            </V3Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="p-0">
             <DropdownMenuLabel>Filter By</DropdownMenuLabel>
@@ -230,12 +227,7 @@ const UserPanelTable = ({
                         <div className="flex justify-end">
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <IconButton
-                                ariaLabel="Options"
-                                colorSchema="secondary"
-                                className="w-6"
-                                variant="plain"
-                              >
+                              <IconButton ariaLabel="Options" size="xs" variant="plain">
                                 <FontAwesomeIcon icon={faEllipsisV} />
                               </IconButton>
                             </DropdownMenuTrigger>
@@ -243,7 +235,10 @@ const UserPanelTable = ({
                               <DropdownMenuItem
                                 onClick={(e) => {
                                   e.stopPropagation();
-                                  handlePopUpOpen("removeUser", { username, id });
+                                  handlePopUpOpen("removeUser", {
+                                    username,
+                                    id
+                                  });
                                 }}
                                 icon={<FontAwesomeIcon icon={faUserXmark} />}
                               >
@@ -262,7 +257,10 @@ const UserPanelTable = ({
                                       });
                                       return;
                                     }
-                                    handlePopUpOpen("upgradeToServerAdmin", { username, id });
+                                    handlePopUpOpen("upgradeToServerAdmin", {
+                                      username,
+                                      id
+                                    });
                                   }}
                                 >
                                   Make User Server Admin
@@ -290,7 +288,10 @@ const UserPanelTable = ({
                                       });
                                       return;
                                     }
-                                    handlePopUpOpen("removeServerAdmin", { username, id });
+                                    handlePopUpOpen("removeServerAdmin", {
+                                      username,
+                                      id
+                                    });
                                   }}
                                 >
                                   Remove Server Admin
@@ -375,7 +376,10 @@ export const UserIdentitiesTable = () => {
   };
 
   const handleGrantServerAdminAccess = async () => {
-    const { id } = popUp?.upgradeToServerAdmin?.data as { id: string; username: string };
+    const { id } = popUp?.upgradeToServerAdmin?.data as {
+      id: string;
+      username: string;
+    };
 
     await grantAdminAccess(id);
     createNotification({
@@ -387,7 +391,10 @@ export const UserIdentitiesTable = () => {
   };
 
   const handleRemoveServerAdminAccess = async () => {
-    const { id } = popUp?.removeServerAdmin?.data as { id: string; username: string };
+    const { id } = popUp?.removeServerAdmin?.data as {
+      id: string;
+      username: string;
+    };
 
     await removeAdminAccess(id);
     createNotification({
@@ -443,7 +450,7 @@ export const UserIdentitiesTable = () => {
           </Button>
         </div>
       </div>
-      <div className="mb-6 rounded-lg border border-mineshaft-600 bg-mineshaft-900 p-4">
+      <div className="mb-6 rounded-lg border border-border bg-card p-5 text-foreground">
         <div className="mb-4 flex items-center justify-between">
           <div>
             <p className="text-xl font-medium text-mineshaft-100">User Identities</p>
@@ -478,7 +485,12 @@ export const UserIdentitiesTable = () => {
         <DeleteActionModal
           isOpen={popUp.upgradeToServerAdmin.isOpen}
           title={`Are you sure you want to grant Server Admin permissions to ${
-            (popUp?.upgradeToServerAdmin?.data as { id: string; username: string })?.username || ""
+            (
+              popUp?.upgradeToServerAdmin?.data as {
+                id: string;
+                username: string;
+              }
+            )?.username || ""
           }?`}
           subTitle=""
           onChange={(isOpen) => handlePopUpToggle("upgradeToServerAdmin", isOpen)}

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/UserIdentitiesTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/UserIdentitiesTable.tsx
@@ -121,6 +121,7 @@ const UserPanelTable = ({
     <>
       <div className="flex gap-2">
         <Input
+          aria-label="Search users"
           value={searchUserFilter}
           onChange={(e) => setSearchUserFilter(e.target.value)}
           leftIcon={<FontAwesomeIcon icon={faMagnifyingGlass} />}
@@ -162,6 +163,7 @@ const UserPanelTable = ({
               <Tr>
                 <Th className="w-5">
                   <Checkbox
+                    aria-label="Select all users on this page"
                     id="member-page-select"
                     isChecked={isPageSelected || isPageIndeterminate}
                     isIndeterminate={isPageIndeterminate}
@@ -197,6 +199,7 @@ const UserPanelTable = ({
                     <Tr key={`user-${id}`} className="w-full">
                       <Td>
                         <Checkbox
+                          aria-label={`Select user ${username || email}`}
                           id={`select-user-${id}`}
                           isChecked={isSelected}
                           onClick={(e) => {

--- a/frontend/src/pages/admin/components/AdminTable.tsx
+++ b/frontend/src/pages/admin/components/AdminTable.tsx
@@ -1,0 +1,80 @@
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import {
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Skeleton,
+  Table as V3Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+
+type TableContainerProps = React.ComponentProps<"div">;
+const SKELETON_ROWS = ["one", "two", "three", "four", "five", "six", "seven", "eight"];
+const SKELETON_COLUMNS = ["one", "two", "three", "four", "five", "six", "seven", "eight"];
+
+export const TableContainer = ({ className, ...props }: TableContainerProps) => (
+  <div className={cn("overflow-x-auto rounded-md border border-border", className)} {...props} />
+);
+
+export const Table = ({ containerClassName, ...props }: React.ComponentProps<typeof V3Table>) => (
+  <V3Table containerClassName={cn("border-0", containerClassName)} {...props} />
+);
+
+export const EmptyState = ({
+  title,
+  icon,
+  className
+}: {
+  title: string;
+  icon?: IconDefinition;
+  className?: string;
+}) => (
+  <Empty className={cn("border-0", className)}>
+    <EmptyHeader>
+      {icon && (
+        <EmptyMedia variant="icon">
+          <FontAwesomeIcon icon={icon} />
+        </EmptyMedia>
+      )}
+      <EmptyTitle>{title}</EmptyTitle>
+    </EmptyHeader>
+  </Empty>
+);
+
+export const TableSkeleton = ({
+  columns,
+  innerKey,
+  rows = 5
+}: {
+  columns: number;
+  innerKey: string;
+  rows?: number;
+}) => (
+  <>
+    {SKELETON_ROWS.slice(0, rows).map((row) => (
+      <TableRow key={`${innerKey}-skeleton-${row}`}>
+        {SKELETON_COLUMNS.slice(0, columns).map((column) => (
+          <TableCell key={`${innerKey}-skeleton-${row}-${column}`}>
+            <Skeleton className="h-5 w-full" />
+          </TableCell>
+        ))}
+      </TableRow>
+    ))}
+  </>
+);
+
+export {
+  TableBody as TBody,
+  TableCell as Td,
+  TableHead as Th,
+  TableHeader as THead,
+  TableRow as Tr
+};

--- a/frontend/src/pages/admin/components/AdminV3Adapters.tsx
+++ b/frontend/src/pages/admin/components/AdminV3Adapters.tsx
@@ -290,7 +290,7 @@ export const DeleteActionModal = ({
           className="contents"
           onSubmit={(event) => {
             event.preventDefault();
-            void handleAction();
+            handleAction().catch(() => undefined);
           }}
         >
           <AlertDialogHeader className="text-left">

--- a/frontend/src/pages/admin/components/AdminV3Adapters.tsx
+++ b/frontend/src/pages/admin/components/AdminV3Adapters.tsx
@@ -1,0 +1,391 @@
+import {
+  ComponentProps,
+  ElementType,
+  forwardRef,
+  ReactElement,
+  ReactNode,
+  useId,
+  useLayoutEffect,
+  useState
+} from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button as V3Button,
+  Checkbox as V3Checkbox,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem as V3DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  IconButton as V3IconButton,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Tooltip as V3Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+
+type LegacyVariant =
+  | "danger"
+  | "info"
+  | "neutral"
+  | "outline_bg"
+  | "plain"
+  | "primary"
+  | "secondary";
+
+const mapVariant = (variant?: LegacyVariant, colorSchema?: LegacyVariant) => {
+  const value = colorSchema ?? variant;
+  if (value === "danger") return "danger";
+  if (value === "info") return "info";
+  if (value === "plain") return "ghost";
+  return "neutral";
+};
+
+const mapIconVariant = (variant?: LegacyVariant, colorSchema?: LegacyVariant) => {
+  const value = colorSchema ?? variant;
+  if (value === "danger") return "danger";
+  if (value === "info") return "info";
+  if (value === "plain") return "ghost";
+  return "outline";
+};
+
+type ButtonProps = Omit<ComponentProps<typeof V3Button>, "asChild" | "variant"> & {
+  variant?: LegacyVariant;
+  colorSchema?: LegacyVariant;
+  isLoading?: boolean;
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    { children, colorSchema, isLoading, leftIcon, rightIcon, variant, isDisabled, ...props },
+    ref
+  ) => (
+    <V3Button
+      ref={ref}
+      asChild={false}
+      variant={mapVariant(variant, colorSchema)}
+      isPending={isLoading}
+      isDisabled={isDisabled}
+      {...props}
+    >
+      {leftIcon}
+      {children}
+      {rightIcon}
+    </V3Button>
+  )
+);
+
+Button.displayName = "Button";
+
+type IconButtonProps = Omit<ComponentProps<typeof V3IconButton>, "asChild" | "variant"> & {
+  variant?: LegacyVariant;
+  colorSchema?: LegacyVariant;
+  ariaLabel?: string;
+};
+
+export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ ariaLabel, colorSchema, variant, ...props }, ref) => (
+    <V3IconButton
+      ref={ref}
+      asChild={false}
+      aria-label={ariaLabel}
+      variant={mapIconVariant(variant, colorSchema)}
+      {...props}
+    />
+  )
+);
+
+IconButton.displayName = "IconButton";
+
+type InputProps = Omit<ComponentProps<typeof InputGroupInput>, "size"> & {
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+  isDisabled?: boolean;
+  isReadOnly?: boolean;
+  isRequired?: boolean;
+  isFullWidth?: boolean;
+  containerClassName?: string;
+};
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      leftIcon,
+      rightIcon,
+      isDisabled,
+      isReadOnly,
+      isRequired,
+      isFullWidth = true,
+      containerClassName,
+      className,
+      ...props
+    },
+    ref
+  ) => (
+    <InputGroup className={containerClassName} data-full-width={isFullWidth}>
+      {leftIcon && <InputGroupAddon>{leftIcon}</InputGroupAddon>}
+      <InputGroupInput
+        ref={ref}
+        disabled={isDisabled}
+        readOnly={isReadOnly}
+        required={isRequired}
+        className={className}
+        {...props}
+      />
+      {rightIcon && <InputGroupAddon align="inline-end">{rightIcon}</InputGroupAddon>}
+    </InputGroup>
+  )
+);
+
+Input.displayName = "Input";
+
+type CheckboxProps = ComponentProps<typeof V3Checkbox> & {
+  isChecked?: boolean;
+  isDisabled?: boolean;
+  isIndeterminate?: boolean;
+  children?: ReactNode;
+};
+
+export const Checkbox = ({
+  children,
+  id,
+  isChecked,
+  isDisabled,
+  isIndeterminate,
+  ...props
+}: CheckboxProps) => (
+  <div className="flex items-center gap-2">
+    <V3Checkbox
+      id={id}
+      isChecked={isChecked}
+      isIndeterminate={isIndeterminate}
+      isDisabled={isDisabled}
+      {...props}
+    />
+    {children && <label htmlFor={id}>{children}</label>}
+  </div>
+);
+
+type TooltipProps = {
+  children: ReactElement;
+  content: ReactNode;
+  className?: string;
+  position?: "top" | "right" | "bottom" | "left";
+};
+
+export const Tooltip = ({ children, content, className, position = "top" }: TooltipProps) => (
+  <V3Tooltip>
+    <TooltipTrigger asChild>{children}</TooltipTrigger>
+    <TooltipContent className={className} side={position}>
+      {content}
+    </TooltipContent>
+  </V3Tooltip>
+);
+
+type DropdownMenuItemProps = ComponentProps<typeof V3DropdownMenuItem> & {
+  icon?: ReactNode;
+  iconPos?: "left" | "right";
+  as?: ElementType;
+};
+
+export const DropdownMenuItem = ({
+  children,
+  icon,
+  iconPos = "left",
+  as: _as,
+  ...props
+}: DropdownMenuItemProps) => (
+  <V3DropdownMenuItem {...props}>
+    {icon && iconPos === "left" && icon}
+    {children}
+    {icon && iconPos === "right" && icon}
+  </V3DropdownMenuItem>
+);
+
+type DeleteActionModalProps = {
+  isOpen?: boolean;
+  onClose?: () => void;
+  onChange?: (isOpen: boolean) => void;
+  deleteKey: string;
+  title: string;
+  subTitle?: string;
+  onDeleteApproved: () => Promise<void>;
+  buttonText?: string;
+  formContent?: ReactNode;
+  children?: ReactNode;
+  deletionMessage?: ReactNode;
+  isDisabled?: boolean;
+};
+
+export const DeleteActionModal = ({
+  isOpen,
+  onClose,
+  onChange,
+  deleteKey,
+  onDeleteApproved,
+  title,
+  subTitle = "This action is irreversible.",
+  buttonText = "Delete",
+  formContent,
+  deletionMessage,
+  isDisabled,
+  children
+}: DeleteActionModalProps) => {
+  const [confirmation, setConfirmation] = useState("");
+  const [isPending, setIsPending] = useState(false);
+  const confirmationInputId = useId();
+
+  useLayoutEffect(() => setConfirmation(""), [isOpen, deleteKey]);
+
+  const handleAction = async () => {
+    setIsPending(true);
+    try {
+      await onDeleteApproved();
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <AlertDialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        onChange?.(open);
+        if (!open) {
+          setConfirmation("");
+          onClose?.();
+        }
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader className="text-left">
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{subTitle}</AlertDialogDescription>
+        </AlertDialogHeader>
+        {formContent}
+        <label className="flex flex-col gap-2 text-sm" htmlFor={confirmationInputId}>
+          {deletionMessage || (
+            <span>
+              Type <strong>{deleteKey}</strong> to perform this action
+            </span>
+          )}
+          <InputGroup>
+            <InputGroupInput
+              id={confirmationInputId}
+              name={confirmationInputId}
+              value={confirmation}
+              onChange={(event) => setConfirmation(event.target.value)}
+              placeholder={`Type ${deleteKey} here`}
+              autoComplete="new-password"
+              data-1p-ignore
+              data-lpignore="true"
+              spellCheck={false}
+            />
+          </InputGroup>
+        </label>
+        {children}
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="danger"
+            isPending={isPending}
+            isDisabled={confirmation !== deleteKey || isDisabled}
+            onClick={handleAction}
+          >
+            {buttonText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export const Modal = ({
+  isOpen,
+  onOpenChange,
+  children
+}: {
+  isOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: ReactNode;
+}) => (
+  <Dialog open={isOpen} onOpenChange={onOpenChange}>
+    {children}
+  </Dialog>
+);
+
+export const ModalContent = ({
+  title,
+  subTitle,
+  footerContent,
+  bodyClassName,
+  className,
+  onClose: _onClose,
+  children,
+  ...props
+}: Omit<ComponentProps<typeof DialogContent>, "title"> & {
+  title?: ReactNode;
+  subTitle?: ReactNode;
+  footerContent?: ReactNode;
+  bodyClassName?: string;
+  onClose?: () => void;
+}) => (
+  <DialogContent className={cn("sm:max-w-lg", bodyClassName, className)} {...props}>
+    {(title || subTitle) && (
+      <DialogHeader className="text-left">
+        {title && <DialogTitle>{title}</DialogTitle>}
+        {subTitle && <DialogDescription>{subTitle}</DialogDescription>}
+      </DialogHeader>
+    )}
+    {children}
+    {footerContent && <DialogFooter>{footerContent}</DialogFooter>}
+  </DialogContent>
+);
+
+export const FormControl = ({
+  label,
+  errorText,
+  tooltipText,
+  className,
+  isError,
+  children
+}: {
+  label?: ReactNode;
+  errorText?: ReactNode;
+  tooltipText?: ReactNode;
+  className?: string;
+  isError?: boolean;
+  children: ReactNode;
+}) => (
+  <Field className={className} data-invalid={isError}>
+    {label && <FieldLabel>{label}</FieldLabel>}
+    {children}
+    {tooltipText && <FieldDescription>{tooltipText}</FieldDescription>}
+    {errorText && <FieldError>{errorText}</FieldError>}
+  </Field>
+);
+
+export { DropdownMenu, DropdownMenuContent, DropdownMenuLabel, DropdownMenuTrigger };

--- a/frontend/src/pages/admin/components/AdminV3Adapters.tsx
+++ b/frontend/src/pages/admin/components/AdminV3Adapters.tsx
@@ -11,7 +11,6 @@ import {
 
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
@@ -264,6 +263,11 @@ export const DeleteActionModal = ({
     setIsPending(true);
     try {
       await onDeleteApproved();
+      onChange?.(false);
+      setConfirmation("");
+      onClose?.();
+    } catch {
+      // MutationCache reports request errors globally; keep the dialog and confirmation available.
     } finally {
       setIsPending(false);
     }
@@ -273,6 +277,7 @@ export const DeleteActionModal = ({
     <AlertDialog
       open={isOpen}
       onOpenChange={(open) => {
+        if (isPending && !open) return;
         onChange?.(open);
         if (!open) {
           setConfirmation("");
@@ -281,43 +286,52 @@ export const DeleteActionModal = ({
       }}
     >
       <AlertDialogContent>
-        <AlertDialogHeader className="text-left">
-          <AlertDialogTitle>{title}</AlertDialogTitle>
-          <AlertDialogDescription>{subTitle}</AlertDialogDescription>
-        </AlertDialogHeader>
-        {formContent}
-        <label className="flex flex-col gap-2 text-sm" htmlFor={confirmationInputId}>
-          {deletionMessage || (
-            <span>
-              Type <strong>{deleteKey}</strong> to perform this action
-            </span>
-          )}
-          <InputGroup>
-            <InputGroupInput
-              id={confirmationInputId}
-              name={confirmationInputId}
-              value={confirmation}
-              onChange={(event) => setConfirmation(event.target.value)}
-              placeholder={`Type ${deleteKey} here`}
-              autoComplete="new-password"
-              data-1p-ignore
-              data-lpignore="true"
-              spellCheck={false}
-            />
-          </InputGroup>
-        </label>
-        {children}
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            variant="danger"
-            isPending={isPending}
-            isDisabled={confirmation !== deleteKey || isDisabled}
-            onClick={handleAction}
-          >
-            {buttonText}
-          </AlertDialogAction>
-        </AlertDialogFooter>
+        <form
+          className="contents"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleAction();
+          }}
+        >
+          <AlertDialogHeader className="text-left">
+            <AlertDialogTitle>{title}</AlertDialogTitle>
+            <AlertDialogDescription>{subTitle}</AlertDialogDescription>
+          </AlertDialogHeader>
+          {formContent}
+          <label className="flex flex-col gap-2 text-sm" htmlFor={confirmationInputId}>
+            {deletionMessage || (
+              <span>
+                Type <strong>{deleteKey}</strong> to perform this action
+              </span>
+            )}
+            <InputGroup>
+              <InputGroupInput
+                id={confirmationInputId}
+                name={confirmationInputId}
+                value={confirmation}
+                onChange={(event) => setConfirmation(event.target.value)}
+                placeholder={`Type ${deleteKey} here`}
+                autoComplete="new-password"
+                data-1p-ignore
+                data-lpignore="true"
+                spellCheck={false}
+              />
+            </InputGroup>
+          </label>
+          {children}
+          <AlertDialogFooter>
+            <AlertDialogCancel isDisabled={isPending}>Cancel</AlertDialogCancel>
+            <V3Button
+              type="submit"
+              variant="danger"
+              size="sm"
+              isPending={isPending}
+              isDisabled={confirmation !== deleteKey || isDisabled}
+            >
+              {buttonText}
+            </V3Button>
+          </AlertDialogFooter>
+        </form>
       </AlertDialogContent>
     </AlertDialog>
   );

--- a/frontend/src/pages/admin/components/AdminV3Adapters.tsx
+++ b/frontend/src/pages/admin/components/AdminV3Adapters.tsx
@@ -30,10 +30,6 @@ import {
   DropdownMenuItem as V3DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel,
   IconButton as V3IconButton,
   InputGroup,
   InputGroupAddon,
@@ -377,29 +373,6 @@ export const ModalContent = ({
     {children}
     {footerContent && <DialogFooter>{footerContent}</DialogFooter>}
   </DialogContent>
-);
-
-export const FormControl = ({
-  label,
-  errorText,
-  tooltipText,
-  className,
-  isError,
-  children
-}: {
-  label?: ReactNode;
-  errorText?: ReactNode;
-  tooltipText?: ReactNode;
-  className?: string;
-  isError?: boolean;
-  children: ReactNode;
-}) => (
-  <Field className={className} data-invalid={isError}>
-    {label && <FieldLabel>{label}</FieldLabel>}
-    {children}
-    {tooltipText && <FieldDescription>{tooltipText}</FieldDescription>}
-    {errorText && <FieldError>{errorText}</FieldError>}
-  </Field>
 );
 
 export { DropdownMenu, DropdownMenuContent, DropdownMenuLabel, DropdownMenuTrigger };


### PR DESCRIPTION
## Context

Migrates the PLATFOR-548 server admin console pages from v2 visual components to v3 components while retaining the documented blocked `PageHeader` usage and nonvisual `HighlightText`.

This covers page and card layouts, forms, Resource Overview and Access Control tables, dialogs and alerts, pagination, dropdowns, empty and loading states, responsive dialog widths, destructive-confirmation reset and autofill hardening, and consistent table action styling.

Previously, the server console used v2 components and inconsistent admin-specific styling. The migrated pages use v3 primitives and admin-local adapters where repeated legacy call shapes remain.

Review follow-ups additionally:

- keep asynchronous destructive and cache-invalidation dialogs open through failure and close them only after success;
- preserve Enter submission, pending feedback, retry state, and duplicate-submission prevention;
- add programmatic names and label associations to migrated pagination, switches, selects, searches, and selection controls;
- await the machine-identity admin-removal mutation correctly;
- normalize the View Members table surfaces to semantic v3 tokens;
- use mobile-safe input text sizing.

Related: PLATFOR-548. Related ticket: PLATFOR-547.

## Screenshots

<img width="735" height="706" alt="image" src="https://github.com/user-attachments/assets/0f2cd910-2444-4963-9f2a-be1b52a9de98" />

## Steps to verify the change

- Run the server console preview and sign in as a server admin.
- Exercise `/admin/`, every `/admin/resources/overview` tab, `/admin/access-management`, `/admin/encryption`, `/admin/authentication`, `/admin/integrations`, `/admin/caching`, and `/admin/environment`.
- Verify populated, empty, and loading tables; pagination; row menus; filtering; and multi-select user deletion.
- Verify add-organization, add-admin, and add-email-domain dialogs at laptop and narrow viewport widths.
- Verify destructive confirmations using pointer and Enter: fresh empty input, pending state, success and failure behavior, retry state, duplicate prevention, and focus return.
- Verify cache invalidation pending, failure, polling, and completion behavior.
- Run frontend ESLint and type checks.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
