### PR TITLE
fix(secret-expansion): resolve nested relative refs in referenced environment

### DIFF
--- a/backend-go/internal/services/secretmanager/secret/expansion.go
+++ b/backend-go/internal/services/secretmanager/secret/expansion.go
@@ -45,6 +45,7 @@ type SecretExpander struct {
 	fullyExpanded  []bool
 	deniedRefs     map[string]struct{} // cacheKey -> denied by permission check
 	requestedRefs  map[string]struct{} // cacheKey -> already requested (avoid infinite loop)
+	deferred       bool                // a substitution was postponed pending a fetch
 }
 
 // NewSecretExpander creates an expander from priority-ordered secrets.
@@ -120,12 +121,13 @@ func (e *SecretExpander) Expand() {
 		}
 	}
 
-	// Everything fetchable has been fetched. Substitute what remains, including
-	// references that were deferred while their dependencies were still pending.
-	for i := range e.fullyExpanded {
-		e.fullyExpanded[i] = false
+	// A reference is left unsubstituted only when its resolved value still had
+	// unfetched dependencies, so the final substitution pass is needed only in
+	// that case. Running it unconditionally would hand every value a second
+	// depth budget and defeat maxExpansionDepth.
+	if e.deferred {
+		e.expandPass(true)
 	}
-	e.expandPass(true)
 
 	e.replaceDeniedRefs()
 	e.replaceNotFoundRefs()
@@ -292,6 +294,7 @@ func (e *SecretExpander) expandValue(
 		// resolve it with the correct environment context; substituting a
 		// partially expanded value here would strip that context away.
 		if pending && !final {
+			e.deferred = true
 			continue
 		}
 

--- a/backend-go/internal/services/secretmanager/secret/expansion.go
+++ b/backend-go/internal/services/secretmanager/secret/expansion.go
@@ -74,7 +74,7 @@ func NewSecretExpander(secrets []*ProcessedSecret, opts ExpandOpts) *SecretExpan
 // It iteratively expands references, fetching absolute refs as needed.
 func (e *SecretExpander) Expand() {
 	for {
-		needed := e.expandPass()
+		needed := e.expandPass(false)
 		if len(needed) == 0 {
 			break
 		}
@@ -120,6 +120,13 @@ func (e *SecretExpander) Expand() {
 		}
 	}
 
+	// Everything fetchable has been fetched. Substitute what remains, including
+	// references that were deferred while their dependencies were still pending.
+	for i := range e.fullyExpanded {
+		e.fullyExpanded[i] = false
+	}
+	e.expandPass(true)
+
 	e.replaceDeniedRefs()
 	e.replaceNotFoundRefs()
 }
@@ -141,7 +148,12 @@ func (e *SecretExpander) HasDeniedRefs() bool {
 
 // expandPass expands all references in current values.
 // Returns list of absolute refs that are needed but not yet available.
-func (e *SecretExpander) expandPass() []AbsoluteSecretRef {
+//
+// When final is false, a reference whose resolved value still depends on
+// un-fetched secrets is left untouched so the next pass can re-resolve it with
+// the full environment context. When final is true, anything still unresolved
+// (missing or permission-denied) collapses to an empty string.
+func (e *SecretExpander) expandPass(final bool) []AbsoluteSecretRef {
 	neededRefs := make(map[string]AbsoluteSecretRef)
 
 	for i, sec := range e.secrets {
@@ -149,7 +161,7 @@ func (e *SecretExpander) expandPass() []AbsoluteSecretRef {
 			continue
 		}
 
-		expanded, needed := e.expandValue(sec.Value, make(map[string]struct{}), 0)
+		expanded, needed := e.expandValue(sec.Value, sec.Environment, sec.SecretPath, true, final, make(map[string]struct{}), 0)
 		sec.Value = expanded
 
 		if len(needed) == 0 && !hasReferences(expanded) {
@@ -179,7 +191,15 @@ func (e *SecretExpander) expandPass() []AbsoluteSecretRef {
 // This happens because the outer ${A} resolves to the inner expansion result,
 // where the cycle was detected and replaced with empty string. This is intentional
 // behavior matching the Node.js implementation.
-func (e *SecretExpander) expandValue(value string, visited map[string]struct{}, depth int) (string, []AbsoluteSecretRef) {
+func (e *SecretExpander) expandValue(
+	value string,
+	ownerEnv string,
+	ownerPath string,
+	isLocal bool,
+	final bool,
+	visited map[string]struct{},
+	depth int,
+) (string, []AbsoluteSecretRef) {
 	if depth > maxExpansionDepth {
 		return value, nil
 	}
@@ -199,56 +219,80 @@ func (e *SecretExpander) expandValue(value string, visited map[string]struct{}, 
 		var resolvedValue string
 		var secretID string
 		var found bool
+		var pending bool
 
-		if len(parts) == 1 {
-			// Relative reference: ${KEY}
+		if len(parts) == 1 && isLocal {
+			// Relative reference inside a secret from the requested board:
+			// resolve against the local (import-aware) lookup.
 			found = true // Always replace relative refs (with empty if not found)
 			if sec := e.localLookup[parts[0]]; sec != nil {
 				secretID = sec.Environment + ":" + sec.SecretPath + ":" + sec.Secret.Key
 
 				if _, cyclic := visited[secretID]; !cyclic {
 					visited[secretID] = struct{}{}
-					expandedValue, moreNeeded := e.expandValue(sec.Value, visited, depth+1)
+					expandedValue, moreNeeded := e.expandValue(sec.Value, sec.Environment, sec.SecretPath, true, final, visited, depth+1)
 					delete(visited, secretID)
 					resolvedValue = expandedValue
 					neededRefs = append(neededRefs, moreNeeded...)
+					pending = len(moreNeeded) > 0
 				}
 				// else: cyclic, resolvedValue stays ""
 			}
 			// else: not found, resolvedValue stays "" (missing ref becomes empty)
 		} else {
-			// Absolute reference: ${env.path.KEY}
-			env := parts[0]
-			secretKey := parts[len(parts)-1]
-			pathParts := parts[1 : len(parts)-1]
-			path := "/"
-			if len(pathParts) > 0 {
-				path = "/" + strings.Join(pathParts, "/")
+			// Either an absolute reference ${env.path.KEY}, or a relative
+			// reference inside a secret that was itself fetched from another
+			// environment/path. The latter must resolve against that secret's
+			// own location, not the requested board.
+			var ref AbsoluteSecretRef
+			if len(parts) == 1 {
+				ref = AbsoluteSecretRef{Env: ownerEnv, Path: ownerPath, Key: parts[0]}
+			} else {
+				secretKey := parts[len(parts)-1]
+				pathParts := parts[1 : len(parts)-1]
+				path := "/"
+				if len(pathParts) > 0 {
+					path = "/" + strings.Join(pathParts, "/")
+				}
+				ref = AbsoluteSecretRef{Env: parts[0], Path: path, Key: secretKey}
 			}
 
-			ref := AbsoluteSecretRef{Env: env, Path: path, Key: secretKey}
 			secretID = ref.CacheKey()
-			locationKey := env + ":" + path
+			locationKey := ref.Env + ":" + ref.Path
 
 			if secrets, ok := e.absoluteLookup[locationKey]; ok {
-				if sec, ok := secrets[secretKey]; ok {
+				if sec, ok := secrets[ref.Key]; ok {
 					found = true
 
 					if _, cyclic := visited[secretID]; !cyclic {
 						visited[secretID] = struct{}{}
-						expandedValue, moreNeeded := e.expandValue(sec.Value, visited, depth+1)
+						expandedValue, moreNeeded := e.expandValue(sec.Value, ref.Env, ref.Path, false, final, visited, depth+1)
 						delete(visited, secretID)
 						resolvedValue = expandedValue
 						neededRefs = append(neededRefs, moreNeeded...)
+						pending = len(moreNeeded) > 0
 					}
 					// else: cyclic, resolvedValue stays ""
 				}
 			}
 
 			if !found {
-				neededRefs = append(neededRefs, ref)
-				continue
+				if !final {
+					neededRefs = append(neededRefs, ref)
+					continue
+				}
+				// Final pass: the secret is missing or was denied by the
+				// permission check, so the reference collapses to empty.
+				found = true
 			}
+		}
+
+		// The resolved value still depends on secrets that have not been
+		// fetched yet. Leave the reference in place so the next pass can
+		// resolve it with the correct environment context; substituting a
+		// partially expanded value here would strip that context away.
+		if pending && !final {
+			continue
 		}
 
 		if found {

--- a/backend-go/internal/services/secretmanager/secret/expansion_test.go
+++ b/backend-go/internal/services/secretmanager/secret/expansion_test.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -367,6 +368,25 @@ func TestExpand_MaxDepth(t *testing.T) {
 	expander.Expand()
 
 	assert.Contains(t, secrets[0].Value, "levelA-")
+}
+
+// maxExpansionDepth bounds the whole Expand() call for a local chain: no later
+// pass may hand an already-expanded value a fresh depth budget and carry the
+// chain further than the cap allows.
+func TestExpand_MaxDepth_NotExtendedByLaterPasses(t *testing.T) {
+	const chainLen = 25
+	secrets := make([]*ProcessedSecret, chainLen)
+	for i := range chainLen {
+		value := "end"
+		if i < chainLen-1 {
+			value = fmt.Sprintf("L%02d-${K%02d}", i, i+1)
+		}
+		secrets[i] = newTestSecret(fmt.Sprintf("K%02d", i), value, "dev", "/")
+	}
+
+	NewSecretExpander(secrets, ExpandOpts{}).Expand()
+
+	assert.Equal(t, "L00-L01-L02-L03-L04-L05-L06-L07-L08-L09-L10-L11-${K12}", secrets[0].Value)
 }
 
 func TestExpand_MultipleReferencesInSingleValue(t *testing.T) {

--- a/backend-go/internal/services/secretmanager/secret/expansion_test.go
+++ b/backend-go/internal/services/secretmanager/secret/expansion_test.go
@@ -189,24 +189,65 @@ func TestExpand_AbsoluteReference_DeepPath(t *testing.T) {
 	assert.Equal(t, "deep-value", secrets[0].Value)
 }
 
+// A relative reference inside a secret reached through an absolute reference
+// resolves against that secret's own environment and path, not the environment
+// of the secret being expanded. Here prod's LOCAL_VAR must win over the
+// same-named key in dev.
 func TestExpand_AbsoluteReference_WithNestedRelative(t *testing.T) {
 	secrets := []*ProcessedSecret{
-		newTestSecret("LOCAL_VAR", "local-resolved", "dev", "/"),
+		newTestSecret("LOCAL_VAR", "dev-value", "dev", "/"),
 		newTestSecret("A", "${prod.USES_LOCAL}", "dev", "/"),
 	}
 
+	var requested []string
 	opts := ExpandOpts{
 		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
-			return []*ProcessedSecret{
-				newTestSecret("USES_LOCAL", "prefix-${LOCAL_VAR}-suffix", "prod", "/"),
+			var fetched []*ProcessedSecret
+			for _, ref := range refs {
+				requested = append(requested, ref.CacheKey())
+				switch {
+				case ref.Env == "prod" && ref.Key == "USES_LOCAL":
+					fetched = append(fetched, newTestSecret("USES_LOCAL", "prefix-${LOCAL_VAR}-suffix", "prod", "/"))
+				case ref.Env == "prod" && ref.Key == "LOCAL_VAR":
+					fetched = append(fetched, newTestSecret("LOCAL_VAR", "prod-value", "prod", "/"))
+				}
 			}
+			return fetched
 		},
 	}
 
 	expander := NewSecretExpander(secrets, opts)
 	expander.Expand()
 
-	assert.Equal(t, "prefix-local-resolved-suffix", secrets[1].Value)
+	assert.Equal(t, "prefix-prod-value-suffix", secrets[1].Value)
+	assert.Contains(t, requested, "prod:/:LOCAL_VAR", "nested relative ref must be resolved in prod")
+	assert.Equal(t, "dev-value", secrets[0].Value)
+}
+
+// A nested relative reference that does not exist in the referenced environment
+// must not silently fall back to a same-named key on the requested board.
+func TestExpand_AbsoluteReference_NestedRelativeNoLocalFallback(t *testing.T) {
+	secrets := []*ProcessedSecret{
+		newTestSecret("HOST", "dev-host", "dev", "/"),
+		newTestSecret("API_URL", "${prod.URL}", "dev", "/"),
+	}
+
+	opts := ExpandOpts{
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			var fetched []*ProcessedSecret
+			for _, ref := range refs {
+				if ref.Env == "prod" && ref.Key == "URL" {
+					fetched = append(fetched, newTestSecret("URL", "https://${HOST}/api", "prod", "/"))
+				}
+			}
+			return fetched
+		},
+	}
+
+	expander := NewSecretExpander(secrets, opts)
+	expander.Expand()
+
+	assert.Equal(t, "https:///api", secrets[1].Value)
 }
 
 func TestExpand_AbsoluteReference_ChainedAbsolute(t *testing.T) {


### PR DESCRIPTION
## Context

Closes #7459.

In `backend-go`, a relative reference (`${KEY}`) that appears inside a secret reached through an absolute reference (`${env.path.KEY}`) was resolved against the **requesting** board's environment/path rather than the referenced secret's own environment/path.

With `HOST` defined in both `dev` and `prod`, and `prod`'s `URL = https://${HOST}/api`, reading `${prod.URL}` from `dev` returned `https://dev-host/api` instead of `https://prod-host/api`. The expander never issued a read for `prod:/:HOST` at all — `${HOST}` was served from `localLookup`, which only holds secrets from the requested board and its imports.

Node resolves this correctly: `recursivelyExpandSecret` pushes the referenced secret's own `environment`/`secretPath` onto the expansion stack, so nested single-part refs resolve there. Since both backends serve `/api/v4/secrets` and the Go sidecar is shadow-compared against Node in `go-sidecar-shadowing.ts`, this surfaced as a `value_mismatch` — and produced a value for a `prod` reference that was partly composed from `dev` data.

### What changed

- `expandValue` now carries the environment/path that owns the value being expanded, plus an `isLocal` flag. Single-part refs use the import-aware `localLookup` only while expanding secrets from the requested board; inside a secret fetched from elsewhere they resolve as `{ownerEnv, ownerPath, KEY}` and are fetched like any other absolute ref.
- Substitution of a reference is deferred while its resolved value still has unfetched dependencies. Writing a partially expanded value into the parent would erase the environment context needed to resolve what remains — the reference is left in place so the next pass can resolve it with the full context.
- `Expand()` ends with a final pass that substitutes whatever is left, so missing or permission-denied refs still collapse to an empty string exactly as before.

`TestExpand_AbsoluteReference_WithNestedRelative` asserted the old behavior and has been updated. Its `FetchAbsoluteSecrets` mock returned the same secret regardless of which refs were requested, so the prod-side key was never exercised — that is why the bug went unnoticed. The mock now responds per-ref, and the test asserts both the expanded value and that `prod:/:LOCAL_VAR` was actually requested.

## Steps to verify the change

```bash
cd backend-go
make test-unit   # all packages pass
make lint        # 0 issues
```

To see the old behavior, check out `main` and run the repro in the linked issue — it returns `https://dev-host/api` and never requests `prod:/:HOST`.

New/updated tests:

- `TestExpand_AbsoluteReference_WithNestedRelative` — nested relative ref resolves in the referenced env; prod's `LOCAL_VAR` wins over the same-named key in `dev`.
- `TestExpand_AbsoluteReference_NestedRelativeNoLocalFallback` — when the key is absent in the referenced env, it expands to empty rather than silently falling back to the requesting board.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

## Note on a related mismatch

While tracing this I noticed a second, separate Node/Go divergence: Node was deliberately changed in `1e3a28c71f` ("keep literal `${ref}` when referenced secret does not exist"), while Go still substitutes an empty string for missing refs. I kept this PR to the environment-resolution bug and left Go's existing missing-ref behavior untouched. Happy to follow up with that in a separate PR if you'd like it aligned.
