### PR TITLE
fix(helm): stop hardcoding DB/Redis env vars in standalone-postgres chart

### DIFF
--- a/helm-charts/infisical-standalone-postgres/CHANGELOG.md
+++ b/helm-charts/infisical-standalone-postgres/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.11.0 (July 28, 2026)
+Changes:
+* Fixed `DB_CONNECTION_URI` being rendered twice (once from `postgresql.useExistingPostgresSecret`, once from the bundled-Postgres connection string) whenever both `postgresql.enabled` and `postgresql.useExistingPostgresSecret.enabled` were set, which caused the existing-secret value to be silently overridden.
+* Added `redis.useExistingRedisSecret`, mirroring `postgresql.useExistingPostgresSecret`, so `REDIS_URL` can be sourced from an existing Kubernetes Secret instead of requiring the Redis password in plaintext Helm values.
+* Backwards compatible. No action needed unless you want to move your Redis password out of Helm values, in which case set `redis.useExistingRedisSecret.enabled: true` and point it at a Secret containing the full `REDIS_URL` connection string.
+
 ## 1.10.0 (July 3, 2026)
 Changes:
 * Added configurable `securityContext` via `infisical.podSecurityContext` and `infisical.containerSecurityContext`, with secure defaults so the Infisical Deployment and the auto-bootstrap Job run under the Kubernetes Pod Security "restricted" standard out of the box.

--- a/helm-charts/infisical-standalone-postgres/CHANGELOG.md
+++ b/helm-charts/infisical-standalone-postgres/CHANGELOG.md
@@ -2,6 +2,8 @@
 Changes:
 * Fixed `DB_CONNECTION_URI` being rendered twice (once from `postgresql.useExistingPostgresSecret`, once from the bundled-Postgres connection string) whenever both `postgresql.enabled` and `postgresql.useExistingPostgresSecret.enabled` were set, which caused the existing-secret value to be silently overridden.
 * Added `redis.useExistingRedisSecret`, mirroring `postgresql.useExistingPostgresSecret`, so `REDIS_URL` can be sourced from an existing Kubernetes Secret instead of requiring the Redis password in plaintext Helm values.
+* Documented that `postgresql.enabled`/`redis.enabled` must be set to `false` alongside the corresponding `useExisting*Secret.enabled: true` or the bundled subchart is deployed and left unused.
+* Guarded the `redis.useExistingRedisSecret.enabled` lookup so `helm upgrade --reuse-values` from 1.10.0 doesn't fail on the newly added key.
 * Backwards compatible. No action needed unless you want to move your Redis password out of Helm values, in which case set `redis.useExistingRedisSecret.enabled: true` and point it at a Secret containing the full `REDIS_URL` connection string.
 
 ## 1.10.0 (July 3, 2026)

--- a/helm-charts/infisical-standalone-postgres/Chart.yaml
+++ b/helm-charts/infisical-standalone-postgres/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -60,7 +60,7 @@ A helm chart to deploy Infisical
 | postgresql.enabled | bool | `true` | Enables an in-cluster PostgreSQL deployment. To achieve HA for Postgres, we recommend deploying https://github.com/zalando/postgres-operator instead. |
 | postgresql.fullnameOverride | string | `"postgresql"` | Full name override for PostgreSQL resources |
 | postgresql.name | string | `"postgresql"` | PostgreSQL resource name |
-| postgresql.useExistingPostgresSecret.enabled | bool | `false` | Set to true if using an existing Kubernetes secret that contains PostgreSQL connection string |
+| postgresql.useExistingPostgresSecret.enabled | bool | `false` | Set to true if using an existing Kubernetes secret that contains PostgreSQL connection string. Also set `postgresql.enabled: false` or the bundled PostgreSQL instance is deployed and left unused. |
 | postgresql.useExistingPostgresSecret.existingConnectionStringSecret.key | string | `""` | Key name in the Kubernetes secret that holds the connection string |
 | postgresql.useExistingPostgresSecret.existingConnectionStringSecret.name | string | `""` | Kubernetes secret name containing the PostgreSQL connection string |
 | redis.architecture | string | `"standalone"` | Redis deployment type (e.g., standalone or cluster) |
