### PR TITLE
fix(jwt-auth): handle array-valued aud claim in audience check

### DIFF
--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.test.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+
+import { doesAudValueMatchJwtPolicy, doesFieldValueMatchJwtPolicy } from "./identity-jwt-auth-fns";
+
+describe("doesFieldValueMatchJwtPolicy", () => {
+  test("matches equal boolean values", () => {
+    expect(doesFieldValueMatchJwtPolicy(true, "true")).toBe(true);
+    expect(doesFieldValueMatchJwtPolicy(false, "true")).toBe(false);
+  });
+
+  test("matches equal number values", () => {
+    expect(doesFieldValueMatchJwtPolicy(42, "42")).toBe(true);
+    expect(doesFieldValueMatchJwtPolicy(42, "43")).toBe(false);
+  });
+
+  test("matches exact and glob string values", () => {
+    expect(doesFieldValueMatchJwtPolicy("system:serviceaccount:ns:sa", "system:serviceaccount:ns:sa")).toBe(true);
+    expect(doesFieldValueMatchJwtPolicy("system:serviceaccount:ns:sa", "system:serviceaccount:ns:*")).toBe(true);
+    expect(doesFieldValueMatchJwtPolicy("system:serviceaccount:ns:sa", "system:serviceaccount:other:*")).toBe(false);
+  });
+});
+
+describe("doesAudValueMatchJwtPolicy", () => {
+  test("matches an exact scalar aud", () => {
+    expect(doesAudValueMatchJwtPolicy("infisical", "infisical")).toBe(true);
+  });
+
+  test("does not match a mismatched scalar aud", () => {
+    expect(doesAudValueMatchJwtPolicy("infisical", "other")).toBe(false);
+  });
+
+  test("matches a glob scalar aud", () => {
+    expect(doesAudValueMatchJwtPolicy("infisical-prod", "infisical-*")).toBe(true);
+  });
+
+  test("matches an array aud containing the configured audience (Kubernetes ServiceAccount shape)", () => {
+    expect(doesAudValueMatchJwtPolicy(["infisical", "other"], "infisical")).toBe(true);
+  });
+
+  test("does not match an array aud that lacks the configured audience", () => {
+    expect(doesAudValueMatchJwtPolicy(["foo", "bar"], "infisical")).toBe(false);
+  });
+
+  test("matches an array aud via a glob entry", () => {
+    expect(doesAudValueMatchJwtPolicy(["foo", "infisical-prod"], "infisical-*")).toBe(true);
+  });
+
+  test("never throws on an array aud", () => {
+    expect(() => doesAudValueMatchJwtPolicy(["infisical"], "infisical")).not.toThrow();
+  });
+});

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.ts
@@ -11,3 +11,11 @@ export const doesFieldValueMatchJwtPolicy = (fieldValue: string | boolean | numb
 
   return policyValue === fieldValue || picomatch.isMatch(fieldValue, policyValue, { bash: true });
 };
+
+export const doesAudValueMatchJwtPolicy = (fieldValue: string | string[], policyValue: string) => {
+  if (Array.isArray(fieldValue)) {
+    return fieldValue.some((entry) => entry === policyValue || picomatch.isMatch(entry, policyValue, { bash: true }));
+  }
+
+  return policyValue === fieldValue || picomatch.isMatch(fieldValue, policyValue, { bash: true });
+};

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -51,7 +51,7 @@ import { TMembershipIdentityDALFactory } from "../membership-identity/membership
 import { TOrgDALFactory } from "../org/org-dal";
 import { validateIdentityUpdateForSuperAdminPrivileges } from "../super-admin/super-admin-fns";
 import { TIdentityJwtAuthDALFactory } from "./identity-jwt-auth-dal";
-import { doesFieldValueMatchJwtPolicy } from "./identity-jwt-auth-fns";
+import { doesAudValueMatchJwtPolicy, doesFieldValueMatchJwtPolicy } from "./identity-jwt-auth-fns";
 import {
   JwtConfigurationType,
   TAttachJwtAuthDTO,
@@ -251,7 +251,7 @@ export const identityJwtAuthServiceFactory = ({
         if (
           !identityJwtAuth.boundAudiences
             .split(", ")
-            .some((policyValue) => doesFieldValueMatchJwtPolicy(tokenData.aud, policyValue))
+            .some((policyValue) => doesAudValueMatchJwtPolicy(tokenData.aud as string | string[], policyValue))
         ) {
           throw new UnauthorizedError({
             message: "Access denied: token audience not allowed",


### PR DESCRIPTION
## Context

Machine Identities using **JWT Auth** with an **Audiences** bound claim configured return
a `500 Internal Server Error` when the presented token's `aud` claim is a JSON array
rather than a scalar string — even when the configured audience is a member of that
array. Array-valued `aud` is spec-legal (RFC 7519 §4.1.3) and is the guaranteed shape of
every Kubernetes ServiceAccount token, so this blocks any Kubernetes workload
authenticating via JWT Auth with an audience constraint.

Root cause: the audience check calls `doesFieldValueMatchJwtPolicy`
(`backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.ts`), which is typed for
`string | boolean | number` only. An array value matches neither the `boolean` nor
`number` branch, so it falls through to `picomatch.isMatch(fieldValue, policyValue, { bash: true })`,
which throws on a non-string input:

```
$ node -e "require('picomatch').isMatch(['infisical','other'], 'infisical', {bash:true})"
Uncaught Error: Expected input to be a string
```

That uncaught throw is what the global error handler turns into the reported `500`.

This repo already solved the identical problem on the **OIDC** auth path —
`identity-oidc-auth-fns.ts` has a dedicated `doesAudValueMatchOidcPolicy(fieldValue: string | string[], ...)`
used only for the audience check, while `boundSubject`/`boundClaims` keep the scalar-only
function. This PR adds the equivalent for JWT auth, following that existing precedent
exactly, rather than widening the general-purpose function (which would change behavior
for `boundSubject`/`boundClaims` beyond what's reported here).

Fixes #7462

## Steps to verify the change

1. Configure a Machine Identity with JWT Auth (JWKS) and set **Audiences** to a value.
2. Present a token whose `aud` claim is a JSON array containing that audience (e.g. a
   Kubernetes ServiceAccount token minted with `kubectl create token <sa> --audience <aud>`).
3. Before this change: login returns `500`. After this change: login succeeds (`200`) when
   the audience is a member of the array, and correctly returns `401` (not `500`) when it
   isn't.

Also covered by the new unit tests in `identity-jwt-auth-fns.test.ts`:
- scalar `aud` exact/glob match and mismatch (regression coverage for existing behavior)
- array `aud` containing the configured audience → matches (previously threw)
- array `aud` not containing the configured audience → no match, no throw (previously threw)
- array `aud` matching via a glob entry

## Type

- [x] Fix

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
