### PR TITLE
fix(identity-auth): use stored accessTokenTTL as fallback in update TTL validation

### DIFF
--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -497,7 +497,7 @@ export const identityAwsAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityAwsAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityAwsAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityAwsAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityAwsAuth.accessTokenTTL) > (accessTokenMaxTTL || identityAwsAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
+++ b/backend/src/services/identity-azure-auth/identity-azure-auth-service.ts
@@ -393,11 +393,11 @@ export const identityAzureAuthServiceFactory = ({
       });
     }
 
-    const identityGcpAuth = await identityAzureAuthDAL.findOne({ identityId });
+    const identityAzureAuth = await identityAzureAuthDAL.findOne({ identityId });
 
     if (
-      (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityGcpAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL)
+      (accessTokenMaxTTL || identityAzureAuth.accessTokenMaxTTL) > 0 &&
+      (accessTokenTTL || identityAzureAuth.accessTokenTTL) > (accessTokenMaxTTL || identityAzureAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }
@@ -445,7 +445,7 @@ export const identityAzureAuthServiceFactory = ({
       return extractIPDetails(accessTokenTrustedIp.ipAddress);
     });
 
-    const updatedAzureAuth = await identityAzureAuthDAL.updateById(identityGcpAuth.id, {
+    const updatedAzureAuth = await identityAzureAuthDAL.updateById(identityAzureAuth.id, {
       tenantId,
       resource,
       allowedServicePrincipalIds,

--- a/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
+++ b/backend/src/services/identity-gcp-auth/identity-gcp-auth-service.ts
@@ -444,7 +444,7 @@ export const identityGcpAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityGcpAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityGcpAuth.accessTokenTTL) > (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -591,7 +591,7 @@ export const identityJwtAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityJwtAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityJwtAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityJwtAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityJwtAuth.accessTokenTTL) > (accessTokenMaxTTL || identityJwtAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -1094,7 +1094,7 @@ export const identityKubernetesAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityKubernetesAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityKubernetesAuth.accessTokenMaxTTL) >
+      (accessTokenTTL || identityKubernetesAuth.accessTokenTTL) >
         (accessTokenMaxTTL || identityKubernetesAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });

--- a/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
+++ b/backend/src/services/identity-oidc-auth/identity-oidc-auth-service.ts
@@ -752,7 +752,7 @@ export const identityOidcAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityOidcAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityOidcAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityOidcAuth.accessTokenMaxTTL)
+      (accessTokenTTL || identityOidcAuth.accessTokenTTL) > (accessTokenMaxTTL || identityOidcAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }

--- a/backend/src/services/identity-token-auth/identity-token-auth-service.ts
+++ b/backend/src/services/identity-token-auth/identity-token-auth-service.ts
@@ -215,7 +215,7 @@ export const identityTokenAuthServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || identityTokenAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || identityTokenAuth.accessTokenMaxTTL) >
+      (accessTokenTTL || identityTokenAuth.accessTokenTTL) >
         (accessTokenMaxTTL || identityTokenAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });

