### PR TITLE
docs(style): add dark mode

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -703,9 +703,7 @@
                       "integrations/platforms/apache-airflow",
                       {
                         "group": "AWS",
-                        "pages": [
-                          "integrations/platforms/aws/lambda"
-                        ]
+                        "pages": ["integrations/platforms/aws/lambda"]
                       },
                       "integrations/platforms/infisical-proxy",
                       {
@@ -1500,9 +1498,7 @@
               },
               {
                 "group": "Service Tokens",
-                "pages": [
-                  "api-reference/endpoints/service-tokens/get"
-                ]
+                "pages": ["api-reference/endpoints/service-tokens/get"]
               }
             ]
           },
@@ -2332,15 +2328,11 @@
               },
               {
                 "group": "Audit Logs",
-                "pages": [
-                  "api-reference/endpoints/audit-logs/export-audit-log"
-                ]
+                "pages": ["api-reference/endpoints/audit-logs/export-audit-log"]
               },
               {
                 "group": "Events",
-                "pages": [
-                  "api-reference/endpoints/events/project-events"
-                ]
+                "pages": ["api-reference/endpoints/events/project-events"]
               }
             ]
           },
@@ -4153,9 +4145,7 @@
             "pages": [
               {
                 "group": "Admin",
-                "pages": [
-                  "api-reference/endpoints/admin/bootstrap-instance"
-                ]
+                "pages": ["api-reference/endpoints/admin/bootstrap-instance"]
               }
             ]
           }
@@ -4166,9 +4156,7 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": [
-              "sdks/overview"
-            ]
+            "pages": ["sdks/overview"]
           },
           {
             "group": "SDK's",
@@ -4196,9 +4184,7 @@
   "api": {
     "openapi": "https://app.infisical.com/api/docs/json",
     "mdx": {
-      "server": [
-        "https://app.infisical.com"
-      ]
+      "server": ["https://app.infisical.com"]
     }
   },
   "background": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,7 +4,7 @@
   "name": "Infisical",
   "colors": {
     "primary": "#26272b",
-    "light": "#97b31d",
+    "light": "#EFFF33",
     "dark": "#A1B659"
   },
   "styling": {
@@ -703,7 +703,9 @@
                       "integrations/platforms/apache-airflow",
                       {
                         "group": "AWS",
-                        "pages": ["integrations/platforms/aws/lambda"]
+                        "pages": [
+                          "integrations/platforms/aws/lambda"
+                        ]
                       },
                       "integrations/platforms/infisical-proxy",
                       {
@@ -1498,7 +1500,9 @@
               },
               {
                 "group": "Service Tokens",
-                "pages": ["api-reference/endpoints/service-tokens/get"]
+                "pages": [
+                  "api-reference/endpoints/service-tokens/get"
+                ]
               }
             ]
           },
@@ -2328,11 +2332,15 @@
               },
               {
                 "group": "Audit Logs",
-                "pages": ["api-reference/endpoints/audit-logs/export-audit-log"]
+                "pages": [
+                  "api-reference/endpoints/audit-logs/export-audit-log"
+                ]
               },
               {
                 "group": "Events",
-                "pages": ["api-reference/endpoints/events/project-events"]
+                "pages": [
+                  "api-reference/endpoints/events/project-events"
+                ]
               }
             ]
           },
@@ -4145,7 +4153,9 @@
             "pages": [
               {
                 "group": "Admin",
-                "pages": ["api-reference/endpoints/admin/bootstrap-instance"]
+                "pages": [
+                  "api-reference/endpoints/admin/bootstrap-instance"
+                ]
               }
             ]
           }
