### PR TITLE
fix(status): log event loop stats at debug level

### DIFF
--- a/backend/src/lib/logger/logger.ts
+++ b/backend/src/lib/logger/logger.ts
@@ -107,9 +107,14 @@ const extractOrgId = () => {
 };
 
 export const initLogger = () => {
+  // Each transport target filters independently of the root logger level, so this has to honor
+  // PINO_LOG_LEVEL too — otherwise raising the level has no effect and every logger.debug call
+  // is discarded by the transport.
+  const logLevel = process.env.PINO_LOG_LEVEL || "info";
+
   const targets: pino.TransportMultiOptions["targets"][number][] = [
     {
-      level: "info",
+      level: logLevel,
       target: "pino/file",
       options: {
         destination: 1,
@@ -151,7 +156,7 @@ export const initLogger = () => {
       mixin(_context, level) {
         return { severity: logLevelToSeverityLookup[level] || logLevelToSeverityLookup["30"] };
       },
-      level: process.env.PINO_LOG_LEVEL || "info",
+      level: logLevel,
       formatters: {
         bindings: (bindings) => ({
           pid: bindings.pid,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -4185,13 +4185,16 @@ export const registerRoutes = async (
       const maxLagMs = histogram.max / 1e6;
       const p99LagMs = histogram.percentile(99) / 1e6;
 
-      logger.info(
+      // Kept at debug level: /api/status is the liveness/readiness probe target, so anything logged
+      // here is emitted on every probe interval. The histogram is never reset, so these values are
+      // cumulative over the process lifetime — windowed event loop delay is exported as
+      // nodejs.eventloop.delay.* by RuntimeNodeInstrumentation when telemetry is enabled.
+      logger.debug(
+        { eventLoopStats: histogram },
         `Event loop stats - Mean: ${meanLagMs.toFixed(2)}ms, Max: ${maxLagMs.toFixed(2)}ms, p99: ${p99LagMs.toFixed(
           2
         )}ms`
       );
-
-      logger.info(`Raw event loop stats: ${JSON.stringify(histogram, null, 2)}`);
 
       return {
         date: new Date(),


### PR DESCRIPTION
## Context

Closes #7392.

`GET /api/status` is the endpoint liveness/readiness probes hit — the `infisical-standalone` Helm chart probes it every 5s — and its handler wrote two `logger.info` lines on **every** request: a formatted summary plus a full `JSON.stringify(histogram, null, 2)` dump of the event loop delay histogram. On a single self-hosted replica that is ~1,440 log records/hour, with the raw dump alone accounting for roughly 45% of the container's log volume (see the measurements in the issue). There was no way to turn it off: neither call was gated by log level or any env var.

The logged values were also cumulative rather than windowed. The histogram is created once at startup (`monitorEventLoopDelay` at the top of `server/routes/index.ts`) and never `.reset()`, so `mean`/`p50` sit on the 20ms sampling-resolution floor for the life of the process and `max` stays frozen at the worst stall since boot. Windowed event loop delay is already exported properly as `nodejs.eventloop.delay.*` by `RuntimeNodeInstrumentation`, registered in `initTelemetryInstrumentation` (`backend/src/lib/telemetry/instrumentation.ts`), whenever telemetry is enabled.

Two commits:

**1. `fix(status): log event loop stats at debug level`** — takes the diagnostic off the default log path without dropping it:

- The two `logger.info` calls become a single `logger.debug`, so nothing is emitted at the default `info` level.
- The raw histogram is passed as a structured field (`{ eventLoopStats: histogram }`) rather than pre-stringified into the message. Pino checks the level before serializing a merge object, so the `JSON.stringify` work no longer runs on every probe — only when the level is raised. `IntervalHistogram` implements `toJSON`, so the serialized payload is the same data as before (`count`, `min`, `max`, `mean`, `stddev`, `percentiles`), and this matches the backend logging convention of a structured object alongside a self-contained message.
- A comment records why this has to stay at debug level and where the windowed metrics come from, so it doesn't regress.

The response body is unchanged.

**2. `fix(logger): honor PINO_LOG_LEVEL on the transport target`** — needed for the above to mean anything, and a pre-existing bug in its own right. `initLogger()` set the root logger level from `PINO_LOG_LEVEL` but hardcoded `level: "info"` on the sole `pino/file` transport target. Transport targets filter independently of the root logger, so a `debug` record passed the root level and was then discarded by the transport: **setting `PINO_LOG_LEVEL=debug` had no effect, and every `logger.debug` call in the backend (~64 sites) was unreachable.** Both now read the same resolved `logLevel`.

Default behavior is unchanged — with `PINO_LOG_LEVEL` unset both levels resolve to `info`, exactly as before. This only affects operators who explicitly opt in. Credit to the Codex review bot for catching that the first commit alone would have made the diagnostic unreachable rather than on-demand.

Happy to split commit 2 into its own PR if you'd rather keep this scoped strictly to #7392 — but on its own, commit 1 would just be a silent removal.

## Steps to verify the change

1. Start the backend with `PINO_LOG_LEVEL` unset (default `info`) and hit the endpoint repeatedly:
   ```sh
   for i in $(seq 1 20); do curl -s -o /dev/null localhost:8080/api/status; done
   ```
   No `Event loop stats` or `Raw event loop stats` lines appear, and each response is still `200` with the same JSON body.
2. Restart with `PINO_LOG_LEVEL=debug` and repeat — one line per request carrying the formatted `Mean/Max/p99` summary and an `eventLoopStats` object with the full histogram. (Before commit 2, this printed nothing.)
3. `backend/e2e-test/routes/v1/status.spec.ts` still covers the `200` response; no test changes are needed for a log-level change, and asserting on log output here would mean mocking the logger singleton.

What I verified locally, reproducing this repo's exact transport config against `pino@8` in isolation:

- Root level `debug` + target level `"info"` (the state before commit 2) → the debug record is dropped, only `info` reaches stdout. This is the bug commit 2 fixes.
- Both levels wired to `PINO_LOG_LEVEL` → `debug` and `info` both reach stdout with the level set to `debug`; with it unset, only `info` does and `trace` is still filtered.
- `IntervalHistogram` passed as a pino merge object serializes via `toJSON` at `debug`, and is not serialized at all at `info`.
- `prettier --check` clean on both changed files.

I did not boot the full stack for steps 1–2, since that needs Postgres and Redis.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally — the logging behavior is verified in isolation against `pino@8`, not against a booted stack; see the note above.
- [x] Updated docs (if needed) — not needed; the removed lines were not documented, and `PINO_LOG_LEVEL` keeps its documented default.
- [x] Updated CLAUDE.md files (if needed) — not needed; no new pattern or architectural change.
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
