### PR TITLE
improvement: re-vamp org selection page

### DIFF
--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -1,4 +1,13 @@
-import { Fragment, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  Fragment,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useRouteContext, useRouter, useSearch } from "@tanstack/react-router";
@@ -19,13 +28,11 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
-  CardDescription,
-  CardHeader,
-  CardTitle,
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
-  ScrollableContent
+  ScrollableContent,
+  VerificationCodeHeader
 } from "@app/components/v3";
 import { cn } from "@app/components/v3/utils";
 import { SessionStorageKeys } from "@app/const";
@@ -44,41 +51,42 @@ import { setAuthToken } from "@app/hooks/api/reactQuery";
 import { navigateUserToOrg } from "../LoginPage/Login.utils";
 import { getSsoEnforcementError } from "./SelectOrg.utils";
 
-const OrgCard = ({
-  name,
-  label,
-  joinedAt,
-  onClick,
-  footer
-}: {
+type OrgCardProps = {
   name: string;
   label?: string;
   joinedAt?: string | null;
   onClick: () => void;
   footer?: ReactNode;
-}) => (
-  <div className="overflow-hidden rounded-lg border border-border bg-card">
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label={`Login to ${name}`}
-      className="group grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 p-4 text-left transition-colors hover:bg-container-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-inset"
-    >
-      <span className="min-w-0">
-        <span className="block truncate text-sm font-medium text-foreground">{name}</span>
-        {(label || joinedAt) && (
-          <span className="block text-sm leading-relaxed text-muted">
-            {label}
-            {label && joinedAt && " · "}
-            {joinedAt && <>Member since {format(new Date(joinedAt), "MMM d, yyyy")}</>}
-          </span>
-        )}
-      </span>
-      <ArrowRight className="size-4 self-center text-muted transition-all group-hover:translate-x-0.5 group-hover:text-foreground" />
-    </button>
-    {footer}
-  </div>
+};
+
+const OrgCard = forwardRef<HTMLButtonElement, OrgCardProps>(
+  ({ name, label, joinedAt, onClick, footer }, ref) => (
+    <div className="overflow-hidden rounded-lg border border-border bg-card">
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClick}
+        aria-label={`Login to ${name}`}
+        className="group grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 p-4 text-left transition-colors hover:bg-container-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-inset"
+      >
+        <span className="min-w-0">
+          <span className="block truncate text-sm font-medium text-foreground">{name}</span>
+          {(label || joinedAt) && (
+            <span className="block text-sm leading-relaxed text-muted">
+              {label}
+              {label && joinedAt && " · "}
+              {joinedAt && <>Member since {format(new Date(joinedAt), "MMM d, yyyy")}</>}
+            </span>
+          )}
+        </span>
+        <ArrowRight className="size-4 self-center text-muted transition-all group-hover:translate-x-0.5 group-hover:text-foreground" />
+      </button>
+      {footer}
+    </div>
+  )
 );
