### PR TITLE
fix(ui): use TableCell component for skeleton rows in Secret Sharing tables

### DIFF
--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsTable.tsx
@@ -9,6 +9,7 @@ import {
   Skeleton,
   Table,
   TableBody,
+  TableCell,
   TableHead,
   TableHeader,
   TableRow
@@ -56,9 +57,9 @@ export const RequestedSecretsTable = ({ handlePopUpOpen }: Props) => {
                 <TableRow key={`skeleton-${i}`}>
                   {Array.from({ length: 6 }).map((__, j) => (
                     // eslint-disable-next-line react/no-array-index-key
-                    <td key={`skeleton-cell-${j}`} className="px-3 py-3">
+                    <TableCell key={`skeleton-cell-${j}`}>
                       <Skeleton className="h-4 w-full" />
-                    </td>
+                    </TableCell>
                   ))}
                 </TableRow>
               ))}

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
@@ -9,6 +9,7 @@ import {
   Skeleton,
   Table,
   TableBody,
+  TableCell,
   TableHead,
   TableHeader,
   TableRow
@@ -62,9 +63,9 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
                 <TableRow key={`skeleton-${i}`}>
                   {Array.from({ length: 7 }).map((__, j) => (
                     // eslint-disable-next-line react/no-array-index-key
-                    <td key={`skeleton-cell-${j}`} className="px-3 py-3">
+                    <TableCell key={`skeleton-cell-${j}`}>
                       <Skeleton className="h-4 w-full" />
-                    </td>
+                    </TableCell>
                   ))}
                 </TableRow>
               ))}


### PR DESCRIPTION
## Context

In the Secret Sharing page (`frontend/src/pages/organization/SecretSharingPage`), both `ShareSecretsTable` and `RequestedSecretsTable` components rendered skeleton placeholder loading rows using raw `<td>` elements with manual padding (`px-3 py-3`) instead of the standard `<TableCell>` component from `@app/components/v3`.

This PR replaces the raw `<td>` wrappers with `<TableCell>`, ensuring consistent row height (`h-[40px]`) and standard bottom table borders (`border-b border-border`) during loading states, matching the rest of the platform tables (e.g., `OrgRoleTable`).

## Screenshots

<!-- Video demonstration of loading state -->


https://github.com/user-attachments/assets/08ce2991-fa8f-436c-bcd2-d5f65eab2e69



## Steps to verify the change

1. Navigate to Organization -> Secret Sharing.
2. Enable network throttling (e.g. Slow 3G) in browser DevTools.
3. Refresh or switch between "Share Secrets" and "Request Secrets" tabs.
4. Verify that skeleton loading placeholder rows use `<TableCell>` with consistent height and bottom border dividers.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
