### PR TITLE
feat(ovhcloud kms):  add token connection

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2833,7 +2833,8 @@ export const AppConnections = {
       certificate:
         "The PEM-encoded public certificate issued by OVHcloud KMS for client certificate authentication (including the -----BEGIN/END CERTIFICATE----- markers).",
       okmsDomain: "The OVHcloud KMS base URL (e.g., 'https://ca-east-bhs.okms.ovh.net').",
-      okmsId: "The OVHcloud KMS instance identifier from the OVH Control Panel, used as a path segment in all API calls.",
+      okmsId:
+        "The OVHcloud KMS instance identifier from the OVH Control Panel, used as a path segment in all API calls.",
       token: "The access token used to authenticate to the OVHcloud KMS REST API"
     },
     SNOWFLAKE: {

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2829,11 +2829,12 @@ export const AppConnections = {
     },
     OVH: {
       privateKey:
-        "The PEM-encoded private key issued by OVH OKMS for client certificate authentication (including the -----BEGIN/END PRIVATE KEY----- markers).",
+        "The PEM-encoded private key issued by OVHcloud KMS for client certificate authentication (including the -----BEGIN/END PRIVATE KEY----- markers).",
       certificate:
-        "The PEM-encoded public certificate issued by OVH OKMS for client certificate authentication (including the -----BEGIN/END CERTIFICATE----- markers).",
-      okmsDomain: "The OKMS base URL (e.g., 'https://ca-east-bhs.okms.ovh.net').",
-      okmsId: "The OKMS instance identifier from the OVH Control Panel, used as a path segment in all API calls."
+        "The PEM-encoded public certificate issued by OVHcloud KMS for client certificate authentication (including the -----BEGIN/END CERTIFICATE----- markers).",
+      okmsDomain: "The OVHcloud KMS base URL (e.g., 'https://ca-east-bhs.okms.ovh.net').",
+      okmsId: "The OVHcloud KMS instance identifier from the OVH Control Panel, used as a path segment in all API calls.",
+      token: "The access token used to authenticate to the OVHcloud KMS REST API"
     },
     SNOWFLAKE: {
       account: "The Snowflake account identifier (e.g., xy12345.us-east-1).",
@@ -3083,7 +3084,7 @@ export const SecretSyncs = {
       path: "The Hashicorp Vault path to sync secrets to."
     },
     OVH: {
-      path: "The path in OVH OKMS where secrets will be stored as key/value pairs."
+      path: "The path in OVHcloud KMS where secrets will be stored as key/value pairs."
     },
     TEAMCITY: {
       project: "The TeamCity project to sync secrets to.",

--- a/backend/src/services/app-connection/app-connection-fns.ts
+++ b/backend/src/services/app-connection/app-connection-fns.ts
@@ -23,6 +23,7 @@ import {
   transferSqlConnectionCredentialsToPlatform,
   validateSqlConnectionCredentials
 } from "@app/services/app-connection/shared/sql";
+import { TVenafiTppConnectionConfig } from "@app/services/app-connection/venafi-tpp";
 import { EXTERNAL_MIGRATION_APP_CONNECTIONS } from "@app/services/external-migration/external-migration-map";
 import { TGitHubAppDALFactory } from "@app/services/github-app/github-app-dal";
 import { TIdentityUaDALFactory } from "@app/services/identity-ua/identity-ua-dal";
@@ -293,7 +294,6 @@ import {
   validateVenafiTppConnectionCredentials,
   VenafiTppConnectionMethod
 } from "./venafi-tpp";
-import { TVenafiTppConnectionConfig } from "./venafi-tpp/venafi-tpp-connection-types";
 import { VercelConnectionMethod } from "./vercel";
 import { getVercelConnectionListItem, validateVercelConnectionCredentials } from "./vercel/vercel-connection-fns";
 import {
@@ -802,6 +802,8 @@ export const getAppConnectionMethodName = (method: TAppConnection["method"]) => 
       return "API Token";
     case OVHConnectionMethod.Certificate:
       return "Certificate";
+    case OVHConnectionMethod.Token:
+      return "Token";
     default:
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new Error(`Unhandled App Connection Method: ${method}`);

--- a/backend/src/services/app-connection/app-connection-maps.ts
+++ b/backend/src/services/app-connection/app-connection-maps.ts
@@ -64,7 +64,7 @@ export const APP_CONNECTION_NAME_MAP: Record<AppConnection, string> = {
   [AppConnection.NetScaler]: "NetScaler",
   [AppConnection.KempLoadMaster]: "Kemp LoadMaster",
   [AppConnection.Anthropic]: "Anthropic",
-  [AppConnection.OVH]: "OVH",
+  [AppConnection.OVH]: "OVHcloud",
   [AppConnection.Devin]: "Devin",
   [AppConnection.Ona]: "Ona",
   [AppConnection.DigiCert]: "DigiCert",

--- a/backend/src/services/app-connection/ovh/ovh-connection-enums.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-enums.ts
@@ -1,3 +1,4 @@
 export enum OVHConnectionMethod {
-  Certificate = "certificate"
+  Certificate = "certificate",
+  Token = "token"
 }

--- a/backend/src/services/app-connection/ovh/ovh-connection-fns.test.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-fns.test.ts
@@ -1,0 +1,60 @@
+import { OVHConnectionMethod } from "@app/services/app-connection/ovh/ovh-connection-enums";
+import { getOvhRequestOptions } from "@app/services/app-connection/ovh/ovh-connection-fns";
+import { ValidateOvhConnectionCredentialsSchema } from "@app/services/app-connection/ovh/ovh-connection-schemas";
+
+const OKMS_DOMAIN = "https://eu-west-rbx.okms.ovh.net";
+const OKMS_ID = "734b9b45-8b1a-469c-b140-b10bd6540017";
+
+describe("getOvhRequestOptions", () => {
+  test("certificate method sets the client cert and key on https.Agent and sets no header", () => {
+    const requestOptions = getOvhRequestOptions({
+      method: OVHConnectionMethod.Certificate,
+      credentials: {
+        privateKey: "privateKey",
+        certificate: "certificate",
+        okmsDomain: OKMS_DOMAIN,
+        okmsId: OKMS_ID
+      }
+    });
+
+    expect(requestOptions.headers).toBeUndefined();
+    expect(requestOptions.httpsAgent).toBeDefined();
+    expect(requestOptions.httpsAgent?.options.key).toContain("privateKey");
+    expect(requestOptions.httpsAgent?.options.cert).toContain("certificate");
+  });
+
+  test("token method sets the token on headers and sets not https.Agent", () => {
+    const requestOptions = getOvhRequestOptions({
+      method: OVHConnectionMethod.Token,
+      credentials: {
+        token: "secret-token",
+        okmsDomain: OKMS_DOMAIN,
+        okmsId: OKMS_ID
+      }
+    });
+
+    expect(requestOptions.headers).toBeDefined();
+    expect(requestOptions.httpsAgent).toBeUndefined();
+    expect(requestOptions.headers).toEqual({ Authorization: "Bearer secret-token" });
+  });
+});
+
+describe("ValidateOvhConnectionCredentialsSchema", () => {
+  test("certificate method requires privateKey and certificate", () => {
+    const result = ValidateOvhConnectionCredentialsSchema.safeParse({
+      method: OVHConnectionMethod.Certificate,
+      credentials: { token: "secret-token", okmsDomain: OKMS_DOMAIN, okmsId: OKMS_ID }
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("token method requires token", () => {
+    const result = ValidateOvhConnectionCredentialsSchema.safeParse({
+      method: OVHConnectionMethod.Certificate,
+      credentials: { okmsDomain: OKMS_DOMAIN, okmsId: OKMS_ID }
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/services/app-connection/ovh/ovh-connection-fns.test.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-fns.test.ts
@@ -23,7 +23,7 @@ describe("getOvhRequestOptions", () => {
     expect(requestOptions.httpsAgent?.options.cert).toContain("certificate");
   });
 
-  test("token method sets the token on headers and sets not https.Agent", () => {
+  test("token method sets the token on headers and sets no https.Agent", () => {
     const requestOptions = getOvhRequestOptions({
       method: OVHConnectionMethod.Token,
       credentials: {
@@ -51,7 +51,7 @@ describe("ValidateOvhConnectionCredentialsSchema", () => {
 
   test("token method requires token", () => {
     const result = ValidateOvhConnectionCredentialsSchema.safeParse({
-      method: OVHConnectionMethod.Certificate,
+      method: OVHConnectionMethod.Token,
       credentials: { okmsDomain: OKMS_DOMAIN, okmsId: OKMS_ID }
     });
 

--- a/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
@@ -3,6 +3,7 @@ import https from "https";
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 import { removeTrailingSlash } from "@app/lib/fn";
+import { DiscriminativePick } from "@app/lib/types";
 import { validateSsrfUrl } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 
@@ -11,19 +12,45 @@ import { TOvhConnection, TOvhConnectionConfig } from "./ovh-connection-types";
 
 export const getOvhConnectionListItem = () => {
   return {
-    name: "OVH" as const,
+    name: "OVHcloud" as const,
     app: AppConnection.OVH as const,
-    methods: Object.values(OVHConnectionMethod) as [OVHConnectionMethod.Certificate]
+    methods: Object.values(OVHConnectionMethod) as [OVHConnectionMethod.Certificate, OVHConnectionMethod.Token]
   };
 };
 
-export const getOvhHttpsAgent = (connection: Pick<TOvhConnection, "credentials"> | TOvhConnectionConfig) => {
-  const { privateKey, certificate } = connection.credentials;
+export type TOvhRequestOptions = {
+  httpsAgent?: https.Agent;
+  headers?: Record<string, string>;
+};
 
-  return new https.Agent({
-    key: privateKey,
-    cert: certificate
-  });
+export const getOvhRequestOptions = (
+  connection: DiscriminativePick<TOvhConnection, "method" | "credentials"> | TOvhConnectionConfig
+): TOvhRequestOptions => {
+  switch (connection.method) {
+    case OVHConnectionMethod.Certificate: {
+      const { privateKey, certificate } = connection.credentials;
+
+      return {
+        httpsAgent: new https.Agent({
+          key: privateKey,
+          cert: certificate
+        })
+      };
+    }
+    case OVHConnectionMethod.Token: {
+      const { token } = connection.credentials;
+
+      return {
+        headers: {
+          Authorization: `Bearer ${token}`
+        }
+      };
+    }
+    default:
+      throw new BadRequestError({
+        message: `Unhandled OVHcloud connection method: ${(connection as { method: string }).method}`
+      });
+  }
 };
 
 const normalizeOvhOkmsDomain = (okmsDomain: string) => {
@@ -34,12 +61,12 @@ const normalizeOvhOkmsDomain = (okmsDomain: string) => {
     url = new URL(normalized);
   } catch {
     throw new BadRequestError({
-      message: "OKMS domain must be a valid URL "
+      message: "OVHcloud KMS domain must be a valid URL "
     });
   }
 
   if (url.protocol !== "https:") {
-    throw new BadRequestError({ message: "OKMS domain must use https" });
+    throw new BadRequestError({ message: "OVHcloud KMS domain must be a valid URL (e.g. https://eu-west-rbx.okms.ovh.net)" });
   }
 
   return normalized;
@@ -51,11 +78,12 @@ export const validateOvhConnectionCredentials = async (config: TOvhConnectionCon
 
   await validateSsrfUrl(okmsDomain);
 
-  const httpsAgent = getOvhHttpsAgent(config);
+  const { httpsAgent, headers } = getOvhRequestOptions(config);
 
   try {
     await request.get(`${okmsDomain}/api/${encodeURIComponent(okmsId)}/v1/servicekey`, {
       httpsAgent,
+      headers,
       timeout: 15000,
       validateStatus: (status) => status === 200
     });

--- a/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-fns.ts
@@ -66,7 +66,9 @@ const normalizeOvhOkmsDomain = (okmsDomain: string) => {
   }
 
   if (url.protocol !== "https:") {
-    throw new BadRequestError({ message: "OVHcloud KMS domain must be a valid URL (e.g. https://eu-west-rbx.okms.ovh.net)" });
+    throw new BadRequestError({
+      message: "OVHcloud KMS domain must be a valid URL (e.g. https://eu-west-rbx.okms.ovh.net)"
+    });
   }
 
   return normalized;

--- a/backend/src/services/app-connection/ovh/ovh-connection-schemas.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-schemas.ts
@@ -17,7 +17,11 @@ const OkmsDomainSchema = z
   .min(1, "OVHcloud KMS domain required")
   .url("OVHcloud KMS domain must be a valid URL (e.g. https://eu-west-rbx.okms.ovh.net)")
   .describe(AppConnections.CREDENTIALS.OVH.okmsDomain);
-const OkmsIdSchema = z.string().trim().min(1, "OVHcloud KMS ID required").describe(AppConnections.CREDENTIALS.OVH.okmsId);
+const OkmsIdSchema = z
+  .string()
+  .trim()
+  .min(1, "OVHcloud KMS ID required")
+  .describe(AppConnections.CREDENTIALS.OVH.okmsId);
 
 export const OvhConnectionCertificateCredentialsSchema = z.object({
   privateKey: z.string().trim().min(1, "Private key required").describe(AppConnections.CREDENTIALS.OVH.privateKey),

--- a/backend/src/services/app-connection/ovh/ovh-connection-schemas.ts
+++ b/backend/src/services/app-connection/ovh/ovh-connection-schemas.ts
@@ -11,24 +11,42 @@ import {
 import { APP_CONNECTION_NAME_MAP } from "../app-connection-maps";
 import { OVHConnectionMethod } from "./ovh-connection-enums";
 
+const OkmsDomainSchema = z
+  .string()
+  .trim()
+  .min(1, "OVHcloud KMS domain required")
+  .url("OVHcloud KMS domain must be a valid URL (e.g. https://eu-west-rbx.okms.ovh.net)")
+  .describe(AppConnections.CREDENTIALS.OVH.okmsDomain);
+const OkmsIdSchema = z.string().trim().min(1, "OVHcloud KMS ID required").describe(AppConnections.CREDENTIALS.OVH.okmsId);
+
 export const OvhConnectionCertificateCredentialsSchema = z.object({
   privateKey: z.string().trim().min(1, "Private key required").describe(AppConnections.CREDENTIALS.OVH.privateKey),
   certificate: z.string().trim().min(1, "Certificate required").describe(AppConnections.CREDENTIALS.OVH.certificate),
-  okmsDomain: z
-    .string()
-    .trim()
-    .min(1, "OKMS domain required")
-    .url("OKMS domain must be a valid URL (e.g. https://example.com)")
-    .describe(AppConnections.CREDENTIALS.OVH.okmsDomain),
-  okmsId: z.string().trim().min(1, "OKMS ID required").describe(AppConnections.CREDENTIALS.OVH.okmsId)
+  okmsDomain: OkmsDomainSchema,
+  okmsId: OkmsIdSchema
+});
+
+export const OvhConnectionTokenCredentialsSchema = z.object({
+  token: z.string().trim().min(1, "Token required").describe(AppConnections.CREDENTIALS.OVH.token),
+  okmsDomain: OkmsDomainSchema,
+  okmsId: OkmsIdSchema
 });
 
 const BaseOvhConnectionSchema = BaseAppConnectionSchema.extend({ app: z.literal(AppConnection.OVH) });
 
-export const OvhConnectionSchema = BaseOvhConnectionSchema.extend({
-  method: z.literal(OVHConnectionMethod.Certificate),
-  credentials: OvhConnectionCertificateCredentialsSchema
-});
+export const OvhConnectionSchema = z.intersection(
+  BaseOvhConnectionSchema,
+  z.discriminatedUnion("method", [
+    z.object({
+      method: z.literal(OVHConnectionMethod.Certificate),
+      credentials: OvhConnectionCertificateCredentialsSchema
+    }),
+    z.object({
+      method: z.literal(OVHConnectionMethod.Token),
+      credentials: OvhConnectionTokenCredentialsSchema
+    })
+  ])
+);
 
 export const SanitizedOvhConnectionSchema = z.discriminatedUnion("method", [
   BaseOvhConnectionSchema.extend({
@@ -37,7 +55,14 @@ export const SanitizedOvhConnectionSchema = z.discriminatedUnion("method", [
       okmsDomain: true,
       okmsId: true
     })
-  }).describe(JSON.stringify({ title: `${APP_CONNECTION_NAME_MAP[AppConnection.OVH]} (Certificate)` }))
+  }).describe(JSON.stringify({ title: `${APP_CONNECTION_NAME_MAP[AppConnection.OVH]} (Certificate)` })),
+  BaseOvhConnectionSchema.extend({
+    method: z.literal(OVHConnectionMethod.Token),
+    credentials: OvhConnectionTokenCredentialsSchema.pick({
+      okmsDomain: true,
+      okmsId: true
+    })
+  }).describe(JSON.stringify({ title: `${APP_CONNECTION_NAME_MAP[AppConnection.OVH]} (Token)` }))
 ]);
 
 export const ValidateOvhConnectionCredentialsSchema = z.discriminatedUnion("method", [
@@ -46,6 +71,10 @@ export const ValidateOvhConnectionCredentialsSchema = z.discriminatedUnion("meth
     credentials: OvhConnectionCertificateCredentialsSchema.describe(
       AppConnections.CREATE(AppConnection.OVH).credentials
     )
+  }),
+  z.object({
+    method: z.literal(OVHConnectionMethod.Token).describe(AppConnections.CREATE(AppConnection.OVH).method),
+    credentials: OvhConnectionTokenCredentialsSchema.describe(AppConnections.CREATE(AppConnection.OVH).credentials)
   })
 ]);
 
@@ -55,15 +84,16 @@ export const CreateOvhConnectionSchema = ValidateOvhConnectionCredentialsSchema.
 
 export const UpdateOvhConnectionSchema = z
   .object({
-    credentials: OvhConnectionCertificateCredentialsSchema.optional().describe(
-      AppConnections.UPDATE(AppConnection.OVH).credentials
-    )
+    credentials: z
+      .union([OvhConnectionCertificateCredentialsSchema, OvhConnectionTokenCredentialsSchema])
+      .optional()
+      .describe(AppConnections.UPDATE(AppConnection.OVH).credentials)
   })
   .and(GenericUpdateAppConnectionFieldsSchema(AppConnection.OVH));
 
 export const OvhConnectionListItemSchema = z
   .object({
-    name: z.literal("OVH"),
+    name: z.literal("OVHcloud"),
     app: z.literal(AppConnection.OVH),
     methods: z.nativeEnum(OVHConnectionMethod).array()
   })

--- a/backend/src/services/secret-sync/ovh/ovh-sync-constants.ts
+++ b/backend/src/services/secret-sync/ovh/ovh-sync-constants.ts
@@ -3,7 +3,7 @@ import { SecretSync } from "@app/services/secret-sync/secret-sync-enums";
 import { TSecretSyncListItem } from "@app/services/secret-sync/secret-sync-types";
 
 export const OVH_SYNC_LIST_OPTION: TSecretSyncListItem = {
-  name: "OVH",
+  name: "OVHcloud",
   destination: SecretSync.OVH,
   connection: AppConnection.OVH,
   canRemoveSecretsOnDeletion: true,

--- a/backend/src/services/secret-sync/ovh/ovh-sync-fns.ts
+++ b/backend/src/services/secret-sync/ovh/ovh-sync-fns.ts
@@ -1,10 +1,9 @@
 import { isAxiosError } from "axios";
-import https from "https";
 
 import { request } from "@app/lib/config/request";
 import { deepEqual } from "@app/lib/fn/object";
 import { validateSsrfUrl } from "@app/lib/validator";
-import { getOvhHttpsAgent } from "@app/services/app-connection/ovh";
+import { getOvhRequestOptions, TOvhRequestOptions } from "@app/services/app-connection/ovh";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
@@ -33,12 +32,12 @@ const sanitizeOvhError = (error: unknown): Error => {
     if (body?.error_code !== undefined) parts.push(`code=${body.error_code}`);
     if (body?.errors?.length) parts.push(body.errors.join("; "));
     if (body?.request_id) parts.push(`requestId=${body.request_id}`);
-    return new Error(`OVH OKMS request failed${parts.length ? `: ${parts.join(" ")}` : ""}`);
+    return new Error(`OVHcloud KMS request failed${parts.length ? `: ${parts.join(" ")}` : ""}`);
   }
-  return new Error("OVH OKMS request failed");
+  return new Error("OVHcloud KMS request failed");
 };
 
-// Shape of `GET /v2/secret/{path}?includeData=true` per OVH OKMS swagger.
+// Shape of `GET /v2/secret/{path}?includeData=true` per OVHcloud KMS swagger.
 type TOvhGetSecretResponse = {
   metadata?: { currentVersion?: number };
   version?: { data?: Record<string, unknown> };
@@ -62,14 +61,15 @@ const readSecret = async (
   okmsDomain: string,
   okmsId: string,
   path: string,
-  httpsAgent: https.Agent
+  requestOptions: TOvhRequestOptions
 ): Promise<TOvhSecretRead> => {
   try {
     await validateSsrfUrl(okmsDomain);
     const { data } = await request.get<TOvhGetSecretResponse>(
       `${getSecretUrl(okmsDomain, okmsId, path)}?includeData=true`,
       {
-        httpsAgent,
+        httpsAgent: requestOptions.httpsAgent,
+        headers: requestOptions.headers,
         timeout: REQUEST_TIMEOUT_MS
       }
     );
@@ -91,16 +91,17 @@ const createSecret = async (
   okmsId: string,
   path: string,
   data: Record<string, string>,
-  httpsAgent: https.Agent
+  requestOptions: TOvhRequestOptions
 ) => {
   await validateSsrfUrl(okmsDomain);
   return request.post(
     `${okmsDomain}/api/${encodeURIComponent(okmsId)}/v2/secret`,
     { path, version: { data } },
     {
-      httpsAgent,
+      httpsAgent: requestOptions.httpsAgent,
       timeout: REQUEST_TIMEOUT_MS,
       headers: {
+        ...requestOptions.headers,
         "Content-Type": "application/json",
         accept: "application/json"
       }
@@ -114,7 +115,7 @@ const updateSecret = async (
   path: string,
   data: Record<string, string>,
   cas: number | null,
-  httpsAgent: https.Agent
+  requestOptions: TOvhRequestOptions
 ) => {
   await validateSsrfUrl(okmsDomain);
   const base = getSecretUrl(okmsDomain, okmsId, path);
@@ -123,9 +124,10 @@ const updateSecret = async (
     url,
     { version: { data } },
     {
-      httpsAgent,
+      httpsAgent: requestOptions.httpsAgent,
       timeout: REQUEST_TIMEOUT_MS,
       headers: {
+        ...requestOptions.headers,
         "Content-Type": "application/json",
         accept: "application/json"
       }
@@ -133,7 +135,7 @@ const updateSecret = async (
   );
 };
 
-// OVH OKMS stores all keys of a path in a single versioned bundle; any change
+// OVHcloud KMS stores all keys of a path in a single versioned bundle; any change
 // requires rewriting the whole bundle. Callers describe the desired bundle as
 // a pure function of the existing bundle; this helper decides whether to skip,
 // create, or CAS-update based on what's actually on the remote.
@@ -144,18 +146,18 @@ const writeSecretBundle = async (
   const { connection, destinationConfig } = secretSync;
   const path = String(destinationConfig.path);
   const { okmsDomain, okmsId } = connection.credentials;
-  const httpsAgent = getOvhHttpsAgent(connection);
+  const requestOptions = getOvhRequestOptions(connection);
 
   try {
-    const { exists, data: existingData, currentVersion } = await readSecret(okmsDomain, okmsId, path, httpsAgent);
+    const { exists, data: existingData, currentVersion } = await readSecret(okmsDomain, okmsId, path, requestOptions);
     const desiredData = buildDesiredBundle(existingData);
 
     if (deepEqual(existingData, desiredData)) return;
 
     if (exists) {
-      await updateSecret(okmsDomain, okmsId, path, desiredData, currentVersion, httpsAgent);
+      await updateSecret(okmsDomain, okmsId, path, desiredData, currentVersion, requestOptions);
     } else {
-      await createSecret(okmsDomain, okmsId, path, desiredData, httpsAgent);
+      await createSecret(okmsDomain, okmsId, path, desiredData, requestOptions);
     }
   } catch (error) {
     throw new SecretSyncError({ error: sanitizeOvhError(error) });
@@ -192,10 +194,10 @@ export const OvhSyncFns = {
     const { connection, destinationConfig } = secretSync;
     const path = String(destinationConfig.path);
     const { okmsDomain, okmsId } = connection.credentials;
-    const httpsAgent = getOvhHttpsAgent(connection);
+    const requestOptions = getOvhRequestOptions(connection);
 
     try {
-      const { data } = await readSecret(okmsDomain, okmsId, path, httpsAgent);
+      const { data } = await readSecret(okmsDomain, okmsId, path, requestOptions);
       return Object.fromEntries(Object.entries(data).map(([key, value]) => [key, { value }]));
     } catch (error) {
       throw new SecretSyncError({ error: sanitizeOvhError(error) });

--- a/backend/src/services/secret-sync/ovh/ovh-sync-schemas.ts
+++ b/backend/src/services/secret-sync/ovh/ovh-sync-schemas.ts
@@ -22,7 +22,7 @@ export const OvhSyncDestinationConfigSchema = z.object({
     .transform((val) => new RE2("^/+|/+$", "g").replace(val, ""))
     .refine((val) => new RE2("^([a-zA-Z0-9._-]+/)*[a-zA-Z0-9._-]+$").test(val), {
       message:
-        "Invalid OVH OKMS path format. Use alphanumerics, dots, dashes, underscores, and single slashes between segments."
+        "Invalid OVHcloud KMS path format. Use alphanumerics, dots, dashes, underscores, and single slashes between segments."
     })
     .describe(SecretSyncs.DESTINATION_CONFIG.OVH.path)
 });
@@ -46,7 +46,7 @@ export const UpdateOvhSyncSchema = GenericUpdateSecretSyncFieldsSchema(SecretSyn
 
 export const OvhSyncListItemSchema = z
   .object({
-    name: z.literal("OVH"),
+    name: z.literal("OVHcloud"),
     connection: z.literal(AppConnection.OVH),
     destination: z.literal(SecretSync.OVH),
     canImportSecrets: z.literal(true),

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -45,7 +45,7 @@ export const SECRET_SYNC_NAME_MAP: Record<SecretSync, string> = {
   [SecretSync.CircleCI]: "CircleCI",
   [SecretSync.AzureEntraIdScim]: "Azure Entra ID SCIM",
   [SecretSync.ExternalInfisical]: "Infisical",
-  [SecretSync.OVH]: "OVH",
+  [SecretSync.OVH]: "OVHcloud",
   [SecretSync.Devin]: "Devin",
   [SecretSync.Ona]: "Ona",
   [SecretSync.TravisCI]: "Travis CI",

--- a/docs/integrations/app-connections/ovh.mdx
+++ b/docs/integrations/app-connections/ovh.mdx
@@ -1,9 +1,11 @@
 ---
-title: "OVH Cloud Connection"
-description: "Learn how to configure an OVH Cloud Connection for Infisical."
+title: "OVHcloud Connection"
+description: "Learn how to configure an OVHcloud Connection for Infisical."
 ---
 
-Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.ovhcloud.com/en/identity-security-operations/secret-manager/) using mutual TLS (mTLS) with a PEM-encoded client certificate pair issued by OVH for your OKMS instance.
+Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.ovhcloud.com/en/identity-security-operations/secret-manager/) using one of two methods:
+- **Certificate (mTLS):** mutual TLS (mTLS) with a PEM-encoded client certificate pair issued by OVHcloud for your OKMS instance.
+- **Token:** OVHcloud KMS access token.
 
 ## Generate an OVHcloud KMS Access Certificate
 
@@ -15,7 +17,7 @@ Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.
   </Step>
 
   <Step title="Create a OVHcloud KMS Domain">
-    Click on **Order an OVHcloud KMS Domain**
+    Click on **Order an OKMS Domain**
 
     ![OVHcloud KMS Dashboard](/images/app-connections/ovh/okms-order-domain.png)
   </Step>
@@ -28,14 +30,14 @@ Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.
   </Step>
 
   <Step title="Check your summary">
-    On your summary, the desired domain by clicking on it. 
+    On your summary, select the desired domain by clicking on it.
 
     ![OVHcloud KMS Summary](/images/app-connections/ovh/okms-summary.png)
 
     You will need to get the following values to create a connection. 
 
     - **OKMS ID** — the UUID-style identifier shown on the OVHcloud KMS summary page.
-    - **REST API endpoint** — the base URL of the OVHcloud KMS instance (e.g. `https://ca-east-bhs.okms.ovh.net`). This is the **OKMS Domain** value in Infisical.
+    - **REST API endpoint** — the base URL of the OVHcloud KMS instance (e.g. `https://eu-west-rbx.okms.ovh.net`). This is the **OKMS Domain** value in Infisical.
 
     ![OVHcloud KMS Details](/images/app-connections/ovh/okms-details.png)
   </Step>
@@ -56,12 +58,12 @@ Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.
     ![Create Access Certificate](/images/app-connections/ovh/okms-create-certificate.png)
 
     <Warning>
-      Infisical does **not** support the PKCS12 (`.p12`) format. If OVH offers a PKCS12 download or asks you to convert the PEM files with `openssl pkcs12`, ignore those options and keep the PEM files as-is. Node.js's TLS layer (used by Infisical's HTTP client) cannot parse PKCS12 bundles and returns `Unsupported PKCS12 PFX data.` when one is provided.
+      Infisical does **not** support the PKCS12 (`.p12`) format. If OVHcloud offers a PKCS12 download or asks you to convert the PEM files with `openssl pkcs12`, ignore those options and keep the PEM files as-is. Node.js's TLS layer (used by Infisical's HTTP client) cannot parse PKCS12 bundles and returns `Unsupported PKCS12 PFX data.` when one is provided.
     </Warning>
   </Step>
 </Steps>
 
-## Create an OVH Cloud Connection in Infisical
+## Create an OVHcloud Connection in Infisical
 
 <Tabs>
   <Tab title="Infisical UI">
@@ -71,37 +73,45 @@ Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.
 
         ![App Connections Tab](/images/app-connections/general/add-connection.png)
       </Step>
-      <Step title="Select OVH Cloud Connection">
-        Click **+ Add Connection** and choose **OVH Cloud Connection** from the list of integrations.
+      <Step title="Select OVHcloud Connection">
+        Click **+ Add Connection** and choose **OVHcloud Connection** from the list of integrations.
 
-        ![Select OVH Cloud Connection](/images/app-connections/ovh/app-connection-option.png)
+        ![Select OVHcloud Connection](/images/app-connections/ovh/app-connection-option.png)
       </Step>
-      <Step title="Fill out the OVH Cloud Connection form">
+      <Step title="Fill out the OVHcloud Connection form">
         Complete the form by providing:
 
         - A descriptive **Name** for the connection.
         - An optional **Description**.
+        - Choose a **Method** to authenticate (Certificate (mTLS) or Token).
+
+        For the **Certificate** method:
         - **Private Key (PEM)** — paste the full contents of `*_privatekey.pem`, including the `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` markers.
         - **Certificate (PEM)** — paste the full contents of `*_certificate.pem`, including the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` markers.
+
+        For the **Token** method:
+          - **Token**: paste the OVHcloud KMS access token.
+
+        For both methods:
         - **OKMS Domain** — the OVHcloud KMS base URL (e.g. `https://eu-west-rbx.okms.ovh.net`). Do not include the `/api` suffix; Infisical appends it automatically.
         - **OKMS ID** — the OVHcloud KMS instance identifier from the OVHcloud Control Panel.
 
-        ![OVH Cloud Connection Form](/images/app-connections/ovh/app-connection-form.png)
+        ![OVHcloud Connection Form](/images/app-connections/ovh/app-connection-form.png)
 
-        Infisical validates the credentials by calling `GET {OKMS Domain}/api/{OKMS ID}/v1/servicekey` with mTLS. A successful `200` response means the PEM pair is trusted by your OKMS instance.
+        Infisical validates the credentials by calling `GET {OKMS Domain}/api/{OKMS ID}/v1/servicekey` with mTLS. A successful `200` response means the PEM pair is trusted by your OVHcloud KMS instance.
       </Step>
       <Step title="Connection created">
-        After submitting the form, your **OVH Cloud Connection** is created and ready to use with Secret Syncs.
+        After submitting the form, your **OVHcloud Connection** is created and ready to use with Secret Syncs.
 
-        ![OVH Cloud Connection Created](/images/app-connections/ovh/app-connection-created.png)
+        ![OVHcloud Connection Created](/images/app-connections/ovh/app-connection-created.png)
       </Step>
     </Steps>
   </Tab>
 
   <Tab title="API">
-    To create an OVH Cloud Connection via API, send a request to the [Create OVH Cloud Connection](/api-reference/endpoints/app-connections/ovh/create) endpoint.
+    To create an OVHcloud Connection via API, send a request to the [Create OVHcloud Connection](/api-reference/endpoints/app-connections/ovh/create) endpoint.
 
-    ### Sample request
+    ### Sample request (Certificate)
 
     ```bash Request
     curl    --request POST \
@@ -114,7 +124,25 @@ Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.
                 "credentials": {
                     "privateKey": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
                     "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n",
-                    "okmsDomain": "https://ca-east-bhs.okms.ovh.net",
+                    "okmsDomain": "https://eu-west-rbx.okms.ovh.net",
+                    "okmsId": "00000000-0000-0000-0000-000000000000"
+                }
+            }'
+    ```
+
+    ### Sample request (Token)
+
+    ```bash Request
+    curl    --request POST \
+            --url https://app.infisical.com/api/v1/app-connections/ovh \
+            --header 'Content-Type: application/json' \
+            --data '{
+                "name": "my-ovh-connection",
+                "method": "token",
+                "projectId": "7ffbb072-2575-495a-b5b0-127f88caef78",
+                "credentials": {
+                    "token": "secret-token",
+                    "okmsDomain": "https://eu-west-rbx.okms.ovh.net",
                     "okmsId": "00000000-0000-0000-0000-000000000000"
                 }
             }'

--- a/docs/integrations/app-connections/ovh.mdx
+++ b/docs/integrations/app-connections/ovh.mdx
@@ -5,39 +5,39 @@ description: "Learn how to configure an OVH Cloud Connection for Infisical."
 
 Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.ovhcloud.com/en/identity-security-operations/secret-manager/) using mutual TLS (mTLS) with a PEM-encoded client certificate pair issued by OVH for your OKMS instance.
 
-## Generate an OVH OKMS Access Certificate
+## Generate an OVHcloud KMS Access Certificate
 
 <Steps>
-  <Step title="Open the OKMS dashboard">
+  <Step title="Open the OVHcloud KMS dashboard">
     Log in to the [OVHcloud Control Panel](https://www.ovh.com/manager/) and navigate to **Identity, Security & Operations** > **Key Management Service**.
 
-    ![OKMS Dashboard](/images/app-connections/ovh/okms-dashboard.png)
+    ![OVHcloud KMS Dashboard](/images/app-connections/ovh/okms-dashboard.png)
   </Step>
 
-  <Step title="Create a OKMS Domain">
-    Click on **Order an OKMS Domain** 
+  <Step title="Create a OVHcloud KMS Domain">
+    Click on **Order an OVHcloud KMS Domain**
 
-    ![OKMS Dashboard](/images/app-connections/ovh/okms-order-domain.png)
+    ![OVHcloud KMS Dashboard](/images/app-connections/ovh/okms-order-domain.png)
   </Step>
-  <Step title="Select your OKMS region">
-    Select the OKMS region that you want to use. You will also need to confirm by accepting the terms  
+  <Step title="Select your OVHcloud KMS region">
+    Select the OVHcloud KMS region that you want to use. You will also need to confirm by accepting the terms
 
-    ![OKMS Region](/images/app-connections/ovh/okms-select-region.png)
+    ![OVHcloud KMS Region](/images/app-connections/ovh/okms-select-region.png)
 
-    ![OKMS Activate Region](/images/app-connections/ovh/okms-activate-region.png)
+    ![OVHcloud KMS Activate Region](/images/app-connections/ovh/okms-activate-region.png)
   </Step>
 
   <Step title="Check your summary">
     On your summary, the desired domain by clicking on it. 
 
-    ![OKMS Summary](/images/app-connections/ovh/okms-summary.png)
+    ![OVHcloud KMS Summary](/images/app-connections/ovh/okms-summary.png)
 
     You will need to get the following values to create a connection. 
 
-    - **OKMS ID** — the UUID-style identifier shown on the OKMS summary page.
-    - **REST API endpoint** — the base URL of the OKMS instance (e.g. `https://ca-east-bhs.okms.ovh.net`). This is the **OKMS Domain** value in Infisical.
+    - **OKMS ID** — the UUID-style identifier shown on the OVHcloud KMS summary page.
+    - **REST API endpoint** — the base URL of the OVHcloud KMS instance (e.g. `https://ca-east-bhs.okms.ovh.net`). This is the **OKMS Domain** value in Infisical.
 
-    ![OKMS Details](/images/app-connections/ovh/okms-details.png)
+    ![OVHcloud KMS Details](/images/app-connections/ovh/okms-details.png)
   </Step>
   <Step title="Generate an access certificate">
     Open the **Access certificate** tab 
@@ -83,8 +83,8 @@ Infisical authenticates to [OVHcloud Key Management Service (OKMS)](https://www.
         - An optional **Description**.
         - **Private Key (PEM)** — paste the full contents of `*_privatekey.pem`, including the `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` markers.
         - **Certificate (PEM)** — paste the full contents of `*_certificate.pem`, including the `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` markers.
-        - **OKMS Domain** — the OKMS base URL (e.g. `https://ca-east-bhs.okms.ovh.net`). Do not include the `/api` suffix; Infisical appends it automatically.
-        - **OKMS ID** — the OKMS instance identifier from the OVHcloud Control Panel.
+        - **OKMS Domain** — the OVHcloud KMS base URL (e.g. `https://eu-west-rbx.okms.ovh.net`). Do not include the `/api` suffix; Infisical appends it automatically.
+        - **OKMS ID** — the OVHcloud KMS instance identifier from the OVHcloud Control Panel.
 
         ![OVH Cloud Connection Form](/images/app-connections/ovh/app-connection-form.png)
 

--- a/docs/integrations/secret-syncs/ovh.mdx
+++ b/docs/integrations/secret-syncs/ovh.mdx
@@ -1,11 +1,11 @@
 ---
-title: "OVH Cloud Sync"
-description: "Learn how to configure an OVH Cloud Sync for Infisical."
+title: "OVHcloud Sync"
+description: "Learn how to configure an OVHcloud Sync for Infisical."
 ---
 
 **Prerequisites:**
     - Set up and add secrets to [Infisical Cloud](https://app.infisical.com)
-    - Create an [OVH Cloud Connection](/integrations/app-connections/ovh)
+    - Create an [OVHcloud Connection](/integrations/app-connections/ovh)
 
 <Tabs>
     <Tab title="Infisical UI">
@@ -15,8 +15,8 @@ description: "Learn how to configure an OVH Cloud Sync for Infisical."
 
                 ![Secret Syncs Tab](/images/secret-syncs/general/secret-sync-tab.png)
             </Step>
-            <Step title="Select OVH Cloud">
-                ![Select OVH Cloud](/images/secret-syncs/ovh/select-option.png)
+            <Step title="Select OVHcloud">
+                ![Select OVHcloud](/images/secret-syncs/ovh/select-option.png)
             </Step>
             <Step title="Configure Source">
                 Configure the **Source** from where secrets should be retrieved, then click **Next**.
@@ -35,7 +35,7 @@ description: "Learn how to configure an OVH Cloud Sync for Infisical."
 
                 ![Configure Destination](/images/secret-syncs/ovh/sync-destination.png)
 
-                - **OVH Cloud Connection**: The OVH Cloud Connection to authenticate with.
+                - **OVHcloud Connection**: The OVHcloud Connection to authenticate with.
                 - **Path**: The path in OVHcloud KMS where secrets will be stored as key/value pairs (e.g. `app/production`). Allowed characters are alphanumerics, dots, dashes, underscores, and single slashes between segments.
 
                 After configuring these parameters, click the **Next** button to continue to the Sync Options step.
@@ -54,8 +54,8 @@ description: "Learn how to configure an OVH Cloud Sync for Infisical."
 
                 - **Initial Sync Behavior**: Determines how Infisical should resolve the initial sync.
                     - **Overwrite Destination Secrets**: Removes any secrets at the destination endpoint not present in Infisical.
-                    - **Import Secrets (Prioritize Infisical)**: Imports secrets from the destination endpoint before syncing, prioritizing values from Infisical over OVH Cloud when keys conflict.
-                    - **Import Secrets (Prioritize OVH Cloud)**: Imports secrets from the destination endpoint before syncing, prioritizing values from OVH Cloud over Infisical when keys conflict.
+                    - **Import Secrets (Prioritize Infisical)**: Imports secrets from the destination endpoint before syncing, prioritizing values from Infisical over OVHcloud when keys conflict.
+                    - **Import Secrets (Prioritize OVHcloud)**: Imports secrets from the destination endpoint before syncing, prioritizing values from OVHcloud over Infisical when keys conflict.
                 - **Key Schema**: Template that determines how secret names are transformed when syncing, using `{{secretKey}}` as a placeholder for the original secret name and `{{environment}}` for the environment.
                 <Note>
                     We highly recommend using a Key Schema to ensure that Infisical only manages the specific keys you intend, keeping everything else untouched.
@@ -64,7 +64,7 @@ description: "Learn how to configure an OVH Cloud Sync for Infisical."
                 - **Disable Secret Deletion**: If enabled, Infisical will not remove secrets from the sync destination. Enable this option if you intend to manage some secrets manually outside of Infisical.
             </Step>
             <Step title="Configure Details">
-                Configure the **Details** of your OVH Cloud Sync, then click **Next**.
+                Configure the **Details** of your OVHcloud Sync, then click **Next**.
 
                 ![Configure Details](/images/secret-syncs/ovh/sync-details.png)
 
@@ -72,19 +72,19 @@ description: "Learn how to configure an OVH Cloud Sync for Infisical."
                 - **Description**: An optional description for your sync.
             </Step>
             <Step title="Review Configuration">
-                Review your OVH Cloud Sync configuration, then click **Create Sync**.
+                Review your OVHcloud Sync configuration, then click **Create Sync**.
 
                 ![Confirm Configuration](/images/secret-syncs/ovh/sync-review.png)
             </Step>
             <Step title="Sync Created">
-                If enabled, your OVH Cloud Sync will begin syncing your secrets to the destination endpoint.
+                If enabled, your OVHcloud Sync will begin syncing your secrets to the destination endpoint.
 
                 ![Sync Created](/images/secret-syncs/ovh/sync-created.png)
             </Step>
         </Steps>
     </Tab>
     <Tab title="API">
-        To create an **OVH Cloud Sync**, make an API request to the [Create OVH Cloud Sync](/api-reference/endpoints/secret-syncs/ovh/create) API endpoint.
+        To create an **OVHcloud Sync**, make an API request to the [Create OVHcloud Sync](/api-reference/endpoints/secret-syncs/ovh/create) API endpoint.
 
         ### Sample request
 

--- a/docs/integrations/secret-syncs/ovh.mdx
+++ b/docs/integrations/secret-syncs/ovh.mdx
@@ -36,15 +36,15 @@ description: "Learn how to configure an OVH Cloud Sync for Infisical."
                 ![Configure Destination](/images/secret-syncs/ovh/sync-destination.png)
 
                 - **OVH Cloud Connection**: The OVH Cloud Connection to authenticate with.
-                - **Path**: The path in OVH OKMS where secrets will be stored as key/value pairs (e.g. `app/production`). Allowed characters are alphanumerics, dots, dashes, underscores, and single slashes between segments.
+                - **Path**: The path in OVHcloud KMS where secrets will be stored as key/value pairs (e.g. `app/production`). Allowed characters are alphanumerics, dots, dashes, underscores, and single slashes between segments.
 
                 After configuring these parameters, click the **Next** button to continue to the Sync Options step.
 
                 <Note>
-                    If the **path** you provide does not exist in OVH OKMS, it will be created.
+                    If the **path** you provide does not exist in OVHcloud KMS, it will be created.
                 </Note>
                 <Note>
-                    All Infisical secrets under the selected source path are packed as key/value pairs into a **single** OVH OKMS secret at the destination path. OVH OKMS caps each secret at **64 KB** (total JSON payload), so keep the combined size of all synced secrets within that limit.
+                    All Infisical secrets under the selected source path are packed as key/value pairs into a **single** OVHcloud KMS secret at the destination path. OVHcloud KMS caps each secret at **64 KB** (total JSON payload), so keep the combined size of all synced secrets within that limit.
                 </Note>
             </Step>
             <Step title="Configure Sync Options">

--- a/docs/snippets/AppConnectionsBrowser.jsx
+++ b/docs/snippets/AppConnectionsBrowser.jsx
@@ -476,7 +476,7 @@ export const AppConnectionsBrowser = () => {
       slug: "ovh",
       path: "/integrations/app-connections/ovh",
       description:
-        "Learn how to connect OVH Cloud to pull secrets from OVH Secret Manager to Infisical.",
+        "Learn how to connect OVHcloud to pull secrets from OVHcloud Secret Manager to Infisical.",
       category: "Cloud Providers",
     },
     {

--- a/docs/snippets/SecretSyncsBrowser.jsx
+++ b/docs/snippets/SecretSyncsBrowser.jsx
@@ -46,7 +46,7 @@ export const SecretSyncsBrowser = () => {
     {"name": "Octopus Deploy", "slug": "octopus-deploy", "path": "/integrations/secret-syncs/octopus-deploy", "description": "Learn how to sync secrets from Infisical to Octopus Deploy.", "category": "DevOps Tools"},
     {"name": "Azure Entra ID SCIM", "slug": "azure-entra-id-scim", "path": "/integrations/secret-syncs/azure-entra-id-scim", "description": "Learn how to sync SCIM provisioning tokens from Infisical to Azure Entra ID.", "category": "Identity & Auth"},
     {"name": "Infisical", "slug": "external-infisical", "path": "/integrations/secret-syncs/external-infisical", "description": "Learn how to sync secrets from one Infisical instance to another.", "category": "Security"},
-    {"name": "OVH", "slug": "ovh", "path": "/integrations/secret-syncs/ovh", "description": "Learn how to sync secrets from Infisical to OVH Secret Manager.", "category": "Cloud Providers"},
+    {"name": "OVHcloud", "slug": "ovh", "path": "/integrations/secret-syncs/ovh", "description": "Learn how to sync secrets from Infisical to OVHcloud Secret Manager.", "category": "Cloud Providers"},
     {"name": "Travis CI", "slug": "travis-ci", "path": "/integrations/secret-syncs/travis-ci", "description": "Learn how to sync secrets from Infisical to Travis CI.", "category": "CI/CD"},
     {"name": "Snowflake", "slug": "snowflake", "path": "/integrations/secret-syncs/snowflake", "description": "Learn how to sync secrets from Infisical to Snowflake.", "category": "Databases"},
     {"name": "Trigger.dev", "slug": "trigger-dev", "path": "/integrations/secret-syncs/trigger-dev", "description": "Learn how to sync secrets from Infisical to Trigger.dev.", "category": "DevOps Tools"},

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/OvhSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/OvhSyncFields.tsx
@@ -39,8 +39,8 @@ export const OvhSyncFields = () => {
                   <Info />
                 </TooltipTrigger>
                 <TooltipContent className="max-w-sm">
-                  The path in OVHcloud KMS where secrets will be stored as key/value pairs. If the path
-                  does not exist, it will be created.
+                  The path in OVHcloud KMS where secrets will be stored as key/value pairs. If the
+                  path does not exist, it will be created.
                 </TooltipContent>
               </Tooltip>
             </FieldLabel>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/OvhSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/OvhSyncFields.tsx
@@ -39,7 +39,7 @@ export const OvhSyncFields = () => {
                   <Info />
                 </TooltipTrigger>
                 <TooltipContent className="max-w-sm">
-                  The path in OVH OKMS where secrets will be stored as key/value pairs. If the path
+                  The path in OVHcloud KMS where secrets will be stored as key/value pairs. If the path
                   does not exist, it will be created.
                 </TooltipContent>
               </Tooltip>

--- a/frontend/src/components/secret-syncs/forms/schemas/ovh-sync-destination-schema.ts
+++ b/frontend/src/components/secret-syncs/forms/schemas/ovh-sync-destination-schema.ts
@@ -14,7 +14,7 @@ export const OvhSyncDestinationSchema = BaseSecretSyncSchema().merge(
         .transform((val) => val.trim().replace(/^\/+|\/+$/g, ""))
         .refine((val) => /^([a-zA-Z0-9._-]+\/)*[a-zA-Z0-9._-]+$/.test(val), {
           message:
-            "Invalid OVH OKMS path format. Use alphanumerics, dots, dashes, underscores, and single slashes between segments."
+            "Invalid OVHcloud KMS path format. Use alphanumerics, dots, dashes, underscores, and single slashes between segments."
         })
     })
   })

--- a/frontend/src/helpers/appConnections.ts
+++ b/frontend/src/helpers/appConnections.ts
@@ -527,7 +527,7 @@ export const APP_CONNECTION_MAP: Record<
     description: "GraphQL API and data access for Hasura Cloud."
   },
   [AppConnection.OVH]: {
-    name: "OVH Cloud",
+    name: "OVHcloud",
     image: "OVH.png",
     category: "CLOUD",
     description: "Account and service access for OVHcloud."
@@ -773,6 +773,8 @@ export const getAppConnectionMethodDetails = (method: TAppConnection["method"]) 
       return { name: "API Key", icon: faKey };
     case OVHConnectionMethod.Certificate:
       return { name: "Certificate", icon: faCertificate };
+    case OVHConnectionMethod.Token:
+      return { name: "Token", icon: faKey };
     default:
       throw new Error(`Unhandled App Connection Method: ${method}`);
   }

--- a/frontend/src/helpers/secretSyncs.ts
+++ b/frontend/src/helpers/secretSyncs.ts
@@ -247,7 +247,7 @@ export const SECRET_SYNC_MAP: Record<
     description: "Secrets in another Infisical instance."
   },
   [SecretSync.OVH]: {
-    name: "OVH Cloud",
+    name: "OVHcloud",
     image: "OVH.png",
     category: "CLOUD",
     description: "Secret vault on OVHcloud."

--- a/frontend/src/hooks/api/appConnections/types/ovh-connection.ts
+++ b/frontend/src/hooks/api/appConnections/types/ovh-connection.ts
@@ -2,15 +2,26 @@ import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { TRootAppConnection } from "@app/hooks/api/appConnections/types/root-connection";
 
 export enum OVHConnectionMethod {
-  Certificate = "certificate"
+  Certificate = "certificate",
+  Token = "token"
 }
 
-export type TOvhConnection = TRootAppConnection & { app: AppConnection.OVH } & {
-  method: OVHConnectionMethod.Certificate;
-  credentials: {
-    privateKey: string;
-    certificate: string;
-    okmsDomain: string;
-    okmsId: string;
-  };
-};
+export type TOvhConnection = TRootAppConnection & { app: AppConnection.OVH } & (
+    | {
+        method: OVHConnectionMethod.Certificate;
+        credentials: {
+          privateKey: string;
+          certificate: string;
+          okmsDomain: string;
+          okmsId: string;
+        };
+      }
+    | {
+        method: OVHConnectionMethod.Token;
+        credentials: {
+          token: string;
+          okmsDomain: string;
+          okmsId: string;
+        };
+      }
+  );

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OVHConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/OVHConnectionForm.tsx
@@ -10,10 +10,16 @@ import {
   FieldLabel,
   Input,
   SecretInput,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Tooltip,
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
+import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import {
   OVHConnectionMethod,
@@ -51,14 +57,32 @@ const pemCertificate = z
     message: "Certificate must be in PEM format (starts with -----BEGIN CERTIFICATE-----)"
   });
 
+const okmsDomain = z
+  .string()
+  .trim()
+  .min(1, "KMS rest API endpoint required")
+  .url("KMS rest API endpoint must be a valid URL (e.g. https://eu-west-rbx.okms.ovh.net)")
+  .refine((val) => val.startsWith("https://"), {
+    message: "KMS rest API endpoint must use https"
+  });
+const okmsId = z.string().trim().min(1, "KMS ID required");
+
 const formSchema = z.discriminatedUnion("method", [
   rootSchema.extend({
     method: z.literal(OVHConnectionMethod.Certificate),
     credentials: z.object({
       privateKey: pemPrivateKey,
       certificate: pemCertificate,
-      okmsDomain: z.string().trim().min(1, "OKMS domain required"),
-      okmsId: z.string().trim().min(1, "OKMS ID required")
+      okmsDomain,
+      okmsId
+    })
+  }),
+  rootSchema.extend({
+    method: z.literal(OVHConnectionMethod.Token),
+    credentials: z.object({
+      token: z.string().trim().min(1, "Token required"),
+      okmsDomain,
+      okmsId
     })
   })
 ]);
@@ -75,8 +99,9 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
           ...appConnection,
           credentials: {
             ...appConnection.credentials,
-            privateKey: "",
-            certificate: ""
+            ...(appConnection.method === OVHConnectionMethod.Certificate
+              ? { privateKey: "", certificate: "" }
+              : { token: "" })
           }
         }
       : {
@@ -91,7 +116,9 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
         }
   });
 
-  const { handleSubmit, control } = form;
+  const { handleSubmit, control, watch } = form;
+
+  const selectedMethod = watch("method");
 
   return (
     <FormProvider {...form}>
@@ -100,56 +127,110 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
         <Controller
           name="method"
           control={control}
-          render={({ field }) => (
-            <input type="hidden" {...field} value={OVHConnectionMethod.Certificate} />
-          )}
-        />
-        <Controller
-          name="credentials.privateKey"
-          control={control}
-          shouldUnregister
           render={({ field: { value, onChange }, fieldState: { error } }) => (
             <Field className="mb-4">
-              <FieldLabel htmlFor="private-key">
-                Private Key (PEM)
+              <FieldLabel>
+                Method
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Info />
                   </TooltipTrigger>
                   <TooltipContent className="max-w-sm">
-                    Paste the PEM-encoded private key issued by OVH OKMS, including the
-                    -----BEGIN/END PRIVATE KEY----- markers.
+                    The method you would like to use to connect with{" "}
+                    {APP_CONNECTION_MAP[AppConnection.OVH].name}. This field cannot be changed after
+                    creation.
                   </TooltipContent>
                 </Tooltip>
               </FieldLabel>
-              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+              <Select disabled={isUpdate} value={value} onValueChange={(val) => onChange(val)}>
+                <SelectTrigger className="w-full" isError={Boolean(error)}>
+                  <SelectValue placeholder="Select a method..." />
+                </SelectTrigger>
+                <SelectContent position="popper">
+                  {Object.values(OVHConnectionMethod).map((method) => (
+                    <SelectItem value={method} key={method}>
+                      {getAppConnectionMethodDetails(method).name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <FieldError errors={[error]} />
             </Field>
           )}
         />
-        <Controller
-          name="credentials.certificate"
-          control={control}
-          shouldUnregister
-          render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <Field className="mb-4">
-              <FieldLabel htmlFor="certificate">
-                Certificate (PEM)
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-sm">
-                    Paste the PEM-encoded public certificate issued by OVH OKMS, including the
-                    -----BEGIN/END CERTIFICATE----- markers.
-                  </TooltipContent>
-                </Tooltip>
-              </FieldLabel>
-              <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
-              <FieldError errors={[error]} />
-            </Field>
-          )}
-        />
+        {selectedMethod === OVHConnectionMethod.Certificate ? (
+          <>
+            <Controller
+              name="credentials.privateKey"
+              control={control}
+              shouldUnregister
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="private-key">
+                    Private Key (PEM)
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        Paste the PEM-encoded private key issued by OVHcloud KMS, including the
+                        -----BEGIN/END PRIVATE KEY----- markers.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+            <Controller
+              name="credentials.certificate"
+              control={control}
+              shouldUnregister
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field className="mb-4">
+                  <FieldLabel htmlFor="certificate">
+                    Certificate (PEM)
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Info />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-sm">
+                        Paste the PEM-encoded public certificate issued by OVHcloud KMS, including
+                        the -----BEGIN/END CERTIFICATE----- markers.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                  <FieldError errors={[error]} />
+                </Field>
+              )}
+            />
+          </>
+        ) : (
+          <Controller
+            name="credentials.token"
+            control={control}
+            shouldUnregister
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <Field className="mb-4">
+                <FieldLabel htmlFor="token">
+                  Token
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Info />
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-sm">
+                      Paste the OVHcloud access token.
+                    </TooltipContent>
+                  </Tooltip>
+                </FieldLabel>
+                <SecretInput value={value} onChange={(e) => onChange(e.target.value)} />
+                <FieldError errors={[error]} />
+              </Field>
+            )}
+          />
+        )}
         <Controller
           name="credentials.okmsDomain"
           control={control}
@@ -157,20 +238,20 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
           render={({ field, fieldState: { error } }) => (
             <Field className="mb-4">
               <FieldLabel htmlFor="okms-domain">
-                OKMS Domain
+                Rest API endpoint
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Info />
                   </TooltipTrigger>
                   <TooltipContent className="max-w-sm">
-                    The OKMS base URL, e.g. &apos;https://ca-east-bhs.okms.ovh.net&apos;.
+                    The OVHcloud KMS base URL, e.g. &apos;https://eu-west-rbx.okms.ovh.net&apos;.
                   </TooltipContent>
                 </Tooltip>
               </FieldLabel>
               <Input
                 id="okms-domain"
                 {...field}
-                placeholder="https://ca-east-bhs.okms.ovh.net"
+                placeholder="https://eu-west-rbx.okms.ovh.net"
                 isError={Boolean(error?.message)}
               />
               <FieldError errors={[error]} />
@@ -183,23 +264,25 @@ export const OVHConnectionForm = ({ appConnection, onSubmit }: Props) => {
           shouldUnregister
           render={({ field, fieldState: { error } }) => (
             <Field className="mb-4">
-              <FieldLabel htmlFor="okms-id">OKMS ID</FieldLabel>
+              <FieldLabel htmlFor="okms-id">KMS ID</FieldLabel>
               <Input
                 id="okms-id"
                 {...field}
-                placeholder="your-okms-instance-id"
+                placeholder="your-kms-instance-id"
                 isError={Boolean(error?.message)}
               />
               {!error && (
                 <FieldDescription>
-                  Your OKMS instance identifier from the OVH Control Panel.
+                  Your KMS instance identifier from OVHcloud Control Panel.
                 </FieldDescription>
               )}
               <FieldError errors={[error]} />
             </Field>
           )}
         />
-        <AppConnectionFormFooter submitLabel={isUpdate ? "Update Credentials" : "Connect to OVH"} />
+        <AppConnectionFormFooter
+          submitLabel={isUpdate ? "Update Credentials" : "Connect to OVHcloud"}
+        />
       </form>
     </FormProvider>
   );


### PR DESCRIPTION
## Context

The OVHcloud connection previously supported only mTLS (client certificate) authentication. In PR @Sakutaroo adds a token auth method alongside the existing Certificate method.

## Steps to verify the change

1. create an app connection with OVHcloud provider
2. choose token auth method

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)