### PR TITLE
feature(helm): add infisical-nkp chart and cloudsmith release workflow for NKP partner catalog

### DIFF
--- a/.github/workflows/helm-release-infisical-nkp.yml
+++ b/.github/workflows/helm-release-infisical-nkp.yml
@@ -1,0 +1,40 @@
+name: Release Infisical NKP Helm chart
+
+on: [workflow_dispatch]
+
+jobs:
+  test-helm:
+    name: Lint Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 Nov 14, 2025
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.17.0
+
+      - name: Run helm lint
+        run: helm lint helm-charts/infisical-nkp
+
+      - name: Run helm template
+        run: helm template infisical helm-charts/infisical-nkp > /dev/null
+
+  release:
+    needs: test-helm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 Nov 14, 2025
+      - name: Install Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.17.0
+      - name: Build and push helm package to Cloudsmith
+        run: cd helm-charts && sh upload-infisical-nkp-helm-cloudsmith.sh
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          CLOUDSMITH_USERNAME: ${{ secrets.CLOUDSMITH_USERNAME }}

--- a/helm-charts/infisical-nkp/.helmignore
+++ b/helm-charts/infisical-nkp/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when packaging Helm charts.
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.orig
+.vscode/

--- a/helm-charts/infisical-nkp/Chart.yaml
+++ b/helm-charts/infisical-nkp/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: infisical-nkp
+description: Infisical, the open-source secrets management platform, packaged for the Nutanix NKP partner catalog.
+type: application
+version: 0.1.0
+appVersion: "v0.162.11"
+home: https://infisical.com
+sources:
+  - https://github.com/Infisical/infisical
+maintainers:
+  - name: Infisical
+    url: https://infisical.com
+keywords:
+  - secrets
+  - secrets-management
+  - security
+  - pki
+  - kms

--- a/helm-charts/infisical-nkp/templates/NOTES.txt
+++ b/helm-charts/infisical-nkp/templates/NOTES.txt
@@ -1,0 +1,17 @@
+Infisical has been deployed.
+
+1. Wait for the pod to become ready:
+   kubectl -n {{ .Release.Namespace }} rollout status deploy/{{ include "infisical.fullname" . }}
+
+2. Reach the UI at the ingress host (served via the NKP kommander-traefik controller):
+   {{ .Values.config.siteUrl }}
+
+   Ensure DNS for "{{ .Values.ingress.host }}" points at the Traefik ingress
+   IP/hostname of the workload cluster.
+
+{{- if not .Values.secrets.encryptionKey }}
+
+NOTE: ENCRYPTION_KEY was auto-generated on first install and is stored in the
+Secret "{{ include "infisical.fullname" . }}-secrets". Do not delete it — losing
+it makes existing encrypted data unrecoverable.
+{{- end }}