@@ -70,7 +70,7 @@ A helm chart to deploy Infisical
 | redis.fullnameOverride | string | `"redis"` | Full name override for Redis resources |
 | redis.name | string | `"redis"` | Redis resource name |
 | redis.usePassword | bool | `true` | Requires a password for Redis authentication |
-| redis.useExistingRedisSecret.enabled | bool | `false` | Set to true if using an existing Kubernetes secret that contains the Redis connection string |
+| redis.useExistingRedisSecret.enabled | bool | `false` | Set to true if using an existing Kubernetes secret that contains the Redis connection string. Also set `redis.enabled: false` or the bundled Redis instance is deployed and left unused. |
 | redis.useExistingRedisSecret.existingConnectionStringSecret.key | string | `""` | Key name in the Kubernetes secret that holds the connection string |
 | redis.useExistingRedisSecret.existingConnectionStringSecret.name | string | `""` | Kubernetes secret name containing the Redis connection string |
 | ingress-nginx.controller.ingressClassResource.name | string | `"infisical-nginx"` | IngressClass name used by the bundled NGINX controller. Uses a unique name to avoid conflicts with existing cluster ingress controllers |

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -1,6 +1,6 @@
 # infisical-standalone
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 1.11.0](https://img.shields.io/badge/Version-1.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 A helm chart to deploy Infisical
 
@@ -70,6 +70,9 @@ A helm chart to deploy Infisical
 | redis.fullnameOverride | string | `"redis"` | Full name override for Redis resources |
 | redis.name | string | `"redis"` | Redis resource name |
 | redis.usePassword | bool | `true` | Requires a password for Redis authentication |
+| redis.useExistingRedisSecret.enabled | bool | `false` | Set to true if using an existing Kubernetes secret that contains the Redis connection string |
+| redis.useExistingRedisSecret.existingConnectionStringSecret.key | string | `""` | Key name in the Kubernetes secret that holds the connection string |
+| redis.useExistingRedisSecret.existingConnectionStringSecret.name | string | `""` | Kubernetes secret name containing the Redis connection string |
 | ingress-nginx.controller.ingressClassResource.name | string | `"infisical-nginx"` | IngressClass name used by the bundled NGINX controller. Uses a unique name to avoid conflicts with existing cluster ingress controllers |
 | ingress-nginx.controller.ingressClassResource.controllerValue | string | `"k8s.io/infisical-nginx"` | Controller value for the bundled IngressClass |
 | ingress-nginx.controller.ingressClassResource.default | bool | `false` | Whether the bundled IngressClass should be set as the cluster default |

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -75,12 +75,17 @@ spec:
             secretKeyRef:
               name: {{ .Values.postgresql.useExistingPostgresSecret.existingConnectionStringSecret.name }}
               key: {{ .Values.postgresql.useExistingPostgresSecret.existingConnectionStringSecret.key }}
-        {{- end }}
-        {{- if .Values.postgresql.enabled }}
+        {{- else if .Values.postgresql.enabled }}
         - name: DB_CONNECTION_URI
           value: {{ include "infisical.postgresDBConnectionString" . }}
         {{- end }}
-        {{- if .Values.redis.enabled }}
+        {{- if .Values.redis.useExistingRedisSecret.enabled }}
+        - name: REDIS_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.redis.useExistingRedisSecret.existingConnectionStringSecret.name }}
+              key: {{ .Values.redis.useExistingRedisSecret.existingConnectionStringSecret.key }}
+        {{- else if .Values.redis.enabled }}
         - name: REDIS_URL
           value: {{ include "infisical.redisConnectionString" . }}
         {{- end }}

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -79,7 +79,7 @@ spec:
         - name: DB_CONNECTION_URI
           value: {{ include "infisical.postgresDBConnectionString" . }}
         {{- end }}
