### PR TITLE
fix(ui): restore default input styling

### DIFF
--- a/frontend/src/components/auth/EnterEmailStep.tsx
+++ b/frontend/src/components/auth/EnterEmailStep.tsx
@@ -64,6 +64,7 @@ export default function EnterEmailStep({
         <CardContent className="flex flex-col gap-4">
           <div className="flex w-full flex-col gap-2">
             <Input
+              variant="outlined"
               placeholder="Enter your email address..."
               onChange={(e) => setEmail(e.target.value)}
               value={email}

--- a/frontend/src/components/auth/InitialSignupStep.tsx
+++ b/frontend/src/components/auth/InitialSignupStep.tsx
@@ -142,6 +142,7 @@ export default function InitialSignupStep({
           {shouldDisplaySignupMethod(LoginMethod.EMAIL) && (
             <div className="flex w-full flex-col gap-4">
               <Input
+                variant="outlined"
                 value={email}
                 onChange={(e) => {
                   setEmail(e.target.value);

--- a/frontend/src/components/auth/PasswordField.tsx
+++ b/frontend/src/components/auth/PasswordField.tsx
@@ -13,7 +13,8 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
-  InputGroupInput
+  InputGroupInput,
+  type InputGroupProps
 } from "@app/components/v3";
 import { TPasswordPolicy } from "@app/hooks/api/admin/types";
 
@@ -26,6 +27,7 @@ type PasswordFieldProps = {
   placeholder?: string;
   error?: ReactHookFormFieldError;
   submitCount: number;
+  variant?: InputGroupProps["variant"];
 };
 
 export const PasswordField = ({
@@ -36,7 +38,8 @@ export const PasswordField = ({
   registration,
   placeholder,
   error,
-  submitCount
+  submitCount,
+  variant = "default"
 }: PasswordFieldProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
@@ -49,7 +52,7 @@ export const PasswordField = ({
   return (
     <Field data-invalid={Boolean(error)}>
       <FieldLabel htmlFor={id}>Password</FieldLabel>
-      <InputGroup variant="outlined">
+      <InputGroup variant={variant}>
         <InputGroupInput
           {...registration}
           id={id}

--- a/frontend/src/components/auth/PasswordField.tsx
+++ b/frontend/src/components/auth/PasswordField.tsx
@@ -49,7 +49,7 @@ export const PasswordField = ({
   return (
     <Field data-invalid={Boolean(error)}>
       <FieldLabel htmlFor={id}>Password</FieldLabel>
-      <InputGroup>
+      <InputGroup variant="outlined">
         <InputGroupInput
           {...registration}
           id={id}

--- a/frontend/src/components/auth/TeamInviteStep.tsx
+++ b/frontend/src/components/auth/TeamInviteStep.tsx
@@ -85,6 +85,7 @@ export default function TeamInviteStep(): JSX.Element {
         <CardContent className="flex flex-col gap-4">
           <Field data-invalid={Boolean(validationError)}>
             <TextArea
+              variant="outlined"
               className="min-h-20"
               value={emails}
               onChange={(e) => {

--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -178,6 +178,7 @@ export default function UserInfoStep({
                     First Name
                   </FieldLabel>
                   <Input
+                    variant="outlined"
                     {...register("firstName")}
                     id="signup-first-name"
                     placeholder="First Name"
@@ -193,6 +194,7 @@ export default function UserInfoStep({
                     Last Name
                   </FieldLabel>
                   <Input
+                    variant="outlined"
                     {...register("lastName")}
                     id="signup-last-name"
                     placeholder="Last Name"
@@ -210,6 +212,7 @@ export default function UserInfoStep({
                     Organization Name
                   </FieldLabel>
                   <Input
+                    variant="outlined"
                     {...register("organizationName")}
                     id="signup-organization-name"
                     placeholder="Organization Name"
@@ -238,7 +241,7 @@ export default function UserInfoStep({
               >
                 <Field data-invalid={showDangerState && Boolean(errors.confirmPassword)}>
                   <FieldLabel htmlFor="confirm-password">Confirm Password</FieldLabel>
-                  <InputGroup>
+                  <InputGroup variant="outlined">
                     <InputGroupInput
                       {...register("confirmPassword")}
                       id="confirm-password"

--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -226,6 +226,7 @@ export default function UserInfoStep({
                 </Field>
               )}
               <PasswordField
+                variant="outlined"
                 id="new-password"
                 value={passwordValue}
                 policy={config.passwordPolicy}

--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -313,6 +313,7 @@ export default function UserInfoStep({
                   Where did you hear about us? <span className="font-light">(optional)</span>
                 </FieldLabel>
                 <TextArea
+                  variant="outlined"
                   {...register("attributionSource")}
                   id="signup-attribution-source"
                   placeholder="Where did you hear about us? (optional)"

--- a/frontend/src/components/mfa/setup/VerifyStep.tsx
+++ b/frontend/src/components/mfa/setup/VerifyStep.tsx
@@ -100,6 +100,7 @@ const WebAuthnVerify = ({ onVerified }: { onVerified: Props["onVerified"] }) => 
         it a name so you can recognize it later.
       </p>
       <Input
+        variant="outlined"
         value={name}
         onChange={(e) => setName(e.target.value)}
         placeholder="Passkey name (optional)"

--- a/frontend/src/components/v3/generic/Input/Input.stories.tsx
+++ b/frontend/src/components/v3/generic/Input/Input.stories.tsx
@@ -28,6 +28,10 @@ const meta = {
       control: "select",
       options: ["text", "email", "password", "number", "date", "url", "search", "tel", "file"]
     },
+    variant: {
+      control: "select",
+      options: ["default", "outlined"]
+    },
     isError: {
       control: "boolean"
     },
@@ -46,6 +50,7 @@ const meta = {
   },
   args: {
     type: "text",
+    variant: "default",
     placeholder: "Enter text...",
     isError: false,
     disabled: false,
@@ -72,6 +77,20 @@ export const Default: Story = {
       description: {
         story:
           "Baseline empty input with placeholder text. Use as the starting point for any text input — toggle `type` in the controls panel for specialised browser UX (email, password, number, date, file, etc.)."
+      }
+    }
+  }
+};
+
+export const Outlined: Story = {
+  args: {
+    variant: "outlined"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Detached outline treatment for selected onboarding and authentication flows. Use the default variant for ordinary product forms and search controls."
       }
     }
   }

--- a/frontend/src/components/v3/generic/Input/Input.tsx
+++ b/frontend/src/components/v3/generic/Input/Input.tsx
@@ -1,21 +1,37 @@
 import { forwardRef } from "react";
+import { cva, type VariantProps } from "cva";
 
 import { cn } from "../../utils";
 
-const Input = forwardRef<HTMLInputElement, React.ComponentProps<"input"> & { isError?: boolean }>(
-  ({ className, type, isError, ...props }, ref) => {
+const inputVariants = cva(
+  "h-9 w-full min-w-0 rounded-md border border-border bg-transparent px-3 py-1 text-sm text-foreground shadow-xs file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 selection:bg-foreground selection:text-background",
+  {
+    variants: {
+      variant: {
+        default:
+          "outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-danger aria-invalid:ring-danger/40",
+        outlined:
+          "outline-1 outline-offset-4 outline-transparent transition-colors outline-solid hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60 aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+);
+
+type InputProps = React.ComponentProps<"input"> &
+  VariantProps<typeof inputVariants> & { isError?: boolean };
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, variant = "default", isError, ...props }, ref) => {
     return (
       <input
         ref={ref}
         type={type}
         data-slot="input"
-        className={cn(
-          "h-9 w-full min-w-0 rounded-md border border-border bg-transparent px-3 py-1 text-sm text-foreground shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
-          "hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60",
-          "aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60",
-          "selection:bg-foreground selection:text-background",
-          className
-        )}
+        data-variant={variant}
+        className={cn(inputVariants({ variant, className }))}
         aria-invalid={isError}
         {...props}
       />
@@ -25,4 +41,4 @@ const Input = forwardRef<HTMLInputElement, React.ComponentProps<"input"> & { isE
 
 Input.displayName = "Input";
 
-export { Input };
+export { Input, type InputProps, inputVariants };

--- a/frontend/src/components/v3/generic/InputGroup/InputGroup.stories.tsx
+++ b/frontend/src/components/v3/generic/InputGroup/InputGroup.stories.tsx
@@ -38,10 +38,6 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: {
-    variant: {
-      control: "select",
-      options: ["default", "outlined"]
-    },
     className: { table: { disable: true } },
     children: { table: { disable: true } }
   },

--- a/frontend/src/components/v3/generic/InputGroup/InputGroup.stories.tsx
+++ b/frontend/src/components/v3/generic/InputGroup/InputGroup.stories.tsx
@@ -38,6 +38,10 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "outlined"]
+    },
     className: { table: { disable: true } },
     children: { table: { disable: true } }
   },
@@ -68,6 +72,22 @@ export const Default: Story = {
   },
   render: () => (
     <InputGroup>
+      <InputGroupInput placeholder="Acme Corporation" />
+    </InputGroup>
+  )
+};
+
+export const Outlined: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Detached outline treatment for selected onboarding and authentication flows. Use the default variant for ordinary product forms and search controls."
+      }
+    }
+  },
+  render: () => (
+    <InputGroup variant="outlined">
       <InputGroupInput placeholder="Acme Corporation" />
     </InputGroup>
   )

--- a/frontend/src/components/v3/generic/InputGroup/InputGroup.tsx
+++ b/frontend/src/components/v3/generic/InputGroup/InputGroup.tsx
@@ -7,30 +7,39 @@ import { IconButton, type IconButtonProps } from "../IconButton";
 import { Input } from "../Input";
 import { TextArea } from "../TextArea";
 
-function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+const inputGroupVariants = cva(
+  "group/input-group dark:bg-input/30 relative flex h-9 min-w-0 w-full items-center rounded-md border border-border shadow-xs has-[>textarea]:h-auto",
+  {
+    variants: {
+      variant: {
+        default:
+          "outline-none transition-[color,box-shadow] has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-danger has-[[data-slot][aria-invalid=true]]:ring-danger/40",
+        outlined:
+          "outline-1 outline-offset-4 outline-transparent transition-colors outline-solid hover:border-foreground/20 has-[:focus-visible]:border-accent has-[:focus-visible]:outline-accent/60 has-[[data-slot][aria-invalid=true]]:border-danger has-[[data-slot][aria-invalid=true]]:outline-danger/60 [&_[data-slot=icon-button]:focus-visible]:ring-0"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+);
+
+type InputGroupProps = React.ComponentProps<"div"> & VariantProps<typeof inputGroupVariants>;
+
+function InputGroup({ className, variant = "default", ...props }: InputGroupProps) {
   return (
     <div
       data-slot="input-group"
+      data-variant={variant}
       role="group"
       className={cn(
-        "group/input-group dark:bg-input/30 relative flex w-full items-center rounded-md border border-border shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid",
-        "h-9 min-w-0 has-[>textarea]:h-auto",
-        "[&_[data-slot=icon-button]:focus-visible]:ring-0",
+        inputGroupVariants({ variant }),
 
         // Variants based on alignment.
         "has-[>[data-align=inline-start]]:[&>input]:pl-2",
         "has-[>[data-align=inline-end]]:[&>input]:pr-2",
         "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
         "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
-
-        // Hover state.
-        "hover:border-foreground/20",
-
-        // Focus state.
-        "has-[:focus-visible]:border-accent has-[:focus-visible]:outline-accent/60",
-
-        // Error state.
-        "has-[[data-slot][aria-invalid=true]]:border-danger has-[[data-slot][aria-invalid=true]]:outline-danger/60",
 
         className
       )}
@@ -132,7 +141,7 @@ const InputGroupInput = React.forwardRef<HTMLInputElement, React.ComponentProps<
         ref={ref}
         data-slot="input-group-control"
         className={cn(
-          "flex-1 rounded-none border-0 bg-transparent shadow-none outline-none focus-visible:border-0 dark:bg-transparent",
+          "flex-1 rounded-none border-0 bg-transparent shadow-none outline-none focus-visible:border-0 focus-visible:ring-0 dark:bg-transparent",
           className
         )}
         {...props}
@@ -152,7 +161,7 @@ const InputGroupTextArea = React.forwardRef<
       ref={ref}
       data-slot="input-group-control"
       className={cn(
-        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none outline-none focus-visible:border-0 dark:bg-transparent",
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none outline-none focus-visible:border-0 focus-visible:ring-0 dark:bg-transparent",
         className
       )}
       {...props}
@@ -167,6 +176,8 @@ export {
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
+  type InputGroupProps,
   InputGroupText,
-  InputGroupTextArea
+  InputGroupTextArea,
+  inputGroupVariants
 };

--- a/frontend/src/components/v3/generic/Select/Select.stories.tsx
+++ b/frontend/src/components/v3/generic/Select/Select.stories.tsx
@@ -101,6 +101,29 @@ export const Default: Story = {
   )
 };
 
+export const Outlined: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Detached outline treatment for selected onboarding and authentication flows. Use the default trigger variant for ordinary product forms."
+      }
+    }
+  },
+  render: () => (
+    <Select>
+      <SelectTrigger variant="outlined" className="w-full">
+        <SelectValue placeholder="Choose an environment" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="dev">Development</SelectItem>
+        <SelectItem value="staging">Staging</SelectItem>
+        <SelectItem value="prod">Production</SelectItem>
+      </SelectContent>
+    </Select>
+  )
+};
+
 export const SizeSmall: Story = {
   name: "Size: Small",
   parameters: {

--- a/frontend/src/components/v3/generic/Select/Select.tsx
+++ b/frontend/src/components/v3/generic/Select/Select.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
+import { cva, type VariantProps } from "cva";
 import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
@@ -60,25 +61,44 @@ function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.V
   return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
+const selectTriggerVariants = cva(
+  "flex w-fit !cursor-pointer items-center justify-between gap-1.5 rounded-md border border-border bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap text-foreground select-none disabled:cursor-not-allowed disabled:opacity-50 data-placeholder:text-muted data-[size=default]:h-9 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 *:data-[slot=select-value]:truncate [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span]:truncate",
+  {
+    variants: {
+      variant: {
+        default:
+          "outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-danger aria-invalid:ring-danger/40",
+        outlined:
+          "outline-1 outline-offset-4 outline-transparent transition-colors outline-solid hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60 aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+);
+
+type SelectTriggerProps = React.ComponentProps<typeof SelectPrimitive.Trigger> &
+  VariantProps<typeof selectTriggerVariants> & {
+    size?: "sm" | "default";
+    isError?: boolean;
+  };
+
 function SelectTrigger({
   className,
   size = "default",
+  variant = "default",
   isError,
   children,
   ...props
-}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default";
-  isError?: boolean;
-}) {
+}: SelectTriggerProps) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
+      data-variant={variant}
       aria-invalid={isError}
-      className={cn(
-        "flex w-fit !cursor-pointer items-center justify-between gap-1.5 rounded-md border border-border bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap text-foreground outline-1 outline-offset-4 outline-transparent transition-colors outline-solid select-none hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60 data-placeholder:text-muted data-[size=default]:h-9 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 *:data-[slot=select-value]:truncate [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&>span]:truncate",
-        className
-      )}
+      className={cn(selectTriggerVariants({ variant, className }))}
       {...props}
     >
       {children}
@@ -197,5 +217,7 @@ export {
   SelectScrollUpButton,
   SelectSeparator,
   SelectTrigger,
-  SelectValue
+  type SelectTriggerProps,
+  SelectValue,
+  selectTriggerVariants
 };

--- a/frontend/src/components/v3/generic/Select/Select.tsx
+++ b/frontend/src/components/v3/generic/Select/Select.tsx
@@ -218,6 +218,6 @@ export {
   SelectSeparator,
   SelectTrigger,
   type SelectTriggerProps,
-  SelectValue,
-  selectTriggerVariants
+  selectTriggerVariants,
+  SelectValue
 };

--- a/frontend/src/components/v3/generic/TextArea/TextArea.stories.tsx
+++ b/frontend/src/components/v3/generic/TextArea/TextArea.stories.tsx
@@ -25,6 +25,10 @@ const meta = {
   },
   tags: ["autodocs"],
   argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "outlined"]
+    },
     rows: {
       control: "number"
     },
@@ -45,6 +49,7 @@ const meta = {
     }
   },
   args: {
+    variant: "default",
     placeholder: "Tell us a little about your team...",
     isError: false,
     disabled: false,
@@ -71,6 +76,20 @@ export const Default: Story = {
       description: {
         story:
           "Baseline empty textarea with placeholder text. The control auto-grows as the user types — only set `rows` when you specifically want to cap the starting height."
+      }
+    }
+  }
+};
+
+export const Outlined: Story = {
+  args: {
+    variant: "outlined"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Detached outline treatment for selected onboarding and authentication flows. Use the default variant for ordinary product forms."
       }
     }
   }

--- a/frontend/src/components/v3/generic/TextArea/TextArea.tsx
+++ b/frontend/src/components/v3/generic/TextArea/TextArea.tsx
@@ -1,26 +1,44 @@
 /* eslint-disable react/prop-types */
 import * as React from "react";
+import { cva, type VariantProps } from "cva";
 
 import { cn } from "../../utils";
 
-const TextArea = React.forwardRef<
-  HTMLTextAreaElement,
-  React.ComponentProps<"textarea"> & { isError?: boolean }
->(({ className, isError, ...props }, ref) => {
-  return (
-    <textarea
-      ref={ref}
-      data-slot="textarea"
-      className={cn(
-        "placeholder:text-muted-foreground flex min-h-16 thin-scrollbar w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm text-foreground shadow-xs outline-1 outline-offset-4 outline-transparent transition-colors outline-solid hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60",
-        className
-      )}
-      aria-invalid={isError}
-      {...props}
-    />
-  );
-});
+const textAreaVariants = cva(
+  "placeholder:text-muted-foreground flex min-h-16 thin-scrollbar w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm text-foreground shadow-xs disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default:
+          "outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-danger aria-invalid:ring-danger/40",
+        outlined:
+          "outline-1 outline-offset-4 outline-transparent transition-colors outline-solid hover:border-foreground/20 focus-visible:border-accent focus-visible:outline-accent/60 aria-invalid:border-danger aria-invalid:focus-visible:outline-danger/60"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+);
+
+type TextAreaProps = React.ComponentProps<"textarea"> &
+  VariantProps<typeof textAreaVariants> & { isError?: boolean };
+
+const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  ({ className, variant = "default", isError, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        data-slot="textarea"
+        data-variant={variant}
+        className={cn(textAreaVariants({ variant, className }))}
+        aria-invalid={isError}
+        {...props}
+      />
+    );
+  }
+);
 
 TextArea.displayName = "TextArea";
 
-export { TextArea };
+export { TextArea, type TextAreaProps, textAreaVariants };

--- a/frontend/src/pages/admin/SignUpPage/components/AdminSignUpForm.tsx
+++ b/frontend/src/pages/admin/SignUpPage/components/AdminSignUpForm.tsx
@@ -112,6 +112,7 @@ export const AdminSignUpForm = ({ onSuccess }: AdminSignUpFormProps) => {
               First Name
             </FieldLabel>
             <Input
+              variant="outlined"
               {...register("firstName")}
               id="admin-signup-first-name"
               placeholder="First Name"
@@ -127,6 +128,7 @@ export const AdminSignUpForm = ({ onSuccess }: AdminSignUpFormProps) => {
               Last Name
             </FieldLabel>
             <Input
+              variant="outlined"
               {...register("lastName")}
               id="admin-signup-last-name"
               placeholder="Last Name"
@@ -143,6 +145,7 @@ export const AdminSignUpForm = ({ onSuccess }: AdminSignUpFormProps) => {
             Email
           </FieldLabel>
           <Input
+            variant="outlined"
             {...register("email")}
             id="admin-signup-email"
             type="email"
@@ -168,7 +171,7 @@ export const AdminSignUpForm = ({ onSuccess }: AdminSignUpFormProps) => {
         >
           <Field data-invalid={showDangerState && Boolean(errors.confirmPassword)}>
             <FieldLabel htmlFor="admin-signup-confirm-password">Confirm Password</FieldLabel>
-            <InputGroup>
+            <InputGroup variant="outlined">
               <InputGroupInput
                 {...register("confirmPassword")}
                 id="admin-signup-confirm-password"

--- a/frontend/src/pages/admin/SignUpPage/components/AdminSignUpForm.tsx
+++ b/frontend/src/pages/admin/SignUpPage/components/AdminSignUpForm.tsx
@@ -156,6 +156,7 @@ export const AdminSignUpForm = ({ onSuccess }: AdminSignUpFormProps) => {
           {showDangerState && errors.email ? <FieldError>{errors.email.message}</FieldError> : null}
         </Field>
         <PasswordField
+          variant="outlined"
           id="admin-signup-password"
           value={password}
           policy={config.passwordPolicy}

--- a/frontend/src/pages/auth/AccountRecoveryEmailPage/AccountRecoveryEmailPage.tsx
+++ b/frontend/src/pages/auth/AccountRecoveryEmailPage/AccountRecoveryEmailPage.tsx
@@ -69,6 +69,7 @@ export const AccountRecoveryEmailPage = () => {
                   Enter your email to receive recovery instructions.
                 </p>
                 <Input
+                  variant="outlined"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   type="email"

--- a/frontend/src/pages/auth/AccountRecoveryResetPage/components/EnterPasswordStep.tsx
+++ b/frontend/src/pages/auth/AccountRecoveryResetPage/components/EnterPasswordStep.tsx
@@ -114,7 +114,7 @@ export const EnterPasswordStep = ({ verificationToken, onComplete, onBack }: Pro
       >
         <Field data-invalid={showDangerState && Boolean(errors.confirmPassword)}>
           <FieldLabel htmlFor="account-recovery-confirm-password">Confirm Password</FieldLabel>
-          <InputGroup>
+          <InputGroup variant="outlined">
             <InputGroupInput
               {...register("confirmPassword")}
               id="account-recovery-confirm-password"

--- a/frontend/src/pages/auth/AccountRecoveryResetPage/components/EnterPasswordStep.tsx
+++ b/frontend/src/pages/auth/AccountRecoveryResetPage/components/EnterPasswordStep.tsx
@@ -98,6 +98,7 @@ export const EnterPasswordStep = ({ verificationToken, onComplete, onBack }: Pro
       </p>
       <div className="mt-8 w-full">
         <PasswordField
+          variant="outlined"
           id="account-recovery-password"
           value={password}
           policy={config.passwordPolicy}

--- a/frontend/src/pages/auth/LoginLdapPage/LoginLDAPPage.tsx
+++ b/frontend/src/pages/auth/LoginLdapPage/LoginLDAPPage.tsx
@@ -102,6 +102,7 @@ export const LoginLdapPage = () => {
           <CardContent className="flex flex-col gap-4">
             {!config.defaultAuthOrgSlug && !passedOrgSlug && (
               <Input
+                variant="outlined"
                 value={organizationSlug}
                 onChange={(e) => setOrganizationSlug(e.target.value)}
                 type="text"
@@ -111,6 +112,7 @@ export const LoginLdapPage = () => {
               />
             )}
             <Input
+              variant="outlined"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
               type="text"
@@ -120,6 +122,7 @@ export const LoginLdapPage = () => {
               className="h-10"
             />
             <Input
+              variant="outlined"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               type="password"

--- a/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
+++ b/frontend/src/pages/auth/LoginPage/components/InitialStep/InitialStep.tsx
@@ -440,6 +440,7 @@ export const InitialStep = ({ isAdmin }: Props) => {
           {shouldDisplayLoginMethod(LoginMethod.EMAIL) && (
             <div className="flex w-full flex-col gap-4">
               <Input
+                variant="outlined"
                 {...register("email", { onChange: () => setLoginError(false) })}
                 type="email"
                 id="email"
@@ -448,7 +449,7 @@ export const InitialStep = ({ isAdmin }: Props) => {
                 className="h-10"
                 isError={(showDangerState && Boolean(errors.email)) || loginError}
               />
-              <InputGroup className="h-10">
+              <InputGroup variant="outlined" className="h-10">
                 <InputGroupInput
                   {...register("password", { onChange: () => setLoginError(false) })}
                   type={showPassword ? "text" : "password"}

--- a/frontend/src/pages/auth/LoginSsoPage/LoginSsoPage.tsx
+++ b/frontend/src/pages/auth/LoginSsoPage/LoginSsoPage.tsx
@@ -105,6 +105,7 @@ export const LoginSsoPage = ({ type }: Props) => {
               <Field>
                 <FieldLabel htmlFor={`${type.toLowerCase()}-work-email`}>Work Email</FieldLabel>
                 <Input
+                  variant="outlined"
                   id={`${type.toLowerCase()}-work-email`}
                   value={workEmail}
                   onChange={(event) => setWorkEmail(event.target.value)}

--- a/frontend/src/pages/auth/PasswordSetupPage/PasswordSetupPage.tsx
+++ b/frontend/src/pages/auth/PasswordSetupPage/PasswordSetupPage.tsx
@@ -115,6 +115,7 @@ export const PasswordSetupPage = () => {
           </CardHeader>
           <CardContent className="flex flex-col gap-4">
             <PasswordField
+              variant="outlined"
               id="password-setup-password"
               value={password}
               policy={config.passwordPolicy}

--- a/frontend/src/pages/auth/PasswordSetupPage/PasswordSetupPage.tsx
+++ b/frontend/src/pages/auth/PasswordSetupPage/PasswordSetupPage.tsx
@@ -129,7 +129,7 @@ export const PasswordSetupPage = () => {
             >
               <Field data-invalid={showDangerState && Boolean(errors.confirmPassword)}>
                 <FieldLabel htmlFor="password-setup-confirm-password">Confirm Password</FieldLabel>
-                <InputGroup>
+                <InputGroup variant="outlined">
                   <InputGroupInput
                     {...register("confirmPassword")}
                     id="password-setup-confirm-password"


### PR DESCRIPTION
## Context

The auth-screen redesign changed the shared v3 `Input` and `InputGroup` base styles from the earlier ring-based focus treatment to a detached outline. Because that treatment became the default, it also propagated to ordinary product forms and search controls, producing unintended outlines and spacing artifacts.

This change restores the earlier Storybook styling as the default and preserves the newer treatment as an explicit `outlined` variant. Authentication, signup, account-recovery, MFA, and initial admin onboarding consumers now opt into `outlined`, while regular product consumers inherit the restored default.

Linear: [PLATFOR-610](https://linear.app/infisical/issue/PLATFOR-610/revert-input-base-variant-and-make-outlined-style-a-separate)

## Screenshots

Outstanding capture request:

<img width="1070" height="1338" alt="CleanShot 2026-07-30 at 08 03 41@2x" src="https://github.com/user-attachments/assets/8dbc56b3-a196-4d11-a557-8498de90a2fc" />
<img width="1940" height="1216" alt="CleanShot 2026-07-30 at 08 04 27@2x" src="https://github.com/user-attachments/assets/fcde40de-9751-4064-ac3c-b51e2dfafec6" />


To reproduce: from `frontend`, run `npm run storybook`, open the `Generic/Input` and `Generic/InputGroup` stories, and focus each control with the keyboard. No account or test data is required.

## Steps to verify the change

1. Open Storybook at `Generic/Input` and confirm Default uses the ring-based focus treatment.
2. Switch the Input `variant` control to `outlined` and confirm the detached outline remains available.
3. Repeat for `Generic/InputGroup`, including a group with an inline addon.
4. Open a login, signup, account-recovery, or password-setup form and confirm its inputs retain the outlined treatment.
5. Open a regular product form or search control and confirm it uses the restored default without the detached outline spacing artifact.
6. Run ESLint on the touched frontend files and `npm run type:check`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)