--- a/helm-charts/infisical-nkp/templates/_helpers.tpl
+++ b/helm-charts/infisical-nkp/templates/_helpers.tpl
@@ -8,7 +8,12 @@
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" (include "infisical.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -23,6 +28,7 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
 {{/* Selector labels */}}
 {{- define "infisical.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "infisical.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: backend
 {{- end -}}
 
@@ -61,12 +67,18 @@ use the external URI stored in the chart's own secret.
 {{- end }}
 {{- end -}}
 
-{{/* REDIS_URL: in-cluster Redis service when enabled, else the external URL. */}}
-{{- define "infisical.redisUrl" -}}
-{{- if .Values.redis.enabled -}}
-redis://{{ include "infisical.fullname" . }}-redis:{{ .Values.redis.port }}
+{{/*
+Password for the bundled Redis: reuse the one already stored in the Secret
+(so upgrades don't rotate it), else generate a new one. Call this exactly once
+per render and reuse the result (each call generates a fresh random value on
+first install).
+*/}}
+{{- define "infisical.redisPassword" -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-secrets" (include "infisical.fullname" .)) -}}
+{{- if and $existing $existing.data.REDIS_PASSWORD -}}
+{{- $existing.data.REDIS_PASSWORD | b64dec -}}
 {{- else -}}
-{{ .Values.secrets.redisUrl }}
+{{- randAlphaNum 32 -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm-charts/infisical-nkp/templates/_helpers.tpl
+++ b/helm-charts/infisical-nkp/templates/_helpers.tpl
@@ -1,0 +1,84 @@
+{{/* Chart name */}}
+{{- define "infisical.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Fully qualified app name */}}
+{{- define "infisical.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" (include "infisical.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Common labels */}}
+{{- define "infisical.labels" -}}
+app.kubernetes.io/name: {{ include "infisical.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{/* Selector labels */}}
+{{- define "infisical.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "infisical.name" . }}
+app.kubernetes.io/component: backend
+{{- end -}}
+
+{{/*
+Resolve the encryption key: use the provided value, else reuse the one already
+stored in the Secret (so upgrades don't rotate it), else generate a new one.
+*/}}
+{{- define "infisical.encryptionKey" -}}
+{{- if .Values.secrets.encryptionKey -}}
+{{- .Values.secrets.encryptionKey -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-secrets" (include "infisical.fullname" .)) -}}
+{{- if and $existing $existing.data.ENCRYPTION_KEY -}}
+{{- $existing.data.ENCRYPTION_KEY | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+DB_CONNECTION_URI env entry. With CNPG enabled, pull the ready-made connection
+string from the CNPG-generated "<release>-db-app" secret's "uri" key. Otherwise
+use the external URI stored in the chart's own secret.
+*/}}
+{{- define "infisical.dbEnv" -}}
+- name: DB_CONNECTION_URI
+  valueFrom:
+    secretKeyRef:
+{{- if .Values.postgres.cnpg.enabled }}
+      name: {{ include "infisical.fullname" . }}-db-app
+      key: uri
+{{- else }}
+      name: {{ include "infisical.fullname" . }}-secrets
+      key: DB_CONNECTION_URI
+{{- end }}
+{{- end -}}
+
+{{/* REDIS_URL: in-cluster Redis service when enabled, else the external URL. */}}
+{{- define "infisical.redisUrl" -}}
+{{- if .Values.redis.enabled -}}
+redis://{{ include "infisical.fullname" . }}-redis:{{ .Values.redis.port }}
+{{- else -}}
+{{ .Values.secrets.redisUrl }}
+{{- end -}}
+{{- end -}}
+
+{{- define "infisical.authSecret" -}}
+{{- if .Values.secrets.authSecret -}}
+{{- .Values.secrets.authSecret -}}
+{{- else -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-secrets" (include "infisical.fullname" .)) -}}
+{{- if and $existing $existing.data.AUTH_SECRET -}}
+{{- $existing.data.AUTH_SECRET | b64dec -}}
+{{- else -}}
+{{- randAlphaNum 44 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm-charts/infisical-nkp/templates/configmap.yaml
+++ b/helm-charts/infisical-nkp/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "infisical.fullname" . }}-config
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+data:
+  SITE_URL: {{ .Values.config.siteUrl | quote }}
+  PORT: {{ .Values.config.port | quote }}
+  TELEMETRY_ENABLED: {{ .Values.config.telemetryEnabled | quote }}

--- a/helm-charts/infisical-nkp/templates/deployment.yaml
+++ b/helm-charts/infisical-nkp/templates/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "infisical.fullname" . }}
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "infisical.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "infisical.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if or .Values.postgres.cnpg.enabled .Values.migration.enabled }}
+      initContainers:
+        {{- if .Values.postgres.cnpg.enabled }}
+        # Block startup until the CNPG database endpoint is accepting connections.
+        - name: wait-for-db
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - 'until nc -z "$DB_HOST" "$DB_PORT"; do echo "waiting for postgres..."; sleep 3; done'
+          env:
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "infisical.fullname" . }}-db-app
+                  key: host
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "infisical.fullname" . }}-db-app
+                  key: port
+        {{- end }}
+        {{- if .Values.migration.enabled }}
+        - name: migration
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["npm", "run", "migration:latest"]
+          envFrom:
+            - configMapRef:
+                name: {{ include "infisical.fullname" . }}-config
+            - secretRef:
+                name: {{ include "infisical.fullname" . }}-secrets
+          env:
+            {{- include "infisical.dbEnv" . | nindent 12 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: infisical
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "infisical.fullname" . }}-config
+            - secretRef:
+                name: {{ include "infisical.fullname" . }}-secrets
+          env:
+            {{- include "infisical.dbEnv" . | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /api/status
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-charts/infisical-nkp/templates/deployment.yaml
+++ b/helm-charts/infisical-nkp/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
       {{- include "infisical.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Roll pods when generated configuration changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         {{- include "infisical.selectorLabels" . | nindent 8 }}
     spec:
@@ -56,7 +60,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ .Values.config.port }}
               protocol: TCP
           envFrom:
             - configMapRef:

--- a/helm-charts/infisical-nkp/templates/ingress.yaml
+++ b/helm-charts/infisical-nkp/templates/ingress.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "infisical.fullname" . }}
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "infisical.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/helm-charts/infisical-nkp/templates/postgres-cluster.yaml
+++ b/helm-charts/infisical-nkp/templates/postgres-cluster.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.postgres.cnpg.enabled }}
+# PostgreSQL provisioned by the NKP CloudNativePG (CNPG) operator.
+# CNPG auto-creates a "{{ include "infisical.fullname" . }}-db-app" Secret
+# containing a ready-to-use "uri" key that Infisical consumes.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "infisical.fullname" . }}-db
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.postgres.cnpg.instances }}
+  {{- with .Values.postgres.cnpg.imageName }}
+  imageName: {{ . }}
+  {{- end }}
+  storage:
+    size: {{ .Values.postgres.cnpg.storageSize }}
+    {{- with .Values.postgres.cnpg.storageClass }}
+    storageClass: {{ . }}
+    {{- end }}
+  bootstrap:
+    initdb:
+      database: {{ .Values.postgres.cnpg.database }}
+      owner: {{ .Values.postgres.cnpg.owner }}
+{{- end }}

--- a/helm-charts/infisical-nkp/templates/redis.yaml
+++ b/helm-charts/infisical-nkp/templates/redis.yaml
@@ -11,17 +11,32 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "infisical.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: redis
   template:
     metadata:
       labels:
         app.kubernetes.io/name: {{ include "infisical.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: redis
     spec:
       containers:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          # $(REDIS_PASSWORD) is expanded by the kubelet from the env var below,
+          # so the password itself never appears in the pod spec.
+          args:
+            - --port
+            - {{ .Values.redis.port | quote }}
+            - --requirepass
+            - $(REDIS_PASSWORD)
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "infisical.fullname" . }}-secrets
+                  key: REDIS_PASSWORD
           ports:
             - name: redis
               containerPort: {{ .Values.redis.port }}
@@ -49,10 +64,39 @@ spec:
   type: ClusterIP
   selector:
     app.kubernetes.io/name: {{ include "infisical.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: redis
   ports:
     - name: redis
       port: {{ .Values.redis.port }}
       targetPort: redis
       protocol: TCP
+{{- if .Values.redis.networkPolicy }}
+---
+# Defense in depth alongside requirepass: only Infisical pods may reach Redis.
+# Enforced only where the cluster CNI supports NetworkPolicy (NKP's does).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "infisical.fullname" . }}-redis
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "infisical.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: redis
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "infisical.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.redis.port }}
+{{- end }}
 {{- end }}

--- a/helm-charts/infisical-nkp/templates/redis.yaml
+++ b/helm-charts/infisical-nkp/templates/redis.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "infisical.fullname" . }}-redis
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "infisical.name" . }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "infisical.name" . }}
+        app.kubernetes.io/component: redis
+    spec:
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.redis.port }}
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "infisical.fullname" . }}-redis
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ include "infisical.name" . }}
+    app.kubernetes.io/component: redis
+  ports:
+    - name: redis
+      port: {{ .Values.redis.port }}
+      targetPort: redis
+      protocol: TCP
+{{- end }}

