### PR TITLE
fix: personal org creation fix

### DIFF
--- a/frontend/src/hooks/api/organization/index.ts
+++ b/frontend/src/hooks/api/organization/index.ts
@@ -1,5 +1,6 @@
 export type { TOrgWithSubOrgs } from "./queries";
 export {
+  fetchOrganizations,
   fetchOrganizationsWithSubOrgs,
   organizationKeys,
   useAddOrgPmtMethod,

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -178,6 +178,8 @@ export const Navbar = () => {
     ? orgs?.find((org) => org.id === currentOrg.rootOrgId) || currentOrg
     : currentOrg;
 
+  const otherOrgs = orgs?.filter((org) => org.id !== rootOrg.id) ?? [];
+
   useEffect(() => {
     if (isModalIntrusive) {
       setShowCardDeclinedModal(true);
@@ -549,30 +551,29 @@ export const Navbar = () => {
                               }
                             </OrgPermissionCan>
                           </CommandGroup>
-                          <CommandSeparator />
+                          {otherOrgs.length > 0 && <CommandSeparator />}
                         </>
                       )}
                       {/* Other Organizations */}
-                      {orgs && orgs.filter((o) => o.id !== rootOrg.id).length > 0 && (
+                      {otherOrgs.length > 0 && (
                         <CommandGroup heading="Other Organizations">
-                          {orgs
-                            .filter((o) => o.id !== rootOrg.id)
-                            .map((org) => (
-                              <CommandItem
-                                key={org.id}
-                                value={org.id}
-                                keywords={[org.name]}
-                                onSelect={() => {
-                                  setIsOrgSelectOpen(false);
-                                  handleOrgNav(org);
-                                }}
-                              >
-                                <span className="truncate">{org.name}</span>
-                              </CommandItem>
-                            ))}
+                          {otherOrgs.map((org) => (
+                            <CommandItem
+                              key={org.id}
+                              value={org.id}
+                              keywords={[org.name]}
+                              onSelect={() => {
+                                setIsOrgSelectOpen(false);
+                                handleOrgNav(org);
+                              }}
+                            >
+                              <span className="truncate">{org.name}</span>
+                            </CommandItem>
+                          ))}
                         </CommandGroup>
                       )}
                     </CommandList>
+                    <CommandSeparator />
                     <div className="p-1">
                       <button
                         type="button"

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -452,7 +452,8 @@ export const Navbar = () => {
                       {/* Current Organization */}
                       <CommandGroup heading="Current Organization">
                         <CommandItem
-                          value={rootOrg.name}
+                          value={rootOrg.id}
+                          keywords={[rootOrg.name]}
                           onSelect={() => {
                             setIsOrgSelectOpen(false);
                             if (isSubOrganization) {
@@ -513,7 +514,8 @@ export const Navbar = () => {
                             {subOrganizations.map((subOrg) => (
                               <CommandItem
                                 key={subOrg.id}
-                                value={subOrg.name}
+                                value={subOrg.id}
+                                keywords={[subOrg.name]}
                                 onSelect={() => {
                                   setIsOrgSelectOpen(false);
                                   handleOrgSelection({ organizationId: subOrg.id });
@@ -558,7 +560,8 @@ export const Navbar = () => {
                             .map((org) => (
                               <CommandItem
                                 key={org.id}
-                                value={org.name}
+                                value={org.id}
+                                keywords={[org.name]}
                                 onSelect={() => {
                                   setIsOrgSelectOpen(false);
                                   handleOrgNav(org);

--- a/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
+++ b/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
@@ -7,7 +7,12 @@ import { useNavigate } from "@tanstack/react-router";
 import { createNotification } from "@app/components/notifications";
 import { CreateOrgModal } from "@app/components/organization/CreateOrgModal";
 import { ContentLoader } from "@app/components/v2";
-import { organizationKeys, useCreateOrg, useGetOrganizations, useSelectOrganization } from "@app/hooks/api";
+import {
+  fetchOrganizations,
+  organizationKeys,
+  useCreateOrg,
+  useSelectOrganization
+} from "@app/hooks/api";
 
 const PERSONAL_ORG_NAME = "Personal Org";
 // A useRef gate resets on a full unmount/remount; this sessionStorage flag survives it, so an
@@ -32,8 +37,6 @@ export const NoOrgPage = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const organizations = useGetOrganizations();
-
   const { mutateAsync: createOrg } = useCreateOrg({ invalidate: false });
   const { mutateAsync: selectOrg } = useSelectOrganization();
 
@@ -43,7 +46,6 @@ export const NoOrgPage = () => {
 
   useEffect(() => {
     if (hasRun.current) return;
-    if (organizations.isPending) return;
 
     hasRun.current = true;
 
@@ -51,7 +53,8 @@ export const NoOrgPage = () => {
     sessionStorage.setItem(CREATION_STARTED_KEY, "true");
 
     const createPersonalOrg = async () => {
-      const orgName = generatePersonalOrgName((organizations.data ?? []).map((org) => org.name));
+      const existingOrgs = await fetchOrganizations().catch(() => []);
+      const orgName = generatePersonalOrgName(existingOrgs.map((org) => org.name));
 
       let organization;
       try {
@@ -93,7 +96,7 @@ export const NoOrgPage = () => {
     };
 
     createPersonalOrg();
-  }, [createOrg, selectOrg, navigate, queryClient, organizations.isPending, organizations.data]);
+  }, [createOrg, selectOrg, navigate, queryClient]);
 
   return (
     <>

--- a/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
+++ b/frontend/src/pages/organization/NoOrgPage/NoOrgPage.tsx
@@ -7,17 +7,32 @@ import { useNavigate } from "@tanstack/react-router";
 import { createNotification } from "@app/components/notifications";
 import { CreateOrgModal } from "@app/components/organization/CreateOrgModal";
 import { ContentLoader } from "@app/components/v2";
-import { organizationKeys, useCreateOrg, useSelectOrganization } from "@app/hooks/api";
+import { organizationKeys, useCreateOrg, useGetOrganizations, useSelectOrganization } from "@app/hooks/api";
 
 const PERSONAL_ORG_NAME = "Personal Org";
 // A useRef gate resets on a full unmount/remount; this sessionStorage flag survives it, so an
 // interrupted-then-remounted page can't fire a second createOrg and leave a duplicate org behind.
 const CREATION_STARTED_KEY = "personalOrgCreationStarted";
 
+const generatePersonalOrgName = (existingNames: string[]) => {
+  const taken = new Set(existingNames.map((name) => name.trim().toLowerCase()));
+  const isTaken = (candidate: string) => taken.has(candidate.trim().toLowerCase());
+
+  if (!isTaken(PERSONAL_ORG_NAME)) return PERSONAL_ORG_NAME;
+
+  let suffix = 1;
+  while (isTaken(`${PERSONAL_ORG_NAME} ${suffix}`)) {
+    suffix += 1;
+  }
+  return `${PERSONAL_ORG_NAME} ${suffix}`;
+};
+
 export const NoOrgPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+
+  const organizations = useGetOrganizations();
 
   const { mutateAsync: createOrg } = useCreateOrg({ invalidate: false });
   const { mutateAsync: selectOrg } = useSelectOrganization();
@@ -28,15 +43,19 @@ export const NoOrgPage = () => {
 
   useEffect(() => {
     if (hasRun.current) return;
+    if (organizations.isPending) return;
+
     hasRun.current = true;
 
     if (sessionStorage.getItem(CREATION_STARTED_KEY)) return;
     sessionStorage.setItem(CREATION_STARTED_KEY, "true");
 
     const createPersonalOrg = async () => {
+      const orgName = generatePersonalOrgName((organizations.data ?? []).map((org) => org.name));
+
       let organization;
       try {
-        organization = await createOrg({ name: PERSONAL_ORG_NAME });
+        organization = await createOrg({ name: orgName });
       } catch {
         // Nothing was created, so reset both guards and let the user create an org manually.
         createNotification({
@@ -74,7 +93,7 @@ export const NoOrgPage = () => {
     };
 
     createPersonalOrg();
-  }, [createOrg, selectOrg, navigate, queryClient]);
+  }, [createOrg, selectOrg, navigate, queryClient, organizations.isPending, organizations.data]);
 
   return (
     <>


### PR DESCRIPTION
## Context

Fixes the following:
1. If you have multiple orgs with the same name, they all get the on hover effect in the org selector.
2. When navigating to the `/organizations/none` endpoint, it used to always create a new `Personal Org` org. Now with this update it'll be numerated to avoid folks ending up with multiple orgs with identical names. 

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)