### PR TITLE
feat(ui): add selected action bar

### DIFF
--- a/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.stories.tsx
+++ b/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "../Button";
+import { SelectedActionBar } from "./SelectedActionBar";
+
+const meta = {
+  title: "Generic/SelectedActionBar",
+  component: SelectedActionBar,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "A viewport-fixed action bar for manipulating a multi-selection without shifting page content. Selection state and domain actions stay with the callsite."
+      }
+    }
+  },
+  args: {
+    selectedCount: 3,
+    onClearSelection: () => {},
+    children: (
+      <>
+        <Button size="sm">Move</Button>
+        <Button size="sm" variant="danger">
+          Delete
+        </Button>
+      </>
+    )
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-screen bg-background p-6 text-foreground">
+        <p className="text-sm text-accent">Scroll the page to verify viewport positioning.</p>
+        <div className="h-[120vh]" />
+        <Story />
+      </div>
+    )
+  ]
+} satisfies Meta<typeof SelectedActionBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Example: Story = {
+  name: "Example: Multiple Selection Actions"
+};
+
+export const Hidden: Story = {
+  name: "Example: No Selection",
+  args: {
+    selectedCount: 0
+  }
+};

--- a/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
+++ b/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
@@ -43,8 +43,8 @@ function SelectedActionBar({
         "pointer-events-none fixed inset-x-4 bottom-16 z-40 flex justify-center",
         "transition-[opacity,translate,filter,scale] ease-out motion-reduce:transition-none",
         isVisible
-          ? "translate-y-0 opacity-100 duration-200 blur-none scale-100"
-          : "translate-y-3 opacity-0 duration-100 blur-[4px] scale-98"
+          ? "translate-y-0 scale-100 opacity-100 blur-none duration-200"
+          : "translate-y-3 scale-98 opacity-0 blur-[4px] duration-100"
       )}
       aria-hidden={!isVisible}
       // React 18 does not type the inert attribute yet.

