### PR TITLE
fix(secret-sharing): branding on sub-orgs

### DIFF
--- a/backend/src/lib/request-context/memo-keys.ts
+++ b/backend/src/lib/request-context/memo-keys.ts
@@ -64,5 +64,7 @@ export const requestMemoKeys = {
 
   orgFindById: (orgId: string) => `org:findById:${orgId}`,
 
-  orgFindOrgById: (orgId: string) => `org:findOrgById:${orgId}`
+  orgFindOrgById: (orgId: string) => `org:findOrgById:${orgId}`,
+
+  orgFindRootOrgDetails: (orgId: string) => `org:findRootOrgDetails:${orgId}`
 };

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -870,8 +870,10 @@ export const secretSharingServiceFactory = ({
       return null;
     }
 
-    const org = await requestMemoize(requestMemoKeys.orgFindOrgById(orgId), () => orgDAL.findOrgById(orgId));
-    const assets = await orgAssetDAL.listAssetsByType(orgId, ["brand-logo", "brand-favicon"]);
+    const org = await requestMemoize(requestMemoKeys.orgFindRootOrgDetails(orgId), () =>
+      orgDAL.findRootOrgDetails(orgId)
+    );
+    const assets = await orgAssetDAL.listAssetsByType(org?.id ?? orgId, ["brand-logo", "brand-favicon"]);
 
     const hasLogo = assets.some((a) => a.assetType === "brand-logo");
     const hasFavicon = assets.some((a) => a.assetType === "brand-favicon");
@@ -913,7 +915,11 @@ export const secretSharingServiceFactory = ({
       return null;
     }
 
-    const asset = await orgAssetDAL.getFirstAsset(orgId, assetType);
+    const org = await requestMemoize(requestMemoKeys.orgFindRootOrgDetails(orgId), () =>
+      orgDAL.findRootOrgDetails(orgId)
+    );
+
+    const asset = await orgAssetDAL.getFirstAsset(org?.id ?? orgId, assetType);
     return asset;
   };
 


### PR DESCRIPTION
## Context

Fixed secret sharing branding on sub-orgs. We don't allow users to configure branding on sub orgs, so it should always infer the branding from the root organization.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)