### PR TITLE
fix: diff API spec against the merge base instead of production

### DIFF
--- a/.github/actions/generate-openapi-spec/action.yml
+++ b/.github/actions/generate-openapi-spec/action.yml
@@ -1,0 +1,109 @@
+name: "Generate OpenAPI spec"
+description: "Builds the backend image from a checkout, boots it, and dumps its OpenAPI spec to a file."
+
+inputs:
+  source-path:
+    description: "Path to the repository checkout to build from."
+    required: false
+    default: "."
+  output:
+    description: "Path to write the normalized OpenAPI spec to."
+    required: true
+  port:
+    description: "Host port to bind the API container to."
+    required: false
+    default: "4000"
+  container-name:
+    description: "Name for the API container."
+    required: false
+    default: "infisical-api"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+    - name: Build the API image
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+      with:
+        context: ${{ inputs.source-path }}/backend
+        load: true
+        tags: ${{ inputs.container-name }}
+        cache-from: type=gha,scope=openapi-spec
+        cache-to: type=gha,mode=max,scope=openapi-spec
+
+    - name: Create the database
+      shell: bash
+      run: |
+        DB_NAME="$(echo '${{ inputs.container-name }}' | tr '-' '_')"
+        echo "OPENAPI_SPEC_DB=$DB_NAME" >> "$GITHUB_ENV"
+
+        # `compose up -d` returns before postgres accepts connections. With a warm
+        # image layer cache the build above no longer absorbs that delay, so wait.
+        for _ in $(seq 1 30); do
+          if docker compose -f docker-compose.dev.yml exec -T db pg_isready -U infisical -q; then
+            break
+          fi
+          sleep 2
+        done
+
+        docker compose -f docker-compose.dev.yml exec -T db \
+          psql -U infisical -d postgres -c "CREATE DATABASE \"$DB_NAME\"" \
+          || echo "Database $DB_NAME already exists, reusing it."
+
+    - name: Boot the API
+      shell: bash
+      run: |
+        docker run --name "${{ inputs.container-name }}" -d -p ${{ inputs.port }}:4000 \
+          -e DB_CONNECTION_URI="postgres://infisical:infisical@172.17.0.1:5432/${OPENAPI_SPEC_DB}?sslmode=disable" \
+          -e REDIS_URL=redis://172.17.0.1:6379 \
+          -e JWT_AUTH_SECRET=something-random \
+          -e ENCRYPTION_KEY=4bnfe4e407b8921c104518903515b218 \
+          -e TELEMETRY_ENABLED=false \
+          -e SECRET_SCANNING_GIT_APP_ID=793712 \
+          -e SECRET_SCANNING_PRIVATE_KEY=some-random \
+          -e SECRET_SCANNING_WEBHOOK_SECRET=some-random \
+          "${{ inputs.container-name }}"
+
+    - name: Wait for the API to serve its spec
+      shell: bash
+      run: |
+        for _ in $(seq 1 24); do
+          if ! docker ps --format '{{.Names}}' | grep -qx "${{ inputs.container-name }}"; then
+            echo "::error::Container ${{ inputs.container-name }} exited during boot."
+            docker logs "${{ inputs.container-name }}" || true
+            exit 1
+          fi
+          if curl -sf "http://localhost:${{ inputs.port }}/api/docs/json" -o /dev/null; then
+            echo "API is serving its spec."
+            exit 0
+          fi
+          sleep 5
+        done
+
+        echo "::error::Container ${{ inputs.container-name }} did not serve its spec within 120s."
+        docker logs "${{ inputs.container-name }}" || true
+        exit 1
+
+    - name: Dump the spec
+      shell: bash
+      run: |
+        mkdir -p "$(dirname "${{ inputs.output }}")"
+        curl -sf "http://localhost:${{ inputs.port }}/api/docs/json" -o /tmp/raw-spec.json
+
+        # Sorting object keys keeps the bytes stable across runs, so a cached baseline
+        # and a freshly built one are byte-identical for the same source tree.
+        python3 -c '
+        import json, sys
+        spec = json.load(open(sys.argv[1]))
+        json.dump(spec, open(sys.argv[2], "w"), sort_keys=True, separators=(",", ":"))
+        ' /tmp/raw-spec.json "${{ inputs.output }}"
+
+        echo "Wrote $(du -h "${{ inputs.output }}" | cut -f1) to ${{ inputs.output }}"
+
+    - name: Stop the API
+      if: always()
+      shell: bash
+      run: |
+        docker stop "${{ inputs.container-name }}" || true
+        docker rm "${{ inputs.container-name }}" || true