@@ -4156,7 +4166,9 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["sdks/overview"]
+            "pages": [
+              "sdks/overview"
+            ]
           },
           {
             "group": "SDK's",
@@ -4184,12 +4196,10 @@
   "api": {
     "openapi": "https://app.infisical.com/api/docs/json",
     "mdx": {
-      "server": ["https://app.infisical.com"]
+      "server": [
+        "https://app.infisical.com"
+      ]
     }
-  },
-  "appearance": {
-    "default": "light",
-    "strict": true
   },
   "background": {
     "color": {

--- a/docs/snippets/AppConnectionsBrowser.jsx
+++ b/docs/snippets/AppConnectionsBrowser.jsx
@@ -693,7 +693,7 @@ export const AppConnectionsBrowser = () => {
           <input
             type="text"
             placeholder="Search app connections..."
-            className="block w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -709,8 +709,8 @@ export const AppConnectionsBrowser = () => {
               onClick={() => setSelectedCategory(category)}
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
-                  ? "bg-yellow-100 text-yellow-700 border border-yellow-200"
-                  : "bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200"
+                  ? "bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700"
+                  : "bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
               }`}
             >
               {category}
@@ -721,7 +721,7 @@ export const AppConnectionsBrowser = () => {
 
       {/* Results Count */}
       <div className="mb-4">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
           {filteredConnections.length} app connection
           {filteredConnections.length !== 1 ? "s" : ""} found
           {selectedCategory !== "All" && ` in ${selectedCategory}`}
@@ -736,18 +736,18 @@ export const AppConnectionsBrowser = () => {
             <a
               key={connection.slug}
               href={connection.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">
-                  <h3 className="text-base font-medium text-gray-900 leading-none m-0">
+                  <h3 className="text-base font-medium text-gray-900 leading-none m-0 dark:text-gray-100">
                     {connection.name}
                   </h3>
-                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0">
+                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0 dark:bg-yellow-900/30 dark:text-yellow-300">
                     {connection.category}
                   </span>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed">
+                <p className="text-sm text-gray-600 leading-relaxed dark:text-gray-400">
                   {connection.description}
                 </p>
               </div>
@@ -757,7 +757,7 @@ export const AppConnectionsBrowser = () => {
       ) : (
         <div className="text-center py-8">
           <div className="flex flex-col items-center space-y-2">
-            <p className="text-gray-500">
+            <p className="text-gray-500 dark:text-gray-400">
               No app connections found matching your criteria
             </p>
             {searchTerm && (

--- a/docs/snippets/DynamicSecretsBrowser.jsx
+++ b/docs/snippets/DynamicSecretsBrowser.jsx
@@ -71,7 +71,7 @@ export const DynamicSecretsBrowser = () => {
           <input
             type="text"
             placeholder="Search dynamic secrets..."
-            className="block w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -87,8 +87,8 @@ export const DynamicSecretsBrowser = () => {
               onClick={() => setSelectedCategory(category)}
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
-                  ? 'bg-yellow-100 text-yellow-700 border border-yellow-200'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200'
+                  ? 'bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700'
+                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
               }`}
             >
               {category}
@@ -99,7 +99,7 @@ export const DynamicSecretsBrowser = () => {
 
       {/* Results Count */}
       <div className="mb-4">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
           {filteredDynamicSecrets.length} dynamic secret{filteredDynamicSecrets.length !== 1 ? 's' : ''} found
           {selectedCategory !== 'All' && ` in ${selectedCategory}`}
           {searchTerm && ` for "${searchTerm}"`}
@@ -113,18 +113,18 @@ export const DynamicSecretsBrowser = () => {
             <a
               key={secret.slug}
               href={secret.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">
-                  <h3 className="text-base font-medium text-gray-900 leading-none m-0">
+                  <h3 className="text-base font-medium text-gray-900 leading-none m-0 dark:text-gray-100">
                     {secret.name}
                   </h3>
-                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0">
+                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0 dark:bg-yellow-900/30 dark:text-yellow-300">
                     {secret.category}
                   </span>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed">
+                <p className="text-sm text-gray-600 leading-relaxed dark:text-gray-400">
                   {secret.description}
                 </p>
               </div>
@@ -134,7 +134,7 @@ export const DynamicSecretsBrowser = () => {
       ) : (
         <div className="text-center py-8">
           <div className="flex flex-col items-center space-y-2">
-            <p className="text-gray-500">No dynamic secrets found matching your criteria</p>
+            <p className="text-gray-500 dark:text-gray-400">No dynamic secrets found matching your criteria</p>
             {searchTerm && (
               <p className="text-gray-400 text-sm">Try adjusting your search terms or filters</p>
             )}

--- a/docs/snippets/FrameworkIntegrationsBrowser.jsx
+++ b/docs/snippets/FrameworkIntegrationsBrowser.jsx
@@ -49,7 +49,7 @@ export const FrameworkIntegrationsBrowser = () => {
           <input
             type="text"
             placeholder="Search framework integrations..."
-            className="block w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -58,7 +58,7 @@ export const FrameworkIntegrationsBrowser = () => {
 
       {/* Results Count */}
       <div className="mb-4">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
           {filteredIntegrations.length} framework integration{filteredIntegrations.length !== 1 ? 's' : ''} found
           {searchTerm && ` for "${searchTerm}"`}
         </p>
@@ -71,15 +71,15 @@ export const FrameworkIntegrationsBrowser = () => {
             <a
               key={integration.slug}
               href={integration.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="mb-0.5">
-                  <h3 className="text-base font-medium text-gray-900 leading-none m-0">
+                  <h3 className="text-base font-medium text-gray-900 leading-none m-0 dark:text-gray-100">
                     {integration.name}
                   </h3>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed">
+                <p className="text-sm text-gray-600 leading-relaxed dark:text-gray-400">
                   {integration.description}
                 </p>
               </div>
@@ -89,7 +89,7 @@ export const FrameworkIntegrationsBrowser = () => {
       ) : (
         <div className="text-center py-8">
           <div className="flex flex-col items-center space-y-2">
-            <p className="text-gray-500">No framework integrations found matching your criteria</p>
+            <p className="text-gray-500 dark:text-gray-400">No framework integrations found matching your criteria</p>
             {searchTerm && (
               <p className="text-gray-400 text-sm">Try adjusting your search terms or filters</p>
             )}

--- a/docs/snippets/MachineAuthenticationBrowser.jsx
+++ b/docs/snippets/MachineAuthenticationBrowser.jsx
@@ -62,7 +62,7 @@ export const MachineAuthenticationBrowser = () => {
           <input
             type="text"
             placeholder="Search machine authentication methods..."
-            className="block w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -78,8 +78,8 @@ export const MachineAuthenticationBrowser = () => {
               onClick={() => setSelectedCategory(category)}
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
-                  ? 'bg-yellow-100 text-yellow-700 border border-yellow-200'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200'
+                  ? 'bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700'
+                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
               }`}
             >
               {category}
@@ -90,7 +90,7 @@ export const MachineAuthenticationBrowser = () => {
 
       {/* Results Count */}
       <div className="mb-4">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
           {filteredAuthMethods.length} authentication method{filteredAuthMethods.length !== 1 ? 's' : ''} found
           {selectedCategory !== 'All' && ` in ${selectedCategory}`}
           {searchTerm && ` for "${searchTerm}"`}
@@ -104,18 +104,18 @@ export const MachineAuthenticationBrowser = () => {
             <a
               key={method.slug}
               href={method.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">
-                  <h3 className="text-base font-medium text-gray-900 leading-none m-0">
+                  <h3 className="text-base font-medium text-gray-900 leading-none m-0 dark:text-gray-100">
                     {method.name}
                   </h3>
-                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0">
+                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0 dark:bg-yellow-900/30 dark:text-yellow-300">
                     {method.category}
                   </span>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed">
+                <p className="text-sm text-gray-600 leading-relaxed dark:text-gray-400">
                   {method.description}
                 </p>
               </div>
@@ -125,7 +125,7 @@ export const MachineAuthenticationBrowser = () => {
       ) : (
         <div className="text-center py-8">
           <div className="flex flex-col items-center space-y-2">
-            <p className="text-gray-500">No authentication methods found matching your criteria</p>
+            <p className="text-gray-500 dark:text-gray-400">No authentication methods found matching your criteria</p>
             {searchTerm && (
               <p className="text-gray-400 text-sm">Try adjusting your search terms or filters</p>
             )}

--- a/docs/snippets/RotationsBrowser.jsx
+++ b/docs/snippets/RotationsBrowser.jsx
@@ -298,7 +298,7 @@ export const RotationsBrowser = () => {
           <input
             type="text"
             placeholder="Search secret rotations..."
-            className="block w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -314,8 +314,8 @@ export const RotationsBrowser = () => {
               onClick={() => setSelectedCategory(category)}
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
-                  ? "bg-yellow-100 text-yellow-700 border border-yellow-200"
-                  : "bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200"
+                  ? "bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700"
+                  : "bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
               }`}
             >
               {category}
@@ -326,7 +326,7 @@ export const RotationsBrowser = () => {
 
       {/* Results Count */}
       <div className="mb-4">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
           {filteredRotations.length} secret rotation
           {filteredRotations.length !== 1 ? "s" : ""} found
           {selectedCategory !== "All" && ` in ${selectedCategory}`}
@@ -341,27 +341,27 @@ export const RotationsBrowser = () => {
             <a
               key={rotation.slug}
               href={rotation.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">
-                  <h3 className="text-base font-medium text-gray-900 leading-none m-0">
+                  <h3 className="text-base font-medium text-gray-900 leading-none m-0 dark:text-gray-100">
                     {rotation.name}
                   </h3>
                   <div className="ml-3 flex items-center gap-2 flex-shrink-0">
                     <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
                       rotation.rotationType === "Dual-Phase"
-                        ? "bg-green-100 text-green-700"
-                        : "bg-orange-100 text-orange-700"
+                        ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+                        : "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300"
                     }`}>
                       {rotation.rotationType}
                     </span>
-                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700">
+                    <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300">
                       {rotation.category}
                     </span>
                   </div>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed">
+                <p className="text-sm text-gray-600 leading-relaxed dark:text-gray-400">
                   {rotation.description}
                 </p>
               </div>
@@ -371,7 +371,7 @@ export const RotationsBrowser = () => {
       ) : (
         <div className="text-center py-8">
           <div className="flex flex-col items-center space-y-2">
-            <p className="text-gray-500">
+            <p className="text-gray-500 dark:text-gray-400">
               No secret rotations found matching your criteria
             </p>
             {searchTerm && (

--- a/docs/snippets/SecretSyncsBrowser.jsx
+++ b/docs/snippets/SecretSyncsBrowser.jsx
@@ -89,7 +89,7 @@ export const SecretSyncsBrowser = () => {
           <input
             type="text"
             placeholder="Search secret syncs..."
-            className="block w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -105,8 +105,8 @@ export const SecretSyncsBrowser = () => {
               onClick={() => setSelectedCategory(category)}
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
-                  ? 'bg-yellow-100 text-yellow-700 border border-yellow-200'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200'
+                  ? 'bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700'
+                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
               }`}
             >
               {category}
@@ -117,7 +117,7 @@ export const SecretSyncsBrowser = () => {
 
       {/* Results Count */}
       <div className="mb-4">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
           {filteredSyncs.length} secret sync{filteredSyncs.length !== 1 ? 's' : ''} found
           {selectedCategory !== 'All' && ` in ${selectedCategory}`}
           {searchTerm && ` for "${searchTerm}"`}
@@ -131,18 +131,18 @@ export const SecretSyncsBrowser = () => {
             <a
               key={sync.slug}
               href={sync.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">
-                  <h3 className="text-base font-medium text-gray-900 leading-none m-0">
+                  <h3 className="text-base font-medium text-gray-900 leading-none m-0 dark:text-gray-100">
                     {sync.name}
                   </h3>
-                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0">
+                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0 dark:bg-yellow-900/30 dark:text-yellow-300">
                     {sync.category}
                   </span>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed">
+                <p className="text-sm text-gray-600 leading-relaxed dark:text-gray-400">
                   {sync.description}
                 </p>
               </div>
@@ -152,7 +152,7 @@ export const SecretSyncsBrowser = () => {
       ) : (
         <div className="text-center py-8">
           <div className="flex flex-col items-center space-y-2">
-            <p className="text-gray-500">No secret syncs found matching your criteria</p>
+            <p className="text-gray-500 dark:text-gray-400">No secret syncs found matching your criteria</p>
             {searchTerm && (
               <p className="text-gray-400 text-sm">Try adjusting your search terms or filters</p>
             )}

--- a/docs/snippets/UserAuthenticationBrowser.jsx
+++ b/docs/snippets/UserAuthenticationBrowser.jsx
@@ -60,7 +60,7 @@ export const UserAuthenticationBrowser = () => {
           <input
             type="text"
             placeholder="Search user authentication methods..."
-            className="block w-full pl-9 pr-3 py-2 text-sm border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -76,8 +76,8 @@ export const UserAuthenticationBrowser = () => {
               onClick={() => setSelectedCategory(category)}
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
-                  ? 'bg-yellow-100 text-yellow-700 border border-yellow-200'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200'
+                  ? 'bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700'
+                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
               }`}
             >
               {category}
@@ -88,7 +88,7 @@ export const UserAuthenticationBrowser = () => {
 
       {/* Results Count */}
       <div className="mb-4">
-        <p className="text-sm text-gray-600">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
           {filteredAuthMethods.length} user authentication method{filteredAuthMethods.length !== 1 ? 's' : ''} found
           {selectedCategory !== 'All' && ` in ${selectedCategory}`}
           {searchTerm && ` for "${searchTerm}"`}
@@ -102,18 +102,18 @@ export const UserAuthenticationBrowser = () => {
             <a
               key={method.slug}
               href={method.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">
-                  <h3 className="text-base font-medium text-gray-900 leading-none m-0">
+                  <h3 className="text-base font-medium text-gray-900 leading-none m-0 dark:text-gray-100">
                     {method.name}
                   </h3>
-                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0">
+                  <span className="ml-3 inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700 flex-shrink-0 dark:bg-yellow-900/30 dark:text-yellow-300">
                     {method.category}
                   </span>
                 </div>
-                <p className="text-sm text-gray-600 leading-relaxed">
+                <p className="text-sm text-gray-600 leading-relaxed dark:text-gray-400">
                   {method.description}
                 </p>
               </div>
@@ -123,7 +123,7 @@ export const UserAuthenticationBrowser = () => {
       ) : (
         <div className="text-center py-8">
           <div className="flex flex-col items-center space-y-2">
-            <p className="text-gray-500">No user authentication methods found matching your criteria</p>
+            <p className="text-gray-500 dark:text-gray-400">No user authentication methods found matching your criteria</p>
             {searchTerm && (
               <p className="text-gray-400 text-sm">Try adjusting your search terms or filters</p>
             )}

--- a/docs/style.css
+++ b/docs/style.css
@@ -120,6 +120,39 @@
   /* background-color: #f5f5f5; */
 }
 
+.dark #navbar .max-w-8xl {
+  border-bottom-color: #333330;
+  background-color: #1C1C1A;
+}
+
+.dark #sidebar {
+  border-right-color: #333330;
+  background-color: #1C1C1A;
+}
+
+.dark #sidebar li > a.text-primary {
+  background-color: #34380B;
+  border-left-color: #DCEB30;
+}
+
+.dark #header {
+  background-color: #292B16;
+  border-left-color: #DCEB30;
+}
+
+.dark #content-area .mt-8 .block {
+  border-color: #333330;
+  background-color: #242421;
+}
+
+.dark #topbar-cta-button .group .absolute {
+  background-color: white;
+}
+
+.dark #topbar-cta-button .group .flex > * {
+  color: #1C1C1A;
+}
+
 @media (min-width: 1024px) {
   #navbar.is-not-custom.is-not-center + div:has(> #sidebar) {
     max-width: none !important;


### PR DESCRIPTION
## Context

This PR adds dark mode support to the Infisical docs.

I took some liberties with styling and color choices but am happy to revisit any of these. My goal was to keep the styling as consistent as possible with the current light mode variant, so I didn't iterate on the design more generally.

## Screenshots

<img width="1510" height="835" alt="Screenshot 2026-08-02 at 1 25 33 PM" src="https://github.com/user-attachments/assets/3fb6bb37-6dab-475a-8d58-773247bc084e" />
<img width="1510" height="830" alt="Screenshot 2026-08-02 at 1 26 10 PM" src="https://github.com/user-attachments/assets/51a0539f-e639-40f5-b1f8-e241c14273b3" />

## Steps to verify the change

1. Run `mint dev` to preview the docs site.
2. Switch to dark mode and verify colors apply correctly.
3. Check any pages that contain snippets to make sure their colors are consistent too.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)