### PR TITLE
improvement(redis): add throttled structured logging for connection errors

### DIFF
--- a/backend/src/ee/services/event-bus/redis-bus.ts
+++ b/backend/src/ee/services/event-bus/redis-bus.ts
@@ -1,5 +1,6 @@
 import { Cluster, Redis } from "ioredis";
 
+import { attachConnectionLogging } from "@app/lib/config/redis";
 import { logger } from "@app/lib/logger";
 
 import { EventBusSchema, EventBusTopicName, TEventBusEvent } from "./event-bus-types";
@@ -9,8 +10,9 @@ export type TRedisBusOnMessage = (event: TEventBusEvent) => void;
 export const createRedisBus = (redis: Redis | Cluster, topic: EventBusTopicName) => {
   // Duplicate the redis connection for pub/sub
   // Redis doesn't allow a single connection to both publish and subscribe
-  const publisher = redis.duplicate();
-  const subscriber = publisher.duplicate();
+  // Logging is attached here rather than in init() because duplicate() connects eagerly, long before init() runs
+  const publisher = attachConnectionLogging(redis.duplicate(), "event-bus-publisher");
+  const subscriber = attachConnectionLogging(publisher.duplicate(), "event-bus-subscriber");
 
   let messageHandler: TRedisBusOnMessage | null = null;
 
@@ -18,14 +20,6 @@ export const createRedisBus = (redis: Redis | Cluster, topic: EventBusTopicName)
    * Initialize the Redis bus by subscribing to the topic
    */
   const init = async (): Promise<void> => {
-    subscriber.on("error", (error) => {
-      logger.error(error, "Event bus Redis subscriber error");
-    });
-
-    publisher.on("error", (error) => {
-      logger.error(error, "Event bus Redis publisher error");
-    });
-
     subscriber.on("message", (channel: string, message: string) => {
       if (channel !== topic || !messageHandler) {
         logger.info("Received emtpy channel or message in event bus");

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -303,21 +303,23 @@ export const keyStoreFactory = (
   redisConfigKeys: TKeyStoreFactoryDTO,
   keyValueStoreDAL: TKeyValueStoreDALFactory
 ): TKeyStoreFactory => {
-  const primaryRedis = buildRedisFromConfig(redisConfigKeys);
+  const primaryRedis = buildRedisFromConfig(redisConfigKeys, "keystore");
 
   const redisReadReplicas = redisConfigKeys.REDIS_READ_REPLICAS?.map((el) => {
+    const replicaName = `keystore-replica:${el.host}:${el.port}`;
+
     if (redisConfigKeys.REDIS_URL) {
       const primaryNode = new URL(redisConfigKeys?.REDIS_URL);
       primaryNode.hostname = el.host;
       primaryNode.port = String(el.port);
-      return buildRedisFromConfig({ ...redisConfigKeys, REDIS_URL: primaryNode.toString() });
+      return buildRedisFromConfig({ ...redisConfigKeys, REDIS_URL: primaryNode.toString() }, replicaName);
     }
 
     if (redisConfigKeys.REDIS_SENTINEL_HOSTS) {
-      return buildRedisFromConfig({ ...redisConfigKeys, REDIS_SENTINEL_HOSTS: [el] });
+      return buildRedisFromConfig({ ...redisConfigKeys, REDIS_SENTINEL_HOSTS: [el] }, replicaName);
     }
 
-    return buildRedisFromConfig({ ...redisConfigKeys, REDIS_CLUSTER_HOSTS: [el] });
+    return buildRedisFromConfig({ ...redisConfigKeys, REDIS_CLUSTER_HOSTS: [el] }, replicaName);
   });
   const redisLock = new Redlock([primaryRedis], { retryCount: 2, retryDelay: 200 });
 

--- a/backend/src/lib/config/redis.ts
+++ b/backend/src/lib/config/redis.ts
@@ -21,7 +21,7 @@ export type TRedisConfigKeys = Partial<{
 
 const REDIS_ERROR_LOG_THROTTLE_MS = 10_000;
 
-const attachConnectionLogging = (client: Redis | Cluster) => {
+const attachConnectionLogging = (client: Redis | Cluster, name: string) => {
   let lastLoggedAt = 0;
   let isDown = false;
 
@@ -31,7 +31,7 @@ const attachConnectionLogging = (client: Redis | Cluster) => {
 
     lastLoggedAt = now;
     isDown = true;
-    logger.error({ err }, `Redis connection error [error=${err.message}]`);
+    logger.error({ err, redisClient: name }, `Redis connection error [client=${name}] [error=${err.message}]`);
   });
 
   client.on("ready", () => {
@@ -39,13 +39,13 @@ const attachConnectionLogging = (client: Redis | Cluster) => {
     if (!isDown) return;
     isDown = false;
     lastLoggedAt = 0;
-    logger.info("Redis connection restored");
+    logger.info({ redisClient: name }, `Redis connection restored [client=${name}]`);
   });
 
   return client;
 };
 
-export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
+export const buildRedisFromConfig = (cfg: TRedisConfigKeys, name = "unknown") => {
   if (cfg.REDIS_URL) {
     return attachConnectionLogging(
       new Redis(cfg.REDIS_URL, {
@@ -58,7 +58,8 @@ export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
           }
           return false;
         }
-      })
+      }),
+      name
     );
   }
 
@@ -81,7 +82,8 @@ export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
             return false;
           }
         }
-      })
+      }),
+      name
     );
   }
 