--- a/.github/actions/generate-openapi-spec/action.yml
+++ b/.github/actions/generate-openapi-spec/action.yml
@@ -55,8 +55,9 @@ runs:
       shell: bash
       run: |
         docker run --name "${{ inputs.container-name }}" -d -p ${{ inputs.port }}:4000 \
-          -e DB_CONNECTION_URI="postgres://infisical:infisical@172.17.0.1:5432/${OPENAPI_SPEC_DB}?sslmode=disable" \
-          -e REDIS_URL=redis://172.17.0.1:6379 \
+          --add-host=host.docker.internal:host-gateway \
+          -e DB_CONNECTION_URI="postgres://infisical:infisical@host.docker.internal:5432/${OPENAPI_SPEC_DB}?sslmode=disable" \
+          -e REDIS_URL=redis://host.docker.internal:6379 \
           -e JWT_AUTH_SECRET=something-random \
           -e ENCRYPTION_KEY=4bnfe4e407b8921c104518903515b218 \
           -e TELEMETRY_ENABLED=false \

--- a/.github/actions/generate-openapi-spec/action.yml
+++ b/.github/actions/generate-openapi-spec/action.yml
@@ -17,12 +17,18 @@ inputs:
     description: "Name for the API container."
     required: false
     default: "infisical-api"
+  write-layer-cache:
+    description: >-
+      Whether to export the Docker layer cache. Leave this off outside the default branch:
+      a cache a PR writes is readable only by that PR, so it does nothing for anyone else
+      while still consuming the repository's cache quota and evicting the entries on main
+      that every PR reads from.
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
   steps:
-    - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
     - name: Build the API image
       uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
       with:
@@ -30,7 +36,7 @@ runs:
         load: true
         tags: ${{ inputs.container-name }}
         cache-from: type=gha,scope=openapi-spec
-        cache-to: type=gha,mode=max,scope=openapi-spec
+        cache-to: ${{ inputs.write-layer-cache == 'true' && 'type=gha,mode=max,scope=openapi-spec' || '' }}
 
     - name: Create the database
       shell: bash

--- a/.github/actions/generate-openapi-spec/action.yml
+++ b/.github/actions/generate-openapi-spec/action.yml
@@ -61,9 +61,6 @@ runs:
           -e JWT_AUTH_SECRET=something-random \
           -e ENCRYPTION_KEY=4bnfe4e407b8921c104518903515b218 \
           -e TELEMETRY_ENABLED=false \
-          -e SECRET_SCANNING_GIT_APP_ID=793712 \
-          -e SECRET_SCANNING_PRIVATE_KEY=some-random \
-          -e SECRET_SCANNING_WEBHOOK_SECRET=some-random \
           "${{ inputs.container-name }}"
 
     - name: Wait for the API to serve its spec

--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -1,100 +1,243 @@
 name: "Check API For Breaking Changes"
 
+# Diffs the PR's OpenAPI spec against the spec of the main commit the PR is merged
+# onto, so the result describes what this PR changed and nothing else.
+#
+# The baseline used to be live production (app.infisical.com). Production tracks the
+# last deploy rather than main, so every breaking change legitimately merged to main
+# re-fired on every open PR until the next deploy. Unrelated PRs failed with identical
+# errors and the check stopped being believed.
+#
+# This check is advisory. It reports what the PR changes and comments when something
+# breaks, but it never fails the job. Making it blocking is a separate decision, and
+# one worth taking only once the reports have been observed to be trustworthy.
+
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
     paths:
       - "backend/src/server/routes/**"
       - "backend/src/ee/routes/**"
+      # So changes to the check itself are exercised by the check.
+      - ".github/workflows/check-api-for-breaking-changes.yml"
+      - ".github/actions/generate-openapi-spec/**"
+
+concurrency:
+  group: check-api-breaking-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  OASDIFF_VERSION: v1.26.0
 
 jobs:
   check-be-api-changes:
     name: Check API Changes
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 Nov 14, 2025
-      # uncomment this when testing locally using nektos/act
+        with:
+          fetch-depth: 2
+
       - uses: KengoTODA/actions-setup-docker-compose@17da3fa4493b7303eff3e8f4f84a07ed6ed2e7a7 # v1, Feb 6, 2026
         if: ${{ env.ACT }}
         name: Install `docker compose` for local simulations
         with:
           version: "2.14.2"
