### PR TITLE
fix: restructure personal overrides permission into describe secret

### DIFF
--- a/backend/src/ee/services/permission/permission-fns.test.ts
+++ b/backend/src/ee/services/permission/permission-fns.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "vitest";
 
 import { conditionsMatcher } from "@app/lib/casl";
 
-import { expandLegacyForbidActions, throwIfMissingSecretPersonalOverridePermission } from "./permission-fns";
+import { expandLegacyForbidActions, throwIfMissingSecretReadValueOrDescribePermission } from "./permission-fns";
 import {
   ProjectPermissionActions,
   ProjectPermissionGroupActions,
@@ -184,63 +184,67 @@ describe("expandLegacyForbidActions", () => {
   });
 });
 
-describe("throwIfMissingSecretPersonalOverridePermission", () => {
+describe("throwIfMissingSecretReadValueOrDescribePermission", () => {
   const buildAbility = (rules: Rule[]) => createMongoAbility<ProjectPermissionSet>(rules, { conditionsMatcher });
 
-  test("passes when the actor has PersonalOverride but not the shared fallback action", () => {
+  test("passes when the actor has the requested action", () => {
     const ability = buildAbility([
       allow({
-        action: [ProjectPermissionSecretActions.PersonalOverride],
+        action: [ProjectPermissionSecretActions.DescribeSecret],
         subject: ProjectPermissionSub.Secrets
       })
     ]);
     expect(() =>
-      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create)
+      throwIfMissingSecretReadValueOrDescribePermission(ability, ProjectPermissionSecretActions.DescribeSecret)
     ).not.toThrow();
   });
 
-  test("passes when the actor has the shared fallback action but not PersonalOverride", () => {
+  test("passes when the actor only has the legacy DescribeAndReadValue action", () => {
     const ability = buildAbility([
       allow({
-        action: [ProjectPermissionSecretActions.Create],
+        action: [ProjectPermissionSecretActions.DescribeAndReadValue],
         subject: ProjectPermissionSub.Secrets
       })
     ]);
     expect(() =>
-      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create)
+      throwIfMissingSecretReadValueOrDescribePermission(ability, ProjectPermissionSecretActions.DescribeSecret)
     ).not.toThrow();
   });
 
-  test("throws when the actor has neither PersonalOverride nor the shared fallback action", () => {
+  test("throws when the actor only has write actions on shared secrets", () => {
     const ability = buildAbility([
       allow({
-        action: [ProjectPermissionSecretActions.ReadValue],
+        action: [
+          ProjectPermissionSecretActions.Create,
+          ProjectPermissionSecretActions.Edit,
+          ProjectPermissionSecretActions.Delete
+        ],
         subject: ProjectPermissionSub.Secrets
       })
     ]);
     expect(() =>
-      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create)
+      throwIfMissingSecretReadValueOrDescribePermission(ability, ProjectPermissionSecretActions.DescribeSecret)
     ).toThrow();
   });
 
-  test("respects conditions on the PersonalOverride rule", () => {
+  test("respects conditions on the DescribeSecret rule", () => {
     const ability = buildAbility([
       allow({
-        action: [ProjectPermissionSecretActions.PersonalOverride],
+        action: [ProjectPermissionSecretActions.DescribeSecret],
         subject: ProjectPermissionSub.Secrets,
         conditions: { environment: "dev" }
       })
     ]);
 
     expect(() =>
-      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create, {
+      throwIfMissingSecretReadValueOrDescribePermission(ability, ProjectPermissionSecretActions.DescribeSecret, {
         environment: "dev",
         secretPath: "/"
       })
     ).not.toThrow();
 
     expect(() =>
-      throwIfMissingSecretPersonalOverridePermission(ability, ProjectPermissionSecretActions.Create, {
+      throwIfMissingSecretReadValueOrDescribePermission(ability, ProjectPermissionSecretActions.DescribeSecret, {
         environment: "prod",
         secretPath: "/"
       })

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -50,41 +50,6 @@ export function throwIfMissingSecretReadValueOrDescribePermission(
   }
 }
 
-// Personal secret overrides can be managed either by the dedicated PersonalOverride action or by
-// whoever already has the matching shared-secret action (Create/Edit/Delete). This lets a role grant
-// personal-override-only access while existing shared-secret writers keep managing overrides.
-export function throwIfMissingSecretPersonalOverridePermission(
-  permission: MongoAbility<ProjectPermissionSet> | PureAbility,
-  fallbackAction: Extract<
-    ProjectPermissionSecretActions,
-    ProjectPermissionSecretActions.Create | ProjectPermissionSecretActions.Edit | ProjectPermissionSecretActions.Delete
-  >,
-  subjectFields?: SecretSubjectFields
-) {
-  try {
-    if (subjectFields) {
-      ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionSecretActions.PersonalOverride,
-        subject(ProjectPermissionSub.Secrets, subjectFields)
-      );
-    } else {
-      ForbiddenError.from(permission).throwUnlessCan(
-        ProjectPermissionSecretActions.PersonalOverride,
-        ProjectPermissionSub.Secrets
-      );
-    }
-  } catch {
-    if (subjectFields) {
-      ForbiddenError.from(permission).throwUnlessCan(
-        fallbackAction,
-        subject(ProjectPermissionSub.Secrets, subjectFields)
-      );
-    } else {
-      ForbiddenError.from(permission).throwUnlessCan(fallbackAction, ProjectPermissionSub.Secrets);
-    }
-  }
-}
-
 export function hasSecretReadValueOrDescribePermission(
   permission: MongoAbility<ProjectPermissionSet>,
   action: Extract<

--- a/backend/src/ee/services/permission/project-permission.ts
+++ b/backend/src/ee/services/permission/project-permission.ts
@@ -48,8 +48,7 @@ export enum ProjectPermissionSecretActions {
   ReadValue = "readValue",
   Create = "create",
   Edit = "edit",
-  Delete = "delete",
-  PersonalOverride = "personal-override"
+  Delete = "delete"
 }
 
 export enum ProjectPermissionCmekActions {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -13,7 +13,6 @@ import {
 import { TPermissionDALFactory } from "@app/ee/services/permission/permission-dal";
 import {
   hasSecretReadValueOrDescribePermission,
-  throwIfMissingSecretPersonalOverridePermission,
   throwIfMissingSecretReadValueOrDescribePermission
 } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
@@ -376,7 +375,8 @@ export const secretV2BridgeServiceFactory = ({
     const { secretName, type, ...inputSecretData } = inputSecret;
 
     if (type === SecretType.Personal) {
-      throwIfMissingSecretPersonalOverridePermission(permission, ProjectPermissionSecretActions.Create, {
+      // personal overrides are only visible to their owner, so describe access on the secret suffices to manage them
+      throwIfMissingSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret, {
         environment,
         secretPath,
         secretName,
@@ -586,7 +586,8 @@ export const secretV2BridgeServiceFactory = ({
         folderId
       });
 
-      throwIfMissingSecretPersonalOverridePermission(permission, ProjectPermissionSecretActions.Edit, {
+      // personal overrides are only visible to their owner, so describe access on the secret suffices to manage them
+      throwIfMissingSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret, {
         environment,
         secretPath,
         secretName: inputSecret.secretName,
@@ -919,7 +920,8 @@ export const secretV2BridgeServiceFactory = ({
         folderId
       });
 
-      throwIfMissingSecretPersonalOverridePermission(permission, ProjectPermissionSecretActions.Delete, {
+      // personal overrides are only visible to their owner, so describe access on the secret suffices to manage them
+      throwIfMissingSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret, {
         environment,
         secretPath,
         secretName: inputSecret.secretName,

--- a/frontend/src/context/ProjectPermissionContext/types.ts
+++ b/frontend/src/context/ProjectPermissionContext/types.ts
@@ -24,8 +24,7 @@ export enum ProjectPermissionSecretActions {
   Create = "create",
   Edit = "edit",
   Delete = "delete",
-  Subscribe = "subscribe",
-  PersonalOverride = "personal-override"
+  Subscribe = "subscribe"
 }
 
 export enum ProjectPermissionDynamicSecretActions {

--- a/frontend/src/hooks/api/secrets/queries.tsx
+++ b/frontend/src/hooks/api/secrets/queries.tsx
@@ -131,9 +131,10 @@ export const mergePersonalSecrets = (rawSecrets: SecretV3Raw[]) => {
       sec.overrideAction = "modified";
       sec.isOverrideEmpty = personalSecret.isEmpty;
       // NOTE: do not force `secretValueHidden = false` here. It reflects whether the SHARED value is
-      // readable; a user with only the personal-override permission can read their override but not the
-      // shared value. Keep the shared entry's real value so the shared row renders the no-access state
-      // instead of attempting a forbidden fetch. Override display is gated on the override's own fields.
+      // readable; a user who can only describe the secret (without read value) can read their override
+      // but not the shared value. Keep the shared entry's real value so the shared row renders the
+      // no-access state instead of attempting a forbidden fetch. Override display is gated on the
+      // override's own fields.
     }
   });
 

--- a/frontend/src/lib/fn/permission.ts
+++ b/frontend/src/lib/fn/permission.ts
@@ -388,39 +388,6 @@ export function hasSecretReadValueOrDescribePermission(
   return canNewPermission || canOldPermission;
 }
 
-// Personal secret overrides can be managed either by the dedicated PersonalOverride action or by
-// whoever already holds the matching shared-secret action (Create/Edit/Delete). This mirrors the
-// backend throwIfMissingSecretPersonalOverridePermission check so the UI shows the same controls.
-export function hasSecretPersonalOverridePermission(
-  permission: MongoAbility<ProjectPermissionSet>,
-  action: Extract<
-    ProjectPermissionSecretActions,
-    | ProjectPermissionSecretActions.Create
-    | ProjectPermissionSecretActions.Edit
-    | ProjectPermissionSecretActions.Delete
-  >,
-  subjectFields?: SecretSubjectFields
-) {
-  let canPersonalOverride = false;
-  let canFallback = false;
-
-  if (subjectFields) {
-    canPersonalOverride = permission.can(
-      ProjectPermissionSecretActions.PersonalOverride,
-      subject(ProjectPermissionSub.Secrets, subjectFields)
-    );
-    canFallback = permission.can(action, subject(ProjectPermissionSub.Secrets, subjectFields));
-  } else {
-    canPersonalOverride = permission.can(
-      ProjectPermissionSecretActions.PersonalOverride,
-      ProjectPermissionSub.Secrets
-    );
-    canFallback = permission.can(action, ProjectPermissionSub.Secrets);
-  }
-
-  return canPersonalOverride || canFallback;
-}
-
 // ─── Grant condition extractors ─────────────────────────────────────
 
 // Member extractors

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/ProjectRoleModifySection.utils.tsx
@@ -109,8 +109,7 @@ const SecretPolicyActionSchema = z.object({
   [ProjectPermissionSecretActions.Edit]: z.boolean().optional(),
   [ProjectPermissionSecretActions.Delete]: z.boolean().optional(),
   [ProjectPermissionSecretActions.Create]: z.boolean().optional(),
-  [ProjectPermissionSecretActions.Subscribe]: z.boolean().optional(),
-  [ProjectPermissionSecretActions.PersonalOverride]: z.boolean().optional()
+  [ProjectPermissionSecretActions.Subscribe]: z.boolean().optional()
 });
 
 const ApprovalPolicyActionSchema = z.object({
@@ -1208,9 +1207,6 @@ export const rolePermission2Form = (permissions: TProjectPermission[] = []) => {
           const canDelete = action.includes(ProjectPermissionSecretActions.Delete);
           const canCreate = action.includes(ProjectPermissionSecretActions.Create);
           const canSubscribe = action.includes(ProjectPermissionSecretActions.Subscribe);
-          const canPersonalOverride = action.includes(
-            ProjectPermissionSecretActions.PersonalOverride
-          );
 
           // from above statement we are sure it won't be undefined
           formVal[subject]!.push({
@@ -1221,7 +1217,6 @@ export const rolePermission2Form = (permissions: TProjectPermission[] = []) => {
             edit: canEdit,
             delete: canDelete,
             subscribe: canSubscribe,
-            [ProjectPermissionSecretActions.PersonalOverride]: canPersonalOverride,
             conditions: conditions ? convertCaslConditionToFormOperator(conditions) : [],
             inverted
           });
@@ -2132,12 +2127,6 @@ export const PROJECT_PERMISSION_OBJECT: TProjectPermissionObject = {
         label: "Create",
         description: "Create new secrets in the project",
         value: ProjectPermissionSecretActions.Create
-      },
-      {
-        label: "Personal Override",
-        description:
-          "Create, modify, and delete personal secret overrides. Does not grant access to shared secrets.",
-        value: ProjectPermissionSecretActions.PersonalOverride
       }
     ]
   },

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -91,10 +91,7 @@ import { useGetSecretValue } from "@app/hooks/api/dashboard/queries";
 import { Reminder } from "@app/hooks/api/reminders/types";
 import { PendingAction } from "@app/hooks/api/secretFolders/types";
 import { ProjectEnv, SecretType, SecretV3RawSanitized, WsTag } from "@app/hooks/api/types";
-import {
-  hasSecretPersonalOverridePermission,
-  hasSecretReadValueOrDescribePermission
-} from "@app/lib/fn/permission";
+import { hasSecretReadValueOrDescribePermission } from "@app/lib/fn/permission";
 import { AddShareSecretModal } from "@app/pages/organization/SecretSharingPage/components/ShareSecret/AddShareSecretModal";
 import { CollapsibleSecretImports } from "@app/pages/secret-manager/SecretDashboardPage/components/SecretListView/CollapsibleSecretImports";
 import { HIDDEN_SECRET_VALUE } from "@app/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem";
@@ -884,9 +881,10 @@ export const SecretEditTableRow = ({
       secretTags: ["*"]
     })
   );
-  const canCreatePersonalOverride = hasSecretPersonalOverridePermission(
+  // personal overrides are only visible to their owner, so describe access on the secret suffices to manage them
+  const canCreatePersonalOverride = hasSecretReadValueOrDescribePermission(
     permission,
-    ProjectPermissionSecretActions.Create,
+    ProjectPermissionSecretActions.DescribeSecret,
     { environment, secretPath, secretName, secretTags: ["*"] }
   );
 

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretOverrideRow.tsx
@@ -33,7 +33,7 @@ import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionCo
 import { useToggle } from "@app/hooks";
 import { useGetSecretValue } from "@app/hooks/api/dashboard/queries";
 import { SecretType } from "@app/hooks/api/types";
-import { hasSecretPersonalOverridePermission } from "@app/lib/fn/permission";
+import { hasSecretReadValueOrDescribePermission } from "@app/lib/fn/permission";
 import { HIDDEN_SECRET_VALUE } from "@app/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem";
 
 type Props = {
@@ -82,11 +82,10 @@ export const SecretOverrideRow = ({
 }: Props) => {
   const { currentProject } = useProject();
   const { permission } = useProjectPermission();
-  const canSaveOverride = hasSecretPersonalOverridePermission(
+  // personal overrides are only visible to their owner, so describe access on the secret suffices to manage them
+  const canSaveOverride = hasSecretReadValueOrDescribePermission(
     permission,
-    isCreatingOverride
-      ? ProjectPermissionSecretActions.Create
-      : ProjectPermissionSecretActions.Edit,
+    ProjectPermissionSecretActions.DescribeSecret,
     { environment, secretPath, secretName, secretTags: ["*"] }
   );
   const [isOverrideFieldFocused, setIsOverrideFieldFocused] = useToggle();

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/SecretListView/SecretItem.tsx
@@ -41,10 +41,7 @@ import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { twMerge } from "tailwind-merge";
 
 import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
-import {
-  hasSecretPersonalOverridePermission,
-  hasSecretReadValueOrDescribePermission
-} from "@app/lib/fn/permission";
+import { hasSecretReadValueOrDescribePermission } from "@app/lib/fn/permission";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faEyeSlash,
@@ -254,11 +251,11 @@ export const SecretItem = memo(
     const isOverridden =
       overrideAction === SecretActionType.Created || overrideAction === SecretActionType.Modified;
     const hasTagsApplied = Boolean(fields.length);
-    // Adding a personal override creates a personal secret, which the backend gates on the
-    // Create/PersonalOverride permission — so mirror that check for the "add" case.
-    const canAddOverride = hasSecretPersonalOverridePermission(
+    // Adding a personal override creates a personal secret, which the backend gates on being able
+    // to describe the secret (DescribeSecret or legacy read), so mirror that check for the "add" case.
+    const canAddOverride = hasSecretReadValueOrDescribePermission(
       permission,
-      ProjectPermissionSecretActions.Create,
+      ProjectPermissionSecretActions.DescribeSecret,
       { environment, secretPath, secretName, secretTags: selectedTagSlugs }
     );
     // Removing an existing override deletes the user's own personal secret, which the backend allows


### PR DESCRIPTION
## Context

Removed the recently added `Personal Overrides` permission and baked it into the `Describe Secret` permission. This means anyone that are able to see a secret exists, are able to create personal overrides on that secret.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)