--- a/helm-charts/infisical-nkp/templates/secret.yaml
+++ b/helm-charts/infisical-nkp/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "infisical.fullname" . }}-secrets
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  ENCRYPTION_KEY: {{ include "infisical.encryptionKey" . | quote }}
+  AUTH_SECRET: {{ include "infisical.authSecret" . | quote }}
+  REDIS_URL: {{ include "infisical.redisUrl" . | quote }}
+  {{- if not .Values.postgres.cnpg.enabled }}
+  # Only used when CNPG is disabled and an external Postgres is provided.
+  DB_CONNECTION_URI: {{ .Values.postgres.externalConnectionUri | quote }}
+  {{- end }}

--- a/helm-charts/infisical-nkp/templates/secret.yaml
+++ b/helm-charts/infisical-nkp/templates/secret.yaml
@@ -8,7 +8,13 @@ type: Opaque
 stringData:
   ENCRYPTION_KEY: {{ include "infisical.encryptionKey" . | quote }}
   AUTH_SECRET: {{ include "infisical.authSecret" . | quote }}
-  REDIS_URL: {{ include "infisical.redisUrl" . | quote }}
+  {{- if .Values.redis.enabled }}
+  {{- $redisPassword := include "infisical.redisPassword" . }}
+  REDIS_PASSWORD: {{ $redisPassword | quote }}
+  REDIS_URL: {{ printf "redis://:%s@%s-redis:%v" $redisPassword (include "infisical.fullname" .) .Values.redis.port | quote }}
+  {{- else }}
+  REDIS_URL: {{ .Values.secrets.redisUrl | quote }}
+  {{- end }}
   {{- if not .Values.postgres.cnpg.enabled }}
   # Only used when CNPG is disabled and an external Postgres is provided.
   DB_CONNECTION_URI: {{ .Values.postgres.externalConnectionUri | quote }}

