### PR TITLE
feat(telemetry): report PKI certificate issuance from profile-based flows

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -3457,7 +3457,8 @@ export const registerRoutes = async (
     pkiApplicationProfileDAL,
     apiEnrollmentConfigDAL,
     gatewayV2Service,
-    gatewayPoolService
+    gatewayPoolService,
+    telemetryService
   });
 
   const certificateApprovalService = certificateApprovalServiceFactory({
@@ -3530,7 +3531,8 @@ export const registerRoutes = async (
     pkiAlertV2Queue,
     pkiApplicationProfileDAL,
     apiEnrollmentConfigDAL,
-    licenseService
+    licenseService,
+    telemetryService
   });
 
   const certificateV3Queue = certificateV3QueueServiceFactory({

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -3333,7 +3333,8 @@ export const registerRoutes = async (
     usageMeteringService,
     hsmConnectorService,
     certificateAuthoritySecretDAL,
-    licenseService
+    licenseService,
+    telemetryService
   });
 
   const certificateEstService = certificateEstServiceFactory({
@@ -3550,7 +3551,9 @@ export const registerRoutes = async (
     appConnectionDAL,
     kmsService,
     resourceMetadataDAL,
-    digicertFns: digicertCaFns
+    digicertFns: digicertCaFns,
+    projectDAL,
+    telemetryService
   });
 
   const digicertRevocationSyncQueue = digicertRevocationSyncQueueFactory({
@@ -3571,7 +3574,9 @@ export const registerRoutes = async (
     appConnectionDAL,
     kmsService,
     resourceMetadataDAL,
-    godaddyFns: godaddyCaFns
+    godaddyFns: godaddyCaFns,
+    projectDAL,
+    telemetryService
   });
 
   const certificateEstV3Service = certificateEstV3ServiceFactory({

--- a/backend/src/server/routes/v1/pki-application-router.ts
+++ b/backend/src/server/routes/v1/pki-application-router.ts
@@ -76,7 +76,8 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         distinctId: getTelemetryDistinctId(req),
         organizationId: req.permission.orgId,
         properties: {
-          orgId: req.permission.orgId
+          orgId: req.permission.orgId,
+          applicationId: application.id
         }
       });
 
@@ -303,6 +304,16 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         }
       });
 
+      await server.services.telemetry.sendPostHogEvents({
+        event: PostHogEventTypes.PkiApplicationUpdated,
+        distinctId: getTelemetryDistinctId(req),
+        organizationId: req.permission.orgId,
+        properties: {
+          orgId: req.permission.orgId,
+          applicationId: application.id
+        }
+      });
+
       return { application };
     }
   });
@@ -344,7 +355,8 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         distinctId: getTelemetryDistinctId(req),
         organizationId: req.permission.orgId,
         properties: {
-          orgId: req.permission.orgId
+          orgId: req.permission.orgId,
+          applicationId: application.id
         }
       });
 

--- a/backend/src/services/certificate-authority/certificate-authority-service.ts
+++ b/backend/src/services/certificate-authority/certificate-authority-service.ts
@@ -37,6 +37,7 @@ import { TPkiSyncDALFactory } from "../pki-sync/pki-sync-dal";
 import { TPkiSyncQueueFactory } from "../pki-sync/pki-sync-queue";
 import { TProjectDALFactory } from "../project/project-dal";
 import { TResourceMetadataDALFactory } from "../resource-metadata/resource-metadata-dal";
