### PR TITLE
feat(agent-proxy): add Helm chart for the Agent Proxy

### DIFF
--- a/.github/workflows/release_helm_agent_proxy.yaml
+++ b/.github/workflows/release_helm_agent_proxy.yaml
@@ -1,0 +1,65 @@
+name: Release Agent Proxy Helm Chart
+on:
+  workflow_dispatch:
+
+jobs:
+  test-helm:
+    name: Test Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 Nov 14, 2025
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.17.0
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.x"
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+        with:
+          yamale_version: "6.0.0"
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml --charts helm-charts/infisical-agent-proxy
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+
+      - name: Validate rendered manifests against the API server
+        run: |
+          kubectl create namespace infisical-agent-proxy
+          for values in helm-charts/infisical-agent-proxy/ci/*-values.yaml; do
+            echo "::group::$values"
+            helm template agent-proxy helm-charts/infisical-agent-proxy \
+              --namespace infisical-agent-proxy \
+              --values "$values" \
+              | kubectl apply --dry-run=server --namespace infisical-agent-proxy -f -
+            echo "::endgroup::"
+          done
+
+  release-helm:
+    name: Release Helm Chart
+    needs: test-helm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 Nov 14, 2025
+
+      - name: Install Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3 latest
+        with:
+          version: v3.10.0
+
+      - name: Build and push helm package to Cloudsmith
+        run: cd helm-charts && sh upload-agent-proxy-cloudsmith.sh
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          CLOUDSMITH_USERNAME: ${{ secrets.CLOUDSMITH_USERNAME }}

--- a/.github/workflows/run-helm-chart-tests-infisical-agent-proxy.yml
+++ b/.github/workflows/run-helm-chart-tests-infisical-agent-proxy.yml
@@ -1,0 +1,69 @@
+name: Run Helm Chart Tests for Agent Proxy
+on:
+  pull_request:
+    paths:
+      - "helm-charts/infisical-agent-proxy/**"
+      - ".github/workflows/run-helm-chart-tests-infisical-agent-proxy.yml"
+
+jobs:
+  test-helm:
+    name: Test Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 Nov 14, 2025
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.17.0
+
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: "3.x"
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b # v2.7.0
+        with:
+          yamale_version: "6.0.0"
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml --charts helm-charts/infisical-agent-proxy
+
+      - name: Create kind cluster
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+
+      # `ct install` is deliberately not used here. The Agent Proxy authenticates against a real
+      # Infisical instance at startup and exits when it cannot, so an install with CI credentials
+      # would always CrashLoopBackOff. Instead every values permutation is rendered and validated
+      # against the live API server, which catches schema errors without needing real credentials.
+      - name: Validate rendered manifests against the API server
+        run: |
+          kubectl create namespace infisical-agent-proxy
+          for values in helm-charts/infisical-agent-proxy/ci/*-values.yaml; do
+            echo "::group::$values"
+            helm template agent-proxy helm-charts/infisical-agent-proxy \
+              --namespace infisical-agent-proxy \
+              --values "$values" \
+              | kubectl apply --dry-run=server --namespace infisical-agent-proxy -f -
+            echo "::endgroup::"
+          done
+
+      - name: Reject invalid unmatched-host values
+        run: |
+          if helm template agent-proxy helm-charts/infisical-agent-proxy \
+            --set auth.clientId=id --set auth.clientSecret=secret \
+            --set agentProxy.unmatchedHost=nonsense > /dev/null 2>&1; then
+            echo "expected an invalid agentProxy.unmatchedHost to fail rendering"
+            exit 1
+          fi
+
+      - name: Reject missing credentials
+        run: |
+          if helm template agent-proxy helm-charts/infisical-agent-proxy > /dev/null 2>&1; then
+            echo "expected a chart with no credentials configured to fail rendering"
+            exit 1
+          fi

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -374,7 +374,8 @@
                   "self-hosting/helm-charts/gateway",
                   "self-hosting/helm-charts/pki-issuer",
                   "self-hosting/helm-charts/csi-provider",
-                  "self-hosting/helm-charts/agent-injector"
+                  "self-hosting/helm-charts/agent-injector",
+                  "self-hosting/helm-charts/agent-proxy"
                 ]
               },
               "self-hosting/guides/replication",

--- a/docs/documentation/platform/agent-proxy/deployment.mdx
+++ b/docs/documentation/platform/agent-proxy/deployment.mdx
@@ -61,6 +61,27 @@ However you run the Agent Proxy, provide its identity's credentials, publish por
 
     Add `-e INFISICAL_DOMAIN=https://eu.infisical.com` for EU Cloud or a self-hosted instance.
   </Tab>
+  <Tab title="Kubernetes (Helm)">
+    Store the proxy identity's credentials in a Secret, then install the chart:
+
+    ```bash
+    kubectl create namespace infisical-agent-proxy
+
+    kubectl create secret generic agent-proxy-credentials \
+      --namespace infisical-agent-proxy \
+      --from-literal=clientId=<agent-proxy-client-id> \
+      --from-literal=clientSecret=<agent-proxy-client-secret>
+
+    helm repo add infisical-helm-charts 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/'
+    helm install infisical-agent-proxy infisical-helm-charts/infisical-agent-proxy \
+      --namespace infisical-agent-proxy \
+      --set auth.existingSecretRef=agent-proxy-credentials
+    ```
+
+    Add `--set agentProxy.domain=https://eu.infisical.com` for EU Cloud or a self-hosted instance.
+
+    Agents reach the proxy at `infisical-agent-proxy.infisical-agent-proxy.svc.cluster.local:17322`. The chart can also restrict inbound traffic to your agent pods with a NetworkPolicy, and run multiple instances with `replicaCount`. See the [Agent Proxy Helm chart](/self-hosting/helm-charts/agent-proxy) for the full configuration reference.
+  </Tab>
   <Tab title="PaaS (Render, Railway, Fly)">
     Deploy the `infisical/cli` image as a service:
 

--- a/docs/self-hosting/helm-charts/agent-proxy.mdx
+++ b/docs/self-hosting/helm-charts/agent-proxy.mdx
@@ -1,0 +1,147 @@
+---
+title: "Infisical Agent Proxy"
+sidebarTitle: "Agent Proxy"
+description: "Deploy the Infisical Agent Proxy on Kubernetes using the official Helm chart."
+---
+
+The Infisical Agent Proxy brokers credentials to AI agents: agents route their traffic through it, and it applies the real secret values on the way out, so the agent never reads them.
+
+For a full overview of how the Agent Proxy works, see the [Agent Proxy documentation](/documentation/platform/agent-proxy/overview).
+
+## Before you begin
+
+You need a machine identity for the Agent Proxy with the permissions listed in [Permissions](/documentation/platform/agent-proxy/security#permissions), and a Universal Auth Client ID and Client Secret for it. The [Quickstart](/documentation/platform/agent-proxy/quickstart) covers creating both.
+
+This identity reads your real secret values. Keep it separate from the identity your agents use, and install it in a namespace your agents cannot read Secrets from.
+
+## Installation
+
+<Steps>
+  <Step title="Add the Helm repository">
+    ```bash
+    helm repo add infisical-helm-charts 'https://dl.cloudsmith.io/public/infisical/helm-charts/helm/charts/'
+    helm repo update
+    ```
+  </Step>
+
+  <Step title="Store the credentials in a Secret">
+    ```bash
+    kubectl create namespace infisical-agent-proxy
+
+    kubectl create secret generic agent-proxy-credentials \
+      --namespace infisical-agent-proxy \
+      --from-literal=clientId=<agent-proxy-client-id> \
+      --from-literal=clientSecret=<agent-proxy-client-secret>
+    ```
+
+    Use the Client ID and Client Secret of the Agent Proxy machine identity.
+  </Step>
+
+  <Step title="Install the chart">
+    <Tabs>
+      <Tab title="Infisical Cloud (US)">
+        ```bash
+        helm install infisical-agent-proxy infisical-helm-charts/infisical-agent-proxy \
+          --namespace infisical-agent-proxy \
+          --set auth.existingSecretRef=agent-proxy-credentials
+        ```
+      </Tab>
+
+      <Tab title="Infisical Cloud (EU)">
+        ```bash
+        helm install infisical-agent-proxy infisical-helm-charts/infisical-agent-proxy \
+          --namespace infisical-agent-proxy \
+          --set auth.existingSecretRef=agent-proxy-credentials \
+          --set agentProxy.domain=https://eu.infisical.com
+        ```
+      </Tab>
+
+      <Tab title="Self-Hosted">
+        ```bash
+        helm install infisical-agent-proxy infisical-helm-charts/infisical-agent-proxy \
+          --namespace infisical-agent-proxy \
+          --set auth.existingSecretRef=agent-proxy-credentials \
+          --set agentProxy.domain=https://infisical.your-domain.com
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+
+  <Step title="Verify the deployment">
+    ```bash
+    kubectl get pods -n infisical-agent-proxy
+    kubectl logs -n infisical-agent-proxy deployment/infisical-agent-proxy
+    ```
+
+    A healthy proxy logs `Agent proxy authenticated; starting MITM proxy` followed by `Infisical agent proxy listening on :17322`, then stays quiet until an agent connects. If the pod restarts instead, the logs almost always show a `401 Unauthorized`, which means the Client ID or Client Secret in the Secret is wrong, or `agentProxy.domain` points at the wrong instance.
+  </Step>
+</Steps>
+
+## Connecting your agents
+
+Agents reach the proxy at the Service's in-cluster address. Point `INFISICAL_AGENT_PROXY_ADDRESS` at it when running [`infisical secrets agent-proxy connect`](/documentation/platform/agent-proxy/connecting-agents):
+
+```bash
+INFISICAL_AGENT_PROXY_ADDRESS=infisical-agent-proxy.infisical-agent-proxy.svc.cluster.local:17322
+```
+
+## Restricting access
+
+The Agent Proxy holds real credentials, so only your agent pods should be able to reach it. Enable the bundled NetworkPolicy and describe those pods:
+
+```yaml
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: my-agent
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: agents
+```
+
+Leaving `ingressFrom` empty denies all ingress. Leave `networkPolicy.enabled` off if you manage network policy elsewhere, and note that it only takes effect if your cluster runs a CNI that enforces NetworkPolicy.
+
+## High availability
+
+Set `replicaCount` above `1`. Instances are stateless and coordinate through Infisical rather than with each other, so no further configuration is needed. See [High availability](/documentation/platform/agent-proxy/deployment#high-availability) for how caching behaves across instances.
+
+## Uninstall
+
+```bash
+helm uninstall infisical-agent-proxy --namespace infisical-agent-proxy
+```
+
+## Configuration reference
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `auth.existingSecretRef` | `""` | Kubernetes Secret holding the machine identity credentials. Takes precedence over the inline values. |
+| `auth.clientIdKey` | `"clientId"` | Key in the existing Secret that holds the Client ID. |
+| `auth.clientSecretKey` | `"clientSecret"` | Key in the existing Secret that holds the Client Secret. |
+| `auth.clientId` | `""` | Inline Client ID. The chart creates a Secret from it. |
+| `auth.clientSecret` | `""` | Inline Client Secret. The chart creates a Secret from it. |
+| `agentProxy.domain` | `""` | Infisical instance URL. Empty for Infisical Cloud (US). |
+| `agentProxy.port` | `17322` | Port the Agent Proxy listens on. |
+| `agentProxy.unmatchedHost` | `allow` | Policy for hosts with no matching proxied service: `allow` or `block`. |
+| `agentProxy.pollInterval` | `60` | Seconds between permission and credential refreshes. |
+| `agentProxy.logFormat` | `json` | Log output format: `console` or `json`. |
+| `replicaCount` | `1` | Number of Agent Proxy instances. |
+| `service.type` | `ClusterIP` | Service type. |
+| `service.port` | `17322` | Port the Service exposes. |
+| `networkPolicy.enabled` | `false` | Create a NetworkPolicy restricting inbound traffic. |
+| `networkPolicy.ingressFrom` | `[]` | NetworkPolicy `from` peers allowed to reach the proxy. |
+| `image.repository` | `infisical/cli` | Container image. |
+| `image.tag` | `""` | Image tag. Defaults to the chart's `appVersion`. |
+| `resources.requests.cpu` | `100m` | CPU request. |
+| `resources.requests.memory` | `256Mi` | Memory request. |
+| `resources.limits.cpu` | `1000m` | CPU limit. |
+| `resources.limits.memory` | `512Mi` | Memory limit. |
+| `livenessProbe.enabled` | `true` | Enable the TCP liveness probe. |
+| `readinessProbe.enabled` | `true` | Enable the TCP readiness probe. |
+| `serviceAccount.create` | `true` | Create a service account. |
+| `extraEnv` | `[]` | Additional environment variables. |
+| `extraEnvFrom` | `[]` | Load environment variables from Secrets or ConfigMaps. |
+| `extraArgs` | `[]` | Extra arguments appended to the start command. |
+| `extraObjects` | `[]` | Additional Kubernetes manifests to deploy with the chart. |

--- a/docs/self-hosting/helm-charts/overview.mdx
+++ b/docs/self-hosting/helm-charts/overview.mdx
@@ -21,4 +21,5 @@ helm repo update
 | [PKI Issuer](/self-hosting/helm-charts/pki-issuer) | cert-manager external issuer for automated X.509 certificate issuance via Infisical PKI. | `infisical-pki-issuer` |
 | [CSI Provider](/self-hosting/helm-charts/csi-provider) | Mounts Infisical secrets directly into pods as files via the Secrets Store CSI Driver. | `infisical-csi-provider` |
 | [Agent Injector](/self-hosting/helm-charts/agent-injector) | Mutating webhook that automatically injects an Infisical Agent sidecar into pods. | `infisical-agent-injector` |
+| [Agent Proxy](/self-hosting/helm-charts/agent-proxy) | Brokers credentials to AI agents so they can call APIs without reading the secret values. | `infisical-agent-proxy` |
 

--- a/helm-charts/infisical-agent-proxy/.helmignore
+++ b/helm-charts/infisical-agent-proxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-charts/infisical-agent-proxy/CHANGELOG.md
+++ b/helm-charts/infisical-agent-proxy/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 1.0.0 (July 28, 2026)
+* Initial helm release for the Infisical Agent Proxy.
+* Runs `infisical secrets agent-proxy start` from the `infisical/cli` image. Requires CLI v0.43.105 or newer.
+* Universal Auth credentials via `auth.existingSecretRef`, or inline `auth.clientId` / `auth.clientSecret`.
+* Exposes the proxy on `agentProxy.port` (default `17322`) through a ClusterIP Service.
+* Optional NetworkPolicy (`networkPolicy.*`) to restrict inbound traffic to your agent pods.
+* Added `extraEnv`, `extraEnvFrom`, `extraArgs`, and `extraObjects` escape hatches.

--- a/helm-charts/infisical-agent-proxy/Chart.yaml
+++ b/helm-charts/infisical-agent-proxy/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: infisical-agent-proxy
+description: A Helm chart to deploy the Infisical Agent Proxy
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+# The `secrets agent-proxy start` command requires CLI v0.43.105 or newer.
+appVersion: "0.43.114"

--- a/helm-charts/infisical-agent-proxy/ci/default-values.yaml
+++ b/helm-charts/infisical-agent-proxy/ci/default-values.yaml
@@ -1,0 +1,4 @@
+# Inline credentials, the smallest working install.
+auth:
+  clientId: ci-test-client-id
+  clientSecret: ci-test-client-secret

--- a/helm-charts/infisical-agent-proxy/ci/existing-secret-values.yaml
+++ b/helm-charts/infisical-agent-proxy/ci/existing-secret-values.yaml
@@ -1,0 +1,11 @@
+# Credentials sourced from a Secret the user manages, with non-default keys.
+auth:
+  existingSecretRef: my-agent-proxy-credentials
+  clientIdKey: UA_CLIENT_ID
+  clientSecretKey: UA_CLIENT_SECRET
+
+agentProxy:
+  domain: https://eu.infisical.com
+  unmatchedHost: block
+  pollInterval: 30
+  logFormat: console

--- a/helm-charts/infisical-agent-proxy/ci/network-policy-values.yaml
+++ b/helm-charts/infisical-agent-proxy/ci/network-policy-values.yaml
@@ -1,0 +1,22 @@
+# Locked-down install: multiple replicas, custom port, ingress restricted to agent pods.
+auth:
+  clientId: ci-test-client-id
+  clientSecret: ci-test-client-secret
+
+replicaCount: 3
+
+agentProxy:
+  port: 18322
+
+service:
+  port: 18322
+
+networkPolicy:
+  enabled: true
+  ingressFrom:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: my-agent
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: agents

--- a/helm-charts/infisical-agent-proxy/templates/_helpers.tpl
+++ b/helm-charts/infisical-agent-proxy/templates/_helpers.tpl
@@ -1,0 +1,97 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "infisical-agent-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "infisical-agent-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "infisical-agent-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "infisical-agent-proxy.labels" -}}
+helm.sh/chart: {{ include "infisical-agent-proxy.chart" . }}
+{{ include "infisical-agent-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "infisical-agent-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "infisical-agent-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "infisical-agent-proxy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "infisical-agent-proxy.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret holding the machine identity credentials. Either the user's own Secret
+or the one this chart renders from the inline values.
+*/}}
+{{- define "infisical-agent-proxy.authSecretName" -}}
+{{- if .Values.auth.existingSecretRef }}
+{{- .Values.auth.existingSecretRef }}
+{{- else }}
+{{- printf "%s-auth" (include "infisical-agent-proxy.fullname" .) }}
+{{- end }}
+{{- end }}
+
+{{/*
+Key within the auth Secret that holds the client id. The chart-rendered Secret always uses
+the documented default; an existing Secret may use whatever key the user configured.
+*/}}
+{{- define "infisical-agent-proxy.clientIdKey" -}}
+{{- if .Values.auth.existingSecretRef }}
+{{- .Values.auth.clientIdKey | default "clientId" }}
+{{- else }}
+{{- "clientId" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Key within the auth Secret that holds the client secret.
+*/}}
+{{- define "infisical-agent-proxy.clientSecretKey" -}}
+{{- if .Values.auth.existingSecretRef }}
+{{- .Values.auth.clientSecretKey | default "clientSecret" }}
+{{- else }}
+{{- "clientSecret" }}
+{{- end }}
+{{- end }}