--- a/helm-charts/infisical-nkp/templates/service.yaml
+++ b/helm-charts/infisical-nkp/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "infisical.fullname" . }}
+  labels:
+    {{- include "infisical.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "infisical.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/helm-charts/infisical-nkp/values.yaml
+++ b/helm-charts/infisical-nkp/values.yaml
@@ -1,0 +1,83 @@
+# Default values for the Infisical chart (NKP catalog build).
+# These mirror the params helmify extracts from ./manifests, cleaned up so the
+# common knobs are configurable from the NKP UI.
+
+replicaCount: 1
+
+image:
+  repository: infisical/infisical
+  tag: "v0.162.11"
+  pullPolicy: IfNotPresent
+
+# Non-secret application configuration (rendered into a ConfigMap).
+config:
+  siteUrl: "https://infisical.example.com"
+  port: 8080
+  telemetryEnabled: false
+
+# Sensitive configuration (rendered into a Secret).
+# Leave encryptionKey / authSecret empty to have the chart generate random
+# values on first install (persisted across upgrades).
+secrets:
+  encryptionKey: ""            # openssl rand -hex 16
+  authSecret: ""               # openssl rand -base64 32
+  # Only used when redis.enabled=false (external Redis). When redis.enabled=true
+  # the chart wires REDIS_URL to the in-cluster Redis service automatically.
+  redisUrl: ""
+
+# Lightweight in-cluster Redis (Infisical requires REDIS_URL). Set enabled=false
+# to point at an external Redis via secrets.redisUrl instead.
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7.4-alpine"
+    pullPolicy: IfNotPresent
+  port: 6379
+
+# PostgreSQL is provided by the NKP CloudNativePG (CNPG) operator.
+# REQUIRES the CloudNativePG platform application to be enabled in the
+# workspace/cluster (it ships with NKP).
+postgres:
+  cnpg:
+    # When true, the chart creates a CNPG "Cluster" and wires Infisical to the
+    # auto-generated "<release>-db-app" secret (its "uri" key).
+    enabled: true
+    instances: 1
+    storageSize: 20Gi
+    storageClass: ""           # empty = cluster default StorageClass
+    database: infisical
+    owner: infisical
+    # imageName: ""            # optional image pin; else CNPG operator default
+  # To use an external Postgres instead, set cnpg.enabled=false and provide a
+  # full connection string here (postgres://user:pass@host:5432/db?sslmode=...).
+  externalConnectionUri: ""
+
+# Run "npm run migration:latest" as an initContainer before the app starts.
+migration:
+  enabled: true
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  className: kommander-traefik
+  host: infisical.example.com
+  annotations:
+    traefik.ingress.kubernetes.io/router.tls: "true"
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+  tls: true
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: "1"
+    memory: 1Gi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm-charts/infisical-nkp/values.yaml
+++ b/helm-charts/infisical-nkp/values.yaml
@@ -34,6 +34,10 @@ redis:
     tag: "7.4-alpine"
     pullPolicy: IfNotPresent
   port: 6379
+  # Restrict Redis ingress to the Infisical pods (enforced where the CNI
+  # supports NetworkPolicy). The bundled Redis is also password-protected with
+  # a generated password stored in the chart Secret (REDIS_PASSWORD).
+  networkPolicy: true
 
 # PostgreSQL is provided by the NKP CloudNativePG (CNPG) operator.
 # REQUIRES the CloudNativePG platform application to be enabled in the
@@ -61,6 +65,8 @@ service:
   type: ClusterIP
   port: 8080
 
+# TLS is handled by the NKP kommander-traefik controller via the router
+# annotations below; there is no separate tls toggle.
 ingress:
   enabled: true
   className: kommander-traefik
@@ -68,7 +74,6 @@ ingress:
   annotations:
     traefik.ingress.kubernetes.io/router.tls: "true"
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
-  tls: true
 
 resources:
   requests:

--- a/helm-charts/upload-infisical-nkp-helm-cloudsmith.sh
+++ b/helm-charts/upload-infisical-nkp-helm-cloudsmith.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -z "$CLOUDSMITH_API_KEY" ] || [ -z "$CLOUDSMITH_USERNAME" ]; then
+    echo "Error: CLOUDSMITH_API_KEY and CLOUDSMITH_USERNAME environment variables must be set."
+    exit 1
+fi
+
+cd "infisical-nkp"
+helm dependency update
+helm package .
+
+echo "$CLOUDSMITH_API_KEY" | helm registry login helm.oci.cloudsmith.io \
+    --username "$CLOUDSMITH_USERNAME" \
+    --password-stdin
+
+for i in *.tgz; do
+    [ -f "$i" ] || break
+    helm push "$i" oci://helm.oci.cloudsmith.io/infisical/helm-charts
+done
+
+helm registry logout helm.oci.cloudsmith.io
+
+cd ..


### PR DESCRIPTION
## What

Adds the Helm chart used for Infisical's listing in the Nutanix NKP partner catalog, plus the tooling to publish it to Cloudsmith:

- `helm-charts/infisical-nkp/`: NKP-specific chart (v0.1.0, app v0.162.11). It is separate from `infisical-standalone-postgres` because it targets NKP clusters specifically: Postgres is provisioned through the NKP CloudNativePG operator (`postgresql.cnpg.io/v1` Cluster), with a bundled Redis and defaults tuned for the NKP workspace install model. Named `infisical-nkp` to avoid colliding with the legacy `infisical` chart already on Cloudsmith.
- `helm-charts/upload-infisical-nkp-helm-cloudsmith.sh`: copy of the existing core upload script pointed at this chart. Publishes to `oci://helm.oci.cloudsmith.io/infisical/helm-charts` (the chart is created automatically from Chart.yaml).
- `.github/workflows/helm-release-infisical-nkp.yml`: workflow_dispatch release action modeled on `helm-release-infisical-core.yml`, using the existing `CLOUDSMITH_API_KEY`/`CLOUDSMITH_USERNAME` repo secrets. The test job runs `helm lint` and `helm template` rather than a kind install test, since the chart depends on the CloudNativePG operator CRDs that NKP provides at runtime.

## Why

Nutanix's partner catalog (nutanix-cloud-native/nkp-partner-catalog) installs apps by pulling a chart from a public OCI registry. The catalog PR for Infisical points at this chart on Cloudsmith. Discussed with Maidul and Victor: hosting on Cloudsmith with our other charts, published via the same script/action pattern.

## After merge

Run the "Release Infisical NKP Helm chart" workflow once (Actions tab) to publish `infisical-nkp:0.1.0`, then the Nutanix catalog PR can go in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/infisical/infisical/pull/7467" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->