### PR TITLE
improvement(pki): migrate sync detail surfaces to v3

### DIFF
--- a/frontend/src/components/pki-syncs/CertificateManagementModal.tsx
+++ b/frontend/src/components/pki-syncs/CertificateManagementModal.tsx
@@ -324,131 +324,128 @@ export const CertificateManagementModal = ({
             </div>
           </div>
 
-          <>
-            <Table>
-              <THead>
-                <Tr>
-                  <Th className="w-12">
-                    {!isSingleSelect && (
+          <Table>
+            <THead>
+              <Tr>
+                <Th className="w-12">
+                  {!isSingleSelect && (
+                    <Checkbox
+                      id="select-all-certificates"
+                      isChecked={
+                        allCertificates.length > 0 &&
+                        allCertificates.every((cert) => selectedIds.includes(cert.id))
+                      }
+                      onCheckedChange={handleSelectAll}
+                    />
+                  )}
+                </Th>
+                <Th className="w-1/3">SAN / CN</Th>
+                <Th className="w-1/4">Serial Number</Th>
+                <Th className="w-1/6">Issued At</Th>
+                <Th className="w-1/6">Expires At</Th>
+              </Tr>
+            </THead>
+            <TBody>
+              {allCertificates.map((cert) => {
+                const isExpired = new Date(cert.notAfter) < new Date();
+                const isRevoked = cert.status === CertStatus.REVOKED;
+                const cannotBeAdded = isExpired || isRevoked;
+                const isAlreadySynced = syncedCertificateIds.includes(cert.id);
+
+                let originalDisplayName = "—";
+                if (cert.altNames && cert.altNames.trim()) {
+                  originalDisplayName = cert.altNames.trim();
+                } else if (cert.commonName && cert.commonName.trim()) {
+                  originalDisplayName = cert.commonName.trim();
+                }
+
+                let displayName = originalDisplayName;
+                let isTruncated = false;
+                if (originalDisplayName.length > 34) {
+                  displayName = `${originalDisplayName.substring(0, 34)}...`;
+                  isTruncated = true;
+                }
+
+                const truncatedSerial =
+                  cert.serialNumber.length > 8
+                    ? `${cert.serialNumber.slice(0, 4)}...${cert.serialNumber.slice(-4)}`
+                    : cert.serialNumber;
+
+                return (
+                  <Tr
+                    key={cert.id}
+                    className={`cursor-pointer hover:bg-mineshaft-700 ${
+                      cannotBeAdded && !isAlreadySynced ? "opacity-50" : ""
+                    }`}
+                    onClick={() => {
+                      if (!cannotBeAdded || isAlreadySynced) {
+                        handleToggleSelection(cert.id);
+                      }
+                    }}
+                  >
+                    <Td className="max-w-0" onClick={(e) => e.stopPropagation()}>
                       <Checkbox
-                        id="select-all-certificates"
-                        isChecked={
-                          allCertificates.length > 0 &&
-                          allCertificates.every((cert) => selectedIds.includes(cert.id))
-                        }
-                        onCheckedChange={handleSelectAll}
+                        id={cert.id}
+                        isChecked={selectedIds.includes(cert.id)}
+                        onCheckedChange={() => {
+                          if (!cannotBeAdded || isAlreadySynced) {
+                            handleToggleSelection(cert.id);
+                          }
+                        }}
+                        isDisabled={cannotBeAdded && !isAlreadySynced}
                       />
-                    )}
-                  </Th>
-                  <Th className="w-1/3">SAN / CN</Th>
-                  <Th className="w-1/4">Serial Number</Th>
-                  <Th className="w-1/6">Issued At</Th>
-                  <Th className="w-1/6">Expires At</Th>
-                </Tr>
-              </THead>
-              <TBody>
-                {allCertificates.map((cert) => {
-                  const isExpired = new Date(cert.notAfter) < new Date();
-                  const isRevoked = cert.status === CertStatus.REVOKED;
-                  const cannotBeAdded = isExpired || isRevoked;
-                  const isAlreadySynced = syncedCertificateIds.includes(cert.id);
-
-                  let originalDisplayName = "—";
-                  if (cert.altNames && cert.altNames.trim()) {
-                    originalDisplayName = cert.altNames.trim();
-                  } else if (cert.commonName && cert.commonName.trim()) {
-                    originalDisplayName = cert.commonName.trim();
-                  }
-
-                  let displayName = originalDisplayName;
-                  let isTruncated = false;
-                  if (originalDisplayName.length > 34) {
-                    displayName = `${originalDisplayName.substring(0, 34)}...`;
-                    isTruncated = true;
-                  }
-
-                  const truncatedSerial =
-                    cert.serialNumber.length > 8
-                      ? `${cert.serialNumber.slice(0, 4)}...${cert.serialNumber.slice(-4)}`
-                      : cert.serialNumber;
-
-                  return (
-                    <Tr
-                      key={cert.id}
-                      className={`cursor-pointer hover:bg-mineshaft-700 ${
-                        cannotBeAdded && !isAlreadySynced ? "opacity-50" : ""
-                      }`}
-                      onClick={() => {
-                        if (!cannotBeAdded || isAlreadySynced) {
-                          handleToggleSelection(cert.id);
-                        }
-                      }}
-                    >
-                      <Td className="max-w-0" onClick={(e) => e.stopPropagation()}>
-                        <Checkbox
-                          id={cert.id}
-                          isChecked={selectedIds.includes(cert.id)}
-                          onCheckedChange={() => {
-                            if (!cannotBeAdded || isAlreadySynced) {
-                              handleToggleSelection(cert.id);
-                            }
-                          }}
-                          isDisabled={cannotBeAdded && !isAlreadySynced}
-                        />
-                      </Td>
-                      <Td className="max-w-0">
-                        {isTruncated ? (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <div className="truncate">{displayName}</div>
-                            </TooltipTrigger>
-                            <TooltipContent className="max-w-lg">
-                              {originalDisplayName}
-                            </TooltipContent>
-                          </Tooltip>
-                        ) : (
-                          <div className="truncate">{displayName}</div>
-                        )}
-                      </Td>
-                      <Td className="max-w-0">
-                        <div
-                          className="font-mono text-xs text-bunker-300"
-                          title={cert.serialNumber}
-                        >
-                          {truncatedSerial}
-                        </div>
-                      </Td>
-                      <Td className="max-w-0">
-                        <span className="text-sm text-bunker-300">
-                          {new Date(cert.notBefore).toLocaleDateString()}
-                        </span>
-                      </Td>
-                      <Td className="max-w-0">
-                        <span
-                          className={`text-sm ${isExpired ? "text-red-400" : "text-bunker-300"}`}
-                        >
-                          {new Date(cert.notAfter).toLocaleDateString()}
-                        </span>
-                      </Td>
-                    </Tr>
-                  );
-                })}
-              </TBody>
-            </Table>
-            {allCertificates.length === 0 && (
-              <Empty className="rounded-t-none border-t-0">
-                <EmptyHeader>
-                  <EmptyTitle>No certificates found</EmptyTitle>
-                  <EmptyDescription>
-                    {searchTerm
-                      ? "No certificates match your search criteria."
-                      : "No certificates available for sync."}
-                  </EmptyDescription>
-                </EmptyHeader>
-              </Empty>
-            )}
-          </>
-
+                    </Td>
+                    <Td className="max-w-0">
+                      {isTruncated ? (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="truncate">{displayName}</div>
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-lg">
+                            {originalDisplayName}
+                          </TooltipContent>
+                        </Tooltip>
+                      ) : (
+                        <div className="truncate">{displayName}</div>
+                      )}
+                    </Td>
+                    <Td className="max-w-0">
+                      <div
+                        className="font-mono text-xs text-bunker-300"
+                        title={cert.serialNumber}
+                      >
+                        {truncatedSerial}
+                      </div>
+                    </Td>
+                    <Td className="max-w-0">
+                      <span className="text-sm text-bunker-300">
+                        {new Date(cert.notBefore).toLocaleDateString()}
+                      </span>
+                    </Td>
+                    <Td className="max-w-0">
+                      <span
+                        className={`text-sm ${isExpired ? "text-red-400" : "text-bunker-300"}`}
+                      >
+                        {new Date(cert.notAfter).toLocaleDateString()}
+                      </span>
+                    </Td>
+                  </Tr>
+                );
+              })}
+            </TBody>
+          </Table>
+          {allCertificates.length === 0 && (
+            <Empty className="rounded-t-none border-t-0">
+              <EmptyHeader>
+                <EmptyTitle>No certificates found</EmptyTitle>
+                <EmptyDescription>
+                  {searchTerm
+                    ? "No certificates match your search criteria."
+                    : "No certificates available for sync."}
+                </EmptyDescription>
+              </EmptyHeader>
+            </Empty>
+          )}
           {totalPages > 1 && (
             <div className="mt-4 flex justify-center">
               <Pagination
@@ -466,11 +463,7 @@ export const CertificateManagementModal = ({
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
-          <Button
-            variant="project"
-            onClick={handleSaveCertificates}
-            isPending={isLoading}
-          >
+          <Button variant="project" onClick={handleSaveCertificates} isPending={isLoading}>
             {saveButtonText}
           </Button>
         </DialogFooter>

--- a/frontend/src/components/pki-syncs/CertificateManagementModal.tsx
+++ b/frontend/src/components/pki-syncs/CertificateManagementModal.tsx
@@ -324,7 +324,7 @@ export const CertificateManagementModal = ({
             </div>
           </div>
 
-          <Table>
+          <Table containerClassName={allCertificates.length === 0 ? "hidden" : undefined}>
             <THead>
               <Tr>
                 <Th className="w-12">
@@ -430,7 +430,7 @@ export const CertificateManagementModal = ({
             </TBody>
           </Table>
           {allCertificates.length === 0 && (
-            <Empty className="rounded-t-none border-t-0">
+            <Empty className="border">
               <EmptyHeader>
                 <EmptyTitle>No certificates found</EmptyTitle>
                 <EmptyDescription>

--- a/frontend/src/components/pki-syncs/CertificateManagementModal.tsx
+++ b/frontend/src/components/pki-syncs/CertificateManagementModal.tsx
@@ -1,25 +1,33 @@
 import React, { useEffect, useState } from "react";
-import { faSearch, faX } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { SearchIcon, XIcon } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
   Button,
   Checkbox,
-  EmptyState,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  IconButton,
   Input,
-  Modal,
-  ModalContent,
   Pagination,
   Table,
-  TableContainer,
-  TBody,
-  Td,
-  Th,
-  THead,
+  TableBody as TBody,
+  TableCell as Td,
+  TableHead as Th,
+  TableHeader as THead,
+  TableRow as Tr,
   Tooltip,
-  Tr
-} from "@app/components/v2";
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useProject } from "@app/context";
 import {
   CertStatus,
@@ -283,8 +291,12 @@ export const CertificateManagementModal = ({
   const isLoading = addCertificatesToSync.isPending || removeCertificatesFromSync.isPending;
 
   return (
-    <Modal isOpen={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <ModalContent title={title} subTitle={subtitle} className="max-w-4xl">
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{subtitle}</DialogDescription>
+        </DialogHeader>
         <div className="space-y-4">
           <div className="space-y-3">
             <div className="relative">
@@ -297,23 +309,22 @@ export const CertificateManagementModal = ({
                 }}
                 className="pl-9"
               />
-              <FontAwesomeIcon
-                icon={faSearch}
-                className="absolute top-1/2 left-3 h-3 w-3 -translate-y-1/2 transform text-bunker-300"
-              />
+              <SearchIcon className="absolute top-1/2 left-3 size-3 -translate-y-1/2 text-muted" />
               {searchTerm && (
-                <button
-                  type="button"
+                <IconButton
+                  aria-label="Clear certificate search"
+                  size="xs"
+                  variant="ghost-muted"
                   onClick={clearSearch}
-                  className="absolute top-1/2 right-3 -translate-y-1/2 transform text-bunker-300 hover:text-bunker-100"
+                  className="absolute top-1/2 right-1.5 -translate-y-1/2"
                 >
-                  <FontAwesomeIcon icon={faX} className="h-3 w-3" />
-                </button>
+                  <XIcon />
+                </IconButton>
               )}
             </div>
           </div>
 
-          <TableContainer>
+          <>
             <Table>
               <THead>
                 <Tr>
@@ -387,8 +398,13 @@ export const CertificateManagementModal = ({
                       </Td>
                       <Td className="max-w-0">
                         {isTruncated ? (
-                          <Tooltip content={originalDisplayName} className="max-w-lg">
-                            <div className="truncate">{displayName}</div>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div className="truncate">{displayName}</div>
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-lg">
+                              {originalDisplayName}
+                            </TooltipContent>
                           </Tooltip>
                         ) : (
                           <div className="truncate">{displayName}</div>
@@ -420,13 +436,18 @@ export const CertificateManagementModal = ({
               </TBody>
             </Table>
             {allCertificates.length === 0 && (
-              <EmptyState title="No certificates found">
-                {searchTerm
-                  ? "No certificates match your search criteria."
-                  : "No certificates available for sync."}
-              </EmptyState>
+              <Empty className="rounded-t-none border-t-0">
+                <EmptyHeader>
+                  <EmptyTitle>No certificates found</EmptyTitle>
+                  <EmptyDescription>
+                    {searchTerm
+                      ? "No certificates match your search criteria."
+                      : "No certificates available for sync."}
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
             )}
-          </TableContainer>
+          </>
 
           {totalPages > 1 && (
             <div className="mt-4 flex justify-center">
@@ -441,20 +462,19 @@ export const CertificateManagementModal = ({
           )}
         </div>
 
-        <div className="mt-6 flex justify-end gap-2">
-          <Button variant="outline_bg" onClick={onClose}>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
           <Button
-            variant="solid"
-            colorSchema="primary"
+            variant="project"
             onClick={handleSaveCertificates}
-            isLoading={isLoading}
+            isPending={isLoading}
           >
             {saveButtonText}
           </Button>
-        </div>
-      </ModalContent>
-    </Modal>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/components/pki-syncs/CertificateManagementModal.tsx
+++ b/frontend/src/components/pki-syncs/CertificateManagementModal.tsx
@@ -410,10 +410,7 @@ export const CertificateManagementModal = ({
                       )}
                     </Td>
                     <Td className="max-w-0">
-                      <div
-                        className="font-mono text-xs text-bunker-300"
-                        title={cert.serialNumber}
-                      >
+                      <div className="font-mono text-xs text-bunker-300" title={cert.serialNumber}>
                         {truncatedSerial}
                       </div>
                     </Td>
@@ -423,9 +420,7 @@ export const CertificateManagementModal = ({
                       </span>
                     </Td>
                     <Td className="max-w-0">
-                      <span
-                        className={`text-sm ${isExpired ? "text-red-400" : "text-bunker-300"}`}
-                      >
+                      <span className={`text-sm ${isExpired ? "text-red-400" : "text-bunker-300"}`}>
                         {new Date(cert.notAfter).toLocaleDateString()}
                       </span>
                     </Td>

--- a/frontend/src/components/pki-syncs/DeletePkiSyncModal.tsx
+++ b/frontend/src/components/pki-syncs/DeletePkiSyncModal.tsx
@@ -1,5 +1,17 @@
+import { useState } from "react";
+
 import { createNotification } from "@app/components/notifications";
-import { DeleteActionModal } from "@app/components/v2";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Input
+} from "@app/components/v3";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { TPkiSync, useDeletePkiSync } from "@app/hooks/api/pkiSyncs";
 
@@ -12,6 +24,7 @@ type Props = {
 
 export const DeletePkiSyncModal = ({ isOpen, onOpenChange, pkiSync, onComplete }: Props) => {
   const deleteSync = useDeletePkiSync();
+  const [confirmation, setConfirmation] = useState("");
 
   if (!pkiSync) return null;
 
@@ -36,12 +49,38 @@ export const DeletePkiSyncModal = ({ isOpen, onOpenChange, pkiSync, onComplete }
   };
 
   return (
-    <DeleteActionModal
-      isOpen={isOpen}
-      onChange={onOpenChange}
-      title={`Are you sure you want to delete ${name}?`}
-      deleteKey={name}
-      onDeleteApproved={handleDeletePkiSync}
-    />
+    <AlertDialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        onOpenChange(open);
+        if (!open) setConfirmation("");
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete {name}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This permanently deletes the PKI sync. Type {name} to confirm.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <Input
+          aria-label={`Type ${name} to confirm deletion`}
+          value={confirmation}
+          onChange={(event) => setConfirmation(event.target.value)}
+          placeholder={name}
+        />
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="danger"
+            isDisabled={confirmation !== name}
+            isPending={deleteSync.isPending}
+            onClick={handleDeletePkiSync}
+          >
+            Delete PKI Sync
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 };

--- a/frontend/src/components/pki-syncs/EditPkiSyncModal.tsx
+++ b/frontend/src/components/pki-syncs/EditPkiSyncModal.tsx
@@ -1,5 +1,5 @@
 import { PkiSyncEditFields } from "@app/components/pki-syncs/types";
-import { Modal, ModalContent } from "@app/components/v2";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@app/components/v3";
 import { TPkiSync } from "@app/hooks/api/pkiSyncs";
 
 import { EditPkiSyncForm } from "./forms";
@@ -12,25 +12,20 @@ type Props = {
   fields: PkiSyncEditFields;
 };
 
-export const EditPkiSyncModal = ({ pkiSync, onOpenChange, fields, ...props }: Props) => {
+export const EditPkiSyncModal = ({ pkiSync, isOpen, onOpenChange, fields }: Props) => {
   if (!pkiSync) return null;
 
-  // z-50 (not the v2 default z-[60]) so the inline "Create Connection" Sheet and its v3 Select
-  // menus (all z-50, portaled later) stack above this modal instead of being buried behind it,
-  // while the backdrop still covers page chrome up to z-50 by portal order.
-  const modalClassName =
-    fields === PkiSyncEditFields.Mappings ? "z-50 max-w-4xl" : "z-50 max-w-2xl";
+  const dialogClassName = fields === PkiSyncEditFields.Mappings ? "max-w-4xl" : "max-w-2xl";
 
   return (
-    <Modal {...props} onOpenChange={onOpenChange}>
-      <ModalContent
-        overlayClassName="z-50"
-        title={<PkiSyncModalHeader isConfigured destination={pkiSync.destination} />}
-        className={modalClassName}
-        bodyClassName="overflow-visible"
-      >
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent className={`${dialogClassName} overflow-visible`}>
+        <DialogHeader>
+          <DialogTitle className="sr-only">Edit PKI Sync</DialogTitle>
+          <PkiSyncModalHeader isConfigured destination={pkiSync.destination} />
+        </DialogHeader>
         <EditPkiSyncForm onComplete={() => onOpenChange(false)} fields={fields} pkiSync={pkiSync} />
-      </ModalContent>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/components/pki-syncs/PkiSyncImportCertificatesModal.tsx
+++ b/frontend/src/components/pki-syncs/PkiSyncImportCertificatesModal.tsx
@@ -1,5 +1,14 @@
 import { createNotification } from "@app/components/notifications";
-import { Button, Modal, ModalClose, ModalContent } from "@app/components/v2";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@app/components/v3";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { TPkiSync, useTriggerPkiSyncImportCertificates } from "@app/hooks/api/pkiSyncs";
 
@@ -9,16 +18,13 @@ type Props = {
   onOpenChange: (isOpen: boolean) => void;
 };
 
-type ContentProps = {
-  pkiSync: TPkiSync;
-  onComplete: () => void;
-};
+export const PkiSyncImportCertificatesModal = ({ isOpen, onOpenChange, pkiSync }: Props) => {
+  const triggerImportCertificates = useTriggerPkiSyncImportCertificates();
 
-const Content = ({ pkiSync, onComplete }: ContentProps) => {
+  if (!pkiSync) return null;
+
   const { id: syncId, destination, projectId } = pkiSync;
   const destinationName = PKI_SYNC_MAP[destination].name;
-
-  const triggerImportCertificates = useTriggerPkiSyncImportCertificates();
 
   const handleTriggerImportCertificates = async () => {
     await triggerImportCertificates.mutateAsync({
@@ -32,55 +38,30 @@ const Content = ({ pkiSync, onComplete }: ContentProps) => {
       type: "success"
     });
 
-    onComplete();
+    onOpenChange(false);
   };
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        handleTriggerImportCertificates();
-      }}
-    >
-      <p className="mb-8 text-sm text-mineshaft-200">
-        Are you sure you want to import certificates from this {destinationName} destination into
-        Infisical?
-      </p>
-      <p className="mb-6 text-xs text-bunker-300">
-        This operation will retrieve certificates from {destinationName} and make them available in
-        your PKI subscriber. Only certificates that are not already imported will be processed.
-      </p>
-      <div className="mt-8 flex w-full items-center justify-between gap-2">
-        <ModalClose asChild>
-          <Button colorSchema="secondary" variant="plain">
-            Cancel
-          </Button>
-        </ModalClose>
-        <Button
-          type="submit"
-          isLoading={triggerImportCertificates.isPending}
-          colorSchema="secondary"
-        >
-          Import Certificates
-        </Button>
-      </div>
-    </form>
-  );
-};
-
-export const PkiSyncImportCertificatesModal = ({ isOpen, onOpenChange, pkiSync }: Props) => {
-  if (!pkiSync) return null;
-
-  const destinationName = PKI_SYNC_MAP[pkiSync.destination].name;
-
-  return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        title="Import Certificates"
-        subTitle={`Import certificates into Infisical from this ${destinationName} Sync destination.`}
-      >
-        <Content pkiSync={pkiSync} onComplete={() => onOpenChange(false)} />
-      </ModalContent>
-    </Modal>
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Import Certificates</AlertDialogTitle>
+          <AlertDialogDescription>
+            Retrieve certificates from this {destinationName} destination and make certificates
+            that have not already been imported available in Infisical.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="project"
+            isPending={triggerImportCertificates.isPending}
+            onClick={handleTriggerImportCertificates}
+          >
+            Import Certificates
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 };

--- a/frontend/src/components/pki-syncs/PkiSyncImportCertificatesModal.tsx
+++ b/frontend/src/components/pki-syncs/PkiSyncImportCertificatesModal.tsx
@@ -47,8 +47,8 @@ export const PkiSyncImportCertificatesModal = ({ isOpen, onOpenChange, pkiSync }
         <AlertDialogHeader>
           <AlertDialogTitle>Import Certificates</AlertDialogTitle>
           <AlertDialogDescription>
-            Retrieve certificates from this {destinationName} destination and make certificates
-            that have not already been imported available in Infisical.
+            Retrieve certificates from this {destinationName} destination and make certificates that
+            have not already been imported available in Infisical.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>

--- a/frontend/src/components/pki-syncs/PkiSyncRemoveCertificatesModal.tsx
+++ b/frontend/src/components/pki-syncs/PkiSyncRemoveCertificatesModal.tsx
@@ -1,5 +1,14 @@
 import { createNotification } from "@app/components/notifications";
-import { Button, Modal, ModalClose, ModalContent } from "@app/components/v2";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@app/components/v3";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { TPkiSync, useTriggerPkiSyncRemoveCertificates } from "@app/hooks/api/pkiSyncs";
 
@@ -9,16 +18,13 @@ type Props = {
   onOpenChange: (isOpen: boolean) => void;
 };
 
-type ContentProps = {
-  pkiSync: TPkiSync;
-  onComplete: () => void;
-};
+export const PkiSyncRemoveCertificatesModal = ({ isOpen, onOpenChange, pkiSync }: Props) => {
+  const triggerRemoveCertificates = useTriggerPkiSyncRemoveCertificates();
 
-const Content = ({ pkiSync, onComplete }: ContentProps) => {
+  if (!pkiSync) return null;
+
   const { id: syncId, destination, projectId } = pkiSync;
   const destinationName = PKI_SYNC_MAP[destination].name;
-
-  const triggerRemoveCertificates = useTriggerPkiSyncRemoveCertificates();
 
   const handleTriggerRemoveCertificates = async () => {
     await triggerRemoveCertificates.mutateAsync({
@@ -32,47 +38,29 @@ const Content = ({ pkiSync, onComplete }: ContentProps) => {
       type: "success"
     });
 
-    onComplete();
+    onOpenChange(false);
   };
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        handleTriggerRemoveCertificates();
-      }}
-    >
-      <p className="mb-8 text-sm text-mineshaft-200">
-        Are you sure you want to remove certificates synced by Infisical from this {destinationName}{" "}
-        destination?
-      </p>
-      <div className="mt-8 flex w-full items-center justify-between gap-2">
-        <ModalClose asChild>
-          <Button colorSchema="secondary" variant="plain">
-            Cancel
-          </Button>
-        </ModalClose>
-        <Button type="submit" isLoading={triggerRemoveCertificates.isPending} colorSchema="danger">
-          Remove Certificates
-        </Button>
-      </div>
-    </form>
-  );
-};
-
-export const PkiSyncRemoveCertificatesModal = ({ isOpen, onOpenChange, pkiSync }: Props) => {
-  if (!pkiSync) return null;
-
-  const destinationName = PKI_SYNC_MAP[pkiSync.destination].name;
-
-  return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        title="Remove Certificates"
-        subTitle={`Remove certificates synced by Infisical from this ${destinationName} Sync destination.`}
-      >
-        <Content pkiSync={pkiSync} onComplete={() => onOpenChange(false)} />
-      </ModalContent>
-    </Modal>
+    <AlertDialog open={isOpen} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove Certificates</AlertDialogTitle>
+          <AlertDialogDescription>
+            Remove certificates synced by Infisical from this {destinationName} destination?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            variant="danger"
+            isPending={triggerRemoveCertificates.isPending}
+            onClick={handleTriggerRemoveCertificates}
+          >
+            Remove Certificates
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 };

--- a/frontend/src/components/pki-syncs/forms/AwsCertificateManagerPkiSyncFields.tsx
+++ b/frontend/src/components/pki-syncs/forms/AwsCertificateManagerPkiSyncFields.tsx
@@ -1,6 +1,19 @@
 import { Controller, useFormContext } from "react-hook-form";
+import { InfoIcon } from "lucide-react";
 
-import { FormControl, Select, SelectItem } from "@app/components/v2";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { AWS_REGIONS } from "@app/helpers/appConnections";
 import { PkiSync } from "@app/hooks/api/pkiSyncs";
 
@@ -23,26 +36,33 @@ export const AwsCertificateManagerPkiSyncFields = () => {
         name="destinationConfig.region"
         control={control}
         render={({ field, fieldState: { error } }) => (
-          <FormControl
-            isError={Boolean(error)}
-            errorText={error?.message}
-            label="AWS Region"
-            tooltipText="Select the AWS region where your Certificate Manager certificates should be stored."
-          >
-            <Select
-              value={field.value}
-              onValueChange={field.onChange}
-              className="w-full border border-mineshaft-500 capitalize"
-              position="popper"
-              placeholder="Select an AWS region"
-            >
-              {AWS_REGIONS.map(({ name, slug }) => (
-                <SelectItem value={slug} key={slug}>
-                  {name}
-                </SelectItem>
-              ))}
+          <Field data-invalid={Boolean(error)}>
+            <FieldLabel>
+              AWS Region
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <InfoIcon />
+                </TooltipTrigger>
+                <TooltipContent>
+                  Select the AWS region where your Certificate Manager certificates should be
+                  stored.
+                </TooltipContent>
+              </Tooltip>
+            </FieldLabel>
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger className="w-full capitalize" isError={Boolean(error)}>
+                <SelectValue placeholder="Select an AWS region" />
+              </SelectTrigger>
+              <SelectContent position="popper">
+                {AWS_REGIONS.map(({ name, slug }) => (
+                  <SelectItem value={slug} key={slug}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
             </Select>
-          </FormControl>
+            <FieldError errors={[error]} />
+          </Field>
         )}
       />
     </>

--- a/frontend/src/components/pki-syncs/forms/EditPkiSyncForm.tsx
+++ b/frontend/src/components/pki-syncs/forms/EditPkiSyncForm.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 import { createNotification } from "@app/components/notifications";
 import { PkiSyncEditFields } from "@app/components/pki-syncs/types";
-import { Button, ModalClose } from "@app/components/v2";
+import { Button, DialogClose } from "@app/components/v3";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { TPkiSync, useUpdatePkiSync } from "@app/hooks/api/pkiSyncs";
 
@@ -88,16 +88,14 @@ export const EditPkiSyncForm = ({ pkiSync, fields, onComplete }: Props) => {
     <form onSubmit={handleSubmit(onSubmit)}>
       <FormProvider {...formMethods}>{Component}</FormProvider>
       <div className="flex w-full justify-between gap-4 pt-4">
-        <ModalClose asChild>
-          <Button colorSchema="secondary" variant="plain">
-            Cancel
-          </Button>
-        </ModalClose>
+        <DialogClose asChild>
+          <Button variant="ghost">Cancel</Button>
+        </DialogClose>
         <Button
-          isLoading={isSubmitting}
+          isPending={isSubmitting}
           isDisabled={!isDirty || isSubmitting}
           type="submit"
-          colorSchema="secondary"
+          variant="project"
         >
           Update PKI Sync
         </Button>

--- a/frontend/src/components/pki-syncs/forms/PkiSyncConnectionField.tsx
+++ b/frontend/src/components/pki-syncs/forms/PkiSyncConnectionField.tsx
@@ -1,11 +1,19 @@
 import { Controller, useFormContext } from "react-hook-form";
 import { SingleValue } from "react-select";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useRouterState } from "@tanstack/react-router";
+import { InfoIcon } from "lucide-react";
 
 import { AppConnectionOption } from "@app/components/app-connections";
-import { FilterableSelect, FormControl } from "@app/components/v2";
+import {
+  Field,
+  FieldContent,
+  FieldError,
+  FieldLabel,
+  FilterableSelect,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { ProjectPermissionSub, useProject, useProjectPermission } from "@app/context";
 import { ProjectPermissionAppConnectionActions } from "@app/context/ProjectPermissionContext/types";
 import { APP_CONNECTION_MAP } from "@app/helpers/appConnections";
@@ -68,45 +76,55 @@ export const PkiSyncConnectionField = ({ onChange: callback }: Props) => {
       </p>
       <Controller
         render={({ field: { value, onChange }, fieldState: { error } }) => (
-          <FormControl
-            tooltipText="App Connections can be created from the Project Settings page."
-            isError={Boolean(error)}
-            errorText={error?.message}
-            label={`${connectionName} Connection`}
-          >
-            <FilterableSelect
-              value={value}
-              onChange={(newValue) => {
-                if ((newValue as SingleValue<{ id: string; name: string }>)?.id === "_create") {
-                  handlePopUpOpen("addConnection");
-                  onChange(null);
-                  const formData = { ...watch(), returnUrl: getPkiSyncReturnUrl() };
-                  localStorage.setItem("pkiSyncFormData", JSON.stringify(formData));
-                  if (callback) callback();
-                  return;
-                }
+          <Field data-invalid={Boolean(error)}>
+            <FieldLabel>
+              {connectionName} Connection
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <InfoIcon />
+                </TooltipTrigger>
+                <TooltipContent>
+                  App Connections can be created from the Project Settings page.
+                </TooltipContent>
+              </Tooltip>
+            </FieldLabel>
+            <FieldContent>
+              <FilterableSelect
+                value={value}
+                onChange={(newValue) => {
+                  if ((newValue as SingleValue<{ id: string; name: string }>)?.id === "_create") {
+                    handlePopUpOpen("addConnection");
+                    onChange(null);
+                    const formData = { ...watch(), returnUrl: getPkiSyncReturnUrl() };
+                    localStorage.setItem("pkiSyncFormData", JSON.stringify(formData));
+                    if (callback) callback();
+                    return;
+                  }
 
-                onChange(newValue);
-                if (callback) callback();
-              }}
-              isLoading={isPending}
-              options={[
-                ...(canCreateConnection ? [{ id: "_create", name: "Create Connection" }] : []),
-                ...(availableConnections ?? [])
-              ]}
-              placeholder="Select connection..."
-              getOptionLabel={(option) => option.name}
-              getOptionValue={(option) => option.id}
-              components={{ Option: AppConnectionOption }}
-            />
-          </FormControl>
+                  onChange(newValue);
+                  if (callback) callback();
+                }}
+                isLoading={isPending}
+                isError={Boolean(error)}
+                options={[
+                  ...(canCreateConnection ? [{ id: "_create", name: "Create Connection" }] : []),
+                  ...(availableConnections ?? [])
+                ]}
+                placeholder="Select connection..."
+                getOptionLabel={(option) => option.name}
+                getOptionValue={(option) => option.id}
+                components={{ Option: AppConnectionOption }}
+              />
+              <FieldError errors={[error]} />
+            </FieldContent>
+          </Field>
         )}
         control={control}
         name="connection"
       />
       {!isPending && !availableConnections?.length && !canCreateConnection && (
-        <p className="-mt-2.5 mb-2.5 text-xs text-yellow">
-          <FontAwesomeIcon className="mr-1" size="xs" icon={faInfoCircle} />
+        <p className="-mt-2.5 mb-2.5 flex items-center gap-1 text-xs text-warning">
+          <InfoIcon className="size-3.5" />
           You do not have access to any {appName} Connections. Contact an admin to create one.
         </p>
       )}

--- a/frontend/src/components/pki-syncs/forms/PkiSyncDetailsFields.tsx
+++ b/frontend/src/components/pki-syncs/forms/PkiSyncDetailsFields.tsx
@@ -1,6 +1,13 @@
 import { Controller, useFormContext } from "react-hook-form";
 
-import { FormControl, Input, TextArea } from "@app/components/v2";
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  TextArea
+} from "@app/components/v3";
 
 import { TPkiSyncForm } from "./schemas/pki-sync-schema";
 
@@ -14,34 +21,37 @@ export const PkiSyncDetailsFields = () => {
       </p>
       <Controller
         render={({ field: { value, onChange }, fieldState: { error } }) => (
-          <FormControl
-            helperText="Must be slug-friendly"
-            isError={Boolean(error)}
-            errorText={error?.message}
-            label="Name"
-          >
-            <Input value={value} onChange={onChange} placeholder="my-certificate-sync" />
-          </FormControl>
+          <Field className="mb-4" data-invalid={Boolean(error)}>
+            <FieldLabel htmlFor="pki-sync-name">Name</FieldLabel>
+            <Input
+              id="pki-sync-name"
+              value={value}
+              onChange={onChange}
+              isError={Boolean(error)}
+              placeholder="my-certificate-sync"
+            />
+            <FieldDescription>Must be slug-friendly</FieldDescription>
+            <FieldError errors={[error]} />
+          </Field>
         )}
         control={control}
         name="name"
       />
       <Controller
         render={({ field: { value, onChange }, fieldState: { error } }) => (
-          <FormControl
-            isError={Boolean(error)}
-            isOptional
-            errorText={error?.message}
-            label="Description"
-          >
+          <Field data-invalid={Boolean(error)}>
+            <FieldLabel htmlFor="pki-sync-description">Description (optional)</FieldLabel>
             <TextArea
+              id="pki-sync-description"
               value={value}
               onChange={onChange}
+              isError={Boolean(error)}
               placeholder="Describe the purpose of this sync..."
               className="resize-none!"
               rows={4}
             />
-          </FormControl>
+            <FieldError errors={[error]} />
+          </Field>
         )}
         control={control}
         name="description"

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
@@ -204,203 +204,201 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
 
         <div>
           <div className="space-y-4">
-            <>
-              <Table>
-                <THead>
-                  <Tr>
-                    <Th className="w-3/16">SAN / CN</Th>
-                    <Th className="w-1/8">Certificate Status</Th>
-                    <Th className="w-1/8">Serial Number</Th>
-                    <Th className="w-3/16">External ID</Th>
-                    <Th className="w-1/8">Sync Status</Th>
-                    <Th className="w-1/8">Expires At</Th>
-                    <Th className="w-1/8" />
-                  </Tr>
-                </THead>
-                <TBody>
-                  {syncCertificates.map((syncCert) => {
-                    const isExpired = syncCert.certificateNotAfter
-                      ? new Date(syncCert.certificateNotAfter) < new Date()
-                      : false;
-                    const isRevoked = syncCert.certificateStatus === "revoked";
+            <Table>
+              <THead>
+                <Tr>
+                  <Th className="w-3/16">SAN / CN</Th>
+                  <Th className="w-1/8">Certificate Status</Th>
+                  <Th className="w-1/8">Serial Number</Th>
+                  <Th className="w-3/16">External ID</Th>
+                  <Th className="w-1/8">Sync Status</Th>
+                  <Th className="w-1/8">Expires At</Th>
+                  <Th className="w-1/8" />
+                </Tr>
+              </THead>
+              <TBody>
+                {syncCertificates.map((syncCert) => {
+                  const isExpired = syncCert.certificateNotAfter
+                    ? new Date(syncCert.certificateNotAfter) < new Date()
+                    : false;
+                  const isRevoked = syncCert.certificateStatus === "revoked";
 
-                    // Calculate auto-renewal timeline
-                    const hasAutoRenewal = Boolean(
-                      syncCert.certificateRenewBeforeDays &&
-                        syncCert.certificateRenewBeforeDays > 0 &&
-                        !syncCert.certificateRenewalError &&
-                        syncCert.certificateNotAfter
-                    );
+                  // Calculate auto-renewal timeline
+                  const hasAutoRenewal = Boolean(
+                    syncCert.certificateRenewBeforeDays &&
+                      syncCert.certificateRenewBeforeDays > 0 &&
+                      !syncCert.certificateRenewalError &&
+                      syncCert.certificateNotAfter
+                  );
 
-                    const daysUntilRenewal =
-                      hasAutoRenewal && syncCert.certificateNotAfter
-                        ? (() => {
-                            const expiryDate = new Date(syncCert.certificateNotAfter);
-                            const renewalDate = new Date(
-                              expiryDate.getTime() -
-                                syncCert.certificateRenewBeforeDays! * 24 * 60 * 60 * 1000
-                            );
-                            const now = new Date();
-                            const diffInMs = renewalDate.getTime() - now.getTime();
-                            return Math.max(0, Math.ceil(diffInMs / (24 * 60 * 60 * 1000)));
-                          })()
-                        : null;
+                  const daysUntilRenewal =
+                    hasAutoRenewal && syncCert.certificateNotAfter
+                      ? (() => {
+                          const expiryDate = new Date(syncCert.certificateNotAfter);
+                          const renewalDate = new Date(
+                            expiryDate.getTime() -
+                              syncCert.certificateRenewBeforeDays! * 24 * 60 * 60 * 1000
+                          );
+                          const now = new Date();
+                          const diffInMs = renewalDate.getTime() - now.getTime();
+                          return Math.max(0, Math.ceil(diffInMs / (24 * 60 * 60 * 1000)));
+                        })()
+                      : null;
 
-                    const { originalDisplayName } = getCertificateDisplayName(
-                      {
-                        altNames: syncCert.certificateAltNames,
-                        commonName: syncCert.certificateCommonName
-                      },
-                      34,
-                      "Unknown"
-                    );
+                  const { originalDisplayName } = getCertificateDisplayName(
+                    {
+                      altNames: syncCert.certificateAltNames,
+                      commonName: syncCert.certificateCommonName
+                    },
+                    34,
+                    "Unknown"
+                  );
 
-                    const isDefaultCertificate = syncCert.syncMetadata?.isDefault === true;
+                  const isDefaultCertificate = syncCert.syncMetadata?.isDefault === true;
 
-                    return (
-                      <Tr key={syncCert.id}>
-                        <Td className="max-w-0">
-                          <div className="flex items-center gap-2">
-                            <CertificateDisplayName
-                              cert={{
-                                altNames: syncCert.certificateAltNames,
-                                commonName: syncCert.certificateCommonName
-                              }}
-                              maxLength={34}
-                              fallback="Unknown"
-                            />
-                            {supportsDefaultCertificate && isDefaultCertificate && (
-                              <Badge variant="neutral">Default</Badge>
-                            )}
-                          </div>
-                        </Td>
-                        <Td>
-                          <Badge variant={getCertificateStatusVariant(isExpired, isRevoked)}>
-                            {getCertificateStatusText(isExpired, isRevoked)}
-                          </Badge>
-                        </Td>
-                        <Td className="max-w-0">
-                          <div
-                            className="truncate text-xs"
-                            title={syncCert.certificateSerialNumber || "Unknown"}
-                          >
-                            {(() => {
-                              const serial = syncCert.certificateSerialNumber;
-                              if (!serial || serial === "Unknown") return "Unknown";
-                              if (serial.length <= 8) return serial;
-                              return `${serial.substring(0, 4)}...${serial.substring(serial.length - 4)}`;
-                            })()}
-                          </div>
-                        </Td>
-                        <Td className="max-w-0">
-                          {syncCert.externalIdentifier ? (
-                            <div className="flex items-center gap-1">
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <span className="truncate text-xs text-bunker-300">
-                                    {syncCert.externalIdentifier}
-                                  </span>
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-none whitespace-nowrap">
+                  return (
+                    <Tr key={syncCert.id}>
+                      <Td className="max-w-0">
+                        <div className="flex items-center gap-2">
+                          <CertificateDisplayName
+                            cert={{
+                              altNames: syncCert.certificateAltNames,
+                              commonName: syncCert.certificateCommonName
+                            }}
+                            maxLength={34}
+                            fallback="Unknown"
+                          />
+                          {supportsDefaultCertificate && isDefaultCertificate && (
+                            <Badge variant="neutral">Default</Badge>
+                          )}
+                        </div>
+                      </Td>
+                      <Td>
+                        <Badge variant={getCertificateStatusVariant(isExpired, isRevoked)}>
+                          {getCertificateStatusText(isExpired, isRevoked)}
+                        </Badge>
+                      </Td>
+                      <Td className="max-w-0">
+                        <div
+                          className="truncate text-xs"
+                          title={syncCert.certificateSerialNumber || "Unknown"}
+                        >
+                          {(() => {
+                            const serial = syncCert.certificateSerialNumber;
+                            if (!serial || serial === "Unknown") return "Unknown";
+                            if (serial.length <= 8) return serial;
+                            return `${serial.substring(0, 4)}...${serial.substring(serial.length - 4)}`;
+                          })()}
+                        </div>
+                      </Td>
+                      <Td className="max-w-0">
+                        {syncCert.externalIdentifier ? (
+                          <div className="flex items-center gap-1">
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="truncate text-xs text-bunker-300">
                                   {syncCert.externalIdentifier}
-                                </TooltipContent>
-                              </Tooltip>
-                              <CopyButton
-                                value={syncCert.externalIdentifier}
-                                ariaLabel="Copy external identifier"
-                              />
-                            </div>
-                          ) : (
-                            <span className="text-xs text-bunker-400">-</span>
-                          )}
-                        </Td>
-                        <Td>
-                          {syncCert.lastSyncMessage &&
-                          syncCert.syncStatus === CertificateSyncStatus.Failed ? (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Badge variant="danger">Failed</Badge>
+                                </span>
                               </TooltipTrigger>
-                              <TooltipContent>{syncCert.lastSyncMessage}</TooltipContent>
+                              <TooltipContent className="max-w-none whitespace-nowrap">
+                                {syncCert.externalIdentifier}
+                              </TooltipContent>
                             </Tooltip>
-                          ) : (
-                            <Badge variant={getSyncStatusVariant(syncCert.syncStatus)}>
-                              {getSyncStatusText(syncCert.syncStatus)}
-                            </Badge>
-                          )}
-                        </Td>
-                        <Td>
-                          <span
-                            className={`text-sm ${isExpired ? "text-red-400" : "text-bunker-300"}`}
-                          >
-                            {syncCert.certificateNotAfter
-                              ? new Date(syncCert.certificateNotAfter).toLocaleDateString()
-                              : "Unknown"}
-                          </span>
-                        </Td>
-                        <Td className="flex items-center justify-end gap-2 pr-4">
-                          {hasAutoRenewal && daysUntilRenewal !== null && (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <div className="text-primary-500">
-                                  <FontAwesomeIcon icon={faClockRotateLeft} size="sm" />
-                                </div>
-                              </TooltipTrigger>
-                              <TooltipContent>Auto-renews in {daysUntilRenewal}d</TooltipContent>
-                            </Tooltip>
-                          )}
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <IconButton
-                                size="xs"
-                                variant="ghost-muted"
-                                aria-label="Certificate actions"
-                                isDisabled={!canEdit}
-                              >
-                                <MoreHorizontalIcon />
-                              </IconButton>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end">
-                              {supportsDefaultCertificate && !isDefaultCertificate && (
-                                <DropdownMenuItem
-                                  onClick={() => handleSetAsDefault(syncCert.certificateId)}
-                                >
-                                  Set as Default
-                                </DropdownMenuItem>
-                              )}
-                              {supportsDefaultCertificate && isDefaultCertificate && (
-                                <DropdownMenuItem onClick={handleClearDefault}>
-                                  Unset Default
-                                </DropdownMenuItem>
-                              )}
+                            <CopyButton
+                              value={syncCert.externalIdentifier}
+                              ariaLabel="Copy external identifier"
+                            />
+                          </div>
+                        ) : (
+                          <span className="text-xs text-bunker-400">-</span>
+                        )}
+                      </Td>
+                      <Td>
+                        {syncCert.lastSyncMessage &&
+                        syncCert.syncStatus === CertificateSyncStatus.Failed ? (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Badge variant="danger">Failed</Badge>
+                            </TooltipTrigger>
+                            <TooltipContent>{syncCert.lastSyncMessage}</TooltipContent>
+                          </Tooltip>
+                        ) : (
+                          <Badge variant={getSyncStatusVariant(syncCert.syncStatus)}>
+                            {getSyncStatusText(syncCert.syncStatus)}
+                          </Badge>
+                        )}
+                      </Td>
+                      <Td>
+                        <span
+                          className={`text-sm ${isExpired ? "text-red-400" : "text-bunker-300"}`}
+                        >
+                          {syncCert.certificateNotAfter
+                            ? new Date(syncCert.certificateNotAfter).toLocaleDateString()
+                            : "Unknown"}
+                        </span>
+                      </Td>
+                      <Td className="flex items-center justify-end gap-2 pr-4">
+                        {hasAutoRenewal && daysUntilRenewal !== null && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div className="text-primary-500">
+                                <FontAwesomeIcon icon={faClockRotateLeft} size="sm" />
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent>Auto-renews in {daysUntilRenewal}d</TooltipContent>
+                          </Tooltip>
+                        )}
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <IconButton
+                              size="xs"
+                              variant="ghost-muted"
+                              aria-label="Certificate actions"
+                              isDisabled={!canEdit}
+                            >
+                              <MoreHorizontalIcon />
+                            </IconButton>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            {supportsDefaultCertificate && !isDefaultCertificate && (
                               <DropdownMenuItem
-                                onClick={() =>
-                                  handleDeleteClick(syncCert.certificateId, originalDisplayName)
-                                }
-                                variant="danger"
+                                onClick={() => handleSetAsDefault(syncCert.certificateId)}
                               >
-                                <Trash2Icon />
-                                Remove from Sync
+                                Set as Default
                               </DropdownMenuItem>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </Td>
-                      </Tr>
-                    );
-                  })}
-                </TBody>
-              </Table>
-              {syncCertificates.length === 0 && (
-                <Empty className="rounded-t-none border-t-0 py-12">
-                  <EmptyHeader>
-                    <EmptyMedia variant="icon">
-                      <ScrollTextIcon />
-                    </EmptyMedia>
-                    <EmptyTitle>No certificates are part of this certificate sync</EmptyTitle>
-                  </EmptyHeader>
-                </Empty>
-              )}
-            </>
+                            )}
+                            {supportsDefaultCertificate && isDefaultCertificate && (
+                              <DropdownMenuItem onClick={handleClearDefault}>
+                                Unset Default
+                              </DropdownMenuItem>
+                            )}
+                            <DropdownMenuItem
+                              onClick={() =>
+                                handleDeleteClick(syncCert.certificateId, originalDisplayName)
+                              }
+                              variant="danger"
+                            >
+                              <Trash2Icon />
+                              Remove from Sync
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      </Td>
+                    </Tr>
+                  );
+                })}
+              </TBody>
+            </Table>
+            {syncCertificates.length === 0 && (
+              <Empty className="rounded-t-none border-t-0 py-12">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <ScrollTextIcon />
+                  </EmptyMedia>
+                  <EmptyTitle>No certificates are part of this certificate sync</EmptyTitle>
+                </EmptyHeader>
+              </Empty>
+            )}
             {/* Pagination */}
             {totalPages > 1 && (
               <div className="flex justify-center">

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
@@ -10,16 +10,14 @@ import {
   getCertificateDisplayName
 } from "@app/components/utilities/certificateDisplayUtils";
 import {
-  DeleteActionModal,
-  Table,
-  TableContainer,
-  TBody,
-  Td,
-  Th,
-  THead,
-  Tr
-} from "@app/components/v2";
-import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Badge,
   CopyButton,
   DropdownMenu,
@@ -31,7 +29,14 @@ import {
   EmptyMedia,
   EmptyTitle,
   IconButton,
+  Input,
   Pagination,
+  Table,
+  TableBody as TBody,
+  TableCell as Td,
+  TableHead as Th,
+  TableHeader as THead,
+  TableRow as Tr,
   Tooltip,
   TooltipContent,
   TooltipTrigger
@@ -87,6 +92,7 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
     id: string;
     displayName: string;
   } | null>(null);
+  const [deleteConfirmation, setDeleteConfirmation] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const pageSize = 10;
 
@@ -131,6 +137,7 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
 
   const handleDeleteClick = (certificateId: string, displayName: string) => {
     setCertificateToDelete({ id: certificateId, displayName });
+    setDeleteConfirmation("");
     setIsDeleteModalOpen(true);
   };
 
@@ -197,7 +204,7 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
 
         <div>
           <div className="space-y-4">
-            <TableContainer>
+            <>
               <Table>
                 <THead>
                   <Tr>
@@ -384,7 +391,7 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
                 </TBody>
               </Table>
               {syncCertificates.length === 0 && (
-                <Empty className="rounded-none border-0 py-12">
+                <Empty className="rounded-t-none border-t-0 py-12">
                   <EmptyHeader>
                     <EmptyMedia variant="icon">
                       <ScrollTextIcon />
@@ -393,7 +400,7 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
                   </EmptyHeader>
                 </Empty>
               )}
-            </TableContainer>
+            </>
             {/* Pagination */}
             {totalPages > 1 && (
               <div className="flex justify-center">
@@ -419,22 +426,47 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
         }}
       />
 
-      <DeleteActionModal
-        isOpen={isDeleteModalOpen}
-        onClose={() => {
-          setIsDeleteModalOpen(false);
-          setCertificateToDelete(null);
-        }}
-        title="Remove Certificate from Sync"
-        subTitle={`Are you sure you want to remove "${certificateToDelete?.displayName}" from this PKI sync?`}
-        deleteKey="confirm"
-        onDeleteApproved={async () => {
-          if (certificateToDelete) {
-            await handleRemoveCertificate(certificateToDelete.id);
+      <AlertDialog
+        open={isDeleteModalOpen}
+        onOpenChange={(isOpen) => {
+          setIsDeleteModalOpen(isOpen);
+          if (!isOpen) {
+            setCertificateToDelete(null);
+            setDeleteConfirmation("");
           }
         }}
-        buttonText="Remove Certificate"
-      />
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove Certificate from Sync</AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove “{certificateToDelete?.displayName}” from this PKI sync? Type confirm to
+              continue.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <Input
+            aria-label="Type confirm to remove certificate"
+            value={deleteConfirmation}
+            onChange={(event) => setDeleteConfirmation(event.target.value)}
+            placeholder="confirm"
+          />
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="danger"
+              isDisabled={deleteConfirmation !== "confirm"}
+              isPending={removeCertificatesFromSync.isPending}
+              onClick={async () => {
+                if (certificateToDelete) {
+                  await handleRemoveCertificate(certificateToDelete.id);
+                }
+              }}
+            >
+              Remove Certificate
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/components/PkiSyncCertificatesSection.tsx
@@ -204,7 +204,7 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
 
         <div>
           <div className="space-y-4">
-            <Table>
+            <Table containerClassName={syncCertificates.length === 0 ? "hidden" : undefined}>
               <THead>
                 <Tr>
                   <Th className="w-3/16">SAN / CN</Th>
@@ -390,7 +390,7 @@ export const PkiSyncCertificatesSection = ({ pkiSync }: Props) => {
               </TBody>
             </Table>
             {syncCertificates.length === 0 && (
-              <Empty className="rounded-t-none border-t-0 py-12">
+              <Empty className="border py-12">
                 <EmptyHeader>
                   <EmptyMedia variant="icon">
                     <ScrollTextIcon />


### PR DESCRIPTION
## Context

Stacked on #7422 for ENG-5373.

This follow-up migrates the remaining direct PKI sync detail surfaces covered by the UX exploration from V2 to their existing V3 counterparts:

- certificate table and empty state
- certificate management dialog
- edit dialog shell, actions, detail fields, connection field, and AWS Certificate Manager destination field
- delete-sync and remove-certificate confirmations
- import/remove synced-certificate confirmations

No new component primitives or stylesheet rules are introduced. The broader PKI sync create/list workflows and shared provider-specific option forms remain on V2 and are intentionally outside this bounded stacked PR.

## Screenshots

### V3 certificate management

The certificate-management workflow now uses the V3 dialog, search, table, empty state, and actions.

<img width="1480" height="1560" alt="V3 certificate management dialog with search, table, empty state, and actions" src="https://github.com/user-attachments/assets/83549f68-7d36-4c20-89b0-48a95111fb12" />

### V3 destination editor

The destination editor now uses the V3 dialog and matching connection and region controls.

<img width="1480" height="1560" alt="V3 AWS Certificate Manager destination edit dialog" src="https://github.com/user-attachments/assets/a2304ac8-f181-48a3-9281-6973c7a7fb14" />

## Steps to verify the change

1. Open an AWS Certificate Manager PKI sync detail page.
2. Confirm the certificate table and empty state render.
3. Open Edit Details, Edit Destination, and Edit Certificates; verify the V3 dialogs, fields, table, and actions.
4. Open the overflow menu and verify Remove Certificates and Delete Sync use V3 alert dialogs; cancel without submitting.
5. Resize to the narrow breakpoint and confirm the document has no horizontal overflow.

Validation performed:
- GitHub Actions frontend lint and type-check
- GitHub Actions PR-title and non-RE2-regex checks
- `git diff --check`
- private-file verification
- local HMR coverage of the detail page, edit-details and edit-destination dialogs, certificate management dialog, remove/delete confirmations, and a narrow viewport

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [x] Updated docs (not needed)
- [x] Updated CLAUDE.md files (not needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)