### PR TITLE
fix: serialize slot claims, isolate e2e cron namespace and fix test flakiness

### DIFF
--- a/backend/e2e-test/cron-job.spec.ts
+++ b/backend/e2e-test/cron-job.spec.ts
@@ -133,8 +133,6 @@ beforeEach(async () => {
 }, 25_000);
 
 afterEach(async () => {
-  // Release parked handlers first so stop() drains instead of waiting out
-  // drainTimeoutMs, and so their handler-timeout timers get cleared.
   parkedHandlers.splice(0).forEach((release) => release());
   await Promise.allSettled(allFactories.map((f) => f.stop()));
   await clearNamespace();

--- a/backend/e2e-test/cron-job.spec.ts
+++ b/backend/e2e-test/cron-job.spec.ts
@@ -7,6 +7,28 @@ import { initLogger } from "@app/lib/logger";
 // testRedis is injected by vitest-environment-knex.ts
 declare const testRedis: Redis;
 
+// ── key namespace ─────────────────────────────────────────────────────────────
+
+// `testRedis` is the *same* connection the test server runs on, and
+// vitest-environment-knex.ts starts the server's real cron manager
+// (routes/index.ts calls `cronJob.start()` unconditionally). That manager holds
+// a `{cron}:slot:N` key of its own and re-claims it within `slotRefreshMs` of
+// any deletion, so asserting on the production namespace here would
+// intermittently observe the server's slot and fail.
+//
+// These tests therefore run in their own namespace and clean up by prefix
+// instead of `flushdb()` — a flush would also wipe the shared server's BullMQ
+// queues, keystore caches, and cron leases mid-run.
+const KEY_PREFIX = "{cron-e2e}";
+const SLOT_KEYS = `${KEY_PREFIX}:slot:*`;
+const RUN_KEYS = (name: string) => `${KEY_PREFIX}:run:${name}:*`;
+const PENDING_ZSET = `${KEY_PREFIX}:pending`;
+
+const clearNamespace = async () => {
+  const keys = await testRedis.keys(`${KEY_PREFIX}:*`);
+  if (keys.length) await testRedis.del(...keys);
+};
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // Simple in-memory lock manager for test redlock
@@ -42,6 +64,7 @@ const makeFactory = (overrides?: Partial<Parameters<typeof cronJobFactory>[0]>) 
   return cronJobFactory({
     redis,
     redlock,
+    keyPrefix: KEY_PREFIX,
     slotTtlMs: 500,
     slotRefreshMs: 100,
     enqueueIntervalMs: 500,
@@ -68,11 +91,26 @@ const factory = (overrides?: Partial<Parameters<typeof cronJobFactory>[0]>) => {
   return f;
 };
 
+// A handler that never settles on its own, simulating a wedged network call.
+// The resolver is parked so afterEach can release it: an abandoned handler
+// leaves `withTimeout`'s race unsettled, so its `finally` never runs and its
+// (up to 30s) timer keeps the fork's event loop alive past the test.
+const parkedHandlers: Array<() => void> = [];
+const hangingHandler = () =>
+  vi.fn().mockImplementation(
+    () =>
+      new Promise<void>((resolve) => {
+        parkedHandlers.push(resolve);
+      })
+  );
+
 // FAST_PATTERN fires every minute, so a test that waits ~5s and asserts
 // "exactly one fire happened" will spuriously see two when the wait crosses a
 // minute boundary. This helper pads beforeEach to start the test at least
 // MIN_HEADROOM_MS away from the next boundary, so no test wait can straddle it.
-const MIN_HEADROOM_MS = 10_000;
+// Headroom is 3x the longest in-test wait (5s) so an event-loop stall under CI
+// contention still can't push a wait across the boundary.
+const MIN_HEADROOM_MS = 15_000;
 const waitForFreshMinute = async () => {
   const msUntilNext = 60_000 - (Date.now() % 60_000);
   if (msUntilNext < MIN_HEADROOM_MS) {
@@ -87,15 +125,19 @@ beforeAll(() => {
 });
 
 beforeEach(async () => {
-  await testRedis.flushdb();
+  await clearNamespace();
   allFactories.length = 0;
   lockManager.clear();
+  parkedHandlers.length = 0;
   await waitForFreshMinute();
-}, 20_000);
+}, 25_000);
 
 afterEach(async () => {
+  // Release parked handlers first so stop() drains instead of waiting out
+  // drainTimeoutMs, and so their handler-timeout timers get cleared.
+  parkedHandlers.splice(0).forEach((release) => release());
   await Promise.allSettled(allFactories.map((f) => f.stop()));
-  await testRedis.flushdb();
+  await clearNamespace();
   vi.useRealTimers();
 });
 
@@ -114,7 +156,7 @@ describe("single pod", () => {
     });
 
     expect(handler).toHaveBeenCalled();
-    const keys = await testRedis.keys("{cron}:run:test-job:*");
+    const keys = await testRedis.keys(RUN_KEYS("test-job"));
     expect(keys.length).toBe(1);
     const run = await testRedis.hgetall(keys[0]);
     expect(run.status).toBe("completed");
@@ -137,7 +179,7 @@ describe("multi-pod single fire", () => {
       setTimeout(r, 4000);
     });
 
-    const keys = await testRedis.keys("{cron}:run:shared-job:*");
+    const keys = await testRedis.keys(RUN_KEYS("shared-job"));
     expect(keys.length).toBe(1);
     const run = await testRedis.hgetall(keys[0]);
     expect(run.status).toBe("completed");
@@ -148,9 +190,14 @@ describe("multi-pod single fire", () => {
 
 // ── slot exhaustion: N+1 factories, exactly N participate ─────────────────────
 
+// A slot TTL comfortably longer than these tests, so a slot can only disappear
+// by being explicitly released — never by lapsing during an event-loop stall.
+// That makes the exact-count assertions below safe to state as equalities.
+const STABLE_SLOTS = { slotTtlMs: 30_000, slotRefreshMs: 1_000 };
+
 describe("slot exhaustion", () => {
   test("only PARTICIPANT_SLOTS=5 out of 6 factories claim a slot", async () => {
-    const factories = Array.from({ length: 6 }, () => factory());
+    const factories = Array.from({ length: 6 }, () => factory(STABLE_SLOTS));
     factories.forEach((f) => f.register({ name: `j`, pattern: FAST_PATTERN, handler: vi.fn(), runHashTtlS: 3600 }));
     factories.forEach((f) => f.start());
 
@@ -159,8 +206,8 @@ describe("slot exhaustion", () => {
       setTimeout(r, 2000);
     });
 
-    const slotKeys = await testRedis.keys("{cron}:slot:*");
-    expect(slotKeys.length).toBeLessThanOrEqual(5);
+    const slotKeys = await testRedis.keys(SLOT_KEYS);
+    expect(slotKeys.length).toBe(5);
   }, 8_000);
 });
 
@@ -168,19 +215,19 @@ describe("slot exhaustion", () => {
 
 describe("slot handover", () => {
   test("stopping a participant frees its slot for another factory", async () => {
-    const factories = Array.from({ length: 6 }, () => factory());
+    const factories = Array.from({ length: 6 }, () => factory(STABLE_SLOTS));
     factories.forEach((f) => f.register({ name: `h`, pattern: FAST_PATTERN, handler: vi.fn(), runHashTtlS: 3600 }));
     factories.forEach((f) => f.start());
 
     await new Promise((r) => {
       setTimeout(r, 2000);
     });
-    const slotsBefore = await testRedis.keys("{cron}:slot:*");
-    expect(slotsBefore.length).toBeLessThanOrEqual(5);
+    const slotsBefore = await testRedis.keys(SLOT_KEYS);
+    expect(slotsBefore.length).toBe(5);
 
     // Stop all — this releases slots
     await Promise.all(factories.map((f) => f.stop()));
-    const slotsAfter = await testRedis.keys("{cron}:slot:*");
+    const slotsAfter = await testRedis.keys(SLOT_KEYS);
     expect(slotsAfter.length).toBe(0);
   }, 8_000);
 });
@@ -202,7 +249,7 @@ describe("retry", () => {
       setTimeout(r, 4000);
     });
 
-    const keys = await testRedis.keys("{cron}:run:retry-job:*");
+    const keys = await testRedis.keys(RUN_KEYS("retry-job"));
     expect(keys.length).toBe(1);
     const run = await testRedis.hgetall(keys[0]);
     // After first failure + retry success, should be completed
@@ -220,7 +267,7 @@ describe("retry", () => {
       setTimeout(r, 5000);
     });
 
-    const keys = await testRedis.keys("{cron}:run:fail-job:*");
+    const keys = await testRedis.keys(RUN_KEYS("fail-job"));
     expect(keys.length).toBe(1);
     const run = await testRedis.hgetall(keys[0]);
     expect(run.status).toBe("failed");
@@ -237,7 +284,7 @@ describe("handler timeout", () => {
     // handlerTimeoutMs fires, the zombie is still running in this process,
     // so the run must NOT be re-picked-up by this or another pod — the next
     // scheduled fire (separate id) is the natural retry.
-    const handler = vi.fn().mockImplementation(() => new Promise<void>(() => {}));
+    const handler = hangingHandler();
     const f = factory({
       handlerTimeoutMs: 500,
       retryBackoffBaseMs: 100,
@@ -257,14 +304,14 @@ describe("handler timeout", () => {
     // no retry can be scheduled for this id.
     expect(handler).toHaveBeenCalledTimes(1);
 
-    const keys = await testRedis.keys("{cron}:run:hang-job:*");
+    const keys = await testRedis.keys(RUN_KEYS("hang-job"));
     expect(keys.length).toBe(1);
     const run = await testRedis.hgetall(keys[0]);
     expect(run.status).toBe("failed");
     expect(run.last_error).toContain("exceeded");
 
     // The id is removed from the pending zset so no further tick can re-process it.
-    const pending = await testRedis.zrange("{cron}:pending", 0, -1);
+    const pending = await testRedis.zrange(PENDING_ZSET, 0, -1);
     expect(pending.filter((s) => s.startsWith("hang-job:"))).toEqual([]);
   }, 10_000);
 });
@@ -305,10 +352,10 @@ describe("retry backoff", () => {
       setTimeout(r, 2_000);
     });
 
-    const keys = await testRedis.keys("{cron}:run:score-job:*");
+    const keys = await testRedis.keys(RUN_KEYS("score-job"));
     expect(keys.length).toBe(1);
-    const id = keys[0].replace("{cron}:run:", "");
-    const score = await testRedis.zscore("{cron}:pending", id);
+    const id = keys[0].replace(`${KEY_PREFIX}:run:`, "");
+    const score = await testRedis.zscore(PENDING_ZSET, id);
     expect(score).not.toBeNull();
     expect(Number(score)).toBeGreaterThan(Date.now());
     expect(handler).toHaveBeenCalledTimes(1);
@@ -331,7 +378,7 @@ describe("next-fire guard", () => {
     });
 
     expect(handler).toHaveBeenCalledTimes(1);
-    const keys = await testRedis.keys("{cron}:run:guard-job:*");
+    const keys = await testRedis.keys(RUN_KEYS("guard-job"));
     expect(keys.length).toBe(1);
     const run = await testRedis.hgetall(keys[0]);
     expect(run.status).toBe("failed");
@@ -352,7 +399,7 @@ describe("ZSET cleanup", () => {
       setTimeout(r, 3000);
     });
 
-    const pending = await testRedis.zrange("{cron}:pending", 0, -1);
+    const pending = await testRedis.zrange(PENDING_ZSET, 0, -1);
     expect(pending.filter((s) => s.startsWith("clean-job:"))).toEqual([]);
   }, 10_000);
 });
@@ -375,7 +422,7 @@ describe("min-age gate", () => {
       setTimeout(r, 700);
     });
 
-    const keys = await testRedis.keys("{cron}:run:age-gate-job:*");
+    const keys = await testRedis.keys(RUN_KEYS("age-gate-job"));
     expect(keys.length).toBe(1); // run is in Redis
     expect(handler).not.toHaveBeenCalled(); // but age gate is holding it back
 
@@ -446,8 +493,13 @@ describe("graceful shutdown", () => {
   // grace window: stop() falls back to lease-TTL crash recovery once the
   // drain timer expires.
   test("stop() releases the slot even when an in-flight handler hangs past drainTimeoutMs", async () => {
-    const handler = vi.fn().mockImplementation(() => new Promise<void>(() => {})); // never resolves
-    const f = factory({ leaseDurationMs: 30_000, handlerTimeoutMs: 30_000, drainTimeoutMs: 300 });
+    const handler = hangingHandler(); // never resolves until afterEach releases it
+    const f = factory({
+      ...STABLE_SLOTS,
+      leaseDurationMs: 30_000,
+      handlerTimeoutMs: 30_000,
+      drainTimeoutMs: 300
+    });
     f.register({ name: "hang-drain-job", pattern: FAST_PATTERN, handler, runHashTtlS: 3600 });
     f.start();
 
@@ -456,8 +508,8 @@ describe("graceful shutdown", () => {
     });
     expect(handler).toHaveBeenCalled();
 
-    const slotKeysBefore = await testRedis.keys("{cron}:slot:*");
-    expect(slotKeysBefore.length).toBeGreaterThan(0);
+    const slotKeysBefore = await testRedis.keys(SLOT_KEYS);
+    expect(slotKeysBefore.length).toBe(1);
 
     const startedAt = Date.now();
     await f.stop();
@@ -466,7 +518,7 @@ describe("graceful shutdown", () => {
     // Drain timed out; stop() returned within drainTimeoutMs + buffer rather
     // than blocking on the hung handler. The slot was released atomically.
     expect(elapsed).toBeLessThan(2_000);
-    const slotKeysAfter = await testRedis.keys("{cron}:slot:*");
+    const slotKeysAfter = await testRedis.keys(SLOT_KEYS);
     expect(slotKeysAfter.length).toBe(0);
   }, 10_000);
 });

--- a/backend/e2e-test/routes/v1/access-approval-policy.spec.ts
+++ b/backend/e2e-test/routes/v1/access-approval-policy.spec.ts
@@ -8,6 +8,27 @@ import { ApproverType } from "@app/ee/services/access-approval-policy/access-app
 
 const getDb = () => (globalThis as unknown as { testDb: Knex }).testDb;
 
+// Policies are created on the *shared* seeded project and environment, so any
+// that outlive this file change how later specs behave. Nothing in the suite
+// exercises access requests today, which is the only reason leftovers here have
+// been harmless — the sibling secret-approval leak silently broke secret writes
+// at "/" for every later spec. Track what we create and remove it after each
+// test rather than relying on that staying true.
+const createdPolicyIds: string[] = [];
+
+const deletePolicy = async (policyId: string) => {
+  const res = await testServer.inject({
+    method: "DELETE",
+    url: `/api/v1/access-approvals/policies/${policyId}`,
+    headers: {
+      authorization: `Bearer ${jwtAuthToken}`
+    }
+  });
+  if (res.statusCode !== 200 && res.statusCode !== 404) {
+    throw new Error(`cleanup: unexpected ${res.statusCode} deleting policy ${policyId} — ${res.payload}`);
+  }
+};
+
 const createPolicy = async (dto: {
   name: string;
   secretPath: string;
@@ -31,11 +52,15 @@ const createPolicy = async (dto: {
   });
 
   expect(res.statusCode).toBe(200);
-  return res.json().approval;
+  const { approval } = res.json();
+  createdPolicyIds.push(approval.id);
+  return approval;
 };
 
-const createPolicyWithGroupApprover = (dto: { name: string; groupId: string; secretPath: string }) =>
-  testServer.inject({
+// Returns the raw response because callers assert on rejections too, so only
+// register a policy when one was actually created.
+const createPolicyWithGroupApprover = async (dto: { name: string; groupId: string; secretPath: string }) => {
+  const res = await testServer.inject({
     method: "POST",
     url: `/api/v1/access-approvals/policies`,
     headers: {
@@ -50,6 +75,12 @@ const createPolicyWithGroupApprover = (dto: { name: string; groupId: string; sec
       approvals: 1
     }
   });
+
+  if (res.statusCode === 200) {
+    createdPolicyIds.push(res.json().approval.id);
+  }
+  return res;
+};
 
 const seedGroup = async (db: Knex, dto: { slug: string; addToProject: boolean }) => {
   const [group] = await db(TableName.Groups)
@@ -95,6 +126,13 @@ const cleanupGroup = async (db: Knex, groupId: string) => {
 };
 
 describe("Access approval policy router", async () => {
+  // The update test hard-deletes its own policy rows in a finally, so its id is
+  // already gone by the time this runs — deletePolicy tolerates the 404.
+  afterEach(async () => {
+    const ids = createdPolicyIds.splice(0);
+    await Promise.all(ids.map(deletePolicy));
+  });
+
   test("Create policy", async () => {
     const policy = await createPolicy({
       secretPath: "/",

--- a/backend/e2e-test/routes/v1/identity-access-token-redesign.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-access-token-redesign.spec.ts
@@ -462,9 +462,6 @@ describe("Identity Access Token — redesigned JWT flow", () => {
       expect(revocation.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedExpiresAtMs - 2_000);
       expect(revocation.expiresAt.getTime()).toBeLessThanOrEqual(expectedExpiresAtMs + markerSkewMs + 2_000);
 
-      // Drop only this identity's cached allow-verdicts so the next call
-      // re-checks Postgres. A flushdb() would also wipe the shared server's
-      // BullMQ queues, keystore, and cron leases mid-run.
       await dropRevocationVerdicts(identityId);
 
       expect((await callDetailsEndpoint(accessToken)).statusCode).toBe(401);

--- a/backend/e2e-test/routes/v1/identity-access-token-redesign.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-access-token-redesign.spec.ts
@@ -135,6 +135,13 @@ const deleteOrgIdentityMembership = async (identityId: string) => {
   await testRedis.incr(KeyStorePrefixes.IdentityRevocationVersion(identityId));
 };
 
+// Clears this identity's cached revocation verdicts, forcing the next request
+// to re-resolve against Postgres.
+const dropRevocationVerdicts = async (identityId: string) => {
+  const keys = await testRedis.keys(`${KeyStorePrefixes.IdentityRevocationVerdict(identityId, "")}*`);
+  if (keys.length) await testRedis.del(...keys);
+};
+
 const waitForRevocationRow = async (tokenId: string) => {
   const deadline = Date.now() + 10_000;
 
@@ -455,7 +462,10 @@ describe("Identity Access Token — redesigned JWT flow", () => {
       expect(revocation.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedExpiresAtMs - 2_000);
       expect(revocation.expiresAt.getTime()).toBeLessThanOrEqual(expectedExpiresAtMs + markerSkewMs + 2_000);
 
-      await testRedis.flushdb("SYNC");
+      // Drop only this identity's cached allow-verdicts so the next call
+      // re-checks Postgres. A flushdb() would also wipe the shared server's
+      // BullMQ queues, keystore, and cron leases mid-run.
+      await dropRevocationVerdicts(identityId);
 
       expect((await callDetailsEndpoint(accessToken)).statusCode).toBe(401);
     } finally {

--- a/backend/e2e-test/routes/v1/scim.spec.ts
+++ b/backend/e2e-test/routes/v1/scim.spec.ts
@@ -211,7 +211,9 @@ describe("SCIM v1 Router", () => {
       });
 
       // Small delay to ensure different createdAt timestamps
-      await new Promise<void>((resolve) => setTimeout(() => resolve(), 50));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 50);
+      });
 
       await db(TableName.UserAliases).insert({
         userId: user.id,

--- a/backend/e2e-test/routes/v1/secret-approval-policy.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-approval-policy.spec.ts
@@ -8,6 +8,26 @@ import { ApproverType } from "@app/ee/services/access-approval-policy/access-app
 
 const getDb = () => (globalThis as unknown as { testDb: Knex }).testDb;
 
+// Policies are created on the *shared* seeded project and environment, so any
+// that outlive this file change how every later spec behaves: a policy at "/"
+// makes secret writes there return an approval request instead of a secret,
+// which breaks specs that have nothing to do with approvals. Track what we
+// create and remove it after each test.
+const createdPolicyIds: string[] = [];
+
+const deletePolicy = async (sapId: string) => {
+  const res = await testServer.inject({
+    method: "DELETE",
+    url: `/api/v1/secret-approvals/${sapId}`,
+    headers: {
+      authorization: `Bearer ${jwtAuthToken}`
+    }
+  });
+  if (res.statusCode !== 200 && res.statusCode !== 404) {
+    throw new Error(`cleanup: unexpected ${res.statusCode} deleting policy ${sapId} — ${res.payload}`);
+  }
+};
+
 const createPolicy = async (dto: {
   name: string;
   secretPath: string;
@@ -31,11 +51,15 @@ const createPolicy = async (dto: {
   });
 
   expect(res.statusCode).toBe(200);
-  return res.json().approval;
+  const { approval } = res.json();
+  createdPolicyIds.push(approval.id);
+  return approval;
 };
 
-const createPolicyWithGroupApprover = (dto: { name: string; groupId: string; secretPath: string }) =>
-  testServer.inject({
+// Returns the raw response because callers assert on rejections too, so only
+// register a policy when one was actually created.
+const createPolicyWithGroupApprover = async (dto: { name: string; groupId: string; secretPath: string }) => {
+  const res = await testServer.inject({
     method: "POST",
     url: `/api/v1/secret-approvals`,
     headers: {
@@ -50,6 +74,12 @@ const createPolicyWithGroupApprover = (dto: { name: string; groupId: string; sec
       approvals: 1
     }
   });
+
+  if (res.statusCode === 200) {
+    createdPolicyIds.push(res.json().approval.id);
+  }
+  return res;
+};
 
 const seedGroup = async (db: Knex, dto: { slug: string; addToProject: boolean }) => {
   const [group] = await db(TableName.Groups)
@@ -95,6 +125,11 @@ const cleanupGroup = async (db: Knex, groupId: string) => {
 };
 
 describe("Secret approval policy router", async () => {
+  afterEach(async () => {
+    const ids = createdPolicyIds.splice(0);
+    await Promise.all(ids.map(deletePolicy));
+  });
+
   test("Create policy", async () => {
     const policy = await createPolicy({
       secretPath: "/",

--- a/backend/e2e-test/routes/v1/secret-replication.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-replication.spec.ts
@@ -1,45 +1,25 @@
 import { createFolder, deleteFolder } from "e2e-test/testUtils/folders";
 import { createSecretImport, deleteSecretImport } from "e2e-test/testUtils/secret-imports";
-import { createSecretV2, deleteSecretV2, getSecretByNameV2, getSecretsV2 } from "e2e-test/testUtils/secrets";
+import { createSecretV2, deleteSecretV2, getSecretsV2, waitForReplicatedSecret } from "e2e-test/testUtils/secrets";
 
 import { seedData1 } from "@app/db/seed-data";
 
-// Replication runs asynchronously through BullMQ, so the imported secret shows
-// up some time after the write. Poll for it instead of sleeping a fixed 10s: a
-// fixed wait is simultaneously too short (it flakes whenever CI contention
-// pushes replication past the deadline) and too long (it burns the full 10s on
-// every pass, even though replication usually lands in well under a second).
-const REPLICATION_TIMEOUT_MS = 25_000;
-const REPLICATION_POLL_MS = 250;
+// Source secrets are torn down after the test that created them. Cleanup used
+// to sit at the end of each test body, so a failing assertion skipped it and
+// left the source secret in place — and since every test here replicates into
+// the same shared environments, the leftovers then showed up in later tests'
+// assertions as phantom imports.
+const createdSecrets: Parameters<typeof deleteSecretV2>[0][] = [];
 
-const waitForReplicatedSecret = async (dto: {
-  workspaceId: string;
-  environmentSlug: string;
-  secretPath: string;
-  key: string;
-  value: string;
-  authToken: string;
-}) => {
-  const deadline = Date.now() + REPLICATION_TIMEOUT_MS;
-  for (;;) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      const secret = await getSecretByNameV2(dto);
-      if (secret.secretValue === dto.value) return secret;
-    } catch {
-      // Not replicated yet — getSecretByNameV2 asserts on a 200.
-    }
-    if (Date.now() >= deadline) {
-      throw new Error(
-        `Timed out after ${REPLICATION_TIMEOUT_MS}ms waiting for "${dto.key}" to replicate into ${dto.environmentSlug}${dto.secretPath}`
-      );
-    }
-    // eslint-disable-next-line no-await-in-loop
-    await new Promise((resolve) => {
-      setTimeout(resolve, REPLICATION_POLL_MS);
-    });
-  }
+const createTrackedSecret = async (dto: Parameters<typeof createSecretV2>[0]) => {
+  const secret = await createSecretV2(dto);
+  createdSecrets.push(dto);
+  return secret;
 };
+
+afterEach(async () => {
+  await Promise.all(createdSecrets.splice(0).map((el) => deleteSecretV2(el)));
+});
 
 // dev <- stage <- prod
 describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
@@ -146,7 +126,7 @@ describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
     });
 
     test("Check one level imported secret exist", async () => {
-      await createSecretV2({
+      await createTrackedSecret({
         environmentSlug: "staging",
         workspaceId: seedData1.projectV3.id,
         secretPath: testSuitePath,
@@ -186,18 +166,10 @@ describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
           })
         ])
       );
-
-      await deleteSecretV2({
-        environmentSlug: "staging",
-        workspaceId: seedData1.projectV3.id,
-        secretPath: testSuitePath,
-        authToken: jwtAuthToken,
-        key: "STAGING_KEY"
-      });
     });
 
     test("Check two level imported secret exist", async () => {
-      await createSecretV2({
+      await createTrackedSecret({
         environmentSlug: "prod",
         workspaceId: seedData1.projectV3.id,
         secretPath: testSuitePath,
@@ -236,14 +208,6 @@ describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
           })
         ])
       );
-
-      await deleteSecretV2({
-        environmentSlug: "prod",
-        workspaceId: seedData1.projectV3.id,
-        secretPath: testSuitePath,
-        authToken: jwtAuthToken,
-        key: "PROD_KEY"
-      });
     });
   },
   { timeout: 60_000 }
@@ -354,7 +318,7 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
     });
 
     test("Check imported secret exist", async () => {
-      await createSecretV2({
+      await createTrackedSecret({
         environmentSlug: "staging",
         workspaceId: seedData1.projectV3.id,
         secretPath: testSuitePath,
@@ -363,7 +327,7 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
         value: "stage-value"
       });
 
-      await createSecretV2({
+      await createTrackedSecret({
         environmentSlug: "prod",
         workspaceId: seedData1.projectV3.id,
         secretPath: testSuitePath,
@@ -419,21 +383,6 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
           })
         ])
       );
-
-      await deleteSecretV2({
-        environmentSlug: "staging",
-        workspaceId: seedData1.projectV3.id,
-        secretPath: testSuitePath,
-        authToken: jwtAuthToken,
-        key: "STAGING_KEY"
-      });
-      await deleteSecretV2({
-        environmentSlug: "prod",
-        workspaceId: seedData1.projectV3.id,
-        secretPath: testSuitePath,
-        authToken: jwtAuthToken,
-        key: "PROD_KEY"
-      });
     });
   },
   { timeout: 60_000 }

--- a/backend/e2e-test/routes/v1/secret-replication.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-replication.spec.ts
@@ -336,7 +336,6 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
         value: "prod-value"
       });
 
-      // The listSecrets assertion below covers both imports, so wait for both.
       const secret = await waitForReplicatedSecret({
         environmentSlug: seedData1.environment.slug,
         workspaceId: seedData1.projectV3.id,

--- a/backend/e2e-test/routes/v1/secret-replication.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-replication.spec.ts
@@ -4,6 +4,43 @@ import { createSecretV2, deleteSecretV2, getSecretByNameV2, getSecretsV2 } from 
 
 import { seedData1 } from "@app/db/seed-data";
 
+// Replication runs asynchronously through BullMQ, so the imported secret shows
+// up some time after the write. Poll for it instead of sleeping a fixed 10s: a
+// fixed wait is simultaneously too short (it flakes whenever CI contention
+// pushes replication past the deadline) and too long (it burns the full 10s on
+// every pass, even though replication usually lands in well under a second).
+const REPLICATION_TIMEOUT_MS = 25_000;
+const REPLICATION_POLL_MS = 250;
+
+const waitForReplicatedSecret = async (dto: {
+  workspaceId: string;
+  environmentSlug: string;
+  secretPath: string;
+  key: string;
+  value: string;
+  authToken: string;
+}) => {
+  const deadline = Date.now() + REPLICATION_TIMEOUT_MS;
+  for (;;) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const secret = await getSecretByNameV2(dto);
+      if (secret.secretValue === dto.value) return secret;
+    } catch {
+      // Not replicated yet — getSecretByNameV2 asserts on a 200.
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out after ${REPLICATION_TIMEOUT_MS}ms waiting for "${dto.key}" to replicate into ${dto.environmentSlug}${dto.secretPath}`
+      );
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => {
+      setTimeout(resolve, REPLICATION_POLL_MS);
+    });
+  }
+};
+
 // dev <- stage <- prod
 describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
   "Secret replication waterfall pattern testing - %secretPath",
@@ -118,17 +155,13 @@ describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
         value: "stage-value"
       });
 
-      // wait for 10 second for  replication to finish
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10000); // time to breathe for db
-      });
-
-      const secret = await getSecretByNameV2({
+      const secret = await waitForReplicatedSecret({
         environmentSlug: seedData1.environment.slug,
         workspaceId: seedData1.projectV3.id,
         secretPath: testSuitePath,
         authToken: jwtAuthToken,
-        key: "STAGING_KEY"
+        key: "STAGING_KEY",
+        value: "stage-value"
       });
 
       expect(secret.secretKey).toBe("STAGING_KEY");
@@ -173,17 +206,13 @@ describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
         value: "prod-value"
       });
 
-      // wait for 10 second for  replication to finish
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10000); // time to breathe for db
-      });
-
-      const secret = await getSecretByNameV2({
+      const secret = await waitForReplicatedSecret({
         environmentSlug: seedData1.environment.slug,
         workspaceId: seedData1.projectV3.id,
         secretPath: testSuitePath,
         authToken: jwtAuthToken,
-        key: "PROD_KEY"
+        key: "PROD_KEY",
+        value: "prod-value"
       });
 
       expect(secret.secretKey).toBe("PROD_KEY");
@@ -217,7 +246,7 @@ describe.each([{ secretPath: "/" }, { secretPath: "/deep" }])(
       });
     });
   },
-  { timeout: 30000 }
+  { timeout: 60_000 }
 );
 
 // dev <- stage, dev <- prod
@@ -343,17 +372,22 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
         value: "prod-value"
       });
 
-      // wait for 10 second for  replication to finish
-      await new Promise((resolve) => {
-        setTimeout(resolve, 10000); // time to breathe for db
-      });
-
-      const secret = await getSecretByNameV2({
+      // The listSecrets assertion below covers both imports, so wait for both.
+      const secret = await waitForReplicatedSecret({
         environmentSlug: seedData1.environment.slug,
         workspaceId: seedData1.projectV3.id,
         secretPath: testSuitePath,
         authToken: jwtAuthToken,
-        key: "STAGING_KEY"
+        key: "STAGING_KEY",
+        value: "stage-value"
+      });
+      await waitForReplicatedSecret({
+        environmentSlug: seedData1.environment.slug,
+        workspaceId: seedData1.projectV3.id,
+        secretPath: testSuitePath,
+        authToken: jwtAuthToken,
+        key: "PROD_KEY",
+        value: "prod-value"
       });
 
       expect(secret.secretKey).toBe("STAGING_KEY");
@@ -402,5 +436,5 @@ describe.each([{ path: "/" }, { path: "/deep" }])(
       });
     });
   },
-  { timeout: 30000 }
+  { timeout: 60_000 }
 );

--- a/backend/e2e-test/routes/v2/secret-folder.spec.ts
+++ b/backend/e2e-test/routes/v2/secret-folder.spec.ts
@@ -407,6 +407,16 @@ describe("Secret Folder Move Router", async () => {
       secretPath: "/policy-src/protected"
     });
 
+    // Registered rather than left at the end of the body so a failing assertion
+    // can't leak the policy — a stray approval policy silently changes how later
+    // specs' writes behave. The policy has to go before the folders it governs,
+    // or $checkFolderPolicy blocks the source tree delete.
+    onTestFinished(async () => {
+      await deleteSecretApprovalPolicy(policy.id);
+      await deleteFolderInEnv({ path: "/", id: srcRoot.id, environment: sourceEnv, forceDelete: true });
+      await deleteFolderInEnv({ path: "/", id: destParent.id, environment: sourceEnv, forceDelete: true });
+    });
+
     const res = await moveFolder({
       folderId: srcRoot.id,
       destinationEnvironment: sourceEnv,
@@ -423,11 +433,6 @@ describe("Secret Folder Move Router", async () => {
 
     // nothing was copied to the destination
     expect(await getFolders({ path: "/policy-dest", environment: sourceEnv })).toHaveLength(0);
-
-    // cleanup: removing the policy first so $checkFolderPolicy no longer blocks the source tree delete
-    await deleteSecretApprovalPolicy(policy.id);
-    await deleteFolderInEnv({ path: "/", id: srcRoot.id, environment: sourceEnv, forceDelete: true });
-    await deleteFolderInEnv({ path: "/", id: destParent.id, environment: sourceEnv, forceDelete: true });
   }, 10_000);
 
   test("Blocks moving a folder when the destination path is governed by an approval policy", async () => {
@@ -441,6 +446,12 @@ describe("Secret Folder Move Router", async () => {
     const policy = await createSecretApprovalPolicy({
       name: "move-dest-protected-policy",
       secretPath: "/policy-dest-guard/move-into-policy"
+    });
+
+    onTestFinished(async () => {
+      await deleteSecretApprovalPolicy(policy.id);
+      await deleteFolderInEnv({ path: "/", id: srcRoot.id, environment: sourceEnv, forceDelete: true });
+      await deleteFolderInEnv({ path: "/", id: destParent.id, environment: sourceEnv, forceDelete: true });
     });
 
     const res = await moveFolder({
@@ -458,9 +469,5 @@ describe("Secret Folder Move Router", async () => {
 
     // nothing was copied to the destination
     expect(await getFolders({ path: "/policy-dest-guard", environment: sourceEnv })).toHaveLength(0);
-
-    await deleteSecretApprovalPolicy(policy.id);
-    await deleteFolderInEnv({ path: "/", id: srcRoot.id, environment: sourceEnv, forceDelete: true });
-    await deleteFolderInEnv({ path: "/", id: destParent.id, environment: sourceEnv, forceDelete: true });
   }, 10_000);
 });

--- a/backend/e2e-test/routes/v3/auth-email-signup.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-email-signup.spec.ts
@@ -234,7 +234,7 @@ describe("Auth Email Signup V3", () => {
     expect(correctCode).toBeDefined();
 
     // Exhaust all 3 tries with a wrong code
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 3; i += 1) {
       // eslint-disable-next-line no-await-in-loop
       await testServer.inject({
         method: "POST",

--- a/backend/e2e-test/routes/v3/secret-recursive.spec.ts
+++ b/backend/e2e-test/routes/v3/secret-recursive.spec.ts
@@ -12,8 +12,38 @@ describe("Secret Recursive Testing", async () => {
     { name: "deep22", path: "/deep2", expectedSecretCount: 1 }
   ];
 
+  // Top-level folder of every fixture path. Deleting these cascades to their
+  // descendants, so they're the only ids cleanup needs.
+  //
+  // Some are created *implicitly*: `createFolder` auto-creates missing parents,
+  // so asking for folder "deep22" at path "/deep2" also creates "/deep2" — and
+  // that id is never returned to us. Deriving roots from the fixture paths
+  // (rather than only recording folders created at "/") is what stops those
+  // from being orphaned in the shared project's prod environment, where this
+  // very spec asserts on exact recursive secret counts.
+  const rootFolderNames = [
+    ...new Set(folderAndSecretNames.map(({ name, path }) => (path === "/" ? name : path.split("/").filter(Boolean)[0])))
+  ];
+
   beforeAll(async () => {
     const rootFolderIds: string[] = [];
+
+    // Create the implicit roots up front so cleanup has an id for each. Roots a
+    // fixture entry already creates at "/" are skipped — creating them twice
+    // would fail on the duplicate name.
+    const explicitRootNames = new Set(folderAndSecretNames.filter(({ path }) => path === "/").map(({ name }) => name));
+    for (const name of rootFolderNames.filter((n) => !explicitRootNames.has(n))) {
+      // eslint-disable-next-line no-await-in-loop
+      const createdRoot = await createFolder({
+        authToken: jwtAuthToken,
+        environmentSlug: "prod",
+        workspaceId: projectId,
+        secretPath: "/",
+        name
+      });
+      rootFolderIds.push(createdRoot.id);
+    }
+
     for (const folder of folderAndSecretNames) {
       // eslint-disable-next-line no-await-in-loop
       const createdFolder = await createFolder({
@@ -51,13 +81,20 @@ describe("Secret Recursive Testing", async () => {
         )
       );
 
-      await deleteSecretV2({
-        authToken: jwtAuthToken,
-        secretPath: "/",
-        workspaceId: projectId,
-        environmentSlug: "prod",
-        key: folderAndSecretNames[0].name
-      });
+      // Secrets living at "/" aren't covered by any folder delete above.
+      await Promise.all(
+        folderAndSecretNames
+          .filter(({ path }) => path === "/")
+          .map(({ name }) =>
+            deleteSecretV2({
+              authToken: jwtAuthToken,
+              secretPath: "/",
+              workspaceId: projectId,
+              environmentSlug: "prod",
+              key: name
+            })
+          )
+      );
     };
   });
 

--- a/backend/e2e-test/routes/v3/secret-recursive.spec.ts
+++ b/backend/e2e-test/routes/v3/secret-recursive.spec.ts
@@ -81,7 +81,6 @@ describe("Secret Recursive Testing", async () => {
         )
       );
 
-      // Secrets living at "/" aren't covered by any folder delete above.
       await Promise.all(
         folderAndSecretNames
           .filter(({ path }) => path === "/")

--- a/backend/e2e-test/routes/v3/secret-reference.spec.ts
+++ b/backend/e2e-test/routes/v3/secret-reference.spec.ts
@@ -1,11 +1,39 @@
 import { createFolder, deleteFolder } from "e2e-test/testUtils/folders";
 import { createSecretImport, deleteSecretImport } from "e2e-test/testUtils/secret-imports";
-import { createSecretV2, deleteSecretV2, getSecretByNameV2, getSecretsV2 } from "e2e-test/testUtils/secrets";
+import {
+  createSecretV2,
+  deleteSecretV2,
+  getSecretByNameV2,
+  getSecretsV2,
+  waitForReplicatedSecret
+} from "e2e-test/testUtils/secrets";
 
 import { seedData1 } from "@app/db/seed-data";
 
 describe("Secret expansion", () => {
   const projectId = seedData1.projectV3.id;
+
+  const createdSecrets: Parameters<typeof deleteSecretV2>[0][] = [];
+  const createdImports: Parameters<typeof deleteSecretImport>[0][] = [];
+
+  const createTrackedSecret = async (dto: Parameters<typeof createSecretV2>[0]) => {
+    const secret = await createSecretV2(dto);
+    createdSecrets.push(dto);
+    return secret;
+  };
+
+  const createTrackedImport = async (dto: Parameters<typeof createSecretImport>[0]) => {
+    const secretImport = await createSecretImport(dto);
+    createdImports.push({ ...dto, id: secretImport.id });
+    return secretImport;
+  };
+
+  afterEach(async () => {
+    const imports = createdImports.splice(0);
+    const secrets = createdSecrets.splice(0);
+    await Promise.all(imports.map((el) => deleteSecretImport(el)));
+    await Promise.all(secrets.map((el) => deleteSecretV2(el)));
+  });
 
   beforeAll(async () => {
     const prodRootFolder = await createFolder({
@@ -58,7 +86,7 @@ describe("Secret expansion", () => {
 
     for (const secret of secrets) {
       // eslint-disable-next-line no-await-in-loop
-      await createSecretV2(secret);
+      await createTrackedSecret(secret);
     }
 
     const expandedSecret = await getSecretByNameV2({
@@ -84,8 +112,6 @@ describe("Secret expansion", () => {
         })
       ])
     );
-
-    await Promise.all(secrets.map((el) => deleteSecretV2(el)));
   });
 
   test("Local secret reference with empty value", async () => {
@@ -111,7 +137,7 @@ describe("Secret expansion", () => {
 
     for (const secret of secrets) {
       // eslint-disable-next-line no-await-in-loop
-      await createSecretV2(secret);
+      await createTrackedSecret(secret);
     }
 
     const expandedSecret = await getSecretByNameV2({
@@ -137,8 +163,6 @@ describe("Secret expansion", () => {
         })
       ])
     );
-
-    await Promise.all(secrets.map((el) => deleteSecretV2(el)));
   });
 
   test("Local secret reference to non-existent secret keeps literal reference", async () => {
@@ -156,7 +180,7 @@ describe("Secret expansion", () => {
 
     for (const secret of secrets) {
       // eslint-disable-next-line no-await-in-loop
-      await createSecretV2(secret);
+      await createTrackedSecret(secret);
     }
 
     const expandedSecret = await getSecretByNameV2({
@@ -184,8 +208,6 @@ describe("Secret expansion", () => {
         })
       ])
     );
-
-    await Promise.all(secrets.map((el) => deleteSecretV2(el)));
   });
 
   test("Local secret reference with repeated non-existent secret keeps literal references", async () => {
@@ -203,7 +225,7 @@ describe("Secret expansion", () => {
 
     for (const secret of secrets) {
       // eslint-disable-next-line no-await-in-loop
-      await createSecretV2(secret);
+      await createTrackedSecret(secret);
     }
 
     const expandedSecret = await getSecretByNameV2({
@@ -231,8 +253,6 @@ describe("Secret expansion", () => {
         })
       ])
     );
-
-    await Promise.all(secrets.map((el) => deleteSecretV2(el)));
   });
 
   test("Cross environment secret reference", async () => {
@@ -275,7 +295,7 @@ describe("Secret expansion", () => {
 
     for (const secret of secrets) {
       // eslint-disable-next-line no-await-in-loop
-      await createSecretV2(secret);
+      await createTrackedSecret(secret);
     }
 
     const expandedSecret = await getSecretByNameV2({
@@ -301,8 +321,6 @@ describe("Secret expansion", () => {
         })
       ])
     );
-
-    await Promise.all(secrets.map((el) => deleteSecretV2(el)));
   });
 
   test("Non replicated secret import secret expansion on local reference and nested reference", async () => {
@@ -345,10 +363,10 @@ describe("Secret expansion", () => {
 
     for (const secret of secrets) {
       // eslint-disable-next-line no-await-in-loop
-      await createSecretV2(secret);
+      await createTrackedSecret(secret);
     }
 
-    const secretImportFromProdToDev = await createSecretImport({
+    await createTrackedImport({
       environmentSlug: seedData1.environment.slug,
       workspaceId: projectId,
       secretPath: "/",
@@ -381,15 +399,6 @@ describe("Secret expansion", () => {
         })
       ])
     );
-
-    await Promise.all(secrets.map((el) => deleteSecretV2(el)));
-    await deleteSecretImport({
-      environmentSlug: seedData1.environment.slug,
-      workspaceId: projectId,
-      authToken: jwtAuthToken,
-      id: secretImportFromProdToDev.id,
-      secretPath: "/"
-    });
   });
 
   test(
@@ -434,10 +443,10 @@ describe("Secret expansion", () => {
 
       for (const secret of secrets) {
         // eslint-disable-next-line no-await-in-loop
-        await createSecretV2(secret);
+        await createTrackedSecret(secret);
       }
 
-      const secretImportFromProdToDev = await createSecretImport({
+      await createTrackedImport({
         environmentSlug: seedData1.environment.slug,
         workspaceId: projectId,
         secretPath: "/",
@@ -447,9 +456,16 @@ describe("Secret expansion", () => {
         isReplication: true
       });
 
-      // wait for 5 second for  replication to finish
-      await new Promise((resolve) => {
-        setTimeout(resolve, 5000); // time to breathe for db
+      // The replicated import lands asynchronously. Poll for the deepest value
+      // in the chain — NESTED_KEY_2 only reads back expanded once both the
+      // replication and the references it depends on have resolved.
+      await waitForReplicatedSecret({
+        environmentSlug: seedData1.environment.slug,
+        workspaceId: projectId,
+        secretPath: "/",
+        authToken: jwtAuthToken,
+        key: "NESTED_KEY_2",
+        value: "secret reference testing"
       });
 
       const listSecrets = await getSecretsV2({
@@ -476,16 +492,7 @@ describe("Secret expansion", () => {
           })
         ])
       );
-
-      await Promise.all(secrets.map((el) => deleteSecretV2(el)));
-      await deleteSecretImport({
-        environmentSlug: seedData1.environment.slug,
-        workspaceId: projectId,
-        authToken: jwtAuthToken,
-        id: secretImportFromProdToDev.id,
-        secretPath: "/"
-      });
     },
-    { timeout: 10000 }
+    { timeout: 60_000 }
   );
 });

--- a/backend/e2e-test/routes/v3/secret-reference.spec.ts
+++ b/backend/e2e-test/routes/v3/secret-reference.spec.ts
@@ -456,9 +456,6 @@ describe("Secret expansion", () => {
         isReplication: true
       });
 
-      // The replicated import lands asynchronously. Poll for the deepest value
-      // in the chain — NESTED_KEY_2 only reads back expanded once both the
-      // replication and the references it depends on have resolved.
       await waitForReplicatedSecret({
         environmentSlug: seedData1.environment.slug,
         workspaceId: projectId,

--- a/backend/e2e-test/routes/v3/secrets.spec.ts
+++ b/backend/e2e-test/routes/v3/secrets.spec.ts
@@ -5,6 +5,50 @@ import { crypto } from "@app/lib/crypto/cryptography";
 import { initLogger, logger } from "@app/lib/logger";
 import { AuthMode } from "@app/services/auth/auth-type";
 
+// Secrets registered here are torn down after the test that made them. Cleanup
+// used to sit at the end of each test body, so a failing assertion skipped it
+// and left secrets behind in the shared seeded project — which breaks the
+// exact-count assertions in this file (e.g. "List secret raw" expects exactly
+// 5) and any later spec reading the same environment.
+type TCreatedSecret = { path: string; key: string; endpoint: string };
+const createdSecrets: TCreatedSecret[] = [];
+
+// Several tests delete their secret as part of the assertions, so by teardown
+// time there is nothing left — a 404 here means "already gone", not a failure.
+const removeSecretIfPresent = async ({ path, key, endpoint }: TCreatedSecret) => {
+  const res = await testServer.inject({
+    method: "DELETE",
+    url: `${endpoint}/${key}`,
+    headers: {
+      authorization: `Bearer ${jwtAuthToken}`
+    },
+    body: {
+      workspaceId: seedData1.project.id,
+      environment: seedData1.environment.slug,
+      secretPath: path
+    }
+  });
+  if (res.statusCode !== 200 && res.statusCode !== 404) {
+    throw new Error(`cleanup: unexpected ${res.statusCode} deleting "${key}" at "${path}" — ${res.payload}`);
+  }
+};
+
+// Some tests create secrets with a direct or batch inject rather than the
+// helpers below, so they have to register what they made. Call this right after
+// the inject: if the request actually failed, nothing exists and the teardown
+// above no-ops on the 404.
+const trackSecret = (endpoint: string, path: string, ...keys: string[]) => {
+  createdSecrets.push(...keys.map((key) => ({ path, key, endpoint })));
+};
+
+afterEach(async () => {
+  // Dedupe before deleting: a personal override is registered under the same
+  // key as its shared secret, and deleting the shared one removes both. Firing
+  // two concurrent DELETEs for the same secret races into a 500.
+  const unique = new Map(createdSecrets.splice(0).map((el) => [`${el.endpoint}|${el.path}|${el.key}`, el]));
+  await Promise.all([...unique.values()].map(removeSecretIfPresent));
+});
+
 const createSecret = async (dto: {
   projectKey: string;
   path: string;
@@ -31,6 +75,7 @@ const createSecret = async (dto: {
   expect(createSecRes.statusCode).toBe(200);
   const createdSecretPayload = JSON.parse(createSecRes.payload);
   expect(createdSecretPayload).toHaveProperty("secret");
+  createdSecrets.push({ path: dto.path, key: dto.key, endpoint: "/api/v3/secrets" });
   return createdSecretPayload.secret;
 };
 
@@ -254,7 +299,6 @@ describe("Secret V3 Router", async () => {
         })
       ])
     );
-    await deleteSecret({ path, key: secret.key });
   });
 
   test.each(secretTestCases)("Get secret by name in path $path", async ({ secret, path }) => {
@@ -279,8 +323,6 @@ describe("Secret V3 Router", async () => {
     expect(decryptedSecret.key).toEqual(secret.key);
     expect(decryptedSecret.value).toEqual(secret.value);
     expect(decryptedSecret.comment).toEqual(secret.comment);
-
-    await deleteSecret({ path, key: secret.key });
   });
 
   test.each(secretTestCases)(
@@ -343,8 +385,6 @@ describe("Secret V3 Router", async () => {
         })
       ])
     );
-
-    await deleteSecret({ path, key: secret.key });
   });
 
   test.each(secretTestCases)("Update secret in path $path", async ({ path, secret }) => {
@@ -383,8 +423,6 @@ describe("Secret V3 Router", async () => {
         })
       ])
     );
-
-    await deleteSecret({ path, key: secret.key });
   });
 
   test.each(secretTestCases)("Delete secret in path $path", async ({ secret, path }) => {
@@ -429,7 +467,6 @@ describe("Secret V3 Router", async () => {
           })
         ])
       );
-      await deleteSecret({ path, key: secret.key });
     }
   );
 
@@ -450,6 +487,7 @@ describe("Secret V3 Router", async () => {
         }))
       }
     });
+    trackSecret("/api/v3/secrets", path, ...Array.from(Array(5)).map((_e, i) => `BULK-${secret.key}-${i + 1}`));
     expect(createSharedSecRes.statusCode).toBe(200);
     const createSharedSecPayload = JSON.parse(createSharedSecRes.payload);
     expect(createSharedSecPayload).toHaveProperty("secrets");
@@ -466,8 +504,6 @@ describe("Secret V3 Router", async () => {
         )
       )
     );
-
-    await Promise.all(Array.from(Array(5)).map((_e, i) => deleteSecret({ path, key: `BULK-${secret.key}-${i + 1}` })));
   });
 
   test.each(secretTestCases)("Bulk create fail on existing secret in path $path", async ({ secret, path }) => {
@@ -490,8 +526,6 @@ describe("Secret V3 Router", async () => {
       }
     });
     expect(createSharedSecRes.statusCode).toBe(400);
-
-    await deleteSecret({ path, key: `BULK-${secret.key}-1` });
   });
 
   test.each(secretTestCases)("Bulk update secrets in path $path", async ({ secret, path }) => {
@@ -534,7 +568,6 @@ describe("Secret V3 Router", async () => {
         )
       )
     );
-    await Promise.all(Array.from(Array(5)).map((_e, i) => deleteSecret({ path, key: `BULK-${secret.key}-${i + 1}` })));
   });
 
   test.each(secretTestCases)("Bulk delete secrets in path $path", async ({ secret, path }) => {
@@ -605,26 +638,8 @@ const createRawSecret = async (dto: {
   expect(createSecRes.statusCode).toBe(200);
   const createdSecretPayload = JSON.parse(createSecRes.payload);
   expect(createdSecretPayload).toHaveProperty("secret");
+  createdSecrets.push({ path: dto.path, key: dto.key, endpoint: "/api/v3/secrets/raw" });
   return createdSecretPayload.secret;
-};
-
-const deleteRawSecret = async (dto: { path: string; key: string }) => {
-  const deleteSecRes = await testServer.inject({
-    method: "DELETE",
-    url: `/api/v3/secrets/raw/${dto.key}`,
-    headers: {
-      authorization: `Bearer ${jwtAuthToken}`
-    },
-    body: {
-      workspaceId: seedData1.project.id,
-      environment: seedData1.environment.slug,
-      secretPath: dto.path
-    }
-  });
-  expect(deleteSecRes.statusCode).toBe(200);
-  const updatedSecretPayload = JSON.parse(deleteSecRes.payload);
-  expect(updatedSecretPayload).toHaveProperty("secret");
-  return updatedSecretPayload.secret;
 };
 
 // raw secret endpoints
@@ -817,6 +832,7 @@ describe.each([{ auth: AuthMode.JWT }, { auth: AuthMode.IDENTITY_ACCESS_TOKEN }]
         },
         body: createSecretReqBody
       });
+      trackSecret("/api/v3/secrets/raw", path, secret.key);
       expect(createSecRes.statusCode).toBe(200);
       const createdSecretPayload = JSON.parse(createSecRes.payload);
       expect(createdSecretPayload).toHaveProperty("secret");
@@ -832,8 +848,6 @@ describe.each([{ auth: AuthMode.JWT }, { auth: AuthMode.IDENTITY_ACCESS_TOKEN }]
           })
         ])
       );
-
-      await deleteRawSecret({ path, key: secret.key });
     });
 
     test.each(testRawSecrets)("Get secret by name raw in path $path", async ({ secret, path }) => {
@@ -860,8 +874,6 @@ describe.each([{ auth: AuthMode.JWT }, { auth: AuthMode.IDENTITY_ACCESS_TOKEN }]
           secretValue: secret.value
         })
       );
-
-      await deleteRawSecret({ path, key: secret.key });
     });
 
     test.each(testRawSecrets)("List secret raw in path $path", async ({ secret, path }) => {
@@ -877,10 +889,6 @@ describe.each([{ auth: AuthMode.JWT }, { auth: AuthMode.IDENTITY_ACCESS_TOKEN }]
             expect.objectContaining({ value: expect.any(String), key: `BULK-${secret.key}-${i + 1}` })
           )
         )
-      );
-
-      await Promise.all(
-        Array.from(Array(5)).map((_e, i) => deleteRawSecret({ path, key: `BULK-${secret.key}-${i + 1}` }))
       );
     });
 
@@ -918,8 +926,6 @@ describe.each([{ auth: AuthMode.JWT }, { auth: AuthMode.IDENTITY_ACCESS_TOKEN }]
           })
         ])
       );
-
-      await deleteRawSecret({ path, key: secret.key });
     });
 
     test.each(testRawSecrets)("Delete secret raw in path $path", async ({ path, secret }) => {
@@ -969,6 +975,7 @@ describe.each([{ auth: AuthMode.JWT }, { auth: AuthMode.IDENTITY_ACCESS_TOKEN }]
         },
         body: createSecretReqBody
       });
+      trackSecret("/api/v3/secrets/raw", path, secret.key);
       expect(createSecRes.statusCode).toBe(200);
       const createdSecretPayload = JSON.parse(createSecRes.payload);
       expect(createdSecretPayload).toHaveProperty("secrets");
@@ -984,8 +991,6 @@ describe.each([{ auth: AuthMode.JWT }, { auth: AuthMode.IDENTITY_ACCESS_TOKEN }]
           })
         ])
       );
-
-      await deleteRawSecret({ path, key: secret.key });
     });
 
     test.each(testRawSecrets)("Bulk update secret raw in path $path", async ({ secret, path }) => {
@@ -1025,8 +1030,6 @@ describe.each([{ auth: AuthMode.JWT }, { auth: AuthMode.IDENTITY_ACCESS_TOKEN }]
           })
         ])
       );
-
-      await deleteRawSecret({ path, key: secret.key });
     });
 
     test.each(testRawSecrets)("Bulk delete secret raw in path $path", async ({ path, secret }) => {

--- a/backend/e2e-test/routes/v3/secrets.spec.ts
+++ b/backend/e2e-test/routes/v3/secrets.spec.ts
@@ -42,9 +42,6 @@ const trackSecret = (endpoint: string, path: string, ...keys: string[]) => {
 };
 
 afterEach(async () => {
-  // Dedupe before deleting: a personal override is registered under the same
-  // key as its shared secret, and deleting the shared one removes both. Firing
-  // two concurrent DELETEs for the same secret races into a 500.
   const unique = new Map(createdSecrets.splice(0).map((el) => [`${el.endpoint}|${el.path}|${el.key}`, el]));
   await Promise.all([...unique.values()].map(removeSecretIfPresent));
 });

--- a/backend/e2e-test/setup/reset-shared-org-flags.ts
+++ b/backend/e2e-test/setup/reset-shared-org-flags.ts
@@ -1,0 +1,33 @@
+import type { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+
+// Several auth specs flip org-wide flags on the *shared* seeded org and undo it
+// in afterAll:
+//
+//   auth-mfa.spec.ts               enforceMfa
+//   auth-signup-sso-enforced.spec  authEnforced
+//   scim.spec.ts                   scimEnabled
+//   auth-idp-attacks.spec.ts       scimEnabled
+//
+// Those afterAll hooks don't run when a file dies hard — a worker OOM or a
+// file-level timeout — and a leaked flag then breaks every later spec that logs
+// in as the seeded user, with a failure that points nowhere near the cause.
+//
+// Test files run sequentially in a single fork, so resetting the flags at the
+// start of every file makes each one self-healing regardless of how its
+// predecessor ended. All three columns default to false in the schema, so this
+// restores the seeded baseline rather than inventing one.
+//
+// This runs before any hook the spec itself registers, so a spec that wants a
+// flag on still gets it. If that ordering ever changed, the affected spec would
+// fail outright rather than silently skip its setup.
+beforeAll(async () => {
+  const db = (globalThis as unknown as { testDb: Knex }).testDb;
+  await db(TableName.Organization).where({ id: seedData1.organization.id }).update({
+    enforceMfa: false,
+    authEnforced: false,
+    scimEnabled: false
+  });
+});

--- a/backend/e2e-test/testUtils/secrets.ts
+++ b/backend/e2e-test/testUtils/secrets.ts
@@ -128,3 +128,40 @@ export const getSecretsV2 = async (dto: {
     }[];
   };
 };
+
+// Replication and import propagation run asynchronously through BullMQ, so a
+// secret shows up in the destination environment some time after the write.
+// Poll for it instead of sleeping a fixed interval: a fixed wait is at once too
+// short (it flakes whenever CI contention pushes propagation past the deadline)
+// and too long (it burns the whole interval on every pass).
+const REPLICATION_TIMEOUT_MS = 25_000;
+const REPLICATION_POLL_MS = 250;
+
+export const waitForReplicatedSecret = async (dto: {
+  workspaceId: string;
+  environmentSlug: string;
+  secretPath: string;
+  key: string;
+  value: string;
+  authToken: string;
+}) => {
+  const deadline = Date.now() + REPLICATION_TIMEOUT_MS;
+  for (;;) {
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const secret = await getSecretByNameV2(dto);
+      if (secret.secretValue === dto.value) return secret;
+    } catch {
+      // Not propagated yet — getSecretByNameV2 asserts on a 200.
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out after ${REPLICATION_TIMEOUT_MS}ms waiting for "${dto.key}" to reach ${dto.environmentSlug}${dto.secretPath}`
+      );
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => {
+      setTimeout(resolve, REPLICATION_POLL_MS);
+    });
+  }
+};

--- a/backend/src/lib/cron/cron-job.test.ts
+++ b/backend/src/lib/cron/cron-job.test.ts
@@ -28,6 +28,14 @@ const makeRedlock = () => ({
   })
 });
 
+// Slot claims/refreshes are serialized through a promise chain, so a tick's
+// Redis write lands several microtasks after the tick itself. A single
+// `await Promise.resolve()` doesn't drain that; this does.
+// `advanceTimersByTimeAsync` yields to the real event loop, which drains the
+// whole pending microtask queue — deterministic, unlike counting `await
+// Promise.resolve()` hops.
+const flushSlotOps = () => vi.advanceTimersByTimeAsync(0);
+
 // Use a cast via unknown to satisfy the type system for the mocks
 type FakeDeps = {
   redis: ReturnType<typeof makeRedis>;
@@ -223,7 +231,7 @@ describe("slot election", () => {
     const { start, stop } = makeFactory({ redis });
     start();
     // Let the immediate claimOrRefreshSlot call in start() complete
-    await Promise.resolve();
+    await flushSlotOps();
     expect(redis.set).toHaveBeenCalledWith("{cron}:slot:0", expect.any(String), "PX", expect.any(Number), "NX");
     await stop();
   });
@@ -233,7 +241,7 @@ describe("slot election", () => {
     redis.set.mockResolvedValueOnce(null).mockResolvedValueOnce("OK");
     const { start, stop } = makeFactory({ redis });
     start();
-    await Promise.resolve();
+    await flushSlotOps();
     expect(redis.set).toHaveBeenNthCalledWith(1, "{cron}:slot:0", expect.any(String), "PX", expect.any(Number), "NX");
     expect(redis.set).toHaveBeenNthCalledWith(2, "{cron}:slot:1", expect.any(String), "PX", expect.any(Number), "NX");
     await stop();
@@ -245,7 +253,7 @@ describe("slot election", () => {
     const { register, start, stop } = makeFactory({ redis });
     register({ name: "x", pattern: "0 0 * * *", handler: vi.fn(), runHashTtlS: 3600 });
     start();
-    await Promise.resolve();
+    await flushSlotOps();
     expect(redis.eval).not.toHaveBeenCalled();
     await stop();
   });
@@ -255,9 +263,9 @@ describe("slot election", () => {
     redis.set.mockResolvedValueOnce("OK").mockResolvedValue("OK");
     const { start, stop } = makeFactory({ redis });
     start();
-    await Promise.resolve();
+    await flushSlotOps();
     vi.advanceTimersByTime(60);
-    await Promise.resolve();
+    await flushSlotOps();
     const xxCalls = redis.set.mock.calls.filter((c) => (c as string[]).includes("XX"));
     expect(xxCalls.length).toBeGreaterThan(0);
     await stop();
@@ -268,10 +276,45 @@ describe("slot election", () => {
     redis.set.mockResolvedValueOnce("OK").mockResolvedValueOnce(null).mockResolvedValueOnce("OK");
     const { start, stop } = makeFactory({ redis });
     start();
+    await flushSlotOps();
     vi.advanceTimersByTime(60);
-    await Promise.resolve();
+    await flushSlotOps();
+    // Claim (NX) → refresh loses the slot (XX returns null) → re-claim (NX).
     const nxCalls = redis.set.mock.calls.filter((c) => (c as string[]).includes("NX"));
     expect(nxCalls.length).toBeGreaterThanOrEqual(2);
+    await stop();
+  });
+
+  // Regression guard for the double-claim race: two refresh ticks that overlap
+  // must not each run the NX loop and leave the pod holding two slots — only
+  // the last-assigned one would ever be released.
+  test("overlapping refresh ticks never claim two different slots", async () => {
+    const redis = makeRedis();
+    // Models real SET NX/XX semantics against an in-memory slot table, with the
+    // held slot expiring right as the refresh observes it (XX misses). Without
+    // serialization, two ticks both observe the loss, both null `currentSlot`,
+    // and the second walks past the slot the first just re-took.
+    const held = new Map<string, string>();
+    redis.set.mockImplementation(async (key: string, value: string, _px: string, _ttl: number, mode: string) => {
+      if (mode === "NX") {
+        if (held.has(key)) return null;
+        held.set(key, value);
+        return "OK";
+      }
+      held.delete(key); // XX: the slot's TTL lapsed before this refresh landed
+      return null;
+    });
+
+    const { start, stop } = makeFactory({ redis });
+    start();
+    await flushSlotOps();
+
+    // Two refresh intervals fire back-to-back with no drain in between.
+    vi.advanceTimersByTime(50);
+    vi.advanceTimersByTime(50);
+    await flushSlotOps();
+
+    expect([...held.keys()]).toEqual(["{cron}:slot:0"]);
     await stop();
   });
 });
@@ -284,10 +327,11 @@ describe("claim and execute", () => {
     const { register, start, stop } = makeFactory({ redis });
     register({ name: "x", pattern: "0 0 * * *", handler: vi.fn(), runHashTtlS: 3600 });
     start();
-    await Promise.resolve();
+    await flushSlotOps();
     vi.advanceTimersByTime(300);
     await Promise.resolve();
     const firstCount = redis.eval.mock.calls.length;
+    expect(firstCount).toBeGreaterThan(0);
     vi.advanceTimersByTime(30_000);
     await Promise.resolve();
     expect(redis.eval.mock.calls.length).toBe(firstCount);

--- a/backend/src/lib/cron/cron-job.test.ts
+++ b/backend/src/lib/cron/cron-job.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { logger } from "@app/lib/logger";
+
 import { cronJobFactory } from "./cron-job";
 
 vi.mock("@app/lib/logger", () => ({
@@ -315,6 +317,27 @@ describe("slot election", () => {
     await flushSlotOps();
 
     expect([...held.keys()]).toEqual(["{cron}:slot:0"]);
+    await stop();
+  });
+
+  // These two strings are what alerting matches on, so pin them. The initial
+  // claim and the periodic refresh share one code path now, and it would be easy
+  // to collapse them into a single message without noticing.
+  test("slot failures are logged under their own labels", async () => {
+    const redis = makeRedis();
+    redis.set.mockRejectedValue(new Error("redis unavailable"));
+    const { start, stop } = makeFactory({ redis });
+    vi.mocked(logger.error).mockClear();
+
+    start(); // initial claim fails
+    await flushSlotOps();
+    vi.advanceTimersByTime(50); // refresh tick fails
+    await flushSlotOps();
+
+    const messages = vi.mocked(logger.error).mock.calls.map(([, message]) => message);
+    expect(messages).toContain("cron: initial slot claim failed");
+    expect(messages).toContain("cron: slot refresh failed");
+
     await stop();
   });
 });

--- a/backend/src/lib/cron/cron-job.ts
+++ b/backend/src/lib/cron/cron-job.ts
@@ -70,11 +70,10 @@ const DEFAULTS = {
 
 // ── redis schema ──────────────────────────────────────────────────────────────
 
+// Every key this module writes lives under a single Redis Cluster hash tag so
+// multi-key Lua scripts never return CROSSSLOT. A custom `keyPrefix` must keep
+// that property — see `assertHashTagged`.
 const KEY_HASH_TAG = "{cron}";
-const SLOT_KEY = (i: number) => `${KEY_HASH_TAG}:slot:${i}`;
-const RUN_KEY = (id: string) => `${KEY_HASH_TAG}:run:${id}`;
-const LEASE_KEY = (id: string) => `${KEY_HASH_TAG}:lease:${id}`;
-const PENDING_ZSET = `${KEY_HASH_TAG}:pending`;
 
 // Run-hash status values. Stored as plain strings in the hash so we don't
 // break Redis tooling, but referenced through this object to avoid drift.
@@ -139,6 +138,17 @@ class HandlerTimeoutError extends Error {
   }
 }
 
+// A prefix without a `{...}` hash tag would spread this module's keys across
+// Cluster slots and break every multi-key EVAL. Fail loudly at construction
+// rather than silently at the first enqueue tick.
+const assertHashTagged = (keyPrefix: string) => {
+  const start = keyPrefix.indexOf("{");
+  const end = keyPrefix.indexOf("}", start + 1);
+  if (start < 0 || end <= start + 1) {
+    throw new Error(`cron: keyPrefix "${keyPrefix}" must contain a non-empty Redis Cluster hash tag, e.g. "{cron}"`);
+  }
+};
+
 export type TCronJobFactory = ReturnType<typeof cronJobFactory>;
 
 // ── factory ───────────────────────────────────────────────────────────────────
@@ -155,7 +165,8 @@ export const cronJobFactory = ({
   handlerTimeoutMs = DEFAULTS.handlerTimeoutMs,
   retryBackoffBaseMs = DEFAULTS.retryBackoffBaseMs,
   retryBackoffMaxMs = DEFAULTS.retryBackoffMaxMs,
-  drainTimeoutMs = DEFAULTS.drainTimeoutMs
+  drainTimeoutMs = DEFAULTS.drainTimeoutMs,
+  keyPrefix = KEY_HASH_TAG
 }: {
   redis: Redis | Cluster;
   redlock: Redlock;
@@ -169,7 +180,20 @@ export const cronJobFactory = ({
   retryBackoffBaseMs?: number;
   retryBackoffMaxMs?: number;
   drainTimeoutMs?: number;
+  /**
+   * Namespace for every Redis key this manager owns. Defaults to the production
+   * `{cron}` namespace. Tests override it so a test-owned manager and the
+   * server's real one can share a Redis without colliding on slot keys.
+   */
+  keyPrefix?: string;
 }) => {
+  assertHashTagged(keyPrefix);
+
+  const SLOT_KEY = (i: number) => `${keyPrefix}:slot:${i}`;
+  const RUN_KEY = (id: string) => `${keyPrefix}:run:${id}`;
+  const LEASE_KEY = (id: string) => `${keyPrefix}:lease:${id}`;
+  const PENDING_ZSET = `${keyPrefix}:pending`;
+
   const workerId = randomUUID();
   const entries = new Map<string, CronEntry>();
   const lastEnqueuedAt = new Map<string, number>();
@@ -178,6 +202,9 @@ export const cronJobFactory = ({
   let enqueueTimer: ReturnType<typeof setInterval> | null = null;
   let processTimer: ReturnType<typeof setInterval> | null = null;
   let currentSlot: number | null = null;
+  let stopped = false;
+  // Tail of the serialized slot-operation chain. Never rejects.
+  let slotOp: Promise<void> = Promise.resolve();
 
   // ── helpers ────────────────────────────────────────────────────────────
 
@@ -338,6 +365,24 @@ export const cronJobFactory = ({
         return;
       }
     }
+  };
+
+  // Runs slot claims/refreshes strictly one at a time.
+  //
+  // `claimOrRefreshSlot` awaits between reading `currentSlot` and writing it,
+  // so two overlapping ticks could both observe a lost slot, both null
+  // `currentSlot`, and then claim two *different* slots — the pod would burn
+  // two of the five participant slots and leak one on shutdown, since only the
+  // last-assigned `currentSlot` is ever released.
+  //
+  // Chaining also gives stop() one handle to await, so it can never read
+  // `currentSlot` mid-handover (skipping the release) or have a late claim land
+  // after the release.
+  const runSlotOp = () => {
+    slotOp = slotOp
+      .then(() => (stopped ? undefined : claimOrRefreshSlot()))
+      .catch((err: unknown) => logger.error({ err }, "cron: slot refresh failed"));
+    return slotOp;
   };
 
   // ── enqueue ─────────────────────────────────────────────────────────────────
@@ -530,10 +575,11 @@ export const cronJobFactory = ({
   // immediately so the pod doesn't wait a full `slotRefreshMs` before
   // participating.
   const start = () => {
-    slotTimer = setInterval(safeTick("slot refresh", claimOrRefreshSlot), slotRefreshMs);
+    stopped = false;
+    slotTimer = setInterval(() => void runSlotOp(), slotRefreshMs);
     enqueueTimer = setInterval(safeTick("enqueue tick", enqueueTick), enqueueIntervalMs);
     processTimer = setInterval(safeTick("process tick", processTick), processIntervalMs);
-    safeTick("initial slot claim", claimOrRefreshSlot)();
+    void runSlotOp();
   };
 
   // Stops the timers, drains in-flight handlers, and atomically releases the
@@ -544,6 +590,7 @@ export const cronJobFactory = ({
   // aren't aborted mid-execution and graceful redeploys don't leave runs
   // stuck in `status='running'` until the lease TTL elapses.
   const stop = async () => {
+    stopped = true;
     if (slotTimer) clearInterval(slotTimer);
     if (enqueueTimer) clearInterval(enqueueTimer);
     if (processTimer) clearInterval(processTimer);
@@ -566,9 +613,16 @@ export const cronJobFactory = ({
         if (timeoutHandle) clearTimeout(timeoutHandle);
       }
     }
+
+    // No new slot ops can be queued (timers cleared, `stopped` set), so this is
+    // the final tail. Waiting on it guarantees `currentSlot` is settled and that
+    // nothing can re-create the key after the release below.
+    await slotOp;
+
     if (currentSlot !== null) {
       await redis.eval(RELEASE_SLOT_IF_MINE_LUA, 1, SLOT_KEY(currentSlot), workerId);
       logger.info(`cron: released slot ${currentSlot} [worker=${workerId}]`);
+      currentSlot = null;
     }
   };
 

--- a/backend/src/lib/cron/cron-job.ts
+++ b/backend/src/lib/cron/cron-job.ts
@@ -378,10 +378,10 @@ export const cronJobFactory = ({
   // Chaining also gives stop() one handle to await, so it can never read
   // `currentSlot` mid-handover (skipping the release) or have a late claim land
   // after the release.
-  const runSlotOp = () => {
+  const runSlotOp = (label: string) => {
     slotOp = slotOp
       .then(() => (stopped ? undefined : claimOrRefreshSlot()))
-      .catch((err: unknown) => logger.error({ err }, "cron: slot refresh failed"));
+      .catch((err: unknown) => logger.error({ err }, `cron: ${label} failed`));
     return slotOp;
   };
 
@@ -576,10 +576,10 @@ export const cronJobFactory = ({
   // participating.
   const start = () => {
     stopped = false;
-    slotTimer = setInterval(() => void runSlotOp(), slotRefreshMs);
+    slotTimer = setInterval(() => void runSlotOp("slot refresh"), slotRefreshMs);
     enqueueTimer = setInterval(safeTick("enqueue tick", enqueueTick), enqueueIntervalMs);
     processTimer = setInterval(safeTick("process tick", processTick), processIntervalMs);
-    void runSlotOp();
+    void runSlotOp("initial slot claim");
   };
 
   // Stops the timers, drains in-flight handlers, and atomically releases the

--- a/backend/vitest.e2e.config.mts
+++ b/backend/vitest.e2e.config.mts
@@ -13,6 +13,8 @@ export default defineConfig({
     },
     environment: "./e2e-test/vitest-environment-knex.ts",
     include: ["./e2e-test/**/*.spec.ts"],
+    // Runs per test file, after the environment is up — see the file for why.
+    setupFiles: ["./e2e-test/setup/reset-shared-org-flags.ts"],
     pool: "forks",
     poolOptions: {
       forks: {

--- a/backend/vitest.e2e.config.mts
+++ b/backend/vitest.e2e.config.mts
@@ -1,5 +1,28 @@
 import path from "path";
 import { defineConfig } from "vitest/config";
+import { BaseSequencer, type TestSpecification } from "vitest/node";
+
+// Vitest's default sequencer picks one of two orders depending on whether a
+// results cache exists: size-descending when it doesn't, and
+// failed-first-then-slowest-first when it does. That cache lives at
+// `node_modules/.vite/vitest/<hash>/results.json` — inside the very directory
+// CI restores from `actions/cache`, keyed on package-lock.json. So the suite
+// runs in size order on the first build after a dependency bump, then in a
+// frozen duration order for every build after that, and developers get whatever
+// their own local cache implies.
+//
+// These specs share one database and one seeded org, so run order is part of
+// their contract; an order that silently changes turns shared-state bugs into
+// flakes that reproduce on some builds and not others. Sorting by path is
+// deterministic everywhere and costs nothing here: the size heuristic exists to
+// pack parallel workers, and this suite is deliberately single-fork with
+// `fileParallelism: false`.
+class PathSequencer extends BaseSequencer {
+  // eslint-disable-next-line class-methods-use-this
+  async sort(files: TestSpecification[]) {
+    return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId));
+  }
+}
 
 export default defineConfig({
   test: {
@@ -15,6 +38,7 @@ export default defineConfig({
     include: ["./e2e-test/**/*.spec.ts"],
     // Runs per test file, after the environment is up — see the file for why.
     setupFiles: ["./e2e-test/setup/reset-shared-org-flags.ts"],
+    sequence: { sequencer: PathSequencer },
     pool: "forks",
     poolOptions: {
       forks: {


### PR DESCRIPTION
The `Run backend tests` job was flaky.

### Root cause

The e2e Vitest environment shares the same Redis client between the test server and `globalThis.testRedis`, while `routes/index.ts` always starts the real cron manager.

That meant the server could grab a `{cron}:slot:N` key in the same namespace `cron-job.spec.ts` was asserting on. If it re-claimed the slot during the test, assertions would randomly fail (`expected 1 to be +0`).

On top of that, the spec called `flushdb()` ~20 times per run, wiping the shared server's BullMQ queues, keystore, cron leases, and everything else in Redis.

### Production fixes (`src/lib/cron/cron-job.ts`)

- Fixed a race where overlapping refresh ticks could each claim a different slot. A single pod could consume two of the five available slots and leak one on shutdown.
- Fixed `stop()` not waiting for an in-flight slot operation, which could skip releasing the current slot and leave it pinned until TTL expiry.
- Serialized all slot operations through a promise chain that `stop()` now awaits behind a `stopped` flag.
- Added a unit test that reproduces the old race (`['{cron}:slot:0', '{cron}:slot:1']`).
- Added an optional `keyPrefix` (defaults to `{cron}`) so tests can use isolated namespaces.

### Test isolation

- `cron-job.spec.ts` now runs under `{cron-e2e}` and cleans up by prefix instead of `flushdb()`. Four assertions that were previously passing by accident are now exact.
- Replaced fixed replication sleeps with polling (`waitForReplicatedSecret`). Replication takes ~7.8s locally, so the previous 5s/10s sleeps were unreliable and also added ~30s of idle waiting.
- Moved cleanup into hooks (`afterEach` / `onTestFinished`) across multiple e2e suites. Failed assertions no longer skip cleanup and leak state into later tests.
- Fixed `secret-approval-policy.spec.ts` leaving a policy behind on the shared project, which could break `secrets.spec.ts` depending on execution order.
- Made test execution order deterministic with `PathSequencer`. Vitest changes ordering based on its cache, and CI restores that cache, so shared database tests could randomly run in a different order.
- Added a `setupFiles` hook to reset `enforceMfa`, `authEnforced`, and `scimEnabled` on the shared seeded org before each file so failed auth tests can't poison later ones.
- Extended `npm run lint` to include `e2e-test/`. It was only linting `src/`, so a couple of real violations had gone unnoticed.