### PR TITLE
fix(auth): align onboarding form spacing

### DIFF
--- a/frontend/src/components/auth/AuthPageHeader.tsx
+++ b/frontend/src/components/auth/AuthPageHeader.tsx
@@ -4,7 +4,7 @@ import { Link } from "@tanstack/react-router";
 type Props = { children?: ReactNode };
 
 export const AuthPageHeader = ({ children }: Props) => (
-  <header className="relative z-10 flex h-16 w-full shrink-0 items-center justify-between px-8 xl:px-12">
+  <header className="relative z-10 flex h-16 w-full shrink-0 items-center justify-between px-5 sm:px-8 lg:px-10 xl:px-14">
     <Link to="/">
       <img alt="Infisical" src="/images/logotransparent.png" className="h-5" />
     </Link>

--- a/frontend/src/pages/admin/SignUpPage/components/AdminSignUpForm.tsx
+++ b/frontend/src/pages/admin/SignUpPage/components/AdminSignUpForm.tsx
@@ -79,7 +79,7 @@ export const AdminSignUpForm = ({ defaultValues, onContinue }: AdminSignUpFormPr
   return (
     <form className="flex flex-col gap-4" noValidate onSubmit={handleSubmit(onSubmit)}>
       <FieldGroup>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-2 gap-4">
           <Field data-invalid={showDangerState && Boolean(errors.firstName)}>
             <FieldLabel className="sr-only" htmlFor="admin-signup-first-name">
               First Name


### PR DESCRIPTION
 ## Context

The self-hosted admin signup page used a different horizontal padding scale in its header than in the auth content shell, leaving the logo and progress indicator misaligned at several breakpoints. The first- and last-name fields also stacked below the `sm` breakpoint.

This change aligns the header with the shell's `px-5 sm:px-8 lg:px-10 xl:px-14` spacing and keeps both name fields in a two-column row at every viewport size.

No linked ticket.

## Screenshots

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)