@@ -104,6 +106,7 @@ export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
         }
         return false;
       }
-    })
+    }),
+    name
   );
 };

--- a/backend/src/lib/config/redis.ts
+++ b/backend/src/lib/config/redis.ts
@@ -42,10 +42,13 @@ export const attachConnectionLogging = (client: Redis | Cluster, name: string) =
   const throttleByErrorKey = new Map<string, { lastLoggedAt: number; suppressedCount: number }>();
   let isDown = false;
 
-  client.on("error", (err: Error) => {
+  const logConnectionError = (err: Error, nodeAddress?: string) => {
     const errorKey = getRedisErrorKey(err);
+    // Nodes are bucketed separately so one failing node can't absorb another's line. Still bounded,
+    // unlike keying on err.message, since a cluster has a fixed node count.
+    const throttleKey = nodeAddress ? `${errorKey}:${nodeAddress}` : errorKey;
     const now = Date.now();
-    const throttle = throttleByErrorKey.get(errorKey);
+    const throttle = throttleByErrorKey.get(throttleKey);
 
     if (throttle && now - throttle.lastLoggedAt < REDIS_ERROR_LOG_THROTTLE_MS) {
       throttle.suppressedCount += 1;
@@ -53,12 +56,18 @@ export const attachConnectionLogging = (client: Redis | Cluster, name: string) =
     }
 
     const suppressedCount = throttle?.suppressedCount ?? 0;
-    throttleByErrorKey.set(errorKey, { lastLoggedAt: now, suppressedCount: 0 });
+    throttleByErrorKey.set(throttleKey, { lastLoggedAt: now, suppressedCount: 0 });
     logger.error(
-      { err, redisClient: name, redisErrorKey: errorKey, suppressedCount },
-      `Redis connection error [client=${name}] [error=${errorKey}] [suppressedCount=${suppressedCount}] [message=${err.message}]`
+      { err, redisClient: name, redisErrorKey: errorKey, redisNode: nodeAddress, suppressedCount },
+      `Redis connection error [client=${name}] [error=${errorKey}]${nodeAddress ? ` [node=${nodeAddress}]` : ""} [suppressedCount=${suppressedCount}] [message=${err.message}]`
     );
-  });
+  };
+
+  client.on("error", (err: Error) => logConnectionError(err));
+
+  if (client instanceof Cluster) {
+    client.on("node error", (err: Error, nodeAddress: string) => logConnectionError(err, nodeAddress));
+  }
 
   client.on("close", () => {
     isDown = true;

--- a/backend/src/lib/config/redis.ts
+++ b/backend/src/lib/config/redis.ts
@@ -21,24 +21,56 @@ export type TRedisConfigKeys = Partial<{
 
 const REDIS_ERROR_LOG_THROTTLE_MS = 10_000;
 
-const attachConnectionLogging = (client: Redis | Cluster, name: string) => {
-  let lastLoggedAt = 0;
+// The error channel carries more than socket failures: auth failures (NOAUTH/WRONGPASS) reach it via
+// recoverFromFatalError, as do cluster slot-refresh failures. So the throttle is keyed per normalized error code.
+// Keying on err.message instead would grow unbounded, since cluster messages embed host:port.
+const getRedisErrorKey = (err: Error) => {
+  const { code } = err as Error & { code?: string };
+  if (code) return code; // ECONNREFUSED, ETIMEDOUT, ...
+
+  const replyPrefix = /^([A-Z]{4,})/.exec(err.message)?.[1];
+  if (replyPrefix) return replyPrefix; // NOAUTH, WRONGPASS, CLUSTERDOWN, ...
+
+  return err.name;
+};
+
+/**
+ * Attaches throttled, named connection logging to a client. Call this on any client not built by
+ * `buildRedisFromConfig`. Specifically `duplicate()`d clients, since `duplicate()` copies options but not listeners.
+ */
+export const attachConnectionLogging = (client: Redis | Cluster, name: string) => {
+  const throttleByErrorKey = new Map<string, { lastLoggedAt: number; suppressedCount: number }>();
   let isDown = false;
 
   client.on("error", (err: Error) => {
+    const errorKey = getRedisErrorKey(err);
     const now = Date.now();
-    if (now - lastLoggedAt < REDIS_ERROR_LOG_THROTTLE_MS) return;
+    const throttle = throttleByErrorKey.get(errorKey);
 
-    lastLoggedAt = now;
+    if (throttle && now - throttle.lastLoggedAt < REDIS_ERROR_LOG_THROTTLE_MS) {
+      throttle.suppressedCount += 1;
+      return;
+    }
+
+    const suppressedCount = throttle?.suppressedCount ?? 0;
+    throttleByErrorKey.set(errorKey, { lastLoggedAt: now, suppressedCount: 0 });
+    logger.error(
+      { err, redisClient: name, redisErrorKey: errorKey, suppressedCount },
+      `Redis connection error [client=${name}] [error=${errorKey}] [suppressedCount=${suppressedCount}] [message=${err.message}]`
+    );
+  });
+
+  client.on("close", () => {
     isDown = true;
-    logger.error({ err, redisClient: name }, `Redis connection error [client=${name}] [error=${err.message}]`);
   });
 
   client.on("ready", () => {
+    // Must clear, otherwise stale timestamps would throttle the first error of the next outage.
+    throttleByErrorKey.clear();
+
     // Skip the initial connect; only a recovery is worth a line.
     if (!isDown) return;
     isDown = false;
-    lastLoggedAt = 0;
     logger.info({ redisClient: name }, `Redis connection restored [client=${name}]`);
   });
 

--- a/backend/src/lib/config/redis.ts
+++ b/backend/src/lib/config/redis.ts
@@ -1,4 +1,6 @@
-import { Redis } from "ioredis";
+import { Cluster, Redis } from "ioredis";
+
+import { logger } from "@app/lib/logger";
 
 export type TRedisConfigKeys = Partial<{
   REDIS_URL: string;
@@ -17,10 +19,83 @@ export type TRedisConfigKeys = Partial<{
   REDIS_SENTINEL_PASSWORD: string;
 }>;
 
+const REDIS_ERROR_LOG_THROTTLE_MS = 10_000;
+
+const attachConnectionLogging = (client: Redis | Cluster) => {
+  let lastLoggedAt = 0;
+  let isDown = false;
+
+  client.on("error", (err: Error) => {
+    const now = Date.now();
+    if (now - lastLoggedAt < REDIS_ERROR_LOG_THROTTLE_MS) return;
+
+    lastLoggedAt = now;
+    isDown = true;
+    logger.error({ err }, `Redis connection error [error=${err.message}]`);
+  });
+
+  client.on("ready", () => {
+    // Skip the initial connect; only a recovery is worth a line.
+    if (!isDown) return;
+    isDown = false;
+    lastLoggedAt = 0;
+    logger.info("Redis connection restored");
+  });
+
+  return client;
+};
+
 export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
   if (cfg.REDIS_URL) {
-    return new Redis(cfg.REDIS_URL, {
+    return attachConnectionLogging(
+      new Redis(cfg.REDIS_URL, {
+        maxRetriesPerRequest: null,
+        reconnectOnError(err) {
+          // Reconnect when hitting a read-only replica during failover
+          const targetError = "READONLY";
+          if (err.message.includes(targetError)) {
+            return 2; // Reconnect and resend command
+          }
+          return false;
+        }
+      })
+    );
+  }
+
+  if (cfg.REDIS_CLUSTER_HOSTS) {
+    return attachConnectionLogging(
+      new Redis.Cluster(cfg.REDIS_CLUSTER_HOSTS, {
+        dnsLookup: cfg.REDIS_CLUSTER_AWS_ELASTICACHE_DNS_LOOKUP_MODE
+          ? (address, callback) => callback(null, address)
+          : undefined,
+        retryDelayOnClusterDown: 300,
+        redisOptions: {
+          username: cfg.REDIS_USERNAME,
+          password: cfg.REDIS_PASSWORD,
+          tls: cfg?.REDIS_CLUSTER_ENABLE_TLS ? {} : undefined,
+          reconnectOnError(err) {
+            const targetError = "READONLY";
+            if (err.message.includes(targetError)) {
+              return 2; // Reconnect and resend command
+            }
+            return false;
+          }
+        }
+      })
+    );
+  }
+
+  return attachConnectionLogging(
+    new Redis({
+      // refine at tope will catch this case
+      sentinels: cfg.REDIS_SENTINEL_HOSTS!,
+      name: cfg.REDIS_SENTINEL_MASTER_NAME!,
       maxRetriesPerRequest: null,
+      sentinelUsername: cfg.REDIS_SENTINEL_USERNAME,
+      sentinelPassword: cfg.REDIS_SENTINEL_PASSWORD,
+      enableTLSForSentinelMode: cfg.REDIS_SENTINEL_ENABLE_TLS,
+      username: cfg.REDIS_USERNAME,
+      password: cfg.REDIS_PASSWORD,
       reconnectOnError(err) {
         // Reconnect when hitting a read-only replica during failover
         const targetError = "READONLY";
@@ -29,47 +104,6 @@ export const buildRedisFromConfig = (cfg: TRedisConfigKeys) => {
         }
         return false;
       }
-    });
-  }
-
-  if (cfg.REDIS_CLUSTER_HOSTS) {
-    return new Redis.Cluster(cfg.REDIS_CLUSTER_HOSTS, {
-      dnsLookup: cfg.REDIS_CLUSTER_AWS_ELASTICACHE_DNS_LOOKUP_MODE
-        ? (address, callback) => callback(null, address)
-        : undefined,
-      retryDelayOnClusterDown: 300,
-      redisOptions: {
-        username: cfg.REDIS_USERNAME,
-        password: cfg.REDIS_PASSWORD,
-        tls: cfg?.REDIS_CLUSTER_ENABLE_TLS ? {} : undefined,
-        reconnectOnError(err) {
-          const targetError = "READONLY";
-          if (err.message.includes(targetError)) {
-            return 2; // Reconnect and resend command
-          }
-          return false;
-        }
-      }
-    });
-  }
-
-  return new Redis({
-    // refine at tope will catch this case
-    sentinels: cfg.REDIS_SENTINEL_HOSTS!,
-    name: cfg.REDIS_SENTINEL_MASTER_NAME!,
-    maxRetriesPerRequest: null,
-    sentinelUsername: cfg.REDIS_SENTINEL_USERNAME,
-    sentinelPassword: cfg.REDIS_SENTINEL_PASSWORD,
-    enableTLSForSentinelMode: cfg.REDIS_SENTINEL_ENABLE_TLS,
-    username: cfg.REDIS_USERNAME,
-    password: cfg.REDIS_PASSWORD,
-    reconnectOnError(err) {
-      // Reconnect when hitting a read-only replica during failover
-      const targetError = "READONLY";
-      if (err.message.includes(targetError)) {
-        return 2; // Reconnect and resend command
-      }
-      return false;
-    }
-  });
+    })
+  );
 };

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -90,7 +90,7 @@ const run = async () => {
 
   const keyValueStoreDAL = keyValueStoreDALFactory(db);
   const keyStore = keyStoreFactory(envConfig, keyValueStoreDAL);
-  const redis = buildRedisFromConfig(envConfig);
+  const redis = buildRedisFromConfig(envConfig, "app");
 
   const server = await main({
     db,

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -659,7 +659,7 @@ export type TQueueServiceFactory = {
 
 export const queueServiceFactory = (redisCfg: TRedisConfigKeys): TQueueServiceFactory => {
   const isClusterMode = Boolean(redisCfg?.REDIS_CLUSTER_HOSTS);
-  const connection = buildRedisFromConfig(redisCfg);
+  const connection = buildRedisFromConfig(redisCfg, "queue");
   const queueContainer: Partial<Record<QueueName, Queue<TQueueJobTypes[QueueName]["payload"], void, string>>> = {};
 
   const workerContainer: Partial<

--- a/backend/src/server/boot-strap-check.ts
+++ b/backend/src/server/boot-strap-check.ts
@@ -66,7 +66,7 @@ export const bootstrapCheck = async ({ db }: BootstrapOpt) => {
     });
 
   console.log("Testing redis connection");
-  const redis = buildRedisFromConfig(appCfg);
+  const redis = buildRedisFromConfig(appCfg, "bootstrap");
   const redisPing = await redis?.ping();
   if (!redisPing) {
     console.error("Redis - Failed to connect");

--- a/backend/src/server/config/rateLimiter.ts
+++ b/backend/src/server/config/rateLimiter.ts
@@ -6,7 +6,7 @@ import { RateLimitError } from "@app/lib/errors";
 
 export const globalRateLimiterCfg = (): RateLimitPluginOptions => {
   const appCfg = getConfig();
-  const redis = appCfg.isRedisConfigured ? buildRedisFromConfig(appCfg) : null;
+  const redis = appCfg.isRedisConfigured ? buildRedisFromConfig(appCfg, "rate-limiter") : null;
 
   return {
     errorResponseBuilder: (_, context) => {

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -305,8 +305,7 @@ ClickHouse can be used as an alternative audit log storage backend for high-volu
 Redis is used for caching and background tasks. You can use either a standalone Redis instance, Redis Sentinel, or Redis Cluster setup.
 
 Redis is required: the instance will not start unless one of `REDIS_URL`, `REDIS_SENTINEL_HOSTS`, or
-`REDIS_CLUSTER_HOSTS` is set. For what happens when a configured Redis becomes unreachable at
-runtime, see [Behavior when Redis is unavailable](/self-hosting/configuration/requirements#behavior-when-redis-is-unavailable).
+`REDIS_CLUSTER_HOSTS` is set.
 
 <Info>
 An **active-passive** setup is recommended for Redis. Infisical has not been tested with an **active-active** Redis setup, which may result in undocumented behavior.

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -304,6 +304,10 @@ ClickHouse can be used as an alternative audit log storage backend for high-volu
 
 Redis is used for caching and background tasks. You can use either a standalone Redis instance, Redis Sentinel, or Redis Cluster setup.
 
+Redis is required: the instance will not start unless one of `REDIS_URL`, `REDIS_SENTINEL_HOSTS`, or
+`REDIS_CLUSTER_HOSTS` is set. For what happens when a configured Redis becomes unreachable at
+runtime, see [Behavior when Redis is unavailable](/self-hosting/configuration/requirements#behavior-when-redis-is-unavailable).
+
 <Info>
 An **active-passive** setup is recommended for Redis. Infisical has not been tested with an **active-active** Redis setup, which may result in undocumented behavior.
 </Info>

--- a/docs/self-hosting/configuration/requirements.mdx
+++ b/docs/self-hosting/configuration/requirements.mdx
@@ -53,7 +53,10 @@ Recommended resource allocation based on deployment size. You may require more r
 
 ### Redis
 
-Redis is utilized for session management and background tasks in Infisical.
+Infisical treats Redis as a **required, persistent datastore**. Beyond
+caching, it holds the background job queue, distributed locks, cross-instance coordination state
+for scheduled jobs, and rate-limit counters. An instance refuses to start unless a Redis
+connection is configured, and a running instance is degraded for as long as Redis is unreachable.
 
 <Info>
 **Active-passive** setup is recommended for Redis. **Active-active** setup for Redis has not been tested.
@@ -62,9 +65,19 @@ Redis is utilized for session management and background tasks in Infisical.
 Redis requirements:
 
 - Use Redis versions 6.x or 7.x. We advise upgrading to at least Redis 6.2.
-- Redis Cluster mode is currently not supported; use Redis Standalone, with or without High Availability (HA).
+- Redis Standalone (with or without High Availability), Redis Sentinel, and Redis Cluster are all
+  supported. See [Redis configuration](/self-hosting/configuration/envars#redis) for the
+  environment variables each mode expects.
 - Redis storage needs are minimal: a setup with 2 vCPU, 4 GB RAM, and 30GB SSD will be sufficient for small deployments.
-- Set cache eviction policy to `noeviction`.
+- Set cache eviction policy to `noeviction`. Because Redis holds queue and coordination state,
+  evicting keys under memory pressure would silently drop work. This setting is required, not a
+  tuning suggestion.
+- Enable persistence (AOF, or RDB snapshots at minimum) and include Redis in your backup strategy.
+  Pending background jobs (secret rotations, syncs, webhook deliveries) live in Redis; a Redis
+  that comes back empty loses them.
+- Because Redis is a hard dependency, give it the same availability target as the Infisical
+  instances themselves. A single unreplicated Redis is a single point of failure for the whole
+  deployment.
 
 ## Supported Web Browsers
 

--- a/docs/self-hosting/configuration/requirements.mdx
+++ b/docs/self-hosting/configuration/requirements.mdx
@@ -65,7 +65,7 @@ connection is configured, and a running instance is degraded for as long as Redi
 Redis requirements:
 
 - Use Redis versions 6.x or 7.x. We advise upgrading to at least Redis 6.2.
-- Redis Standalone (with or without High Availability), Redis Sentinel, and Redis Cluster are all
+- Redis Standalone (with or without High Availability) and Redis Sentinel are 
   supported. See [Redis configuration](/self-hosting/configuration/envars#redis) for the
   environment variables each mode expects.
 - Redis storage needs are minimal: a setup with 2 vCPU, 4 GB RAM, and 30GB SSD will be sufficient for small deployments.


### PR DESCRIPTION
## Context

Adds throttled pino logging on all Redis clients (URL, Sentinel, Cluster): `ERROR` at most once per 10s on failure, one `INFO` on recovery (skips initial connect). Docs clarify Redis is required persistent storage (queues, locks, rate limits), not just cache.

## Steps to verify the change

1. Stop Redis while API runs → structured `Redis connection error` within ~10s, ≤1 line per 10s.
2. Start Redis → single `Redis connection restored` log.
3. `GET /api/status` still 200 during outage.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)