### PR TITLE
feat(pki): improve certificate sync state UX

### DIFF
--- a/frontend/src/components/pki-syncs/PkiSyncImportStatusBadge.tsx
+++ b/frontend/src/components/pki-syncs/PkiSyncImportStatusBadge.tsx
@@ -4,8 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { differenceInSeconds } from "date-fns";
 import { CheckIcon, DownloadIcon, LucideIcon, TriangleAlertIcon } from "lucide-react";
 
-import { Tooltip } from "@app/components/v2";
-import { Badge, TBadgeProps } from "@app/components/v3";
+import { Badge, TBadgeProps, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { PkiSyncStatus, TPkiSync } from "@app/hooks/api/pkiSyncs";
 
@@ -90,11 +89,16 @@ export const PkiSyncImportStatusBadge = ({ pkiSync, mini }: Props) => {
   }
 
   return (
-    <Tooltip position="bottom" className="max-w-sm" content={tooltipContent}>
-      <Badge isSquare={mini} variant={variant}>
-        <Icon />
-        {!mini && label}
-      </Badge>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge isSquare={mini} variant={variant}>
+          <Icon />
+          {!mini && label}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-sm">
+        {tooltipContent}
+      </TooltipContent>
     </Tooltip>
   );
 };

--- a/frontend/src/components/pki-syncs/PkiSyncRemoveStatusBadge.tsx
+++ b/frontend/src/components/pki-syncs/PkiSyncRemoveStatusBadge.tsx
@@ -4,8 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { differenceInSeconds } from "date-fns";
 import { AlertTriangleIcon, CheckIcon, EraserIcon, LucideIcon } from "lucide-react";
 
-import { Tooltip } from "@app/components/v2";
-import { Badge, TBadgeProps } from "@app/components/v3";
+import { Badge, TBadgeProps, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { PkiSyncStatus, TPkiSync } from "@app/hooks/api/pkiSyncs";
 
@@ -90,11 +89,16 @@ export const PkiSyncRemoveStatusBadge = ({ pkiSync, mini }: Props) => {
   }
 
   return (
-    <Tooltip position="bottom" className="max-w-sm" content={tooltipContent}>
-      <Badge isSquare={mini} variant={variant}>
-        <Icon />
-        {!mini && label}
-      </Badge>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Badge isSquare={mini} variant={variant}>
+          <Icon />
+          {!mini && label}
+        </Badge>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-sm">
+        {tooltipContent}
+      </TooltipContent>
     </Tooltip>
   );
 };

