### PR TITLE
feat(agent-proxy): add adoption telemetry for proxied services

### DIFF
--- a/backend/src/ee/routes/v1/proxied-service-router.ts
+++ b/backend/src/ee/routes/v1/proxied-service-router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
+import { ProxiedServiceCredentialRole } from "@app/ee/services/proxied-service/proxied-service-enums";
 import {
   CredentialsArraySchema,
   hostPatternSchema,
@@ -11,8 +12,10 @@ import {
 import { ApiDocsTags, PROXIED_SERVICES } from "@app/lib/api-docs";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { slugSchema } from "@app/server/lib/schemas";
+import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 export const registerProxiedServiceRouter = async (server: FastifyZodProvider) => {
   server.route({
@@ -59,6 +62,31 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
           }
         }
       });
+
+      void server.services.telemetry
+        .sendPostHogEvents({
+          event: PostHogEventTypes.ProxiedServiceCreated,
+          distinctId: getTelemetryDistinctId(req),
+          organizationId: req.permission.orgId,
+          properties: {
+            projectId: req.body.projectId,
+            headerRewriteCount: req.body.credentials.filter(
+              (c) => c.role === ProxiedServiceCredentialRole.HeaderRewrite
+            ).length,
+            substitutionCount: req.body.credentials.filter(
+              (c) => c.role === ProxiedServiceCredentialRole.CredentialSubstitution
+            ).length,
+            substitutionSurfaces: [
+              ...new Set(req.body.credentials.flatMap((c) => c.substitutionSurfaces ?? []))
+            ].sort(),
+            hostPatternCount: req.body.hostPattern.split(",").filter((p) => p.trim()).length,
+            usesDynamicSecret: req.body.credentials.some((c) => Boolean(c.dynamicSecretName)),
+            usesBasicAuth: req.body.credentials.some((c) => Boolean(c.headerPurpose)),
+            isEnabled: service.isEnabled
+          }
+        })
+        .catch(() => {});
+
       return { service };
     }
   });

--- a/backend/src/ee/routes/v1/proxied-service-router.ts
+++ b/backend/src/ee/routes/v1/proxied-service-router.ts
@@ -77,7 +77,11 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
               (c) => c.role === ProxiedServiceCredentialRole.CredentialSubstitution
             ).length,
             substitutionSurfaces: [
-              ...new Set(req.body.credentials.flatMap((c) => c.substitutionSurfaces ?? []))
+              ...new Set(
+                req.body.credentials
+                  .filter((c) => c.role === ProxiedServiceCredentialRole.CredentialSubstitution)
+                  .flatMap((c) => c.substitutionSurfaces ?? [])
+              )
             ].sort(),
             hostPatternCount: req.body.hostPattern.split(",").filter((p) => p.trim()).length,
             usesDynamicSecret: req.body.credentials.some((c) => Boolean(c.dynamicSecretName)),