--- a/backend/src/services/identity-ua/identity-ua-service.test.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.test.ts
@@ -1,0 +1,138 @@
+import { AbilityBuilder, createMongoAbility, MongoAbility } from "@casl/ability";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { IdentityAuthMethod } from "@app/db/schemas";
+import {
+  OrgPermissionIdentityActions,
+  OrgPermissionSet,
+  OrgPermissionSubjects
+} from "@app/ee/services/permission/org-permission";
+import { conditionsMatcher } from "@app/lib/casl";
+
+import { identityUaServiceFactory } from "./identity-ua-service";
+
+vi.mock("@app/lib/config/env", () => ({
+  getConfig: () => ({})
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+const IDENTITY_ID = "identity-id";
+const ORG_ID = "org-id";
+const ACTOR_ID = "actor-id";
+
+const TTL_ERROR = "Access token TTL cannot be greater than max TTL";
+
+const HOUR = 3600;
+const WEEK = 604800;
+const MONTH = 2592000;
+
+const buildOrgEditAbility = () => {
+  const builder = new AbilityBuilder<MongoAbility<OrgPermissionSet>>(createMongoAbility);
+  builder.can(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
+  return builder.build({ conditionsMatcher });
+};
+
+/**
+ * Builds the service with only the dependencies `updateUniversalAuth` touches.
+ * `storedTTL` / `storedMaxTTL` are what the identity already has persisted.
+ */
+const setup = ({ storedTTL, storedMaxTTL }: { storedTTL: number; storedMaxTTL: number }) => {
+  const identityUaDAL = {
+    findOne: vi.fn().mockResolvedValue({
+      id: "ua-id",
+      identityId: IDENTITY_ID,
+      accessTokenTTL: storedTTL,
+      accessTokenMaxTTL: storedMaxTTL
+    }),
+    updateById: vi
+      .fn()
+      .mockImplementation((id: string, row: Record<string, unknown>) =>
+        Promise.resolve({ id, identityId: IDENTITY_ID, ...row })
+      )
+  };
+
+  const membershipIdentityDAL = {
+    getIdentityById: vi.fn().mockResolvedValue({
+      scopeOrgId: ORG_ID,
+      identity: {
+        id: IDENTITY_ID,
+        orgId: ORG_ID,
+        projectId: null,
+        authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH]
+      }
+    })
+  };
+
+  const permissionService = {
+    getOrgPermission: vi.fn().mockResolvedValue({ permission: buildOrgEditAbility() }),
+    getProjectPermission: vi.fn()
+  };
+
+  const licenseService = { getPlan: vi.fn().mockResolvedValue({ ipAllowlisting: true }) };
+  const identityAccessTokenService = { invalidateTrustedIpsCache: vi.fn().mockResolvedValue(undefined) };
+
+  const service = identityUaServiceFactory({
+    identityDAL: { findById: vi.fn() },
+    identityUaDAL,
+    identityUaClientSecretDAL: {},
+    membershipIdentityDAL,
+    permissionService,
+    licenseService,
+    orgDAL: { findById: vi.fn(), findOne: vi.fn(), findEffectiveOrgMembership: vi.fn() },
+    identityAccessTokenService,
+    keyStore: {}
+  } as unknown as Parameters<typeof identityUaServiceFactory>[0]);
+
+  return { service, identityUaDAL };
+};
+
+const update = (
+  service: ReturnType<typeof identityUaServiceFactory>,
+  patch: { accessTokenTTL?: number; accessTokenMaxTTL?: number }
+) =>
+  service.updateUniversalAuth({
+    identityId: IDENTITY_ID,
+    actorId: ACTOR_ID,
+    actorOrgId: ORG_ID,
+    ...patch
+  } as unknown as Parameters<typeof service.updateUniversalAuth>[0]);
+
+describe("updateUniversalAuth access token TTL validation", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("lowering only accessTokenMaxTTL is accepted when the stored TTL still fits", async () => {
+    // stored: TTL 1h, maxTTL 30d. Request lowers maxTTL to 7d and omits TTL.
+    // 1h < 7d, so this is valid. Regression test: the fallback used to read the
+    // stored accessTokenMaxTTL (30d) instead of the stored accessTokenTTL (1h),
+    // which made 30d > 7d and rejected a legitimate update.
+    const { service, identityUaDAL } = setup({ storedTTL: HOUR, storedMaxTTL: MONTH });
+
+    await expect(update(service, { accessTokenMaxTTL: WEEK })).resolves.toBeDefined();
+    expect(identityUaDAL.updateById).toHaveBeenCalledWith(
+      "ua-id",
+      expect.objectContaining({ accessTokenMaxTTL: WEEK })
+    );
+  });
+
+  test("lowering accessTokenMaxTTL below the stored TTL is still rejected", async () => {
+    // stored: TTL 1h. Request lowers maxTTL to 60s, which is below the stored TTL.
+    const { service } = setup({ storedTTL: HOUR, storedMaxTTL: MONTH });
+
+    await expect(update(service, { accessTokenMaxTTL: 60 })).rejects.toThrow(TTL_ERROR);
+  });
+
+  test("an explicit TTL greater than an explicit max TTL is still rejected", async () => {
+    const { service } = setup({ storedTTL: HOUR, storedMaxTTL: MONTH });
+
+    await expect(update(service, { accessTokenTTL: 7200, accessTokenMaxTTL: HOUR })).rejects.toThrow(TTL_ERROR);
+  });
+
+  test("a max TTL of 0 means unlimited and skips the comparison", async () => {
+    const { service } = setup({ storedTTL: HOUR, storedMaxTTL: 0 });
+
+    await expect(update(service, { accessTokenTTL: MONTH })).resolves.toBeDefined();
+  });
+});

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -604,7 +604,7 @@ export const identityUaServiceFactory = ({
 
     if (
       (accessTokenMaxTTL || uaIdentityAuth.accessTokenMaxTTL) > 0 &&
-      (accessTokenTTL || uaIdentityAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || uaIdentityAuth.accessTokenMaxTTL)
+      (accessTokenTTL || uaIdentityAuth.accessTokenTTL) > (accessTokenMaxTTL || uaIdentityAuth.accessTokenMaxTTL)
     ) {
       throw new BadRequestError({ message: "Access token TTL cannot be greater than max TTL" });
     }


### PR DESCRIPTION
## Context

Fixes #7516.

The update flows for 8 identity auth methods validate that the new access token TTL does not exceed the new max TTL. When `accessTokenTTL` is omitted from the request, the left side of the comparison falls back to the stored `accessTokenMaxTTL` instead of the stored `accessTokenTTL`:

```ts
(accessTokenTTL || identityGcpAuth.accessTokenMaxTTL) > (accessTokenMaxTTL || identityGcpAuth.accessTokenMaxTTL)
```

So lowering only `accessTokenMaxTTL` is rejected with `Access token TTL cannot be greater than max TTL` even when the stored TTL is far below the new max. Example: TTL=1h, maxTTL=30d; `PATCH { accessTokenMaxTTL: 7d }` compares 30d > 7d and 400s, although 1h < 7d is valid.

The five newer auth methods (alicloud, ldap, oci, spiffe, tls-cert) already use the stored `accessTokenTTL` as the fallback. This PR aligns the remaining eight (gcp, kubernetes, oidc, jwt, azure, aws, token-auth, universal-auth) with them. One-word change per service.

Also renames the copy-pasted `identityGcpAuth` variable in the Azure auth service to `identityAzureAuth`.

## Screenshots

N/A (backend validation change).

## Steps to verify the change

1. Create a machine identity with Universal Auth: `accessTokenTTL: 3600`, `accessTokenMaxTTL: 2592000`.
2. `PATCH /api/v1/auth/universal-auth/identities/:identityId` with `{ "accessTokenMaxTTL": 604800 }` only.
3. Before: 400 `Access token TTL cannot be greater than max TTL`. After: 200, maxTTL updated.
4. Invalid updates still rejected: with stored TTL 3600, `{ "accessTokenMaxTTL": 60 }` fails as before, and `{ "accessTokenTTL": 7200, "accessTokenMaxTTL": 3600 }` fails as before.

Covered by a regression test: `backend/src/services/identity-ua/identity-ua-service.test.ts`. On `main` the first case fails with `Access token TTL cannot be greater than max TTL`; with this fix all four pass. The other three cases assert the guards this must not weaken (lowering max TTL below the stored TTL still rejects, an explicit TTL above an explicit max TTL still rejects, max TTL 0 still means unlimited) and pass on `main` too.

Universal auth is the representative case; the other seven services have the identical expression. `npm run test:unit`, `npm run type:check` and eslint are clean.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally (unit test + type:check + eslint)
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