--- a/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
+++ b/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
@@ -1,0 +1,93 @@
+import * as React from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@app/components/v3/utils";
+
+import { Button } from "../Button";
+
+type SelectedActionBarProps = Omit<React.ComponentProps<"div">, "children"> & {
+  selectedCount: number;
+  onClearSelection: () => void;
+  children: React.ReactNode;
+  selectionLabel?: React.ReactNode;
+  clearLabel?: string;
+};
+
+function SelectedActionBar({
+  selectedCount,
+  onClearSelection,
+  children,
+  selectionLabel,
+  clearLabel = "Unselect All",
+  className,
+  "aria-label": ariaLabel = "Selection actions",
+  ...props
+}: SelectedActionBarProps) {
+  const isVisible = selectedCount > 0;
+  const lastVisibleContent = React.useRef({ children, selectedCount, selectionLabel });
+
+  if (isVisible) {
+    lastVisibleContent.current = { children, selectedCount, selectionLabel };
+  }
+
+  const displayedContent = isVisible
+    ? { children, selectedCount, selectionLabel }
+    : lastVisibleContent.current;
+
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      data-slot="selected-action-bar-positioner"
+      className={cn(
+        "pointer-events-none fixed inset-x-4 bottom-16 z-40 flex justify-center",
+        "transition-[opacity,translate,filter,scale] ease-out motion-reduce:transition-none",
+        isVisible
+          ? "translate-y-0 opacity-100 duration-200 blur-none scale-100"
+          : "translate-y-3 opacity-0 duration-100 blur-[4px] scale-98"
+      )}
+      aria-hidden={!isVisible}
+      // React 18 does not type the inert attribute yet.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {...(!isVisible ? { inert: "" as any } : {})}
+    >
+      <div
+        {...props}
+        role="toolbar"
+        aria-label={ariaLabel}
+        data-slot="selected-action-bar"
+        data-state={isVisible ? "open" : "closed"}
+        className={cn(
+          "pointer-events-auto flex max-h-[calc(100vh-2rem)] w-full max-w-xl flex-wrap items-center gap-2 overflow-y-auto rounded-md border border-border bg-popover p-2 pl-4 text-foreground shadow-lg",
+          className
+        )}
+      >
+        <div
+          className={cn(
+            "flex w-full flex-wrap items-center gap-2 transition-opacity duration-50",
+            isVisible ? "opacity-100 delay-0" : "opacity-0 delay-50"
+          )}
+        >
+          <span className="shrink-0 text-sm">
+            {displayedContent.selectionLabel ?? `${displayedContent.selectedCount} Selected`}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            className="mr-auto text-accent underline-offset-2 hover:underline"
+            onClick={onClearSelection}
+          >
+            {clearLabel}
+          </Button>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            {displayedContent.children}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+export { SelectedActionBar, type SelectedActionBarProps };

--- a/frontend/src/components/v3/generic/SelectedActionBar/index.ts
+++ b/frontend/src/components/v3/generic/SelectedActionBar/index.ts
@@ -1,0 +1,1 @@
+export * from "./SelectedActionBar";

--- a/frontend/src/components/v3/generic/index.ts
+++ b/frontend/src/components/v3/generic/index.ts
@@ -30,6 +30,7 @@ export * from "./Popover";
 export * from "./RadioGroup";
 export * from "./ReactSelect";
 export * from "./Select";
+export * from "./SelectedActionBar";
 export * from "./Separator";
 export * from "./Sheet";
 export * from "./Sidebar";

--- a/frontend/src/pages/admin/AccessManagementPage/components/ServerAdminsTable.tsx
+++ b/frontend/src/pages/admin/AccessManagementPage/components/ServerAdminsTable.tsx
@@ -11,11 +11,10 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { AlertTriangleIcon } from "lucide-react";
-import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
-import { Badge, Pagination } from "@app/components/v3";
+import { Badge, Pagination, SelectedActionBar } from "@app/components/v3";
 import { useSubscription, useUser } from "@app/context";
 import {
   getUserTablePreference,
@@ -347,37 +346,24 @@ export const ServerAdminsTable = () => {
 
   return (
     <>
-      <div
-        className={twMerge(
-          "h-0 shrink-0 overflow-hidden transition-all",
-          selectedUsers.length > 0 && "h-16"
-        )}
+      <SelectedActionBar
+        selectedCount={selectedUsers.length}
+        onClearSelection={() => setSelectedUsers([])}
       >
-        <div className="flex items-center rounded-md border border-mineshaft-600 bg-mineshaft-800 px-4 py-2 text-bunker-300">
-          <div className="mr-2 text-sm">{selectedUsers.length} Selected</div>
-          <button
-            type="button"
-            className="mr-auto text-xs text-mineshaft-400 underline-offset-2 hover:text-mineshaft-200 hover:underline"
-            onClick={() => setSelectedUsers([])}
-          >
-            Unselect All
-          </button>
-          <Button
-            variant="outline_bg"
-            colorSchema="danger"
-            leftIcon={<FontAwesomeIcon icon={faTrash} />}
-            className="ml-2"
-            onClick={() => {
-              if (!selectedUsers?.length) return;
+        <Button
+          variant="outline_bg"
+          colorSchema="danger"
+          leftIcon={<FontAwesomeIcon icon={faTrash} />}
+          onClick={() => {
+            if (!selectedUsers?.length) return;
 
-              handlePopUpOpen("removeUsers");
-            }}
-            size="xs"
-          >
-            Delete
-          </Button>
-        </div>
-      </div>
+            handlePopUpOpen("removeUsers");
+          }}
+          size="xs"
+        >
+          Delete
+        </Button>
+      </SelectedActionBar>
       <div className="mb-6 rounded-lg border border-border bg-card p-5 text-foreground">
         <ServerAdminsPanelTable
           handlePopUpOpen={handlePopUpOpen}

--- a/frontend/src/pages/admin/ResourceOverviewPage/components/UserIdentitiesTable.tsx
+++ b/frontend/src/pages/admin/ResourceOverviewPage/components/UserIdentitiesTable.tsx
@@ -17,7 +17,7 @@ import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
-import { Badge, Button as V3Button, Pagination } from "@app/components/v3";
+import { Badge, Button as V3Button, Pagination, SelectedActionBar } from "@app/components/v3";
 import { useSubscription, useUser } from "@app/context";
 import {
   getUserTablePreference,
@@ -422,37 +422,24 @@ export const UserIdentitiesTable = () => {
 
   return (
     <>
-      <div
-        className={twMerge(
-          "h-0 shrink-0 overflow-hidden transition-all",
-          selectedUsers.length > 0 && "h-16"
-        )}
+      <SelectedActionBar
+        selectedCount={selectedUsers.length}
+        onClearSelection={() => setSelectedUsers([])}
       >
-        <div className="flex items-center rounded-md border border-mineshaft-600 bg-mineshaft-800 px-4 py-2 text-bunker-300">
-          <div className="mr-2 text-sm">{selectedUsers.length} Selected</div>
-          <button
-            type="button"
-            className="mr-auto text-xs text-mineshaft-400 underline-offset-2 hover:text-mineshaft-200 hover:underline"
-            onClick={() => setSelectedUsers([])}
-          >
-            Unselect All
-          </button>
-          <Button
-            variant="outline_bg"
-            colorSchema="danger"
-            leftIcon={<FontAwesomeIcon icon={faTrash} />}
-            className="ml-2"
-            onClick={() => {
-              if (!selectedUsers?.length) return;
+        <Button
+          variant="outline_bg"
+          colorSchema="danger"
+          leftIcon={<FontAwesomeIcon icon={faTrash} />}
+          onClick={() => {
+            if (!selectedUsers?.length) return;
 
-              handlePopUpOpen("removeUsers");
-            }}
-            size="xs"
-          >
-            Delete
-          </Button>
-        </div>
-      </div>
+            handlePopUpOpen("removeUsers");
+          }}
+          size="xs"
+        >
+          Delete
+        </Button>
+      </SelectedActionBar>
       <div className="mb-6 rounded-lg border border-border bg-card p-5 text-foreground">
         <div className="mb-4 flex items-center justify-between">
           <div>

--- a/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
@@ -49,6 +49,7 @@ import {
   InputGroupAddon,
   InputGroupInput,
   Pagination,
+  SelectedActionBar,
   Skeleton,
   Table,
   TableBody,
@@ -277,52 +278,40 @@ export const CmekTable = () => {
       animate={{ opacity: 1, translateX: 0 }}
       exit={{ opacity: 0, translateX: 30 }}
     >
-      <div
-        className={twMerge(
-          "mb-2 h-0 shrink-0 overflow-hidden transition-all",
-          selectedKeyIds.length > 0 && "h-16"
-        )}
+      <SelectedActionBar
+        selectedCount={selectedKeyIds.length}
+        onClearSelection={() => setSelectedKeyIds([])}
       >
-        <div className="mt-3.5 flex items-center rounded-md border border-border bg-card p-2 pl-4 text-foreground">
-          <div className="mr-2 text-sm">{selectedKeyIds.length} Selected</div>
-          <button
-            type="button"
-            className="mt-0.5 mr-auto text-xs text-accent underline-offset-2 hover:underline"
-            onClick={() => setSelectedKeyIds([])}
-          >
-            Unselect All
-          </button>
-          <ProjectPermissionCan
-            I={ProjectPermissionCmekActions.ExportPrivateKey}
-            a={ProjectPermissionSub.Cmek}
-            renderTooltip
-          >
-            {(isAllowed) => (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="ml-2">
-                    <Button
-                      variant="project"
-                      size="xs"
-                      onClick={handleBulkExport}
-                      isDisabled={!isAllowed}
-                      isPending={bulkExportMutation.isPending}
-                    >
-                      <DownloadIcon className="mr-1 size-4" />
-                      Export
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {isAllowed
-                    ? "Export all selected keys as a JSON file"
-                    : "You don't have permission to export keys"}
-                </TooltipContent>
-              </Tooltip>
-            )}
-          </ProjectPermissionCan>
-        </div>
-      </div>
+        <ProjectPermissionCan
+          I={ProjectPermissionCmekActions.ExportPrivateKey}
+          a={ProjectPermissionSub.Cmek}
+          renderTooltip
+        >
+          {(isAllowed) => (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span>
+                  <Button
+                    variant="project"
+                    size="xs"
+                    onClick={handleBulkExport}
+                    isDisabled={!isAllowed}
+                    isPending={bulkExportMutation.isPending}
+                  >
+                    <DownloadIcon className="mr-1 size-4" />
+                    Export
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {isAllowed
+                  ? "Export all selected keys as a JSON file"
+                  : "You don't have permission to export keys"}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </ProjectPermissionCan>
+      </SelectedActionBar>
 
       <Card>
         <CardHeader>

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { BanIcon, TrashIcon, UserPlusIcon } from "lucide-react";
-import { twMerge } from "tailwind-merge";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
@@ -22,7 +21,8 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-  DocumentationLinkBadge
+  DocumentationLinkBadge,
+  SelectedActionBar
 } from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import {
@@ -153,49 +153,36 @@ export const OrgMembersSection = () => {
 
   return (
     <>
-      <div
-        className={twMerge(
-          "h-0 shrink-0 overflow-hidden transition-all",
-          selectedMemberIds.length > 0 && "mb-2 h-16"
-        )}
+      <SelectedActionBar
+        selectedCount={selectedMemberIds.length}
+        onClearSelection={() => setSelectedMemberIds([])}
       >
-        <div className="mt-3.5 flex items-center rounded-md border border-border bg-card p-2 pl-4 text-foreground">
-          <div className="mr-2 text-sm">{selectedMemberIds.length} Selected</div>
-          <button
-            type="button"
-            className="mt-0.5 mr-auto text-xs text-accent underline-offset-2 hover:underline"
-            onClick={() => setSelectedMemberIds([])}
-          >
-            Unselect All
-          </button>
-          <OrgPermissionCan
-            I={OrgPermissionActions.Delete}
-            a={OrgPermissionSubjects.Member}
-            renderTooltip
-          >
-            {(isAllowed) => (
-              <Button
-                variant="danger"
-                className="ml-2"
-                onClick={() => {
-                  const selectedOrgMemberships = members.filter((member) =>
-                    selectedMemberIds.includes(member.id)
-                  );
+        <OrgPermissionCan
+          I={OrgPermissionActions.Delete}
+          a={OrgPermissionSubjects.Member}
+          renderTooltip
+        >
+          {(isAllowed) => (
+            <Button
+              variant="danger"
+              onClick={() => {
+                const selectedOrgMemberships = members.filter((member) =>
+                  selectedMemberIds.includes(member.id)
+                );
 
-                  if (!selectedOrgMemberships.length) return;
+                if (!selectedOrgMemberships.length) return;
 
-                  handlePopUpOpen("removeMembers", { selectedOrgMemberships });
-                }}
-                isDisabled={!isAllowed}
-                size="xs"
-              >
-                <TrashIcon />
-                Delete
-              </Button>
-            )}
-          </OrgPermissionCan>
-        </div>
-      </div>
+                handlePopUpOpen("removeMembers", { selectedOrgMemberships });
+              }}
+              isDisabled={!isAllowed}
+              size="xs"
+            >
+              <TrashIcon />
+              Delete
+            </Button>
+          )}
+        </OrgPermissionCan>
+      </SelectedActionBar>
       <Card>
         <CardHeader>
           <CardTitle>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
@@ -1,10 +1,15 @@
 import { useMemo } from "react";
 import { subject } from "@casl/ability";
 import { CopyPlus, FolderInputIcon, TagsIcon, TrashIcon } from "lucide-react";
-import { twMerge } from "tailwind-merge";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
+import {
+  Button,
+  SelectedActionBar,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   ProjectPermissionActions,
   ProjectPermissionSub,
@@ -43,7 +48,6 @@ export enum EntryType {
 
 type Props = {
   secretPath: string;
-  resetSelectedEntries: () => void;
   selectedEntries: {
     [EntryType.FOLDER]: Record<string, Record<string, TSecretFolder>>;
     [EntryType.SECRET]: Record<string, Record<string, SecretV3RawSanitized>>;
@@ -94,7 +98,6 @@ export const SelectionPanel = ({
   const { mutateAsync: deleteBatchSecretV3 } = useDeleteSecretBatch();
   const { mutateAsync: createCommit } = useCreateCommit();
 
-  const isMultiSelectActive = selectedCount > 0;
 
   // user should have the ability to delete secrets/folders in at least one of the envs
   const shouldShowDelete = userAvailableEnvs.some((env) =>
@@ -368,28 +371,16 @@ export const SelectionPanel = ({
 
   return (
     <>
-      <div
-        className={twMerge(
-          "mb-2 h-0 shrink-0 overflow-hidden transition-all",
-          isMultiSelectActive && "h-16"
-        )}
+      <SelectedActionBar
+        selectedCount={selectedCount}
+        onClearSelection={resetSelectedEntries}
       >
-        <div className="mt-3.5 flex items-center rounded-md border border-border bg-card p-2 pl-4 text-foreground">
-          <div className="mr-2 text-sm">{selectedCount} Selected</div>
-          <button
-            type="button"
-            className="mt-0.5 mr-auto text-xs text-accent underline-offset-2 hover:underline"
-            onClick={resetSelectedEntries}
-          >
-            Unselect All
-          </button>
           {selectedKeysCount > 0 && (
             <Tooltip open={isTagActionDisabled ? undefined : false}>
               <TooltipTrigger>
                 <Button
                   isDisabled={isTagActionDisabled}
                   variant="project"
-                  className="ml-2"
                   onClick={() => handlePopUpOpen("bulkTagSecrets")}
                   size="xs"
                 >
@@ -406,7 +397,6 @@ export const SelectionPanel = ({
                 <Button
                   isDisabled={isMoveDisabled}
                   variant="project"
-                  className="ml-2"
                   onClick={() => handlePopUpOpen("bulkMoveSecrets")}
                   size="xs"
                 >
@@ -423,7 +413,6 @@ export const SelectionPanel = ({
                 <Button
                   isDisabled={isDuplicateDisabled}
                   variant="project"
-                  className="ml-2"
                   onClick={() => handlePopUpOpen("bulkDuplicateSecrets")}
                   size="xs"
                 >
@@ -440,7 +429,6 @@ export const SelectionPanel = ({
                 <Button
                   isDisabled={isDeleteDisabled}
                   variant="danger"
-                  className="ml-2"
                   onClick={() => handlePopUpOpen("bulkDeleteEntries")}
                   size="xs"
                 >
@@ -451,8 +439,7 @@ export const SelectionPanel = ({
               <TooltipContent>{deleteDisabledReason}</TooltipContent>
             </Tooltip>
           )}
-        </div>
-      </div>
+      </SelectedActionBar>
       <MoveSecretsModal
         isOpen={popUp.bulkMoveSecrets.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("bulkMoveSecrets", isOpen)}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/SelectionPanel.tsx
@@ -48,6 +48,7 @@ export enum EntryType {
 
 type Props = {
   secretPath: string;
+  resetSelectedEntries: () => void;
   selectedEntries: {
     [EntryType.FOLDER]: Record<string, Record<string, TSecretFolder>>;
     [EntryType.SECRET]: Record<string, Record<string, SecretV3RawSanitized>>;
@@ -97,7 +98,6 @@ export const SelectionPanel = ({
   const userAvailableEnvs = currentProject?.environments || [];
   const { mutateAsync: deleteBatchSecretV3 } = useDeleteSecretBatch();
   const { mutateAsync: createCommit } = useCreateCommit();
-
 
   // user should have the ability to delete secrets/folders in at least one of the envs
   const shouldShowDelete = userAvailableEnvs.some((env) =>
@@ -371,74 +371,71 @@ export const SelectionPanel = ({
 
   return (
     <>
-      <SelectedActionBar
-        selectedCount={selectedCount}
-        onClearSelection={resetSelectedEntries}
-      >
-          {selectedKeysCount > 0 && (
-            <Tooltip open={isTagActionDisabled ? undefined : false}>
-              <TooltipTrigger>
-                <Button
-                  isDisabled={isTagActionDisabled}
-                  variant="project"
-                  onClick={() => handlePopUpOpen("bulkTagSecrets")}
-                  size="xs"
-                >
-                  <TagsIcon />
-                  Add Tags
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Access denied</TooltipContent>
-            </Tooltip>
-          )}
-          {shouldShowMove && (
-            <Tooltip open={isMoveDisabled ? undefined : false}>
-              <TooltipTrigger>
-                <Button
-                  isDisabled={isMoveDisabled}
-                  variant="project"
-                  onClick={() => handlePopUpOpen("bulkMoveSecrets")}
-                  size="xs"
-                >
-                  <FolderInputIcon />
-                  Move
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{moveDisabledReason}</TooltipContent>
-            </Tooltip>
-          )}
-          {shouldShowBulkDuplicate && (
-            <Tooltip open={isDuplicateDisabled ? undefined : false}>
-              <TooltipTrigger>
-                <Button
-                  isDisabled={isDuplicateDisabled}
-                  variant="project"
-                  onClick={() => handlePopUpOpen("bulkDuplicateSecrets")}
-                  size="xs"
-                >
-                  <CopyPlus />
-                  Duplicate
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{duplicateDisabledReason}</TooltipContent>
-            </Tooltip>
-          )}
-          {shouldShowDelete && (
-            <Tooltip open={isDeleteDisabled ? undefined : false}>
-              <TooltipTrigger>
-                <Button
-                  isDisabled={isDeleteDisabled}
-                  variant="danger"
-                  onClick={() => handlePopUpOpen("bulkDeleteEntries")}
-                  size="xs"
-                >
-                  <TrashIcon />
-                  Delete
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>{deleteDisabledReason}</TooltipContent>
-            </Tooltip>
-          )}
+      <SelectedActionBar selectedCount={selectedCount} onClearSelection={resetSelectedEntries}>
+        {selectedKeysCount > 0 && (
+          <Tooltip open={isTagActionDisabled ? undefined : false}>
+            <TooltipTrigger>
+              <Button
+                isDisabled={isTagActionDisabled}
+                variant="project"
+                onClick={() => handlePopUpOpen("bulkTagSecrets")}
+                size="xs"
+              >
+                <TagsIcon />
+                Add Tags
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Access denied</TooltipContent>
+          </Tooltip>
+        )}
+        {shouldShowMove && (
+          <Tooltip open={isMoveDisabled ? undefined : false}>
+            <TooltipTrigger>
+              <Button
+                isDisabled={isMoveDisabled}
+                variant="project"
+                onClick={() => handlePopUpOpen("bulkMoveSecrets")}
+                size="xs"
+              >
+                <FolderInputIcon />
+                Move
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{moveDisabledReason}</TooltipContent>
+          </Tooltip>
+        )}
+        {shouldShowBulkDuplicate && (
+          <Tooltip open={isDuplicateDisabled ? undefined : false}>
+            <TooltipTrigger>
+              <Button
+                isDisabled={isDuplicateDisabled}
+                variant="project"
+                onClick={() => handlePopUpOpen("bulkDuplicateSecrets")}
+                size="xs"
+              >
+                <CopyPlus />
+                Duplicate
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{duplicateDisabledReason}</TooltipContent>
+          </Tooltip>
+        )}
+        {shouldShowDelete && (
+          <Tooltip open={isDeleteDisabled ? undefined : false}>
+            <TooltipTrigger>
+              <Button
+                isDisabled={isDeleteDisabled}
+                variant="danger"
+                onClick={() => handlePopUpOpen("bulkDeleteEntries")}
+                size="xs"
+              >
+                <TrashIcon />
+                Delete
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>{deleteDisabledReason}</TooltipContent>
+          </Tooltip>
+        )}
       </SelectedActionBar>
       <MoveSecretsModal
         isOpen={popUp.bulkMoveSecrets.isOpen}

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/ActionBar.tsx
@@ -56,7 +56,8 @@ import {
   DialogContent,
   DialogDescription,
   DialogHeader,
-  DialogTitle
+  DialogTitle,
+  SelectedActionBar
 } from "@app/components/v3";
 import {
   ProjectPermissionActions,
@@ -202,7 +203,6 @@ export const ActionBar = ({
 
   const selectedSecrets = useSelectedSecrets();
   const { reset: resetSelectedSecret } = useSelectedSecretActions();
-  const isMultiSelectActive = Boolean(Object.keys(selectedSecrets).length);
   const isManagedSecretSelected = Object.values(selectedSecrets).some(
     (secret) => secret.isRotatedSecret || secret.isHoneyTokenSecret
   );
@@ -1160,72 +1160,58 @@ export const ActionBar = ({
           </DropdownMenu>
         </div>
       </div>
-      <div
-        className={twMerge(
-          "h-0 shrink-0 overflow-hidden transition-all",
-          isMultiSelectActive && "h-16"
-        )}
+      <SelectedActionBar
+        selectedCount={Object.keys(selectedSecrets).length}
+        onClearSelection={resetSelectedSecret}
       >
-        <div className="mt-3.5 flex items-center rounded-md border border-mineshaft-600 bg-mineshaft-800 px-4 py-2 text-bunker-300">
-          <div className="mr-2 text-sm">{Object.keys(selectedSecrets).length} Selected</div>
-          <button
-            type="button"
-            className="mr-auto text-xs text-mineshaft-400 underline-offset-2 hover:text-mineshaft-200 hover:underline"
-            onClick={resetSelectedSecret}
-          >
-            Unselect All
-          </button>
-          <ProjectPermissionCan
-            I={ProjectPermissionActions.Delete}
-            a={subject(ProjectPermissionSub.Secrets, {
-              environment,
-              secretPath,
-              secretName: "*",
-              secretTags: ["*"]
-            })}
-            renderTooltip
-            allowedLabel="Move"
-          >
-            {(isAllowed) => (
-              <Button
-                variant="outline_bg"
-                leftIcon={<FontAwesomeIcon icon={faAnglesRight} />}
-                className="ml-4"
-                onClick={() => handlePopUpOpen("moveSecrets")}
-                isDisabled={!isAllowed || isHoneyTokenSelected}
-                size="xs"
-              >
-                Move
-              </Button>
-            )}
-          </ProjectPermissionCan>
-          <ProjectPermissionCan
-            I={ProjectPermissionActions.Delete}
-            a={subject(ProjectPermissionSub.Secrets, {
-              environment,
-              secretPath,
-              secretName: "*",
-              secretTags: ["*"]
-            })}
-            renderTooltip
-            allowedLabel="Delete"
-          >
-            {(isAllowed) => (
-              <Button
-                variant="outline_bg"
-                colorSchema="danger"
-                leftIcon={<FontAwesomeIcon icon={faTrash} />}
-                className="ml-2"
-                onClick={() => handlePopUpOpen("bulkDeleteSecrets")}
-                isDisabled={!isAllowed || isManagedSecretSelected}
-                size="xs"
-              >
-                Delete
-              </Button>
-            )}
-          </ProjectPermissionCan>
-        </div>
-      </div>
+        <ProjectPermissionCan
+          I={ProjectPermissionActions.Delete}
+          a={subject(ProjectPermissionSub.Secrets, {
+            environment,
+            secretPath,
+            secretName: "*",
+            secretTags: ["*"]
+          })}
+          renderTooltip
+          allowedLabel="Move"
+        >
+          {(isAllowed) => (
+            <Button
+              variant="outline_bg"
+              leftIcon={<FontAwesomeIcon icon={faAnglesRight} />}
+              onClick={() => handlePopUpOpen("moveSecrets")}
+              isDisabled={!isAllowed || isHoneyTokenSelected}
+              size="xs"
+            >
+              Move
+            </Button>
+          )}
+        </ProjectPermissionCan>
+        <ProjectPermissionCan
+          I={ProjectPermissionActions.Delete}
+          a={subject(ProjectPermissionSub.Secrets, {
+            environment,
+            secretPath,
+            secretName: "*",
+            secretTags: ["*"]
+          })}
+          renderTooltip
+          allowedLabel="Delete"
+        >
+          {(isAllowed) => (
+            <Button
+              variant="outline_bg"
+              colorSchema="danger"
+              leftIcon={<FontAwesomeIcon icon={faTrash} />}
+              onClick={() => handlePopUpOpen("bulkDeleteSecrets")}
+              isDisabled={!isAllowed || isManagedSecretSelected}
+              size="xs"
+            >
+              Delete
+            </Button>
+          )}
+        </ProjectPermissionCan>
+      </SelectedActionBar>
       {/* all the side triggers from actions like modals etc */}
       <CreateSecretImportForm
         environment={environment}


### PR DESCRIPTION
## Context

Some multi-selection action bars were rendered inline in page flow and expanded from zero height when an item was selected. This shifted surrounding content and allowed the actions to scroll outside the viewport on long tables.

This change introduces a reusable v3 `SelectedActionBar` that:

- renders through a portal at a page-centered, bottom-offset viewport position;
- accepts callsite-owned selection summaries, clear behavior, permissions, and domain actions;
- keeps hidden content inert and unavailable to assistive technology;
- provides responsive action wrapping and reduced-motion behavior;
- retains the last selected content during the short dismissal transition so `0 Selected` does not flash.

The duplicated inline bars are migrated across server administrators, user identities, KMS keys, organization users, the Secret Manager overview, and the environment secret dashboard.

Linear: [DES-49 — Create a Floating Context Bar](https://linear.app/infisical/issue/DES-49/create-a-floating-context-bar)

## Screenshots

<img width="2670" height="1984" alt="CleanShot 2026-07-30 at 16 56 32@2x" src="https://github.com/user-attachments/assets/d6e48d61-7089-4132-ac17-91c87585ca99" />
<img width="2670" height="1984" alt="CleanShot 2026-07-30 at 16 56 03@2x" src="https://github.com/user-attachments/assets/c3109b11-ee68-440f-b772-5dd98605f705" />
<img width="2670" height="1984" alt="CleanShot 2026-07-30 at 16 55 50@2x" src="https://github.com/user-attachments/assets/ff7a78a4-ebda-441f-8752-571b2f1845dd" />
<img width="2670" height="1984" alt="CleanShot 2026-07-30 at 16 54 51@2x" src="https://github.com/user-attachments/assets/2729fcd9-e863-4b09-be22-c45ebaf6b726" />

## Steps to verify the change

1. Open a Secret Management project and navigate to **Overview**.
2. Select a secret, folder, rotation, or honey token using its row checkbox.
3. Confirm the selected count, Unselect All control, and permitted domain actions appear in a centered floating bar.
4. Scroll the table and confirm the bar remains accessible without moving page content.
5. Select and clear items repeatedly; confirm entrance and dismissal are smooth and the bar never flashes `0 Selected`.
6. Repeat selection on representative migrated surfaces:
   - Admin → Access Control
   - Admin → Resource Overview → Users
   - KMS project → Overview
   - Organization → Access Management → Users
   - Secret Management environment → Secrets
7. Resize to a narrow viewport and confirm actions wrap inside the bar without horizontal page overflow.
8. Enable reduced motion and confirm spatial transitions are disabled.

Local verification performed:

- Shared Docker preview served the DES-49 worktree with frontend and `/api/status` returning HTTP 200.
- The selection bar was exercised interactively at normal and slowed animation timing.
- `git diff --check` passed.
- Required private-file verification passed.
- Full frontend type-check was not run because the worktree did not have a local dependency installation.

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)