-      - name: 📦Build the latest image
-        run: docker build --tag infisical-api .
-        working-directory: backend
+
+      - name: Resolve baseline
+        id: baseline
+        run: |
+          set -euo pipefail
+
+          # A merge commit lists itself plus two parents. Anything else means we were
+          # handed the PR head directly (conflicting PR, or a rerun quirk).
+          if [ "$(git rev-list --parents -n 1 HEAD | wc -w)" -eq 3 ]; then
+            BASE_SHA="$(git rev-parse HEAD^1)"
+          else
+            echo "::notice::HEAD is not a merge commit, falling back to the PR base SHA."
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          fi
+
+          if [ -z "$BASE_SHA" ]; then
+            echo "::error::Could not determine the baseline commit for this PR."
+            exit 1
+          fi
+
+          # The shallow checkout usually already carries this tree; fetch only if not.
+          if ! git rev-parse -q --verify "$BASE_SHA:backend" > /dev/null; then
+            git fetch --depth 1 origin "$BASE_SHA"
+          fi
+
+          echo "sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "key=openapi-spec-v1-$(git rev-parse "$BASE_SHA:backend")" >> "$GITHUB_OUTPUT"
+          echo "Baseline commit: $BASE_SHA"
+
+      - name: Restore baseline spec
+        id: baseline-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: base-spec.json
+          key: ${{ steps.baseline.outputs.key }}
+
       - name: Start postgres and redis
         run: touch .env && docker compose -f docker-compose.dev.yml up -d db redis
-      - name: Start the server
-        run: |
-          echo "SECRET_SCANNING_GIT_APP_ID=793712" >> .env
-          echo "SECRET_SCANNING_PRIVATE_KEY=some-random" >> .env
-          echo "SECRET_SCANNING_WEBHOOK_SECRET=some-random" >> .env
 
-          echo "Examining built image:"
-          docker image inspect infisical-api | grep -A 5 "Entrypoint"
-          
-          docker run --name infisical-api -d -p 4000:4000 \
-            -e DB_CONNECTION_URI=$DB_CONNECTION_URI \
-            -e REDIS_URL=$REDIS_URL \
-            -e JWT_AUTH_SECRET=$JWT_AUTH_SECRET \
-            -e ENCRYPTION_KEY=$ENCRYPTION_KEY \
-            -e TELEMETRY_ENABLED=false \
-            --env-file .env \
-            infisical-api
-          
-          echo "Container status right after creation:"
-          docker ps -a | grep infisical-api
-        env:
-          REDIS_URL: redis://172.17.0.1:6379
-          DB_CONNECTION_URI: postgres://infisical:infisical@172.17.0.1:5432/infisical?sslmode=disable
-          JWT_AUTH_SECRET: something-random
-          ENCRYPTION_KEY: 4bnfe4e407b8921c104518903515b218
+      - name: Checkout baseline source
+        if: steps.baseline-cache.outputs.cache-hit != 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 Nov 14, 2025
+        with:
+          ref: ${{ steps.baseline.outputs.sha }}
+          path: base-src
+
+      - name: Build baseline spec
+        if: steps.baseline-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/generate-openapi-spec
+        with:
+          source-path: base-src
+          output: base-spec.json
+          port: "4001"
+          container-name: infisical-api-base
+
+      - name: Cache baseline spec
+        if: steps.baseline-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        continue-on-error: true
+        with:
+          path: base-spec.json
+          key: ${{ steps.baseline.outputs.key }}
+
+      - name: Build PR spec
+        uses: ./.github/actions/generate-openapi-spec
+        with:
+          output: head-spec.json
+          port: "4000"
+          container-name: infisical-api-head
+
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.21.5"
-      - name: Wait for container to be stable and check logs
+
+      - name: Restore oasdiff
+        id: oasdiff-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/go/bin/oasdiff
+          key: oasdiff-${{ runner.os }}-${{ env.OASDIFF_VERSION }}
+
+      - name: Install oasdiff
+        if: steps.oasdiff-cache.outputs.cache-hit != 'true'
+        run: go install github.com/oasdiff/oasdiff@${{ env.OASDIFF_VERSION }}
+
+      - name: Cache oasdiff
+        if: steps.oasdiff-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        continue-on-error: true
+        with:
+          path: ~/go/bin/oasdiff
+          key: oasdiff-${{ runner.os }}-${{ env.OASDIFF_VERSION }}
+
+      - name: Check for breaking changes
+        id: breaking
         run: |
