### PR TITLE
fix(ui): normalize iOS input font sizing

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,10 +1,14 @@
 import type { Preview } from "@storybook/react-vite";
 
+import { initializePlatform } from "../src/lib/fn/platform";
+
 import { DocumentDecorator, RouterDecorator } from "./decorators";
 
 import "@fontsource/inter/400.css";
 import "@fontsource/inter/500.css";
 import "../src/index.css";
+
+initializePlatform();
 
 const preview: Preview = {
   decorators: [DocumentDecorator, RouterDecorator],

--- a/frontend/src/components/v3/generic/Input/Input.tsx
+++ b/frontend/src/components/v3/generic/Input/Input.tsx
@@ -10,7 +10,7 @@ const Input = forwardRef<HTMLInputElement, React.ComponentProps<"input"> & { isE
         type={type}
         data-slot="input"
         className={cn(
-          "h-9 w-full min-w-0 rounded-md border border-border bg-transparent px-3 py-1 text-base text-foreground shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "h-9 w-full min-w-0 rounded-md border border-border bg-transparent px-3 py-1 text-sm text-foreground shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
           "hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60",
           "aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60",
           "selection:bg-foreground selection:text-background",

--- a/frontend/src/components/v3/generic/TextArea/TextArea.tsx
+++ b/frontend/src/components/v3/generic/TextArea/TextArea.tsx
@@ -12,7 +12,7 @@ const TextArea = React.forwardRef<
       ref={ref}
       data-slot="textarea"
       className={cn(
-        "placeholder:text-muted-foreground flex min-h-16 thin-scrollbar w-full rounded-md border border-border bg-transparent px-3 py-2 text-base text-foreground shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60 md:text-sm",
+        "placeholder:text-muted-foreground flex min-h-16 thin-scrollbar w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm text-foreground shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60",
         className
       )}
       aria-invalid={isError}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -235,6 +235,9 @@
   --color-blue-900: #00367d;
 }
 
+/* iOS Safari zooms the viewport when focusing an input whose font-size is below 16px.
+   Bumping the type scale on detected iOS devices keeps form controls at/above that
+   threshold to prevent the zoom while preserving their relationship to surrounding text. */
 html[data-platform="ios"] {
   --text-xs: 0.875rem;
   --text-sm: 1rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -66,6 +66,9 @@
   --breakpoint-dashboard: 1400px;
 
   /* Fonts */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
   --font-alliance:
     "Alliance No. 2", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
     sans-serif;
@@ -230,6 +233,12 @@
   --color-blue-700: #0053bf;
   --color-blue-800: #004299;
   --color-blue-900: #00367d;
+}
+
+html[data-platform="ios"] {
+  --text-xs: 0.875rem;
+  --text-sm: 1rem;
+  --text-base: 1.125rem;
 }
 
 @utility min-table-row {

--- a/frontend/src/lib/fn/platform.ts
+++ b/frontend/src/lib/fn/platform.ts
@@ -1,0 +1,9 @@
+const isIos =
+  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+  (navigator.userAgent.includes("Macintosh") && navigator.maxTouchPoints > 1);
+
+export const initializePlatform = () => {
+  if (isIos) {
+    document.documentElement.dataset.platform = "ios";
+  }
+};

--- a/frontend/src/lib/fn/platform.ts
+++ b/frontend/src/lib/fn/platform.ts
@@ -1,8 +1,8 @@
-const isIos =
-  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-  (navigator.userAgent.includes("Macintosh") && navigator.maxTouchPoints > 1);
-
 export const initializePlatform = () => {
+  const isIos =
+    /iPad|iPhone|iPod/.test(navigator?.userAgent ?? "") ||
+    (!!navigator?.userAgent?.includes("Macintosh") && (navigator?.maxTouchPoints ?? 0) > 1);
+
   if (isIos) {
     document.documentElement.dataset.platform = "ios";
   }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,7 @@ import NProgress from "nprogress";
 
 import { Lottie } from "./components/v2";
 import { queryClient } from "./hooks/api/reactQuery";
+import { initializePlatform } from "./lib/fn/platform";
 import { ErrorPage } from "./pages/public/ErrorPage/ErrorPage";
 import { NotFoundPage } from "./pages/public/NotFoundPage/NotFoundPage";
 // Import the generated route tree
@@ -27,13 +28,7 @@ import "./translation";
 // have a look at the Quick start guide
 // for passing in lng and translations on init/
 
-const isIos =
-  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-  (navigator.userAgent.includes("Macintosh") && navigator.maxTouchPoints > 1);
-
-if (isIos) {
-  document.documentElement.dataset.platform = "ios";
-}
+initializePlatform();
 
 // Configure Lottie player to use local WASM file
 setWasmUrl(lottieWasmUrl);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -27,6 +27,14 @@ import "./translation";
 // have a look at the Quick start guide
 // for passing in lng and translations on init/
 
+const isIos =
+  /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+  (navigator.userAgent.includes("Macintosh") && navigator.maxTouchPoints > 1);
+
+if (isIos) {
+  document.documentElement.dataset.platform = "ios";
+}
+
 // Configure Lottie player to use local WASM file
 setWasmUrl(lottieWasmUrl);
 


### PR DESCRIPTION
## Context

On narrow viewports, the shared v3 `Input` and `TextArea` currently switch from `text-sm` to `text-base` so iOS Safari does not zoom when a control receives focus. Because that exception lives inside each component and applies to every mobile browser, the controls can appear larger than surrounding typography even when Safari zoom prevention is not needed.

This change makes the behavior systematic:

- `Input` and `TextArea` now use `text-sm` at every viewport size, with no component-level mobile font override.
- The global Tailwind theme explicitly defines the normal `text-xs`, `text-sm`, and `text-base` scale as 12px, 14px, and 16px.
- Application bootstrap detects iOS and iPadOS, including iPads presenting a desktop-class user agent, and marks the document with `data-platform="ios"`.
- On detected iOS devices, the same global scale shifts to 14px, 16px, and 18px. This keeps form controls at Safari's 16px focus threshold while preserving their relationship to labels, descriptions, and surrounding text.

Non-iOS typography and desktop component behavior remain unchanged.

Linear: [DES-59](https://linear.app/infisical/issue/DES-59/normalize-mobile-input-font-resizing)

## Screenshots

Visual evidence has not been captured yet.

Outstanding capture requests:

<img width="2120" height="1384" alt="CleanShot 2026-07-29 at 09 38 34@2x" src="https://github.com/user-attachments/assets/fcdb032c-ac54-4449-9194-4951039aa63e" />
<img width="603" height="1311" alt="Infisical  Networking" src="https://github.com/user-attachments/assets/5d4abe60-3141-4687-8984-d352d3983646" />
(no zoom on iphone)

## Steps to verify the change

1. In desktop Chromium, open the `Generic/Input` and `Generic/TextArea` Storybook stories and confirm both controls compute to `text-sm` (14px).
2. Confirm the document root does not receive `data-platform="ios"` and `text-xs`, `text-sm`, and `text-base` compute to 12px, 14px, and 16px.
3. On iOS Safari, open the same stories and confirm the document root receives `data-platform="ios"`.
4. Confirm `text-xs`, `text-sm`, and `text-base` compute to 14px, 16px, and 18px on iOS.
5. Focus the input and textarea and confirm Safari does not zoom the viewport.
6. Exercise default, disabled, error, prefilled, and autofill states, plus textarea growth.
7. Confirm desktop Chromium and non-iOS Safari retain their previous typography and control behavior.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)