### PR TITLE
fix(secret-manager): resolve nested relative refs in the referenced environment

### DIFF
--- a/backend-go/internal/server/api/secretmanager/secret/get_secret_by_name.go
+++ b/backend-go/internal/server/api/secretmanager/secret/get_secret_by_name.go
@@ -164,6 +164,8 @@ func (h *Handler) getSecretByName(ctx context.Context, opts *getSecretByNameInte
 		}
 
 		expander := secretsvc.NewSecretExpander(allSecrets, secretsvc.ExpandOpts{
+			BoardEnv:  opts.Environment,
+			BoardPath: opts.SecretPath,
 			CanAccessAbsolute: func(ref secretsvc.AbsoluteSecretRef, tags []string) bool {
 				return checker.CanReadSecretValue(ref.Env, ref.Path, ref.Key, tags)
 			},

--- a/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
+++ b/backend-go/internal/server/api/secretmanager/secret/list_secrets.go
@@ -102,6 +102,8 @@ func (h *Handler) listSecrets(ctx context.Context, opts *listSecretsInternalOpts
 		}
 
 		expander := secretsvc.NewSecretExpander(filteredPool, secretsvc.ExpandOpts{
+			BoardEnv:  opts.Environment,
+			BoardPath: opts.SecretPath,
 			CanAccessAbsolute: func(ref secretsvc.AbsoluteSecretRef, tags []string) bool {
 				return checker.CanReadSecretValue(ref.Env, ref.Path, ref.Key, tags)
 			},

--- a/backend-go/internal/services/secretmanager/secret/expansion.go
+++ b/backend-go/internal/services/secretmanager/secret/expansion.go
@@ -33,6 +33,18 @@ type ExpandOpts struct {
 
 const maxExpansionDepth = 10
 
+// expansionCtx identifies which board a value being expanded belongs to.
+// Relative references (${KEY}) resolve against this context, so a value pulled
+// in through an absolute reference resolves its own relative references in the
+// referenced environment/path rather than in the requesting board.
+type expansionCtx struct {
+	// local marks the requested board (plus its imports), whose secrets are
+	// resolved through localLookup with import priority ordering.
+	local bool
+	env   string
+	path  string
+}
+
 var interpolationRegex = regexp.MustCompile(`\${([a-zA-Z0-9-_.]+)}`)
 
 // SecretExpander handles secret reference expansion.
@@ -149,7 +161,7 @@ func (e *SecretExpander) expandPass() []AbsoluteSecretRef {
 			continue
 		}
 
-		expanded, needed := e.expandValue(sec.Value, make(map[string]struct{}), 0)
+		expanded, needed := e.expandValue(sec.Value, expansionCtx{local: true}, make(map[string]struct{}), 0)
 		sec.Value = expanded
 
 		if len(needed) == 0 && !hasReferences(expanded) {
@@ -179,7 +191,7 @@ func (e *SecretExpander) expandPass() []AbsoluteSecretRef {
 // This happens because the outer ${A} resolves to the inner expansion result,
 // where the cycle was detected and replaced with empty string. This is intentional
 // behavior matching the Node.js implementation.
-func (e *SecretExpander) expandValue(value string, visited map[string]struct{}, depth int) (string, []AbsoluteSecretRef) {
+func (e *SecretExpander) expandValue(value string, ctx expansionCtx, visited map[string]struct{}, depth int) (string, []AbsoluteSecretRef) {
 	if depth > maxExpansionDepth {
 		return value, nil
 	}
@@ -200,15 +212,16 @@ func (e *SecretExpander) expandValue(value string, visited map[string]struct{}, 
 		var secretID string
 		var found bool
 
-		if len(parts) == 1 {
-			// Relative reference: ${KEY}
+		switch {
+		case len(parts) == 1 && ctx.local:
+			// Relative reference on the requested board: ${KEY}
 			found = true // Always replace relative refs (with empty if not found)
 			if sec := e.localLookup[parts[0]]; sec != nil {
 				secretID = sec.Environment + ":" + sec.SecretPath + ":" + sec.Secret.Key
 
 				if _, cyclic := visited[secretID]; !cyclic {
 					visited[secretID] = struct{}{}
-					expandedValue, moreNeeded := e.expandValue(sec.Value, visited, depth+1)
+					expandedValue, moreNeeded := e.expandValue(sec.Value, ctx, visited, depth+1)
 					delete(visited, secretID)
 					resolvedValue = expandedValue
 					neededRefs = append(neededRefs, moreNeeded...)
@@ -216,7 +229,41 @@ func (e *SecretExpander) expandValue(value string, visited map[string]struct{}, 
 				// else: cyclic, resolvedValue stays ""
 			}
 			// else: not found, resolvedValue stays "" (missing ref becomes empty)
-		} else {
+		case len(parts) == 1:
+			// Relative reference inside a value fetched from another board:
+			// resolve it against that board, not against the requesting one.
+			ref := AbsoluteSecretRef{Env: ctx.env, Path: ctx.path, Key: parts[0]}
+			secretID = ref.CacheKey()
+
+			sec := e.absoluteLookup[ctx.env+":"+ctx.path][parts[0]]
+			if sec == nil {
+				if _, requested := e.requestedRefs[secretID]; !requested {
+					// Not fetched yet — leave the reference in place and retry
+					// once the value is available.
+					neededRefs = append(neededRefs, ref)
+					continue
+				}
+				// Fetched and missing (or denied): resolves to empty string.
+				found = true
+			} else {
+				found = true
+
+				if _, cyclic := visited[secretID]; !cyclic {
+					visited[secretID] = struct{}{}
+					expandedValue, moreNeeded := e.expandValue(sec.Value, expansionCtx{env: sec.Environment, path: sec.SecretPath}, visited, depth+1)
+					delete(visited, secretID)
+
+					if len(moreNeeded) > 0 {
+						// Substituting now would inline unresolved relative refs
+						// into the requesting board and lose their context.
+						neededRefs = append(neededRefs, moreNeeded...)
+						continue
+					}
+					resolvedValue = expandedValue
+				}
+				// else: cyclic, resolvedValue stays ""
+			}
+		default:
 			// Absolute reference: ${env.path.KEY}
 			env := parts[0]
 			secretKey := parts[len(parts)-1]
@@ -236,18 +283,28 @@ func (e *SecretExpander) expandValue(value string, visited map[string]struct{}, 
 
 					if _, cyclic := visited[secretID]; !cyclic {
 						visited[secretID] = struct{}{}
-						expandedValue, moreNeeded := e.expandValue(sec.Value, visited, depth+1)
+						expandedValue, moreNeeded := e.expandValue(sec.Value, expansionCtx{env: sec.Environment, path: sec.SecretPath}, visited, depth+1)
 						delete(visited, secretID)
+
+						if len(moreNeeded) > 0 {
+							// Substituting now would inline unresolved relative refs
+							// into the requesting board and lose their context.
+							neededRefs = append(neededRefs, moreNeeded...)
+							continue
+						}
 						resolvedValue = expandedValue
-						neededRefs = append(neededRefs, moreNeeded...)
 					}
 					// else: cyclic, resolvedValue stays ""
 				}
 			}
 
 			if !found {
-				neededRefs = append(neededRefs, ref)
-				continue
+				if _, requested := e.requestedRefs[secretID]; !requested {
+					neededRefs = append(neededRefs, ref)
+					continue
+				}
+				// Fetched and missing (or denied): resolves to empty string.
+				found = true
 			}
 		}
 

--- a/backend-go/internal/services/secretmanager/secret/expansion.go
+++ b/backend-go/internal/services/secretmanager/secret/expansion.go
@@ -19,6 +19,13 @@ func (r AbsoluteSecretRef) CacheKey() string {
 
 // ExpandOpts configures the expansion behavior.
 type ExpandOpts struct {
+	// BoardEnv and BoardPath identify the requested board. An absolute
+	// reference that points back at it resolves its nested relative references
+	// through localLookup, keeping the board's import fallback and priority
+	// ordering. Leave empty to treat every absolute reference as foreign.
+	BoardEnv  string
+	BoardPath string
+
 	// CanAccessAbsolute checks if the actor can access an absolute reference.
 	// Called AFTER fetching, with actual tags from the database.
 	// Return false to deny (ref becomes empty string and is tracked as denied).
@@ -180,6 +187,16 @@ func (e *SecretExpander) expandPass() []AbsoluteSecretRef {
 	return result
 }
 
+// contextFor returns the expansion context for a value fetched from another
+// board. An absolute reference that resolves back to the requested board keeps
+// the local context so its imports and priority ordering still apply.
+func (e *SecretExpander) contextFor(sec *ProcessedSecret) expansionCtx {
+	if sec.Environment == e.opts.BoardEnv && sec.SecretPath == e.opts.BoardPath {
+		return expansionCtx{local: true}
+	}
+	return expansionCtx{env: sec.Environment, path: sec.SecretPath}
+}
+
 // expandValue recursively expands references in a value.
 // Returns the expanded string and any absolute refs that couldn't be resolved.
 //
@@ -193,6 +210,12 @@ func (e *SecretExpander) expandPass() []AbsoluteSecretRef {
 // behavior matching the Node.js implementation.
 func (e *SecretExpander) expandValue(value string, ctx expansionCtx, visited map[string]struct{}, depth int) (string, []AbsoluteSecretRef) {
 	if depth > maxExpansionDepth {
+		if !ctx.local {
+			// Relative references in a foreign value cannot be resolved past the
+			// depth limit. Leaving them in place would let a later pass resolve
+			// them against the requesting board, so blank them instead.
+			return blankRelativeRefs(value), nil
+		}
 		return value, nil
 	}
 
@@ -250,7 +273,7 @@ func (e *SecretExpander) expandValue(value string, ctx expansionCtx, visited map
 
 				if _, cyclic := visited[secretID]; !cyclic {
 					visited[secretID] = struct{}{}
-					expandedValue, moreNeeded := e.expandValue(sec.Value, expansionCtx{env: sec.Environment, path: sec.SecretPath}, visited, depth+1)
+					expandedValue, moreNeeded := e.expandValue(sec.Value, e.contextFor(sec), visited, depth+1)
 					delete(visited, secretID)
 
 					if len(moreNeeded) > 0 {
@@ -283,7 +306,7 @@ func (e *SecretExpander) expandValue(value string, ctx expansionCtx, visited map
 
 					if _, cyclic := visited[secretID]; !cyclic {
 						visited[secretID] = struct{}{}
-						expandedValue, moreNeeded := e.expandValue(sec.Value, expansionCtx{env: sec.Environment, path: sec.SecretPath}, visited, depth+1)
+						expandedValue, moreNeeded := e.expandValue(sec.Value, e.contextFor(sec), visited, depth+1)
 						delete(visited, secretID)
 
 						if len(moreNeeded) > 0 {
@@ -396,6 +419,17 @@ func (e *SecretExpander) replaceAbsoluteRefsWith(refs map[string]struct{}, repla
 			}
 		}
 	}
+}
+
+// blankRelativeRefs replaces relative references with empty string, leaving
+// absolute references untouched since those carry their own context.
+func blankRelativeRefs(value string) string {
+	return interpolationRegex.ReplaceAllStringFunc(value, func(syntax string) string {
+		if strings.Contains(interpolationRegex.FindStringSubmatch(syntax)[1], ".") {
+			return syntax
+		}
+		return ""
+	})
 }
 
 func hasReferences(value string) bool {

--- a/backend-go/internal/services/secretmanager/secret/expansion_test.go
+++ b/backend-go/internal/services/secretmanager/secret/expansion_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestSecret(key, value, env, path string) *ProcessedSecret {
@@ -190,23 +191,33 @@ func TestExpand_AbsoluteReference_DeepPath(t *testing.T) {
 }
 
 func TestExpand_AbsoluteReference_WithNestedRelative(t *testing.T) {
+	// A relative reference inside a value reached through an absolute reference
+	// resolves in the referenced environment, not in the requesting one.
 	secrets := []*ProcessedSecret{
-		newTestSecret("LOCAL_VAR", "local-resolved", "dev", "/"),
-		newTestSecret("A", "${prod.USES_LOCAL}", "dev", "/"),
+		newTestSecret("VAR", "dev-value", "dev", "/"),
+		newTestSecret("A", "${prod.USES_RELATIVE}", "dev", "/"),
 	}
 
 	opts := ExpandOpts{
 		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
-			return []*ProcessedSecret{
-				newTestSecret("USES_LOCAL", "prefix-${LOCAL_VAR}-suffix", "prod", "/"),
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				switch {
+				case ref.Env == "prod" && ref.Key == "USES_RELATIVE":
+					out = append(out, newTestSecret("USES_RELATIVE", "prefix-${VAR}-suffix", "prod", "/"))
+				case ref.Env == "prod" && ref.Key == "VAR":
+					out = append(out, newTestSecret("VAR", "prod-value", "prod", "/"))
+				}
 			}
+			return out
 		},
 	}
 
 	expander := NewSecretExpander(secrets, opts)
 	expander.Expand()
 
-	assert.Equal(t, "prefix-local-resolved-suffix", secrets[1].Value)
+	assert.Equal(t, "prefix-prod-value-suffix", secrets[1].Value)
+	assert.Equal(t, "dev-value", secrets[0].Value)
 }
 
 func TestExpand_AbsoluteReference_ChainedAbsolute(t *testing.T) {
@@ -679,4 +690,166 @@ func TestExpand_RawValuePreserved(t *testing.T) {
 
 	assert.Equal(t, "${A} world", secrets[1].RawValue)
 	assert.Equal(t, "hello world", secrets[1].Value)
+}
+
+func TestExpand_NestedRelativeResolvesInReferencedEnv(t *testing.T) {
+	secrets := []*ProcessedSecret{
+		newTestSecret("HOST", "dev-host", "dev", "/"),
+		newTestSecret("API_URL", "${prod.URL}", "dev", "/"),
+	}
+
+	var requested []string
+	expander := NewSecretExpander(secrets, ExpandOpts{
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				requested = append(requested, ref.CacheKey())
+				switch {
+				case ref.Env == "prod" && ref.Key == "URL":
+					out = append(out, newTestSecret("URL", "https://${HOST}/api", "prod", "/"))
+				case ref.Env == "prod" && ref.Key == "HOST":
+					out = append(out, newTestSecret("HOST", "prod-host", "prod", "/"))
+				}
+			}
+			return out
+		},
+	})
+	expander.Expand()
+
+	assert.Equal(t, "https://prod-host/api", secrets[1].Value)
+	assert.Contains(t, requested, "prod:/:HOST")
+	assert.Equal(t, "dev-host", secrets[0].Value)
+}
+
+func TestExpand_NestedRelativeInReferencedPath(t *testing.T) {
+	secrets := []*ProcessedSecret{
+		newTestSecret("TOKEN", "local-token", "dev", "/"),
+		newTestSecret("AUTH", "${prod.svc.HEADER}", "dev", "/"),
+	}
+
+	expander := NewSecretExpander(secrets, ExpandOpts{
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				switch {
+				case ref.Env == "prod" && ref.Path == "/svc" && ref.Key == "HEADER":
+					out = append(out, newTestSecret("HEADER", "Bearer ${TOKEN}", "prod", "/svc"))
+				case ref.Env == "prod" && ref.Path == "/svc" && ref.Key == "TOKEN":
+					out = append(out, newTestSecret("TOKEN", "prod-token", "prod", "/svc"))
+				}
+			}
+			return out
+		},
+	})
+	expander.Expand()
+
+	assert.Equal(t, "Bearer prod-token", secrets[1].Value)
+}
+
+func TestExpand_NestedRelativeMissingInReferencedEnv(t *testing.T) {
+	secrets := []*ProcessedSecret{
+		newTestSecret("HOST", "dev-host", "dev", "/"),
+		newTestSecret("API_URL", "${prod.URL}", "dev", "/"),
+	}
+
+	expander := NewSecretExpander(secrets, ExpandOpts{
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				if ref.Env == "prod" && ref.Key == "URL" {
+					out = append(out, newTestSecret("URL", "https://${HOST}/api", "prod", "/"))
+				}
+			}
+			return out
+		},
+	})
+	expander.Expand()
+
+	// The referenced env has no HOST — it must not fall back to the dev value.
+	assert.Equal(t, "https:///api", secrets[1].Value)
+}
+
+func TestExpand_NestedRelativeDeniedInReferencedEnv(t *testing.T) {
+	secrets := []*ProcessedSecret{
+		newTestSecret("HOST", "dev-host", "dev", "/"),
+		newTestSecret("API_URL", "${prod.URL}", "dev", "/"),
+	}
+
+	expander := NewSecretExpander(secrets, ExpandOpts{
+		CanAccessAbsolute: func(ref AbsoluteSecretRef, _ []string) bool {
+			return ref.Key != "HOST"
+		},
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				switch {
+				case ref.Env == "prod" && ref.Key == "URL":
+					out = append(out, newTestSecret("URL", "https://${HOST}/api", "prod", "/"))
+				case ref.Env == "prod" && ref.Key == "HOST":
+					out = append(out, newTestSecret("HOST", "prod-host", "prod", "/"))
+				}
+			}
+			return out
+		},
+	})
+	expander.Expand()
+
+	assert.Equal(t, "https:///api", secrets[1].Value)
+	assert.True(t, expander.HasDeniedRefs())
+	assert.Contains(t, expander.DeniedRefs(), "prod:/:HOST")
+}
+
+func TestExpand_NestedRelativeCycleAcrossEnvs(t *testing.T) {
+	secrets := []*ProcessedSecret{
+		newTestSecret("API_URL", "${prod.URL}", "dev", "/"),
+	}
+
+	expander := NewSecretExpander(secrets, ExpandOpts{
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				if ref.Env == "prod" && ref.Key == "URL" {
+					out = append(out, newTestSecret("URL", "a-${URL}-b", "prod", "/"))
+				}
+			}
+			return out
+		},
+	})
+	expander.Expand()
+
+	assert.False(t, hasReferences(secrets[0].Value))
+}
+
+func TestExpand_NestedRelativeMutualCycleAcrossEnvs(t *testing.T) {
+	// prod.A -> ${B} (in prod) -> ${staging.A} -> ${B} (in staging) -> ...
+	// Expansion must terminate rather than fetching forever.
+	secrets := []*ProcessedSecret{
+		newTestSecret("ROOT", "${prod.A}", "dev", "/"),
+	}
+
+	fetches := 0
+	expander := NewSecretExpander(secrets, ExpandOpts{
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			fetches++
+			require.Less(t, fetches, 50, "expansion did not converge")
+
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				switch ref.Key {
+				case "A":
+					out = append(out, newTestSecret("A", "${B}", ref.Env, ref.Path))
+				case "B":
+					other := "staging"
+					if ref.Env == "staging" {
+						other = "prod"
+					}
+					out = append(out, newTestSecret("B", "${"+other+".A}", ref.Env, ref.Path))
+				}
+			}
+			return out
+		},
+	})
+	expander.Expand()
+
+	assert.False(t, hasReferences(secrets[0].Value))
 }

--- a/backend-go/internal/services/secretmanager/secret/expansion_test.go
+++ b/backend-go/internal/services/secretmanager/secret/expansion_test.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -852,4 +853,65 @@ func TestExpand_NestedRelativeMutualCycleAcrossEnvs(t *testing.T) {
 	expander.Expand()
 
 	assert.False(t, hasReferences(secrets[0].Value))
+}
+
+func TestExpand_SelfAbsoluteRefKeepsImportFallback(t *testing.T) {
+	// dev / imports staging /. An absolute reference that points back at the
+	// requested board must still resolve its nested relative references through
+	// the board's import fallback.
+	secrets := []*ProcessedSecret{
+		newTestSecret("IMPORT_ONLY", "from-import", "staging", "/"),
+		newTestSecret("ROOT", "${dev.B}", "dev", "/"),
+	}
+
+	expander := NewSecretExpander(secrets, ExpandOpts{
+		BoardEnv:  "dev",
+		BoardPath: "/",
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				// IMPORT_ONLY does not exist in the dev folder itself.
+				if ref.Env == "dev" && ref.Path == "/" && ref.Key == "B" {
+					out = append(out, newTestSecret("B", "x-${IMPORT_ONLY}", "dev", "/"))
+				}
+			}
+			return out
+		},
+	})
+	expander.Expand()
+
+	assert.Equal(t, "x-from-import", secrets[1].Value)
+}
+
+func TestExpand_DepthLimitDoesNotLeakForeignRelativeRefs(t *testing.T) {
+	// A foreign chain longer than maxExpansionDepth must not hand an unresolved
+	// relative reference back to the requesting board, where a later pass would
+	// resolve it locally.
+	secrets := []*ProcessedSecret{
+		newTestSecret("K11", "DEV-VALUE", "dev", "/"),
+		newTestSecret("ROOT", "${prod.K0}", "dev", "/"),
+	}
+
+	expander := NewSecretExpander(secrets, ExpandOpts{
+		BoardEnv:  "dev",
+		BoardPath: "/",
+		FetchAbsoluteSecrets: func(refs []AbsoluteSecretRef) []*ProcessedSecret {
+			var out []*ProcessedSecret
+			for _, ref := range refs {
+				if ref.Env != "prod" {
+					continue
+				}
+				for i := range 15 {
+					if ref.Key == fmt.Sprintf("K%d", i) {
+						out = append(out, newTestSecret(ref.Key, fmt.Sprintf("${K%d}", i+1), "prod", "/"))
+					}
+				}
+			}
+			return out
+		},
+	})
+	expander.Expand()
+
+	assert.NotContains(t, secrets[1].Value, "DEV-VALUE")
+	assert.False(t, hasReferences(secrets[1].Value), "unresolved reference escaped to the requesting board")
 }


### PR DESCRIPTION
## Context

Fixes #7459.

In `backend-go`, a **relative** reference (`${KEY}`) inside a value reached through an **absolute** reference (`${env.path.KEY}`) was resolved against the *requesting* board instead of the referenced one.

`localLookup` is built once in `NewSecretExpander` from the requested board's secrets, and `expandValue` carried no notion of which board the value it was expanding belonged to — so single-part references inside a fetched foreign value still hit `localLookup`.

Given `dev` and `prod` that both define `HOST`:

| env | key | value |
|---|---|---|
| dev | `HOST` | `dev-host` |
| dev | `API_URL` | `${prod.URL}` |
| prod | `HOST` | `prod-host` |
| prod | `URL` | `https://${HOST}/api` |

Reading `API_URL` from `dev`:

- Node (`/api/v4/secrets`): `https://prod-host/api`
- Go sidecar before this PR: `https://dev-host/api` — and `prod:/:HOST` was never even requested

Beyond the `value_mismatch` that `go-sidecar-shadowing.ts` reports, the resolved value crossed an environment boundary: anyone who can write a secret in `dev` could change what a `${prod....}` reference expands to, as long as the prod secret contained a relative reference. `CanAccessAbsolute` was not bypassed — prod's own value was still access-checked — but the substituted content silently came from the lower environment.

### The fix

`expandValue` now carries an `expansionCtx` identifying the board a value belongs to. This mirrors what the Node implementation already does in `secret-reference-fns.ts` — it pushes the referenced secret's own `environment` / `secretPath` onto the expansion stack, and the relative branch reads from that popped context. Relative references in a foreign context resolve through `absoluteLookup` for that env/path, requesting the value if it hasn't been fetched yet.

Two supporting changes make that correct and terminating:

1. **Substitution of a foreign value is deferred while it still has pending references.** Otherwise a partially expanded value gets inlined into the requesting board, where its remaining relative references would resolve against the wrong environment on the next pass — reintroducing the same bug one level up.
2. **Absolute refs that were fetched and turned out to be missing or denied now resolve to empty during expansion**, rather than only in the final `replaceNotFoundRefs` / `replaceDeniedRefs` cleanup pass. Without this, a permanently-unresolvable inner ref would keep the deferral in (1) pending forever and leave a literal `${prod.URL}` in the output. Final output for those cases is unchanged; the cleanup passes are retained as a safety net.

The local-board branch is untouched, so import priority ordering (`localLookup`, first-occurrence-wins) behaves exactly as before.

### Note for reviewers

I changed one existing test, `TestExpand_AbsoluteReference_WithNestedRelative`. It asserted `prefix-local-resolved-suffix` — that is, it encoded the bug, asserting that a `dev` value leaks into a `prod` reference. Its `FetchAbsoluteSecrets` stub also ignored the `refs` argument and returned the same secret for every request, which hid the fact that the second fetch was never issued. The stub is now ref-aware and the assertion reflects the referenced environment's value.

One deliberate divergence from Node that this PR does **not** change: Node leaves a literal `${REF}` when a referenced secret does not exist, while Go substitutes an empty string. That is pre-existing Go behavior and out of scope here.

## Steps to verify the change

```
cd backend-go
go test -race ./internal/services/secretmanager/...
make lint
```

The repro from the issue is covered by `TestExpand_NestedRelativeResolvesInReferencedEnv`, which also asserts that `prod:/:HOST` is actually requested.

Verification performed:

| Check | Result |
|---|---|
| Issue's exact repro | passes; `prod:/:HOST` now requested |
| 5 of the new tests reverted against `main` | all 5 fail — they are genuine regression tests |
| `go test -race ./internal/...` (cold cache) | all packages pass |
| `golangci-lint run --build-tags integration` (cold cache) | 0 issues |
| `gofmt -l`, `go vet` | clean |

New test coverage:

- `TestExpand_NestedRelativeResolvesInReferencedEnv` — the reported case
- `TestExpand_NestedRelativeInReferencedPath` — same, across a non-root secret path
- `TestExpand_NestedRelativeMissingInReferencedEnv` — must not fall back to the requesting env's value
- `TestExpand_NestedRelativeDeniedInReferencedEnv` — permission denial in the referenced env is tracked and resolves empty
- `TestExpand_NestedRelativeCycleAcrossEnvs` — self-cycle reached through an absolute ref
- `TestExpand_NestedRelativeMutualCycleAcrossEnvs` — mutual `prod ↔ staging` recursion, with a fetch-count guard proving expansion converges

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [ ] Updated docs (if needed) — not needed, no user-facing behavior documented changes
- [ ] Updated CLAUDE.md files (if needed) — not needed, no architectural change
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