-          SECONDS=0
-          HEALTHY=0
-          while [ $SECONDS -lt 60 ]; do
-            # Check if container is running
-            if docker ps | grep infisical-api; then
-              # Try to access the API endpoint
-              if curl -s -f http://localhost:4000/api/docs/json > /dev/null 2>&1; then
-                echo "API endpoint is responding. Container seems healthy."
-                HEALTHY=1
-                break
-              fi
-            else
-              echo "Container is not running!"
-              docker ps -a | grep infisical-api
-              break
-            fi
-            
-            echo "Waiting for container to be healthy... ($SECONDS seconds elapsed)"
-            sleep 5
-            SECONDS=$((SECONDS+5))
-          done
-          
-          if [ $HEALTHY -ne 1 ]; then
-            echo "Container did not become healthy in time"
-            echo "Container status:"
-            docker ps -a | grep infisical-api
-            echo "Container logs (if any):"
-            docker logs infisical-api || echo "No logs available"
-            echo "Container inspection:"
-            docker inspect infisical-api | grep -A 5 "State"
-            exit 1
+          set +e
+          oasdiff breaking base-spec.json head-spec.json --fail-on ERR --color never > breaking.txt
+          CODE=$?
+          set -e
+
+          cat breaking.txt
+
+          if [ "$CODE" != "0" ] && [ "$CODE" != "1" ]; then
+            echo "::error::oasdiff failed to run (exit $CODE)."
+            exit "$CODE"
           fi
-      - name: Install openapi-diff
-        run: go install github.com/oasdiff/oasdiff@latest
-      - name: Running OpenAPI Spec diff action
-        run: oasdiff breaking https://app.infisical.com/api/docs/json http://localhost:4000/api/docs/json --fail-on ERR
-      - name: cleanup
-        if: always()
+
+          if [ "$CODE" = "1" ]; then
+            echo "breaking=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "breaking=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summarize API changes
         run: |
