### PR TITLE
fix: limit process threads for secret scanning

### DIFF
--- a/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.ts
+++ b/backend/src/ee/services/secret-scanning-v2/secret-scanning-v2-fns.ts
@@ -5,6 +5,7 @@ import RE2 from "re2";
 
 import {
   execFileBounded,
+  getGitThreadLimitArgs,
   getScannerProcessEnv,
   GIT_PROCESS_ENV,
   SecretScanningExecError,
@@ -147,7 +148,7 @@ export const cloneRepository = async ({ cloneUrl, repoPath }: TCloneRepository):
   // eslint-disable-next-line no-new
   new URL(cloneUrl);
 
-  await execFileBounded("git", ["clone", cloneUrl, repoPath, "--bare"], {
+  await execFileBounded("git", [...getGitThreadLimitArgs(), "clone", cloneUrl, repoPath, "--bare"], {
     phase: SecretScanningExecPhase.Clone,
     timeoutMs: getConfig().SECRET_SCANNING_CLONE_TIMEOUT_MS,
     env: GIT_PROCESS_ENV

--- a/backend/src/ee/services/secret-scanning/secret-scanning-exec.test.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-exec.test.ts
@@ -1,13 +1,23 @@
 import { execFile } from "child_process";
 import { promisify } from "util";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import {
   execFileBounded,
+  getGitThreadLimitArgs,
+  getScannerProcessEnv,
   SecretScanningExecError,
   SecretScanningExecFailure,
   SecretScanningExecPhase
 } from "./secret-scanning-exec";
+
+// getConfig is read lazily inside the env/argv helpers; only the resource caps matter here.
+const mockConfig = { SECRET_SCANNING_MEMORY_LIMIT_MB: 2048, SECRET_SCANNING_CPU_THREADS: 1 };
+
+vi.mock("@app/lib/config/env", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/config/env")>()),
+  getConfig: () => mockConfig
+}));
 
 const execFileAsync = promisify(execFile);
 
@@ -124,4 +134,57 @@ describe("execFileBounded", () => {
 
     await execFileAsync("rm", ["-f", grandchildPidFile]);
   }, 15_000);
+});
+
+describe("getScannerProcessEnv", () => {
+  test("caps scanner memory and CPU by default", () => {
+    expect(getScannerProcessEnv()).toEqual({ GOMEMLIMIT: "2048MiB", GOMAXPROCS: "1" });
+  });
+
+  test("omits the CPU cap when disabled with 0", () => {
+    mockConfig.SECRET_SCANNING_CPU_THREADS = 0;
+    try {
+      expect(getScannerProcessEnv()).toEqual({ GOMEMLIMIT: "2048MiB" });
+    } finally {
+      mockConfig.SECRET_SCANNING_CPU_THREADS = 1;
+    }
+  });
+
+  test("returns undefined when both caps are disabled", () => {
+    mockConfig.SECRET_SCANNING_MEMORY_LIMIT_MB = 0;
+    mockConfig.SECRET_SCANNING_CPU_THREADS = 0;
+    try {
+      expect(getScannerProcessEnv()).toBeUndefined();
+    } finally {
+      mockConfig.SECRET_SCANNING_MEMORY_LIMIT_MB = 2048;
+      mockConfig.SECRET_SCANNING_CPU_THREADS = 1;
+    }
+  });
+
+  test("the overrides reach the child without replacing its inherited environment", async () => {
+    // Proves the env option merges over process.env rather than replacing it: PATH must survive for
+    // the binary lookup to work at all, and the override must be visible to the child.
+    const output = await execFileBounded("sh", ["-c", "echo $GOMAXPROCS"], {
+      phase: SecretScanningExecPhase.Scan,
+      timeoutMs: 10_000,
+      env: getScannerProcessEnv()
+    });
+
+    expect(output.trim()).toBe("1");
+  });
+});
+
+describe("getGitThreadLimitArgs", () => {
+  test("caps git pack threads via -c argv", () => {
+    expect(getGitThreadLimitArgs()).toEqual(["-c", "pack.threads=1"]);
+  });
+
+  test("adds nothing when the cap is disabled with 0", () => {
+    mockConfig.SECRET_SCANNING_CPU_THREADS = 0;
+    try {
+      expect(getGitThreadLimitArgs()).toEqual([]);
+    } finally {
+      mockConfig.SECRET_SCANNING_CPU_THREADS = 1;
+    }
+  });
 });

--- a/backend/src/ee/services/secret-scanning/secret-scanning-exec.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-exec.ts
@@ -240,11 +240,30 @@ export const GIT_PROCESS_ENV = { GIT_TERMINAL_PROMPT: "0" };
  * slightly over budget still completes rather than being killed. Runtimes older than Go 1.19 simply
  * ignore it. RLIMIT_AS (`ulimit -v`) is deliberately not used — Go reserves large virtual address
  * arenas at startup, so hard virtual-memory limits break Go binaries in confusing ways.
+ *
+ * GOMAXPROCS is the CPU counterpart: without it the Go runtime schedules scan workers on every
+ * core, so a single full scan pegs the whole host for its duration and starves the API. Capping it
+ * trades scan speed for host headroom.
  */
 export const getScannerProcessEnv = (): Record<string, string> | undefined => {
-  const { SECRET_SCANNING_MEMORY_LIMIT_MB } = getConfig();
+  const { SECRET_SCANNING_MEMORY_LIMIT_MB, SECRET_SCANNING_CPU_THREADS } = getConfig();
 
-  if (!SECRET_SCANNING_MEMORY_LIMIT_MB) return undefined;
+  const env: Record<string, string> = {
+    ...(SECRET_SCANNING_MEMORY_LIMIT_MB ? { GOMEMLIMIT: `${SECRET_SCANNING_MEMORY_LIMIT_MB}MiB` } : {}),
+    ...(SECRET_SCANNING_CPU_THREADS ? { GOMAXPROCS: String(SECRET_SCANNING_CPU_THREADS) } : {})
+  };
 
-  return { GOMEMLIMIT: `${SECRET_SCANNING_MEMORY_LIMIT_MB}MiB` };
+  return Object.keys(env).length > 0 ? env : undefined;
+};
+
+/**
+ * `git clone` resolves the received pack with one thread per core (`pack.threads` defaults to the
+ * online CPU count), so a large clone can peg the host just like an uncapped scan. The limit is
+ * passed as `-c` argv rather than `GIT_CONFIG_*` environment variables so it applies on every git
+ * version, and it shows up in `ps` output for whoever is debugging a hot instance.
+ */
+export const getGitThreadLimitArgs = (): string[] => {
+  const { SECRET_SCANNING_CPU_THREADS } = getConfig();
+
+  return SECRET_SCANNING_CPU_THREADS ? ["-c", `pack.threads=${SECRET_SCANNING_CPU_THREADS}`] : [];
 };

--- a/backend/src/ee/services/secret-scanning/secret-scanning-queue/secret-scanning-fns.ts
+++ b/backend/src/ee/services/secret-scanning/secret-scanning-queue/secret-scanning-fns.ts
@@ -6,6 +6,7 @@ import { join } from "path";
 
 import {
   execFileBounded,
+  getGitThreadLimitArgs,
   getScannerProcessEnv,
   GIT_PROCESS_ENV,
   SecretScanningExecPhase
@@ -43,7 +44,7 @@ export async function cloneRepo(
   // eslint-disable-next-line no-new
   new URL(cloneUrl);
 
-  await execFileBounded("git", ["clone", cloneUrl, repoPath, "--bare"], {
+  await execFileBounded("git", [...getGitThreadLimitArgs(), "clone", cloneUrl, repoPath, "--bare"], {
     phase: SecretScanningExecPhase.Clone,
     timeoutMs: getConfig().SECRET_SCANNING_CLONE_TIMEOUT_MS,
     env: GIT_PROCESS_ENV

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -372,6 +372,14 @@ const envSchema = z
       .describe(
         "Soft memory ceiling (GOMEMLIMIT) handed to the Go scanner process. The runtime GCs harder as it approaches the limit rather than growing. Set to 0 to disable."
       ),
+    SECRET_SCANNING_CPU_THREADS: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .default(1)
+      .describe(
+        "CPU thread ceiling for scanning child processes, applied as GOMAXPROCS to the Go scanner and pack.threads to git clone. Both otherwise use every core on the host, so one full scan can saturate the instance. Set to 0 to remove the cap."
+      ),
     SECRET_SCANNING_MAX_REPO_SIZE_MB: z.coerce
       .number()
       .int()

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -1035,6 +1035,20 @@ You can configure third-party app connections for re-use across Infisical Projec
 {" "}
 
 <ParamField
+  query="SECRET_SCANNING_CPU_THREADS"
+  type="number"
+  default="1"
+  optional
+>
+  Maximum CPU threads a scan may use, applied to both the scanner process and
+  the repository clone. Scans share the instance with the API, so raising this
+  makes scans faster at the cost of API responsiveness during a scan. Defaults
+  to `1`. Set to `0` to remove the cap.
+</ParamField>
+
+{" "}
+
+<ParamField
   query="SECRET_SCANNING_MAX_REPO_SIZE_MB"
   type="number"
   default="5120"


### PR DESCRIPTION
## Context

This PR limits the process count when running infisical scan

## Screenshots

n/a

## Steps to verify the change

run scanning

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)