--- a/helm-charts/infisical-agent-proxy/templates/deployment.yaml
+++ b/helm-charts/infisical-agent-proxy/templates/deployment.yaml
@@ -1,0 +1,133 @@
+{{- if and (not .Values.auth.existingSecretRef) (or (not .Values.auth.clientId) (not .Values.auth.clientSecret)) }}
+  {{- fail "auth.existingSecretRef, or both auth.clientId and auth.clientSecret, must be set. The Agent Proxy authenticates as a machine identity using Universal Auth." }}
+{{- end }}
+{{- if not (has .Values.agentProxy.unmatchedHost (list "allow" "block")) }}
+  {{- fail (printf "agentProxy.unmatchedHost must be 'allow' or 'block', got %q." .Values.agentProxy.unmatchedHost) }}
+{{- end }}
+{{- if not (has .Values.agentProxy.logFormat (list "console" "json")) }}
+  {{- fail (printf "agentProxy.logFormat must be 'console' or 'json', got %q." .Values.agentProxy.logFormat) }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "infisical-agent-proxy.fullname" . }}
+  labels:
+    {{- include "infisical-agent-proxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "infisical-agent-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "infisical-agent-proxy.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "infisical-agent-proxy.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        # The CLI writes its config under $HOME, and the root filesystem is read-only.
+        - name: home
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: HOME
+              value: /home/infisical
+            - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "infisical-agent-proxy.authSecretName" . }}
+                  key: {{ include "infisical-agent-proxy.clientIdKey" . }}
+            - name: INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "infisical-agent-proxy.authSecretName" . }}
+                  key: {{ include "infisical-agent-proxy.clientSecretKey" . }}
+            {{- if .Values.agentProxy.domain }}
+            - name: INFISICAL_DOMAIN
+              value: {{ .Values.agentProxy.domain | quote }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          args:
+            - secrets
+            - agent-proxy
+            - start
+            - --port={{ .Values.agentProxy.port }}
+            - --unmatched-host={{ .Values.agentProxy.unmatchedHost }}
+            - --poll-interval={{ .Values.agentProxy.pollInterval }}
+            - --log-format={{ .Values.agentProxy.logFormat }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: proxy
+              containerPort: {{ .Values.agentProxy.port }}
+              protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: proxy
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: proxy
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+          {{- end }}
+          volumeMounts:
+            - name: home
+              mountPath: /home/infisical
+            - name: tmp
+              mountPath: /tmp
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-charts/infisical-agent-proxy/templates/extra-objects.yaml
+++ b/helm-charts/infisical-agent-proxy/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/helm-charts/infisical-agent-proxy/templates/networkpolicy.yaml
+++ b/helm-charts/infisical-agent-proxy/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "infisical-agent-proxy.fullname" . }}
+  labels:
+    {{- include "infisical-agent-proxy.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "infisical-agent-proxy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: proxy
+          protocol: TCP
+      {{- with .Values.networkPolicy.ingressFrom }}
+      from:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm-charts/infisical-agent-proxy/templates/secret.yaml
+++ b/helm-charts/infisical-agent-proxy/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.auth.existingSecretRef }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "infisical-agent-proxy.fullname" . }}-auth
+  labels:
+    {{- include "infisical-agent-proxy.labels" . | nindent 4 }}
+type: Opaque
+data:
+  clientId: {{ .Values.auth.clientId | b64enc | quote }}
+  clientSecret: {{ .Values.auth.clientSecret | b64enc | quote }}
+{{- end }}

