### PR TITLE
fix(auth): improve invalid invitation state

### DIFF
--- a/frontend/src/pages/auth/SignUpInvitePage/SignUpInvitePage.tsx
+++ b/frontend/src/pages/auth/SignUpInvitePage/SignUpInvitePage.tsx
@@ -1,9 +1,10 @@
 import { Helmet } from "react-helmet";
 import { Link, useRouteContext } from "@tanstack/react-router";
+import { MailX } from "lucide-react";
 
 import { AuthPageLayout } from "@app/components/auth/AuthPageLayout";
 import { AuthPagePanel } from "@app/components/auth/AuthPagePanel";
-import { Button, CardContent, CardDescription, CardHeader, CardTitle } from "@app/components/v3";
+import { CardContent, CardHeader, CardTitle } from "@app/components/v3";
 
 import { SignUpPage } from "../SignUpPage/SignUpPage";
 
@@ -19,18 +20,28 @@ export const SignupInvitePage = () => {
           <title>Invalid Invitation</title>
           <link rel="icon" href="/infisical.ico" />
         </Helmet>
-        <AuthPagePanel>
-          <CardHeader className="mb-6 gap-2 text-center">
-            <CardTitle>Invitation Invalid</CardTitle>
-            <CardDescription>{error}</CardDescription>
-            <CardDescription>
-              Please ask your organization administrator to send a new invitation.
-            </CardDescription>
+        <AuthPagePanel className="text-center">
+          <CardHeader className="mb-6 items-center gap-2 text-center">
+            <div
+              aria-hidden="true"
+              className="mb-4 flex size-12 items-center justify-center justify-self-center rounded-lg bg-card text-foreground/80"
+            >
+              <MailX className="size-5" strokeWidth={1.75} />
+            </div>
+            <CardTitle className="justify-center text-center font-alliance text-2xl font-normal">
+              Invitation invalid.
+            </CardTitle>
           </CardHeader>
-          <CardContent>
-            <Button asChild variant="project" size="lg" isFullWidth>
-              <Link to="/login">Go to Login</Link>
-            </Button>
+          <CardContent className="flex flex-col items-center gap-4">
+            <p className="text-sm text-balance text-label">
+              Ask your organization administrator to send you a new invitation.
+            </p>
+            <Link
+              to="/login"
+              className="self-center text-sm text-foreground/95 underline decoration-project/60 underline-offset-2 transition-colors duration-200 hover:decoration-project"
+            >
+              Back to login
+            </Link>
           </CardContent>
         </AuthPagePanel>
       </AuthPageLayout>


### PR DESCRIPTION
## Context

Fixes [PLATFOR-608](https://linear.app/infisical/issue/PLATFOR-608/fix-the-invitation-invalid-landing-ui).

Invalid organization invitation links previously rendered a loosely aligned generic error state with default card typography, redundant error copy, and an oversized full-width login button. The updated state now follows the established account-recovery/auth-adjacent composition:

- centered status icon and Alliance display title
- one balanced recovery description
- a quiet underlined link back to login
- responsive, centered hierarchy using existing v3 auth primitives

This change is limited to the invalid-invitation landing UI. It does not alter invitation verification, organization roles, or the separate ability to invite a member with the “No Access” role.

## Screenshots

<img width="3492" height="2366" alt="image" src="https://github.com/user-attachments/assets/7b9703df-27dd-4bf9-b431-585b6785588d" />

## Steps to verify the change

1. Start the frontend and backend.
2. Open `/signupinvite?token=invalid&to=invitee%40example.com&organization_id=invalid`.
3. Confirm the invalid invitation state uses the auth-adjacent centered icon and Alliance title.
4. Confirm the description is one balanced phrase and the title ends with a period.
5. Select **Back to login** and confirm navigation to `/login`.
6. Check the layout at desktop and narrow viewport widths.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)