### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Check out the [Quickstart Guides](https://infisical.com/docs/documentation/getti
 
 | Use Infisical Cloud                                                                                                                                     | Deploy Infisical on premise                                                          |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| The fastest and most reliable way to <br> get started with Infisical is signing up <br> for free to [Infisical Cloud](https://app.infisical.com/login). | <br> View all [deployment options](https://infisical.com/docs/self-hosting/overview) <br><br> Already self-hosting? Plan version upgrades with the [Infisical Upgrade Tool](https://upgrade.infisical.com/). |
+| The fastest and most reliable way to <br> get started with Infisical is signing up <br> for free to [Infisical Cloud](https://app.infisical.com/login). | <br> View all [deployment options](https://infisical.com/docs/self-hosting/overview) <br><br> Already self-hosting? Plan version upgrades with the [Infisical Upgrade Tool](https://upgrade.infisical.com/). <br><br> Don't want to run the servers? Get a managed instance in one click: <br> [<img alt="Deploy with Zenith" src="https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg" height="40">](https://zenith.hosting/host/infisical) |
 
 ### Run Infisical locally
 


### PR DESCRIPTION
## Context

hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Infisical to our marketplace, so this PR adds a small "Deploy with Zenith" badge in the Getting started table, in the "Deploy Infisical on premise" column (links to https://zenith.hosting/host/infisical).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

## Screenshots

N/A, a README text change.

## Steps to verify the change

Open `README.md` on this branch. The Getting started table renders the badge under the deployment options column, and it links to https://zenith.hosting/host/infisical.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed) (N/A, no code or workflow change)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