--- a/backend/src/services/telemetry/telemetry-dal.ts
+++ b/backend/src/services/telemetry/telemetry-dal.ts
@@ -63,7 +63,9 @@ export const telemetryDALFactory = (db: TDbClient) => {
         pamResources,
         pamAccounts,
         accessApprovalPolicies,
-        honeyTokens
+        honeyTokens,
+        proxiedServices,
+        proxiedServicesUsedLast7Days
       ] = await Promise.all([
         (async () => {
           const result = (await db(TableName.Users).where({ isGhost: false }).count().first())?.count as string;
@@ -112,7 +114,18 @@ export const telemetryDALFactory = (db: TDbClient) => {
         countTable(db, TableName.PamResource),
         countTable(db, TableName.PamAccount),
         countTable(db, TableName.AccessApprovalPolicy),
-        countTable(db, TableName.HoneyToken)
+        countTable(db, TableName.HoneyToken),
+        countTable(db, TableName.ProxiedService),
+        (async () => {
+          const result = (
+            await db(TableName.ProxiedService)
+              .whereNotNull("lastUsedAt")
+              .whereRaw(`"lastUsedAt" > NOW() - INTERVAL '7 days'`)
+              .count()
+              .first()
+          )?.count as string;
+          return parseInt(result || "0", 10);
+        })()
       ]);
 
       // Per-type identity auth method breakdown
@@ -247,6 +260,8 @@ export const telemetryDALFactory = (db: TDbClient) => {
         pamAccounts,
         accessApprovalPolicies,
         honeyTokens,
+        proxiedServices,
+        proxiedServicesUsedLast7Days,
         integrationBreakdown,
         projectTypeBreakdown,
         secretSyncBreakdown,

--- a/backend/src/services/telemetry/telemetry-types.ts
+++ b/backend/src/services/telemetry/telemetry-types.ts
@@ -16,6 +16,7 @@ import {
   UserActor
 } from "@app/ee/services/audit-log/audit-log-types";
 import { PamSessionEndReason } from "@app/ee/services/pam/pam-enums";
+import { ProxiedServiceSubstitutionSurface } from "@app/ee/services/proxied-service/proxied-service-enums";
 import { SecretRotation } from "@app/ee/services/secret-rotation-v2/secret-rotation-v2-enums";
 import { SecretScanningDataSource } from "@app/ee/services/secret-scanning-v2/secret-scanning-v2-enums";
 import { EnforcementLevel, SecretSharingAccessType } from "@app/lib/types";
@@ -262,7 +263,10 @@ export enum PostHogEventTypes {
   DynamicSecretLeaseRevoked = "Dynamic Secret Lease Revoked",
   SecretApprovalPolicyUpdated = "Secret Approval Policy Updated",
   AccessApprovalPolicyUpdated = "Access Approval Policy Updated",
-  SecretRotationV2Failed = "Secret Rotation V2 Failed"
+  SecretRotationV2Failed = "Secret Rotation V2 Failed",
+
+  // Agent Proxy
+  ProxiedServiceCreated = "Proxied Service Created"
 }
 
 export type TSecretModifiedEvent = {
@@ -533,6 +537,8 @@ export type TTelemetryInstanceStatsEvent = {
     pamAccounts: number;
     accessApprovalPolicies: number;
     honeyTokens: number;
+    proxiedServices: number;
+    proxiedServicesUsedLast7Days: number;
     integrationBreakdown: Record<string, number>;
     projectTypeBreakdown: Record<string, number>;
     secretSyncBreakdown: Record<string, number>;
@@ -1982,6 +1988,20 @@ export type TSecretRotationV2FailedEvent = {
   };
 };
 
+export type TProxiedServiceCreatedEvent = {
+  event: PostHogEventTypes.ProxiedServiceCreated;
+  properties: {
+    projectId: string;
+    headerRewriteCount: number;
+    substitutionCount: number;
+    substitutionSurfaces: ProxiedServiceSubstitutionSurface[];
+    hostPatternCount: number;
+    usesDynamicSecret: boolean;
+    usesBasicAuth: boolean;
+    isEnabled: boolean;
+  };
+};
+
 export type TPostHogEvent = {
   distinctId: string;
   organizationId?: string;
@@ -2179,4 +2199,5 @@ export type TPostHogEvent = {
   | TSecretApprovalPolicyUpdatedEvent
   | TAccessApprovalPolicyUpdatedEvent
   | TSecretRotationV2FailedEvent
+  | TProxiedServiceCreatedEvent
 );


### PR DESCRIPTION
## Context

Agent proxy has no telemetry, so there is no way to tell which orgs are configuring proxied services, which credential shapes they actually need, or whether a service that was configured ever ends up being used. This adds the backend half.

**Event:** `Proxied Service Created`, fired from the create route with `organizationId` so it picks up the org group properties the telemetry service already attaches (name, plan slug, seat count, verified domain, deployment type). Properties describe the shape rather than the contents: `headerRewriteCount`, `substitutionCount`, `substitutionSurfaces`, `hostPatternCount`, `usesDynamicSecret`, `usesBasicAuth`, `isEnabled`. That mix is the thing worth knowing, since it says which auth styles and which substitution surfaces people really configure, and therefore where template work pays off.

**Instance stats:** `proxiedServices` and `proxiedServicesUsedLast7Days` added to the daily self-hosted stats, computed off the existing `lastUsedAt` column. Without these, self-hosted agent proxy adoption is invisible, because that one daily event is the only thing a self-hosted install sends.

**Not captured:** no event on `/report-usage`. `reportUsage` already stamps `lastUsedAt`, so on cloud "configured a service but never used it" is a SQL query and an event would be duplicate. No hostnames, service names or secret keys anywhere in the properties: host patterns and secret names are customer-identifying, and the counts answer the question without them. Update and delete events are left out as noise, since no decision hangs on them.

Companion CLI PR: https://github.com/Infisical/cli/pull/341

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
