### PR TITLE
fix: use ms instead of seconds in histogram metric

### DIFF
--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -518,7 +518,7 @@ export const secretOperationDurationHistogram = infisicalCoreMeter.createHistogr
   "infisical.secret.operation.duration",
   {
     description: "Secret operation latency by operation type, outcome, and environment.",
-    unit: "s"
+    unit: "ms"
   }
 );
 
@@ -533,7 +533,7 @@ export const recordSecretOperationDuration = (params: {
   outcome: "success" | "failure";
 }) => {
   if (!isTelemetryEnabled()) return;
-  secretOperationDurationHistogram.record((performance.now() - params.startTime) / 1000, {
+  secretOperationDurationHistogram.record(performance.now() - params.startTime, {
     operation: params.operation,
     outcome: params.outcome
   });


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Report metric as milliseconds instead of seconds to ensure correct use of buckets in histogram

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)