### PR TITLE
fix: address deadlock for cert issuance

### DIFF
--- a/backend/src/ee/services/pki-acme/pki-acme-order-dal.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-order-dal.ts
@@ -36,6 +36,10 @@ export const pkiAcmeOrderDALFactory = (db: TDbClient) => {
         )
         .forUpdate(TableName.PkiAcmeOrder)
         .where(`${TableName.PkiAcmeOrder}.id`, id)
+        // acmeOrderId is not unique, so an order can end up with more than one certificate request
+        // (e.g. a finalization that was retried after an abandoned attempt). Take the newest so the
+        // order's terminal status is driven by the current attempt rather than an arbitrary row.
+        .orderBy(`${TableName.CertificateRequests}.createdAt`, "desc")
         .first();
       if (!order) {
         return null;

--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -109,6 +109,21 @@ import {
   TRespondToAcmeChallengeResponse
 } from "./pki-acme-types";
 
+/**
+ * How long an order may sit in `processing` before reconciliation treats the issuance attempt as
+ * abandoned. Finalization claims the order, signs outside of any transaction, then records the
+ * outcome, so a crash in between leaves the order in `processing` with nothing to resolve it.
+ *
+ * This has to exceed the worst case of every issuance path, because an attempt that outlives it gets
+ * resolved while it is still legitimately in flight. The binding constraint is the async external-CA
+ * path: `queueCertificateIssuance` gives AWS ACM Public CA `attempts: 30` with a fixed 60s backoff
+ * (~30 minutes) and the certificate request stays PENDING for that entire window. Reaping earlier
+ * would fail the request mid-issuance, and the queue's later `attachCertificate` would then no-op
+ * because the row is no longer in an attachable status, stranding a certificate that AWS did issue.
+ * Keep this above the queue's retry budget in `certificate-issuance-queue.ts` if that changes.
+ */
+const STALE_PROCESSING_ORDER_TIMEOUT_MS = 60 * 60 * 1000;
+
 type TPkiAcmeServiceFactoryDep = {
   projectDAL: Pick<TProjectDALFactory, "findOne" | "updateById" | "transaction" | "findById">;
   certificateAuthorityDAL: Pick<TCertificateAuthorityDALFactory, "findByIdWithAssociatedCa">;
@@ -154,7 +169,7 @@ type TPkiAcmeServiceFactoryDep = {
   auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
   approvalPolicyDAL: Pick<TApprovalPolicyDALFactory, "findByProjectId" | "findStepsByPolicyId">;
   approvalPolicyService: Pick<TApprovalPolicyServiceFactory, "createRequestFromPolicy">;
-  certificateRequestDAL: Pick<TCertificateRequestDALFactory, "create" | "updateById">;
+  certificateRequestDAL: Pick<TCertificateRequestDALFactory, "create" | "updateById" | "transitionFromPending">;
   pkiApplicationProfileDAL: Pick<TPkiApplicationProfileDALFactory, "findOneByApplicationAndProfile">;
   acmeEnrollmentConfigDAL: Pick<TAcmeEnrollmentConfigDALFactory, "findById">;
 };
@@ -416,16 +431,59 @@ export const pkiAcmeServiceFactory = ({
         throw new NotFoundError({ message: "ACME order not found" });
       }
       // Check the status again after we have acquired the lock, as things may have changed since we last checked
-      if (
-        orderWithCertificateRequest.status !== AcmeOrderStatus.Processing ||
-        !orderWithCertificateRequest.certificateRequest
-      ) {
+      if (orderWithCertificateRequest.status !== AcmeOrderStatus.Processing) {
         return orderWithCertificateRequest;
       }
+
+      // Finalization stamps `updatedAt` when it claims the order into `processing`, and nothing touches
+      // the order again until it reaches a terminal state, so this measures how long the current
+      // issuance attempt has been running.
+      const isAttemptStale =
+        Date.now() - new Date(orderWithCertificateRequest.updatedAt).getTime() > STALE_PROCESSING_ORDER_TIMEOUT_MS;
+
+      if (!orderWithCertificateRequest.certificateRequest) {
+        // Finalization claims the order before it records a certificate request, so a `processing`
+        // order with no linked request means the process died in between. Issuance always writes the
+        // request before it does anything irreversible, so no certificate can exist yet, which makes
+        // it safe to hand the order back as `ready` for the client to retry. Only act once the
+        // attempt is stale — before that this is simply an issuance still in flight.
+        if (!isAttemptStale) {
+          return orderWithCertificateRequest;
+        }
+        logger.info(
+          { orderId, processingSince: orderWithCertificateRequest.updatedAt },
+          `Reverting abandoned ACME order to ready [orderId=${orderId}]`
+        );
+        return acmeOrderDAL.updateById(orderId, { status: AcmeOrderStatus.Ready }, tx);
+      }
+
       let newStatus: AcmeOrderStatus | undefined;
       let newCertificateId: string | undefined;
       switch (orderWithCertificateRequest.certificateRequest.status) {
-        case CertificateRequestStatus.PENDING:
+        case CertificateRequestStatus.PENDING: {
+          // Unlike the no-request case above, signing may already have happened here, so this cannot
+          // be rolled back to `ready` without risking a duplicate certificate. Fail it instead and
+          // let the client create a fresh order.
+          if (!isAttemptStale) break;
+          const failedRequest = await certificateRequestDAL.transitionFromPending(
+            orderWithCertificateRequest.certificateRequest.id,
+            CertificateRequestStatus.FAILED,
+            "Certificate issuance did not complete",
+            tx
+          );
+          // A null result means the request left PENDING between our read and this update (it was
+          // issued concurrently). Leave the order alone so the next sync resolves it as valid.
+          if (failedRequest) {
+            logger.info(
+              { orderId, certificateRequestId: orderWithCertificateRequest.certificateRequest.id },
+              `Failing abandoned ACME certificate issuance [orderId=${orderId}]`
+            );
+            newStatus = AcmeOrderStatus.Invalid;
+          }
+          break;
+        }
+        // Both of these are legitimately long-lived — one waits on a human approver, the other on
+        // external DNS validation — so they are never reaped on staleness.
         case CertificateRequestStatus.PENDING_APPROVAL:
         case CertificateRequestStatus.PENDING_VALIDATION:
           break;
@@ -1167,7 +1225,7 @@ export const pkiAcmeServiceFactory = ({
       // TODO: ideally, this should be doen with onRequest: verifyAuth([AuthMode.ACME_JWS_SIGNATURE]), instead?
       const { ownerOrgId: actorOrgId } = (await certificateProfileDAL.findByIdWithOwnerOrgId(profileId))!;
 
-      const ca = await certificateAuthorityDAL.findByIdWithAssociatedCa(profile.caId!);
+      const ca = await certificateAuthorityDAL.findByIdWithAssociatedCa(profile.caId);
       if (!ca) {
         throw new NotFoundError({ message: "Certificate Authority not found" });
       }
@@ -1370,6 +1428,10 @@ export const pkiAcmeServiceFactory = ({
         });
 
         const caType = (ca.externalCa?.type as CaType) ?? CaType.INTERNAL;
+        // Set once the certificate and its order-linked request are durably committed, which happens
+        // inside processCertificateIssuanceForOrder rather than here. Anything that fails after that
+        // point must not invalidate the order, or a real certificate is stranded.
+        let issuedCertificateId: string | undefined;
         try {
           // Signing runs with no ambient transaction. The internal CA and the external-CA paths
           // each open their own short write transaction internally, so at no point does one
@@ -1387,6 +1449,7 @@ export const pkiAcmeServiceFactory = ({
             ca,
             applicationId: accountApplicationId ?? undefined
           });
+          issuedCertificateId = result.certificateId;
           await acmeOrderDAL.updateById(orderId, {
             status: result.certificateId ? AcmeOrderStatus.Valid : AcmeOrderStatus.Processing,
             csr,
@@ -1394,13 +1457,23 @@ export const pkiAcmeServiceFactory = ({
           });
           certIssuanceJobData = result.certIssuanceJobData;
         } catch (exp) {
+          logger.error(exp, "Failed to sign certificate");
+          // TODO: audit log the error
+          if (issuedCertificateId) {
+            // The certificate is already issued and committed, and its certificate request is marked
+            // ISSUED against this order, so marking the order invalid here would strand a real
+            // certificate that nothing reconciles. Leave the order in `processing` instead —
+            // checkAndSyncAcmeOrderStatus resolves it to `valid` off the linked request on the next
+            // poll. Only the order bookkeeping failed; the client's certificate is intact.
+            throw new AcmeServerInternalError({
+              message: "Failed to finalize certificate issuance"
+            });
+          }
           await acmeOrderDAL.updateById(orderId, {
             csr,
             status: AcmeOrderStatus.Invalid,
             error: exp instanceof Error ? exp.message : "Unknown error"
           });
-          logger.error(exp, "Failed to sign certificate");
-          // TODO: audit log the error
           if (exp instanceof BadRequestError) {
             throw new AcmeBadCSRError({ message: `Invalid CSR: ${exp.message}` });
           }

--- a/backend/src/ee/services/pki-acme/pki-acme-service.ts
+++ b/backend/src/ee/services/pki-acme/pki-acme-service.ts
@@ -976,7 +976,10 @@ export const pkiAcmeServiceFactory = ({
           : // ttl is not used if notAfter is provided
             ({ ttl: "0d" } as const),
         enrollmentType: EnrollmentType.ACME,
-        applicationId
+        applicationId,
+        // Links the certificate request to this order so checkAndSyncAcmeOrderStatus can reconcile
+        // an order left in `processing` if the process dies mid-issuance.
+        acmeOrderId: orderId
       });
       if ("certificateId" in result) {
         return {
@@ -1106,117 +1109,137 @@ export const pkiAcmeServiceFactory = ({
       throw new NotFoundError({ message: "ACME order not found" });
     }
     if (order.status === AcmeOrderStatus.Ready) {
-      const {
-        order: updatedOrder,
-        error,
-        certIssuanceJobData
-      } = await acmeOrderDAL.transaction(async (tx) => {
-        const finalizingOrder = (await acmeOrderDAL.findByIdForFinalization(orderId, tx))!;
-        // TODO: ideally, this should be doen with onRequest: verifyAuth([AuthMode.ACME_JWS_SIGNATURE]), instead?
-        const { ownerOrgId: actorOrgId } = (await certificateProfileDAL.findByIdWithOwnerOrgId(profileId, tx))!;
-        if (finalizingOrder.status !== AcmeOrderStatus.Ready) {
+      const { csr } = payload;
+
+      // Everything that can reject the request is validated *before* the order is claimed, so a
+      // rejected finalization leaves the order in `ready` and the client can retry with a
+      // corrected CSR. This mirrors the previous behaviour, where these errors rolled the
+      // enclosing transaction back.
+      const certificateRequest = extractCertificateRequestFromCSR(csr);
+      const allowedSanTypes = new Set([
+        CertSubjectAlternativeNameType.DNS_NAME,
+        CertSubjectAlternativeNameType.IP_ADDRESS
+      ]);
+      if (certificateRequest.subjectAlternativeNames?.some((san) => !allowedSanTypes.has(san.type))) {
+        throw new AcmeBadCSRError({
+          message: "Invalid CSR: Only DNS and IP subject alternative names are supported"
+        });
+      }
+
+      // Build a set of "type:value" pairs from CSR SANs to match against authorized identifiers
+      const sanTypeToIdentifierType: Partial<Record<CertSubjectAlternativeNameType, AcmeIdentifierType>> = {
+        [CertSubjectAlternativeNameType.DNS_NAME]: AcmeIdentifierType.DNS,
+        [CertSubjectAlternativeNameType.IP_ADDRESS]: AcmeIdentifierType.IP
+      };
+      const csrIdentifierPairs = new Set(
+        (certificateRequest.subjectAlternativeNames ?? [])
+          .map((san) => {
+            const identifierType = sanTypeToIdentifierType[san.type];
+            return identifierType ? `${identifierType}:${san.value.toLowerCase()}` : null;
+          })
+          .filter(Boolean)
+      );
+      // ACME clients (e.g., lego) set the CN to the IP address for IP certificate requests.
+      // We need to detect whether the CN is an IP to match it against the correct identifier type,
+      // otherwise "ip:127.0.0.1" in the authorization won't match "dns:127.0.0.1" from the CN.
+      if (certificateRequest.commonName) {
+        const cnType = validateIpIdentifier(certificateRequest.commonName)
+          ? AcmeIdentifierType.IP
+          : AcmeIdentifierType.DNS;
+        csrIdentifierPairs.add(`${cnType}:${certificateRequest.commonName.toLowerCase()}`);
+      }
+      const authIdentifierPairs = new Set(
+        order.authorizations.map((auth) => {
+          const value = auth.wildcard ? `*.${auth.identifierValue}` : auth.identifierValue;
+          return `${auth.identifierType}:${value.toLowerCase()}`;
+        })
+      );
+      if (
+        csrIdentifierPairs.size !== authIdentifierPairs.size ||
+        ![...authIdentifierPairs].every((id) => csrIdentifierPairs.has(id))
+      ) {
+        throw new AcmeBadCSRError({ message: "Invalid CSR: Common name + SANs mismatch with order identifiers" });
+      }
+
+      // Issuance context. These are reads only, and they deliberately run outside a transaction:
+      // holding a pooled connection across signing is what let concurrent finalizations exhaust
+      // the connection pool and deadlock every request in the process.
+      // TODO: ideally, this should be doen with onRequest: verifyAuth([AuthMode.ACME_JWS_SIGNATURE]), instead?
+      const { ownerOrgId: actorOrgId } = (await certificateProfileDAL.findByIdWithOwnerOrgId(profileId))!;
+
+      const ca = await certificateAuthorityDAL.findByIdWithAssociatedCa(profile.caId!);
+      if (!ca) {
+        throw new NotFoundError({ message: "Certificate Authority not found" });
+      }
+
+      assertCaInProfileProject(ca, profile);
+
+      const finalizeAccount = await acmeAccountDAL.findByProjectIdAndAccountId(profile.id, accountId);
+      const accountApplicationProfileId = (finalizeAccount as { applicationProfileId?: string | null } | null)
+        ?.applicationProfileId;
+      const accountApplicationId = accountApplicationProfileId
+        ? await acmeAccountDAL.findApplicationIdByJunctionId(accountApplicationProfileId)
+        : null;
+
+      const approvalFactory = APPROVAL_POLICY_FACTORY_MAP[ApprovalPolicyType.CertRequest](
+        ApprovalPolicyType.CertRequest
+      );
+      const matchedApprovalPolicy = (await approvalFactory.matchPolicy(
+        approvalPolicyDAL as TApprovalPolicyDALFactory,
+        profile.projectId,
+        {
+          profileName: profile.slug,
+          applicationId: accountApplicationId ?? undefined
+        }
+      )) as TCertRequestPolicy | null;
+
+      const approvalContext = matchedApprovalPolicy
+        ? await (async () => {
+            const policy = await certificatePolicyDAL.findById(profile.certificatePolicyId);
+            if (!policy) {
+              throw new NotFoundError({ message: "Certificate policy not found" });
+            }
+
+            const validationResult = await certificatePolicyService.validateCertificateRequest(
+              policy.id,
+              certificateRequest
+            );
+            if (!validationResult.isValid) {
+              throw new AcmeBadCSRError({ message: `Invalid CSR: ${validationResult.errors.join(", ")}` });
+            }
+
+            return {
+              approvalPolicy: matchedApprovalPolicy,
+              policy,
+              policySteps: await approvalPolicyDAL.findStepsByPolicyId(matchedApprovalPolicy.id)
+            };
+          })()
+        : undefined;
+
+      // Claims the order under a row lock and asserts it is still finalizable. The approval path
+      // runs this inside the same transaction as its writes, since it never signs and so never
+      // holds a connection across network I/O. The signing path commits the claim on its own, so
+      // that no connection stays held while the certificate is signed.
+      const $claimOrderForFinalization = async (tx: Knex) => {
+        const claimedOrder = (await acmeOrderDAL.findByIdForFinalization(orderId, tx))!;
+        if (claimedOrder.status !== AcmeOrderStatus.Ready) {
           throw new AcmeOrderNotReadyError({ message: "ACME order is not ready" });
         }
-        if (finalizingOrder.expiresAt < new Date()) {
+        if (claimedOrder.expiresAt < new Date()) {
           throw new AcmeOrderNotReadyError({ message: "ACME order has expired" });
         }
+        return claimedOrder;
+      };
 
-        const { csr } = payload;
+      let certIssuanceJobData: TIssueCertificateFromProfileJobData | undefined;
 
-        // Check and validate the CSR
-        const certificateRequest = extractCertificateRequestFromCSR(csr);
-        const allowedSanTypes = new Set([
-          CertSubjectAlternativeNameType.DNS_NAME,
-          CertSubjectAlternativeNameType.IP_ADDRESS
-        ]);
-        if (certificateRequest.subjectAlternativeNames?.some((san) => !allowedSanTypes.has(san.type))) {
-          throw new AcmeBadCSRError({
-            message: "Invalid CSR: Only DNS and IP subject alternative names are supported"
-          });
-        }
-        const orderWithAuthorizations = (await acmeOrderDAL.findByAccountAndOrderIdWithAuthorizations(
-          accountId,
-          orderId,
-          tx
-        ))!;
+      if (approvalContext) {
+        const { approvalPolicy, policy, policySteps } = approvalContext;
 
-        // Build a set of "type:value" pairs from CSR SANs to match against authorized identifiers
-        const sanTypeToIdentifierType: Partial<Record<CertSubjectAlternativeNameType, AcmeIdentifierType>> = {
-          [CertSubjectAlternativeNameType.DNS_NAME]: AcmeIdentifierType.DNS,
-          [CertSubjectAlternativeNameType.IP_ADDRESS]: AcmeIdentifierType.IP
-        };
-        const csrIdentifierPairs = new Set(
-          (certificateRequest.subjectAlternativeNames ?? [])
-            .map((san) => {
-              const identifierType = sanTypeToIdentifierType[san.type];
-              return identifierType ? `${identifierType}:${san.value.toLowerCase()}` : null;
-            })
-            .filter(Boolean)
-        );
-        // ACME clients (e.g., lego) set the CN to the IP address for IP certificate requests.
-        // We need to detect whether the CN is an IP to match it against the correct identifier type,
-        // otherwise "ip:127.0.0.1" in the authorization won't match "dns:127.0.0.1" from the CN.
-        if (certificateRequest.commonName) {
-          const cnType = validateIpIdentifier(certificateRequest.commonName)
-            ? AcmeIdentifierType.IP
-            : AcmeIdentifierType.DNS;
-          csrIdentifierPairs.add(`${cnType}:${certificateRequest.commonName.toLowerCase()}`);
-        }
-        const authIdentifierPairs = new Set(
-          orderWithAuthorizations.authorizations.map((auth) => {
-            const value = auth.wildcard ? `*.${auth.identifierValue}` : auth.identifierValue;
-            return `${auth.identifierType}:${value.toLowerCase()}`;
-          })
-        );
-        if (
-          csrIdentifierPairs.size !== authIdentifierPairs.size ||
-          ![...authIdentifierPairs].every((id) => csrIdentifierPairs.has(id))
-        ) {
-          throw new AcmeBadCSRError({ message: "Invalid CSR: Common name + SANs mismatch with order identifiers" });
-        }
-
-        const ca = await certificateAuthorityDAL.findByIdWithAssociatedCa(profile.caId!);
-        if (!ca) {
-          throw new NotFoundError({ message: "Certificate Authority not found" });
-        }
-
-        assertCaInProfileProject(ca, profile);
-
-        const finalizeAccount = await acmeAccountDAL.findByProjectIdAndAccountId(profile.id, accountId);
-        const accountApplicationProfileId = (finalizeAccount as { applicationProfileId?: string | null } | null)
-          ?.applicationProfileId;
-        const accountApplicationId = accountApplicationProfileId
-          ? await acmeAccountDAL.findApplicationIdByJunctionId(accountApplicationProfileId)
-          : null;
-
-        const approvalFactory = APPROVAL_POLICY_FACTORY_MAP[ApprovalPolicyType.CertRequest](
-          ApprovalPolicyType.CertRequest
-        );
-        const matchedApprovalPolicy = (await approvalFactory.matchPolicy(
-          approvalPolicyDAL as TApprovalPolicyDALFactory,
-          profile.projectId,
-          {
-            profileName: profile.slug,
-            applicationId: accountApplicationId ?? undefined
-          }
-        )) as TCertRequestPolicy | null;
-
-        if (matchedApprovalPolicy) {
-          const approvalPolicy = matchedApprovalPolicy;
-          const policy = await certificatePolicyDAL.findById(profile.certificatePolicyId);
-          if (!policy) {
-            throw new NotFoundError({ message: "Certificate policy not found" });
-          }
-
-          const validationResult = await certificatePolicyService.validateCertificateRequest(
-            policy.id,
-            certificateRequest
-          );
-          if (!validationResult.isValid) {
-            throw new AcmeBadCSRError({ message: `Invalid CSR: ${validationResult.errors.join(", ")}` });
-          }
-
-          const policySteps = await approvalPolicyDAL.findStepsByPolicyId(approvalPolicy.id);
+        // No signing happens on this path, so it keeps its original single-transaction shape: the
+        // claim, the certificate request, its approval request and the status flip stay atomic.
+        await acmeOrderDAL.transaction(async (tx) => {
+          const finalizingOrder = await $claimOrderForFinalization(tx);
 
           const requesterName = `ACME Account (${accountId})`;
 
@@ -1324,14 +1347,8 @@ export const pkiAcmeServiceFactory = ({
             tx
           );
 
-          await acmeOrderDAL.updateById(
-            orderId,
-            {
-              status: AcmeOrderStatus.Processing,
-              csr
-            },
-            tx
-          );
+          // Return the order in processing status - client will poll until approved
+          await acmeOrderDAL.updateById(orderId, { status: AcmeOrderStatus.Processing, csr }, tx);
 
           logger.info(
             {
@@ -1343,19 +1360,20 @@ export const pkiAcmeServiceFactory = ({
             },
             "ACME certificate request requires approval"
           );
-
-          // Return the order in processing status - client will poll until approved
-          return {
-            order: (await acmeOrderDAL.findByAccountAndOrderIdWithAuthorizations(accountId, orderId, tx))!,
-            error: undefined,
-            certIssuanceJobData: undefined
-          };
-        }
+        });
+      } else {
+        // Commit the claim on its own so the connection is released before signing starts.
+        const finalizingOrder = await acmeOrderDAL.transaction(async (tx) => {
+          const claimedOrder = await $claimOrderForFinalization(tx);
+          await acmeOrderDAL.updateById(orderId, { status: AcmeOrderStatus.Processing, csr }, tx);
+          return claimedOrder;
+        });
 
         const caType = (ca.externalCa?.type as CaType) ?? CaType.INTERNAL;
-        let errorToReturn: Error | undefined;
-        let certIssuanceJobDataToReturn: TIssueCertificateFromProfileJobData | undefined;
         try {
+          // Signing runs with no ambient transaction. The internal CA and the external-CA paths
+          // each open their own short write transaction internally, so at no point does one
+          // request hold a connection while waiting for another.
           const result = await processCertificateIssuanceForOrder({
             caType,
             accountId,
@@ -1367,54 +1385,40 @@ export const pkiAcmeServiceFactory = ({
             certificateRequest,
             profile,
             ca,
-            tx,
             applicationId: accountApplicationId ?? undefined
           });
-          await acmeOrderDAL.updateById(
-            orderId,
-            {
-              status: result.certificateId ? AcmeOrderStatus.Valid : AcmeOrderStatus.Processing,
-              csr,
-              certificateId: result.certificateId
-            },
-            tx
-          );
-          certIssuanceJobDataToReturn = result.certIssuanceJobData;
+          await acmeOrderDAL.updateById(orderId, {
+            status: result.certificateId ? AcmeOrderStatus.Valid : AcmeOrderStatus.Processing,
+            csr,
+            certificateId: result.certificateId
+          });
+          certIssuanceJobData = result.certIssuanceJobData;
         } catch (exp) {
-          await acmeOrderDAL.updateById(
-            orderId,
-            {
-              csr,
-              status: AcmeOrderStatus.Invalid,
-              error: exp instanceof Error ? exp.message : "Unknown error"
-            },
-            tx
-          );
+          await acmeOrderDAL.updateById(orderId, {
+            csr,
+            status: AcmeOrderStatus.Invalid,
+            error: exp instanceof Error ? exp.message : "Unknown error"
+          });
           logger.error(exp, "Failed to sign certificate");
           // TODO: audit log the error
           if (exp instanceof BadRequestError) {
-            errorToReturn = new AcmeBadCSRError({ message: `Invalid CSR: ${exp.message}` });
-          } else if (exp instanceof AcmeError) {
-            errorToReturn = exp;
-          } else {
-            errorToReturn = new AcmeServerInternalError({
-              message: "Failed to sign certificate with internal error"
-            });
+            throw new AcmeBadCSRError({ message: `Invalid CSR: ${exp.message}` });
           }
+          if (exp instanceof AcmeError) {
+            throw exp;
+          }
+          throw new AcmeServerInternalError({
+            message: "Failed to sign certificate with internal error"
+          });
         }
-        return {
-          order: (await acmeOrderDAL.findByAccountAndOrderIdWithAuthorizations(accountId, orderId, tx))!,
-          error: errorToReturn,
-          certIssuanceJobData: certIssuanceJobDataToReturn
-        };
-      });
-      if (error) {
-        throw error;
       }
+
       if (certIssuanceJobData) {
-        // We commit the transaction before queuing the job, otherwise the job may fail with a not-found error.
+        // We commit the order writes before queuing the job, otherwise the job may fail with a
+        // not-found error.
         await certificateIssuanceQueue.queueCertificateIssuance(certIssuanceJobData);
       }
+      const updatedOrder = (await acmeOrderDAL.findByAccountAndOrderIdWithAuthorizations(accountId, orderId))!;
       order = updatedOrder;
       await auditLogService.createAuditLog({
         ...auditLogInfo,

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-service.ts
@@ -2680,11 +2680,22 @@ export const internalCertificateAuthorityServiceFactory = ({
       return newCert;
     };
 
+    // Everything above this point is reads, CA key access and signing, and deliberately runs with no
+    // transaction open. Only the writes below take a connection, so a caller can get atomic issuance
+    // without pinning one across the KMS/HSM round trips.
+    const persist = async (transaction: Knex) => {
+      const newCert = await createSignedCert(transaction);
+      if (dto.onPersisted) {
+        await dto.onPersisted(newCert, transaction);
+      }
+      return newCert;
+    };
+
     let cert;
     if (tx) {
-      cert = await createSignedCert(tx);
+      cert = await persist(tx);
     } else {
-      cert = await certificateDAL.transaction(createSignedCert);
+      cert = await certificateDAL.transaction(persist);
     }
 
     usageMeteringService.emitForProject(ca.projectId, ActiveCerts.key);

--- a/backend/src/services/certificate-authority/internal/internal-certificate-authority-types.ts
+++ b/backend/src/services/certificate-authority/internal/internal-certificate-authority-types.ts
@@ -1,6 +1,7 @@
 import { Knex } from "knex";
 import { z } from "zod";
 
+import { TCertificates } from "@app/db/schemas";
 import { TCertificateAuthorityCrlDALFactory } from "@app/ee/services/certificate-authority-crl/certificate-authority-crl-dal";
 import { TProjectPermission } from "@app/lib/types";
 import { ActorAuthMethod, ActorType } from "@app/services/auth/auth-type";
@@ -277,6 +278,14 @@ export type TSignCertFromCaDTO =
       pathLength?: number | null;
       subjectOverride?: string;
       tx?: Knex;
+      /**
+       * Runs inside the same transaction that writes the certificate rows, after they are created
+       * but before it commits. Use this to record caller-side bookkeeping (profile linkage,
+       * certificate request status, metadata) atomically with the certificate itself, without
+       * having to hold a transaction open across the CA key access and signing that precede it.
+       * Throwing from here rolls the certificate back.
+       */
+      onPersisted?: (cert: TCertificates, tx: Knex) => Promise<void>;
     }
   | ({
       isInternal: false;
@@ -300,6 +309,8 @@ export type TSignCertFromCaDTO =
       pathLength?: number | null;
       subjectOverride?: string;
       tx?: Knex;
+      /** See the `onPersisted` note on the internal variant above. */
+      onPersisted?: (cert: TCertificates, tx: Knex) => Promise<void>;
     } & Omit<TProjectPermission, "projectId">);
 
 export type TGetCaCertificateTemplatesDTO = {

--- a/backend/src/services/certificate-v3/certificate-approval-fns.ts
+++ b/backend/src/services/certificate-v3/certificate-approval-fns.ts
@@ -533,47 +533,43 @@ export const certificateApprovalServiceFactory = (
       domainComponents: reconstructedRequest.domainComponents
     });
 
-    const { certificate, certificateChain, issuingCaCertificate, serialNumber, cert } =
-      await certificateDAL.transaction(async (tx) => {
-        const certResult = await internalCaService.signCertFromCa({
-          isInternal: true,
-          caId: ca.id,
-          csr: csr || "",
-          ttl,
-          subjectOverride,
-          altNames: undefined,
-          keyUsages: reconstructedRequest.keyUsages
-            ? convertKeyUsageArrayToLegacy(reconstructedRequest.keyUsages)
-            : undefined,
-          extendedKeyUsages: reconstructedRequest.extendedKeyUsages
-            ? convertExtendedKeyUsageArrayToLegacy(reconstructedRequest.extendedKeyUsages)
-            : undefined,
-          notBefore: normalizeDateForApi(certRequest.notBefore || undefined),
-          notAfter: normalizeDateForApi(certRequest.notAfter || undefined),
-          signatureAlgorithm: certRequest.signatureAlgorithm || undefined,
-          keyAlgorithm: certRequest.keyAlgorithm || undefined,
-          isFromProfile: true,
-          basicConstraints: effectiveBasicConstraints,
-          pathLength: effectivePathLength,
-          tx
-        });
+    // This path is already intent-first: the certificate request exists (it was created when the
+    // approval was requested), so it only needs the same treatment as direct issuance — no
+    // transaction held across the CA key access and signing, with the bookkeeping committed
+    // atomically alongside the certificate rows via onPersisted.
+    const effectiveApiConfig = await resolveEffectiveApiConfig({
+      applicationId: certRequest.applicationId ?? undefined,
+      profileId,
+      profileApiConfig: profile.apiConfig,
+      pkiApplicationProfileDAL,
+      apiEnrollmentConfigDAL
+    });
 
-        const signedCertRecord = await certificateDAL.findById(certResult.certificateId, tx);
-        if (!signedCertRecord) {
-          throw new NotFoundError({ message: "Certificate was signed but could not be found in database" });
-        }
-
-        const effectiveApiConfig = await resolveEffectiveApiConfig({
-          applicationId: certRequest.applicationId ?? undefined,
-          profileId,
-          profileApiConfig: profile.apiConfig,
-          pkiApplicationProfileDAL,
-          apiEnrollmentConfigDAL
-        });
+    const certResult = await internalCaService.signCertFromCa({
+      isInternal: true,
+      caId: ca.id,
+      csr: csr || "",
+      ttl,
+      subjectOverride,
+      altNames: undefined,
+      keyUsages: reconstructedRequest.keyUsages
+        ? convertKeyUsageArrayToLegacy(reconstructedRequest.keyUsages)
+        : undefined,
+      extendedKeyUsages: reconstructedRequest.extendedKeyUsages
+        ? convertExtendedKeyUsageArrayToLegacy(reconstructedRequest.extendedKeyUsages)
+        : undefined,
+      notBefore: normalizeDateForApi(certRequest.notBefore || undefined),
+      notAfter: normalizeDateForApi(certRequest.notAfter || undefined),
+      signatureAlgorithm: certRequest.signatureAlgorithm || undefined,
+      keyAlgorithm: certRequest.keyAlgorithm || undefined,
+      isFromProfile: true,
+      basicConstraints: effectiveBasicConstraints,
+      pathLength: effectivePathLength,
+      onPersisted: async (newCert, tx) => {
         const finalRenewBeforeDays = calculateFinalRenewBeforeDays(
           { apiConfig: effectiveApiConfig },
           ttl,
-          new Date(signedCertRecord.notAfter)
+          new Date(newCert.notAfter)
         );
 
         const updateData: { profileId: string; renewBeforeDays?: number; applicationId?: string } = { profileId };
@@ -583,13 +579,13 @@ export const certificateApprovalServiceFactory = (
         if (certRequest.applicationId) {
           updateData.applicationId = certRequest.applicationId;
         }
-        await certificateDAL.updateById(signedCertRecord.id, updateData, tx);
+        await certificateDAL.updateById(newCert.id, updateData, tx);
 
         await certificateRequestDAL.updateById(
           certificateRequestId,
           {
             status: CertificateRequestStatus.ISSUED,
-            certificateId: certResult.certificateId
+            certificateId: newCert.id
           },
           tx
         );
@@ -597,12 +593,13 @@ export const certificateApprovalServiceFactory = (
         // Copy metadata from cert request to newly issued cert
         await copyMetadataFromRequestToCertificate(resourceMetadataDAL, {
           certificateRequestId,
-          certificateId: certResult.certificateId,
+          certificateId: newCert.id,
           tx
         });
+      }
+    });
 
-        return { ...certResult, cert: signedCertRecord };
-      });
+    const { certificate, certificateChain, issuingCaCertificate, serialNumber } = certResult;
 
     const certificateString = extractCertificateFromBuffer(certificate as unknown as Buffer);
     const certificateChainString = extractCertificateFromBuffer(certificateChain as unknown as Buffer);
@@ -613,11 +610,11 @@ export const certificateApprovalServiceFactory = (
       issuingCaCertificate: extractCertificateFromBuffer(issuingCaCertificate as unknown as Buffer),
       certificateChain: certificateChainString,
       serialNumber,
-      certificateId: cert.id,
+      certificateId: certResult.certificateId,
       certificateRequestId,
       projectId: profile.projectId,
       profileName: profile.slug,
-      commonName: cert.commonName || ""
+      commonName: certResult.commonName || ""
     };
   };
 

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -792,6 +792,9 @@ describe("CertificateV3Service", () => {
         certificateChain: "chain",
         issuingCaCertificate: "issuing-ca",
         serialNumber: "789012",
+        // signCertFromCa always returns the id of the certificate it persisted, and the response is
+        // built from that rather than from a follow-up read.
+        certificateId: "cert-456",
         commonName: "test.example.com",
         ca: {
           id: "ca-123",

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -247,7 +247,9 @@ describe("CertificateV3Service", () => {
         updateById: vi.fn().mockResolvedValue({ id: "cert-req-123" }),
         findById: vi.fn().mockResolvedValue({ id: "cert-req-123" }),
         create: vi.fn().mockResolvedValue({ id: "cert-req-123" }),
-        transaction: vi.fn()
+        transaction: vi.fn(),
+        transitionFromPending: vi.fn().mockResolvedValue({ id: "cert-req-123" }),
+        attachCertificate: vi.fn().mockResolvedValue({ id: "cert-req-123" })
       },
       userDAL: {
         findById: vi.fn().mockResolvedValue({ id: "user-123" })

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -159,7 +159,10 @@ type TCertificateV3ServiceFactoryDep = {
   >;
   certificateRequestService: Pick<TCertificateRequestServiceFactory, "createCertificateRequest">;
   approvalPolicyDAL: Pick<TApprovalPolicyDALFactory, "findByProjectId" | "findStepsByPolicyId">;
-  certificateRequestDAL: Pick<TCertificateRequestDALFactory, "updateById" | "findById" | "create" | "transaction">;
+  certificateRequestDAL: Pick<
+    TCertificateRequestDALFactory,
+    "updateById" | "findById" | "create" | "transaction" | "attachCertificate" | "transitionFromPending"
+  >;
   userDAL: Pick<TUserDALFactory, "findById">;
   identityDAL: Pick<TIdentityDALFactory, "findById">;
   approvalPolicyService: Pick<TApprovalPolicyServiceFactory, "createRequestFromPolicy">;
@@ -1517,7 +1520,8 @@ export const certificateV3ServiceFactory = ({
     metadata,
     removeRootsFromChain,
     basicConstraints,
-    applicationId: explicitApplicationId
+    applicationId: explicitApplicationId,
+    acmeOrderId
   }: TSignCertificateFromProfileDTO): Promise<TCertificateIssuanceResponse> => {
     const profile = await validateProfileAndPermissions({
       profileId,
@@ -1780,106 +1784,121 @@ export const certificateV3ServiceFactory = ({
       domainComponents: certificateRequest.domainComponents
     });
 
-    const { certificate, certificateChain, issuingCaCertificate, serialNumber, cert, certificateRequestId } =
-      await certificateDAL.transaction(async (tx) => {
-        const certResult = await internalCaService.signCertFromCa({
-          isInternal: true,
-          caId: ca.id,
-          csr,
-          subjectOverride,
-          basicConstraints: caBasicConstraints,
-          pathLength: effectiveBasicConstraints?.pathLength,
-          ttl: effectiveTtl,
-          altNames: undefined,
-          notBefore: normalizeDateForApi(notBefore),
-          notAfter: normalizeDateForApi(notAfter),
-          keyUsages: certificateRequest.keyUsages
-            ? convertKeyUsageArrayToLegacy(certificateRequest.keyUsages)
-            : undefined,
-          extendedKeyUsages: certificateRequest.extendedKeyUsages
-            ? convertExtendedKeyUsageArrayToLegacy(certificateRequest.extendedKeyUsages)
-            : undefined,
-          signatureAlgorithm: effectiveSignatureAlgorithm,
-          keyAlgorithm: effectiveKeyAlgorithm,
-          isFromProfile: true,
-          tx
-        });
+    // Record intent before the irreversible act. Signing is an external side effect that no database
+    // rollback can undo, so the only way to stay accountable for it is to have a row on disk that
+    // says what we were about to do. If signing or persistence fails, this request is what makes the
+    // failure reportable and reconcilable, instead of leaving behind a stored certificate that
+    // nothing references.
+    const pendingRequest = await certificateRequestService.createCertificateRequest({
+      internal: true,
+      actor,
+      actorId,
+      actorAuthMethod,
+      actorOrgId,
+      projectId: profile.projectId,
+      caId: ca.id,
+      profileId: profile.id,
+      applicationId,
+      acmeOrderId,
+      csr,
+      commonName: mappedCertificateRequest.commonName,
+      altNames: mappedCertificateRequest.subjectAlternativeNames,
+      domainComponents: mappedCertificateRequest.domainComponents,
+      keyUsages: convertKeyUsageArrayToLegacy(mappedCertificateRequest.keyUsages),
+      extendedKeyUsages: convertExtendedKeyUsageArrayToLegacy(mappedCertificateRequest.extendedKeyUsages),
+      notBefore,
+      notAfter,
+      keyAlgorithm: effectiveKeyAlgorithm,
+      signatureAlgorithm: effectiveSignatureAlgorithm,
+      status: CertificateRequestStatus.PENDING,
+      basicConstraints,
+      ttl: validity.ttl,
+      enrollmentType
+    });
 
-        const signedCertRecord = await certificateDAL.findById(certResult.certificateId, tx);
-        if (!signedCertRecord) {
-          throw new NotFoundError({ message: "Certificate was signed but could not be found in database" });
+    const effectiveApiConfig = await resolveEffectiveApiConfig({
+      applicationId,
+      profileId: profile.id,
+      profileApiConfig: profile.apiConfig,
+      pkiApplicationProfileDAL,
+      apiEnrollmentConfigDAL
+    });
+
+    let certResult: Awaited<ReturnType<typeof internalCaService.signCertFromCa>>;
+    try {
+      // No transaction is open across this call. signCertFromCa does its reads, CA key access and
+      // signing unwrapped, then opens one short transaction for the writes and invokes onPersisted
+      // inside it, so the certificate rows and the bookkeeping below commit together.
+      certResult = await internalCaService.signCertFromCa({
+        isInternal: true,
+        caId: ca.id,
+        csr,
+        subjectOverride,
+        basicConstraints: caBasicConstraints,
+        pathLength: effectiveBasicConstraints?.pathLength,
+        ttl: effectiveTtl,
+        altNames: undefined,
+        notBefore: normalizeDateForApi(notBefore),
+        notAfter: normalizeDateForApi(notAfter),
+        keyUsages: certificateRequest.keyUsages
+          ? convertKeyUsageArrayToLegacy(certificateRequest.keyUsages)
+          : undefined,
+        extendedKeyUsages: certificateRequest.extendedKeyUsages
+          ? convertExtendedKeyUsageArrayToLegacy(certificateRequest.extendedKeyUsages)
+          : undefined,
+        signatureAlgorithm: effectiveSignatureAlgorithm,
+        keyAlgorithm: effectiveKeyAlgorithm,
+        isFromProfile: true,
+        onPersisted: async (newCert, tx) => {
+          const finalRenewBeforeDays = calculateFinalRenewBeforeDays(
+            { apiConfig: effectiveApiConfig },
+            effectiveTtl,
+            new Date(newCert.notAfter)
+          );
+
+          const updateData: { profileId: string; renewBeforeDays?: number; applicationId?: string } = {
+            profileId
+          };
+          if (finalRenewBeforeDays !== undefined) {
+            updateData.renewBeforeDays = finalRenewBeforeDays;
+          }
+          if (applicationId) {
+            updateData.applicationId = applicationId;
+          }
+          await certificateDAL.updateById(newCert.id, updateData, tx);
+
+          // Records the outcome: flips the request to ISSUED and links the certificate in one update.
+          await certificateRequestDAL.attachCertificate(pendingRequest.id, newCert.id, tx);
+
+          if (metadata && metadata.length > 0) {
+            await insertMetadataForCertificate(resourceMetadataDAL, {
+              metadata,
+              certificateId: newCert.id,
+              orgId: actorOrgId,
+              tx
+            });
+            await insertMetadataForCertificateRequest(resourceMetadataDAL, {
+              metadata,
+              certificateRequestId: pendingRequest.id,
+              certificateRequestCreatedAt: pendingRequest.createdAt,
+              orgId: actorOrgId,
+              tx
+            });
+          }
         }
-
-        const effectiveApiConfig = await resolveEffectiveApiConfig({
-          applicationId,
-          profileId: profile.id,
-          profileApiConfig: profile.apiConfig,
-          pkiApplicationProfileDAL,
-          apiEnrollmentConfigDAL
-        });
-        const finalRenewBeforeDays = calculateFinalRenewBeforeDays(
-          { apiConfig: effectiveApiConfig },
-          effectiveTtl,
-          new Date(signedCertRecord.notAfter)
-        );
-
-        const updateData: { profileId: string; renewBeforeDays?: number; applicationId?: string } = {
-          profileId
-        };
-        if (finalRenewBeforeDays !== undefined) {
-          updateData.renewBeforeDays = finalRenewBeforeDays;
-        }
-        if (applicationId) {
-          updateData.applicationId = applicationId;
-        }
-        await certificateDAL.updateById(signedCertRecord.id, updateData, tx);
-
-        const certRequestResult = await certificateRequestService.createCertificateRequest({
-          internal: true,
-          actor,
-          actorId,
-          actorAuthMethod,
-          actorOrgId,
-          projectId: profile.projectId,
-          tx,
-          caId: ca.id,
-          profileId: profile.id,
-          applicationId,
-          csr,
-          commonName: mappedCertificateRequest.commonName,
-          altNames: mappedCertificateRequest.subjectAlternativeNames,
-          domainComponents: mappedCertificateRequest.domainComponents,
-          keyUsages: convertKeyUsageArrayToLegacy(mappedCertificateRequest.keyUsages),
-          extendedKeyUsages: convertExtendedKeyUsageArrayToLegacy(mappedCertificateRequest.extendedKeyUsages),
-          notBefore,
-          notAfter,
-          keyAlgorithm: effectiveKeyAlgorithm,
-          signatureAlgorithm: effectiveSignatureAlgorithm,
-          status: CertificateRequestStatus.ISSUED,
-          certificateId: certResult.certificateId,
-          basicConstraints,
-          ttl: validity.ttl,
-          enrollmentType
-        });
-
-        if (metadata && metadata.length > 0) {
-          await insertMetadataForCertificate(resourceMetadataDAL, {
-            metadata,
-            certificateId: certResult.certificateId,
-            orgId: actorOrgId,
-            tx
-          });
-          await insertMetadataForCertificateRequest(resourceMetadataDAL, {
-            metadata,
-            certificateRequestId: certRequestResult.id,
-            certificateRequestCreatedAt: certRequestResult.createdAt,
-            orgId: actorOrgId,
-            tx
-          });
-        }
-
-        return { ...certResult, cert: signedCertRecord, certificateRequestId: certRequestResult.id };
       });
+    } catch (err) {
+      // The request row is why this is recoverable. Mark it failed so the certificate is accounted
+      // for as an attempt rather than disappearing silently.
+      await certificateRequestDAL.transitionFromPending(
+        pendingRequest.id,
+        CertificateRequestStatus.FAILED,
+        err instanceof Error ? err.message : "Certificate issuance failed"
+      );
+      throw err;
+    }
+
+    const { certificate, certificateChain, issuingCaCertificate, serialNumber } = certResult;
 
     const certificateString = extractCertificateFromBuffer(certificate as unknown as Buffer);
     let certificateChainString = extractCertificateFromBuffer(certificateChain as unknown as Buffer);
@@ -1889,7 +1908,7 @@ export const certificateV3ServiceFactory = ({
 
     try {
       await pkiAlertV2Queue?.queueCertificateEvent({
-        certificateId: cert.id,
+        certificateId: certResult.certificateId,
         projectId: profile.projectId,
         eventType: PkiAlertEventType.ISSUANCE,
         applicationId: applicationId ?? null
@@ -1904,11 +1923,11 @@ export const certificateV3ServiceFactory = ({
       issuingCaCertificate: extractCertificateFromBuffer(issuingCaCertificate as unknown as Buffer),
       certificateChain: certificateChainString,
       serialNumber,
-      certificateId: cert.id,
-      certificateRequestId,
+      certificateId: certResult.certificateId,
+      certificateRequestId: pendingRequest.id,
       projectId: profile.projectId,
       profileName: profile.slug,
-      commonName: cert.commonName || ""
+      commonName: certResult.commonName || ""
     };
   };
 

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -15,7 +15,7 @@ import {
   ResourcePermissionSub
 } from "@app/ee/services/permission/resource-permission";
 import { TPkiAcmeAccountDALFactory } from "@app/ee/services/pki-acme/pki-acme-account-dal";
-import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, InternalServerError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
@@ -1868,7 +1868,22 @@ export const certificateV3ServiceFactory = ({
           await certificateDAL.updateById(newCert.id, updateData, tx);
 
           // Records the outcome: flips the request to ISSUED and links the certificate in one update.
-          await certificateRequestDAL.attachCertificate(pendingRequest.id, newCert.id, tx);
+          // Returns null when the request is no longer attachable, meaning it left a pending status
+          // while the signing above was in flight — cancelled by a user, or failed by ACME order
+          // reconciliation. Throwing here rolls this transaction back, certificate rows included, so a
+          // cancelled request can never silently yield an issued certificate. The signature itself is
+          // wasted, which is the right trade: an unstored signature costs an HSM operation and a
+          // serial, whereas committing would hand back a certificate nothing accounts for.
+          const attachedRequest = await certificateRequestDAL.attachCertificate(pendingRequest.id, newCert.id, tx);
+          if (!attachedRequest) {
+            logger.error(
+              { certificateRequestId: pendingRequest.id, projectId: profile.projectId },
+              `Certificate request left a pending status during signing, aborting issuance [certificateRequestId=${pendingRequest.id}]`
+            );
+            throw new InternalServerError({
+              message: "Certificate request is no longer pending, so issuance was aborted"
+            });
+          }
 
           if (metadata && metadata.length > 0) {
             await insertMetadataForCertificate(resourceMetadataDAL, {
@@ -1888,13 +1903,21 @@ export const certificateV3ServiceFactory = ({
         }
       });
     } catch (err) {
-      // The request row is why this is recoverable. Mark it failed so the certificate is accounted
-      // for as an attempt rather than disappearing silently.
-      await certificateRequestDAL.transitionFromPending(
-        pendingRequest.id,
-        CertificateRequestStatus.FAILED,
-        err instanceof Error ? err.message : "Certificate issuance failed"
-      );
+      // The request row is why this is recoverable. Mark it failed so the attempt is accounted for
+      // rather than disappearing silently. This is best-effort bookkeeping on an already-failing path,
+      // so its own failure must not replace the error the caller actually needs to see.
+      try {
+        await certificateRequestDAL.transitionFromPending(
+          pendingRequest.id,
+          CertificateRequestStatus.FAILED,
+          err instanceof Error ? err.message : "Certificate issuance failed"
+        );
+      } catch (bookkeepingErr) {
+        logger.error(
+          bookkeepingErr,
+          `Failed to mark certificate request as failed [certificateRequestId=${pendingRequest.id}]`
+        );
+      }
       throw err;
     }
 

--- a/backend/src/services/certificate-v3/certificate-v3-types.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-types.ts
@@ -57,6 +57,11 @@ export type TSignCertificateFromProfileDTO = {
     pathLength?: number;
   };
   applicationId?: string;
+  /**
+   * Links the certificate request this issuance creates back to its ACME order, so a crash between
+   * signing and persistence can be reconciled by `checkAndSyncAcmeOrderStatus`.
+   */
+  acmeOrderId?: string;
 } & Omit<TProjectPermission, "projectId">;
 
 export type TOrderCertificateFromProfileDTO = {


### PR DESCRIPTION
## Context
This PR addresses deadlock issue encountered when multiple ACME requests are received by the API 
<img width="1102" height="855" alt="image" src="https://github.com/user-attachments/assets/3c4d5b24-87c4-490c-a106-724c7ce5483a" />


<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)