-        {{- if .Values.redis.useExistingRedisSecret.enabled }}
+        {{- if (.Values.redis.useExistingRedisSecret | default dict).enabled }}
         - name: REDIS_URL
           valueFrom:
             secretKeyRef:

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -242,6 +242,15 @@ redis:
   # -- Redis deployment type (e.g., standalone or cluster)
   architecture: standalone
 
+  useExistingRedisSecret:
+    # -- Set to true if using an existing Kubernetes secret that contains the Redis connection string
+    enabled: false
+    existingConnectionStringSecret:
+      # -- Kubernetes secret name containing the Redis connection string
+      name: ""
+      # -- Key name in the Kubernetes secret that holds the connection string
+      key: ""
+
 # -- Configuration for the bundled ingress-nginx subchart (only applies when ingress.nginx.enabled=true)
 ingress-nginx:
   controller:

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -206,7 +206,7 @@ postgresql:
     database: infisicalDB
 
   useExistingPostgresSecret:
-    # -- Set to true if using an existing Kubernetes secret that contains PostgreSQL connection string
+    # -- Set to true if using an existing Kubernetes secret that contains PostgreSQL connection string. Also set `postgresql.enabled: false` or the bundled PostgreSQL instance is deployed and left unused.
     enabled: false
     existingConnectionStringSecret:
       # -- Kubernetes secret name containing the PostgreSQL connection string
@@ -243,7 +243,7 @@ redis:
   architecture: standalone
 
   useExistingRedisSecret:
-    # -- Set to true if using an existing Kubernetes secret that contains the Redis connection string
+    # -- Set to true if using an existing Kubernetes secret that contains the Redis connection string. Also set `redis.enabled: false` or the bundled Redis instance is deployed and left unused.
     enabled: false
     existingConnectionStringSecret:
       # -- Kubernetes secret name containing the Redis connection string


### PR DESCRIPTION
## Context

The `infisical-standalone-postgres` Helm chart always rendered a literal `DB_CONNECTION_URI` env var built from `postgresql.auth.*` values, even when `postgresql.useExistingPostgresSecret.enabled` was also set to source it from a Kubernetes Secret instead. Since both `if` blocks were independent (not mutually exclusive), both env entries rendered, and the plaintext literal value always took precedence over the Secret-based one — making it impossible to fully avoid plaintext passwords in Helm values as intended.

Redis had no existing-secret option at all: `REDIS_URL` could only be generated from `redis.auth.password` in plaintext Helm values.

This change:
- Makes the Postgres `DB_CONNECTION_URI` block `if`/`else if` so only one is ever rendered, and the existing-secret path takes priority when enabled.
- Adds `redis.useExistingRedisSecret` (mirroring `postgresql.useExistingPostgresSecret`) so `REDIS_URL` can also come from a Kubernetes Secret.
- Bumps the chart version to 1.11.0 and updates the README values table and CHANGELOG.

Fixes #7241

## Screenshots

N/A — Helm chart only, no UI change.

## Steps to verify the change

1. `helm dependency build` in `helm-charts/infisical-standalone-postgres`
2. `helm template infisical . --set postgresql.useExistingPostgresSecret.enabled=true --set postgresql.useExistingPostgresSecret.existingConnectionStringSecret.name=infisical-postgresql --set postgresql.useExistingPostgresSecret.existingConnectionStringSecret.key=uri` and confirm the rendered Deployment has exactly one `DB_CONNECTION_URI` env entry, sourced via `secretKeyRef`.
3. Repeat with `redis.useExistingRedisSecret.enabled=true` (+ name/key) and confirm `REDIS_URL` is also sourced via `secretKeyRef`.
4. `helm template` with default values and confirm both env vars still render as literal values exactly as before (no regression).
5. `helm lint .` passes.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format: `fix(helm): stop hardcoding DB/Redis env vars in standalone-postgres chart`
- [x] Tested locally (see steps above)
- [x] Updated docs (README values table + CHANGELOG.md)
- [ ] Updated CLAUDE.md files (not applicable — no cross-cutting pattern change)
- [x] Read the contributing guide