### PR TITLE
fix: 500 when listing certificates for a certificate profile

### DIFF
--- a/backend/src/services/certificate-profile/certificate-profile-dal.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-dal.ts
@@ -651,7 +651,7 @@ export const certificateProfileDALFactory = (db: TDbClient) => {
       if (search) {
         query = query.where((builder) => {
           void builder.where((qb) => {
-            void qb.whereILike("cn", `%${search}%`).orWhereILike("serialNumber", `%${search}%`);
+            void qb.whereILike("commonName", `%${search}%`).orWhereILike("serialNumber", `%${search}%`);
           });
         });
       }
@@ -675,7 +675,7 @@ export const certificateProfileDALFactory = (db: TDbClient) => {
       const certificates = await query
         .select((tx || db).ref("id").withSchema(TableName.Certificate))
         .select((tx || db).ref("serialNumber").withSchema(TableName.Certificate))
-        .select((tx || db).ref("cn").withSchema(TableName.Certificate))
+        .select((tx || db).ref("commonName").withSchema(TableName.Certificate).as("cn"))
         .select((tx || db).ref("status").withSchema(TableName.Certificate))
         .select((tx || db).ref("notBefore").withSchema(TableName.Certificate))
         .select((tx || db).ref("notAfter").withSchema(TableName.Certificate))


### PR DESCRIPTION
getCertificatesByProfile selects cn, but the certificates table has commonName, so GET /api/v1/cert-manager/certificate-profiles/:id/certificates always fails with 42703 column certificates.cn does not exist. The search filter hits the same thing. Aliased back to cn so the response shape is unchanged for the route schema, the types and the frontend.