--- a/helm-charts/infisical-agent-proxy/templates/service.yaml
+++ b/helm-charts/infisical-agent-proxy/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "infisical-agent-proxy.fullname" . }}
+  labels:
+    {{- include "infisical-agent-proxy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: proxy
+      protocol: TCP
+      name: proxy
+  selector:
+    {{- include "infisical-agent-proxy.selectorLabels" . | nindent 4 }}

--- a/helm-charts/infisical-agent-proxy/templates/serviceaccount.yaml
+++ b/helm-charts/infisical-agent-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: {{ include "infisical-agent-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "infisical-agent-proxy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm-charts/infisical-agent-proxy/values.yaml
+++ b/helm-charts/infisical-agent-proxy/values.yaml
@@ -1,0 +1,143 @@
+image:
+  repository: infisical/cli
+  # Defaults to the chart's appVersion. `secrets agent-proxy start` requires v0.43.105 or newer.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# Number of Agent Proxy instances. Instances are stateless and coordinate through Infisical, so
+# more than one can run behind a load balancer. Each signs its own intermediate from the same
+# per-organization root CA, so agents trust any instance.
+replicaCount: 1
+
+agentProxy:
+  # Infisical instance URL. Leave empty for Infisical Cloud (US).
+  # Set to https://eu.infisical.com for EU Cloud, or your own URL when self-hosting.
+  domain: ""
+
+  # Port the Agent Proxy listens on.
+  port: 17322
+
+  # Policy for hosts with no matching proxied service: "allow" or "block".
+  # "block" rejects every unmatched host, including your Infisical instance.
+  unmatchedHost: allow
+
+  # Seconds between permission and credential refreshes for active agents.
+  pollInterval: 60
+
+  # Log output format: "console" or "json". Defaults to json, which is what most
+  # cluster log collectors expect.
+  logFormat: json
+
+# Universal Auth credentials for the Agent Proxy machine identity.
+# This identity reads the real secret values, so keep it separate from your agents' identity.
+auth:
+  # Name of an existing Kubernetes Secret holding the credentials.
+  # Takes precedence over the inline clientId/clientSecret below.
+  existingSecretRef: ""
+  # Keys within the existing Secret.
+  clientIdKey: "clientId"
+  clientSecretKey: "clientSecret"
+
+  # Inline credentials. The chart creates a Secret from these.
+  # Prefer existingSecretRef so credentials are not stored in your Helm values.
+  clientId: ""
+  clientSecret: ""
+
+service:
+  type: ClusterIP
+  port: 17322
+  annotations: {}
+
+# Restrict inbound traffic to the pods that run your agents. The Agent Proxy holds real
+# credentials, so only agent machines should be able to reach it.
+# Leave disabled if you manage network policy separately.
+networkPolicy:
+  enabled: false
+  # Selectors describing which clients may reach the Agent Proxy. Standard NetworkPolicy
+  # "from" peers, passed through as-is. An empty list allows no ingress at all.
+  ingressFrom: []
+  #  - podSelector:
+  #      matchLabels:
+  #        app.kubernetes.io/name: my-agent
+  #  - namespaceSelector:
+  #      matchLabels:
+  #        kubernetes.io/metadata.name: agents
+
+# The Agent Proxy terminates TLS for every intercepted host and holds up to 512 concurrent
+# connections, so it is more CPU-hungry than the gateway. Tune to your fleet size.
+resources:
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
+
+# The Agent Proxy serves a raw HTTP CONNECT proxy with no health endpoint, so probes
+# check that the listener accepts TCP connections.
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+podSecurityContext:
+  runAsNonRoot: true
+  fsGroup: 1000
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+affinity: {}
+tolerations: {}
+nodeSelector: {}
+
+# -- Extra environment variables for the agent proxy container
+extraEnv: []
+#  - name: LOG_LEVEL
+#    value: debug
+#  - name: MY_SECRET
+#    valueFrom:
+#      secretKeyRef:
+#        name: my-secret
+#        key: my-key
+
+# -- Load environment variables from Secrets or ConfigMaps
+extraEnvFrom: []
+#  - secretRef:
+#      name: my-secret
+#  - configMapRef:
+#      name: my-configmap
+
+# -- Extra arguments appended to `infisical secrets agent-proxy start`
+extraArgs: []
+#  - --log-file=/var/log/infisical/agent-proxy.log
+
+# -- Extra Kubernetes manifests to deploy with this chart
+extraObjects: []

--- a/helm-charts/upload-agent-proxy-cloudsmith.sh
+++ b/helm-charts/upload-agent-proxy-cloudsmith.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -z "$CLOUDSMITH_API_KEY" ] || [ -z "$CLOUDSMITH_USERNAME" ]; then
+    echo "Error: CLOUDSMITH_API_KEY and CLOUDSMITH_USERNAME environment variables must be set."
+    exit 1
+fi
+
+cd "infisical-agent-proxy"
+helm dependency update
+helm package .
+
+echo "$CLOUDSMITH_API_KEY" | helm registry login helm.oci.cloudsmith.io \
+    --username "$CLOUDSMITH_USERNAME" \
+    --password-stdin
+
+for i in *.tgz; do
+    [ -f "$i" ] || break
+    helm push "$i" oci://helm.oci.cloudsmith.io/infisical/helm-charts
+done
+
+helm registry logout helm.oci.cloudsmith.io
+
+cd ..


### PR DESCRIPTION
## Context

The Agent Proxy's deployment docs covered systemd, Docker, and PaaS but skipped Kubernetes entirely, which is where most agent fleets actually run. Adds an `infisical-agent-proxy` chart that runs `infisical secrets agent-proxy start` from the `infisical/cli` image.

**Statelessness:** the proxy mints its intermediate CA in memory from the per-org root CA on every start (`packages/agentproxy/ca.go` never touches disk), so unlike the gateway chart there's no PVC, no `Recreate` strategy, and no `replicas: 1` pinning. HA is just `replicaCount`.

**Auth:** Universal Auth only, via `auth.existingSecretRef` or inline `auth.clientId` / `auth.clientSecret`. `agent-proxy start` doesn't support `--auth-method`, so Kubernetes auth isn't wired up here. It's an additive values change when the CLI grows it.

**Probes:** `tcpSocket`, not `httpGet`. The proxy serves a raw CONNECT proxy with no health endpoint, so an HTTP probe would be interpreted as a proxy request.

**Hardening:** `readOnlyRootFilesystem` with emptyDirs for `$HOME` (the CLI writes its config there) and `/tmp`, plus an optional NetworkPolicy, since the network-placement guidance on the deployment page ("reachable only by your agent machines") is otherwise unenforced in-cluster.

**Testing:** the PR workflow runs `ct lint`, then renders every `ci/*-values.yaml` permutation and validates it with `kubectl apply --dry-run=server` against a kind cluster. It deliberately does not run `ct install` — the proxy calls `UniversalAuthLogin` at startup and exits when it fails, so an install with CI credentials always CrashLoopBackOffs. Two negative tests assert the chart refuses to render with missing credentials or a bad `unmatchedHost`.

Pinned to CLI `0.43.114`; `secrets agent-proxy start` first shipped in `0.43.105`.

Closes AGE2-75

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

Verified against a local kind cluster:

```bash
# lint every permutation
for v in helm-charts/infisical-agent-proxy/ci/*-values.yaml; do
  helm lint helm-charts/infisical-agent-proxy --values "$v"
done

# validate rendered manifests against a real API server
kind create cluster --name ap-chart-test
kubectl create namespace infisical-agent-proxy
for v in helm-charts/infisical-agent-proxy/ci/*-values.yaml; do
  helm template agent-proxy helm-charts/infisical-agent-proxy \
    -n infisical-agent-proxy --values "$v" \
    | kubectl apply --dry-run=server -n infisical-agent-proxy -f -
done

# run it for real with dummy credentials
helm install agent-proxy helm-charts/infisical-agent-proxy \
  -n infisical-agent-proxy --values helm-charts/infisical-agent-proxy/ci/default-values.yaml
kubectl logs -n infisical-agent-proxy deployment/agent-proxy-infisical-agent-proxy
```

The pod starts as non-root on a read-only root filesystem, parses the start args, reaches Infisical Cloud, and fails only at `401 Unauthorized / Failed to authenticate the agent proxy machine identity`. Everything up to authentication is exercised; a real credential is the only untested step.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

Companion Terraform provider PR: https://github.com/Infisical/terraform-provider-infisical/pull/335
