### PR TITLE
fix(api): change expired kubernetes operator token error from 403 to 401

### DIFF
--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -291,9 +291,9 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
           "The access token is signed with an invalid algorithm. Please provide a valid token and try again.";
       }
 
-      void res.status(HttpStatusCodes.Forbidden).send({
+      void res.status(HttpStatusCodes.Unauthorized).send({
         reqId: req.id,
-        statusCode: HttpStatusCodes.Forbidden,
+        statusCode: HttpStatusCodes.Unauthorized,
         error: "TokenError",
         message: errorMessage
       });


### PR DESCRIPTION
## Context

When the Kubernetes Operator's access token expires, the backend was incorrectly returning a `403 Forbidden` error instead of a `401 Unauthorized` error. 

Because the operator's HTTP client interceptor relies on `401` status codes to know when it needs to re-authenticate and fetch a new token, receiving a `403` caused it to falsely assume it had permanently lost permissions. This resulted in the operator crashing and permanently failing to reconcile secrets until manually restarted. 

This PR updates the `fastifyErrHandler` to correctly return a `401 Unauthorized` (rather than falling through to the generic `JsonWebTokenError` handler that returns `403`) for expired or invalid machine identity tokens, allowing the operator to successfully recover.

Fixes #7179 

## Steps to verify the change

- [x] Force a token expiration for a Machine Identity used by the Kubernetes Operator.
- [x] Verify that the backend now returns `401 Unauthorized` upon the token's expiration.
- [x] Verify that the operator successfully catches the `401`, triggers the re-authentication flow to fetch a new token, and resumes syncing secrets without crashing.
- [x] Run `npm run test:unit` in the backend to ensure no existing authentication or authorization tests were broken.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)