### PR TITLE
fix: replace silent 200 returns with proper errors in org membership DELETE endpoints

### DIFF
--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -8,6 +8,7 @@ import { addAuthOriginDomainCookie } from "@app/server/lib/cookie";
 import { GenericResourceNameSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
+import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
 import { sanitizedOrganizationSchema } from "@app/services/org/org-schema";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
@@ -262,7 +263,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      if (req.auth.actor !== ActorType.USER) return;
+      if (req.auth.actor !== ActorType.USER) throw new BadRequestError({ message: "Auth type not supported for this operation" });
 
       const membership = await server.services.org.deleteOrgMembership({
         userId: req.permission.id,
@@ -271,6 +272,8 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         membershipId: req.params.membershipId,
         actorOrgId: req.permission.orgId
       });
+
+      if (!membership) throw new NotFoundError({ message: "Membership not found" });
 
       void server.services.telemetry.sendPostHogEvents({
         event: PostHogEventTypes.OrgMembershipDeleted,
@@ -322,7 +325,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      if (req.auth.actor !== ActorType.USER) return;
+      if (req.auth.actor !== ActorType.USER) throw new BadRequestError({ message: "Auth type not supported for this operation" });
 
       const memberships = await server.services.org.bulkDeleteOrgMemberships({
         userId: req.permission.id,


### PR DESCRIPTION
## Description

Fixes two endpoints returning HTTP 200 with empty body instead of a proper error when the deletion can't proceed:

- `DELETE /:organizationId/memberships/:membershipId`
- `DELETE /:organizationId/memberships` (bulk)

## Root Cause

1. **Auth guard silent return**: Both endpoints accept `API_KEY` and `IDENTITY_ACCESS_TOKEN` auth modes in `verifyAuth`, but the handler silently returns `undefined` (→ empty 200) when `req.auth.actor !== ActorType.USER`. API-key-authenticated requests succeed with a 200 but no deletion occurs.

2. **No-op on mismatched data**: If the `membershipId` doesn't exist or doesn't belong to the org, the DAL's DELETE affects 0 rows. The handler destructures `[undefined]` from the empty array and returns a response missing required `OrgMembershipsSchema` fields (`id`, `scope`, etc.), which gets silently stripped.

## Changes

| File | Change |
|------|--------|
| `organization-router.ts` (`deleteOrgMembership`) | Replace silent `return` with `BadRequestError`; add `NotFoundError` null-check after deletion |
| `organization-router.ts` (`bulkDeleteOrgMemberships`) | Replace silent `return` with `BadRequestError` |

## Testing

- [x] JWT user: delete works as before
- [x] API KEY / IDENTITY token: now returns 400 with `BadRequestError` instead of empty 200
- [x] Invalid membership ID: now returns 404 with `NotFoundError` instead of empty 200

Closes #7478