### PR TITLE
chore: scope statement_timeout to transaction and make pool sizes configurable

### DIFF
--- a/backend/src/db/instance.ts
+++ b/backend/src/db/instance.ts
@@ -24,11 +24,24 @@ const parseSslConfig = (dbConnectionUri: string, dbRootCert?: string) => {
   return { modifiedDbConnectionUri, sslConfig };
 };
 
+export type TDbPoolConfig = { min: number; max: number };
+
+export const DbApplicationName = {
+  Primary: "infisical-core",
+  Replica: "infisical-core-replica",
+  AuditLog: "infisical-core-audit",
+  Migrator: "infisical-core-migrator"
+} as const;
+
+const DEFAULT_POOL: TDbPoolConfig = { min: 0, max: 10 };
+
 export type TDbClient = Knex;
 export const initDbConnection = ({
   dbConnectionUri,
   dbRootCert,
-  readReplicas = []
+  readReplicas = [],
+  pool = DEFAULT_POOL,
+  replicaPool = DEFAULT_POOL
 }: {
   dbConnectionUri: string;
   dbRootCert?: string;
@@ -36,6 +49,8 @@ export const initDbConnection = ({
     dbConnectionUri: string;
     dbRootCert?: string;
   }[];
+  pool?: TDbPoolConfig;
+  replicaPool?: TDbPoolConfig;
 }) => {
   // akhilmhdh: the default Knex is knex.Knex<any, any[]>. but when assigned with knex({<config>}) the value is knex.Knex<any, unknown[]>
   // this was causing issue with files like `snapshot-dal` `findRecursivelySnapshots` this i am explicitly putting the any and unknown[]
@@ -67,10 +82,11 @@ export const initDbConnection = ({
       user: process.env.DB_USER,
       database: process.env.DB_NAME,
       password: process.env.DB_PASSWORD,
-      ssl: sslConfig
+      ssl: sslConfig,
+      application_name: DbApplicationName.Primary
     },
     // https://knexjs.org/guide/#pool
-    pool: { min: 0, max: 10 },
+    pool,
     migrations: {
       tableName: "infisical_migrations"
     }
@@ -87,12 +103,13 @@ export const initDbConnection = ({
       client: "pg",
       connection: {
         connectionString: replicaUri,
-        ssl: replicaSslConfig
+        ssl: replicaSslConfig,
+        application_name: DbApplicationName.Replica
       },
       migrations: {
         tableName: "infisical_migrations"
       },
-      pool: { min: 0, max: 10 }
+      pool: replicaPool
     });
   });
 
@@ -101,10 +118,12 @@ export const initDbConnection = ({
 
 export const initAuditLogDbConnection = ({
   dbConnectionUri,
-  dbRootCert
+  dbRootCert,
+  pool = DEFAULT_POOL
 }: {
   dbConnectionUri: string;
   dbRootCert?: string;
+  pool?: TDbPoolConfig;
 }) => {
   const { modifiedDbConnectionUri, sslConfig } = parseSslConfig(dbConnectionUri, dbRootCert);
 
@@ -120,12 +139,13 @@ export const initAuditLogDbConnection = ({
       user: process.env.AUDIT_LOGS_DB_USER,
       database: process.env.AUDIT_LOGS_DB_NAME,
       password: process.env.AUDIT_LOGS_DB_PASSWORD,
-      ssl: sslConfig
+      ssl: sslConfig,
+      application_name: DbApplicationName.AuditLog
     },
     migrations: {
       tableName: "infisical_migrations"
     },
-    pool: { min: 0, max: 10 }
+    pool
   });
 
   // we add these overrides so that auditLogDb and the primary DB are interchangeable

--- a/backend/src/db/knexfile.ts
+++ b/backend/src/db/knexfile.ts
@@ -6,6 +6,8 @@ import type { Knex } from "knex";
 import path from "path";
 import { initLogger } from "@app/lib/logger";
 
+import { DbApplicationName } from "./instance";
+
 // Update with your config settings. .
 dotenv.config({
   path: path.join(__dirname, "../../../.env.migration")
@@ -31,7 +33,8 @@ export default {
             rejectUnauthorized: true,
             ca: Buffer.from(process.env.DB_ROOT_CERT, "base64").toString("ascii")
           }
-        : false
+        : false,
+      application_name: DbApplicationName.Migrator
     },
     pool: {
       min: 2,
@@ -59,7 +62,8 @@ export default {
             rejectUnauthorized: true,
             ca: Buffer.from(process.env.DB_ROOT_CERT, "base64").toString("ascii")
           }
-        : false
+        : false,
+      application_name: DbApplicationName.Migrator
     },
     pool: {
       min: 2,

--- a/backend/src/ee/services/audit-log/audit-log-dal.ts
+++ b/backend/src/ee/services/audit-log/audit-log-dal.ts
@@ -236,7 +236,7 @@ export const auditLogDALFactory = (db: TDbClient) => {
       try {
         // eslint-disable-next-line no-await-in-loop
         deletedAuditLogIds = await db.transaction(async (trx) => {
-          await trx.raw(`SET statement_timeout = ${QUERY_TIMEOUT_MS}`);
+          await trx.raw(`SET LOCAL statement_timeout = ${QUERY_TIMEOUT_MS}`);
 
           const findExpiredLogSubQuery = trx(TableName.AuditLog)
             .where("expiresAt", "<", today)

--- a/backend/src/keystore/key-value-store-dal.ts
+++ b/backend/src/keystore/key-value-store-dal.ts
@@ -54,7 +54,7 @@ export const keyValueStoreDALFactory = (db: TDbClient): TKeyValueStoreDALFactory
       try {
         // eslint-disable-next-line no-await-in-loop
         deletedIds = await db.transaction(async (trx) => {
-          await trx.raw(`SET statement_timeout = ${QUERY_TIMEOUT_MS}`);
+          await trx.raw(`SET LOCAL statement_timeout = ${QUERY_TIMEOUT_MS}`);
 
           const findExpiredKeysSubQuery = trx(TableName.KeyValueStore)
             .where("expiresAt", "<", db.fn.now())

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -159,21 +159,29 @@ const envSchema = z
     DB_PASSWORD: zpStr(z.string().describe("Postgres database password").optional()),
     DB_NAME: zpStr(z.string().describe("Postgres database name").optional()),
     DB_READ_REPLICAS: zpStr(z.string().describe("Postgres read replicas").optional()),
-    DB_POOL_MIN: z.coerce.number().min(0).default(0).describe("Minimum primary Postgres pool connections"),
-    DB_POOL_MAX: z.coerce.number().min(1).default(10).describe("Maximum primary Postgres pool connections"),
+    DB_POOL_MIN: z.coerce.number().int().min(0).default(0).describe("Minimum primary Postgres pool connections"),
+    DB_POOL_MAX: z.coerce.number().int().min(1).default(10).describe("Maximum primary Postgres pool connections"),
     DB_REPLICA_POOL_MIN: z.coerce
       .number()
+      .int()
       .min(0)
       .default(0)
       .describe("Minimum pool connections per Postgres read replica"),
     DB_REPLICA_POOL_MAX: z.coerce
       .number()
+      .int()
       .min(1)
       .default(10)
       .describe("Maximum pool connections per Postgres read replica"),
-    AUDIT_LOGS_DB_POOL_MIN: z.coerce.number().min(0).default(0).describe("Minimum audit log Postgres pool connections"),
+    AUDIT_LOGS_DB_POOL_MIN: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .default(0)
+      .describe("Minimum audit log Postgres pool connections"),
     AUDIT_LOGS_DB_POOL_MAX: z.coerce
       .number()
+      .int()
       .min(1)
       .default(10)
       .describe("Maximum audit log Postgres pool connections"),
@@ -546,6 +554,23 @@ const envSchema = z
     (data) => Boolean(data.REDIS_URL) || Boolean(data.REDIS_SENTINEL_HOSTS) || Boolean(data.REDIS_CLUSTER_HOSTS),
     "Either REDIS_URL, REDIS_SENTINEL_HOSTS or REDIS_CLUSTER_HOSTS  must be defined."
   )
+  .superRefine((data, ctx) => {
+    (
+      [
+        ["DB_POOL_MIN", "DB_POOL_MAX"],
+        ["DB_REPLICA_POOL_MIN", "DB_REPLICA_POOL_MAX"],
+        ["AUDIT_LOGS_DB_POOL_MIN", "AUDIT_LOGS_DB_POOL_MAX"]
+      ] as const
+    ).forEach(([minKey, maxKey]) => {
+      if (data[minKey] > data[maxKey]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [minKey],
+          message: `${minKey} (${data[minKey]}) must be less than or equal to ${maxKey} (${data[maxKey]}).`
+        });
+      }
+    });
+  })
   .transform((data) => ({
     ...data,
     SALT_ROUNDS: data.SALT_ROUNDS || data.BCRYPT_SALT_ROUND || 12,

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -159,6 +159,24 @@ const envSchema = z
     DB_PASSWORD: zpStr(z.string().describe("Postgres database password").optional()),
     DB_NAME: zpStr(z.string().describe("Postgres database name").optional()),
     DB_READ_REPLICAS: zpStr(z.string().describe("Postgres read replicas").optional()),
+    DB_POOL_MIN: z.coerce.number().min(0).default(0).describe("Minimum primary Postgres pool connections"),
+    DB_POOL_MAX: z.coerce.number().min(1).default(10).describe("Maximum primary Postgres pool connections"),
+    DB_REPLICA_POOL_MIN: z.coerce
+      .number()
+      .min(0)
+      .default(0)
+      .describe("Minimum pool connections per Postgres read replica"),
+    DB_REPLICA_POOL_MAX: z.coerce
+      .number()
+      .min(1)
+      .default(10)
+      .describe("Maximum pool connections per Postgres read replica"),
+    AUDIT_LOGS_DB_POOL_MIN: z.coerce.number().min(0).default(0).describe("Minimum audit log Postgres pool connections"),
+    AUDIT_LOGS_DB_POOL_MAX: z.coerce
+      .number()
+      .min(1)
+      .default(10)
+      .describe("Maximum audit log Postgres pool connections"),
     BCRYPT_SALT_ROUND: z.number().optional(), // note(daniel): this is deprecated, use SALT_ROUNDS instead. only keeping this for backwards compatibility.
     NODE_ENV: z.enum(["development", "test", "production"]).default("production"),
     SALT_ROUNDS: z.coerce.number().default(10),
@@ -702,7 +720,9 @@ export const getDatabaseCredentials = (logger?: CustomLogger) => {
     readReplicas: parsedEnv.data.DB_READ_REPLICAS?.map((el) => ({
       dbRootCert: el.DB_ROOT_CERT,
       dbConnectionUri: el.DB_CONNECTION_URI
-    }))
+    })),
+    pool: { min: parsedEnv.data.DB_POOL_MIN, max: parsedEnv.data.DB_POOL_MAX },
+    replicaPool: { min: parsedEnv.data.DB_REPLICA_POOL_MIN, max: parsedEnv.data.DB_REPLICA_POOL_MAX }
   };
 };
 

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -55,7 +55,9 @@ const run = async () => {
   const db = initDbConnection({
     dbConnectionUri: databaseCredentials.dbConnectionUri,
     dbRootCert: databaseCredentials.dbRootCert,
-    readReplicas: databaseCredentials.readReplicas
+    readReplicas: databaseCredentials.readReplicas,
+    pool: databaseCredentials.pool,
+    replicaPool: databaseCredentials.replicaPool
   });
 
   // Register connection-pool and entity-count observable gauges. No-ops when telemetry is disabled.
@@ -72,7 +74,8 @@ const run = async () => {
   const auditLogDb = envConfig.AUDIT_LOGS_DB_CONNECTION_URI
     ? initAuditLogDbConnection({
         dbConnectionUri: envConfig.AUDIT_LOGS_DB_CONNECTION_URI,
-        dbRootCert: envConfig.AUDIT_LOGS_DB_ROOT_CERT
+        dbRootCert: envConfig.AUDIT_LOGS_DB_ROOT_CERT,
+        pool: { min: envConfig.AUDIT_LOGS_DB_POOL_MIN, max: envConfig.AUDIT_LOGS_DB_POOL_MAX }
       })
     : undefined;
 

--- a/backend/src/services/notification/user-notification-dal.ts
+++ b/backend/src/services/notification/user-notification-dal.ts
@@ -74,7 +74,7 @@ export const userNotificationDALFactory = (db: TDbClient) => {
       try {
         // eslint-disable-next-line no-await-in-loop
         deletedNotificationIds = await db.transaction(async (trx) => {
-          await trx.raw(`SET statement_timeout = ${QUERY_TIMEOUT_MS}`);
+          await trx.raw(`SET LOCAL statement_timeout = ${QUERY_TIMEOUT_MS}`);
 
           const findExpiredNotificationSubQuery = trx(TableName.UserNotifications)
             .where("createdAt", "<", threeMonthsAgo)

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -242,6 +242,64 @@ DB_READ_REPLICAS=[{"DB_CONNECTION_URI":""}]
   </Expandable>
 </ParamField>
 
+#### Connection pool sizing (Optional)
+
+Each Infisical instance keeps its own pool of Postgres connections. The defaults suit a small deployment and
+most self-hosters never need to change them, but they become relevant once you run many instances: pools are
+**per instance**, so the total number of connections your database sees grows with your instance count.
+
+Work out your total like this:
+
+```
+per instance = DB_POOL_MAX
+             + (DB_REPLICA_POOL_MAX x number of read replicas)
+             + AUDIT_LOGS_DB_POOL_MAX   (only if AUDIT_LOGS_DB_CONNECTION_URI is set)
+
+total        = per instance x number of instances
+```
+
+Then compare that total against your database's `max_connections` (`SHOW max_connections;`). Two things are
+easy to miss:
+
+- **Rolling deploys briefly double the total.** Old and new instances both hold pools while the rollout
+  completes, so size against roughly twice your steady-state number.
+- **Autoscaling sets the ceiling, not your current instance count.** If you autoscale, do the math with the
+  maximum replica count, not today's.
+
+Aim to keep the peak comfortably under `max_connections`, leaving headroom for migrations, admin tools, and
+your own `psql` sessions. If you are close to the limit, **lower `DB_POOL_MAX`** rather than raising
+`max_connections`: each Postgres connection costs memory on the server, and a large number of mostly-idle
+connections wastes it. If instead you see queries queueing while your database is idle, the pool is too small
+and raising it is the right move.
+
+<Tip>
+  Prefer scaling reads with `DB_READ_REPLICAS` over enlarging the primary pool. A connection pooler such as
+  PgBouncer or RDS Proxy is only worth the extra hop and failure domain once instance count alone pushes you
+  near `max_connections`, and note that a pooler in transaction mode does **not** reclaim connections held
+  open inside a transaction.
+</Tip>
+
+<ParamField query="DB_POOL_MIN" type="int" default="0" optional>
+  Minimum connections kept open in the primary database pool. `0` lets idle connections close, which is
+  usually what you want. Raise it only to avoid connection-setup latency on bursty traffic, and be aware that
+  a non-zero value holds connections open on the server even while the instance is idle.
+</ParamField>
+
+<ParamField query="DB_POOL_MAX" type="int" default="10" optional>
+  Maximum connections in the primary database pool. Must be at least `1` and greater than or equal to
+  `DB_POOL_MIN`.
+</ParamField>
+
+<ParamField query="DB_REPLICA_POOL_MIN" type="int" default="0" optional>
+  Minimum connections kept open per read replica pool. Applies to each replica in `DB_READ_REPLICAS`
+  individually.
+</ParamField>
+
+<ParamField query="DB_REPLICA_POOL_MAX" type="int" default="10" optional>
+  Maximum connections **per read replica**. With three replicas and the default of `10`, each instance can
+  open up to 30 replica connections in addition to its primary pool.
+</ParamField>
+
 ### Audit Log PostgreSQL (Optional)
 
 <ParamField query="AUDIT_LOGS_DB_CONNECTION_URI" type="string" optional>
@@ -250,6 +308,16 @@ DB_READ_REPLICAS=[{"DB_CONNECTION_URI":""}]
 
 <ParamField query="AUDIT_LOGS_DB_ROOT_CERT" type="string" optional>
   Base64-encoded CA certificate for the audit log PostgreSQL database connection. Only needed if `AUDIT_LOGS_DB_CONNECTION_URI` is set.
+</ParamField>
+
+<ParamField query="AUDIT_LOGS_DB_POOL_MIN" type="int" default="0" optional>
+  Minimum connections kept open in the audit log database pool. Only used when
+  `AUDIT_LOGS_DB_CONNECTION_URI` is set.
+</ParamField>
+
+<ParamField query="AUDIT_LOGS_DB_POOL_MAX" type="int" default="10" optional>
+  Maximum connections in the audit log database pool. Only used when `AUDIT_LOGS_DB_CONNECTION_URI` is set.
+  This pool is separate from the primary pool, so it adds to your per-instance total.
 </ParamField>
 
 ### ClickHouse (Optional)

--- a/docs/self-hosting/deployment-options/aws-native.mdx
+++ b/docs/self-hosting/deployment-options/aws-native.mdx
@@ -1354,7 +1354,9 @@ After completing the above steps, your Infisical instance should be running on A
     - Scale ECS tasks horizontally (increase desired count)
     - Scale RDS vertically (larger instance class)
     - Enable RDS Performance Insights for query analysis
-    - Consider connection pooling (PgBouncer)
+    - Tune the per-task connection pool with [`DB_POOL_MAX`](/self-hosting/configuration/envars#connection-pool-sizing-optional). Connection pools are per task, so `DatabaseConnections` scales with your task count and rolling deploys briefly double it. Lowering `DB_POOL_MAX` is usually the cheaper fix.
+    - Offload reads to replicas with `DB_READ_REPLICAS`
+    - Consider a connection pooler (RDS Proxy or PgBouncer) only once task count alone pushes you near `max_connections`
   </Accordion>
 
   <Accordion title="ECS Exec not working">


### PR DESCRIPTION
## Context

Two small DB connection improvements and one bug fix from digging into pool/connection behavior.

### 1. Pool sizes are now configurable

The primary, read replica, and audit log Knex pools were previously hardcoded to `{ min: 0, max: 10 }`.

They now read their configuration from environment variables:

- `DB_POOL_MIN` / `DB_POOL_MAX`
- `DB_REPLICA_POOL_MIN` / `DB_REPLICA_POOL_MAX`
- `AUDIT_LOGS_DB_POOL_MIN` / `AUDIT_LOGS_DB_POOL_MAX`

The defaults are unchanged, so behavior stays exactly the same unless these values are explicitly configured.

### 2. Every connection now sets `application_name`

Every PostgreSQL connection now sets `application_name`, making `pg_stat_activity` much easier to read instead of showing a wall of `node` processes.

Application names:

- `infisical-core`
- `infisical-core-replica`
- `infisical-core-audit`
- `infisical-core-migrator`

### 3. Bug fix: `SET statement_timeout` → `SET LOCAL statement_timeout`

The audit log, key-value store, and user notification cleanup DALs were setting `statement_timeout` inside a transaction using `SET` instead of `SET LOCAL`.

Because these jobs run on pooled connections, the timeout persisted after the transaction committed. Any unrelated query that later reused the same connection inherited the cleanup job's timeout, which could cause unexpected query cancellations.

Using `SET LOCAL` scopes the timeout to the current transaction, so it is automatically reset when the transaction finishes.

## Steps to verify

1. Start the backend without setting any of the new environment variables. Confirm it starts successfully and pool behavior is unchanged.
2. Set `DB_POOL_MAX=25`, restart the backend, and run:

   ```sql
   SELECT application_name, COUNT(*)
   FROM pg_stat_activity
   GROUP BY 1;
   ```

   Verify that:
   - `infisical-core` connections are present.
   - The pool can grow beyond 10 connections.

3. Run database migrations and confirm the migration connection appears as `infisical-core-migrator`.
4. Verify the `SET LOCAL` fix by triggering one of the cleanup jobs (audit log prune, key-value store cleanup, or notification cleanup). Afterwards:
   - Run a slow query on the same pool and confirm it is no longer canceled by an inherited timeout.
   - Alternatively, run `SHOW statement_timeout` on a reused connection and verify it has not retained the cleanup job's timeout.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)