### PR TITLE
feat: self hosted support for new license server

### DIFF
--- a/backend/src/ee/services/license-v2/license-v2-service.ts
+++ b/backend/src/ee/services/license-v2/license-v2-service.ts
@@ -15,7 +15,6 @@ import {
 import { TMeteredFeature } from "@app/services/license-client/usage/usage-counters";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 
-import { isV2SelfHostedLicenseKey } from "../license/license-fns";
 import { OrgPermissionBillingActions, OrgPermissionSubjects } from "../permission/org-permission";
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
 import {
@@ -390,9 +389,7 @@ export const licenseV2ServiceFactory = ({
 
     return { planTier: plan.tier, quantities, declaredUsage };
   };
-  // A self-hosted v2 license is managed out-of-band: the billing surface is read-only. Self-serve
-  // mutations don't need an explicit guard here, the self-hosted license client rejects them itself.
-  const isSelfHostedLicense = isV2SelfHostedLicenseKey(envConfig.LICENSE_KEY ?? "");
+  const isSelfHostedLicense = Boolean(envConfig.LICENSE_KEY);
 
   const ensureBillingRead = async (orgId: string, actor: TGetBillingV2OverviewDTO["actor"]) => {
     const { permission } = await permissionService.getOrgPermission({

--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -19,12 +19,6 @@ export const isOfflineLicenseKey = (licenseKey: string): boolean => {
   }
 };
 
-// Self-hosted License Server v2 keys carry this prefix; legacy online keys look like "QVHK-HIGYH".
-export const SELF_HOSTED_V2_LICENSE_KEY_PREFIX = "infisical_lk_";
-
-export const isV2SelfHostedLicenseKey = (licenseKey: string): boolean =>
-  licenseKey.startsWith(SELF_HOSTED_V2_LICENSE_KEY_PREFIX);
-
 export const getLicenseKeyConfig = (
   config?: Pick<TEnvConfig, "LICENSE_KEY" | "LICENSE_KEY_OFFLINE">
 ): TLicenseKeyConfig => {
@@ -37,10 +31,6 @@ export const getLicenseKeyConfig = (
   const licenseKey = cfg.LICENSE_KEY;
 
   if (licenseKey) {
-    if (isV2SelfHostedLicenseKey(licenseKey)) {
-      return { isValid: true, licenseKey, type: LicenseType.OnlineV2 };
-    }
-
     if (isOfflineLicenseKey(licenseKey)) {
       return { isValid: true, licenseKey, type: LicenseType.Offline };
     }

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -78,7 +78,6 @@ type TLicenseServiceFactoryDep = {
 export type TLicenseServiceFactory = ReturnType<typeof licenseServiceFactory>;
 
 const LICENSE_SERVER_CLOUD_LOGIN = "/api/auth/v1/license-server-login";
-const LICENSE_SERVER_ON_PREM_LOGIN = "/api/auth/v1/license-login";
 
 // A self-hosted v2 license is single-tenant: the license key identifies the tenant, so entitlement
 // reads carry no real org id. This fixed id only keys the local entitlement cache for the instance.
@@ -109,51 +108,12 @@ export const licenseServiceFactory = ({
     envConfig.INTERNAL_REGION
   );
 
-  const onlineLicenseKey =
-    licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Online ? licenseKeyConfig.licenseKey : "";
-
-  const licenseServerOnPremApi = setupLicenseRequestWithStore(
-    envConfig.LICENSE_SERVER_URL || "",
-    LICENSE_SERVER_ON_PREM_LOGIN,
-    onlineLicenseKey,
-    envConfig.INTERNAL_REGION
-  );
-
   const isV1CloudKey = () =>
     instanceType === InstanceType.Cloud && envConfig.LICENSE_SERVER_KEY && envConfig.LICENSE_SERVER_V2_MODE !== "on";
 
-  const syncLicenseKeyOnPremFeatures = async (shouldThrow: boolean = false) => {
-    logger.info("Start syncing license key features");
-    try {
-      const {
-        data: { currentPlan }
-      } = await licenseServerOnPremApi.request.get<{ currentPlan: TFeatureSet }>("/api/license/v1/plan");
-
-      const workspacesUsed = await projectDAL.countOfBillableOrgProjects(null);
-      currentPlan.workspacesUsed = workspacesUsed;
-
-      const usedIdentitySeats = await licenseDAL.countOrgUsersAndIdentities(null);
-      if (usedIdentitySeats !== currentPlan.identitiesUsed) {
-        const usedSeats = await licenseDAL.countOfOrgMembers(null);
-        await licenseServerOnPremApi.request.patch(`/api/license/v1/license`, {
-          usedSeats,
-          usedIdentitySeats
-        });
-        currentPlan.identitiesUsed = usedIdentitySeats;
-        currentPlan.membersUsed = usedSeats;
-      }
-
-      onPremFeatures = currentPlan;
-      logger.info("Successfully synchronized license key features");
-    } catch (error) {
-      logger.error(error, "Failed to synchronize license key features");
-      if (shouldThrow) throw error;
-    }
-  };
-
-  // Self-hosted equivalent of syncLicenseKeyOnPremFeatures, but sourced from License Server v2: project
-  // the license's entitlements into the v1 feature shape and refresh the instance-wide onPremFeatures.
-  const syncSelfHostedV2Features = async (shouldThrow: boolean = false) => {
+  // Self-hosted online license: project the license's entitlements (from License Server v2) into the v1
+  // feature shape and refresh the instance-wide onPremFeatures.
+  const syncSelfHostedFeatures = async (shouldThrow: boolean = false) => {
     logger.info("Start syncing self-hosted license features from License Server v2");
     try {
       if (!licenseClient) {
@@ -194,24 +154,13 @@ export const licenseServiceFactory = ({
         return;
       }
 
-      // New self-hosted key (prefix "infisical_lk_") resolves features from License Server v2. The key
-      // authenticates directly (no on-prem login handshake); a successful entitlements sync validates it.
-      if (licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.OnlineV2) {
-        await syncSelfHostedV2Features(true);
-        instanceType = InstanceType.EnterpriseOnPremV2;
-        logger.info(`Instance type: ${InstanceType.EnterpriseOnPremV2}`);
-        isValidLicense = true;
-        return;
-      }
-
+      // Self-hosted online license: features resolve from License Server v2. The key authenticates via
+      // the token endpoint (handled inside the license client); a successful entitlements sync validates it.
       if (licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Online) {
-        const token = await licenseServerOnPremApi.refreshLicense();
-        if (token) {
-          await syncLicenseKeyOnPremFeatures(true);
-          instanceType = InstanceType.EnterpriseOnPrem;
-          logger.info(`Instance type: ${InstanceType.EnterpriseOnPrem}`);
-          isValidLicense = true;
-        }
+        await syncSelfHostedFeatures(true);
+        instanceType = InstanceType.EnterpriseOnPrem;
+        logger.info(`Instance type: ${InstanceType.EnterpriseOnPrem}`);
+        isValidLicense = true;
         return;
       }
 
@@ -236,9 +185,17 @@ export const licenseServiceFactory = ({
         }
 
         if (isValidOfflineLicense) {
+          // v2 offline licenses carry License Server v2 entitlements; project them into the feature
+          // shape. v1 (or version-less) licenses carry the legacy feature set directly.
+          const features =
+            contents.license.version === 2 && contents.license.entitlements
+              ? projectV2ToFeatureSet(getDefaultOnPremFeatures(), contents.license.entitlements)
+              : contents.license.features;
+
           onPremFeatures = {
-            ...contents.license.features,
-            slug: "enterprise"
+            ...features,
+            slug: "enterprise",
+            isOffline: true
           };
           instanceType = InstanceType.EnterpriseOnPremOffline;
           logger.info(`Instance type: ${InstanceType.EnterpriseOnPremOffline}`);
@@ -258,14 +215,8 @@ export const licenseServiceFactory = ({
 
   const initializeBackgroundSync = async () => {
     if (licenseKeyConfig?.isValid && licenseKeyConfig?.type === LicenseType.Online) {
-      logger.info("Setting up background sync process for refresh onPremFeatures");
-      const job = new CronJob("*/10 * * * *", syncLicenseKeyOnPremFeatures);
-      job.start();
-      return job;
-    }
-    if (licenseKeyConfig?.isValid && licenseKeyConfig?.type === LicenseType.OnlineV2) {
-      logger.info("Setting up background sync process for refresh onPremFeatures from License Server v2");
-      const job = new CronJob("*/10 * * * *", () => syncSelfHostedV2Features());
+      logger.info("Setting up background sync process to refresh onPremFeatures from License Server v2");
+      const job = new CronJob("*/10 * * * *", () => syncSelfHostedFeatures());
       job.start();
       return job;
     }
@@ -418,12 +369,9 @@ export const licenseServiceFactory = ({
       await getPlan(orgId);
     }
     if (instanceType === InstanceType.EnterpriseOnPrem) {
-      await syncLicenseKeyOnPremFeatures(true);
-    }
-    if (instanceType === InstanceType.EnterpriseOnPremV2) {
       // Bust the license server's cached entitlements (e.g. after a license change), then re-sync.
       await licenseClient?.refreshEntitlements({ id: SELF_HOSTED_LICENSE_ORG_ID });
-      await syncSelfHostedV2Features(true);
+      await syncSelfHostedFeatures(true);
     }
   };
 
@@ -470,16 +418,7 @@ export const licenseServiceFactory = ({
       }
       await keyStore.deleteItem(KeyStorePrefixes.LicenseCloudPlan(rootOrgId));
     } else if (instanceType === InstanceType.EnterpriseOnPrem) {
-      // const usedSeats = await licenseDAL.countOfOrgMembers(null, tx);
-      // const usedIdentitySeats = await licenseDAL.countOrgUsersAndIdentities(null, tx);
-      // onPremFeatures.membersUsed = usedSeats;
-      // onPremFeatures.identitiesUsed = usedIdentitySeats;
-      // await licenseServerOnPremApi.request.patch(`/api/license/v1/license`, {
-      //   usedSeats,
-      //   usedIdentitySeats
-      // });
-    } else if (instanceType === InstanceType.EnterpriseOnPremV2) {
-      // v2 self-hosted reports usage asynchronously via the usage-snapshot queue, not a synchronous seat
+      // Self-hosted reports usage asynchronously via the usage-snapshot queue, not a synchronous seat
       // patch; keep the in-memory counts current so limit checks are accurate until the next sync.
       onPremFeatures.membersUsed = await licenseDAL.countOfOrgMembers(null, tx);
       onPremFeatures.identitiesUsed = await licenseDAL.countOrgUsersAndIdentities(null, tx);
@@ -736,14 +675,6 @@ export const licenseServiceFactory = ({
       return data;
     }
 
-    if (instanceType === InstanceType.EnterpriseOnPrem) {
-      const { data } = await licenseServerOnPremApi.request.get<{
-        head: { name: string }[];
-        rows: { name: string; allowed: boolean }[];
-      }>(`${baseUrl}/on-prem-plan/table`);
-      return data;
-    }
-
     throw new Error(`Unsupported instance type for server-based plan table: ${instanceType}`);
   };
 
@@ -768,7 +699,7 @@ export const licenseServiceFactory = ({
 
     const { projectCount, totalIdentities } = await getUsageMetrics(orgId);
 
-    if (instanceType === InstanceType.Cloud || instanceType === InstanceType.EnterpriseOnPrem) {
+    if (instanceType === InstanceType.Cloud) {
       const tableResponse = await fetchPlanTableFromServer(organization.customerId);
 
       return {

--- a/backend/src/ee/services/license/license-service.ts
+++ b/backend/src/ee/services/license/license-service.ts
@@ -166,26 +166,6 @@ export const licenseServiceFactory = ({
       }
       const currentPlan = projectV2ToFeatureSet(getDefaultOnPremFeatures(), entitlements);
 
-      // The entitlement projection only carries feature flags; derive the plan tier from the
-      // subscription/contract view. Non-fatal so a subscription read failure keeps the features.
-      try {
-        const subscription = await licenseClient.getSubscription(SELF_HOSTED_LICENSE_ORG_ID);
-        const paidTiers = (subscription?.items ?? [])
-          .map((item) => item.plan.toLowerCase())
-          .filter((tier) => tier !== "free");
-        if (paidTiers.some((tier) => tier.includes("enterprise"))) {
-          currentPlan.slug = "enterprise";
-        } else if (paidTiers.some((tier) => tier.includes("advanced"))) {
-          currentPlan.slug = "advanced";
-        } else if (paidTiers.length > 0) {
-          currentPlan.slug = "pro";
-        }
-      } catch (error) {
-        logger.error(error, "syncSelfHostedV2Features: failed to resolve plan tier from subscription");
-      }
-
-      // Usage is instance-wide for self-hosted (null orgId aggregates the whole instance), as in the v1 sync.
-      currentPlan.workspacesUsed = await projectDAL.countOfBillableOrgProjects(null);
       currentPlan.membersUsed = await licenseDAL.countOfOrgMembers(null);
       currentPlan.identitiesUsed = await licenseDAL.countOrgUsersAndIdentities(null);
 
@@ -490,14 +470,14 @@ export const licenseServiceFactory = ({
       }
       await keyStore.deleteItem(KeyStorePrefixes.LicenseCloudPlan(rootOrgId));
     } else if (instanceType === InstanceType.EnterpriseOnPrem) {
-      const usedSeats = await licenseDAL.countOfOrgMembers(null, tx);
-      const usedIdentitySeats = await licenseDAL.countOrgUsersAndIdentities(null, tx);
-      onPremFeatures.membersUsed = usedSeats;
-      onPremFeatures.identitiesUsed = usedIdentitySeats;
-      await licenseServerOnPremApi.request.patch(`/api/license/v1/license`, {
-        usedSeats,
-        usedIdentitySeats
-      });
+      // const usedSeats = await licenseDAL.countOfOrgMembers(null, tx);
+      // const usedIdentitySeats = await licenseDAL.countOrgUsersAndIdentities(null, tx);
+      // onPremFeatures.membersUsed = usedSeats;
+      // onPremFeatures.identitiesUsed = usedIdentitySeats;
+      // await licenseServerOnPremApi.request.patch(`/api/license/v1/license`, {
+      //   usedSeats,
+      //   usedIdentitySeats
+      // });
     } else if (instanceType === InstanceType.EnterpriseOnPremV2) {
       // v2 self-hosted reports usage asynchronously via the usage-snapshot queue, not a synchronous seat
       // patch; keep the in-memory counts current so limit checks are accurate until the next sync.

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -1,11 +1,11 @@
 import { TOrgPermission } from "@app/lib/types";
+import { TEntitlementsResponse } from "@app/services/license-client/license-client-types";
 
 export enum InstanceType {
   OnPrem = "self-hosted",
+  // Self-hosted online license: features are resolved from License Server v2.
   EnterpriseOnPrem = "enterprise-self-hosted",
   EnterpriseOnPremOffline = "enterprise-self-hosted-offline",
-  // Self-hosted instance whose license is resolved from License Server v2 (new "infisical_lk_" key).
-  EnterpriseOnPremV2 = "enterprise-self-hosted-v2",
   Cloud = "cloud"
 }
 
@@ -21,7 +21,11 @@ export type TOfflineLicense = {
   issuedAt: string;
   expiresAt: string | null;
   terminatesAt: string | null;
+  // v1 (or absent) offline licenses carry the legacy feature-flag set directly; version 2 licenses
+  // carry License Server v2 entitlements, which we project into the same feature shape.
+  version?: number;
   features: TFeatureSet;
+  entitlements?: TEntitlementsResponse;
 };
 
 export type TPlanBillingInfo = {
@@ -36,6 +40,9 @@ export type TPlanBillingInfo = {
 export type TFeatureSet = {
   _id: null;
   slug: string | null;
+  // True when features are sourced from an offline (air-gapped) license; the billing UI renders a
+  // read-only offline banner instead of the live billing surface.
+  isOffline?: boolean;
   tier: -1;
   workspaceLimit: null;
   workspacesUsed: number;
@@ -161,9 +168,8 @@ export type TOrgLicensesDTO = TOrgPermission;
 
 export enum LicenseType {
   Offline = "offline",
-  Online = "online",
-  // New self-hosted key (prefix "infisical_lk_") that resolves entitlements from License Server v2.
-  OnlineV2 = "online-v2"
+  // Self-hosted online license key; resolves entitlements from License Server v2.
+  Online = "online"
 }
 
 export type TLicenseKeyConfig =

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -349,7 +349,7 @@ const envSchema = z
     LICENSE_SERVER_KEY: zpStr(z.string().optional()),
     LICENSE_KEY: zpStr(z.string().optional()),
     LICENSE_KEY_OFFLINE: zpStr(z.string().optional()),
-    LICENSE_SERVER_V2_MODE: z.enum(["off", "read-compare", "on"]).default("off"),
+    LICENSE_SERVER_V2_MODE: z.enum(["off", "read-compare", "on"]).default("on"),
     LICENSE_SERVER_V2_URL: zpStr(z.string().optional()),
     LICENSE_SERVER_V2_SERVICE_KEY: zpStr(z.string().optional()),
     // When true, new checkouts (adding a payment method) and trials on License Server v1 cloud are

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -813,9 +813,15 @@ export const registerRoutes = async (
     permissionService
   });
 
+  // Offline (air-gapped) licenses are stored in LICENSE_KEY too, but must never reach the license
+  // server. The v2 client is left dormant for them so no billing/entitlement read can transmit the
+  // signed license credential; usage reporting + its cron are disabled below for the same reason.
+  const licenseKeyConfig = getLicenseKeyConfig(envConfig);
+  const isOfflineLicense = licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Offline;
+
   // License Server v2 client SDK. Coexists with licenseService during migration - getFeature()
   // is the single read primitive; falls back to feature defaults until the server is configured.
-  const licenseClient = licenseClientFactory({ envConfig, keyStore });
+  const licenseClient = licenseClientFactory({ envConfig, keyStore, isOffline: isOfflineLicense });
 
   // Created before licenseService so the latter can emit the v2 user-seat meter from its
   // updateSubscriptionOrgMemberCount chokepoint.
@@ -837,10 +843,6 @@ export const registerRoutes = async (
   const usageCounterDAL = usageCounterDALFactory(db);
   const meteredFeatures = buildMeteredFeatures({ licenseDAL, usageCounterDAL, isCloud: envConfig.isCloud });
   meteredFeatures.forEach(({ feature, count }) => licenseClient.registerCounter(feature, count));
-  // An offline (air-gapped) license can't reach the license server, so usage reporting + its daily
-  // true-up cron are inert: skip the reporter entirely and disable the cron below.
-  const licenseKeyConfig = getLicenseKeyConfig(envConfig);
-  const isOfflineLicense = licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Offline;
   const usageReporter = isOfflineLicense ? null : buildUsageReporter(envConfig);
   let usageSource = "self-hosted";
   if (envConfig.isCloud) {

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -102,7 +102,9 @@ import { ldapConfigDALFactory } from "@app/ee/services/ldap-config/ldap-config-d
 import { ldapConfigServiceFactory } from "@app/ee/services/ldap-config/ldap-config-service";
 import { ldapGroupMapDALFactory } from "@app/ee/services/ldap-config/ldap-group-map-dal";
 import { licenseDALFactory } from "@app/ee/services/license/license-dal";
+import { getLicenseKeyConfig } from "@app/ee/services/license/license-fns";
 import { licenseServiceFactory } from "@app/ee/services/license/license-service";
+import { LicenseType } from "@app/ee/services/license/license-types";
 import { licenseV2ServiceFactory } from "@app/ee/services/license-v2/license-v2-service";
 import { oidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import { oidcConfigServiceFactory } from "@app/ee/services/oidc/oidc-config-service";
@@ -835,7 +837,11 @@ export const registerRoutes = async (
   const usageCounterDAL = usageCounterDALFactory(db);
   const meteredFeatures = buildMeteredFeatures({ licenseDAL, usageCounterDAL, isCloud: envConfig.isCloud });
   meteredFeatures.forEach(({ feature, count }) => licenseClient.registerCounter(feature, count));
-  const usageReporter = buildUsageReporter(envConfig);
+  // An offline (air-gapped) license can't reach the license server, so usage reporting + its daily
+  // true-up cron are inert: skip the reporter entirely and disable the cron below.
+  const licenseKeyConfig = getLicenseKeyConfig(envConfig);
+  const isOfflineLicense = licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Offline;
+  const usageReporter = isOfflineLicense ? null : buildUsageReporter(envConfig);
   let usageSource = "self-hosted";
   if (envConfig.isCloud) {
     usageSource = "cloud";
@@ -844,12 +850,12 @@ export const registerRoutes = async (
     queueService,
     cronJob,
     keyStore,
-    orgDAL,
     licenseService,
     usageMeteringService,
     meteredFeatures,
     usageReporter,
     isCloud: envConfig.isCloud,
+    isOffline: isOfflineLicense,
     source: usageSource
   });
 

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -35,6 +35,7 @@ import {
   TTrialResult,
   TTrialsResponse
 } from "./license-client-types";
+import { TLicenseTokenProvider } from "./license-token-provider";
 
 // Token-scoped paths for the self-hosted (license-key) backend: the key identifies the license, so
 // no org_id is carried. The global catalog is org-independent and shared by both backends.
@@ -361,76 +362,81 @@ export const licenseServerBackend = (
 const notSupportedOnSelfHosted = (operation: string) => (): Promise<never> =>
   Promise.reject(new Error(`license operation "${operation}" is not supported for self-hosted licenses`));
 
-// Backend for a self-hosted License Server v2 license. Unlike the cloud backend it authenticates with
-// the raw license key as a bearer token (not a minted RS256 service JWT) and is single-tenant: the key
+// Backend for a self-hosted License Server v2 license. Unlike the cloud backend (which mints an RS256
+// service JWT), it exchanges the license key for a short-lived JWT at the token endpoint and sends that
+// as the bearer — the same convention both self-hosted key formats now follow. Single-tenant: the key
 // identifies the license, so entitlement/subscription reads carry no org_id. Only the read + usage +
 // refresh endpoints the self-hosted contract exposes are implemented; everything billing-related throws.
 export const licenseServerSelfHostedBackend = (
   serverUrl: string,
-  licenseKey: string,
+  tokenProvider: TLicenseTokenProvider,
   region?: string
-): TLicenseClientBackend => ({
-  fetchEntitlements: async (): Promise<TEntitlementsResponse> => {
-    const url = new URL(ENTITLEMENTS_PATH, serverUrl);
-    if (region) {
-      url.searchParams.set("region", region);
+): TLicenseClientBackend => {
+  // GET with the exchanged JWT; on a 401 (token expired mid-flight) drop the cache and retry once.
+  const authedGet = async (url: URL): Promise<Response> => {
+    const send = async () =>
+      fetch(url, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${await tokenProvider.getToken()}` },
+        redirect: "manual"
+      });
+    const res = await send();
+    if (res.status !== 401) {
+      return res;
     }
-    const res = await fetch(url, {
-      method: "GET",
-      headers: { Authorization: `Bearer ${licenseKey}` },
-      redirect: "manual"
-    });
-    await throwIfResponseError(res);
-    const body: unknown = await res.json();
-    return entitlementsResponseSchema.parse(body);
-  },
+    tokenProvider.invalidate();
+    return send();
+  };
 
-  fetchCatalog: async (): Promise<TCatalogResponse> => {
-    const url = new URL(PRODUCTS_PATH, serverUrl);
-    const res = await fetch(url, {
-      method: "GET",
-      headers: { Authorization: `Bearer ${licenseKey}` },
-      redirect: "manual"
-    });
-    await throwIfResponseError(res);
-    const body: unknown = await res.json();
-    return catalogResponseSchema.parse(body);
-  },
+  return {
+    fetchEntitlements: async (): Promise<TEntitlementsResponse> => {
+      const url = new URL(ENTITLEMENTS_PATH, serverUrl);
+      if (region) {
+        url.searchParams.set("region", region);
+      }
+      const res = await authedGet(url);
+      await throwIfResponseError(res);
+      const body: unknown = await res.json();
+      return entitlementsResponseSchema.parse(body);
+    },
 
-  // The license's subscription/contract view. A 404 (no contract yet) degrades to "no subscription".
-  fetchSubscription: async (): Promise<TSubscriptionResponse | null> => {
-    const url = new URL(SUBSCRIPTION_PATH, serverUrl);
-    const res = await fetch(url, {
-      method: "GET",
-      headers: { Authorization: `Bearer ${licenseKey}` },
-      redirect: "manual"
-    });
-    if (res.status === 404) {
-      return null;
-    }
-    await throwIfResponseError(res);
-    const body: unknown = await res.json();
-    const parsed = subscriptionResponseSchema.safeParse(body);
-    if (!parsed.success) {
-      logger.error({ err: parsed.error }, "license-client: /subscription failed schema validation (self-hosted)");
-      return null;
-    }
-    if (!parsed.data.status) {
-      return null;
-    }
-    return parsed.data;
-  },
+    fetchCatalog: async (): Promise<TCatalogResponse> => {
+      const res = await authedGet(new URL(PRODUCTS_PATH, serverUrl));
+      await throwIfResponseError(res);
+      const body: unknown = await res.json();
+      return catalogResponseSchema.parse(body);
+    },
 
-  fetchCloudPlan: notSupportedOnSelfHosted("fetchCloudPlan"),
-  fetchBillingProfile: notSupportedOnSelfHosted("fetchBillingProfile"),
-  createPortalSession: notSupportedOnSelfHosted("createPortalSession"),
-  previewSubscriptionChange: notSupportedOnSelfHosted("previewSubscriptionChange"),
-  buyProduct: notSupportedOnSelfHosted("buyProduct"),
-  removeProduct: notSupportedOnSelfHosted("removeProduct"),
-  changeCommitments: notSupportedOnSelfHosted("changeCommitments"),
-  startTrial: notSupportedOnSelfHosted("startTrial"),
-  cancelTrial: notSupportedOnSelfHosted("cancelTrial"),
-  fetchTrials: notSupportedOnSelfHosted("fetchTrials"),
-  cancelSubscription: notSupportedOnSelfHosted("cancelSubscription"),
-  resumeSubscription: notSupportedOnSelfHosted("resumeSubscription")
-});
+    // The license's subscription/contract view. A 404 (no contract yet) degrades to "no subscription".
+    fetchSubscription: async (): Promise<TSubscriptionResponse | null> => {
+      const res = await authedGet(new URL(SUBSCRIPTION_PATH, serverUrl));
+      if (res.status === 404) {
+        return null;
+      }
+      await throwIfResponseError(res);
+      const body: unknown = await res.json();
+      const parsed = subscriptionResponseSchema.safeParse(body);
+      if (!parsed.success) {
+        logger.error({ err: parsed.error }, "license-client: /subscription failed schema validation (self-hosted)");
+        return null;
+      }
+      if (!parsed.data.status) {
+        return null;
+      }
+      return parsed.data;
+    },
+
+    fetchCloudPlan: notSupportedOnSelfHosted("fetchCloudPlan"),
+    fetchBillingProfile: notSupportedOnSelfHosted("fetchBillingProfile"),
+    createPortalSession: notSupportedOnSelfHosted("createPortalSession"),
+    previewSubscriptionChange: notSupportedOnSelfHosted("previewSubscriptionChange"),
+    buyProduct: notSupportedOnSelfHosted("buyProduct"),
+    removeProduct: notSupportedOnSelfHosted("removeProduct"),
+    changeCommitments: notSupportedOnSelfHosted("changeCommitments"),
+    startTrial: notSupportedOnSelfHosted("startTrial"),
+    cancelTrial: notSupportedOnSelfHosted("cancelTrial"),
+    fetchTrials: notSupportedOnSelfHosted("fetchTrials"),
+    cancelSubscription: notSupportedOnSelfHosted("cancelSubscription"),
+    resumeSubscription: notSupportedOnSelfHosted("resumeSubscription")
+  };
+};

--- a/backend/src/services/license-client/license-client.test.ts
+++ b/backend/src/services/license-client/license-client.test.ts
@@ -142,6 +142,7 @@ describe("licenseClientFactory (usage example)", () => {
       LICENSE_SERVER_V2_MODE: "off",
       LICENSE_SERVER_V2_URL: undefined,
       LICENSE_SERVER_V2_SERVICE_KEY: undefined,
+      LICENSE_SERVER_URL: "https://license.example.com",
       INTERNAL_REGION: undefined
     },
     keyStore: createFakeKeyStore()

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -47,9 +47,13 @@ const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicens
     return licenseServerSelfHostedBackend(envConfig.LICENSE_SERVER_URL, tokenProvider, envConfig.INTERNAL_REGION);
   }
 
-  const serverUrl = envConfig.LICENSE_SERVER_V2_URL;
+  // Self-hosted sets only LICENSE_SERVER_URL (that one host now serves both the token endpoint and the
+  // v2 API after the DNS switch); cloud sets LICENSE_SERVER_V2_URL. Accept either as the v2 API base.
+  const serverUrl = envConfig.LICENSE_SERVER_V2_URL || envConfig.LICENSE_SERVER_URL;
   if (!serverUrl) {
-    logger.warn("license-client: enabled but LICENSE_SERVER_V2_URL is missing; serving feature fallbacks");
+    logger.warn(
+      "license-client: enabled but neither LICENSE_SERVER_V2_URL nor LICENSE_SERVER_URL is set; serving feature fallbacks"
+    );
     return null;
   }
 

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -28,13 +28,24 @@ type TLicenseClientFactoryDep = {
     | "INTERNAL_REGION"
   >;
   keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry" | "deleteItem">;
+  // Offline (air-gapped) licenses must never contact the license server; the SDK stays dormant for them.
+  isOffline?: boolean;
 };
 
 export type TLicenseClientFactory = ReturnType<typeof licenseClientFactory>;
 
 // Returns null (SDK dormant -> getFeature serves fallbacks) unless the kill switch is on and either a
 // self-hosted license key or the cloud service key (plus server URL) is configured.
-const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicenseClientBackend | null => {
+const buildBackend = (
+  envConfig: TLicenseClientFactoryDep["envConfig"],
+  isOffline: boolean
+): TLicenseClientBackend | null => {
+  // An offline (air-gapped) license lives in LICENSE_KEY, but transmitting it would violate the
+  // air-gap and leak the signed credential — keep the SDK dormant so no read can POST it to the server.
+  if (isOffline) {
+    return null;
+  }
+
   const licenseKey = envConfig.LICENSE_KEY;
   if (licenseKey) {
     if (!envConfig.LICENSE_SERVER_URL) {
@@ -80,8 +91,8 @@ const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicens
   return licenseServerBackend(serverUrl, signingKey.replace(/\\n/g, "\n"), envConfig.INTERNAL_REGION);
 };
 
-export const licenseClientFactory = ({ envConfig, keyStore }: TLicenseClientFactoryDep) => {
-  const backend = buildBackend(envConfig);
+export const licenseClientFactory = ({ envConfig, keyStore, isOffline = false }: TLicenseClientFactoryDep) => {
+  const backend = buildBackend(envConfig, isOffline);
   const resolver = backend ? entitlementResolverFactory({ keyStore, backend }) : null;
 
   const getEntitlements = async (org: TEntitlementOrg) => {

--- a/backend/src/services/license-client/license-client.ts
+++ b/backend/src/services/license-client/license-client.ts
@@ -15,6 +15,7 @@ import {
   TStartTrialPayload,
   TSubscriptionPreviewPayload
 } from "./license-client-types";
+import { createSelfHostedTokenProvider } from "./license-token-provider";
 
 type TLicenseClientFactoryDep = {
   envConfig: Pick<
@@ -22,6 +23,7 @@ type TLicenseClientFactoryDep = {
     | "LICENSE_SERVER_V2_MODE"
     | "LICENSE_SERVER_V2_URL"
     | "LICENSE_SERVER_V2_SERVICE_KEY"
+    | "LICENSE_SERVER_URL"
     | "LICENSE_KEY"
     | "INTERNAL_REGION"
   >;
@@ -30,15 +32,19 @@ type TLicenseClientFactoryDep = {
 
 export type TLicenseClientFactory = ReturnType<typeof licenseClientFactory>;
 
-// Mirrors SELF_HOSTED_V2_LICENSE_KEY_PREFIX in ee/license-fns; inlined to avoid a services -> ee
-// runtime import cycle (license-client <- license-service <- license-fns).
-const SELF_HOSTED_V2_LICENSE_KEY_PREFIX = "infisical_lk_";
-
 // Returns null (SDK dormant -> getFeature serves fallbacks) unless the kill switch is on and either a
-// self-hosted v2 license key or the cloud service key (plus server URL) is configured.
+// self-hosted license key or the cloud service key (plus server URL) is configured.
 const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicenseClientBackend | null => {
-  if (envConfig.LICENSE_SERVER_V2_MODE === "off") {
-    return null;
+  const licenseKey = envConfig.LICENSE_KEY;
+  if (licenseKey) {
+    if (!envConfig.LICENSE_SERVER_URL) {
+      logger.warn(
+        "license-client: self-hosted key set but LICENSE_SERVER_URL (token endpoint) is missing; serving feature fallbacks"
+      );
+      return null;
+    }
+    const tokenProvider = createSelfHostedTokenProvider(licenseKey, { serverUrl: envConfig.LICENSE_SERVER_URL });
+    return licenseServerSelfHostedBackend(envConfig.LICENSE_SERVER_URL, tokenProvider, envConfig.INTERNAL_REGION);
   }
 
   const serverUrl = envConfig.LICENSE_SERVER_V2_URL;
@@ -58,13 +64,6 @@ const buildBackend = (envConfig: TLicenseClientFactoryDep["envConfig"]): TLicens
   if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
     logger.warn("license-client: LICENSE_SERVER_V2_URL must use http(s); serving feature fallbacks");
     return null;
-  }
-
-  // A self-hosted v2 license authenticates with its own key as a bearer token; the cloud path mints an
-  // RS256 service JWT from the service key instead.
-  const licenseKey = envConfig.LICENSE_KEY;
-  if (licenseKey?.startsWith(SELF_HOSTED_V2_LICENSE_KEY_PREFIX)) {
-    return licenseServerSelfHostedBackend(serverUrl, licenseKey, envConfig.INTERNAL_REGION);
   }
 
   const signingKey = envConfig.LICENSE_SERVER_V2_SERVICE_KEY;

--- a/backend/src/services/license-client/license-token-provider.test.ts
+++ b/backend/src/services/license-client/license-token-provider.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 import { createSelfHostedTokenProvider } from "./license-token-provider";
 

--- a/backend/src/services/license-client/license-token-provider.test.ts
+++ b/backend/src/services/license-client/license-token-provider.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { createSelfHostedTokenProvider } from "./license-token-provider";
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}));
+
+const SERVER_URL = "https://license.example.com";
+const LICENSE_KEY = "infisical_lk_test";
+
+// Build a JWT-shaped string ("header.payload.sig") whose payload carries the given exp (unix seconds).
+const makeJwt = (expSeconds: number | null): string => {
+  const payload = expSeconds === null ? {} : { exp: expSeconds };
+  const encode = (obj: object) => Buffer.from(JSON.stringify(obj)).toString("base64url");
+  return `${encode({ alg: "HS256" })}.${encode(payload)}.sig`;
+};
+
+const nowSeconds = () => Math.floor(Date.now() / 1000);
+
+const mockFetchReturning = (token: string) =>
+  vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ token })
+  })) as unknown as typeof fetch;
+
+describe("createSelfHostedTokenProvider", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("exchanges once and serves the cached token until near expiry", async () => {
+    const fetchMock = mockFetchReturning(makeJwt(nowSeconds() + 3600));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createSelfHostedTokenProvider(LICENSE_KEY, { serverUrl: SERVER_URL });
+
+    const first = await provider.getToken();
+    const second = await provider.getToken();
+
+    expect(first).toBe(second);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Posts the key to the token endpoint as X-API-KEY.
+    const [url, init] = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe(`${SERVER_URL}/api/auth/v1/license-login`);
+    expect((init.headers as Record<string, string>)["X-API-KEY"]).toBe(LICENSE_KEY);
+  });
+
+  test("re-exchanges after invalidate()", async () => {
+    const fetchMock = mockFetchReturning(makeJwt(nowSeconds() + 3600));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createSelfHostedTokenProvider(LICENSE_KEY, { serverUrl: SERVER_URL });
+
+    await provider.getToken();
+    provider.invalidate();
+    await provider.getToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("re-exchanges when the cached token is within the expiry margin", async () => {
+    // exp only 30s out (< 60s margin), so every read is treated as expired.
+    const fetchMock = mockFetchReturning(makeJwt(nowSeconds() + 30));
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createSelfHostedTokenProvider(LICENSE_KEY, { serverUrl: SERVER_URL });
+
+    await provider.getToken();
+    await provider.getToken();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("single-flights concurrent exchanges", async () => {
+    let resolveFetch: (value: { ok: boolean; json: () => Promise<{ token: string }> }) => void = () => {};
+    const fetchMock = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        })
+    ) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createSelfHostedTokenProvider(LICENSE_KEY, { serverUrl: SERVER_URL });
+
+    const token = makeJwt(nowSeconds() + 3600);
+    const [a, b] = await Promise.all([
+      (async () => {
+        const p = provider.getToken();
+        resolveFetch({ ok: true, json: async () => ({ token }) });
+        return p;
+      })(),
+      provider.getToken()
+    ]);
+
+    expect(a).toBe(token);
+    expect(b).toBe(token);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when the token endpoint returns an error", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      text: async () => "unauthorized"
+    })) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+    const provider = createSelfHostedTokenProvider(LICENSE_KEY, { serverUrl: SERVER_URL });
+
+    await expect(provider.getToken()).rejects.toThrow(/token exchange failed/);
+  });
+});

--- a/backend/src/services/license-client/license-token-provider.ts
+++ b/backend/src/services/license-client/license-token-provider.ts
@@ -1,0 +1,95 @@
+import { logger } from "@app/lib/logger";
+
+export type TLicenseTokenProvider = {
+  // Exchanges the license key for a JWT (cached until near expiry) and returns it as a bearer.
+  getToken: () => Promise<string>;
+  // Drops the cached token so the next getToken re-exchanges (used to recover from a mid-flight 401).
+  invalidate: () => void;
+};
+
+// Both self-hosted license key formats (legacy and infisical_lk_) authenticate the same way: POST the
+// key to the license server's token endpoint and use the returned short-lived JWT as a bearer. The
+// endpoint lives on LICENSE_SERVER_URL (the same base the v1 on-prem login uses), not the v2 API base.
+const LICENSE_LOGIN_PATH = "/api/auth/v1/license-login";
+
+// Refresh this many seconds before the JWT's exp so an in-flight request never carries an expired token.
+const EXPIRY_MARGIN_SECONDS = 60;
+
+// Fallback cache lifetime when the token carries no readable exp — short enough to re-exchange often,
+// long enough to avoid a login per request.
+const FALLBACK_TTL_SECONDS = 5 * 60;
+
+// Read exp (unix seconds) from a JWT without verifying it — the license server verifies the signature;
+// we only need the expiry to schedule a refresh. Returns null when exp is missing/unreadable.
+const readJwtExp = (token: string): number | null => {
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(Buffer.from(segments[1], "base64url").toString("utf8")) as { exp?: number };
+    return typeof payload.exp === "number" ? payload.exp : null;
+  } catch {
+    return null;
+  }
+};
+
+export const createSelfHostedTokenProvider = (
+  licenseKey: string,
+  opts: { serverUrl: string }
+): TLicenseTokenProvider => {
+  let cachedToken: string | null = null;
+  let expiresAtSeconds = 0;
+  // Single-flight: concurrent callers on an expired token share one exchange instead of stampeding.
+  let pending: Promise<string> | null = null;
+
+  const exchange = async (): Promise<string> => {
+    const url = new URL(LICENSE_LOGIN_PATH, opts.serverUrl);
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "X-API-KEY": licenseKey, "Content-Type": "application/json" },
+      body: "{}",
+      redirect: "manual"
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => "");
+      throw new Error(`license-client: token exchange failed [status=${res.status}] ${detail}`.trim());
+    }
+    const body = (await res.json()) as { token?: string };
+    if (!body.token) {
+      throw new Error("license-client: token exchange returned no token");
+    }
+    return body.token;
+  };
+
+  const getToken = async (): Promise<string> => {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (cachedToken && nowSeconds < expiresAtSeconds - EXPIRY_MARGIN_SECONDS) {
+      return cachedToken;
+    }
+    if (pending) {
+      return pending;
+    }
+    pending = (async () => {
+      try {
+        const token = await exchange();
+        cachedToken = token;
+        expiresAtSeconds = readJwtExp(token) ?? nowSeconds + FALLBACK_TTL_SECONDS;
+        return token;
+      } catch (error) {
+        logger.error(error, "license-client: failed to obtain a license token");
+        throw error;
+      } finally {
+        pending = null;
+      }
+    })();
+    return pending;
+  };
+
+  const invalidate = () => {
+    cachedToken = null;
+    expiresAtSeconds = 0;
+  };
+
+  return { getToken, invalidate };
+};

--- a/backend/src/services/license-client/license-token-provider.ts
+++ b/backend/src/services/license-client/license-token-provider.ts
@@ -7,9 +7,6 @@ export type TLicenseTokenProvider = {
   invalidate: () => void;
 };
 
-// Both self-hosted license key formats (legacy and infisical_lk_) authenticate the same way: POST the
-// key to the license server's token endpoint and use the returned short-lived JWT as a bearer. The
-// endpoint lives on LICENSE_SERVER_URL (the same base the v1 on-prem login uses), not the v2 API base.
 const LICENSE_LOGIN_PATH = "/api/auth/v1/license-login";
 
 // Refresh this many seconds before the JWT's exp so an in-flight request never carries an expired token.

--- a/backend/src/services/license-client/usage/usage-counters.ts
+++ b/backend/src/services/license-client/usage/usage-counters.ts
@@ -41,7 +41,7 @@ export const buildMeteredFeatures = ({
   usageCounterDAL,
   isCloud
 }: TBuildMeteredFeaturesDep): TMeteredFeature[] => [
-  { feature: IdentitiesMeter, count: (orgId) => licenseDAL.countOrgUsersAndIdentities(orgId) },
+  { feature: IdentitiesMeter, count: (orgId) => licenseDAL.countOrgUsersAndIdentities(isCloud ? orgId : null) },
   { feature: InternalCas, count: (orgId) => usageCounterDAL.countInternalCas(orgId) },
   { feature: ActiveCerts, count: (orgId) => usageCounterDAL.countActiveCerts(orgId) },
   {

--- a/backend/src/services/license-client/usage/usage-event-queue.ts
+++ b/backend/src/services/license-client/usage/usage-event-queue.ts
@@ -161,13 +161,13 @@ export const usageEventQueueFactory = ({
   const init = () => {
     startWorker();
 
-    // cronJob.register({
-    //   name: CronJobName.LicenseUsageFlush,
-    //   pattern: "0 0 * * *", // daily at midnight UTC
-    //   runHashTtlS: 60 * 60,
-    //   enabled: !isCloud && !isOffline,
-    //   handler: flushInstanceUsage
-    // });
+    cronJob.register({
+      name: CronJobName.LicenseUsageFlush,
+      pattern: "0 0 * * *", // daily at midnight UTC
+      runHashTtlS: 60 * 60,
+      enabled: !isCloud && !isOffline,
+      handler: flushInstanceUsage
+    });
   };
 
   return { init, handleUsageEvent, flushInstanceUsage };

--- a/backend/src/services/license-client/usage/usage-event-queue.ts
+++ b/backend/src/services/license-client/usage/usage-event-queue.ts
@@ -3,7 +3,6 @@ import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/
 import { CronJobName, TCronJobFactory } from "@app/lib/cron/cron-job";
 import { logger } from "@app/lib/logger";
 import { QueueName, TQueueServiceFactory } from "@app/queue";
-import { TOrgDALFactory } from "@app/services/org/org-dal";
 
 import { ActiveCerts, InternalCas } from "../features";
 import { TMeteredFeature } from "./usage-counters";
@@ -13,16 +12,22 @@ import { TUsageReporter, UsageReportError } from "./usage-reporter";
 // Temporarily not reporting the internal-CA and certificate meters; events for these drain harmlessly.
 const SKIPPED_DIMENSION_KEYS = new Set<string>([InternalCas.key, ActiveCerts.key]);
 
+// Self-hosted is a single license covering the whole database, so usage is reported once at this
+// instance identity ("full database" level) rather than per organization. Mirrors
+// SELF_HOSTED_LICENSE_ORG_ID in ee/license-service; inlined to avoid a services -> ee import.
+const SELF_HOSTED_LICENSE_ORG_ID = "self-hosted";
+
 type TUsageEventQueueFactoryDep = {
   queueService: Pick<TQueueServiceFactory, "start">;
   cronJob: TCronJobFactory;
   keyStore: Pick<TKeyStoreFactory, "getItem" | "setItemWithExpiry">;
-  orgDAL: Pick<TOrgDALFactory, "find">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
   meteredFeatures: TMeteredFeature[];
   usageReporter: TUsageReporter | null;
   isCloud: boolean;
+  // Offline (air-gapped) licenses can't reach the license server, so the true-up cron stays disabled.
+  isOffline: boolean;
   source: string;
 };
 
@@ -30,12 +35,12 @@ export const usageEventQueueFactory = ({
   queueService,
   cronJob,
   keyStore,
-  orgDAL,
   licenseService,
   usageMeteringService,
   meteredFeatures,
   usageReporter,
   isCloud,
+  isOffline,
   source
 }: TUsageEventQueueFactoryDep) => {
   const featureByKey = new Map(meteredFeatures.map((m) => [m.feature.key, m]));
@@ -58,6 +63,12 @@ export const usageEventQueueFactory = ({
         return;
       }
     }
+
+    // Self-hosted is one license over the whole database: report (and dedup) once at the instance
+    // identity, not per triggering org. The metered counts already span the whole instance in that
+    // mode, so the org that triggered the event is irrelevant here.
+    const reportOrgId = isCloud ? orgId : SELF_HOSTED_LICENSE_ORG_ID;
+
     try {
       const metered = featureByKey.get(dimensionKey);
       if (!metered) {
@@ -65,9 +76,9 @@ export const usageEventQueueFactory = ({
         return;
       }
 
-      const value = await metered.count(orgId);
+      const value = await metered.count(reportOrgId);
 
-      const lastReportedKey = KeyStorePrefixes.LicenseUsageLastReported(orgId, dimensionKey);
+      const lastReportedKey = KeyStorePrefixes.LicenseUsageLastReported(reportOrgId, dimensionKey);
       const lastReported = await keyStore.getItem(lastReportedKey);
       if (lastReported !== null && Number(lastReported) === value) {
         return;
@@ -78,12 +89,12 @@ export const usageEventQueueFactory = ({
       // dimension, so swallow it (no retry, don't record it as reported). Any other failure rethrows to
       // the outer handler so the job retries.
       try {
-        await usageReporter.reportSnapshots(orgId, [
+        await usageReporter.reportSnapshots(reportOrgId, [
           {
             dimension_key: dimensionKey,
             value,
             observed_at: observedAt.toISOString(),
-            idempotency_key: `${source}:${orgId}:${dimensionKey}:${observedAt.getTime()}`,
+            idempotency_key: `${source}:${reportOrgId}:${dimensionKey}:${observedAt.getTime()}`,
             source
           }
         ]);
@@ -91,7 +102,7 @@ export const usageEventQueueFactory = ({
         if (error instanceof UsageReportError) {
           if (error.status === 404 && error.serverMessage.includes("license not found")) {
             logger.info(
-              `usage-event-queue: license not found, skipping [orgId=${orgId}] [dimensionKey=${dimensionKey}]`
+              `usage-event-queue: license not found, skipping [orgId=${reportOrgId}] [dimensionKey=${dimensionKey}]`
             );
             return;
           }
@@ -100,7 +111,7 @@ export const usageEventQueueFactory = ({
             error.serverMessage.includes("not priced by any active product on this license")
           ) {
             logger.info(
-              `usage-event-queue: dimension not priced on this license, skipping [orgId=${orgId}] [dimensionKey=${dimensionKey}]`
+              `usage-event-queue: dimension not priced on this license, skipping [orgId=${reportOrgId}] [dimensionKey=${dimensionKey}]`
             );
             return;
           }
@@ -109,40 +120,29 @@ export const usageEventQueueFactory = ({
       }
 
       logger.info(
-        `usage-event-queue: reported usage event [orgId=${orgId}] [dimensionKey=${dimensionKey}] [value=${value}]`
+        `usage-event-queue: reported usage event [orgId=${reportOrgId}] [dimensionKey=${dimensionKey}] [value=${value}]`
       );
       await keyStore.setItemWithExpiry(lastReportedKey, KeyStoreTtls.LicenseUsageLastReportedInSeconds, String(value));
     } catch (error) {
       logger.error(
         error,
-        `usage-event-queue: failed to handle usage event [orgId=${orgId}] [dimensionKey=${dimensionKey}]`
+        `usage-event-queue: failed to handle usage event [orgId=${reportOrgId}] [dimensionKey=${dimensionKey}]`
       );
       throw error;
     }
   };
 
-  // Self-hosted true-up: online instances also report event-driven, so this is a periodic backstop
-  // for cap visibility and renewal. Cloud is event-driven only.
-  const flushAllOrgs = async () => {
+  // Self-hosted true-up: a daily backstop for cap visibility and renewal on top of event-driven
+  // reporting. Self-hosted usage is metered and reported once at the instance identity, so this just
+  // re-emits each meter once (no per-org fan-out); handleUsageEvent counts instance-wide and dedups.
+  // Cloud is event-driven only.
+  const flushInstanceUsage = async () => {
     if (!usageReporter) {
       return;
     }
 
-    // Page through orgs so a large self-hosted deployment doesn't materialize the whole table.
-    const batchSize = 500;
-    let offset = 0;
-    for (;;) {
-      // eslint-disable-next-line no-await-in-loop
-      const orgs = await orgDAL.find({}, { limit: batchSize, offset });
-      for (const org of orgs) {
-        for (const metered of meteredFeatures) {
-          usageMeteringService.emit(org.id, metered.feature.key);
-        }
-      }
-      if (orgs.length < batchSize) {
-        break;
-      }
-      offset += batchSize;
+    for (const metered of meteredFeatures) {
+      usageMeteringService.emit(SELF_HOSTED_LICENSE_ORG_ID, metered.feature.key);
     }
   };
 
@@ -161,14 +161,14 @@ export const usageEventQueueFactory = ({
   const init = () => {
     startWorker();
 
-    cronJob.register({
-      name: CronJobName.LicenseUsageFlush,
-      pattern: "*/30 * * * *",
-      runHashTtlS: 60 * 60,
-      enabled: !isCloud,
-      handler: flushAllOrgs
-    });
+    // cronJob.register({
+    //   name: CronJobName.LicenseUsageFlush,
+    //   pattern: "0 0 * * *", // daily at midnight UTC
+    //   runHashTtlS: 60 * 60,
+    //   enabled: !isCloud && !isOffline,
+    //   handler: flushInstanceUsage
+    // });
   };
 
-  return { init, handleUsageEvent, flushAllOrgs };
+  return { init, handleUsageEvent, flushInstanceUsage };
 };

--- a/backend/src/services/license-client/usage/usage-metering.test.ts
+++ b/backend/src/services/license-client/usage/usage-metering.test.ts
@@ -295,8 +295,8 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
     overrides: {
       usageReporter?: unknown;
       keyStore?: ReturnType<typeof createFakeKeyStore>;
-      orgFind?: unknown;
       isCloud?: boolean;
+      isOffline?: boolean;
       getPlan?: (orgId: string) => Promise<{ slug: string | null }>;
     } = {}
   ) => {
@@ -304,22 +304,22 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
     const keyStore = overrides.keyStore ?? createFakeKeyStore();
     const usageReporter = overrides.usageReporter === undefined ? { reportSnapshots } : overrides.usageReporter;
     const emit = vi.fn();
-    const find = overrides.orgFind ?? vi.fn(async () => []);
+    const register = vi.fn();
     // Default to a billable plan so the cloud slug gate is a pass-through unless a test overrides it.
     const getPlan = vi.fn(overrides.getPlan ?? (async () => ({ slug: "pro" })));
     const queue = usageEventQueueFactory({
       queueService: { start: vi.fn() },
-      cronJob: { register: vi.fn(), start: vi.fn(), stop: vi.fn() } as never,
+      cronJob: { register, start: vi.fn(), stop: vi.fn() } as never,
       keyStore,
-      orgDAL: { find } as never,
       licenseService: { getPlan } as never,
       usageMeteringService: { emit },
       meteredFeatures,
       usageReporter: usageReporter as never,
       isCloud: overrides.isCloud ?? false,
+      isOffline: overrides.isOffline ?? false,
       source: "test-region"
     });
-    return { queue, reportSnapshots, keyStore, emit, find, getPlan };
+    return { queue, reportSnapshots, keyStore, emit, getPlan, register };
   };
 
   beforeEach(() => {
@@ -332,8 +332,8 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
     expect(meteredFeatures[0].count).not.toHaveBeenCalled();
   });
 
-  test("reports a snapshot and records the value on first observation", async () => {
-    const { queue, reportSnapshots, keyStore } = buildQueue();
+  test("reports a snapshot and records the value on first observation (cloud, per org)", async () => {
+    const { queue, reportSnapshots, keyStore } = buildQueue({ isCloud: true });
     await queue.handleUsageEvent(ORG_ID, IdentitiesMeter.key, new Date());
 
     expect(reportSnapshots).toHaveBeenCalledTimes(1);
@@ -345,6 +345,18 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
       source: "test-region"
     });
     expect(keyStore.store.get(`license-usage-last-reported-${ORG_ID}-${IdentitiesMeter.key}`)).toBe("42");
+  });
+
+  test("self-hosted reports at the instance ('self-hosted') identity, not the triggering org", async () => {
+    const { queue, reportSnapshots, keyStore } = buildQueue({ isCloud: false });
+    await queue.handleUsageEvent(ORG_ID, IdentitiesMeter.key, new Date());
+
+    expect(reportSnapshots).toHaveBeenCalledTimes(1);
+    const [orgId] = reportSnapshots.mock.calls[0] as unknown as [string, TUsageSnapshot[]];
+    expect(orgId).toBe("self-hosted");
+    // Deduped under the instance identity, not the org that triggered the event.
+    expect(keyStore.store.get(`license-usage-last-reported-self-hosted-${IdentitiesMeter.key}`)).toBe("42");
+    expect(keyStore.store.get(`license-usage-last-reported-${ORG_ID}-${IdentitiesMeter.key}`)).toBeUndefined();
   });
 
   test("on cloud, skips a free org (null slug) before counting to avoid a 404", async () => {
@@ -390,7 +402,7 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
   test("skips the report when the count is unchanged", async () => {
     const keyStore = createFakeKeyStore();
     keyStore.store.set(`license-usage-last-reported-${ORG_ID}-${IdentitiesMeter.key}`, "42");
-    const { queue, reportSnapshots } = buildQueue({ keyStore });
+    const { queue, reportSnapshots } = buildQueue({ keyStore, isCloud: true });
 
     await queue.handleUsageEvent(ORG_ID, IdentitiesMeter.key, new Date());
     expect(reportSnapshots).not.toHaveBeenCalled();
@@ -406,7 +418,7 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
     const reportSnapshots = vi.fn(async () => {
       throw new UsageReportError(422, "dimension X is not priced by any active product on this license");
     });
-    const { queue, keyStore } = buildQueue({ usageReporter: { reportSnapshots } });
+    const { queue, keyStore } = buildQueue({ usageReporter: { reportSnapshots }, isCloud: true });
 
     // Does not throw (so the job is not retried).
     await expect(queue.handleUsageEvent(ORG_ID, IdentitiesMeter.key, new Date())).resolves.toBeUndefined();
@@ -425,25 +437,32 @@ describe("usageEventQueue.handleUsageEvent (worker)", () => {
     );
   });
 
-  test("flushAllOrgs pages through orgs and emits per meter", async () => {
-    const fullPage = Array.from({ length: 500 }, (_, i) => ({ id: `org-${i}` }));
-    const lastPage = [{ id: "org-500" }];
-    const orgFind = vi.fn().mockResolvedValueOnce(fullPage).mockResolvedValueOnce(lastPage);
-    const { queue, emit } = buildQueue({ orgFind });
+  test("flushInstanceUsage emits each meter once at the instance identity (no per-org fan-out)", async () => {
+    const { queue, emit } = buildQueue();
 
-    await queue.flushAllOrgs();
+    await queue.flushInstanceUsage();
 
-    expect(orgFind).toHaveBeenCalledTimes(2); // stops after the partial page
-    expect(orgFind).toHaveBeenNthCalledWith(1, {}, { limit: 500, offset: 0 });
-    expect(orgFind).toHaveBeenNthCalledWith(2, {}, { limit: 500, offset: 500 });
-    expect(emit).toHaveBeenCalledTimes(501); // 501 orgs x 1 metered feature
+    expect(emit).toHaveBeenCalledTimes(meteredFeatures.length); // one emit per meter, not per org
+    expect(emit).toHaveBeenCalledWith("self-hosted", IdentitiesMeter.key);
   });
 
-  test("flushAllOrgs no-ops when the reporter is null", async () => {
-    const { queue, emit, find } = buildQueue({ usageReporter: null });
-    await queue.flushAllOrgs();
-    expect(find).not.toHaveBeenCalled();
+  test("flushInstanceUsage no-ops when the reporter is null", async () => {
+    const { queue, emit } = buildQueue({ usageReporter: null });
+    await queue.flushInstanceUsage();
     expect(emit).not.toHaveBeenCalled();
+  });
+
+  test("registers the true-up cron enabled for self-hosted, disabled for cloud/offline", async () => {
+    const enabledFor = (opts: { isCloud?: boolean; isOffline?: boolean }) => {
+      const { queue, register } = buildQueue(opts);
+      queue.init();
+      const [{ enabled }] = register.mock.calls[0] as unknown as [{ enabled: boolean }];
+      return enabled;
+    };
+
+    expect(enabledFor({})).toBe(true); // self-hosted online
+    expect(enabledFor({ isCloud: true })).toBe(false);
+    expect(enabledFor({ isOffline: true })).toBe(false);
   });
 });
 

--- a/backend/src/services/license-client/usage/usage-metering.test.ts
+++ b/backend/src/services/license-client/usage/usage-metering.test.ts
@@ -203,18 +203,23 @@ describe("usageMeteringService.reconcile (demand-driven)", () => {
 
 describe("buildUsageReporter", () => {
   test("is null when disabled", () => {
-    expect(buildUsageReporter({ LICENSE_SERVER_V2_MODE: "off" })).toBeNull();
+    expect(
+      buildUsageReporter({ LICENSE_SERVER_V2_MODE: "off", LICENSE_SERVER_URL: "https://license.example.com" })
+    ).toBeNull();
   });
 
   test("is null when enabled but unconfigured", () => {
-    expect(buildUsageReporter({ LICENSE_SERVER_V2_MODE: "read-compare" })).toBeNull();
+    expect(
+      buildUsageReporter({ LICENSE_SERVER_V2_MODE: "read-compare", LICENSE_SERVER_URL: "https://license.example.com" })
+    ).toBeNull();
   });
 
   test("is a reporter when enabled and configured", () => {
     const reporter = buildUsageReporter({
       LICENSE_SERVER_V2_MODE: "read-compare",
       LICENSE_SERVER_V2_URL: "https://license.example.com",
-      LICENSE_SERVER_V2_SERVICE_KEY: "svc-key"
+      LICENSE_SERVER_V2_SERVICE_KEY: "svc-key",
+      LICENSE_SERVER_URL: "https://license.example.com"
     });
     expect(reporter).not.toBeNull();
     expect(typeof reporter?.reportSnapshots).toBe("function");

--- a/backend/src/services/license-client/usage/usage-reporter.ts
+++ b/backend/src/services/license-client/usage/usage-reporter.ts
@@ -2,6 +2,7 @@ import { TEnvConfig } from "@app/lib/config/env";
 import { logger } from "@app/lib/logger";
 
 import { mintServiceToken } from "../license-client-backends";
+import { createSelfHostedTokenProvider } from "../license-token-provider";
 
 export type TUsageSnapshot = {
   dimension_key: string;
@@ -30,9 +31,9 @@ export class UsageReportError extends Error {
   }
 }
 
-// getBearerToken is called per request so a cloud reporter can mint a fresh short-lived JWT each time
-// (a self-hosted reporter just returns its static license key).
-export const usageReporterFactory = (serverUrl: string, getBearerToken: () => string): TUsageReporter => ({
+// getBearerToken is called per request so a cloud reporter can mint a fresh short-lived JWT each time,
+// while a self-hosted reporter exchanges its license key for a cached JWT at the token endpoint.
+export const usageReporterFactory = (serverUrl: string, getBearerToken: () => Promise<string>): TUsageReporter => ({
   reportSnapshots: async (orgId: string, snapshots: TUsageSnapshot[]) => {
     if (!snapshots.length) {
       return;
@@ -41,7 +42,7 @@ export const usageReporterFactory = (serverUrl: string, getBearerToken: () => st
     const url = new URL(`/v1/organizations/${encodeURIComponent(orgId)}/usage-snapshots`, serverUrl);
     const res = await fetch(url, {
       method: "POST",
-      headers: { Authorization: `Bearer ${getBearerToken()}`, "Content-Type": "application/json" },
+      headers: { Authorization: `Bearer ${await getBearerToken()}`, "Content-Type": "application/json" },
       body: JSON.stringify({ snapshots }),
       redirect: "manual"
     });
@@ -59,17 +60,19 @@ export const usageReporterFactory = (serverUrl: string, getBearerToken: () => st
   }
 });
 
-// Mirrors SELF_HOSTED_V2_LICENSE_KEY_PREFIX in ee/license-fns; inlined to avoid a services -> ee import.
-const SELF_HOSTED_V2_LICENSE_KEY_PREFIX = "infisical_lk_";
-
 // Returns null when the v2 license server is disabled or unconfigured, which keeps usage reporting
-// inert. A self-hosted v2 license reports with its own license key as the bearer; cloud mints a
-// short-lived RS256 service JWT signed with the service key (the same scheme the rest of the v2
-// client uses), so the raw signing key is never sent over the wire.
+// inert. A self-hosted v2 license exchanges its key for a short-lived JWT at the token endpoint (on
+// LICENSE_SERVER_URL) and reports with that bearer; cloud mints a short-lived RS256 service JWT signed
+// with the service key (the same scheme the rest of the v2 client uses). The raw key/signing key is
+// never sent as the bearer.
 export const buildUsageReporter = (
   envConfig: Pick<
     TEnvConfig,
-    "LICENSE_SERVER_V2_MODE" | "LICENSE_SERVER_V2_URL" | "LICENSE_SERVER_V2_SERVICE_KEY" | "LICENSE_KEY"
+    | "LICENSE_SERVER_V2_MODE"
+    | "LICENSE_SERVER_V2_URL"
+    | "LICENSE_SERVER_V2_SERVICE_KEY"
+    | "LICENSE_SERVER_URL"
+    | "LICENSE_KEY"
   >
 ): TUsageReporter | null => {
   if (envConfig.LICENSE_SERVER_V2_MODE === "off") {
@@ -95,10 +98,16 @@ export const buildUsageReporter = (
     return null;
   }
 
-  // Self-hosted: authenticate with the raw license key as the bearer.
+  // Self-hosted (any license key format): exchange the key for a short-lived JWT at the token endpoint
+  // and use that. Cloud sets no LICENSE_KEY, so it falls through to the service-JWT path below.
   const licenseKey = envConfig.LICENSE_KEY;
-  if (licenseKey?.startsWith(SELF_HOSTED_V2_LICENSE_KEY_PREFIX)) {
-    return usageReporterFactory(serverUrl, () => licenseKey);
+  if (licenseKey) {
+    if (!envConfig.LICENSE_SERVER_URL) {
+      logger.warn("usage-reporter: self-hosted key set but LICENSE_SERVER_URL is missing; usage reporting disabled");
+      return null;
+    }
+    const tokenProvider = createSelfHostedTokenProvider(licenseKey, { serverUrl: envConfig.LICENSE_SERVER_URL });
+    return usageReporterFactory(serverUrl, () => tokenProvider.getToken());
   }
 
   // Cloud: mint a fresh service JWT per request signed with the service key (an RSA private key).
@@ -109,5 +118,5 @@ export const buildUsageReporter = (
     );
     return null;
   }
-  return usageReporterFactory(serverUrl, () => mintServiceToken(serviceKey));
+  return usageReporterFactory(serverUrl, () => Promise.resolve(mintServiceToken(serviceKey)));
 };

--- a/backend/src/services/license-client/usage/usage-reporter.ts
+++ b/backend/src/services/license-client/usage/usage-reporter.ts
@@ -79,9 +79,13 @@ export const buildUsageReporter = (
     return null;
   }
 
-  const serverUrl = envConfig.LICENSE_SERVER_V2_URL;
+  // Self-hosted sets only LICENSE_SERVER_URL (that one host now serves both the token endpoint and the
+  // v2 API after the DNS switch); cloud sets LICENSE_SERVER_V2_URL. Accept either as the v2 API base.
+  const serverUrl = envConfig.LICENSE_SERVER_V2_URL || envConfig.LICENSE_SERVER_URL;
   if (!serverUrl) {
-    logger.warn("usage-reporter: enabled but LICENSE_SERVER_V2_URL is missing; usage reporting disabled");
+    logger.warn(
+      "usage-reporter: enabled but neither LICENSE_SERVER_V2_URL nor LICENSE_SERVER_URL is set; usage reporting disabled"
+    );
     return null;
   }
 
@@ -90,11 +94,11 @@ export const buildUsageReporter = (
   try {
     parsedUrl = new URL(serverUrl);
   } catch {
-    logger.warn("usage-reporter: LICENSE_SERVER_V2_URL is not a valid URL; usage reporting disabled");
+    logger.warn("usage-reporter: license server URL is not a valid URL; usage reporting disabled");
     return null;
   }
   if (parsedUrl.protocol !== "https:" && process.env.NODE_ENV !== "development") {
-    logger.warn("usage-reporter: LICENSE_SERVER_V2_URL must use https; usage reporting disabled");
+    logger.warn("usage-reporter: license server URL must use https; usage reporting disabled");
     return null;
   }
 

--- a/frontend/src/hooks/api/subscriptions/types.ts
+++ b/frontend/src/hooks/api/subscriptions/types.ts
@@ -30,6 +30,7 @@ export type SubscriptionPlan = {
   rbac: boolean;
   secretVersioning: boolean;
   slug: SubscriptionPlanTypes;
+  isOffline?: boolean;
   secretApproval: boolean;
   secretRotation: boolean;
   tier: number;

--- a/frontend/src/pages/organization/BillingPage/BillingPage.tsx
+++ b/frontend/src/pages/organization/BillingPage/BillingPage.tsx
@@ -3,14 +3,27 @@ import { useTranslation } from "react-i18next";
 
 import { OrgPermissionCan } from "@app/components/permissions";
 import { PageHeader } from "@app/components/v2";
-import { OrgPermissionBillingActions, OrgPermissionSubjects, useServerConfig } from "@app/context";
+import {
+  OrgPermissionBillingActions,
+  OrgPermissionSubjects,
+  useServerConfig,
+  useSubscription
+} from "@app/context";
 
 import { BillingV2Page } from "../BillingV2Page";
 import { BillingTabGroup } from "./components";
+import { OfflineBillingPage } from "./OfflineBillingPage";
 
 export const BillingPage = () => {
   const { t } = useTranslation();
   const { config } = useServerConfig();
+  const { subscription } = useSubscription();
+
+  // Offline (air-gapped) licenses can't reach the license server, so neither billing surface can load;
+  // short-circuit to the offline page (no API calls) before mounting either.
+  if (subscription?.isOffline) {
+    return <OfflineBillingPage />;
+  }
 
   if (config.licenseServerV2Enabled) {
     return <BillingV2Page />;

--- a/frontend/src/pages/organization/BillingPage/OfflineBillingPage.tsx
+++ b/frontend/src/pages/organization/BillingPage/OfflineBillingPage.tsx
@@ -1,0 +1,49 @@
+import { Helmet } from "react-helmet";
+import { useTranslation } from "react-i18next";
+import { TriangleAlert } from "lucide-react";
+
+import { OrgPermissionCan } from "@app/components/permissions";
+import { PageHeader } from "@app/components/v2";
+import { Alert, AlertDescription, AlertTitle } from "@app/components/v3";
+import { OrgPermissionBillingActions, OrgPermissionSubjects } from "@app/context";
+
+// Standalone billing page for offline (air-gapped) licenses. It makes no API calls — the license
+// server is unreachable, so every billing/subscription request would fail — and just explains that
+// billing is managed out-of-band.
+export const OfflineBillingPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="h-full bg-bunker-800">
+      <Helmet>
+        <title>{t("common.head-title", { title: t("billing.title") })}</title>
+        <link rel="icon" href="/infisical.ico" />
+        <meta property="og:image" content="/images/message.png" />
+      </Helmet>
+      <div className="flex h-full w-full justify-center bg-bunker-800 text-white">
+        <div className="w-full max-w-8xl">
+          <PageHeader
+            scope="org"
+            title={t("billing.title")}
+            description="Your plan is provisioned through an offline license."
+          />
+          <OrgPermissionCan
+            passThrough={false}
+            I={OrgPermissionBillingActions.Read}
+            a={OrgPermissionSubjects.Billing}
+          >
+            <Alert variant="info">
+              <TriangleAlert />
+              <AlertTitle>Offline license</AlertTitle>
+              <AlertDescription>
+                This instance runs on an offline license, so subscription and billing management
+                isn&apos;t available here. Contact your Infisical account manager to make changes to
+                your plan.
+              </AlertDescription>
+            </Alert>
+          </OrgPermissionCan>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/organization/BillingV2Page/billing-v2-format.ts
+++ b/frontend/src/pages/organization/BillingV2Page/billing-v2-format.ts
@@ -192,7 +192,7 @@ export const commitSavingsNudge = (
 // Capitalize a plan tier ("pro" -> "Pro") for the badge beside a product's name.
 // hardcoded legacy for now
 export const tierLabel = (tier: string): string => {
-  const stripped = tier.replace("legacy_", "");
+  const stripped = tier.replace("legacy_", "").replace(/_/g, " ");
   return stripped.charAt(0).toUpperCase() + stripped.slice(1);
 };
 


### PR DESCRIPTION
## Context

This PR implements support for 
1. Self hosted license key changes needed
2. Offline license key new format
3. Tested with old key on old image against server
4. New offline billing page - a simple message


## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)