+
+OrgCard.displayName = "OrgCard";
 
 // Mirrors the step transition on the server admin onboarding (OnboardingPageLayout)
 type ViewTransitionContext = {
@@ -157,6 +165,22 @@ export const SelectOrgPage = () => {
     direction: viewDirection,
     prefersReducedMotion: Boolean(prefersReducedMotion)
   };
+
+  // A view switch unmounts the focused control, dropping keyboard focus to <body>.
+  // Focus the drilled-into org's card on entry and restore the originating
+  // "View sub-organizations" control on return.
+  const rootOrgCardRef = useRef<HTMLButtonElement | null>(null);
+  const subOrgStripRefs = useRef(new Map<string, HTMLButtonElement>());
+  const returnFocusOrgIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (selectedRootOrg) {
+      rootOrgCardRef.current?.focus();
+    } else if (returnFocusOrgIdRef.current) {
+      subOrgStripRefs.current.get(returnFocusOrgIdRef.current)?.focus();
+      returnFocusOrgIdRef.current = null;
+    }
+  }, [selectedRootOrg]);
 
   const handleLogout = useCallback(async () => {
     try {
@@ -336,7 +360,17 @@ export const SelectOrgPage = () => {
                 !isSearching && org.subOrganizations.length > 0 ? (
                   <button
                     type="button"
-                    onClick={() => setSelectedRootOrg(org)}
+                    ref={(el) => {
+                      if (el) {
+                        subOrgStripRefs.current.set(org.id, el);
+                      } else {
+                        subOrgStripRefs.current.delete(org.id);
+                      }
+                    }}
+                    onClick={() => {
+                      returnFocusOrgIdRef.current = org.id;
+                      setSelectedRootOrg(org);
+                    }}
                     aria-label={`View sub-organizations of ${org.name}`}
                     className="flex w-full cursor-pointer items-center gap-1.5 border-t border-border bg-container px-4 py-2 text-left text-xs text-muted transition-colors hover:bg-container-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-inset"
                   >
@@ -375,6 +409,7 @@ export const SelectOrgPage = () => {
     return (
       <div className="flex flex-col gap-3">
         <OrgCard
+          ref={rootOrgCardRef}
           name={selectedRootOrg.name}
           label="Root organization"
           joinedAt={selectedRootOrg.userJoinedAt}
@@ -441,28 +476,20 @@ export const SelectOrgPage = () => {
         <meta name="og:description" content={t("login.og-description") ?? ""} />
       </Helmet>
       <AuthPagePanel>
-        <CardHeader className="mb-6 gap-2">
-          <p className="font-jetbrains-mono text-xs tracking-[0.02em] text-project uppercase">
-            Select organization
-          </p>
-          <CardTitle className="font-alliance text-3xl leading-tight font-normal">
-            Choose your organization
-          </CardTitle>
-          <CardDescription className="text-sm">
-            Signed in as <span className="text-foreground">{user.username}</span>{" "}
-            <span className="whitespace-nowrap">
-              <span aria-hidden="true">· </span>
-              <button
-                aria-label={`Sign out ${user.username}`}
-                className="cursor-pointer text-project underline decoration-project/60 underline-offset-2 transition-colors duration-200 hover:decoration-project"
-                onClick={handleLogout}
-                type="button"
-              >
-                Sign out
-              </button>
-            </span>
-          </CardDescription>
-        </CardHeader>
+        <VerificationCodeHeader
+          title="Choose your organization as"
+          recipient={user.username}
+          action={
+            <button
+              aria-label={`Sign out ${user.username}`}
+              className="shrink-0 cursor-pointer text-sm text-foreground/95 underline decoration-project/60 underline-offset-2 transition-colors duration-200 hover:decoration-project"
+              onClick={handleLogout}
+              type="button"
+            >
+              Sign out
+            </button>
+          }
+        />
 
         <div className="flex flex-col gap-4">
           <InputGroup variant="outlined">
@@ -502,6 +529,7 @@ export const SelectOrgPage = () => {
                           <BreadcrumbLink asChild>
                             <button
                               type="button"
+                              className="focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
                               onClick={() => {
                                 setSelectedRootOrg(null);
                                 setSearchTerm("");
@@ -524,6 +552,9 @@ export const SelectOrgPage = () => {
                       outline={false}
                       containerClassName="min-h-0 flex-1"
                       className="h-full"
+                      // The list is full of focusable cards, so the scroll region
+                      // itself doesn't need to be a tab stop
+                      tabIndex={-1}
                     >
                       {renderSubOrgContent()}
                     </ScrollableContent>
@@ -535,6 +566,9 @@ export const SelectOrgPage = () => {
                     outline={false}
                     containerClassName={listHeightClass}
                     className="h-full"
+                    // The list is full of focusable cards, so the scroll region
+                    // itself doesn't need to be a tab stop
+                    tabIndex={-1}
                   >
                     {renderListContent()}
                   </ScrollableContent>

--- a/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
+++ b/frontend/src/pages/auth/SelectOrgPage/SelectOrgPage.tsx
@@ -1,17 +1,33 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useRouteContext, useRouter, useSearch } from "@tanstack/react-router";
 import { addSeconds, format, formatISO } from "date-fns";
-import { ChevronRight, LogIn, Search } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { ArrowRight, ChevronRight, Search } from "lucide-react";
 
 import { AuthPageLayout } from "@app/components/auth/AuthPageLayout";
 import { AuthPagePanel } from "@app/components/auth/AuthPagePanel";
 import { Mfa } from "@app/components/auth/Mfa";
 import { createNotification } from "@app/components/notifications";
 import SecurityClient from "@app/components/utilities/SecurityClient";
-import { ContentLoader, Input, Spinner } from "@app/components/v2";
-import { VerificationCodeHeader } from "@app/components/v3";
+import { ContentLoader, Spinner } from "@app/components/v2";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  ScrollableContent
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
 import { SessionStorageKeys } from "@app/const";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useToggle } from "@app/hooks";
@@ -28,45 +44,73 @@ import { setAuthToken } from "@app/hooks/api/reactQuery";
 import { navigateUserToOrg } from "../LoginPage/Login.utils";
 import { getSsoEnforcementError } from "./SelectOrg.utils";
 
-const OrgRow = ({
+const OrgCard = ({
   name,
   label,
   joinedAt,
   onClick,
-  variant = "default"
+  footer
 }: {
   name: string;
   label?: string;
   joinedAt?: string | null;
   onClick: () => void;
-  variant?: "default" | "sub" | "root";
-}) => {
-  const bgClass =
-    variant === "sub"
-      ? "bg-mineshaft-800 text-gray-300 hover:bg-mineshaft-700"
-      : "bg-mineshaft-700 text-gray-200 hover:bg-mineshaft-600";
-
-  return (
+  footer?: ReactNode;
+}) => (
+  <div className="overflow-hidden rounded-lg border border-border bg-card">
     <button
       type="button"
       onClick={onClick}
       aria-label={`Login to ${name}`}
-      className={`group flex h-14 w-full cursor-pointer items-center justify-between rounded-md border border-mineshaft-600 px-4 shadow-md transition-colors ${bgClass}`}
+      className="group grid w-full cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 p-4 text-left transition-colors hover:bg-container-hover focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-inset"
     >
-      <div className="flex flex-col items-start">
-        <p className="truncate font-alliance">{name}</p>
+      <span className="min-w-0">
+        <span className="block truncate text-sm font-medium text-foreground">{name}</span>
         {(label || joinedAt) && (
-          <p className="text-xs text-mineshaft-400">
+          <span className="block text-sm leading-relaxed text-muted">
             {label}
             {label && joinedAt && " · "}
             {joinedAt && <>Member since {format(new Date(joinedAt), "MMM d, yyyy")}</>}
-          </p>
+          </span>
         )}
-      </div>
-      <LogIn className="size-4 text-gray-400 transition-all group-hover:text-primary-400" />
+      </span>
+      <ArrowRight className="size-4 self-center text-muted transition-all group-hover:translate-x-0.5 group-hover:text-foreground" />
     </button>
-  );
+    {footer}
+  </div>
+);
+
+// Mirrors the step transition on the server admin onboarding (OnboardingPageLayout)
+type ViewTransitionContext = {
+  direction: number;
+  prefersReducedMotion: boolean;
 };
+
+const viewTransitionVariants = {
+  enter: ({ direction, prefersReducedMotion }: ViewTransitionContext) =>
+    prefersReducedMotion
+      ? {
+          opacity: 0
+        }
+      : {
+          transform: `translate3d(${direction * 32}px, 0, 0) scale(1.01)`,
+          opacity: 0.28
+        },
+  center: {
+    transform: "translate3d(0, 0, 0) scale(1)",
+    opacity: 1
+  },
+  exit: {
+    opacity: 0,
+    transition: {
+      duration: 0
+    }
+  }
+};
+
+// Fixed (viewport-adaptive) list height — matches ScrollableContent's lg max-height clamp —
+// so filtering or switching views never reflows the vertically-centered header and search
+const listHeightClass = "h-[clamp(12rem,calc(100dvh_-_24rem),28rem)]";
 
 export const SelectOrgPage = () => {
   const navigate = useNavigate();
@@ -95,6 +139,25 @@ export const SelectOrgPage = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const mfaOrgInfo = useRef<{ rootOrg: TOrgWithSubOrgs; subOrgId?: string } | null>(null);
 
+  const prefersReducedMotion = useReducedMotion();
+  const viewDepth = selectedRootOrg ? 1 : 0;
+  const previousViewDepthRef = useRef(viewDepth);
+  let viewDirection = 0;
+  if (viewDepth > previousViewDepthRef.current) {
+    viewDirection = 1;
+  } else if (viewDepth < previousViewDepthRef.current) {
+    viewDirection = -1;
+  }
+
+  useEffect(() => {
+    previousViewDepthRef.current = viewDepth;
+  }, [viewDepth]);
+
+  const viewTransitionContext: ViewTransitionContext = {
+    direction: viewDirection,
+    prefersReducedMotion: Boolean(prefersReducedMotion)
+  };
+
   const handleLogout = useCallback(async () => {
     try {
       await logout.mutateAsync();
@@ -122,11 +185,6 @@ export const SelectOrgPage = () => {
           : org.subOrganizations.filter((sub) => sub.name.toLowerCase().includes(term))
       }));
   }, [orgs, searchTerm]);
-
-  const totalOrgCount = useMemo(() => {
-    if (!orgs) return 0;
-    return orgs.reduce((sum, org) => sum + 1 + org.subOrganizations.length, 0);
-  }, [orgs]);
 
   const filteredSubOrgs = useMemo(() => {
     if (!selectedRootOrg) return [];
@@ -260,104 +318,83 @@ export const SelectOrgPage = () => {
       );
     }
 
-    if (selectedRootOrg) {
-      return (
-        <div className="space-y-2">
-          <OrgRow
-            name={selectedRootOrg.name}
-            label="Root organization"
-            joinedAt={selectedRootOrg.userJoinedAt}
-            onClick={() => handleSelectOrganization(selectedRootOrg)}
-            variant="root"
-          />
-          <p className="px-1 pt-1 text-xs font-medium tracking-wider text-mineshaft-400 uppercase">
-            Sub-organizations
-          </p>
-          {filteredSubOrgs.length === 0 ? (
-            <p className="py-4 text-center text-sm text-mineshaft-400">
-              No sub-organizations found
-            </p>
-          ) : (
-            filteredSubOrgs.map((sub) => (
-              <OrgRow
-                key={sub.id}
-                name={sub.name}
-                joinedAt={sub.userJoinedAt}
-                onClick={() => handleSelectOrganization(selectedRootOrg, sub.id)}
-                variant="sub"
-              />
-            ))
-          )}
-        </div>
-      );
-    }
-
     if (filteredOrgs.length === 0) {
-      return <p className="py-4 text-center text-sm text-mineshaft-400">No organizations found</p>;
+      return <p className="py-4 text-center text-sm text-muted">No organizations found</p>;
     }
 
     const isSearching = Boolean(searchTerm.trim());
-    return (
-      <div className="space-y-2">
-        {filteredOrgs.map((org) => {
-          const hasSubOrgs = org.subOrganizations.length > 0;
 
-          return (
-            <div key={org.id}>
-              {hasSubOrgs && !isSearching ? (
-                <div className="relative overflow-clip rounded-md border border-mineshaft-600 text-gray-200 shadow-md">
-                  <button
-                    type="button"
-                    onClick={() => handleSelectOrganization(org)}
-                    aria-label={`Login to ${org.name}`}
-                    className="group relative z-10 flex w-full cursor-pointer items-center justify-between bg-mineshaft-700 px-4 py-3 transition-colors hover:bg-mineshaft-600"
-                  >
-                    <div className="flex flex-col items-start gap-1.5">
-                      <p className="truncate transition-colors">{org.name}</p>
-                      {org.userJoinedAt && (
-                        <p className="text-xs text-mineshaft-400">
-                          Member since {format(new Date(org.userJoinedAt), "MMM d yyyy")}
-                        </p>
-                      )}
-                    </div>
-                    <LogIn className="size-4.5 text-gray-400 transition-all group-hover:text-primary-400" />
-                  </button>
+    return (
+      <div className="flex flex-col gap-3">
+        {filteredOrgs.map((org) => (
+          <Fragment key={org.id}>
+            <OrgCard
+              name={org.name}
+              joinedAt={org.userJoinedAt}
+              onClick={() => handleSelectOrganization(org)}
+              footer={
+                !isSearching && org.subOrganizations.length > 0 ? (
                   <button
                     type="button"
                     onClick={() => setSelectedRootOrg(org)}
                     aria-label={`View sub-organizations of ${org.name}`}
-                    className="pointer-events-auto flex w-full cursor-pointer items-center gap-1 bg-mineshaft-500 px-2 py-2 text-xs text-mineshaft-300 transition-colors hover:bg-mineshaft-500 hover:text-gray-200"
+                    className="flex w-full cursor-pointer items-center gap-1.5 border-t border-border bg-container px-4 py-2 text-left text-xs text-muted transition-colors hover:bg-container-hover hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-inset"
                   >
-                    <ChevronRight className="size-4" />
+                    <ChevronRight className="size-3.5" />
                     View {org.subOrganizations.length} sub-organization
                     {org.subOrganizations.length !== 1 ? "s" : ""}
                   </button>
-                </div>
-              ) : (
-                <OrgRow
-                  name={org.name}
-                  joinedAt={org.userJoinedAt}
-                  onClick={() => handleSelectOrganization(org)}
-                />
-              )}
+                ) : undefined
+              }
+            />
+            {/* While searching, surface matching sub-orgs inline so they stay discoverable */}
+            {isSearching && org.subOrganizations.length > 0 && (
+              <div className="ml-4 flex flex-col gap-3 border-l border-border pl-4">
+                <p className="px-1 pt-1 font-jetbrains-mono text-xs tracking-widest text-muted uppercase">
+                  Sub-organizations
+                </p>
+                {org.subOrganizations.map((sub) => (
+                  <OrgCard
+                    key={sub.id}
+                    name={sub.name}
+                    joinedAt={sub.userJoinedAt}
+                    onClick={() => handleSelectOrganization(org, sub.id)}
+                  />
+                ))}
+              </div>
+            )}
+          </Fragment>
+        ))}
+      </div>
+    );
+  };
 
-              {isSearching && hasSubOrgs && (
-                <div className="mt-2 ml-1 space-y-1 border-l border-primary pl-2">
-                  {org.subOrganizations.map((sub) => (
-                    <OrgRow
-                      key={sub.id}
-                      name={sub.name}
-                      label="Sub-organization"
-                      joinedAt={sub.userJoinedAt}
-                      onClick={() => handleSelectOrganization(org, sub.id)}
-                      variant="sub"
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          );
-        })}
+  const renderSubOrgContent = () => {
+    if (!selectedRootOrg) return null;
+
+    return (
+      <div className="flex flex-col gap-3">
+        <OrgCard
+          name={selectedRootOrg.name}
+          label="Root organization"
+          joinedAt={selectedRootOrg.userJoinedAt}
+          onClick={() => handleSelectOrganization(selectedRootOrg)}
+        />
+        <p className="px-1 pt-1 font-jetbrains-mono text-xs tracking-widest text-muted uppercase">
+          Sub-organizations
+        </p>
+        {filteredSubOrgs.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted">No sub-organizations found</p>
+        ) : (
+          filteredSubOrgs.map((sub) => (
+            <OrgCard
+              key={sub.id}
+              name={sub.name}
+              joinedAt={sub.userJoinedAt}
+              onClick={() => handleSelectOrganization(selectedRootOrg, sub.id)}
+            />
+          ))
+        )}
       </div>
     );
   };
@@ -404,56 +441,107 @@ export const SelectOrgPage = () => {
         <meta name="og:description" content={t("login.og-description") ?? ""} />
       </Helmet>
       <AuthPagePanel>
-        <VerificationCodeHeader
-          title="Choose your organization as"
-          recipient={user.username}
-          action={
-            <button
-              aria-label={`Sign out ${user.username}`}
-              className="shrink-0 cursor-pointer text-sm text-foreground/95 underline decoration-project/60 underline-offset-2 transition-colors duration-200 hover:decoration-project"
-              onClick={handleLogout}
-              type="button"
-            >
-              Sign out
-            </button>
-          }
-        />
+        <CardHeader className="mb-6 gap-2">
+          <p className="font-jetbrains-mono text-xs tracking-[0.02em] text-project uppercase">
+            Select organization
+          </p>
+          <CardTitle className="font-alliance text-3xl leading-tight font-normal">
+            Choose your organization
+          </CardTitle>
+          <CardDescription className="text-sm">
+            Signed in as <span className="text-foreground">{user.username}</span>{" "}
+            <span className="whitespace-nowrap">
+              <span aria-hidden="true">· </span>
+              <button
+                aria-label={`Sign out ${user.username}`}
+                className="cursor-pointer text-project underline decoration-project/60 underline-offset-2 transition-colors duration-200 hover:decoration-project"
+                onClick={handleLogout}
+                type="button"
+              >
+                Sign out
+              </button>
+            </span>
+          </CardDescription>
+        </CardHeader>
 
-        <div className="rounded-xl border-2 border-mineshaft-500 shadow-lg">
-          {totalOrgCount >= 5 && (
-            <div className="border-b border-mineshaft-600 px-4 py-3">
-              <Input
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder={
-                  selectedRootOrg ? "Search sub-organizations..." : "Search organizations..."
-                }
-                leftIcon={<Search className="size-4" />}
-                className="h-10"
-              />
-            </div>
-          )}
+        <div className="flex flex-col gap-4">
+          <InputGroup variant="outlined">
+            <InputGroupAddon align="inline-start">
+              <Search />
+            </InputGroupAddon>
+            <InputGroupInput
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              placeholder={
+                selectedRootOrg ? "Search sub-organizations..." : "Search organizations..."
+              }
+              aria-label={selectedRootOrg ? "Search sub-organizations" : "Search organizations"}
+            />
+          </InputGroup>
 
-          {selectedRootOrg && (
-            <div className="border-b border-mineshaft-600 px-4 py-2">
-              <nav className="flex items-center gap-1.5 text-sm">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setSelectedRootOrg(null);
-                    setSearchTerm("");
-                  }}
-                  className="text-mineshaft-400 transition-colors hover:text-gray-200"
-                >
-                  All organizations
-                </button>
-                <span className="text-white">›</span>
-                <span className="font-medium text-gray-300">{selectedRootOrg.name}</span>
-              </nav>
-            </div>
-          )}
+          <div className="relative -m-2 overflow-hidden p-2">
+            <AnimatePresence mode="popLayout" initial={false} custom={viewTransitionContext}>
+              <motion.div
+                key={selectedRootOrg?.id ?? "all-organizations"}
+                custom={viewTransitionContext}
+                variants={viewTransitionVariants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+                transition={{
+                  duration: prefersReducedMotion ? 0.12 : 0.18,
+                  ease: [0.23, 1, 0.32, 1]
+                }}
+                className="w-full will-change-transform"
+              >
+                {selectedRootOrg ? (
+                  <div className={cn("flex flex-col gap-4", listHeightClass)}>
+                    <Breadcrumb>
+                      <BreadcrumbList>
+                        <BreadcrumbItem>
+                          <BreadcrumbLink asChild>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setSelectedRootOrg(null);
+                                setSearchTerm("");
+                              }}
+                            >
+                              All organizations
+                            </button>
+                          </BreadcrumbLink>
+                        </BreadcrumbItem>
+                        <BreadcrumbSeparator />
+                        <BreadcrumbItem>
+                          <BreadcrumbPage>{selectedRootOrg.name}</BreadcrumbPage>
+                        </BreadcrumbItem>
+                      </BreadcrumbList>
+                    </Breadcrumb>
 
-          <div className="max-h-96 thin-scrollbar overflow-y-auto p-2">{renderListContent()}</div>
+                    <ScrollableContent
+                      aria-label={`${selectedRootOrg.name} sub-organizations`}
+                      edgeBehavior="fade"
+                      outline={false}
+                      containerClassName="min-h-0 flex-1"
+                      className="h-full"
+                    >
+                      {renderSubOrgContent()}
+                    </ScrollableContent>
+                  </div>
+                ) : (
+                  <ScrollableContent
+                    aria-label="Your organizations"
+                    edgeBehavior="fade"
+                    outline={false}
+                    containerClassName={listHeightClass}
+                    className="h-full"
+                  >
+                    {renderListContent()}
+                  </ScrollableContent>
+                )}
+              </motion.div>
+            </AnimatePresence>
+          </div>
         </div>
       </AuthPagePanel>
     </AuthPageLayout>


### PR DESCRIPTION
## Context

This PR revamps our org selection page, bringing it update to date with our new onboarding/login design

## Screenshots

<img width="3456" height="1926" alt="CleanShot 2026-08-03 at 15 58 14@2x" src="https://github.com/user-attachments/assets/b9b23980-b35d-4a30-8145-655721c271c0" />
<img width="3456" height="1926" alt="CleanShot 2026-08-03 at 15 58 17@2x" src="https://github.com/user-attachments/assets/31bd18df-7c97-4671-8be1-e8163fd32629" />
<img width="3456" height="1926" alt="CleanShot 2026-08-03 at 15 58 20@2x" src="https://github.com/user-attachments/assets/13a6d542-f086-45a0-866b-16e09bb82717" />

## Steps to verify the change

- [ ] Log in with a multi-org account → orgs render as separate cards with arrow icons, header/eyebrow/"Signed in as · Sign out" match design
- [ ] Type in search → title and search bar don't shift; matching sub-orgs appear grouped under their parent with a rail + SUB-ORGANIZATIONS label
- [ ] Click "View N sub-organizations" → view slides forward to breadcrumb + root card + sub cards; "All organizations" slides back and clears search
- [ ] Search inside sub-org view filters subs only; no-results states render without layout shift
- [ ] Click a root org and a sub-org card → each logs in and lands on the org (MFA/CLI flows unaffected)
- [ ] Single-org account with no subs → no strips, list still renders; reduced-motion pref swaps slide for fade

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)