--- a/frontend/src/components/v3/generic/Pagination/Pagination.tsx
+++ b/frontend/src/components/v3/generic/Pagination/Pagination.tsx
@@ -60,7 +60,7 @@ const Pagination = ({
         </div>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <IconButton variant="ghost" size="xs">
+            <IconButton aria-label="Select rows per page" variant="ghost" size="xs">
               <ChevronDownIcon />
             </IconButton>
           </DropdownMenuTrigger>
@@ -87,6 +87,7 @@ const Pagination = ({
       </div>
       <div className="flex items-center space-x-2">
         <IconButton
+          aria-label="Go to first page"
           variant="ghost"
           size="xs"
           onClick={() => onChangePage(1)}
@@ -95,6 +96,7 @@ const Pagination = ({
           <ChevronFirstIcon />
         </IconButton>
         <IconButton
+          aria-label="Go to previous page"
           variant="ghost"
           size="xs"
           onClick={() => onChangePage(prevPageNumber)}
@@ -103,6 +105,7 @@ const Pagination = ({
           <ChevronLeftIcon />
         </IconButton>
         <IconButton
+          aria-label="Go to next page"
           variant="ghost"
           size="xs"
           onClick={() => onChangePage(nextPageNumber)}
@@ -111,6 +114,7 @@ const Pagination = ({
           <ChevronRightIcon />
         </IconButton>
         <IconButton
+          aria-label="Go to last page"
           variant="ghost"
           size="xs"
           onClick={() => onChangePage(upperLimit)}

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
@@ -107,7 +107,7 @@ const PageContent = () => {
                 className="size-12 shrink-0 object-contain sm:size-14"
               />
               <div className="min-w-0">
-                <h1 className="break-words text-2xl font-medium leading-tight text-white sm:text-3xl">
+                <h1 className="text-2xl leading-tight font-medium break-words text-white sm:text-3xl">
                   {pkiSync.name}
                 </h1>
                 <p className="mt-1 text-sm leading-snug text-bunker-300 sm:text-base">

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
@@ -31,6 +31,16 @@ import {
   PkiSyncOptionsSection
 } from "./components";
 
+const formatSyncErrorMessage = (message?: string | null) => {
+  if (!message) return "An unknown error occurred.";
+
+  try {
+    return JSON.stringify(JSON.parse(message), null, 2);
+  } catch {
+    return message;
+  }
+};
+
 const PageContent = () => {
   const { syncId, projectId, orgId } = useParams({
     from: ROUTE_PATHS.CertManager.PkiSyncDetailsByIDPage.id
@@ -110,7 +120,7 @@ const PageContent = () => {
                 <h1 className="text-2xl leading-tight font-medium break-words text-white sm:text-3xl">
                   {pkiSync.name}
                 </h1>
-                <p className="mt-1 text-sm leading-snug text-bunker-300 sm:text-base">
+                <p className="mt-1 text-sm leading-snug text-muted sm:text-base">
                   {destinationDetails.name} PKI Sync
                 </p>
               </div>
@@ -125,7 +135,9 @@ const PageContent = () => {
                 {pkiSync.lastSyncedAt && (
                   <p>{format(new Date(pkiSync.lastSyncedAt), "MMM d, yyyy 'at' h:mm aaa")}</p>
                 )}
-                <p>{pkiSync.lastSyncMessage || "An unknown error occurred."}</p>
+                <p className="whitespace-pre-wrap break-words">
+                  {formatSyncErrorMessage(pkiSync.lastSyncMessage)}
+                </p>
               </AlertDescription>
             </Alert>
           )}

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
@@ -1,15 +1,24 @@
 import { Helmet } from "react-helmet";
-import { faBan, faChevronLeft } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { Link, useParams, useSearch } from "@tanstack/react-router";
+import { format } from "date-fns";
+import { BanIcon, ChevronLeftIcon, TriangleAlertIcon } from "lucide-react";
 
 import { EditPkiSyncModal } from "@app/components/pki-syncs";
 import { PkiSyncEditFields } from "@app/components/pki-syncs/types";
-import { Button, ContentLoader, EmptyState } from "@app/components/v2";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  PageLoader
+} from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { usePopUp } from "@app/hooks";
-import { useGetPkiSync } from "@app/hooks/api/pkiSyncs";
+import { PkiSyncStatus, useGetPkiSync } from "@app/hooks/api/pkiSyncs";
 import { IntegrationsListPageTabs } from "@app/types/integrations";
 
 import {
@@ -23,7 +32,6 @@ import {
 } from "./components";
 
 const PageContent = () => {
-  const navigate = useNavigate();
   const { syncId, projectId, orgId } = useParams({
     from: ROUTE_PATHS.CertManager.PkiSyncDetailsByIDPage.id
   });
@@ -41,21 +49,20 @@ const PageContent = () => {
   );
 
   if (isPending) {
-    return (
-      <div className="flex h-full w-full items-center justify-center">
-        <ContentLoader />
-      </div>
-    );
+    return <PageLoader />;
   }
 
   if (!pkiSync) {
     return (
-      <div className="flex h-full w-full items-center justify-center px-20">
-        <EmptyState
-          className="max-w-2xl rounded-md text-center"
-          icon={faBan}
-          title={`Could not find PKI Sync with ID ${syncId}`}
-        />
+      <div className="flex h-full w-full items-center justify-center px-4 sm:px-20">
+        <Empty className="max-w-2xl">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <BanIcon />
+            </EmptyMedia>
+            <EmptyTitle>Could not find PKI Sync with ID {syncId}</EmptyTitle>
+          </EmptyHeader>
+        </Empty>
       </div>
     );
   }
@@ -69,54 +76,66 @@ const PageContent = () => {
 
   return (
     <>
-      <div className="mx-auto flex flex-col justify-between bg-bunker-800 font-inter text-white">
+      <div className="mx-auto flex min-w-0 flex-col justify-between bg-bunker-800 px-4 font-inter text-white sm:px-6">
         <div className="mx-auto mb-6 w-full max-w-8xl">
-          <Button
-            variant="link"
-            type="submit"
-            leftIcon={<FontAwesomeIcon icon={faChevronLeft} />}
-            onClick={() => {
-              if (applicationName) {
-                navigate({
-                  to: "/organizations/$orgId/projects/cert-manager/$projectId/applications/$applicationName",
-                  params: { orgId, projectId, applicationName },
-                  search: { selectedTab: "syncs" }
-                });
-                return;
-              }
-              navigate({
-                to: ROUTE_PATHS.CertManager.IntegrationsListPage.path,
-                params: {
-                  projectId,
-                  orgId
-                },
-                search: {
-                  selectedTab: IntegrationsListPageTabs.PkiSyncs
-                }
-              });
-            }}
-          >
-            {applicationName ? "Back to Application" : "PKI Syncs"}
-          </Button>
-          <div className="mb-6 flex w-full items-center gap-3">
-            <img
-              alt={`${destinationDetails.name} sync`}
-              src={`/images/integrations/${destinationDetails.image}`}
-              className="mt-3 ml-1 w-16"
-            />
-            <div className="min-w-0">
-              <p className="truncate text-3xl font-medium text-white">{pkiSync.name}</p>
-              <p className="leading-3 text-bunker-300">{destinationDetails.name} PKI Sync</p>
+          {applicationName ? (
+            <Link
+              to="/organizations/$orgId/projects/cert-manager/$projectId/applications/$applicationName"
+              params={{ orgId, projectId, applicationName }}
+              search={{ selectedTab: "syncs" }}
+              className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-project transition-colors hover:text-project/80 focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            >
+              <ChevronLeftIcon className="size-4" />
+              Back to Application
+            </Link>
+          ) : (
+            <Link
+              to={ROUTE_PATHS.CertManager.IntegrationsListPage.path}
+              params={{ projectId, orgId }}
+              search={{ selectedTab: IntegrationsListPageTabs.PkiSyncs }}
+              className="mb-4 inline-flex items-center gap-1 text-sm font-medium text-project transition-colors hover:text-project/80 focus-visible:rounded-sm focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+            >
+              <ChevronLeftIcon className="size-4" />
+              PKI Syncs
+            </Link>
+          )}
+          <div className="mb-6 flex w-full min-w-0 flex-col gap-4 lg:flex-row lg:items-center">
+            <div className="flex min-w-0 items-center gap-3">
+              <img
+                alt={`${destinationDetails.name} sync`}
+                src={`/images/integrations/${destinationDetails.image}`}
+                className="size-12 shrink-0 object-contain sm:size-14"
+              />
+              <div className="min-w-0">
+                <h1 className="break-words text-2xl font-medium leading-tight text-white sm:text-3xl">
+                  {pkiSync.name}
+                </h1>
+                <p className="mt-1 text-sm leading-snug text-bunker-300 sm:text-base">
+                  {destinationDetails.name} PKI Sync
+                </p>
+              </div>
             </div>
             <PkiSyncActionTriggers pkiSync={pkiSync} />
           </div>
-          <div className="flex justify-center">
-            <div className="mr-4 flex w-72 flex-col gap-4">
+          {pkiSync.syncStatus === PkiSyncStatus.Failed && (
+            <Alert variant="danger" className="mb-6">
+              <TriangleAlertIcon />
+              <AlertTitle>Latest sync failed</AlertTitle>
+              <AlertDescription>
+                {pkiSync.lastSyncedAt && (
+                  <p>{format(new Date(pkiSync.lastSyncedAt), "MMM d, yyyy 'at' h:mm aaa")}</p>
+                )}
+                <p>{pkiSync.lastSyncMessage || "An unknown error occurred."}</p>
+              </AlertDescription>
+            </Alert>
+          )}
+          <div className="grid min-w-0 grid-cols-1 gap-4 xl:grid-cols-[18rem_minmax(0,1fr)]">
+            <div className="grid min-w-0 gap-4 md:grid-cols-2 xl:flex xl:w-72 xl:flex-col">
               <PkiSyncDetailsSection pkiSync={pkiSync} onEditDetails={handleEditDetails} />
               <PkiSyncOptionsSection pkiSync={pkiSync} onEditOptions={handleEditOptions} />
               <PkiSyncFieldMappingsSection pkiSync={pkiSync} onEditMappings={handleEditMappings} />
             </div>
-            <div className="flex flex-1 flex-col gap-4">
+            <div className="flex min-w-0 flex-col gap-4">
               <PkiSyncDestinationSection
                 pkiSync={pkiSync}
                 onEditDestination={handleEditDestination}

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
@@ -135,7 +135,7 @@ const PageContent = () => {
                 {pkiSync.lastSyncedAt && (
                   <p>{format(new Date(pkiSync.lastSyncedAt), "MMM d, yyyy 'at' h:mm aaa")}</p>
                 )}
-                <p className="whitespace-pre-wrap break-words">
+                <p className="break-words whitespace-pre-wrap">
                   {formatSyncErrorMessage(pkiSync.lastSyncMessage)}
                 </p>
               </AlertDescription>

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
@@ -126,7 +126,7 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
       <div className="flex w-full min-w-0 flex-wrap items-center gap-2 lg:ml-auto lg:w-auto lg:shrink-0 lg:justify-end">
         {syncOption?.canImportCertificates && <PkiSyncImportStatusBadge pkiSync={pkiSync} />}
         <PkiSyncRemoveStatusBadge pkiSync={pkiSync} />
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 sm:mr-2">
           <Switch
             id="pki-auto-sync"
             variant="success"
@@ -135,7 +135,7 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
             disabled={!canEditSync || updatePkiSyncMutation.isPending}
           />
           <Label htmlFor="pki-auto-sync" className="whitespace-nowrap">
-            Auto-Sync {pkiSync.isAutoSyncEnabled ? "Enabled" : "Disabled"}
+            Auto-Sync
           </Label>
         </div>
         <ButtonGroup className="w-full sm:w-fit">
@@ -147,7 +147,7 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
             onClick={handleTriggerSync}
           >
             <RefreshCwIcon />
-            Trigger Sync
+            Sync now
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
@@ -27,10 +27,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   IconButton,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
+  Label,
+  Switch,
   Tooltip,
   TooltipContent,
   TooltipTrigger
@@ -106,9 +104,7 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
   }, [triggerSyncMutation, id, destination, projectId]);
 
   const handleAutoSyncChange = useCallback(
-    async (value: string) => {
-      const isAutoSyncEnabled = value === "enabled";
-
+    async (isAutoSyncEnabled: boolean) => {
       if (isAutoSyncEnabled === pkiSync.isAutoSyncEnabled) return;
 
       await updatePkiSyncMutation.mutateAsync({
@@ -130,20 +126,18 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
       <div className="flex w-full min-w-0 flex-wrap items-center gap-2 lg:ml-auto lg:w-auto lg:shrink-0 lg:justify-end">
         {syncOption?.canImportCertificates && <PkiSyncImportStatusBadge pkiSync={pkiSync} />}
         <PkiSyncRemoveStatusBadge pkiSync={pkiSync} />
-        <Select
-          value={pkiSync.isAutoSyncEnabled ? "enabled" : "disabled"}
-          onValueChange={handleAutoSyncChange}
-          disabled={!canEditSync || updatePkiSyncMutation.isPending}
-        >
-          <SelectTrigger aria-label="Auto-sync setting">
-            <RefreshCwIcon className={pkiSync.isAutoSyncEnabled ? "text-success" : "text-muted"} />
+        <div className="flex items-center gap-2">
+          <Switch
+            id="pki-auto-sync"
+            variant="success"
+            checked={pkiSync.isAutoSyncEnabled}
+            onCheckedChange={handleAutoSyncChange}
+            disabled={!canEditSync || updatePkiSyncMutation.isPending}
+          />
+          <Label htmlFor="pki-auto-sync" className="whitespace-nowrap">
             Auto-Sync {pkiSync.isAutoSyncEnabled ? "Enabled" : "Disabled"}
-          </SelectTrigger>
-          <SelectContent position="popper" align="end" sideOffset={4}>
-            <SelectItem value="enabled">Enabled</SelectItem>
-            <SelectItem value="disabled">Disabled</SelectItem>
-          </SelectContent>
-        </Select>
+          </Label>
+        </div>
         <ButtonGroup className="w-full sm:w-fit">
           <Button
             variant="outline"

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
@@ -136,7 +136,7 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
             <RefreshCwIcon />
             Auto-Sync {pkiSync.isAutoSyncEnabled ? "Enabled" : "Disabled"}
           </SelectTrigger>
-          <SelectContent align="end">
+          <SelectContent position="popper" align="end" sideOffset={4}>
             <SelectItem value="enabled">Enabled</SelectItem>
             <SelectItem value="disabled">Disabled</SelectItem>
           </SelectContent>

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
@@ -133,7 +133,9 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
           disabled={!canEditSync || updatePkiSyncMutation.isPending}
         >
           <SelectTrigger aria-label="Auto-sync setting">
-            <RefreshCwIcon />
+            <RefreshCwIcon
+              className={pkiSync.isAutoSyncEnabled ? "text-success" : "text-muted"}
+            />
             Auto-Sync {pkiSync.isAutoSyncEnabled ? "Enabled" : "Disabled"}
           </SelectTrigger>
           <SelectContent position="popper" align="end" sideOffset={4}>

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
@@ -107,16 +107,23 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
     async (isAutoSyncEnabled: boolean) => {
       if (isAutoSyncEnabled === pkiSync.isAutoSyncEnabled) return;
 
-      await updatePkiSyncMutation.mutateAsync({
-        syncId: id,
-        projectId,
-        destination,
-        isAutoSyncEnabled
-      });
-      createNotification({
-        text: `Auto-sync ${isAutoSyncEnabled ? "enabled" : "disabled"} successfully`,
-        type: "success"
-      });
+      try {
+        await updatePkiSyncMutation.mutateAsync({
+          syncId: id,
+          projectId,
+          destination,
+          isAutoSyncEnabled
+        });
+        createNotification({
+          text: `Auto-sync ${isAutoSyncEnabled ? "enabled" : "disabled"} successfully`,
+          type: "success"
+        });
+      } catch {
+        createNotification({
+          text: "Failed to update auto-sync setting",
+          type: "error"
+        });
+      }
     },
     [updatePkiSyncMutation, id, projectId, destination, pkiSync.isAutoSyncEnabled]
   );

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
@@ -105,22 +105,25 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
     });
   }, [triggerSyncMutation, id, destination, projectId]);
 
-  const handleAutoSyncChange = useCallback(async (value: string) => {
-    const isAutoSyncEnabled = value === "enabled";
+  const handleAutoSyncChange = useCallback(
+    async (value: string) => {
+      const isAutoSyncEnabled = value === "enabled";
 
-    if (isAutoSyncEnabled === pkiSync.isAutoSyncEnabled) return;
+      if (isAutoSyncEnabled === pkiSync.isAutoSyncEnabled) return;
 
-    await updatePkiSyncMutation.mutateAsync({
-      syncId: id,
-      projectId,
-      destination,
-      isAutoSyncEnabled
-    });
-    createNotification({
-      text: `Auto-sync ${isAutoSyncEnabled ? "enabled" : "disabled"} successfully`,
-      type: "success"
-    });
-  }, [updatePkiSyncMutation, id, projectId, destination, pkiSync.isAutoSyncEnabled]);
+      await updatePkiSyncMutation.mutateAsync({
+        syncId: id,
+        projectId,
+        destination,
+        isAutoSyncEnabled
+      });
+      createNotification({
+        text: `Auto-sync ${isAutoSyncEnabled ? "enabled" : "disabled"} successfully`,
+        type: "success"
+      });
+    },
+    [updatePkiSyncMutation, id, projectId, destination, pkiSync.isAutoSyncEnabled]
+  );
 
   return (
     <>
@@ -133,9 +136,7 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
           disabled={!canEditSync || updatePkiSyncMutation.isPending}
         >
           <SelectTrigger aria-label="Auto-sync setting">
-            <RefreshCwIcon
-              className={pkiSync.isAutoSyncEnabled ? "text-success" : "text-muted"}
-            />
+            <RefreshCwIcon className={pkiSync.isAutoSyncEnabled ? "text-success" : "text-muted"} />
             Auto-Sync {pkiSync.isAutoSyncEnabled ? "Enabled" : "Disabled"}
           </SelectTrigger>
           <SelectContent position="popper" align="end" sideOffset={4}>

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncActionTriggers.tsx
@@ -1,19 +1,15 @@
 import { useCallback } from "react";
-import {
-  faCheck,
-  faCopy,
-  faDownload,
-  faEllipsisV,
-  faEraser,
-  faInfoCircle,
-  faRotate,
-  faToggleOff,
-  faToggleOn,
-  faTrash
-} from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useNavigate } from "@tanstack/react-router";
-import { BanIcon, RefreshCwIcon } from "lucide-react";
+import {
+  CheckIcon,
+  CopyIcon,
+  DownloadIcon,
+  EllipsisIcon,
+  EraserIcon,
+  InfoIcon,
+  RefreshCwIcon,
+  Trash2Icon
+} from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -25,14 +21,20 @@ import {
 } from "@app/components/pki-syncs";
 import {
   Button,
+  ButtonGroup,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
   IconButton,
-  Tooltip
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useOrganization } from "@app/context";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
@@ -103,130 +105,122 @@ export const PkiSyncActionTriggers = ({ pkiSync }: Props) => {
     });
   }, [triggerSyncMutation, id, destination, projectId]);
 
-  const handleToggleAutoSync = useCallback(async () => {
+  const handleAutoSyncChange = useCallback(async (value: string) => {
+    const isAutoSyncEnabled = value === "enabled";
+
+    if (isAutoSyncEnabled === pkiSync.isAutoSyncEnabled) return;
+
     await updatePkiSyncMutation.mutateAsync({
       syncId: id,
       projectId,
       destination,
-      isAutoSyncEnabled: !pkiSync.isAutoSyncEnabled
+      isAutoSyncEnabled
     });
     createNotification({
-      text: `Auto-sync ${pkiSync.isAutoSyncEnabled ? "disabled" : "enabled"} successfully`,
+      text: `Auto-sync ${isAutoSyncEnabled ? "enabled" : "disabled"} successfully`,
       type: "success"
     });
-  }, [updatePkiSyncMutation, id, projectId, pkiSync.isAutoSyncEnabled]);
+  }, [updatePkiSyncMutation, id, projectId, destination, pkiSync.isAutoSyncEnabled]);
 
   return (
     <>
-      <div className="mt-4 ml-auto flex shrink-0 flex-wrap items-center justify-end gap-2">
+      <div className="flex w-full min-w-0 flex-wrap items-center gap-2 lg:ml-auto lg:w-auto lg:shrink-0 lg:justify-end">
         {syncOption?.canImportCertificates && <PkiSyncImportStatusBadge pkiSync={pkiSync} />}
         <PkiSyncRemoveStatusBadge pkiSync={pkiSync} />
-        {pkiSync.isAutoSyncEnabled ? (
-          <Badge variant="info">
+        <Select
+          value={pkiSync.isAutoSyncEnabled ? "enabled" : "disabled"}
+          onValueChange={handleAutoSyncChange}
+          disabled={!canEditSync || updatePkiSyncMutation.isPending}
+        >
+          <SelectTrigger aria-label="Auto-sync setting">
             <RefreshCwIcon />
-            Auto-Sync Enabled
-          </Badge>
-        ) : (
-          <Tooltip
-            className="text-xs"
-            content="Auto-Sync is disabled. Certificate changes in this application will not be automatically synced to the destination."
-          >
-            <Badge variant="neutral">
-              <BanIcon />
-              Auto-Sync Disabled
-            </Badge>
-          </Tooltip>
-        )}
-        <div>
+            Auto-Sync {pkiSync.isAutoSyncEnabled ? "Enabled" : "Disabled"}
+          </SelectTrigger>
+          <SelectContent align="end">
+            <SelectItem value="enabled">Enabled</SelectItem>
+            <SelectItem value="disabled">Disabled</SelectItem>
+          </SelectContent>
+        </Select>
+        <ButtonGroup className="w-full sm:w-fit">
           <Button
-            variant="outline_bg"
-            leftIcon={<FontAwesomeIcon icon={faRotate} />}
-            className="h-9 rounded-r-none bg-mineshaft-500"
+            variant="outline"
+            className="min-w-0 flex-1 sm:flex-none"
             isDisabled={!canTriggerSync || triggerSyncMutation.isPending}
-            isLoading={triggerSyncMutation.isPending}
+            isPending={triggerSyncMutation.isPending}
             onClick={handleTriggerSync}
           >
+            <RefreshCwIcon />
             Trigger Sync
           </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <IconButton
-                ariaLabel="add-folder-or-import"
-                variant="outline_bg"
-                className="h-9 w-10 rounded-l-none border-l-2 border-mineshaft border-l-mineshaft-700 bg-mineshaft-500"
-              >
-                <FontAwesomeIcon icon={faEllipsisV} />
+              <IconButton aria-label="PKI sync options" variant="outline" className="shrink-0">
+                <EllipsisIcon />
               </IconButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               <DropdownMenuItem
-                icon={<FontAwesomeIcon icon={isIdCopied ? faCheck : faCopy} />}
                 onClick={(e) => {
                   e.stopPropagation();
                   handleCopyId();
                 }}
               >
+                {isIdCopied ? <CheckIcon /> : <CopyIcon />}
                 Copy Sync ID
               </DropdownMenuItem>
 
               {syncOption?.canImportCertificates && (
                 <DropdownMenuItem
-                  icon={<FontAwesomeIcon icon={faDownload} />}
                   onClick={() => handlePopUpOpen("importCertificates")}
                   isDisabled={!canImportCertificates}
                 >
-                  <Tooltip
-                    position="left"
-                    sideOffset={42}
-                    content={`Import certificates from this ${destinationName} destination into Infisical.`}
-                  >
-                    <div className="flex h-full w-full items-center justify-between gap-1">
-                      <span>Import Certificates</span>
-                      <FontAwesomeIcon className="text-bunker-300" size="sm" icon={faInfoCircle} />
-                    </div>
+                  <DownloadIcon />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="flex h-full w-full items-center justify-between gap-2">
+                        <span>Import Certificates</span>
+                        <InfoIcon className="size-3.5 text-muted" />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="left" sideOffset={14}>
+                      Import certificates from this {destinationName} destination into Infisical.
+                    </TooltipContent>
                   </Tooltip>
                 </DropdownMenuItem>
               )}
 
               {syncOption?.canRemoveCertificates && (
                 <DropdownMenuItem
-                  icon={<FontAwesomeIcon icon={faEraser} />}
                   onClick={() => handlePopUpOpen("removeCertificates")}
                   isDisabled={!canRemoveCertificates}
                 >
-                  <Tooltip
-                    position="left"
-                    sideOffset={42}
-                    content={`Remove certificates synced by Infisical from this ${destinationName} destination.`}
-                  >
-                    <div className="flex h-full w-full items-center justify-between gap-1">
-                      <span>Remove Certificates</span>
-                      <FontAwesomeIcon className="text-bunker-300" size="sm" icon={faInfoCircle} />
-                    </div>
+                  <EraserIcon />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="flex h-full w-full items-center justify-between gap-2">
+                        <span>Remove Certificates</span>
+                        <InfoIcon className="size-3.5 text-muted" />
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="left" sideOffset={14}>
+                      Remove certificates synced by Infisical from this {destinationName}{" "}
+                      destination.
+                    </TooltipContent>
                   </Tooltip>
                 </DropdownMenuItem>
               )}
 
               <DropdownMenuItem
-                isDisabled={!canEditSync || updatePkiSyncMutation.isPending}
-                icon={
-                  <FontAwesomeIcon icon={pkiSync.isAutoSyncEnabled ? faToggleOff : faToggleOn} />
-                }
-                onClick={handleToggleAutoSync}
-              >
-                {pkiSync.isAutoSyncEnabled ? "Disable" : "Enable"} Auto-Sync
-              </DropdownMenuItem>
-
-              <DropdownMenuItem
                 isDisabled={!canDeleteSync}
-                icon={<FontAwesomeIcon icon={faTrash} />}
                 onClick={() => handlePopUpOpen("deleteSync")}
+                variant="danger"
               >
+                <Trash2Icon />
                 Delete Sync
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-        </div>
+        </ButtonGroup>
       </div>
 
       {syncOption?.canImportCertificates && (

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncAuditLogsSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncAuditLogsSection.tsx
@@ -25,7 +25,7 @@ export const PkiSyncAuditLogsSection = ({ pkiSync }: Props) => {
 
   return (
     <div className="flex max-h-full w-full flex-col gap-3 rounded-lg border border-mineshaft-600 bg-mineshaft-900 px-4 py-3">
-      <div className="flex items-center justify-between border-b border-mineshaft-400 pb-2">
+      <div className="flex flex-col items-start gap-1 border-b border-mineshaft-400 pb-2 sm:flex-row sm:items-center sm:justify-between">
         <h3 className="text-lg font-medium text-mineshaft-100">Sync Logs</h3>
         {subscription.auditLogs && (
           <p className="text-xs text-bunker-300">

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
@@ -1,12 +1,7 @@
 import { useState } from "react";
-import {
-  faCertificate,
-  faClockRotateLeft,
-  faEdit,
-  faEllipsisV,
-  faTrash
-} from "@fortawesome/free-solid-svg-icons";
+import { faClockRotateLeft } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { MoreHorizontalIcon, PencilIcon, ScrollTextIcon, Trash2Icon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import { CertificateManagementModal } from "@app/components/pki-syncs/CertificateManagementModal";
@@ -16,23 +11,31 @@ import {
 } from "@app/components/utilities/certificateDisplayUtils";
 import {
   DeleteActionModal,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  EmptyState,
-  IconButton,
-  Pagination,
   Table,
   TableContainer,
   TBody,
   Td,
   Th,
   THead,
-  Tooltip,
   Tr
 } from "@app/components/v2";
-import { Badge, CopyButton } from "@app/components/v3";
+import {
+  Badge,
+  CopyButton,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  Empty,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  IconButton,
+  Pagination,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   useClearDefaultCertificate,
   useListPkiSyncCertificates,
@@ -182,13 +185,13 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
         <div className="flex items-center justify-between border-b border-mineshaft-400 pb-2">
           <h3 className="text-lg font-medium text-mineshaft-100">Certificates</h3>
           <IconButton
-            variant="plain"
-            colorSchema="secondary"
+            variant="ghost-muted"
+            size="xs"
             isDisabled={!canEdit}
-            ariaLabel="Edit certificates"
+            aria-label="Edit certificates"
             onClick={() => setIsManageModalOpen(true)}
           >
-            <FontAwesomeIcon icon={faEdit} />
+            <PencilIcon />
           </IconButton>
         </div>
 
@@ -285,13 +288,15 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
                         <Td className="max-w-0">
                           {syncCert.externalIdentifier ? (
                             <div className="flex items-center gap-1">
-                              <Tooltip
-                                content={syncCert.externalIdentifier}
-                                className="max-w-none whitespace-nowrap"
-                              >
-                                <span className="truncate text-xs text-bunker-300">
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <span className="truncate text-xs text-bunker-300">
+                                    {syncCert.externalIdentifier}
+                                  </span>
+                                </TooltipTrigger>
+                                <TooltipContent className="max-w-none whitespace-nowrap">
                                   {syncCert.externalIdentifier}
-                                </span>
+                                </TooltipContent>
                               </Tooltip>
                               <CopyButton
                                 value={syncCert.externalIdentifier}
@@ -305,8 +310,11 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
                         <Td>
                           {syncCert.lastSyncMessage &&
                           syncCert.syncStatus === CertificateSyncStatus.Failed ? (
-                            <Tooltip content={syncCert.lastSyncMessage}>
-                              <Badge variant="danger">Failed</Badge>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Badge variant="danger">Failed</Badge>
+                              </TooltipTrigger>
+                              <TooltipContent>{syncCert.lastSyncMessage}</TooltipContent>
                             </Tooltip>
                           ) : (
                             <Badge variant={getSyncStatusVariant(syncCert.syncStatus)}>
@@ -325,22 +333,24 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
                         </Td>
                         <Td className="flex items-center justify-end gap-2 pr-4">
                           {hasAutoRenewal && daysUntilRenewal !== null && (
-                            <Tooltip content={`Auto-renews in ${daysUntilRenewal}d`}>
-                              <div className="text-primary-500">
-                                <FontAwesomeIcon icon={faClockRotateLeft} size="sm" />
-                              </div>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <div className="text-primary-500">
+                                  <FontAwesomeIcon icon={faClockRotateLeft} size="sm" />
+                                </div>
+                              </TooltipTrigger>
+                              <TooltipContent>Auto-renews in {daysUntilRenewal}d</TooltipContent>
                             </Tooltip>
                           )}
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <IconButton
                                 size="xs"
-                                variant="plain"
-                                colorSchema="secondary"
-                                ariaLabel="Certificate actions"
+                                variant="ghost-muted"
+                                aria-label="Certificate actions"
                                 isDisabled={!canEdit}
                               >
-                                <FontAwesomeIcon icon={faEllipsisV} />
+                                <MoreHorizontalIcon />
                               </IconButton>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
@@ -360,9 +370,10 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
                                 onClick={() =>
                                   handleDeleteClick(syncCert.certificateId, originalDisplayName)
                                 }
-                                icon={<FontAwesomeIcon icon={faTrash} className="text-red-500" />}
+                                variant="danger"
                               >
-                                <span className="text-red-500">Remove from Sync</span>
+                                <Trash2Icon />
+                                Remove from Sync
                               </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>
@@ -373,10 +384,14 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
                 </TBody>
               </Table>
               {syncCertificates.length === 0 && (
-                <EmptyState
-                  title="No certificates are part of this certificate sync"
-                  icon={faCertificate}
-                />
+                <Empty className="rounded-none border-0 py-12">
+                  <EmptyHeader>
+                    <EmptyMedia variant="icon">
+                      <ScrollTextIcon />
+                    </EmptyMedia>
+                    <EmptyTitle>No certificates are part of this certificate sync</EmptyTitle>
+                  </EmptyHeader>
+                </Empty>
               )}
             </TableContainer>
             {/* Pagination */}

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncDestinationSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncDestinationSection.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { ReactNode } from "react";
-import { faEdit } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { PencilIcon } from "lucide-react";
 
-import { IconButton } from "@app/components/v2";
+import { IconButton } from "@app/components/v3";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { PkiSync, TPkiSync, usePkiSyncPermissions } from "@app/hooks/api/pkiSyncs";
 
@@ -85,13 +84,13 @@ export const PkiSyncDestinationSection = ({ pkiSync, onEditDestination }: Props)
       <div className="flex items-center justify-between border-b border-mineshaft-400 pb-2">
         <h3 className="text-lg font-medium text-mineshaft-100">Destination Configuration</h3>
         <IconButton
-          variant="plain"
-          colorSchema="secondary"
+          variant="ghost-muted"
+          size="xs"
           isDisabled={!canEdit}
-          ariaLabel="Edit destination"
+          aria-label="Edit destination"
           onClick={onEditDestination}
         >
-          <FontAwesomeIcon icon={faEdit} />
+          <PencilIcon />
         </IconButton>
       </div>
       <div className="flex w-full flex-wrap gap-8 pt-2">

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncDestinationSection/AwsElasticLoadBalancerPkiSyncDestinationSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncDestinationSection/AwsElasticLoadBalancerPkiSyncDestinationSection.tsx
@@ -1,4 +1,4 @@
-import { Tag } from "@app/components/v2";
+import { Badge } from "@app/components/v3";
 import { TPkiSync } from "@app/hooks/api/pkiSyncs";
 
 const GenericFieldLabel = ({ label, children }: { label: string; children: React.ReactNode }) => (
@@ -51,9 +51,9 @@ export const AwsElasticLoadBalancerPkiSyncDestinationSection = ({ pkiSync }: Pro
         ) : (
           <div className="flex flex-wrap gap-1">
             {listeners.map((listener) => (
-              <Tag key={listener.listenerArn} size="xs">
+              <Badge key={listener.listenerArn} variant="neutral">
                 {listener.protocol}:{listener.port}
-              </Tag>
+              </Badge>
             ))}
           </div>
         )}

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncDetailsSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncDetailsSection.tsx
@@ -19,7 +19,7 @@ const GenericFieldLabel = ({
 }) => (
   <div className="mb-4">
     <p className={`text-sm font-medium text-mineshaft-300 ${labelClassName || ""}`}>{label}</p>
-    <div className={`text-sm text-mineshaft-300 ${truncate ? "truncate" : ""}`}>{children}</div>
+    <div className={`text-sm text-mineshaft-400 ${truncate ? "truncate" : ""}`}>{children}</div>
   </div>
 );
 

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncDetailsSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncDetailsSection.tsx
@@ -1,12 +1,10 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
-import { useMemo } from "react";
-import { faEdit } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { format } from "date-fns";
+import { PencilIcon } from "lucide-react";
 
 import { PkiSyncStatusBadge } from "@app/components/pki-syncs";
-import { IconButton } from "@app/components/v2";
-import { PkiSyncStatus, TPkiSync, usePkiSyncPermissions } from "@app/hooks/api/pkiSyncs";
+import { IconButton } from "@app/components/v3";
+import { TPkiSync, usePkiSyncPermissions } from "@app/hooks/api/pkiSyncs";
 
 const GenericFieldLabel = ({
   label,
@@ -31,21 +29,7 @@ type Props = {
 };
 
 export const PkiSyncDetailsSection = ({ pkiSync, onEditDetails }: Props) => {
-  const { syncStatus, lastSyncMessage, lastSyncedAt, name, description, subscriber } = pkiSync;
-
-  const failureMessage = useMemo(() => {
-    if (syncStatus === PkiSyncStatus.Failed) {
-      if (lastSyncMessage)
-        try {
-          return JSON.stringify(JSON.parse(lastSyncMessage), null, 2);
-        } catch {
-          return lastSyncMessage;
-        }
-
-      return "An Unknown Error Occurred.";
-    }
-    return null;
-  }, [syncStatus, lastSyncMessage]);
+  const { syncStatus, lastSyncedAt, name, description, subscriber } = pkiSync;
 
   const { canEdit } = usePkiSyncPermissions(pkiSync);
 
@@ -54,13 +38,13 @@ export const PkiSyncDetailsSection = ({ pkiSync, onEditDetails }: Props) => {
       <div className="flex items-center justify-between border-b border-mineshaft-400 pb-2">
         <h3 className="text-lg font-medium text-mineshaft-100">Details</h3>
         <IconButton
-          variant="plain"
-          colorSchema="secondary"
+          variant="ghost-muted"
+          size="xs"
           isDisabled={!canEdit}
-          ariaLabel="Edit sync details"
+          aria-label="Edit sync details"
           onClick={onEditDetails}
         >
-          <FontAwesomeIcon icon={faEdit} />
+          <PencilIcon />
         </IconButton>
       </div>
       <div className="pt-2">
@@ -79,11 +63,6 @@ export const PkiSyncDetailsSection = ({ pkiSync, onEditDetails }: Props) => {
         {lastSyncedAt && (
           <GenericFieldLabel label="Last Synced">
             {format(new Date(lastSyncedAt), "yyyy-MM-dd, h:mm aaa")}
-          </GenericFieldLabel>
-        )}
-        {syncStatus === PkiSyncStatus.Failed && failureMessage && (
-          <GenericFieldLabel labelClassName="text-red" label="Last Sync Error">
-            <p className="rounded-sm bg-mineshaft-600 p-2 text-xs break-words">{failureMessage}</p>
           </GenericFieldLabel>
         )}
       </div>

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncFieldMappingsSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncFieldMappingsSection.tsx
@@ -1,8 +1,6 @@
-import { faEdit } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { PencilIcon } from "lucide-react";
 
-import { IconButton } from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, IconButton } from "@app/components/v3";
 import { PkiSync, TPkiSync, usePkiSyncPermissions } from "@app/hooks/api/pkiSyncs";
 
 const GenericFieldLabel = ({
@@ -39,13 +37,13 @@ export const PkiSyncFieldMappingsSection = ({ pkiSync, onEditMappings }: Props) 
         <div className="flex items-center justify-between border-b border-mineshaft-400 pb-2">
           <h3 className="text-lg font-medium text-mineshaft-100">Field Mappings</h3>
           <IconButton
-            variant="plain"
-            colorSchema="secondary"
+            variant="ghost-muted"
+            size="xs"
             isDisabled={!canEdit}
-            ariaLabel="Edit field mappings"
+            aria-label="Edit field mappings"
             onClick={onEditMappings}
           >
-            <FontAwesomeIcon icon={faEdit} />
+            <PencilIcon />
           </IconButton>
         </div>
         <div className="pt-1">

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncOptionsSection/PkiSyncOptionsSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncOptionsSection/PkiSyncOptionsSection.tsx
@@ -1,8 +1,6 @@
-import { faEdit } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { PencilIcon } from "lucide-react";
 
-import { IconButton } from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, IconButton } from "@app/components/v3";
 import { TPkiSync, usePkiSyncPermissions } from "@app/hooks/api/pkiSyncs";
 
 const GenericFieldLabel = ({
@@ -37,13 +35,13 @@ export const PkiSyncOptionsSection = ({ pkiSync, onEditOptions }: Props) => {
         <div className="flex items-center justify-between border-b border-mineshaft-400 pb-2">
           <h3 className="text-lg font-medium text-mineshaft-100">Sync Options</h3>
           <IconButton
-            variant="plain"
-            colorSchema="secondary"
+            variant="ghost-muted"
+            size="xs"
             isDisabled={!canEdit}
-            ariaLabel="Edit sync options"
+            aria-label="Edit sync options"
             onClick={onEditOptions}
           >
-            <FontAwesomeIcon icon={faEdit} />
+            <PencilIcon />
           </IconButton>
         </div>
         <div className="pt-1">

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncSourceSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncSourceSection.tsx
@@ -1,10 +1,7 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
-import { faEdit } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { AlertTriangleIcon } from "lucide-react";
+import { AlertTriangleIcon, PencilIcon } from "lucide-react";
 
-import { IconButton, Tooltip } from "@app/components/v2";
-import { Badge } from "@app/components/v3";
+import { Badge, IconButton, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { TPkiSync, usePkiSyncPermissions } from "@app/hooks/api/pkiSyncs";
 
 const GenericFieldLabel = ({ label, children }: { label: string; children: React.ReactNode }) => (
@@ -30,21 +27,27 @@ export const PkiSyncSourceSection = ({ pkiSync, onEditSource }: Props) => {
           <h3 className="font-medium text-mineshaft-100">Source</h3>
           <div>
             {!subscriberId && (
-              <Tooltip content="The PKI subscriber for this sync has been deleted. Configure a new source or remove this sync.">
-                <Badge variant="danger" className="mr-1">
-                  <AlertTriangleIcon />
-                  Source Deleted
-                </Badge>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge variant="danger" className="mr-1">
+                    <AlertTriangleIcon />
+                    Source Deleted
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  The PKI subscriber for this sync has been deleted. Configure a new source or
+                  remove this sync.
+                </TooltipContent>
               </Tooltip>
             )}
             <IconButton
-              variant="plain"
-              colorSchema="secondary"
+              variant="ghost-muted"
+              size="xs"
               isDisabled={!canEdit}
-              ariaLabel="Edit sync source"
+              aria-label="Edit sync source"
               onClick={onEditSource}
             >
-              <FontAwesomeIcon icon={faEdit} />
+              <PencilIcon />
             </IconButton>
           </div>
         </div>


### PR DESCRIPTION
## Context

Addresses ENG-5373 by making PKI sync state and controls easier to understand on the certificate sync detail page.

Previously, auto-sync appeared as a passive status badge, the latest failed run was buried in the Details card, the page header could collide at narrower widths, and several ready V3 primitives were still represented by V2 components.

This change:
- adds a prominent V3 failure alert with the latest attempt time and error;
- keeps persistent Status and Last Synced metadata while removing the duplicated error block;
- replaces the auto-sync badge and duplicate overflow action with one V3 Switch;
- clarifies and groups manual sync actions;
- makes the detail header and content layout responsive;
- migrates ready badges, buttons, dropdowns, tooltips, loaders, empty states, pagination, tags, and icon buttons to V3.

The certificate table and complex modal/form workflows remain unchanged where V3 parity is partial; those migrations are intentionally separated into a stacked follow-up PR.

## Screenshots

### Sync state and controls

The latest failure is surfaced beside persistent status metadata, while auto-sync and manual triggering are presented as explicit actions. This screenshot captures the earlier select iteration; the final branch uses the existing V3 Switch and the concise “Sync now” action copy, verified through local HMR.

<img width="1542" height="1486" alt="PKI sync detail page with latest failure alert, auto-sync select, and manual trigger" src="https://github.com/user-attachments/assets/42266212-d576-4921-972c-70abaf817f65" />

## Steps to verify the change

1. Open a PKI certificate sync detail page with a failed latest sync.
2. Confirm the failure alert shows the latest attempt time and error.
3. Confirm Details still shows Status and Last Synced without repeating Last Sync Error.
4. Toggle the Auto-Sync switch and confirm the checked state updates; confirm the control is permission-gated.
5. Confirm Sync now and the overflow actions remain available.
6. Resize the page and confirm the header, controls, cards, certificate table container, and log header do not cause page-level horizontal overflow.

Validation performed:
- GitHub Actions frontend lint and type-check
- GitHub Actions PR-title and non-RE2-regex checks
- `git diff --check`
- private-file verification
- local HMR browser verification of the failed-state alert, retained details, responsive layout, and disabling/re-enabling the V3 auto-sync Switch

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)