-          docker compose -f "docker-compose.dev.yml" down
-          docker stop infisical-api || true
-          docker rm infisical-api || true
+          oasdiff changelog base-spec.json head-spec.json --format markdown > changelog.md || true
+
+          {
+            echo "## API changes"
+            echo
+            echo "Baseline: \`${{ steps.baseline.outputs.sha }}\` (the main commit this PR is merged onto)"
+            echo
+
+            if [ "${{ steps.breaking.outputs.breaking }}" = "true" ]; then
+              echo "> [!WARNING]"
+              echo "> This PR contains breaking API changes. This check is advisory and does"
+              echo "> not block the merge, so please confirm they are intentional."
+              echo
+              echo '```'
+              cat breaking.txt
+              echo '```'
+              echo
+            fi
+
+            echo "<details><summary>Full API changelog</summary>"
+            echo
+            # Empty only when oasdiff itself failed; it prints "No changes detected"
+            # rather than nothing when the specs match.
+            if [ -s changelog.md ]; then cat changelog.md; else echo "_Changelog unavailable._"; fi
+            echo
+            echo "</details>"
+          } > summary.md
+
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on the PR
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- openapi-breaking-check -->";
+            const breaking = "${{ steps.breaking.outputs.breaking }}" === "true";
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const existing = (await github.rest.issues.listComments({ owner, repo, issue_number }))
+              .data.find((c) => c.body?.startsWith(marker));
+
+            // Comment only when something breaks, so the bot stays quiet on the large
+            // majority of PRs. The full changelog is always in the job summary.
+            if (!breaking) {
+              // A previous push did break something and this one fixed it. Replace the
+              // stale warning instead of leaving it to be read as still current.
+              if (existing) {
+                const head = context.payload.pull_request.head.sha.slice(0, 7);
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body: `${marker}\n## API changes\n\nThe breaking changes reported earlier are resolved as of \`${head}\`.`
+                });
+              }
+              return;
+            }
+
+            let body = marker + "\n" + fs.readFileSync("summary.md", "utf8");
+            if (body.length > 60000) {
+              body = body.slice(0, 60000) + "\n\n_Truncated. See the job summary for the full diff._";
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker-compose.dev.yml down || true

--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -48,6 +48,9 @@ jobs:
         with:
           version: "2.14.2"
 
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
       - name: Resolve baseline
         id: baseline
         run: |

--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -11,6 +11,15 @@ name: "Check API For Breaking Changes"
 # This check is advisory. It reports what the PR changes and comments when something
 # breaks, but it never fails the job. Making it blocking is a separate decision, and
 # one worth taking only once the reports have been observed to be trustworthy.
+#
+# Merges to main do not re-run this: no pull_request event fires for open PRs when the
+# base branch moves, and a manual re-run replays the original event's merge commit. A
+# report therefore describes main as of the last push to the PR branch. That direction
+# of staleness is safe — the head spec is built from that same older main, so the diff
+# still isolates this PR and another PR's merge can never light up this one. What it
+# can miss is an interaction: main changed something this PR also touches. Catching
+# that needs the head re-diffed against current main, which is what a merge queue
+# (`merge_group`) is for, and the repo does not use one yet.
 
 on:
   pull_request:
@@ -166,7 +175,9 @@ jobs:
           {
             echo "## API changes"
             echo
-            echo "Baseline: \`${{ steps.baseline.outputs.sha }}\` (the main commit this PR is merged onto)"
+            echo "Baseline: \`${{ steps.baseline.outputs.sha }}\` (the main commit this PR was merged onto"
+            echo "when \`${{ github.event.pull_request.head.sha }}\` was pushed). Nothing re-runs this check"
+            echo "when main moves, so push to the branch to re-diff against a newer main."
             echo
 
             if [ "${{ steps.breaking.outputs.breaking }}" = "true" ]; then

--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Restore baseline spec
         id: baseline-cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: base-spec.json
           key: ${{ steps.baseline.outputs.key }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Cache baseline spec
         if: steps.baseline-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         continue-on-error: true
         with:
           path: base-spec.json
@@ -119,28 +119,23 @@ jobs:
           port: "4000"
           container-name: infisical-api-head
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
-        with:
-          go-version: "1.21.5"
-
-      - name: Restore oasdiff
-        id: oasdiff-cache
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        with:
-          path: ~/go/bin/oasdiff
-          key: oasdiff-${{ runner.os }}-${{ env.OASDIFF_VERSION }}
-
       - name: Install oasdiff
-        if: steps.oasdiff-cache.outputs.cache-hit != 'true'
-        run: go install github.com/oasdiff/oasdiff@${{ env.OASDIFF_VERSION }}
+        run: |
+          set -euo pipefail
 
-      - name: Cache oasdiff
-        if: steps.oasdiff-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-        continue-on-error: true
-        with:
-          path: ~/go/bin/oasdiff
-          key: oasdiff-${{ runner.os }}-${{ env.OASDIFF_VERSION }}
+          VERSION="${OASDIFF_VERSION#v}"
+          TARBALL="oasdiff_${VERSION}_linux_amd64.tar.gz"
+          BASE="https://github.com/oasdiff/oasdiff/releases/download/${OASDIFF_VERSION}"
+
+          curl -fsSL -o "$TARBALL" "$BASE/$TARBALL"
+          curl -fsSL -o oasdiff-checksums.txt "$BASE/checksums.txt"
+          grep " $TARBALL\$" oasdiff-checksums.txt | sha256sum -c -
+
+          tar -xzf "$TARBALL" oasdiff
+          sudo install -m 0755 oasdiff /usr/local/bin/oasdiff
+          rm -f "$TARBALL" oasdiff-checksums.txt oasdiff
+
+          oasdiff --version
 
       - name: Check for breaking changes
         id: breaking

--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -207,14 +207,16 @@ jobs:
 
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const existing = (await github.rest.issues.listComments({ owner, repo, issue_number }))
-              .data.find((c) => c.body?.startsWith(marker));
 
-            // Comment only when something breaks, so the bot stays quiet on the large
-            // majority of PRs. The full changelog is always in the job summary.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+            const existing = comments.find((c) => c.body?.startsWith(marker));
+
             if (!breaking) {
-              // A previous push did break something and this one fixed it. Replace the
-              // stale warning instead of leaving it to be read as still current.
               if (existing) {
                 const head = context.payload.pull_request.head.sha.slice(0, 7);
                 await github.rest.issues.updateComment({

--- a/.github/workflows/check-api-for-breaking-changes.yml
+++ b/.github/workflows/check-api-for-breaking-changes.yml
@@ -16,9 +16,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - "backend/src/server/routes/**"
-      - "backend/src/ee/routes/**"
-      # So changes to the check itself are exercised by the check.
+      - "backend/**"
       - ".github/workflows/check-api-for-breaking-changes.yml"
       - ".github/actions/generate-openapi-spec/**"
 

--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Check for an existing spec
         id: probe
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: base-spec.json
           key: ${{ steps.key.outputs.key }}
@@ -60,7 +60,7 @@ jobs:
 
       - name: Publish spec
         if: steps.probe.outputs.cache-hit != 'true'
-        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: base-spec.json
           key: ${{ steps.key.outputs.key }}

--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -6,6 +6,11 @@ name: "Publish OpenAPI Spec"
 # This job exists because of GitHub's cache scoping: a PR can read caches written on
 # the default branch, but caches a PR writes are visible only to that PR. Baselines
 # therefore have to be produced by a run on main.
+#
+# The cache path below MUST stay identical to the one the checker restores, because
+# actions/cache folds the path into the cache version. A mismatched path misses even
+# on an exact key match, and it misses silently: the checker just rebuilds the
+# baseline every time and this job's work is thrown away.
 
 on:
   push:
@@ -39,7 +44,7 @@ jobs:
         id: probe
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: spec.json
+          path: base-spec.json
           key: ${{ steps.key.outputs.key }}
           lookup-only: true
 
@@ -51,13 +56,13 @@ jobs:
         if: steps.probe.outputs.cache-hit != 'true'
         uses: ./.github/actions/generate-openapi-spec
         with:
-          output: spec.json
+          output: base-spec.json
 
       - name: Publish spec
         if: steps.probe.outputs.cache-hit != 'true'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
-          path: spec.json
+          path: base-spec.json
           key: ${{ steps.key.outputs.key }}
 
       - name: Cleanup

--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -1,0 +1,65 @@
+name: "Publish OpenAPI Spec"
+
+# Publishes the OpenAPI spec for each state of backend/ that lands on main, so that
+# "Check API For Breaking Changes" has a trustworthy baseline to diff PRs against.
+#
+# This job exists because of GitHub's cache scoping: a PR can read caches written on
+# the default branch, but caches a PR writes are visible only to that PR. Baselines
+# therefore have to be produced by a run on main.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/**"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-openapi-spec-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish spec
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 Nov 14, 2025
+
+      - name: Resolve cache key
+        id: key
+        run: echo "key=openapi-spec-v1-$(git rev-parse HEAD:backend)" >> "$GITHUB_OUTPUT"
+
+      - name: Check for an existing spec
+        id: probe
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: spec.json
+          key: ${{ steps.key.outputs.key }}
+          lookup-only: true
+
+      - name: Start postgres and redis
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: touch .env && docker compose -f docker-compose.dev.yml up -d db redis
+
+      - name: Generate spec
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: ./.github/actions/generate-openapi-spec
+        with:
+          output: spec.json
+
+      - name: Publish spec
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: spec.json
+          key: ${{ steps.key.outputs.key }}
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker-compose.dev.yml down || true

--- a/.github/workflows/publish-openapi-spec.yml
+++ b/.github/workflows/publish-openapi-spec.yml
@@ -5,7 +5,8 @@ name: "Publish OpenAPI Spec"
 #
 # This job exists because of GitHub's cache scoping: a PR can read caches written on
 # the default branch, but caches a PR writes are visible only to that PR. Baselines
-# therefore have to be produced by a run on main.
+# therefore have to be produced by a run on main. The Docker layer cache the spec
+# generator uses is scoped the same way, so this job is also the only writer of that.
 #
 # The cache path below MUST stay identical to the one the checker restores, because
 # actions/cache folds the path into the cache version. A mismatched path misses even
@@ -48,6 +49,10 @@ jobs:
           key: ${{ steps.key.outputs.key }}
           lookup-only: true
 
+      - name: Set up buildx
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
       - name: Start postgres and redis
         if: steps.probe.outputs.cache-hit != 'true'
         run: touch .env && docker compose -f docker-compose.dev.yml up -d db redis
@@ -57,6 +62,7 @@ jobs:
         uses: ./.github/actions/generate-openapi-spec
         with:
           output: base-spec.json
+          write-layer-cache: "true"
 
       - name: Publish spec
         if: steps.probe.outputs.cache-hit != 'true'

--- a/backend/src/server/routes/v1/project-env-router.ts
+++ b/backend/src/server/routes/v1/project-env-router.ts
@@ -138,7 +138,9 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
       body: z.object({
         name: z.string().trim().min(1).max(255).describe(ENVIRONMENTS.CREATE.name),
         position: z.number().min(1).optional().describe(ENVIRONMENTS.CREATE.position),
-        slug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.CREATE.slug)
+        slug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.CREATE.slug),
+        // TEMPORARY: exercises the breaking-API check. Revert before merging.
+        __breakingCheckProbe: z.string()
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/project-env-router.ts
+++ b/backend/src/server/routes/v1/project-env-router.ts
@@ -138,9 +138,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
       body: z.object({
         name: z.string().trim().min(1).max(255).describe(ENVIRONMENTS.CREATE.name),
         position: z.number().min(1).optional().describe(ENVIRONMENTS.CREATE.position),
-        slug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.CREATE.slug),
-        // TEMPORARY: exercises the breaking-API check. Revert before merging.
-        __breakingCheckProbe: z.string()
+        slug: slugSchema({ max: 64 }).describe(ENVIRONMENTS.CREATE.slug)
       }),
       response: {
         200: z.object({


### PR DESCRIPTION
## Context

The breaking API check previously compared every PR against **live production** (`app.infisical.com`). Since production reflects the latest deployment—not the current `main` branch—any legitimate breaking change merged into `main` caused every subsequent PR to fail until the next deployment. As a result, unrelated PRs showed the same failures, and the check gradually lost credibility.

### What changed

- **Baseline is now `HEAD^1`** (the `main` commit the PR is merged onto). Results are now reproducible—re-running the workflow later produces the same verdict.
- Added **`publish-openapi-spec.yml`**, which publishes the OpenAPI spec cache on every push to `main`, keyed by the `backend/` git tree hash. This is required because PR workflows can only restore caches created on the default branch.
- Added a shared composite action: **`generate-openapi-spec`**.
- The check is now **advisory only**. It never fails the workflow. Instead, it:
  - Posts a PR comment when breaking changes are detected.
  - Updates that comment once the breaking changes are resolved.
  - Always publishes the full changelog in the job summary.

Expected steady state:

- **~5 minutes** on a cache hit
- **~10 minutes** on a cache miss

## Steps to verify

This PR triggers the workflow on itself because the `paths` filter now includes both the workflow and the composite action.

1. **Quiet path** (this run)
   - No backend changes, so the base and head specs should be identical.
   - Expected result:
     - ✅ Workflow succeeds
     - ✅ No PR comment
     - ✅ Changelog appears in the job summary
     - First run is a cache miss, so both specs are generated.

2. **Breaking path**
   - Push a commit that adds a required field to any request body under `backend/src/server/routes/`.
   - Expected result:
     - ✅ Workflow still succeeds
     - ✅ PR comment is posted with the breaking-change warning
     - ✅ Baseline spec is restored from cache (cache hit), reducing runtime by roughly half.
     
<img width="954" height="518" alt="image" src="https://github.com/user-attachments/assets/9e641f5c-0feb-4ede-979a-8d7d917de3b3" />

3. **Resolved path**
   - Revert the breaking commit.
   - Expected result:
     - ✅ Existing PR comment is updated to indicate the issue was resolved, including the resolving commit SHA.
     
   <img width="932" height="226" alt="image" src="https://github.com/user-attachments/assets/3b3beb5d-e7a6-4404-af82-c658e26b68a5" />

### Post-merge verification

The following behavior can only be verified after merging:

- `publish-openapi-spec.yml` runs on every push to `main`.
- The next backend PR should restore the baseline spec from cache, logging a **cache hit** and skipping baseline spec generation entirely.

## Type

- [x] fix

## Checklist

- [x] Title follows the Conventional Commits format
- [x] Tested locally
- [ ] Updated documentation (if needed)
- [ ] Updated `CLAUDE.md` files (if needed)
- [ ] Read the contributing guide