### PR TITLE
fix(backend): return empty from diff() when root is nullish

### DIFF
--- a/backend/src/lib/fn/array.test.ts
+++ b/backend/src/lib/fn/array.test.ts
@@ -1,0 +1,26 @@
+import { diff } from "./array";
+
+describe("diff", () => {
+  test("returns items in root that are not in other", () => {
+    expect(diff([1, 2, 3], [2])).toEqual([1, 3]);
+  });
+
+  test("uses the identity function when provided", () => {
+    const root = [{ id: "a" }, { id: "b" }];
+    const other = [{ id: "b" }];
+    expect(diff(root, other, (x) => x.id)).toEqual([{ id: "a" }]);
+  });
+
+  test("an empty other returns a copy of root", () => {
+    expect(diff([1, 2], [])).toEqual([1, 2]);
+  });
+
+  test("an empty or nullish root returns an empty array", () => {
+    // A missing root means there are no items to diff, so both an empty array
+    // and a nullish root must produce []. Previously a nullish root returned
+    // `other`, which is the opposite of what diff should do.
+    expect(diff([], [1, 2, 3])).toEqual([]);
+    expect(diff(null as unknown as number[], [1, 2, 3])).toEqual([]);
+    expect(diff(undefined as unknown as number[], [1, 2, 3])).toEqual([]);
+  });
+});

--- a/backend/src/lib/fn/array.ts
+++ b/backend/src/lib/fn/array.ts
@@ -92,7 +92,10 @@ export const diff = <T>(
   identity: (item: T) => string | number | symbol = (t: T) => t as unknown as string | number | symbol
 ): T[] => {
   if (!root?.length && !other?.length) return [];
-  if (root?.length === undefined) return [...other];
+  // A missing/empty root means "no items", so the diff is empty. This also
+  // guards the `.filter` below against a nullish root. (Previously this
+  // returned `other`, so a null root behaved differently from an empty one.)
+  if (!root?.length) return [];
   if (!other?.length) return [...root];
   const bKeys = other.reduce(
     (acc, item) => {


### PR DESCRIPTION
`diff` in `backend/src/lib/fn/array.ts` returns the wrong result for a nullish root.

## Problem

`diff(root, other)` is documented as "all items from the first list that do not exist in the second list". But a nullish root returns a copy of `other`, so a `null` root behaves the opposite of an empty one:

```ts
diff([], [1, 2, 3])    // []         (correct - nothing in root)
diff(null, [1, 2, 3])  // [1, 2, 3]  (wrong - should be [])
```

The guard `if (root?.length === undefined) return [...other]` fires only when root is null/undefined, and returns `other` - the opposite of "items in root".

## Fix

Return `[]` when root has no items. That makes a nullish root consistent with an empty one and still guards the `.filter` below against a nullish root. Existing behaviour for a non-empty root and an empty `other` is unchanged.

## Tests

`array.ts` had no test file; added `array.test.ts` covering the basic diff, a custom identity function, an empty `other`, and the empty/nullish-root cases.

## Verification note

The backend deps do not install in my environment (an npm config conflict, unrelated to this change), so I could not run the vitest suite here. `diff` is a pure function, so I verified the exact logic in isolation: all six assertions in the new test pass with the fix, and the nullish-root case returns `[1, 2, 3]` before and `[]` after. It should run cleanly under `test:unit` in CI.