### PR TITLE
fix(telemetry): strongly type integration field with Integrations enum

### DIFF
--- a/backend/src/services/telemetry/telemetry-types.ts
+++ b/backend/src/services/telemetry/telemetry-types.ts
@@ -21,6 +21,7 @@ import { EnforcementLevel, SecretSharingAccessType } from "@app/lib/types";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { AuthMethod } from "@app/services/auth/auth-type";
 import { WebhookType } from "@app/services/webhook/webhook-types";
+import { Integrations } from "@app/services/integration-auth/integration-list";
 
 export type HubSpotSignupMethod = AuthMethod | "invite";
 
@@ -422,7 +423,7 @@ export type TIntegrationCreatedEvent = {
   properties: {
     projectId: string;
     integrationId: string;
-    integration: string; // TODO: fix type
+    integration: Integrations;
     environment: string;
     secretPath: string;
     url?: string;


### PR DESCRIPTION
## Summary
Resolves a TODO in the telemetry types to enforce strict typing on the `integration` field rather than a generic string.

## Changes
- Imported the `Integrations` enum from `integration-list.ts`.
- Typed the `integration` field in `TIntegrationCreatedEvent` correctly to prevent invalid telemetry integration types.
