### PR TITLE
feat: improvement in caching and reconcile trial mechanism

### DIFF
--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -53,7 +53,7 @@ type TLicenseV2ServiceFactoryDep = {
   licenseClient: Pick<
     TLicenseClientFactory,
     | "getEntitlements"
-    | "invalidateEntitlements"
+    | "markEntitlementsStale"
     | "refreshEntitlements"
     | "getCatalog"
     | "getSubscription"
@@ -866,7 +866,7 @@ export const licenseV2ServiceFactory = ({
     });
 
     if (result.outcome === "subscription_updated") {
-      await licenseClient.invalidateEntitlements(orgId);
+      await licenseClient.markEntitlementsStale(orgId);
       return { outcome: "subscription_updated" as const, subscriptionId: result.subscriptionId };
     }
 
@@ -953,7 +953,7 @@ export const licenseV2ServiceFactory = ({
       productId,
       dimensions: changes.map((change) => ({ dimensionKey: change.dimensionKey, quantity: change.quantity }))
     });
-    await licenseClient.invalidateEntitlements(orgId);
+    await licenseClient.markEntitlementsStale(orgId);
     if (result.outcome === "checkout_created") {
       if (!result.checkoutUrl) {
         throw new InternalServerError({ message: "Checkout session did not return a URL" });
@@ -970,15 +970,24 @@ export const licenseV2ServiceFactory = ({
     // The trial has no Stripe customer yet, so the server creates one from the org's own name + the
     // authenticated user's email; neither is client-supplied.
     const organization = await orgDAL.findById(orgId);
+
+    // Seed the trial with the org's present usage so it opens showing current quantities, exactly as
+    // checkout does. A trial converts to a monthly usage-based line, so derive declaredUsage at the
+    // monthly cadence; skip it silently if the product/plan can't be resolved (server floors it).
+    const catalog = await licenseClient.getCatalog(orgId);
+    const product = catalog?.products.find((candidate) => candidate.id === productId);
+    const resolved = product ? await buildProductLineItem(product, "monthly", orgId, plan) : null;
+
     const result = await licenseClient.startTrial(orgId, {
       productKey: productId,
       planKey: plan,
       email,
       name: organization?.name,
+      declaredUsage: resolved?.declaredUsage,
       // The trial's card-setup checkout redirects here; built server-side from SITE_URL like checkout.
       returnUrl: buildReturnUrl(orgId)
     });
-    await licenseClient.invalidateEntitlements(orgId);
+    await licenseClient.markEntitlementsStale(orgId);
     return { outcome: result.outcome, cardSetupUrl: result.cardSetupUrl };
   };
 
@@ -987,7 +996,7 @@ export const licenseV2ServiceFactory = ({
   const cancelTrial = async ({ orgId, actor, productId }: TCancelBillingV2TrialDTO) => {
     await ensureManageBilling(orgId, actor);
     const result = await licenseClient.cancelTrial(orgId, { productKey: productId });
-    await licenseClient.invalidateEntitlements(orgId);
+    await licenseClient.markEntitlementsStale(orgId);
     return { outcome: result.outcome };
   };
 
@@ -996,21 +1005,21 @@ export const licenseV2ServiceFactory = ({
   const removeProduct = async ({ orgId, actor, productId }: TRemoveBillingV2ProductDTO) => {
     await ensureManageBilling(orgId, actor);
     const result = await licenseClient.removeProduct(orgId, productId);
-    await licenseClient.invalidateEntitlements(orgId);
+    await licenseClient.markEntitlementsStale(orgId);
     return { subscriptionId: result.subscriptionId };
   };
 
   const cancelSubscription = async ({ orgId, actor }: TBillingV2SubscriptionLifecycleDTO) => {
     await ensureManageBilling(orgId, actor);
     const result = await licenseClient.cancelSubscription(orgId);
-    await licenseClient.invalidateEntitlements(orgId);
+    await licenseClient.markEntitlementsStale(orgId);
     return { subscriptionId: result.subscriptionId };
   };
 
   const resumeSubscription = async ({ orgId, actor }: TBillingV2SubscriptionLifecycleDTO) => {
     await ensureManageBilling(orgId, actor);
     const result = await licenseClient.resumeSubscription(orgId);
-    await licenseClient.invalidateEntitlements(orgId);
+    await licenseClient.markEntitlementsStale(orgId);
     return { subscriptionId: result.subscriptionId };
   };
 

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -874,7 +874,7 @@ export const licenseV2ServiceFactory = ({
     if (!result.checkoutUrl) {
       throw new InternalServerError({ message: "Checkout session did not return a URL" });
     }
-    await licenseClient.markEntitlementsStale(orgId);
+    await licenseClient.markEntitlementsStale(orgId, { checkout: true });
     return { outcome: "checkout_created" as const, checkoutUrl: result.checkoutUrl };
   };
 
@@ -954,13 +954,15 @@ export const licenseV2ServiceFactory = ({
       productId,
       dimensions: changes.map((change) => ({ dimensionKey: change.dimensionKey, quantity: change.quantity }))
     });
-    await licenseClient.markEntitlementsStale(orgId);
     if (result.outcome === "checkout_created") {
       if (!result.checkoutUrl) {
         throw new InternalServerError({ message: "Checkout session did not return a URL" });
       }
+      // Longer window: the change only applies once the customer completes the hosted checkout.
+      await licenseClient.markEntitlementsStale(orgId, { checkout: true });
       return { outcome: "checkout_created" as const, checkoutUrl: result.checkoutUrl };
     }
+    await licenseClient.markEntitlementsStale(orgId);
     return { outcome: "subscription_updated" as const, subscriptionId: result.subscriptionId };
   };
 
@@ -988,7 +990,9 @@ export const licenseV2ServiceFactory = ({
       // The trial's card-setup checkout redirects here; built server-side from SITE_URL like checkout.
       returnUrl: buildReturnUrl(orgId)
     });
-    await licenseClient.markEntitlementsStale(orgId);
+    // awaiting_card redirects to a Stripe card-setup checkout; the trial is granted by webhook only
+    // after it's completed, so hold the revalidation window open longer than an immediate trial_started.
+    await licenseClient.markEntitlementsStale(orgId, { checkout: result.outcome === "awaiting_card" });
     return { outcome: result.outcome, cardSetupUrl: result.cardSetupUrl };
   };
 

--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -874,6 +874,7 @@ export const licenseV2ServiceFactory = ({
     if (!result.checkoutUrl) {
       throw new InternalServerError({ message: "Checkout session did not return a URL" });
     }
+    await licenseClient.markEntitlementsStale(orgId);
     return { outcome: "checkout_created" as const, checkoutUrl: result.checkoutUrl };
   };
 

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -69,7 +69,7 @@ type TLicenseServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findRootOrgDetails" | "countAllOrgMembers" | "findById">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
   licenseDAL: TLicenseDALFactory;
-  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "deleteItem">;
+  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "setItemWithExpiryNX" | "getItem" | "deleteItem">;
   projectDAL: TProjectDALFactory;
   licenseClient?: Pick<TLicenseClientFactory, "getEntitlements" | "getSubscription" | "refreshEntitlements">;
   licenseDualRead?: Pick<TDualReadServiceFactory, "compareInBackground">;
@@ -292,12 +292,44 @@ export const licenseServiceFactory = ({
     }
   };
 
+  // Stale-while-revalidate refresh fired (fire-and-forget) when a cache hit carries the passThrough
+  // marker a billing mutation set. Single-flight via a self-expiring NX lock, which doubles as a
+  // throttle (at most one refresh per org per lock window). Drops the projected plan cache and rebuilds
+  // it via getPlan, which fetches the (now reconciled) entitlements fresh from the license server. Never
+  // throws — it runs detached from the request.
+  const revalidatePlanInBackground = async (orgId: string) => {
+    try {
+      const acquired = await keyStore.setItemWithExpiryNX(
+        KeyStorePrefixes.LicenseCacheRevalidateLock(orgId),
+        KeyStoreTtls.LicenseCacheRevalidateLockInSeconds,
+        "1"
+      );
+      if (acquired !== "OK") {
+        return;
+      }
+
+      await keyStore.deleteItem(KeyStorePrefixes.LicenseCloudPlan(orgId));
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion; getPlan rebuilds the plan cache
+      await getPlan(orgId);
+    } catch (error) {
+      logger.error(error, `getPlan: background revalidation failed [orgId=${orgId}]`);
+    }
+  };
+
   const getPlan = async (orgId: string, projectId?: string) => {
     logger.info(`getPlan: attempting to fetch plan for [orgId=${orgId}] [projectId=${projectId}]`);
     try {
       if (instanceType === InstanceType.Cloud) {
-        const cachedPlan = await keyStore.getItem(KeyStorePrefixes.LicenseCloudPlan(orgId));
+        const [cachedPlan, passThrough] = await Promise.all([
+          keyStore.getItem(KeyStorePrefixes.LicenseCloudPlan(orgId)),
+          keyStore.getItem(KeyStorePrefixes.LicenseCachePassThrough(orgId))
+        ]);
         if (cachedPlan) {
+          // A billing mutation flagged this org: serve the cached plan now but kick a background refresh
+          // so the cache converges as the license server reconciles, instead of waiting out the TTL.
+          if (passThrough) {
+            void revalidatePlanInBackground(orgId);
+          }
           logger.info(`getPlan: plan fetched from cache [orgId=${orgId}] [projectId=${projectId}]`);
           return JSON.parse(cachedPlan) as TFeatureSet;
         }

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -69,12 +69,13 @@ type TLicenseServiceFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findRootOrgDetails" | "countAllOrgMembers" | "findById">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
   licenseDAL: TLicenseDALFactory;
-  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "setItemWithExpiryNX" | "getItem" | "deleteItem">;
+  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "setItemWithExpiryNX" | "getItems" | "deleteItem">;
   projectDAL: TProjectDALFactory;
   licenseClient?: Pick<TLicenseClientFactory, "getEntitlements" | "getSubscription" | "refreshEntitlements">;
   licenseDualRead?: Pick<TDualReadServiceFactory, "compareInBackground">;
-  // Fire-and-forget v2 usage meter for org user seats; no-ops when the v2 license server is disabled.
-  usageMeteringService?: Pick<TUsageMeteringServiceFactory, "emit">;
+  // Fire-and-forget v2 usage meter for org user seats + demand-driven reconciliation; both no-op when
+  // the v2 license server is disabled.
+  usageMeteringService?: Pick<TUsageMeteringServiceFactory, "emit" | "reconcile">;
 };
 
 export type TLicenseServiceFactory = ReturnType<typeof licenseServiceFactory>;
@@ -320,18 +321,33 @@ export const licenseServiceFactory = ({
     logger.info(`getPlan: attempting to fetch plan for [orgId=${orgId}] [projectId=${projectId}]`);
     try {
       if (instanceType === InstanceType.Cloud) {
-        const [cachedPlan, passThrough] = await Promise.all([
-          keyStore.getItem(KeyStorePrefixes.LicenseCloudPlan(orgId)),
-          keyStore.getItem(KeyStorePrefixes.LicenseCachePassThrough(orgId))
+        // One MGET for the plan cache + the two markers instead of three separate round-trips.
+        const [cachedPlan, passThrough, reconcileMarker] = await keyStore.getItems([
+          KeyStorePrefixes.LicenseCloudPlan(orgId),
+          KeyStorePrefixes.LicenseCachePassThrough(orgId),
+          KeyStorePrefixes.LicenseUsageReconcileMarker(orgId)
         ]);
+
+        // Demand-driven usage reconciliation: for a billable org (a paid plan → non-null slug) that
+        // hasn't been reconciled this interval, re-emit its meters in the background. reconcile()
+        // self-throttles on the same marker, so this is a no-op on the vast majority of calls and never
+        // blocks the request. Free orgs (null slug) never enter the reconcile path.
+        const maybeReconcile = (plan: TFeatureSet) => {
+          if (!reconcileMarker && plan.slug) {
+            usageMeteringService?.reconcile(orgId);
+          }
+        };
+
         if (cachedPlan) {
           // A billing mutation flagged this org: serve the cached plan now but kick a background refresh
           // so the cache converges as the license server reconciles, instead of waiting out the TTL.
           if (passThrough) {
             void revalidatePlanInBackground(orgId);
           }
+          const plan = JSON.parse(cachedPlan) as TFeatureSet;
+          maybeReconcile(plan);
           logger.info(`getPlan: plan fetched from cache [orgId=${orgId}] [projectId=${projectId}]`);
-          return JSON.parse(cachedPlan) as TFeatureSet;
+          return plan;
         }
 
         const org = await orgDAL.findRootOrgDetails(orgId);
@@ -395,6 +411,7 @@ export const licenseServiceFactory = ({
           licenseDualRead?.compareInBackground(rootOrgId, currentPlan);
         }
 
+        maybeReconcile(currentPlan);
         return currentPlan;
       }
     } catch (error) {

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -18,7 +18,6 @@ import { logger } from "@app/lib/logger";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { UserIdentities } from "@app/services/license-client";
-import { TDualReadServiceFactory } from "@app/services/license-client/dual-read/dual-read-service";
 import { projectV2ToFeatureSet } from "@app/services/license-client/dual-read/entitlement-projection";
 import { TLicenseClientFactory } from "@app/services/license-client/license-client";
 import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage";
@@ -72,9 +71,6 @@ type TLicenseServiceFactoryDep = {
   keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "setItemWithExpiryNX" | "getItems" | "deleteItem">;
   projectDAL: TProjectDALFactory;
   licenseClient?: Pick<TLicenseClientFactory, "getEntitlements" | "getSubscription" | "refreshEntitlements">;
-  licenseDualRead?: Pick<TDualReadServiceFactory, "compareInBackground">;
-  // Fire-and-forget v2 usage meter for org user seats + demand-driven reconciliation; both no-op when
-  // the v2 license server is disabled.
   usageMeteringService?: Pick<TUsageMeteringServiceFactory, "emit" | "reconcile">;
 };
 
@@ -95,7 +91,6 @@ export const licenseServiceFactory = ({
   projectDAL,
   envConfig,
   licenseClient,
-  licenseDualRead,
   usageMeteringService
 }: TLicenseServiceFactoryDep) => {
   let isValidLicense = false;
@@ -293,11 +288,76 @@ export const licenseServiceFactory = ({
     }
   };
 
+  // Fetches the org's cloud plan fresh (v2 entitlements projected into the v1 shape, or the v1 plan),
+  // enriches it with live usage counts, writes it to the plan cache, and returns it. Throws on any
+  // failure — it never persists the free-tier fallback itself, so callers control that decision.
+  const fetchAndCacheCloudPlan = async (orgId: string): Promise<TFeatureSet> => {
+    const org = await requestMemoize(requestMemoKeys.orgFindRootOrgDetails(orgId), () =>
+      orgDAL.findRootOrgDetails(orgId)
+    );
+    if (!org) throw new NotFoundError({ message: `Organization with ID '${orgId}' not found` });
+    const rootOrgId = org.id;
+
+    let currentPlan: TFeatureSet;
+    if (envConfig.LICENSE_SERVER_V2_MODE === "on") {
+      // Serve from License Server v2, projected into the v1 plan shape so getPlan callers are unchanged.
+      if (!licenseClient) {
+        throw new BadRequestError({ message: "License Server v2 client is not configured" });
+      }
+      const entitlements = await licenseClient.getEntitlements({ id: rootOrgId, name: org.name, slug: org.slug });
+      if (!entitlements) {
+        throw new BadRequestError({ message: "License Server v2 entitlements are unavailable" });
+      }
+      currentPlan = projectV2ToFeatureSet(getDefaultOnPremFeatures(), entitlements);
+    } else {
+      const {
+        data: { currentPlan: v1Plan }
+      } = await licenseServerCloudApi.request.get<{ currentPlan: TFeatureSet }>(
+        `/api/license-server/v1/customers/${org.customerId}/cloud-plan`
+      );
+      currentPlan = v1Plan;
+    }
+
+    currentPlan.workspacesUsed = await projectDAL.countOfBillableOrgProjects(rootOrgId);
+
+    const membersUsed = await licenseDAL.countOfOrgMembers(rootOrgId);
+    currentPlan.membersUsed = membersUsed;
+    const identityUsed = await licenseDAL.countOrgUsersAndIdentities(rootOrgId);
+
+    // Seat sync targets the v1 license server only; v2 derives usage from registered counters.
+    if (
+      envConfig.LICENSE_SERVER_V2_MODE !== "on" &&
+      currentPlan?.identitiesUsed &&
+      currentPlan.identitiesUsed !== identityUsed
+    ) {
+      try {
+        await licenseServerCloudApi.request.patch(`/api/license-server/v1/customers/${org.customerId}/cloud-plan`, {
+          quantity: membersUsed,
+          quantityIdentities: identityUsed
+        });
+      } catch (error) {
+        logger.error(
+          error,
+          `Update seats used: encountered an error when updating plan for customer [customerId=${org.customerId}]`
+        );
+      }
+    }
+    currentPlan.identitiesUsed = identityUsed;
+
+    await keyStore.setItemWithExpiry(
+      KeyStorePrefixes.LicenseCloudPlan(org.id),
+      KeyStoreTtls.LicenseCloudPlanInSeconds,
+      JSON.stringify(currentPlan)
+    );
+
+    return currentPlan;
+  };
+
   // Stale-while-revalidate refresh fired (fire-and-forget) when a cache hit carries the passThrough
   // marker a billing mutation set. Single-flight via a self-expiring NX lock, which doubles as a
-  // throttle (at most one refresh per org per lock window). Drops the projected plan cache and rebuilds
-  // it via getPlan, which fetches the (now reconciled) entitlements fresh from the license server. Never
-  // throws — it runs detached from the request.
+  // throttle (at most one refresh per org per lock window). Recomputes and overwrites the plan cache
+  // only on success — it never deletes the existing valid plan first, so a transient License Server / DB
+  // failure can't downgrade a paid org to the free-tier fallback mid-refresh. Never throws.
   const revalidatePlanInBackground = async (orgId: string) => {
     try {
       const acquired = await keyStore.setItemWithExpiryNX(
@@ -309,9 +369,7 @@ export const licenseServiceFactory = ({
         return;
       }
 
-      await keyStore.deleteItem(KeyStorePrefixes.LicenseCloudPlan(orgId));
-      // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutual recursion; getPlan rebuilds the plan cache
-      await getPlan(orgId);
+      await fetchAndCacheCloudPlan(orgId);
     } catch (error) {
       logger.error(error, `getPlan: background revalidation failed [orgId=${orgId}]`);
     }
@@ -350,67 +408,7 @@ export const licenseServiceFactory = ({
           return plan;
         }
 
-        const org = await orgDAL.findRootOrgDetails(orgId);
-        if (!org) throw new NotFoundError({ message: `Organization with ID '${orgId}' not found` });
-        const rootOrgId = org.id;
-
-        let currentPlan: TFeatureSet;
-        if (envConfig.LICENSE_SERVER_V2_MODE === "on") {
-          // Serve from License Server v2, projected into the v1 plan shape so getPlan callers are unchanged.
-          if (!licenseClient) {
-            throw new BadRequestError({ message: "License Server v2 client is not configured" });
-          }
-          const entitlements = await licenseClient.getEntitlements({ id: rootOrgId, name: org.name, slug: org.slug });
-          if (!entitlements) {
-            throw new BadRequestError({ message: "License Server v2 entitlements are unavailable" });
-          }
-          currentPlan = projectV2ToFeatureSet(getDefaultOnPremFeatures(), entitlements);
-        } else {
-          const {
-            data: { currentPlan: v1Plan }
-          } = await licenseServerCloudApi.request.get<{ currentPlan: TFeatureSet }>(
-            `/api/license-server/v1/customers/${org.customerId}/cloud-plan`
-          );
-          currentPlan = v1Plan;
-        }
-
-        currentPlan.workspacesUsed = await projectDAL.countOfBillableOrgProjects(rootOrgId);
-
-        const membersUsed = await licenseDAL.countOfOrgMembers(rootOrgId);
-        currentPlan.membersUsed = membersUsed;
-        const identityUsed = await licenseDAL.countOrgUsersAndIdentities(rootOrgId);
-
-        // Seat sync targets the v1 license server only; v2 derives usage from registered counters.
-        if (
-          envConfig.LICENSE_SERVER_V2_MODE !== "on" &&
-          currentPlan?.identitiesUsed &&
-          currentPlan.identitiesUsed !== identityUsed
-        ) {
-          try {
-            await licenseServerCloudApi.request.patch(`/api/license-server/v1/customers/${org.customerId}/cloud-plan`, {
-              quantity: membersUsed,
-              quantityIdentities: identityUsed
-            });
-          } catch (error) {
-            logger.error(
-              error,
-              `Update seats used: encountered an error when updating plan for customer [customerId=${org.customerId}]`
-            );
-          }
-        }
-        currentPlan.identitiesUsed = identityUsed;
-
-        await keyStore.setItemWithExpiry(
-          KeyStorePrefixes.LicenseCloudPlan(org.id),
-          KeyStoreTtls.LicenseCloudPlanInSeconds,
-          JSON.stringify(currentPlan)
-        );
-
-        // read-compare bake: serve v1 but shadow-compare against v2 in the background ahead of the cutover.
-        if (envConfig.LICENSE_SERVER_V2_MODE === "read-compare") {
-          licenseDualRead?.compareInBackground(rootOrgId, currentPlan);
-        }
-
+        const currentPlan = await fetchAndCacheCloudPlan(orgId);
         maybeReconcile(currentPlan);
         return currentPlan;
       }

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -13,6 +13,7 @@ import { OrganizationActionScope } from "@app/db/schemas";
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { TEnvConfig } from "@app/lib/config/env";
 import { verifyOfflineLicense } from "@app/lib/crypto";
+import { applyJitter } from "@app/lib/dates";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
@@ -82,6 +83,8 @@ const LICENSE_SERVER_ON_PREM_LOGIN = "/api/auth/v1/license-login";
 // A self-hosted v2 license is single-tenant: the license key identifies the tenant, so entitlement
 // reads carry no real org id. This fixed id only keys the local entitlement cache for the instance.
 const SELF_HOSTED_LICENSE_ORG_ID = "self-hosted";
+
+const jitteredLicenseCloudPlanTtl = () => applyJitter(KeyStoreTtls.LicenseCloudPlanInSeconds, 90);
 
 export const licenseServiceFactory = ({
   orgDAL,
@@ -346,7 +349,7 @@ export const licenseServiceFactory = ({
 
     await keyStore.setItemWithExpiry(
       KeyStorePrefixes.LicenseCloudPlan(org.id),
-      KeyStoreTtls.LicenseCloudPlanInSeconds,
+      jitteredLicenseCloudPlanTtl(),
       JSON.stringify(currentPlan)
     );
 
@@ -419,7 +422,7 @@ export const licenseServiceFactory = ({
       );
       await keyStore.setItemWithExpiry(
         KeyStorePrefixes.LicenseCloudPlan(orgId),
-        KeyStoreTtls.LicenseCloudPlanInSeconds,
+        jitteredLicenseCloudPlanTtl(),
         JSON.stringify(onPremFeatures)
       );
       return onPremFeatures;

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -204,6 +204,9 @@ export const KeyStoreTtls = {
   PamDefaultProjectInSeconds: 300, // 5 minutes
   // How long reads stay in stale-while-revalidate mode after a billing mutation (covers Stripe reconciliation).
   LicenseCachePassThroughInSeconds: 180, // 3 minutes
+  // Longer window for redirect-to-Stripe-checkout paths, where the purchase applies via webhook only
+  // after the customer finishes the hosted checkout/card-setup (which can take a few minutes).
+  LicenseCachePassThroughCheckoutInSeconds: 900, // 15 minutes
   // Throttle window for the single-flight background revalidation.
   LicenseCacheRevalidateLockInSeconds: 10,
   // How often a billable org's usage is re-emitted for reconciliation (demand-driven from getPlan).

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -154,6 +154,8 @@ export const KeyStorePrefixes = {
   LicenseCachePassThrough: (orgId: string) => `license-cache-passthrough-${orgId}` as const,
   // Single-flight guard so only one background revalidation runs per org per lock window.
   LicenseCacheRevalidateLock: (orgId: string) => `license-cache-revalidate-lock-${orgId}` as const,
+  // Throttles the demand-driven usage reconciliation (fired from getPlan) to once per org per interval.
+  LicenseUsageReconcileMarker: (orgId: string) => `license-usage-reconcile-${orgId}` as const,
   LicenseUsageLastReported: (orgId: string, featureKey: string) =>
     `license-usage-last-reported-${orgId}-${featureKey}` as const,
   IdentityLockoutState: (identityId: string, authMethod: string, slug: string) =>
@@ -204,6 +206,8 @@ export const KeyStoreTtls = {
   LicenseCachePassThroughInSeconds: 180, // 3 minutes
   // Throttle window for the single-flight background revalidation.
   LicenseCacheRevalidateLockInSeconds: 10,
+  // How often a billable org's usage is re-emitted for reconciliation (demand-driven from getPlan).
+  LicenseUsageReconcileIntervalInSeconds: 21600, // 6 hours
   LicenseUsageLastReportedInSeconds: 604800, // 7 days
   AiMcpEndpointOAuthFlowInSeconds: 300, // 5 minutes
   OauthAuthorizationCodeInSeconds: 600, // 10 minutes

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -150,8 +150,10 @@ export const KeyStorePrefixes = {
   SecretManagerCachePattern: "secret-manager:*",
   AuditLogMigrationAlert: "audit-log-migration-alert-last-row-count",
   LicenseCloudPlan: (orgId: string) => `infisical-cloud-plan-${orgId}` as const,
-  LicenseEntitlements: (orgId: string) => `license-entitlements-${orgId}` as const,
-  LicenseEntitlementsIdentitySynced: (orgId: string) => `license-entitlements-identity-synced-${orgId}` as const,
+  // Set after a billing mutation to flag the org's plan cache for stale-while-revalidate reads.
+  LicenseCachePassThrough: (orgId: string) => `license-cache-passthrough-${orgId}` as const,
+  // Single-flight guard so only one background revalidation runs per org per lock window.
+  LicenseCacheRevalidateLock: (orgId: string) => `license-cache-revalidate-lock-${orgId}` as const,
   LicenseUsageLastReported: (orgId: string, featureKey: string) =>
     `license-usage-last-reported-${orgId}-${featureKey}` as const,
   IdentityLockoutState: (identityId: string, authMethod: string, slug: string) =>
@@ -196,9 +198,12 @@ export const KeyStoreTtls = {
   UpdateCheckLatestVersionInSeconds: 1209600, // 14 days (survives one missed weekly check)
   InvalidatingCacheInSeconds: 1800, // 30 minutes max lock for cache invalidation job
   AuditLogMigrationAlertInSeconds: 604800, // 7 days
-  LicenseCloudPlanInSeconds: 300, // 5 minutes
+  LicenseCloudPlanInSeconds: 900, // 15 minutes
   PamDefaultProjectInSeconds: 300, // 5 minutes
-  LicenseEntitlementsInSeconds: 1800, // 30 minutes
+  // How long reads stay in stale-while-revalidate mode after a billing mutation (covers Stripe reconciliation).
+  LicenseCachePassThroughInSeconds: 180, // 3 minutes
+  // Throttle window for the single-flight background revalidation.
+  LicenseCacheRevalidateLockInSeconds: 10,
   LicenseUsageLastReportedInSeconds: 604800, // 7 days
   AiMcpEndpointOAuthFlowInSeconds: 300, // 5 minutes
   OauthAuthorizationCodeInSeconds: 600, // 10 minutes

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -807,7 +807,7 @@ export const registerRoutes = async (
 
   // Created before licenseService so the latter can emit the v2 user-seat meter from its
   // updateSubscriptionOrgMemberCount chokepoint.
-  const usageMeteringService = usageMeteringServiceFactory({ queueService, projectDAL, envConfig });
+  const usageMeteringService = usageMeteringServiceFactory({ queueService, projectDAL, keyStore, envConfig });
 
   const licenseService = licenseServiceFactory({
     permissionService,
@@ -836,9 +836,11 @@ export const registerRoutes = async (
     cronJob,
     keyStore,
     orgDAL,
+    licenseService,
     usageMeteringService,
     meteredFeatures,
     usageReporter,
+    isCloud: envConfig.isCloud,
     source: usageSource
   });
 

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -380,7 +380,6 @@ import { TKmsRootConfigDALFactory } from "@app/services/kms/kms-root-config-dal"
 import { kmsServiceFactory } from "@app/services/kms/kms-service";
 import { RootKeyEncryptionStrategy } from "@app/services/kms/kms-types";
 import { licenseClientFactory } from "@app/services/license-client";
-import { dualReadServiceFactory } from "@app/services/license-client/dual-read/dual-read-service";
 import {
   buildMeteredFeatures,
   buildUsageReporter,
@@ -802,9 +801,6 @@ export const registerRoutes = async (
   // is the single read primitive; falls back to feature defaults until the server is configured.
   const licenseClient = licenseClientFactory({ envConfig, keyStore });
 
-  // Shadow-compares v1 getPlan against v2 entitlements in read-compare mode; reads v2 via the real SDK.
-  const licenseDualRead = dualReadServiceFactory({ licenseClient, envConfig });
-
   // Created before licenseService so the latter can emit the v2 user-seat meter from its
   // updateSubscriptionOrgMemberCount chokepoint.
   const usageMeteringService = usageMeteringServiceFactory({ queueService, projectDAL, keyStore, envConfig });
@@ -817,7 +813,6 @@ export const registerRoutes = async (
     projectDAL,
     envConfig,
     licenseClient,
-    licenseDualRead,
     usageMeteringService
   });
 

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -39,7 +39,6 @@ import {
 // Token-scoped paths for the self-hosted (license-key) backend: the key identifies the license, so
 // no org_id is carried. The global catalog is org-independent and shared by both backends.
 const ENTITLEMENTS_PATH = "/v1/entitlements";
-const ENTITLEMENTS_REFRESH_PATH = "/v1/entitlements/refresh";
 const PRODUCTS_PATH = "/v1/products";
 const SUBSCRIPTION_PATH = "/v1/subscription";
 
@@ -129,16 +128,6 @@ export const licenseServerBackend = (
     await throwIfResponseError(res);
     const body: unknown = await res.json();
     return entitlementsResponseSchema.parse(body);
-  },
-
-  refreshEntitlements: async (org: TEntitlementOrg): Promise<void> => {
-    const url = new URL(orgScoped(org.id, "/entitlements/refresh"), serverUrl);
-    const res = await fetch(url, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}` },
-      redirect: "manual"
-    });
-    await throwIfResponseError(res);
   },
 
   fetchCatalog: async (orgId: string): Promise<TCatalogResponse> => {
@@ -394,16 +383,6 @@ export const licenseServerSelfHostedBackend = (
     await throwIfResponseError(res);
     const body: unknown = await res.json();
     return entitlementsResponseSchema.parse(body);
-  },
-
-  refreshEntitlements: async (): Promise<void> => {
-    const url = new URL(ENTITLEMENTS_REFRESH_PATH, serverUrl);
-    const res = await fetch(url, {
-      method: "POST",
-      headers: { Authorization: `Bearer ${licenseKey}` },
-      redirect: "manual"
-    });
-    await throwIfResponseError(res);
   },
 
   fetchCatalog: async (): Promise<TCatalogResponse> => {

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -298,6 +298,7 @@ export const licenseServerBackend = (
         plan_key: payload.planKey,
         email: payload.email,
         name: payload.name,
+        declaredUsage: payload.declaredUsage,
         returnUrl: payload.returnUrl
       }),
       redirect: "manual"

--- a/backend/src/services/license-client/license-client-cache.ts
+++ b/backend/src/services/license-client/license-client-cache.ts
@@ -30,11 +30,15 @@ export const entitlementResolverFactory = ({ keyStore, backend }: TEntitlementRe
   // mutation the license server reconciles asynchronously (Stripe webhook), so an immediate hard bust
   // would just re-cache the pre-reconciliation value for a full TTL. With the marker set, reads keep
   // serving the cached value while a background refresh converges the cache once reconciliation lands.
-  const markPassThrough = async (orgId: string): Promise<void> => {
+  // checkout uses a longer window because the change only applies once the customer finishes the
+  // Stripe-hosted checkout/card-setup, which can take several minutes.
+  const markPassThrough = async (orgId: string, opts?: { checkout?: boolean }): Promise<void> => {
     try {
       await keyStore.setItemWithExpiry(
         KeyStorePrefixes.LicenseCachePassThrough(orgId),
-        KeyStoreTtls.LicenseCachePassThroughInSeconds,
+        opts?.checkout
+          ? KeyStoreTtls.LicenseCachePassThroughCheckoutInSeconds
+          : KeyStoreTtls.LicenseCachePassThroughInSeconds,
         "1"
       );
     } catch (error) {

--- a/backend/src/services/license-client/license-client-cache.ts
+++ b/backend/src/services/license-client/license-client-cache.ts
@@ -1,5 +1,4 @@
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
-import { withCache } from "@app/lib/cache/with-cache";
 import { logger } from "@app/lib/logger";
 
 import { TEntitlementOrg, TEntitlementsResponse, TLicenseClientBackend } from "./license-client-types";
@@ -12,62 +11,47 @@ type TEntitlementResolverDep = {
 export type TEntitlementResolver = ReturnType<typeof entitlementResolverFactory>;
 
 export const entitlementResolverFactory = ({ keyStore, backend }: TEntitlementResolverDep) => {
-  const ttlSeconds = KeyStoreTtls.LicenseEntitlementsInSeconds;
-  const entitlementsCacheKey = (orgId: string) => KeyStorePrefixes.LicenseEntitlements(orgId);
-  const identitySyncedKey = (orgId: string) => KeyStorePrefixes.LicenseEntitlementsIdentitySynced(orgId);
-
-  // The license server learns an org's name/slug from whatever identity a request carries. Entitlement
-  // reads are cached per org and most callers (feature checks) send no identity, so a cached read would
-  // usually answer without reaching the server and the name/slug would never get there. So the first
-  // identity-carrying read in a cache window is sent uncached (delivering the identity); this marker then
-  // records that the window's identity has been delivered so later reads can serve from the cache again.
-  const identityNeedsSync = async (org: TEntitlementOrg): Promise<boolean> => {
-    if (!org.name && !org.slug) {
-      return false;
-    }
-    const alreadySynced = await keyStore.getItem(identitySyncedKey(org.id));
-    return !alreadySynced;
-  };
-
-  // One uncached read that carries the org's identity to the server, then primes the entitlement cache
-  // with the response and marks this window's identity as delivered.
-  const fetchForwardingIdentity = async (org: TEntitlementOrg): Promise<TEntitlementsResponse> => {
-    const entitlements = await backend.fetchEntitlements(org);
-    await keyStore.setItemWithExpiry(entitlementsCacheKey(org.id), ttlSeconds, JSON.stringify(entitlements));
-    await keyStore.setItemWithExpiry(identitySyncedKey(org.id), ttlSeconds, "1");
-    return entitlements;
-  };
-
-  // Returns null on total failure so the caller falls back to the feature's declared fallback.
+  // Entitlements are not cached here: the only hot reader is licenseService.getPlan, which caches its
+  // projection in LicenseCloudPlan and so only reaches this on an L1 miss. The remaining callers
+  // (billing overview, self-hosted sync) are low frequency and want fresh reads, so a direct fetch is
+  // simpler and avoids a second cache to keep coherent. Returns null on failure so the caller falls back
+  // to the feature's declared default. The org's name/slug ride along on the query params, keeping the
+  // license server's copy current.
   const getEntitlements = async (org: TEntitlementOrg): Promise<TEntitlementsResponse | null> => {
     try {
-      if (await identityNeedsSync(org)) {
-        return await fetchForwardingIdentity(org);
-      }
-
-      return await withCache({
-        keyStore,
-        key: entitlementsCacheKey(org.id),
-        ttlSeconds,
-        fetcher: () => backend.fetchEntitlements(org)
-      });
+      return await backend.fetchEntitlements(org);
     } catch (error) {
       logger.error(error, `license-client: failed to resolve entitlements [orgId=${org.id}]`);
       return null;
     }
   };
 
-  // Drop the cached entitlements so the next read reflects a just-committed subscription change
-  // instead of waiting out the 30-minute TTL. The license server reconciles asynchronously via
-  // its Stripe webhook, so a stale read here is what otherwise makes a removed product linger.
+  // Flag the org's license caches for stale-while-revalidate instead of dropping them. After a billing
+  // mutation the license server reconciles asynchronously (Stripe webhook), so an immediate hard bust
+  // would just re-cache the pre-reconciliation value for a full TTL. With the marker set, reads keep
+  // serving the cached value while a background refresh converges the cache once reconciliation lands.
+  const markPassThrough = async (orgId: string): Promise<void> => {
+    try {
+      await keyStore.setItemWithExpiry(
+        KeyStorePrefixes.LicenseCachePassThrough(orgId),
+        KeyStoreTtls.LicenseCachePassThroughInSeconds,
+        "1"
+      );
+    } catch (error) {
+      logger.error(error, `license-client: failed to mark entitlements for revalidation [orgId=${orgId}]`);
+    }
+  };
+
+  // Hard-drop the projected plan cache so the next read reflects a just-committed change instead of
+  // waiting out the TTL. Used by the explicit refresh path (refreshEntitlements); billing mutations use
+  // markPassThrough for stale-while-revalidate instead.
   const invalidateEntitlements = async (orgId: string): Promise<void> => {
     try {
       await keyStore.deleteItem(KeyStorePrefixes.LicenseCloudPlan(orgId));
-      await keyStore.deleteItem(KeyStorePrefixes.LicenseEntitlements(orgId));
     } catch (error) {
       logger.error(error, `license-client: failed to invalidate entitlements [orgId=${orgId}]`);
     }
   };
 
-  return { getEntitlements, invalidateEntitlements };
+  return { getEntitlements, invalidateEntitlements, markPassThrough };
 };

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -459,8 +459,6 @@ export { trialsResponseSchema };
 
 export type TLicenseClientBackend = {
   fetchEntitlements: (org: TEntitlementOrg) => Promise<TEntitlementsResponse>;
-  // Ask the license server to recompute/bust its cached entitlements after a license change.
-  refreshEntitlements: (org: TEntitlementOrg) => Promise<void>;
   // Org-scoped on cloud (the catalog is filtered per calling org). The self-hosted backend ignores the
   // arg and hits its single-tenant /v1/products.
   fetchCatalog: (orgId: string) => Promise<TCatalogResponse>;

--- a/backend/src/services/license-client/license-client-types.ts
+++ b/backend/src/services/license-client/license-client-types.ts
@@ -407,6 +407,9 @@ export type TStartTrialPayload = {
   // A trial starts with no Stripe customer yet, so the server needs an email + org name to create one.
   email?: string;
   name?: string;
+  // Present actual usage per per_resource dimension, so the trial opens with the org's current
+  // quantities on display instead of zero (same shape checkout sends; the server floors omitted ones).
+  declaredUsage?: Record<string, number>;
   returnUrl?: string;
 };
 

--- a/backend/src/services/license-client/license-client.test.ts
+++ b/backend/src/services/license-client/license-client.test.ts
@@ -62,7 +62,9 @@ const createStubBackend = (response: TEntitlementsResponse, opts: { fail?: boole
 };
 
 describe("entitlementResolverFactory", () => {
-  test("fetches once then serves subsequent reads from the cache", async () => {
+  // Entitlements are no longer cached here — the hot reader (getPlan) caches its projection upstream —
+  // so every read hits the backend directly.
+  test("fetches from the backend on every read", async () => {
     const keyStore = createFakeKeyStore();
     const { backend, getCalls } = createStubBackend(makeEntitlements({ identities: { value: 100, source: "plan" } }));
     const resolver = entitlementResolverFactory({ keyStore, backend });
@@ -72,7 +74,7 @@ describe("entitlementResolverFactory", () => {
     expect(getCalls()).toBe(1);
 
     await resolver.getEntitlements({ id: ORG_ID });
-    expect(getCalls()).toBe(1); // served from the cache
+    expect(getCalls()).toBe(2); // no cache — fetched again
   });
 
   test("returns null when the server is unreachable", async () => {
@@ -83,32 +85,13 @@ describe("entitlementResolverFactory", () => {
     expect(await resolver.getEntitlements({ id: ORG_ID })).toBeNull();
   });
 
-  test("forwards org identity to the backend even after an identity-less call seeded the cache", async () => {
+  test("forwards the org identity to the backend so the license server stays current", async () => {
     const keyStore = createFakeKeyStore();
-    const { backend, getCalls, getOrgs } = createStubBackend(
-      makeEntitlements({ identities: { value: 100, source: "plan" } })
-    );
-    const resolver = entitlementResolverFactory({ keyStore, backend });
-
-    await resolver.getEntitlements({ id: ORG_ID }); // feature-check style, identity-less
-    expect(getCalls()).toBe(1);
-    expect(getOrgs()[0]).toEqual({ id: ORG_ID });
-
-    await resolver.getEntitlements({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
-    expect(getCalls()).toBe(2); // bypassed the identity-less cache entry
-    expect(getOrgs()[1]).toEqual({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
-  });
-
-  test("syncs org identity once per ttl window then serves from the cache", async () => {
-    const keyStore = createFakeKeyStore();
-    const { backend, getCalls } = createStubBackend(makeEntitlements({ identities: { value: 100, source: "plan" } }));
+    const { backend, getOrgs } = createStubBackend(makeEntitlements({ identities: { value: 100, source: "plan" } }));
     const resolver = entitlementResolverFactory({ keyStore, backend });
 
     await resolver.getEntitlements({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
-    expect(getCalls()).toBe(1);
-
-    await resolver.getEntitlements({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
-    expect(getCalls()).toBe(1); // identity already synced, served from the cache
+    expect(getOrgs()[0]).toEqual({ id: ORG_ID, name: "Acme Corp", slug: "acme" });
   });
 });
 

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -95,6 +95,15 @@ export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFact
     await resolver.invalidateEntitlements(orgId);
   };
 
+  // Flag the org's license caches for stale-while-revalidate after a billing mutation instead of a hard
+  // bust, so reads keep serving cached data while a background refresh converges once Stripe reconciles.
+  const markEntitlementsStale = async (orgId: string) => {
+    if (!resolver) {
+      return;
+    }
+    await resolver.markPassThrough(orgId);
+  };
+
   // Ask the license server to recompute its cached entitlements (used after a license change), then
   // drop the local cache so the next read reflects them. No-op when the backend is dormant.
   const refreshEntitlements = async (org: TEntitlementOrg) => {
@@ -208,6 +217,7 @@ export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFact
     ...featureReaderFactory({ getEntitlements }),
     getEntitlements,
     invalidateEntitlements,
+    markEntitlementsStale,
     refreshEntitlements,
     getCatalog,
     getSubscription,

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -97,11 +97,11 @@ export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFact
 
   // Flag the org's license caches for stale-while-revalidate after a billing mutation instead of a hard
   // bust, so reads keep serving cached data while a background refresh converges once Stripe reconciles.
-  const markEntitlementsStale = async (orgId: string) => {
+  const markEntitlementsStale = async (orgId: string, opts?: { checkout?: boolean }) => {
     if (!resolver) {
       return;
     }
-    await resolver.markPassThrough(orgId);
+    await resolver.markPassThrough(orgId, opts);
   };
 
   // Drop the local plan cache so the next read reflects a change immediately. The license server no

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -104,13 +104,13 @@ export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFact
     await resolver.markPassThrough(orgId);
   };
 
-  // Ask the license server to recompute its cached entitlements (used after a license change), then
-  // drop the local cache so the next read reflects them. No-op when the backend is dormant.
+  // Drop the local plan cache so the next read reflects a change immediately. The license server no
+  // longer caches entitlements (reads are always live), so there's nothing to ask it to recompute.
+  // No-op when the backend is dormant.
   const refreshEntitlements = async (org: TEntitlementOrg) => {
     if (!backend) {
       return;
     }
-    await backend.refreshEntitlements(org);
     await invalidateEntitlements(org.id);
   };
 

--- a/backend/src/services/license-client/usage/usage-counters.ts
+++ b/backend/src/services/license-client/usage/usage-counters.ts
@@ -16,6 +16,17 @@ export type TMeteredFeature = {
   count: TFeatureCounterFn;
 };
 
+// Static list of every metered dimension key (no DAL needed). For callers that only need the keys, not
+// the count fns — e.g. background reconciliation emitting one event per dimension for an org.
+export const METERED_DIMENSION_KEYS: string[] = [
+  IdentitiesMeter,
+  InternalCas,
+  ActiveCerts,
+  SecretIdentities,
+  PamIdentities,
+  UserIdentities
+].map((feature) => feature.key);
+
 type TBuildMeteredFeaturesDep = {
   licenseDAL: Pick<TLicenseDALFactory, "countOrgUsersAndIdentities" | "countOfOrgMembers">;
   usageCounterDAL: TUsageCounterDALFactory;

--- a/backend/src/services/license-client/usage/usage-event-queue.ts
+++ b/backend/src/services/license-client/usage/usage-event-queue.ts
@@ -1,22 +1,28 @@
+import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
-import { getConfig } from "@app/lib/config/env";
 import { CronJobName, TCronJobFactory } from "@app/lib/cron/cron-job";
 import { logger } from "@app/lib/logger";
 import { QueueName, TQueueServiceFactory } from "@app/queue";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 
+import { ActiveCerts, InternalCas } from "../features";
 import { TMeteredFeature } from "./usage-counters";
 import { TUsageMeteringServiceFactory } from "./usage-metering-service";
 import { TUsageReporter, UsageReportError } from "./usage-reporter";
+
+// Temporarily not reporting the internal-CA and certificate meters; events for these drain harmlessly.
+const SKIPPED_DIMENSION_KEYS = new Set<string>([InternalCas.key, ActiveCerts.key]);
 
 type TUsageEventQueueFactoryDep = {
   queueService: Pick<TQueueServiceFactory, "start">;
   cronJob: TCronJobFactory;
   keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry">;
   orgDAL: Pick<TOrgDALFactory, "find">;
+  licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
   meteredFeatures: TMeteredFeature[];
   usageReporter: TUsageReporter | null;
+  isCloud: boolean;
   source: string;
 };
 
@@ -25,9 +31,11 @@ export const usageEventQueueFactory = ({
   cronJob,
   keyStore,
   orgDAL,
+  licenseService,
   usageMeteringService,
   meteredFeatures,
   usageReporter,
+  isCloud,
   source
 }: TUsageEventQueueFactoryDep) => {
   const featureByKey = new Map(meteredFeatures.map((m) => [m.feature.key, m]));
@@ -35,8 +43,20 @@ export const usageEventQueueFactory = ({
   // Counts the meter and reports it to the License Server only when the value changed since the last
   // report. No-ops when the reporter is null (v2 disabled), so queued events drain harmlessly.
   const handleUsageEvent = async (orgId: string, dimensionKey: string, observedAt: Date) => {
+    if (SKIPPED_DIMENSION_KEYS.has(dimensionKey)) {
+      return;
+    }
     if (!usageReporter) {
       return;
+    }
+    // On cloud, an org with no active paid plan (null slug) has no license on the server, so a report
+    // would just 404 "license not found". Skip the round-trip. Self-hosted is a single licensed
+    // instance, so this gate doesn't apply there.
+    if (isCloud) {
+      const plan = await licenseService.getPlan(orgId);
+      if (!plan.slug) {
+        return;
+      }
     }
     try {
       const metered = featureByKey.get(dimensionKey);
@@ -141,12 +161,11 @@ export const usageEventQueueFactory = ({
   const init = () => {
     startWorker();
 
-    const appCfg = getConfig();
     cronJob.register({
       name: CronJobName.LicenseUsageFlush,
       pattern: "*/30 * * * *",
       runHashTtlS: 60 * 60,
-      enabled: !appCfg.isCloud,
+      enabled: !isCloud,
       handler: flushAllOrgs
     });
   };

--- a/backend/src/services/license-client/usage/usage-metering-service.ts
+++ b/backend/src/services/license-client/usage/usage-metering-service.ts
@@ -1,13 +1,17 @@
+import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { TEnvConfig } from "@app/lib/config/env";
 import { logger } from "@app/lib/logger";
 import { QueueJobs, QueueName, TQueueServiceFactory } from "@app/queue";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
+
+import { METERED_DIMENSION_KEYS } from "./usage-counters";
 
 export type TUsageMeteringServiceFactory = ReturnType<typeof usageMeteringServiceFactory>;
 
 type TUsageMeteringServiceFactoryDep = {
   queueService: Pick<TQueueServiceFactory, "queue">;
   projectDAL: Pick<TProjectDALFactory, "findById">;
+  keyStore: Pick<TKeyStoreFactory, "setItemWithExpiryNX">;
   envConfig: Pick<TEnvConfig, "LICENSE_SERVER_V2_MODE">;
 };
 
@@ -16,6 +20,7 @@ const DEBOUNCE_MS = 5000;
 export const usageMeteringServiceFactory = ({
   queueService,
   projectDAL,
+  keyStore,
   envConfig
 }: TUsageMeteringServiceFactoryDep) => {
   const enqueue = async (orgId: string, dimensionKey: string) => {
@@ -73,5 +78,29 @@ export const usageMeteringServiceFactory = ({
     });
   };
 
-  return { emit, emitForProject };
+  // Demand-driven reconciliation: re-emit every metered dimension for an org so a missed/dropped event
+  // or an expired lastReported converges. Fired fire-and-forget from getPlan for billable orgs; the NX
+  // marker throttles it to once per org per interval (and coalesces concurrent callers). The emits reuse
+  // the normal pipeline, so the slug gate and lastReported dedup still apply downstream.
+  const reconcile = (orgId: string) => {
+    if (envConfig.LICENSE_SERVER_V2_MODE === "off") {
+      return;
+    }
+
+    void (async () => {
+      const acquired = await keyStore.setItemWithExpiryNX(
+        KeyStorePrefixes.LicenseUsageReconcileMarker(orgId),
+        KeyStoreTtls.LicenseUsageReconcileIntervalInSeconds,
+        "1"
+      );
+      if (acquired !== "OK") {
+        return;
+      }
+      METERED_DIMENSION_KEYS.forEach((dimensionKey) => emit(orgId, dimensionKey));
+    })().catch((error) => {
+      logger.error(error, `usage-metering: failed to reconcile org usage [orgId=${orgId}]`);
+    });
+  };
+
+  return { emit, emitForProject, reconcile };
 };

--- a/backend/src/services/license-client/usage/usage-metering-service.ts
+++ b/backend/src/services/license-client/usage/usage-metering-service.ts
@@ -1,5 +1,6 @@
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { TEnvConfig } from "@app/lib/config/env";
+import { applyJitter } from "@app/lib/dates";
 import { logger } from "@app/lib/logger";
 import { QueueJobs, QueueName, TQueueServiceFactory } from "@app/queue";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
@@ -88,9 +89,11 @@ export const usageMeteringServiceFactory = ({
     }
 
     void (async () => {
+      // ±30min jitter so a cold-start burst of first-reconciles doesn't set markers that all expire
+      // together and trigger a synchronized reconcile wave an interval later.
       const acquired = await keyStore.setItemWithExpiryNX(
         KeyStorePrefixes.LicenseUsageReconcileMarker(orgId),
-        KeyStoreTtls.LicenseUsageReconcileIntervalInSeconds,
+        applyJitter(KeyStoreTtls.LicenseUsageReconcileIntervalInSeconds, 1800),
         "1"
       );
       if (acquired !== "OK") {

--- a/backend/src/services/license-client/usage/usage-metering.test.ts
+++ b/backend/src/services/license-client/usage/usage-metering.test.ts
@@ -11,7 +11,7 @@ import {
   SecretIdentities,
   UserIdentities
 } from "../features";
-import { buildMeteredFeatures } from "./usage-counters";
+import { buildMeteredFeatures, METERED_DIMENSION_KEYS } from "./usage-counters";
 import { usageEventQueueFactory } from "./usage-event-queue";
 import { usageMeteringServiceFactory } from "./usage-metering-service";
 import { buildUsageReporter, TUsageSnapshot, UsageReportError } from "./usage-reporter";
@@ -45,6 +45,13 @@ const createFakeKeyStore = () => {
       store.set(key, String(value));
       return "OK" as const;
     }),
+    setItemWithExpiryNX: vi.fn(async (key: string, _ttl: number | string, value: string | number | Buffer) => {
+      if (store.has(key)) {
+        return null;
+      }
+      store.set(key, String(value));
+      return "OK" as const;
+    }),
     store
   };
 };
@@ -54,6 +61,7 @@ describe("usageMeteringService.emit (org-scoped)", () => {
     const queue = makeQueueMock();
     const svc = usageMeteringServiceFactory({
       queueService: { queue },
+      keyStore: createFakeKeyStore(),
       projectDAL: { findById: vi.fn() },
       envConfig: { LICENSE_SERVER_V2_MODE: "off" }
     });
@@ -68,6 +76,7 @@ describe("usageMeteringService.emit (org-scoped)", () => {
     const queue = makeQueueMock();
     const svc = usageMeteringServiceFactory({
       queueService: { queue },
+      keyStore: createFakeKeyStore(),
       projectDAL: { findById: vi.fn() },
       envConfig: { LICENSE_SERVER_V2_MODE: "read-compare" }
     });
@@ -90,6 +99,7 @@ describe("usageMeteringService.emit (org-scoped)", () => {
     });
     const svc = usageMeteringServiceFactory({
       queueService: { queue },
+      keyStore: createFakeKeyStore(),
       projectDAL: { findById: vi.fn() },
       envConfig: { LICENSE_SERVER_V2_MODE: "read-compare" }
     });
@@ -105,6 +115,7 @@ describe("usageMeteringService.emitForProject (project-scoped)", () => {
     const findById = vi.fn(async () => ({ id: PROJECT_ID, orgId: ORG_ID }));
     const svc = usageMeteringServiceFactory({
       queueService: { queue },
+      keyStore: createFakeKeyStore(),
       projectDAL: { findById } as never,
       envConfig: { LICENSE_SERVER_V2_MODE: "read-compare" }
     });
@@ -123,6 +134,7 @@ describe("usageMeteringService.emitForProject (project-scoped)", () => {
     const queue = makeQueueMock();
     const svc = usageMeteringServiceFactory({
       queueService: { queue },
+      keyStore: createFakeKeyStore(),
       projectDAL: { findById: vi.fn(async () => undefined) } as never,
       envConfig: { LICENSE_SERVER_V2_MODE: "read-compare" }
     });
@@ -138,6 +150,7 @@ describe("usageMeteringService.emitForProject (project-scoped)", () => {
     const findById = vi.fn();
     const svc = usageMeteringServiceFactory({
       queueService: { queue },
+      keyStore: createFakeKeyStore(),
       projectDAL: { findById },
       envConfig: { LICENSE_SERVER_V2_MODE: "off" }
     });
@@ -146,6 +159,44 @@ describe("usageMeteringService.emitForProject (project-scoped)", () => {
     await flushAsync();
 
     expect(findById).not.toHaveBeenCalled();
+    expect(queue).not.toHaveBeenCalled();
+  });
+});
+
+describe("usageMeteringService.reconcile (demand-driven)", () => {
+  test("does nothing when the v2 license server is disabled", async () => {
+    const queue = makeQueueMock();
+    const svc = usageMeteringServiceFactory({
+      queueService: { queue },
+      keyStore: createFakeKeyStore(),
+      projectDAL: { findById: vi.fn() },
+      envConfig: { LICENSE_SERVER_V2_MODE: "off" }
+    });
+
+    svc.reconcile(ORG_ID);
+    await flushAsync();
+
+    expect(queue).not.toHaveBeenCalled();
+  });
+
+  test("emits every metered dimension once, then throttles repeats via the NX marker", async () => {
+    const queue = makeQueueMock();
+    const keyStore = createFakeKeyStore();
+    const svc = usageMeteringServiceFactory({
+      queueService: { queue },
+      keyStore,
+      projectDAL: { findById: vi.fn() },
+      envConfig: { LICENSE_SERVER_V2_MODE: "on" }
+    });
+
+    svc.reconcile(ORG_ID);
+    await flushAsync();
+    expect(queue).toHaveBeenCalledTimes(METERED_DIMENSION_KEYS.length);
+
+    // A second call within the interval is throttled by the marker set on the first.
+    queue.mockClear();
+    svc.reconcile(ORG_ID);
+    await flushAsync();
     expect(queue).not.toHaveBeenCalled();
   });
 });
@@ -245,6 +296,8 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
       usageReporter?: unknown;
       keyStore?: ReturnType<typeof createFakeKeyStore>;
       orgFind?: unknown;
+      isCloud?: boolean;
+      getPlan?: (orgId: string) => Promise<{ slug: string | null }>;
     } = {}
   ) => {
     const reportSnapshots = vi.fn(async () => {});
@@ -252,17 +305,21 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
     const usageReporter = overrides.usageReporter === undefined ? { reportSnapshots } : overrides.usageReporter;
     const emit = vi.fn();
     const find = overrides.orgFind ?? vi.fn(async () => []);
+    // Default to a billable plan so the cloud slug gate is a pass-through unless a test overrides it.
+    const getPlan = vi.fn(overrides.getPlan ?? (async () => ({ slug: "pro" })));
     const queue = usageEventQueueFactory({
       queueService: { start: vi.fn() },
       cronJob: { register: vi.fn(), start: vi.fn(), stop: vi.fn() } as never,
       keyStore,
       orgDAL: { find } as never,
+      licenseService: { getPlan } as never,
       usageMeteringService: { emit },
       meteredFeatures,
       usageReporter: usageReporter as never,
+      isCloud: overrides.isCloud ?? false,
       source: "test-region"
     });
-    return { queue, reportSnapshots, keyStore, emit, find };
+    return { queue, reportSnapshots, keyStore, emit, find, getPlan };
   };
 
   beforeEach(() => {
@@ -288,6 +345,46 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
       source: "test-region"
     });
     expect(keyStore.store.get(`license-usage-last-reported-${ORG_ID}-${IdentitiesMeter.key}`)).toBe("42");
+  });
+
+  test("on cloud, skips a free org (null slug) before counting to avoid a 404", async () => {
+    const { queue, reportSnapshots, getPlan } = buildQueue({
+      isCloud: true,
+      getPlan: async () => ({ slug: null })
+    });
+
+    await queue.handleUsageEvent(ORG_ID, IdentitiesMeter.key, new Date());
+
+    expect(getPlan).toHaveBeenCalledWith(ORG_ID);
+    expect(meteredFeatures[0].count).not.toHaveBeenCalled();
+    expect(reportSnapshots).not.toHaveBeenCalled();
+  });
+
+  test("on cloud, proceeds for a billable org (non-null slug)", async () => {
+    const { queue, reportSnapshots } = buildQueue({ isCloud: true, getPlan: async () => ({ slug: "pro" }) });
+
+    await queue.handleUsageEvent(ORG_ID, IdentitiesMeter.key, new Date());
+
+    expect(reportSnapshots).toHaveBeenCalledTimes(1);
+  });
+
+  test("self-hosted does not consult the plan slug gate", async () => {
+    const { queue, reportSnapshots, getPlan } = buildQueue({ isCloud: false });
+
+    await queue.handleUsageEvent(ORG_ID, IdentitiesMeter.key, new Date());
+
+    expect(getPlan).not.toHaveBeenCalled();
+    expect(reportSnapshots).toHaveBeenCalledTimes(1);
+  });
+
+  test("skips the internal-CA and certificate meters entirely (before any plan lookup)", async () => {
+    const { queue, reportSnapshots, getPlan } = buildQueue({ isCloud: true });
+
+    await queue.handleUsageEvent(ORG_ID, InternalCas.key, new Date());
+    await queue.handleUsageEvent(ORG_ID, ActiveCerts.key, new Date());
+
+    expect(getPlan).not.toHaveBeenCalled();
+    expect(reportSnapshots).not.toHaveBeenCalled();
   });
 
   test("skips the report when the count is unchanged", async () => {


### PR DESCRIPTION
## Context

This PR introduces following things.
1. When any billing changes like starting a trial or upgrading a plan - this will mark the the subscription cache as re validate while serving stale mode. Which will update the cache in background
2. Removed refresh entitlement endpoints from license client as it's not needed as license server is not caching anymore
3. Added a reconciliation mechanism once in a while doing get plan so that unchanged events are send to the server correctly.
4. Declared usage send while starting trial

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)