+import { TTelemetryServiceFactory } from "../telemetry/telemetry-service";
 import {
   AcmeCertificateAuthorityFns,
   castDbEntryToAcmeCertificateAuthority
@@ -135,6 +136,7 @@ type TCertificateAuthorityServiceFactoryDep = {
   externalCertificateAuthorityDAL: Pick<TExternalCertificateAuthorityDALFactory, "create" | "update" | "findOne">;
   internalCertificateAuthorityService: TInternalCertificateAuthorityServiceFactory;
   projectDAL: Pick<TProjectDALFactory, "findProjectBySlug" | "findOne" | "updateById" | "findById" | "transaction">;
+  telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
   certificateDAL: Pick<TCertificateDALFactory, "create" | "findById" | "findOne" | "transaction" | "updateById">;
   certificateBodyDAL: Pick<TCertificateBodyDALFactory, "create">;
@@ -165,6 +167,7 @@ export type TCertificateAuthorityServiceFactory = ReturnType<typeof certificateA
 export const certificateAuthorityServiceFactory = ({
   certificateAuthorityDAL,
   projectDAL,
+  telemetryService,
   permissionService,
   internalCertificateAuthorityService,
   appConnectionDAL,
@@ -1420,7 +1423,9 @@ export const certificateAuthorityServiceFactory = ({
               certificateRequestDAL,
               certificateRequestService,
               resourceMetadataDAL,
-              godaddyFns
+              godaddyFns,
+              projectDAL,
+              telemetryService
             },
             certificateRequest
           )
@@ -1432,7 +1437,9 @@ export const certificateAuthorityServiceFactory = ({
               certificateRequestDAL,
               certificateRequestService,
               resourceMetadataDAL,
-              digicertFns
+              digicertFns,
+              projectDAL,
+              telemetryService
             },
             certificateRequest
           );

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -441,9 +441,8 @@ export const certificateIssuanceQueueFactory = ({
       );
     };
 
-    // DigiCert and GoDaddy can finish this job at PENDING_VALIDATION, with the certificate only
-    // arriving later in their polling processors. Those processors report issuance themselves, so
-    // this job must not report anything when it leaves the request pending.
+    // DigiCert and GoDaddy attach the certificate later in their processors, so a pending order
+    // must not be reported as issued. Tracked here rather than re-read: the replica lags the write.
     let certificateExistsAfterThisJob = true;
 
     try {
@@ -1216,8 +1215,6 @@ export const certificateIssuanceQueueFactory = ({
       }
 
       if (certificateExistsAfterThisJob) {
-        // ACME and SCEP fall back to this async path when the profile is backed by an external CA,
-        // so the enrollment method has to come from the profile rather than being assumed to be API.
         const telemetryProfile = profileId ? await certificateProfileDAL?.findById(profileId) : undefined;
 
         await reportCertificateIssued({

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -441,6 +441,11 @@ export const certificateIssuanceQueueFactory = ({
       );
     };
 
+    // DigiCert and GoDaddy can finish this job at PENDING_VALIDATION, with the certificate only
+    // arriving later in their polling processors. Those processors report issuance themselves, so
+    // this job must not report anything when it leaves the request pending.
+    let certificateExistsAfterThisJob = true;
+
     try {
       logger.info(`Processing certificate issuance job for [certificateId=${certificateId}] [caId=${caId}]`);
 
@@ -955,12 +960,14 @@ export const certificateIssuanceQueueFactory = ({
               `DigiCert order issued immediately (pre-validated domains), attached certificate [certificateRequestId=${certificateRequestId}] [certificateId=${attachedCertificateId}]`
             );
           } catch (finaliseError) {
+            certificateExistsAfterThisJob = false;
             logger.error(
               finaliseError,
               `DigiCert immediate finalisation failed, will be retried by polling queue [certificateRequestId=${certificateRequestId}]`
             );
           }
         } else {
+          certificateExistsAfterThisJob = false;
           await setPending(`DigiCert is processing the request — order #${digicertResult.metadata.digicert.orderId}`);
           logger.info(
             `DigiCert order placed, awaiting validation [certificateRequestId=${certificateRequestId}] [orderId=${digicertResult.metadata.digicert.orderId}]`
@@ -1043,6 +1050,7 @@ export const certificateIssuanceQueueFactory = ({
           return;
         }
 
+        certificateExistsAfterThisJob = false;
         await setPending(
           `GoDaddy is processing the request — certificate ${godaddyResult.metadata.godaddy.certificateId}`
         );
@@ -1207,15 +1215,7 @@ export const certificateIssuanceQueueFactory = ({
         logger.debug("Failed to queue PKI alert event for async certificate issuance");
       }
 
-      // Not every CA finishes inside this job. DigiCert and GoDaddy can stop at PENDING_VALIDATION
-      // and only produce a certificate later, in their polling processors — which report issuance
-      // themselves. Reporting unconditionally here would count those pending orders as issued, so
-      // this only fires once the request has actually reached ISSUED.
-      const issuedInThisJob = certificateRequestId
-        ? (await certificateRequestDAL?.findById(certificateRequestId))?.status === CertificateRequestStatus.ISSUED
-        : true;
-
-      if (issuedInThisJob) {
+      if (certificateExistsAfterThisJob) {
         // ACME and SCEP fall back to this async path when the profile is backed by an external CA,
         // so the enrollment method has to come from the profile rather than being assumed to be API.
         const telemetryProfile = profileId ? await certificateProfileDAL?.findById(profileId) : undefined;

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -19,7 +19,6 @@ import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
-import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { TAppConnectionDALFactory } from "../app-connection/app-connection-dal";
 import { TAppConnectionServiceFactory } from "../app-connection/app-connection-service";
@@ -31,6 +30,7 @@ import {
   resolveEffectiveApiConfig
 } from "../certificate-common/certificate-issuance-utils";
 import { CertificateRequestCancelledError } from "../certificate-common/certificate-request-errors";
+import { reportCertificateIssued } from "../certificate-common/certificate-telemetry-fns";
 import {
   DigiCertExternalMetadataSchema,
   GoDaddyExternalMetadataSchema
@@ -1207,32 +1207,28 @@ export const certificateIssuanceQueueFactory = ({
         logger.debug("Failed to queue PKI alert event for async certificate issuance");
       }
 
-      // External CAs complete asynchronously, so orderCertificate returns PENDING and this job is
-      // where the certificate actually comes into existence. Reported here so external-CA issuance
-      // is counted alongside the synchronous paths in certificate-v3-service.
-      try {
-        const project = await projectDAL.findById(ca.projectId);
-        if (project?.orgId) {
-          // ACME and SCEP fall back to this async path when the profile is backed by an external CA,
-          // so the enrollment method has to come from the profile rather than being assumed to be API.
-          const telemetryProfile = profileId ? await certificateProfileDAL?.findById(profileId) : undefined;
+      // Not every CA finishes inside this job. DigiCert and GoDaddy can stop at PENDING_VALIDATION
+      // and only produce a certificate later, in their polling processors — which report issuance
+      // themselves. Reporting unconditionally here would count those pending orders as issued, so
+      // this only fires once the request has actually reached ISSUED.
+      const issuedInThisJob = certificateRequestId
+        ? (await certificateRequestDAL?.findById(certificateRequestId))?.status === CertificateRequestStatus.ISSUED
+        : true;
 
-          await telemetryService.sendPostHogEvents({
-            event: PostHogEventTypes.IssueCert,
-            distinctId: `platform/${ca.projectId}`,
-            organizationId: project.orgId,
-            properties: {
-              orgId: project.orgId,
-              projectId: ca.projectId,
-              profileId,
-              applicationId: scopedApplicationId ?? undefined,
-              enrollmentType: telemetryProfile?.enrollmentType ?? EnrollmentType.API,
-              operation: isRenewal ? "renew" : "order"
-            }
-          });
-        }
-      } catch (error) {
-        logger.debug({ error }, "Failed to report async certificate issuance telemetry");
+      if (issuedInThisJob) {
+        // ACME and SCEP fall back to this async path when the profile is backed by an external CA,
+        // so the enrollment method has to come from the profile rather than being assumed to be API.
+        const telemetryProfile = profileId ? await certificateProfileDAL?.findById(profileId) : undefined;
+
+        await reportCertificateIssued({
+          telemetryService,
+          projectDAL,
+          projectId: ca.projectId,
+          profileId,
+          applicationId: scopedApplicationId,
+          enrollmentType: telemetryProfile?.enrollmentType ?? EnrollmentType.API,
+          operation: isRenewal ? "renew" : "order"
+        });
       }
     } catch (error: unknown) {
       if (error instanceof CertificateRequestCancelledError) {

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -24,7 +24,7 @@ import { TAppConnectionDALFactory } from "../app-connection/app-connection-dal";
 import { TAppConnectionServiceFactory } from "../app-connection/app-connection-service";
 import { TCertificateBodyDALFactory } from "../certificate/certificate-body-dal";
 import { TCertificateSecretDALFactory } from "../certificate/certificate-secret-dal";
-import { CertKeyAlgorithm } from "../certificate-common/certificate-constants";
+import { CertificateIssuanceOperation, CertKeyAlgorithm } from "../certificate-common/certificate-constants";
 import {
   calculateFinalRenewBeforeDays,
   resolveEffectiveApiConfig
@@ -1224,7 +1224,7 @@ export const certificateIssuanceQueueFactory = ({
           profileId,
           applicationId: scopedApplicationId,
           enrollmentType: telemetryProfile?.enrollmentType ?? EnrollmentType.API,
-          operation: isRenewal ? "renew" : "order"
+          operation: isRenewal ? CertificateIssuanceOperation.RENEW : CertificateIssuanceOperation.ORDER
         });
       }
     } catch (error: unknown) {

--- a/backend/src/services/certificate-authority/certificate-issuance-queue.ts
+++ b/backend/src/services/certificate-authority/certificate-issuance-queue.ts
@@ -14,9 +14,12 @@ import {
   CertSubjectAlternativeNameType
 } from "@app/services/certificate/certificate-types";
 import { TCertificateProfileDALFactory } from "@app/services/certificate-profile/certificate-profile-dal";
+import { EnrollmentType } from "@app/services/certificate-profile/certificate-profile-types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns";
+import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
+import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { TAppConnectionDALFactory } from "../app-connection/app-connection-dal";
 import { TAppConnectionServiceFactory } from "../app-connection/app-connection-service";
@@ -176,6 +179,7 @@ type TCertificateIssuanceQueueFactoryDep = {
   apiEnrollmentConfigDAL?: Pick<TApiEnrollmentConfigDALFactory, "findById">;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
   gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
+  telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
 };
 
 export type TCertificateIssuanceQueueFactory = ReturnType<typeof certificateIssuanceQueueFactory>;
@@ -203,7 +207,8 @@ export const certificateIssuanceQueueFactory = ({
   pkiApplicationProfileDAL,
   apiEnrollmentConfigDAL,
   gatewayV2Service,
-  gatewayPoolService
+  gatewayPoolService,
+  telemetryService
 }: TCertificateIssuanceQueueFactoryDep) => {
   const acmeFns = AcmeCertificateAuthorityFns({
     appConnectionDAL,
@@ -1200,6 +1205,34 @@ export const certificateIssuanceQueueFactory = ({
         });
       } catch {
         logger.debug("Failed to queue PKI alert event for async certificate issuance");
+      }
+
+      // External CAs complete asynchronously, so orderCertificate returns PENDING and this job is
+      // where the certificate actually comes into existence. Reported here so external-CA issuance
+      // is counted alongside the synchronous paths in certificate-v3-service.
+      try {
+        const project = await projectDAL.findById(ca.projectId);
+        if (project?.orgId) {
+          // ACME and SCEP fall back to this async path when the profile is backed by an external CA,
+          // so the enrollment method has to come from the profile rather than being assumed to be API.
+          const telemetryProfile = profileId ? await certificateProfileDAL?.findById(profileId) : undefined;
+
+          await telemetryService.sendPostHogEvents({
+            event: PostHogEventTypes.IssueCert,
+            distinctId: `platform/${ca.projectId}`,
+            organizationId: project.orgId,
+            properties: {
+              orgId: project.orgId,
+              projectId: ca.projectId,
+              profileId,
+              applicationId: scopedApplicationId ?? undefined,
+              enrollmentType: telemetryProfile?.enrollmentType ?? EnrollmentType.API,
+              operation: isRenewal ? "renew" : "order"
+            }
+          });
+        }
+      } catch (error) {
+        logger.debug({ error }, "Failed to report async certificate issuance telemetry");
       }
     } catch (error: unknown) {
       if (error instanceof CertificateRequestCancelledError) {

--- a/backend/src/services/certificate-authority/digicert/digicert-certificate-authority-processor.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-certificate-authority-processor.ts
@@ -10,7 +10,7 @@ import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 
-import { CertificateRequestStatus } from "../../certificate-common/certificate-constants";
+import { CertificateIssuanceOperation, CertificateRequestStatus } from "../../certificate-common/certificate-constants";
 import { reportCertificateIssued } from "../../certificate-common/certificate-telemetry-fns";
 import { TCertificateRequestDALFactory } from "../../certificate-request/certificate-request-dal";
 import {
@@ -195,7 +195,7 @@ export const processDigiCertPendingValidationRequest = async (
       profileId: request.profileId,
       applicationId: request.applicationId,
       enrollmentType: EnrollmentType.API,
-      operation: parsed.digicert.isRenewal ? "renew" : "order"
+      operation: parsed.digicert.isRenewal ? CertificateIssuanceOperation.RENEW : CertificateIssuanceOperation.ORDER
     });
 
     return { status: CertificateRequestStatus.ISSUED, certificateId, orderStatus };

--- a/backend/src/services/certificate-authority/digicert/digicert-certificate-authority-processor.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-certificate-authority-processor.ts
@@ -5,9 +5,13 @@ import { AppConnection } from "@app/services/app-connection/app-connection-enums
 import { decryptAppConnectionCredentials } from "@app/services/app-connection/app-connection-fns";
 import { getDigiCertApiBaseUrl } from "@app/services/app-connection/digicert/digicert-connection-fns";
 import { TDigiCertConnection } from "@app/services/app-connection/digicert/digicert-connection-types";
+import { EnrollmentType } from "@app/services/certificate-profile/certificate-profile-types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
+import { TProjectDALFactory } from "@app/services/project/project-dal";
+import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 
 import { CertificateRequestStatus } from "../../certificate-common/certificate-constants";
+import { reportCertificateIssued } from "../../certificate-common/certificate-telemetry-fns";
 import { TCertificateRequestDALFactory } from "../../certificate-request/certificate-request-dal";
 import {
   TAttachCertificateToRequestDTO,
@@ -57,6 +61,8 @@ export type TProcessDigiCertRequestDeps = {
   certificateRequestService: TDigiCertCertificateRequestServiceDep;
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "find" | "insertMany">;
   digicertFns: Pick<TDigiCertCertificateAuthorityFns, "fetchAndAttachIssuedCertificate">;
+  projectDAL: Pick<TProjectDALFactory, "findById">;
+  telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
 };
 
 export type TProcessDigiCertRequestResult =
@@ -181,6 +187,19 @@ export const processDigiCertPendingValidationRequest = async (
     logger.info(
       `DigiCert order issued, attached certificate [certificateRequestId=${request.id}] [certificateId=${certificateId}]`
     );
+
+    // The issuance queue stops at PENDING_VALIDATION for DigiCert, so this is where the certificate
+    // actually comes into existence and therefore where issuance is reported.
+    await reportCertificateIssued({
+      telemetryService: deps.telemetryService,
+      projectDAL: deps.projectDAL,
+      projectId: request.projectId,
+      profileId: request.profileId,
+      applicationId: request.applicationId,
+      enrollmentType: EnrollmentType.API,
+      operation: parsed.digicert.isRenewal ? "renew" : "order"
+    });
+
     return { status: CertificateRequestStatus.ISSUED, certificateId, orderStatus };
   }
 

--- a/backend/src/services/certificate-authority/digicert/digicert-certificate-authority-processor.ts
+++ b/backend/src/services/certificate-authority/digicert/digicert-certificate-authority-processor.ts
@@ -188,8 +188,6 @@ export const processDigiCertPendingValidationRequest = async (
       `DigiCert order issued, attached certificate [certificateRequestId=${request.id}] [certificateId=${certificateId}]`
     );
 
-    // The issuance queue stops at PENDING_VALIDATION for DigiCert, so this is where the certificate
-    // actually comes into existence and therefore where issuance is reported.
     await reportCertificateIssued({
       telemetryService: deps.telemetryService,
       projectDAL: deps.projectDAL,

--- a/backend/src/services/certificate-authority/godaddy/godaddy-certificate-authority-processor.ts
+++ b/backend/src/services/certificate-authority/godaddy/godaddy-certificate-authority-processor.ts
@@ -11,7 +11,7 @@ import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 
-import { CertificateRequestStatus } from "../../certificate-common/certificate-constants";
+import { CertificateIssuanceOperation, CertificateRequestStatus } from "../../certificate-common/certificate-constants";
 import { reportCertificateIssued } from "../../certificate-common/certificate-telemetry-fns";
 import { TCertificateRequestDALFactory } from "../../certificate-request/certificate-request-dal";
 import {
@@ -189,7 +189,7 @@ export const processGoDaddyPendingValidationRequest = async (
         profileId: request.profileId,
         applicationId: request.applicationId,
         enrollmentType: EnrollmentType.API,
-        operation: parsed.godaddy.isRenewal ? "renew" : "order"
+        operation: parsed.godaddy.isRenewal ? CertificateIssuanceOperation.RENEW : CertificateIssuanceOperation.ORDER
       });
 
       return { status: CertificateRequestStatus.ISSUED, certificateId, orderStatus };

--- a/backend/src/services/certificate-authority/godaddy/godaddy-certificate-authority-processor.ts
+++ b/backend/src/services/certificate-authority/godaddy/godaddy-certificate-authority-processor.ts
@@ -6,9 +6,13 @@ import { decryptAppConnectionCredentials } from "@app/services/app-connection/ap
 import { buildGoDaddySsoKeyHeader } from "@app/services/app-connection/godaddy/godaddy-connection-constants";
 import { getGoDaddyApiBaseUrl } from "@app/services/app-connection/godaddy/godaddy-connection-fns";
 import { TGoDaddyConnection } from "@app/services/app-connection/godaddy/godaddy-connection-types";
+import { EnrollmentType } from "@app/services/certificate-profile/certificate-profile-types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
+import { TProjectDALFactory } from "@app/services/project/project-dal";
+import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 
 import { CertificateRequestStatus } from "../../certificate-common/certificate-constants";
+import { reportCertificateIssued } from "../../certificate-common/certificate-telemetry-fns";
 import { TCertificateRequestDALFactory } from "../../certificate-request/certificate-request-dal";
 import {
   TAttachCertificateToRequestDTO,
@@ -57,6 +61,8 @@ export type TProcessGoDaddyRequestDeps = {
   certificateRequestService: TGoDaddyCertificateRequestServiceDep;
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "find" | "insertMany">;
   godaddyFns: Pick<TGoDaddyCertificateAuthorityFns, "fetchAndAttachIssuedCertificate">;
+  projectDAL: Pick<TProjectDALFactory, "findById">;
+  telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
 };
 
 export type TProcessGoDaddyRequestResult =
@@ -175,6 +181,19 @@ export const processGoDaddyPendingValidationRequest = async (
       logger.info(
         `GoDaddy certificate issued, attached certificate [certificateRequestId=${request.id}] [certificateId=${certificateId}]`
       );
+
+      // The issuance queue always stops at PENDING_VALIDATION for GoDaddy, so this is where the
+      // certificate actually comes into existence and therefore where issuance is reported.
+      await reportCertificateIssued({
+        telemetryService: deps.telemetryService,
+        projectDAL: deps.projectDAL,
+        projectId: request.projectId,
+        profileId: request.profileId,
+        applicationId: request.applicationId,
+        enrollmentType: EnrollmentType.API,
+        operation: parsed.godaddy.isRenewal ? "renew" : "order"
+      });
+
       return { status: CertificateRequestStatus.ISSUED, certificateId, orderStatus };
     } catch (error) {
       // A renewal can report ISSUED/CURRENT while GoDaddy is still serving the previous certificate

--- a/backend/src/services/certificate-authority/godaddy/godaddy-certificate-authority-processor.ts
+++ b/backend/src/services/certificate-authority/godaddy/godaddy-certificate-authority-processor.ts
@@ -182,8 +182,6 @@ export const processGoDaddyPendingValidationRequest = async (
         `GoDaddy certificate issued, attached certificate [certificateRequestId=${request.id}] [certificateId=${certificateId}]`
       );
 
-      // The issuance queue always stops at PENDING_VALIDATION for GoDaddy, so this is where the
-      // certificate actually comes into existence and therefore where issuance is reported.
       await reportCertificateIssued({
         telemetryService: deps.telemetryService,
         projectDAL: deps.projectDAL,

--- a/backend/src/services/certificate-common/certificate-constants.ts
+++ b/backend/src/services/certificate-common/certificate-constants.ts
@@ -53,6 +53,13 @@ export enum CertificateRequestStatus {
   REJECTED = "rejected"
 }
 
+export enum CertificateIssuanceOperation {
+  ISSUE = "issue",
+  SIGN = "sign",
+  ORDER = "order",
+  RENEW = "renew"
+}
+
 export enum CertSubjectAlternativeNameType {
   DNS_NAME = "dns_name",
   IP_ADDRESS = "ip_address",

--- a/backend/src/services/certificate-common/certificate-telemetry-fns.ts
+++ b/backend/src/services/certificate-common/certificate-telemetry-fns.ts
@@ -1,15 +1,14 @@
 import { logger } from "@app/lib/logger";
+import { CertificateIssuanceOperation } from "@app/services/certificate-common/certificate-constants";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
-
-export type TCertificateIssuanceOperation = "issue" | "sign" | "order" | "renew";
 
 export type TReportCertificateIssuedDTO = {
   telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
   projectId: string;
   enrollmentType: string;
-  operation: TCertificateIssuanceOperation;
+  operation: CertificateIssuanceOperation;
   profileId?: string | null;
   applicationId?: string | null;
   orgId?: string;
@@ -32,7 +31,11 @@ export const reportCertificateIssued = async ({
 }: TReportCertificateIssuedDTO) => {
   try {
     const resolvedOrgId = orgId || (projectDAL ? (await projectDAL.findById(projectId))?.orgId : undefined);
-    if (!resolvedOrgId) return;
+    // orgId is non-nullable on a project, so this only happens if the project was deleted mid-issuance.
+    if (!resolvedOrgId) {
+      logger.warn(`Skipping certificate issuance telemetry, project not found [projectId=${projectId}]`);
+      return;
+    }
 
     await telemetryService.sendPostHogEvents({
       event: PostHogEventTypes.IssueCert,

--- a/backend/src/services/certificate-common/certificate-telemetry-fns.ts
+++ b/backend/src/services/certificate-common/certificate-telemetry-fns.ts
@@ -1,0 +1,66 @@
+import { logger } from "@app/lib/logger";
+import { TProjectDALFactory } from "@app/services/project/project-dal";
+import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
+import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
+
+export type TCertificateIssuanceOperation = "issue" | "sign" | "order" | "renew";
+
+export type TReportCertificateIssuedDTO = {
+  telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
+  projectId: string;
+  enrollmentType: string;
+  operation: TCertificateIssuanceOperation;
+  profileId?: string | null;
+  applicationId?: string | null;
+  /** Supply when already known, to avoid the project lookup. */
+  orgId?: string;
+  /** Falls back to `platform/<projectId>` for protocol flows and background jobs. */
+  distinctId?: string;
+  /** Only needed when `orgId` is not supplied. */
+  projectDAL?: Pick<TProjectDALFactory, "findById">;
+};
+
+/**
+ * Single reporting point for "a certificate now exists".
+ *
+ * Certificates are issued from several places — the synchronous profile paths, the async external-CA
+ * queue, and the DigiCert/GoDaddy polling processors — and every one of them needs to report the same
+ * event with the same shape, so they all call this rather than assembling the payload themselves.
+ *
+ * Only call once the certificate actually exists. An order that is still pending validation has not
+ * been issued and must not be counted.
+ *
+ * Never throws: analytics must not fail an issuance.
+ */
+export const reportCertificateIssued = async ({
+  telemetryService,
+  projectId,
+  enrollmentType,
+  operation,
+  profileId,
+  applicationId,
+  orgId,
+  distinctId,
+  projectDAL
+}: TReportCertificateIssuedDTO) => {
+  try {
+    const resolvedOrgId = orgId || (projectDAL ? (await projectDAL.findById(projectId))?.orgId : undefined);
+    if (!resolvedOrgId) return;
+
+    await telemetryService.sendPostHogEvents({
+      event: PostHogEventTypes.IssueCert,
+      distinctId: distinctId || `platform/${projectId}`,
+      organizationId: resolvedOrgId,
+      properties: {
+        orgId: resolvedOrgId,
+        projectId,
+        profileId: profileId ?? undefined,
+        applicationId: applicationId ?? undefined,
+        enrollmentType,
+        operation
+      }
+    });
+  } catch (error) {
+    logger.debug({ error }, "Failed to report certificate issuance telemetry");
+  }
+};

--- a/backend/src/services/certificate-common/certificate-telemetry-fns.ts
+++ b/backend/src/services/certificate-common/certificate-telemetry-fns.ts
@@ -12,26 +12,13 @@ export type TReportCertificateIssuedDTO = {
   operation: TCertificateIssuanceOperation;
   profileId?: string | null;
   applicationId?: string | null;
-  /** Supply when already known, to avoid the project lookup. */
   orgId?: string;
-  /** Falls back to `platform/<projectId>` for protocol flows and background jobs. */
   distinctId?: string;
   /** Only needed when `orgId` is not supplied. */
   projectDAL?: Pick<TProjectDALFactory, "findById">;
 };
 
-/**
- * Single reporting point for "a certificate now exists".
- *
- * Certificates are issued from several places — the synchronous profile paths, the async external-CA
- * queue, and the DigiCert/GoDaddy polling processors — and every one of them needs to report the same
- * event with the same shape, so they all call this rather than assembling the payload themselves.
- *
- * Only call once the certificate actually exists. An order that is still pending validation has not
- * been issued and must not be counted.
- *
- * Never throws: analytics must not fail an issuance.
- */
+// Call only once the certificate exists — an order still pending validation is not an issuance.
 export const reportCertificateIssued = async ({
   telemetryService,
   projectId,

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -25,6 +25,7 @@ import {
 import { TCertificatePolicyServiceFactory } from "@app/services/certificate-policy/certificate-policy-service";
 import { TCertificateProfileDALFactory } from "@app/services/certificate-profile/certificate-profile-dal";
 import { EnrollmentType, IssuerType } from "@app/services/certificate-profile/certificate-profile-types";
+import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 import { ActorType, AuthMethod } from "../auth/auth-type";
 import {
@@ -55,6 +56,10 @@ vi.mock("../certificate-authority/certificate-authority-fns", () => ({
 
 describe("CertificateV3Service", () => {
   let service: TCertificateV3ServiceFactory;
+
+  const mockTelemetryService = {
+    sendPostHogEvents: vi.fn().mockResolvedValue(undefined)
+  };
 
   const mockCertificateDAL: Pick<
     TCertificateDALFactory,
@@ -279,7 +284,8 @@ describe("CertificateV3Service", () => {
       },
       licenseService: {
         getPlan: vi.fn().mockResolvedValue({ pkiPqc: true })
-      }
+      },
+      telemetryService: mockTelemetryService
     });
   });
 
@@ -455,6 +461,18 @@ describe("CertificateV3Service", () => {
       expect(result).toHaveProperty("privateKey");
       expect(result).toHaveProperty("serialNumber", "123456");
       expect(result).toHaveProperty("certificateId", "cert-123");
+
+      expect(mockTelemetryService.sendPostHogEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: PostHogEventTypes.IssueCert,
+          properties: expect.objectContaining({
+            profileId,
+            projectId: "project-123",
+            enrollmentType: EnrollmentType.API,
+            operation: "issue"
+          })
+        })
+      );
     });
 
     it("should correctly map camelCase key usages to snake_case before validation", async () => {
@@ -910,6 +928,16 @@ describe("CertificateV3Service", () => {
       expect(result).toHaveProperty("serialNumber", "789012");
       expect(result).toHaveProperty("certificateId", "cert-456");
       expect(result).not.toHaveProperty("privateKey");
+
+      expect(mockTelemetryService.sendPostHogEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: PostHogEventTypes.IssueCert,
+          properties: expect.objectContaining({
+            enrollmentType: EnrollmentType.API,
+            operation: "sign"
+          })
+        })
+      );
     });
 
     it("should throw ForbiddenRequestError when profile is not configured for API enrollment", async () => {

--- a/backend/src/services/certificate-v3/certificate-v3-service.test.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.test.ts
@@ -17,6 +17,7 @@ import { CaStatus } from "@app/services/certificate-authority/certificate-author
 import { TInternalCertificateAuthorityServiceFactory } from "@app/services/certificate-authority/internal/internal-certificate-authority-service";
 import {
   CertExtendedKeyUsageType,
+  CertificateIssuanceOperation,
   CertIncludeType,
   CertKeyUsageType,
   CertSubjectAlternativeNameType,
@@ -469,7 +470,7 @@ describe("CertificateV3Service", () => {
             profileId,
             projectId: "project-123",
             enrollmentType: EnrollmentType.API,
-            operation: "issue"
+            operation: CertificateIssuanceOperation.ISSUE
           })
         })
       );
@@ -934,7 +935,7 @@ describe("CertificateV3Service", () => {
           event: PostHogEventTypes.IssueCert,
           properties: expect.objectContaining({
             enrollmentType: EnrollmentType.API,
-            operation: "sign"
+            operation: CertificateIssuanceOperation.SIGN
           })
         })
       );

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -64,6 +64,7 @@ import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import {
   CertExtendedKeyUsageType,
+  CertificateIssuanceOperation,
   CertKeyUsageType,
   CertPolicyState,
   mapExtendedKeyUsageToLegacy,
@@ -87,10 +88,7 @@ import {
   validateAlgorithmCompatibility,
   validateCaSupport
 } from "../certificate-common/certificate-issuance-utils";
-import {
-  reportCertificateIssued,
-  TCertificateIssuanceOperation
-} from "../certificate-common/certificate-telemetry-fns";
+import { reportCertificateIssued } from "../certificate-common/certificate-telemetry-fns";
 import {
   bufferToString,
   buildCertificateSubjectFromTemplate,
@@ -726,7 +724,7 @@ export const certificateV3ServiceFactory = ({
     profileId?: string | null;
     applicationId?: string | null;
     enrollmentType: EnrollmentType;
-    operation: TCertificateIssuanceOperation;
+    operation: CertificateIssuanceOperation;
     actor?: ActorType;
     actorId?: string;
   }) => {
@@ -1325,7 +1323,7 @@ export const certificateV3ServiceFactory = ({
         profileId,
         applicationId,
         enrollmentType: EnrollmentType.API,
-        operation: "issue",
+        operation: CertificateIssuanceOperation.ISSUE,
         actor,
         actorId
       });
@@ -1559,7 +1557,7 @@ export const certificateV3ServiceFactory = ({
       profileId,
       applicationId,
       enrollmentType: EnrollmentType.API,
-      operation: "issue",
+      operation: CertificateIssuanceOperation.ISSUE,
       actor,
       actorId
     });
@@ -2019,7 +2017,7 @@ export const certificateV3ServiceFactory = ({
       profileId,
       applicationId,
       enrollmentType,
-      operation: "sign",
+      operation: CertificateIssuanceOperation.SIGN,
       actor,
       actorId
     });
@@ -3012,7 +3010,7 @@ export const certificateV3ServiceFactory = ({
       profileId: renewalResult.originalCert.profileId ?? undefined,
       applicationId: renewalResult.originalCert.applicationId ?? undefined,
       enrollmentType: EnrollmentType.API,
-      operation: "renew",
+      operation: CertificateIssuanceOperation.RENEW,
       actor,
       actorId
     });

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -60,7 +60,6 @@ import { PkiAlertEventType } from "@app/services/pki-alert-v2/pki-alert-v2-types
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
-import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import {
@@ -88,6 +87,10 @@ import {
   validateAlgorithmCompatibility,
   validateCaSupport
 } from "../certificate-common/certificate-issuance-utils";
+import {
+  reportCertificateIssued,
+  TCertificateIssuanceOperation
+} from "../certificate-common/certificate-telemetry-fns";
 import {
   bufferToString,
   buildCertificateSubjectFromTemplate,
@@ -708,9 +711,9 @@ export const certificateV3ServiceFactory = ({
   licenseService,
   telemetryService
 }: TCertificateV3ServiceFactoryDep) => {
-  // Certificates are issued through four entry points here, and every modern enrollment protocol
-  // (API, ACME, EST, SCEP) funnels through one of them, so issuance telemetry is reported here
-  // rather than per-route. Failures are swallowed: analytics must never fail an issuance.
+  // Every modern enrollment protocol (API, ACME, EST, SCEP) funnels through the issuance entry
+  // points in this file, so issuance telemetry is reported here rather than per-route. Only the
+  // actor resolution is local; the event itself is assembled by the shared reporter.
   const $reportCertificateIssued = async ({
     orgId,
     projectId,
@@ -723,33 +726,36 @@ export const certificateV3ServiceFactory = ({
   }: {
     orgId?: string;
     projectId: string;
-    profileId?: string;
-    applicationId?: string;
+    profileId?: string | null;
+    applicationId?: string | null;
     enrollmentType: EnrollmentType;
-    operation: "issue" | "sign" | "order" | "renew";
+    operation: TCertificateIssuanceOperation;
     actor?: ActorType;
     actorId?: string;
   }) => {
-    if (!orgId) return;
-
+    let distinctId: string | undefined;
     try {
-      let distinctId = `platform/${projectId}`;
       if (actor === ActorType.USER && actorId) {
         const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
-        distinctId = user?.username ?? user?.email ?? distinctId;
+        distinctId = user?.username ?? user?.email;
       } else if (actor === ActorType.IDENTITY && actorId) {
         distinctId = `identity-${actorId}`;
       }
-
-      await telemetryService.sendPostHogEvents({
-        event: PostHogEventTypes.IssueCert,
-        distinctId,
-        organizationId: orgId,
-        properties: { orgId, projectId, profileId, applicationId, enrollmentType, operation }
-      });
     } catch (error) {
-      logger.debug({ error }, "Failed to report certificate issuance telemetry");
+      logger.debug({ error }, "Failed to resolve distinctId for certificate issuance telemetry");
     }
+
+    await reportCertificateIssued({
+      telemetryService,
+      projectDAL,
+      orgId,
+      projectId,
+      profileId,
+      applicationId,
+      enrollmentType,
+      operation,
+      distinctId
+    });
   };
 
   const $resolveApplicationIdForProfile = async (
@@ -1315,6 +1321,17 @@ export const certificateV3ServiceFactory = ({
       } catch {
         logger.debug("Failed to queue PKI issuance alert event");
       }
+
+      await $reportCertificateIssued({
+        orgId: profile.project?.orgId ?? actorOrgId,
+        projectId: profile.projectId,
+        profileId,
+        applicationId,
+        enrollmentType: EnrollmentType.API,
+        operation: "issue",
+        actor,
+        actorId
+      });
 
       return {
         status: CertificateRequestStatus.ISSUED,

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -711,9 +711,6 @@ export const certificateV3ServiceFactory = ({
   licenseService,
   telemetryService
 }: TCertificateV3ServiceFactoryDep) => {
-  // Every modern enrollment protocol (API, ACME, EST, SCEP) funnels through the issuance entry
-  // points in this file, so issuance telemetry is reported here rather than per-route. Only the
-  // actor resolution is local; the event itself is assembled by the shared reporter.
   const $reportCertificateIssued = async ({
     orgId,
     projectId,

--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -59,6 +59,8 @@ import { TPkiAlertV2QueueServiceFactory } from "@app/services/pki-alert-v2/pki-a
 import { PkiAlertEventType } from "@app/services/pki-alert-v2/pki-alert-v2-types";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { getProjectKmsCertificateKeyId } from "@app/services/project/project-fns";
+import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
+import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import {
@@ -174,6 +176,7 @@ type TCertificateV3ServiceFactoryDep = {
   >;
   apiEnrollmentConfigDAL: Pick<TApiEnrollmentConfigDALFactory, "findById">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
+  telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
 };
 
 export type TCertificateV3ServiceFactory = ReturnType<typeof certificateV3ServiceFactory>;
@@ -702,8 +705,53 @@ export const certificateV3ServiceFactory = ({
   pkiAlertV2Queue,
   pkiApplicationProfileDAL,
   apiEnrollmentConfigDAL,
-  licenseService
+  licenseService,
+  telemetryService
 }: TCertificateV3ServiceFactoryDep) => {
+  // Certificates are issued through four entry points here, and every modern enrollment protocol
+  // (API, ACME, EST, SCEP) funnels through one of them, so issuance telemetry is reported here
+  // rather than per-route. Failures are swallowed: analytics must never fail an issuance.
+  const $reportCertificateIssued = async ({
+    orgId,
+    projectId,
+    profileId,
+    applicationId,
+    enrollmentType,
+    operation,
+    actor,
+    actorId
+  }: {
+    orgId?: string;
+    projectId: string;
+    profileId?: string;
+    applicationId?: string;
+    enrollmentType: EnrollmentType;
+    operation: "issue" | "sign" | "order" | "renew";
+    actor?: ActorType;
+    actorId?: string;
+  }) => {
+    if (!orgId) return;
+
+    try {
+      let distinctId = `platform/${projectId}`;
+      if (actor === ActorType.USER && actorId) {
+        const user = await requestMemoize(requestMemoKeys.userFindById(actorId), () => userDAL.findById(actorId));
+        distinctId = user?.username ?? user?.email ?? distinctId;
+      } else if (actor === ActorType.IDENTITY && actorId) {
+        distinctId = `identity-${actorId}`;
+      }
+
+      await telemetryService.sendPostHogEvents({
+        event: PostHogEventTypes.IssueCert,
+        distinctId,
+        organizationId: orgId,
+        properties: { orgId, projectId, profileId, applicationId, enrollmentType, operation }
+      });
+    } catch (error) {
+      logger.debug({ error }, "Failed to report certificate issuance telemetry");
+    }
+  };
+
   const $resolveApplicationIdForProfile = async (
     profile: {
       id: string;
@@ -1491,6 +1539,17 @@ export const certificateV3ServiceFactory = ({
       logger.debug("Failed to queue PKI issuance alert event");
     }
 
+    await $reportCertificateIssued({
+      orgId: profile.project?.orgId ?? actorOrgId,
+      projectId: profile.projectId,
+      profileId,
+      applicationId,
+      enrollmentType: EnrollmentType.API,
+      operation: "issue",
+      actor,
+      actorId
+    });
+
     return {
       status: CertificateRequestStatus.ISSUED,
       certificate: bufferToString(certificate),
@@ -1939,6 +1998,17 @@ export const certificateV3ServiceFactory = ({
     } catch {
       logger.debug("Failed to queue PKI issuance alert event");
     }
+
+    await $reportCertificateIssued({
+      orgId: profile.project?.orgId ?? actorOrgId,
+      projectId: profile.projectId,
+      profileId,
+      applicationId,
+      enrollmentType,
+      operation: "sign",
+      actor,
+      actorId
+    });
 
     return {
       status: CertificateRequestStatus.ISSUED,
@@ -2921,6 +2991,17 @@ export const certificateV3ServiceFactory = ({
     } catch {
       logger.debug("Failed to queue PKI renewal alert event");
     }
+
+    await $reportCertificateIssued({
+      orgId: renewalResult.profile?.project?.orgId ?? actorOrgId,
+      projectId: renewalResult.originalCert.projectId,
+      profileId: renewalResult.originalCert.profileId ?? undefined,
+      applicationId: renewalResult.originalCert.applicationId ?? undefined,
+      enrollmentType: EnrollmentType.API,
+      operation: "renew",
+      actor,
+      actorId
+    });
 
     return {
       status: CertificateRequestStatus.ISSUED,

--- a/backend/src/services/telemetry/telemetry-service.ts
+++ b/backend/src/services/telemetry/telemetry-service.ts
@@ -38,7 +38,8 @@ export const POSTHOG_AGGREGATED_EVENTS = [
 // in the grouping key so each unique value produces its own aggregated event with the
 // property as a flat string — enabling clean PostHog breakdowns.
 const AGGREGATION_BREAKDOWN_DIMENSIONS: Partial<Record<PostHogEventTypes, string[]>> = {
-  [PostHogEventTypes.PkiSyncExecuted]: ["destination"]
+  [PostHogEventTypes.PkiSyncExecuted]: ["destination"],
+  [PostHogEventTypes.IssueCert]: ["enrollmentType", "operation"]
 };
 
 // Bucket configuration

--- a/backend/src/services/telemetry/telemetry-types.ts
+++ b/backend/src/services/telemetry/telemetry-types.ts
@@ -22,6 +22,7 @@ import { SecretScanningDataSource } from "@app/ee/services/secret-scanning-v2/se
 import { EnforcementLevel, SecretSharingAccessType } from "@app/lib/types";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { AuthMethod } from "@app/services/auth/auth-type";
+import { CertificateIssuanceOperation } from "@app/services/certificate-common/certificate-constants";
 import { WebhookType } from "@app/services/webhook/webhook-types";
 
 export type HubSpotSignupMethod = AuthMethod | "invite";
@@ -670,7 +671,7 @@ export type TIssueCertificateEvent = {
     profileId?: string;
     applicationId?: string;
     enrollmentType?: string;
-    operation?: "issue" | "sign" | "order" | "renew";
+    operation?: CertificateIssuanceOperation;
   };
 };
 

--- a/backend/src/services/telemetry/telemetry-types.ts
+++ b/backend/src/services/telemetry/telemetry-types.ts
@@ -665,8 +665,6 @@ export type TIssueCertificateEvent = {
     subscriberId?: string;
     commonName?: string;
     userAgent?: string;
-    // Set by the profile-based issuance paths (certificate-v3-service and the async issuance
-    // queue). The legacy CA/subscriber routes above predate profiles and leave these unset.
     orgId?: string;
     projectId?: string;
     profileId?: string;

--- a/backend/src/services/telemetry/telemetry-types.ts
+++ b/backend/src/services/telemetry/telemetry-types.ts
@@ -154,6 +154,7 @@ export enum PostHogEventTypes {
   CertificateProfileCreated = "Certificate Profile Created",
   CertificateProfileDeleted = "Certificate Profile Deleted",
   PkiApplicationCreated = "PKI Application Created",
+  PkiApplicationUpdated = "PKI Application Updated",
   PkiApplicationDeleted = "PKI Application Deleted",
   PkiApplicationMemberAdded = "PKI Application Member Added",
   PkiApplicationProfileAttached = "PKI Application Profile Attached",
@@ -662,8 +663,16 @@ export type TIssueCertificateEvent = {
     caId?: string;
     certificateTemplateId?: string;
     subscriberId?: string;
-    commonName: string;
+    commonName?: string;
     userAgent?: string;
+    // Set by the profile-based issuance paths (certificate-v3-service and the async issuance
+    // queue). The legacy CA/subscriber routes above predate profiles and leave these unset.
+    orgId?: string;
+    projectId?: string;
+    profileId?: string;
+    applicationId?: string;
+    enrollmentType?: string;
+    operation?: "issue" | "sign" | "order" | "renew";
   };
 };
 
@@ -1297,6 +1306,15 @@ export type TPkiApplicationCreatedEvent = {
   event: PostHogEventTypes.PkiApplicationCreated;
   properties: {
     orgId: string;
+    applicationId?: string;
+  };
+};
+
+export type TPkiApplicationUpdatedEvent = {
+  event: PostHogEventTypes.PkiApplicationUpdated;
+  properties: {
+    orgId: string;
+    applicationId?: string;
   };
 };
 
@@ -1304,6 +1322,7 @@ export type TPkiApplicationDeletedEvent = {
   event: PostHogEventTypes.PkiApplicationDeleted;
   properties: {
     orgId: string;
+    applicationId?: string;
   };
 };
 
@@ -2157,6 +2176,7 @@ export type TPostHogEvent = {
   | TCertificateProfileCreatedEvent
   | TCertificateProfileDeletedEvent
   | TPkiApplicationCreatedEvent
+  | TPkiApplicationUpdatedEvent
   | TPkiApplicationDeletedEvent
   | TPkiApplicationMemberAddedEvent
   | TPkiApplicationProfileAttachedEvent


### PR DESCRIPTION
## Context

PKI metrics were broken in two separate ways:

1. **The dashboards pointed at an event that no longer exists.** `Issue PKI Certificate` was renamed to `Issue PKI Certificate aggregated` back in May, so every PKI dashboard silently read zero. Already fixed on the PostHog side — screenshots below.

2. **Most certificate issuance never emitted an event at all.** The modern path logged `Certificate Request Created` instead of an issuance, and ACME, EST and SCEP logged nothing. Only **5 orgs** looked like they were issuing certificates. **54** actually were.

This PR fixes the second one. Every issuance flow now emits `Issue PKI Certificate`, tagged with the application, profile and enrollment method, so issuance can be broken down by ACME vs EST vs SCEP vs API and attributed to a PKI application.

## Screenshots

**Infisical PKI dashboard** — empty → MAU ~40, WAU ~14-21, DAU 1-10

| Before | After |
|---|---|
| <img width="1456" alt="PKI dashboard before" src="https://github.com/user-attachments/assets/7dabb430-07c9-4c2f-ad8d-c8f0621d1413" /> | <img width="1456" alt="PKI dashboard after" src="https://github.com/user-attachments/assets/cbe46941-9bc2-4f38-801b-db44af1904c5" /> |

**PKI Activation Rate (30d)** — `0%` → `0.1%`

| Before | After |
|---|---|
| <img width="1456" alt="PKI activation rate before" src="https://github.com/user-attachments/assets/5cbf5659-aebb-4447-8776-7d80d836bdb6" /> | <img width="1456" alt="PKI activation rate after" src="https://github.com/user-attachments/assets/9b9fa46a-6e18-4103-b934-b8e3cc091e1a" /> |

**PKI Activation Funnel** — step 3: `0 orgs` → `21 orgs`

| Before | After |
|---|---|
| <img width="1456" alt="PKI activation funnel before" src="https://github.com/user-attachments/assets/ef3c1c6a-701d-4f1b-8414-90aeeac7034c" /> | <img width="1456" alt="PKI activation funnel after" src="https://github.com/user-attachments/assets/557f04ef-71d7-4558-9ac7-03285363616d" /> |

These stay low until this ships, since the orgs on the modern path still aren't emitting an issuance event.

<details>
<summary><b>Implementation notes</b></summary>

**Where the event is emitted**

| Flow | Reported from |
|---|---|
| API / UI — issue, sign | `certificate-v3-service` |
| ACME, EST, SCEP | `certificate-v3-service` — all three converge on `signCertificateFromProfile` |
| Self-signed | `certificate-v3-service` |
| Renewal — API and auto-renew cron | `certificate-v3-service` |
| External CAs that finish in one job — ACME, Azure AD CS, ADCS, AWS ACM, AWS PCA, Venafi TPP | `certificate-issuance-queue` |
| DigiCert, GoDaddy | their own polling processors |

Two things make that split necessary:

- `orderCertificate` always returns `PENDING` for external CAs, so instrumenting it would have counted orders rather than issuances. The queue reports instead.
- DigiCert and GoDaddy can end that queue job at `PENDING_VALIDATION`, with the certificate only arriving later. The queue tracks whether a certificate actually exists by the end of the job and stays silent when it doesn't; the two processors report at the point they attach the certificate. (This is tracked in the handler rather than re-read from the DB — a re-read hits the read replica moments after the write, so replica lag could drop the event.)

All six call sites go through one shared reporter, `certificate-common/certificate-telemetry-fns.ts`, rather than assembling the payload each time.

**Event properties:** `applicationId`, `profileId`, `enrollmentType`, `operation` (`issue` / `sign` / `order` / `renew`). The last two are registered in `AGGREGATION_BREAKDOWN_DIMENSIONS` so the hourly aggregation keeps them as flat values instead of histogramming them into `{"acme": 12}`. `enrollmentType` is read from the profile on the async path, since ACME and SCEP land there for external CAs.

**PKI applications:** `Created` / `Deleted` now carry `applicationId` (previously only `orgId`, so an application couldn't be joined to anything), and `PKI Application Updated` was added — it wasn't tracked at all.

**Left alone:** legacy CA, subscriber and deprecated certificate routes keep their existing events. `SignCert` has had zero events in 90 days but its emit sites are on working routes, so removing it buys nothing. Every emit is wrapped in try/catch — analytics must never fail an issuance.

**Tests:** unit tests assert the event fires with the right properties on the synchronous issue and sign paths. The async queue and the two processors are not covered.

</details>

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
