### PR TITLE
feat(auth): show organization name on invite signup

### DIFF
--- a/backend/e2e-test/routes/v1/auth-invite.spec.ts
+++ b/backend/e2e-test/routes/v1/auth-invite.spec.ts
@@ -23,7 +23,7 @@ describe("Auth Org Invite V1", () => {
       .completeInviteLinks?.find(({ email }: { email: string }) => email === inviteeEmail)?.link;
     expect(inviteLink).toBeDefined();
 
-    const inviteToken = new URL(inviteLink as string).searchParams.get("token");
+    const inviteToken = new URL(inviteLink as string, "http://localhost").searchParams.get("token");
     expect(inviteToken).toBeTruthy();
 
     const invalidRes = await testServer.inject({

--- a/backend/e2e-test/routes/v1/auth-invite.spec.ts
+++ b/backend/e2e-test/routes/v1/auth-invite.spec.ts
@@ -1,6 +1,61 @@
+import crypto from "node:crypto";
+
 import { seedData1 } from "@app/db/seed-data";
 
 describe("Auth Org Invite V1", () => {
+  test("Verified invitation returns the organization name only after token validation", async () => {
+    const inviteeEmail = `auth-invite-${crypto.randomUUID()}@localhost.local`;
+    const inviteRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/invite-org/signup",
+      headers: {
+        authorization: `Bearer ${jwtAuthToken}`
+      },
+      body: {
+        inviteeEmails: [inviteeEmail],
+        organizationId: seedData1.organization.id
+      }
+    });
+
+    expect(inviteRes.statusCode).toBe(200);
+    const inviteLink = inviteRes
+      .json()
+      .completeInviteLinks?.find(({ email }: { email: string }) => email === inviteeEmail)?.link;
+    expect(inviteLink).toBeDefined();
+
+    const inviteToken = new URL(inviteLink as string).searchParams.get("token");
+    expect(inviteToken).toBeTruthy();
+
+    const invalidRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/invite-org/verify",
+      body: {
+        email: inviteeEmail,
+        organizationId: seedData1.organization.id,
+        code: "invalid-token"
+      }
+    });
+
+    expect(invalidRes.statusCode).toBeGreaterThanOrEqual(400);
+    expect(invalidRes.json()).not.toHaveProperty("organizationName");
+
+    const validRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/invite-org/verify",
+      body: {
+        email: inviteeEmail,
+        organizationId: seedData1.organization.id,
+        code: inviteToken
+      }
+    });
+
+    expect(validRes.statusCode).toBe(200);
+    expect(validRes.json()).toMatchObject({
+      organizationName: seedData1.organization.name,
+      token: expect.any(String)
+    });
+  });
+
   test("Verify invite with valid token for existing accepted user returns user without token", async () => {
     // Create a membership invite for the seed user in the seed org
     // The seed user is already accepted, so verifyUserToOrg should return { user } without a token

--- a/backend/src/server/routes/v1/invite-org-router.ts
+++ b/backend/src/server/routes/v1/invite-org-router.ts
@@ -244,12 +244,13 @@ export const registerInviteOrgRouter = async (server: FastifyZodProvider) => {
       response: {
         200: z.object({
           message: z.string(),
-          token: z.string().optional()
+          token: z.string().optional(),
+          organizationName: z.string().describe("Name of the organization associated with the verified invitation")
         })
       }
     },
     handler: async (req) => {
-      const { token } = await server.services.org.verifyUserToOrg({
+      const { token, organizationName } = await server.services.org.verifyUserToOrg({
         orgId: req.body.organizationId,
         code: req.body.code,
         email: req.body.email
@@ -257,7 +258,8 @@ export const registerInviteOrgRouter = async (server: FastifyZodProvider) => {
 
       return {
         message: "Successfully verified email",
-        token
+        token,
+        organizationName
       };
     }
   });

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -1109,14 +1109,14 @@ export const orgServiceFactory = ({
       });
     }
 
-    const organization = await requestMemoize(requestMemoKeys.orgFindById(orgId), () => orgDAL.findById(orgId));
-
     await tokenService.validateTokenForUser({
       type: TokenType.TOKEN_EMAIL_ORG_INVITATION,
       userId: user.id,
       orgId: orgMembership.scopeOrgId,
       code
     });
+
+    const organization = await requestMemoize(requestMemoKeys.orgFindById(orgId), () => orgDAL.findById(orgId));
 
     await userDAL.updateById(user.id, {
       isEmailVerified: true
@@ -1125,7 +1125,7 @@ export const orgServiceFactory = ({
     // If user already completed signup, they'll be promoted to Accepted
     // when they authenticate via selectOrganization or processProviderCallback
     if (user.isAccepted) {
-      return { user };
+      return { user, organizationName: organization.name };
     }
 
     const membershipRole = await membershipRoleDAL.findOne({ membershipId: orgMembership.id });
@@ -1133,7 +1133,7 @@ export const orgServiceFactory = ({
       organization.authEnforced &&
       !(organization.bypassOrgAuthEnabled && membershipRole.role === OrgMembershipRole.Admin)
     ) {
-      return { user };
+      return { user, organizationName: organization.name };
     }
 
     const appCfg = getConfig();
@@ -1148,7 +1148,7 @@ export const orgServiceFactory = ({
       }
     );
 
-    return { token, user };
+    return { token, user, organizationName: organization.name };
   };
 
   const getOrgMembership = async ({

--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -102,8 +102,9 @@ export default function UserInfoStep({
   const isPasswordValidated =
     passwordBreachStatus === "safe" || passwordBreachStatus === "unavailable";
   const canSubmit = isPasswordValidated && !isLoading;
-  const stepTitle = isInvite ? "Set up your account" : t("signup.step3-message");
   const normalizedInviteOrganizationName = inviteOrganizationName?.trim();
+  const inviteOrganizationLabel = normalizedInviteOrganizationName || "an organization";
+  const stepTitle = t("signup.step3-message");
   const submitLabel = isInvite ? String(t("signup.signup")) : "Continue";
 
   const onSubmit = async (formData: UserInfoFormData) => {
@@ -147,25 +148,30 @@ export default function UserInfoStep({
   return (
     <div className="mx-auto flex w-full flex-col items-center justify-center">
       <AuthPagePanel>
-        <CardHeader className="mb-4 gap-2">
+        <CardHeader className={isInvite ? "mb-6 gap-2" : "mb-4 gap-2"}>
           <CardTitle
             role="heading"
             aria-level={1}
-            className="bg-linear-to-b from-white to-bunker-200 bg-clip-text font-alliance text-2xl font-normal text-transparent"
+            className="ml-0.5 font-alliance text-2xl font-normal break-words"
           >
-            {stepTitle}
+            {isInvite ? (
+              <>
+                <span className="bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent opacity-70">
+                  Join
+                </span>
+                <span className="ml-1 bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent">
+                  {inviteOrganizationLabel}
+                </span>
+              </>
+            ) : (
+              <span className="bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent">
+                {stepTitle}
+              </span>
+            )}
           </CardTitle>
           {isInvite ? (
-            <CardDescription className="break-words text-label">
-              You’ve been invited to join{" "}
-              {normalizedInviteOrganizationName ? (
-                <span className="font-medium text-foreground">
-                  {normalizedInviteOrganizationName}
-                </span>
-              ) : (
-                "an organization"
-              )}
-              .
+            <CardDescription className="ml-0.5 font-alliance text-base break-words text-accent">
+              Set up your Infisical account
             </CardDescription>
           ) : null}
         </CardHeader>

--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -159,7 +159,7 @@ export default function UserInfoStep({
                 <span className="bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent opacity-70">
                   Join
                 </span>
-                <span className="ml-1 bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent">
+                <span className="bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent">
                   {inviteOrganizationLabel}
                 </span>
               </>

--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -12,6 +12,7 @@ import {
   AnimatedCollapse,
   Button,
   CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
   Field,
@@ -54,12 +55,14 @@ interface UserInfoStepProps {
   onComplete: (orgId?: string) => void;
   email: string;
   isInvite?: boolean;
+  inviteOrganizationName?: string;
 }
 
 export default function UserInfoStep({
   onComplete,
   email,
-  isInvite = false
+  isInvite = false,
+  inviteOrganizationName
 }: UserInfoStepProps): JSX.Element {
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
@@ -100,6 +103,7 @@ export default function UserInfoStep({
     passwordBreachStatus === "safe" || passwordBreachStatus === "unavailable";
   const canSubmit = isPasswordValidated && !isLoading;
   const stepTitle = isInvite ? "Set up your account" : t("signup.step3-message");
+  const normalizedInviteOrganizationName = inviteOrganizationName?.trim();
   const submitLabel = isInvite ? String(t("signup.signup")) : "Continue";
 
   const onSubmit = async (formData: UserInfoFormData) => {
@@ -144,9 +148,26 @@ export default function UserInfoStep({
     <div className="mx-auto flex w-full flex-col items-center justify-center">
       <AuthPagePanel>
         <CardHeader className="mb-4 gap-2">
-          <CardTitle className="bg-linear-to-b from-white to-bunker-200 bg-clip-text font-alliance text-2xl font-normal text-transparent">
+          <CardTitle
+            role="heading"
+            aria-level={1}
+            className="bg-linear-to-b from-white to-bunker-200 bg-clip-text font-alliance text-2xl font-normal text-transparent"
+          >
             {stepTitle}
           </CardTitle>
+          {isInvite ? (
+            <CardDescription className="break-words text-label">
+              You’ve been invited to join{" "}
+              {normalizedInviteOrganizationName ? (
+                <span className="font-medium text-foreground">
+                  {normalizedInviteOrganizationName}
+                </span>
+              ) : (
+                "an organization"
+              )}
+              .
+            </CardDescription>
+          ) : null}
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/frontend/src/hooks/api/auth/queries.tsx
+++ b/frontend/src/hooks/api/auth/queries.tsx
@@ -32,7 +32,8 @@ import {
   UserAgentType,
   VerifyMfaTokenDTO,
   VerifyMfaTokenRes,
-  VerifySignupInviteDTO
+  VerifySignupInviteDTO,
+  VerifySignupInviteRes
 } from "./types";
 
 export const authKeys = {
@@ -200,7 +201,10 @@ export const verifyRecoveryCode = async (recoveryCode: string) => {
 };
 
 export const verifySignupInvite = async (details: VerifySignupInviteDTO) => {
-  const { data } = await apiRequest.post("/api/v1/invite-org/verify", details);
+  const { data } = await apiRequest.post<VerifySignupInviteRes>(
+    "/api/v1/invite-org/verify",
+    details
+  );
   return data;
 };
 

--- a/frontend/src/hooks/api/auth/types.ts
+++ b/frontend/src/hooks/api/auth/types.ts
@@ -139,6 +139,12 @@ export type VerifySignupInviteDTO = {
   organizationId: string;
 };
 
+export type VerifySignupInviteRes = {
+  message: string;
+  token?: string;
+  organizationName?: string;
+};
+
 export type ResetPasswordDTO = {
   protectedKey: string;
   protectedKeyIV: string;

--- a/frontend/src/pages/auth/SignUpInvitePage/SignUpInvitePage.tsx
+++ b/frontend/src/pages/auth/SignUpInvitePage/SignUpInvitePage.tsx
@@ -8,9 +8,9 @@ import { Button, CardContent, CardDescription, CardHeader, CardTitle } from "@ap
 import { SignUpPage } from "../SignUpPage/SignUpPage";
 
 export const SignupInvitePage = () => {
-  const { inviteEmail, error } = useRouteContext({
+  const { inviteEmail, inviteOrganizationName, error } = useRouteContext({
     from: "/_restrict-login-signup/signupinvite"
-  }) as { inviteEmail?: string; error?: string };
+  }) as { inviteEmail?: string; inviteOrganizationName?: string; error?: string };
 
   if (error) {
     return (
@@ -37,5 +37,7 @@ export const SignupInvitePage = () => {
     );
   }
 
-  return <SignUpPage invite={{ email: inviteEmail ?? "" }} />;
+  return (
+    <SignUpPage invite={{ email: inviteEmail ?? "", organizationName: inviteOrganizationName }} />
+  );
 };

--- a/frontend/src/pages/auth/SignUpInvitePage/route.tsx
+++ b/frontend/src/pages/auth/SignUpInvitePage/route.tsx
@@ -59,7 +59,7 @@ export const Route = createFileRoute("/_restrict-login-signup/signupinvite")({
       if (result.token) {
         // New user — store signup token, render the signup form
         SecurityClient.setSignupToken(result.token);
-        return { inviteEmail: email };
+        return { inviteEmail: email, inviteOrganizationName: result.organizationName };
       }
 
       // Existing user, not logged in, membership accepted — send to login

--- a/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
@@ -45,6 +45,7 @@ type PendingEmailVerification = {
 export interface SignUpPageProps {
   invite?: {
     email: string;
+    organizationName?: string;
   };
 }
 
@@ -182,7 +183,12 @@ export const SignUpPage = ({ invite }: SignUpPageProps) => {
         );
       case SignupSection.UserInfo:
         return (
-          <UserInfoStep onComplete={handleUserInfoComplete} email={email} isInvite={isInvite} />
+          <UserInfoStep
+            onComplete={handleUserInfoComplete}
+            email={email}
+            isInvite={isInvite}
+            inviteOrganizationName={invite?.organizationName}
+          />
         );
       case SignupSection.ProductSelect:
         return <ProductSelectionStep onComplete={handleProductSelectComplete} />;


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

[PLATFOR-609](https://linear.app/infisical/issue/PLATFOR-609/include-the-invited-resource-group-name-on-the-invite-sign-up-page)

Organization invite sign-up previously showed only the generic account-setup heading, so invitees could not tell which organization they were joining.

This change:
- returns the organization name only after the invitation token has been validated;
- threads the verified name through the invite route into the account-setup form;
- displays “You’ve been invited to join <organization>.” with a safe “an organization” fallback for absent or blank names;
- preserves name privacy for invalid, expired, revoked, or unauthorized invitations; and
- keeps the PLATFOR-608 invalid-invitation UI work separate.

Organization invitations carrying optional project or PAM grants use this same verified organization context.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="2928" height="2076" alt="CleanShot 2026-08-03 at 11 38 35@2x" src="https://github.com/user-attachments/assets/1f8af0af-42a3-4bc1-a9f0-60c4cb21ecf7" />

## Steps to verify the change

1. Invite a new email address to an organization.
2. Open the generated invitation link while signed out.
3. Confirm the account setup form says “You’ve been invited to join <organization name>.”
4. Verify a missing or blank response name falls back to “an organization.”
5. Submit an invalid or stale token and confirm no organization name is returned or displayed.

Local checks completed:

- Focused frontend and backend ESLint.
- Frontend and backend TypeScript checks.
- Prettier and `git diff --check`.

The focused invite E2E was attempted, but Vitest could not collect tests because the available local dependency tree lacked the macOS `@infisical/quic` native binding.

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)