### PR TITLE
docs(agent-proxy): document the canceled decision and the agent's own sandbox layer

### DIFF
--- a/docs/cli/commands/agent-proxy.mdx
+++ b/docs/cli/commands/agent-proxy.mdx
@@ -334,7 +334,7 @@ $ infisical secrets agent-proxy start --port 17322 --unmatched-host=block
   </Accordion>
 
   <Accordion title="--log-level">
-    Controls how much is logged. Each [activity decision](/documentation/platform/agent-proxy/activity-logs) maps to a level (`passthrough`=debug, `brokered`=info, `blocked`=warn, `error`=error), so this doubles as the activity filter: `debug` shows everything, the default `info` hides passthrough, `warn` shows only blocked and errors.
+    Controls how much is logged. Each [activity decision](/documentation/platform/agent-proxy/activity-logs) maps to a level (`passthrough`=debug, `canceled`=debug, `brokered`=info, `blocked`=warn, `error`=error), so this doubles as the activity filter: `debug` shows everything, the default `info` hides passthrough and canceled requests, `warn` shows only blocked and errors.
 
     ```bash
     # Example

--- a/docs/documentation/platform/agent-proxy/activity-logs.mdx
+++ b/docs/documentation/platform/agent-proxy/activity-logs.mdx
@@ -48,7 +48,7 @@ Each decision is logged at a level, so `--log-level` controls how much you see: 
 | `blocked` | warn |
 | `error` | error |
 
-`canceled` means the agent hung up before the request finished, which happens whenever you interrupt a prompt or the agent exits with calls in flight. Nothing failed, and there was no one left to return a response to, so these sit at debug alongside passthrough and stay off your terminal. A request that genuinely failed, because the upstream was unreachable or permissions could not be resolved, is still an `error`.
+`canceled` means the agent hung up before the request finished, which happens when you interrupt a prompt or the agent exits mid-request. Nothing failed and there was nobody left to answer, so these stay at debug and off your terminal. A request that really failed, an unreachable upstream or permissions that could not be resolved, is still an `error`.
 
 ## Where the records go
 

--- a/docs/documentation/platform/agent-proxy/activity-logs.mdx
+++ b/docs/documentation/platform/agent-proxy/activity-logs.mdx
@@ -17,12 +17,12 @@ Each request is logged with these fields (plus the standard `time`, `level`, and
 | Field | Meaning |
 | --- | --- |
 | `event` | Always `agent-proxy.request`, so activity is easy to filter from other logs |
-| `decision` | `brokered`, `passthrough`, `blocked`, or `error` |
+| `decision` | `brokered`, `passthrough`, `blocked`, `canceled`, or `error` |
 | `agentId` / `agentName` | Who made the request: the agent's machine identity behind a standalone proxy, or your own account (or `token`) on a local proxy |
 | `projectId` / `environment` / `secretPath` | The folder the request was scoped to |
 | `serviceName` / `serviceId` | The matched proxied service (omitted when none matched) |
 | `method` / `host` / `port` / `path` | The request line, before substitution (so `path` shows the placeholder) |
-| `status` | Upstream status on `brokered` / `passthrough`; `403` on `blocked`; `502` on `error` |
+| `status` | Upstream status on `brokered` / `passthrough`; `403` on `blocked`; `502` on `error`; omitted on `canceled`, where no response was ever returned |
 | `credentials` | What was injected: each entry's secret key (or, for a dynamic secret, its name and output field), and the header or surfaces it landed in |
 
 Written out, two records look like this:
@@ -38,14 +38,17 @@ Written out, two records look like this:
 
 ## Log levels
 
-Each decision is logged at a level, so `--log-level` controls how much you see: the default `info` hides passthrough, `debug` shows everything, `warn` shows only blocked and errors.
+Each decision is logged at a level, so `--log-level` controls how much you see: the default `info` hides passthrough and canceled requests, `debug` shows everything, `warn` shows only blocked and errors.
 
 | decision | level |
 | --- | --- |
 | `passthrough` | debug |
+| `canceled` | debug |
 | `brokered` | info |
 | `blocked` | warn |
 | `error` | error |
+
+`canceled` means the agent hung up before the request finished, which happens whenever you interrupt a prompt or the agent exits with calls in flight. Nothing failed, and there was no one left to return a response to, so these sit at debug alongside passthrough and stay off your terminal. A request that genuinely failed, because the upstream was unreachable or permissions could not be resolved, is still an `error`.
 
 ## Where the records go
 

--- a/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
@@ -264,21 +264,21 @@ A placeholder wins over a variable of the same name from your own environment, a
 
 ### Agents that sandbox themselves
 
-Some agents come with a sandbox of their own. Claude Code restricts the shell commands it runs, and other agents offer something similar, often built on the same operating system features `run` uses. That layer is configured in the agent and is independent of this one.
+Some agents have a sandbox of their own. Claude Code limits the shell commands it runs, and other agents do something similar. That sandbox is set up inside the agent, separately from this one.
 
-The sandbox on this page is the one that protects your credentials. `run` applies it to the agent process before the agent starts, and the operating system extends it to every command the agent runs and everything those commands spawn. No setting inside the agent can widen it.
+This is the sandbox that protects your credentials. `run` applies it to the agent process before the agent starts, and the operating system extends it to everything the agent runs. No setting inside the agent can widen it.
 
-Knowing which layer you are looking at matters when a command fails, because both produce the same `operation not permitted`:
+Both sandboxes fail the same way, with `operation not permitted`, so it helps to know which one you are looking at:
 
-- An agent that hits a denied path often reads it as its own sandbox being too strict, and reruns the command with that sandbox turned off. In Claude Code this is `dangerouslyDisableSandbox`.
-- The rerun leaves the agent's own sandbox, not this one, so the command fails exactly as before.
-- A denial that survives one of those retries comes from the deny list above. Open the specific file with `--allow-read` if the agent genuinely needs it.
+- An agent that hits a denied path often assumes its own sandbox is at fault and runs the command again with that sandbox off. Claude Code calls this `dangerouslyDisableSandbox`.
+- The second try leaves the agent's sandbox, not this one, so it fails again.
+- A denial that survives the retry comes from the deny list above. If the agent really needs the file, open it with `--allow-read`.
 
 <Note>
-  On macOS an agent's own sandbox usually cannot start under `run`, because a second Seatbelt profile cannot be applied inside the first. Agents normally warn and continue without it, and nothing is lost, since this sandbox is unaffected. If yours is set to refuse to start when its sandbox is unavailable, turn that setting off for sessions you run behind the proxy.
+  On macOS an agent's own sandbox usually cannot start under `run`, because macOS does not allow one sandbox inside another. Agents normally warn and carry on without it, and nothing is lost, since this sandbox still applies. If your agent is set to refuse to start without its sandbox, turn that off.
 </Note>
 
-An agent's own sandbox is still worth configuring for the sessions you run **without** `run`, where it is the only boundary in place.
+Configure your agent's own sandbox for the sessions you run **without** `run`, where it is your only boundary.
 
 ## Certificates and the macOS keychain prompt
 
@@ -324,7 +324,7 @@ Every request records a decision: `brokered` (a service matched and a credential
 
 Without `--log-file` you still see problems: warnings and errors print to your terminal, including a credential the proxy had to skip and a dropped authorization. What you lose is the per-request trail, so reach for `--log-file` when you need to see what happened on a specific request.
 
-`passthrough` and `canceled` are the two decisions left out by default. Passthrough is usually the bulk of an agent's traffic, so leaving it out keeps a log small, and a cancellation means the agent hung up rather than that anything failed. `--log-level debug` adds both, which is useful when you are working out why a host is not being brokered and noisy the rest of the time.
+`passthrough` and `canceled` are left out by default. Passthrough is usually most of an agent's traffic, so leaving it out keeps a log small, and a cancellation just means the agent hung up. `--log-level debug` adds both, which is useful when you are working out why a host is not being brokered and noisy the rest of the time.
 
 <Note>
   A path you pass to `--log-file` is appended to on every run and never rotated for you, so rotate it with `logrotate` (`copytruncate`) if you keep one around.
@@ -351,9 +351,9 @@ Without `--log-file` you still see problems: warnings and errors print to your t
     The same pattern applies to any tool with a config-directory override.
   </Accordion>
   <Accordion title="The agent asks me to log in again inside the sandbox">
-    The keychain is blocked, so an agent that keeps its own login there cannot read it inside the sandbox. An agent that keeps it in a file under its state directory is unaffected, since those directories stay readable and writable. Claude Code, for instance, starts already signed in when `~/.claude/.credentials.json` is present.
+    The keychain is blocked, so an agent that keeps its login there cannot read it inside the sandbox. An agent that keeps it in a file is fine, since its state directory stays readable: Claude Code starts already signed in when `~/.claude/.credentials.json` exists.
 
-    Where your agent stores its login is up to the agent, so check for that file first. If it is keychain-backed, pass a token through the environment rather than re-opening the keychain, for example `--pass-env ANTHROPIC_API_KEY`. That name matches the secret-shaped sweep, so it has to be passed through explicitly.
+    Check for that file first. If your agent is keychain-backed, pass a token in with `--pass-env ANTHROPIC_API_KEY` instead of re-opening the keychain.
   </Accordion>
   <Accordion title="Everything is passthrough, nothing is brokered">
     No proxied service matched the host. Check the [host pattern](/documentation/platform/agent-proxy/proxied-services#host-patterns) against the exact hostname the agent calls, that the service is enabled, and that you are pointed at the folder the service lives in.

--- a/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
@@ -347,7 +347,9 @@ Without `--log-file` you still see problems: warnings and errors print to your t
   <Accordion title="The agent cannot read a file it needs">
     It is probably in a denied credential path. Re-open just that file with `--allow-read <path>`. Reach for `--no-sandbox` last, not first.
 
-    Agents that have a sandbox of their own often blame it for the denial and run the command again with that sandbox off, which changes nothing here: this sandbox still applies, and the command fails the same way. If your agent is set to refuse to start when its own sandbox is unavailable, turn that setting off, since it cannot start one inside this one on macOS.
+    Some agents run a sandbox of their own inside this one, and a denied file looks the same in both. Faced with one, an agent will often assume its own sandbox is too strict and run the command a second time with that sandbox switched off. That does not help: this sandbox is still in force, so the command fails exactly as it did the first time.
+
+    On macOS an agent usually cannot start its own sandbox at all under `run`, because macOS does not allow a second sandbox inside an existing one. Most agents warn about it and carry on without it, which costs you nothing, since this sandbox is the one protecting your credentials. If your agent is set to quit when its sandbox is unavailable, switch that off before you run it here.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
@@ -139,7 +139,7 @@ A per-run `0700` temporary directory holds the only things that touch disk:
 
 ## The sandbox
 
-The sandbox is on by default, and it is what makes brokering safe when the proxy and the agent share a machine. Its restrictions are deliberate, and a few are surprising the first time, so this is the part worth reading before you use `run` for real work.
+The sandbox is on by default, and it is what makes brokering safe when the proxy and the agent share a machine. `run` applies it to the agent process before the agent starts, and the operating system extends it to every command the agent runs, so nothing inside the agent can lift it, including an agent's own sandbox settings. Its restrictions are deliberate, and a few are surprising the first time, so this is the part worth reading before you use `run` for real work.
 
 ```text
                                   |
@@ -262,24 +262,6 @@ Add back what the sweep took, one variable at a time:
 
 A placeholder wins over a variable of the same name from your own environment, and `--set-env` wins over everything, including a placeholder.
 
-### Agents that sandbox themselves
-
-Some agents have a sandbox of their own. Claude Code limits the shell commands it runs, and other agents do something similar. That sandbox is set up inside the agent, separately from this one.
-
-This is the sandbox that protects your credentials. `run` applies it to the agent process before the agent starts, and the operating system extends it to everything the agent runs. No setting inside the agent can widen it.
-
-Both sandboxes fail the same way, with `operation not permitted`, so it helps to know which one you are looking at:
-
-- An agent that hits a denied path often assumes its own sandbox is at fault and runs the command again with that sandbox off. Claude Code calls this `dangerouslyDisableSandbox`.
-- The second try leaves the agent's sandbox, not this one, so it fails again.
-- A denial that survives the retry comes from the deny list above. If the agent really needs the file, open it with `--allow-read`.
-
-<Note>
-  On macOS an agent's own sandbox usually cannot start under `run`, because macOS does not allow one sandbox inside another. Agents normally warn and carry on without it, and nothing is lost, since this sandbox still applies. If your agent is set to refuse to start without its sandbox, turn that off.
-</Note>
-
-Configure your agent's own sandbox for the sessions you run **without** `run`, where it is your only boundary.
-
 ## Certificates and the macOS keychain prompt
 
 For the proxy to apply credentials to HTTPS requests it terminates TLS, so the agent has to trust the certificates it presents. `run` uses a **self-signed local root**, generated on your machine; it never involves your organization's root CA, and the private key stays on the parent side of the sandbox. Leaf certificates are minted per hostname from it.
@@ -369,6 +351,8 @@ Without `--log-file` you still see problems: warnings and errors print to your t
   </Accordion>
   <Accordion title="The agent cannot read a file it needs">
     It is probably in a denied credential path. Re-open just that file with `--allow-read <path>`. Reach for `--no-sandbox` last, not first.
+
+    Agents that have a sandbox of their own often blame it for the denial and run the command again with that sandbox off, which changes nothing here: this sandbox still applies, and the command fails the same way. If your agent is set to refuse to start when its own sandbox is unavailable, turn that setting off, since it cannot start one inside this one on macOS.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
@@ -262,19 +262,23 @@ Add back what the sweep took, one variable at a time:
 
 A placeholder wins over a variable of the same name from your own environment, and `--set-env` wins over everything, including a placeholder.
 
-### Your agent's own sandbox is a separate thing
+### Agents that sandbox themselves
 
-Several agents sandbox themselves. Claude Code, for one, has a sandboxed Bash tool that restricts the commands it runs, using the same operating system features `run` does. That is a different layer from this one, with its own settings, and it is worth knowing how the two interact because the failures look identical from inside.
+Some agents come with a sandbox of their own. Claude Code restricts the shell commands it runs, and other agents offer something similar, often built on the same operating system features `run` uses. That layer is configured in the agent and is independent of this one.
 
-`run` wraps the whole agent process before it starts, so its restrictions apply to the agent, every command the agent runs, and every child of those commands. An agent cannot lift them for itself: the operating system hands them down and offers no way to hand them back.
+The sandbox on this page is the one that protects your credentials. `run` applies it to the agent process before the agent starts, and the operating system extends it to every command the agent runs and everything those commands spawn. No setting inside the agent can widen it.
 
-That has a practical consequence you will probably meet. An agent that finds a file unreadable often assumes its own sandbox is responsible and retries the command outside it. Claude Code calls this `dangerouslyDisableSandbox`, and other harnesses have an equivalent. The retry is honest about what it does, and it does not help here: the command runs outside the agent's own sandbox and stays inside this one, so it fails the same way twice. When you see a denial repeat itself after an unsandboxed retry, the deny list on this page is what you are looking at, not the agent's.
+Knowing which layer you are looking at matters when a command fails, because both produce the same `operation not permitted`:
+
+- An agent that hits a denied path often reads it as its own sandbox being too strict, and reruns the command with that sandbox turned off. In Claude Code this is `dangerouslyDisableSandbox`.
+- The rerun leaves the agent's own sandbox, not this one, so the command fails exactly as before.
+- A denial that survives one of those retries comes from the deny list above. Open the specific file with `--allow-read` if the agent genuinely needs it.
 
 <Note>
-  On macOS the agent's own sandbox usually cannot start at all under `run`, because a second Seatbelt profile cannot be applied inside the first. Agents normally warn and carry on with their own layer off, which loses you nothing: the boundary that protects your credentials is this one, and it is fully in force. If your agent is configured to refuse to start when its sandbox is unavailable, that setting will stop it from launching here, so turn it off for sessions you run behind the proxy.
+  On macOS an agent's own sandbox usually cannot start under `run`, because a second Seatbelt profile cannot be applied inside the first. Agents normally warn and continue without it, and nothing is lost, since this sandbox is unaffected. If yours is set to refuse to start when its sandbox is unavailable, turn that setting off for sessions you run behind the proxy.
 </Note>
 
-An agent's sandbox settings are still worth configuring for the sessions you run **without** `run`, where they are the only boundary you have.
+An agent's own sandbox is still worth configuring for the sessions you run **without** `run`, where it is the only boundary in place.
 
 ## Certificates and the macOS keychain prompt
 

--- a/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
@@ -332,11 +332,6 @@ Without `--log-file` you still see problems: warnings and errors print to your t
 
     The same pattern applies to any tool with a config-directory override.
   </Accordion>
-  <Accordion title="The agent asks me to log in again inside the sandbox">
-    The keychain is blocked, so an agent that keeps its login there cannot read it inside the sandbox. An agent that keeps it in a file is fine, since its state directory stays readable: Claude Code starts already signed in when `~/.claude/.credentials.json` exists.
-
-    Check for that file first. If your agent is keychain-backed, pass a token in with `--pass-env ANTHROPIC_API_KEY` instead of re-opening the keychain.
-  </Accordion>
   <Accordion title="Everything is passthrough, nothing is brokered">
     No proxied service matched the host. Check the [host pattern](/documentation/platform/agent-proxy/proxied-services#host-patterns) against the exact hostname the agent calls, that the service is enabled, and that you are pointed at the folder the service lives in.
   </Accordion>

--- a/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/local-agent-proxy.mdx
@@ -262,6 +262,20 @@ Add back what the sweep took, one variable at a time:
 
 A placeholder wins over a variable of the same name from your own environment, and `--set-env` wins over everything, including a placeholder.
 
+### Your agent's own sandbox is a separate thing
+
+Several agents sandbox themselves. Claude Code, for one, has a sandboxed Bash tool that restricts the commands it runs, using the same operating system features `run` does. That is a different layer from this one, with its own settings, and it is worth knowing how the two interact because the failures look identical from inside.
+
+`run` wraps the whole agent process before it starts, so its restrictions apply to the agent, every command the agent runs, and every child of those commands. An agent cannot lift them for itself: the operating system hands them down and offers no way to hand them back.
+
+That has a practical consequence you will probably meet. An agent that finds a file unreadable often assumes its own sandbox is responsible and retries the command outside it. Claude Code calls this `dangerouslyDisableSandbox`, and other harnesses have an equivalent. The retry is honest about what it does, and it does not help here: the command runs outside the agent's own sandbox and stays inside this one, so it fails the same way twice. When you see a denial repeat itself after an unsandboxed retry, the deny list on this page is what you are looking at, not the agent's.
+
+<Note>
+  On macOS the agent's own sandbox usually cannot start at all under `run`, because a second Seatbelt profile cannot be applied inside the first. Agents normally warn and carry on with their own layer off, which loses you nothing: the boundary that protects your credentials is this one, and it is fully in force. If your agent is configured to refuse to start when its sandbox is unavailable, that setting will stop it from launching here, so turn it off for sessions you run behind the proxy.
+</Note>
+
+An agent's sandbox settings are still worth configuring for the sessions you run **without** `run`, where they are the only boundary you have.
+
 ## Certificates and the macOS keychain prompt
 
 For the proxy to apply credentials to HTTPS requests it terminates TLS, so the agent has to trust the certificates it presents. `run` uses a **self-signed local root**, generated on your machine; it never involves your organization's root CA, and the private key stays on the parent side of the sandbox. Leaf certificates are minted per hostname from it.
@@ -302,11 +316,11 @@ infisical secrets agent-proxy run -e dev --log-file=/tmp/broker.log -- claude
 tail -f /tmp/broker.log
 ```
 
-Every request records a decision: `brokered` (a service matched and a credential was applied), `passthrough` (no service matched, forwarded untouched), `blocked` (rejected by `--unmatched-host=block`), or `error`. Records carry the same fields as in [Activity Logs](/documentation/platform/agent-proxy/activity-logs), written in the human-readable console format.
+Every request records a decision: `brokered` (a service matched and a credential was applied), `passthrough` (no service matched, forwarded untouched), `blocked` (rejected by `--unmatched-host=block`), `canceled` (the agent hung up before the request finished), or `error`. Records carry the same fields as in [Activity Logs](/documentation/platform/agent-proxy/activity-logs), written in the human-readable console format.
 
 Without `--log-file` you still see problems: warnings and errors print to your terminal, including a credential the proxy had to skip and a dropped authorization. What you lose is the per-request trail, so reach for `--log-file` when you need to see what happened on a specific request.
 
-`passthrough` is the one decision left out by default, and it is usually the bulk of an agent's traffic, so a log stays small. `--log-level debug` adds it, which is useful when you are working out why a host is not being brokered and noisy the rest of the time.
+`passthrough` and `canceled` are the two decisions left out by default. Passthrough is usually the bulk of an agent's traffic, so leaving it out keeps a log small, and a cancellation means the agent hung up rather than that anything failed. `--log-level debug` adds both, which is useful when you are working out why a host is not being brokered and noisy the rest of the time.
 
 <Note>
   A path you pass to `--log-file` is appended to on every run and never rotated for you, so rotate it with `logrotate` (`copytruncate`) if you keep one around.
@@ -331,6 +345,11 @@ Without `--log-file` you still see problems: warnings and errors print to your t
     ```
 
     The same pattern applies to any tool with a config-directory override.
+  </Accordion>
+  <Accordion title="The agent asks me to log in again inside the sandbox">
+    The keychain is blocked, so an agent that keeps its own login there cannot read it inside the sandbox. An agent that keeps it in a file under its state directory is unaffected, since those directories stay readable and writable. Claude Code, for instance, starts already signed in when `~/.claude/.credentials.json` is present.
+
+    Where your agent stores its login is up to the agent, so check for that file first. If it is keychain-backed, pass a token through the environment rather than re-opening the keychain, for example `--pass-env ANTHROPIC_API_KEY`. That name matches the secret-shaped sweep, so it has to be passed through explicitly.
   </Accordion>
   <Accordion title="Everything is passthrough, nothing is brokered">
     No proxied service matched the host. Check the [host pattern](/documentation/platform/agent-proxy/proxied-services#host-patterns) against the exact hostname the agent calls, that the service is enabled, and that you are pointed at the folder the service lives in.


### PR DESCRIPTION
## Context

**Activity logs:** adds the new `canceled` decision to the field table, the status row (it reports no status, since no response was ever returned) and the level table. The decision-to-level mapping is repeated inline under `--log-level` in the CLI reference and in the activity section of the local proxy page, so both are updated.

**The agent's own sandbox:** new section on the local proxy page. Agents that sandbox themselves use the same OS features `run` does, so a denial from either layer looks identical from inside. `run` wraps the whole process before it starts and the OS hands its restrictions down to every child, which means an agent retrying a command outside its own sandbox (`dangerouslyDisableSandbox` in Claude Code) stays inside ours and fails the same way. On macOS the agent's own sandbox usually cannot start at all, since a second Seatbelt profile cannot be applied inside the first, and an agent configured to refuse to start without one will not launch behind the proxy.

**Keychain-backed agent logins:** new troubleshooting entry. Keychain services are blocked, so an agent that keeps its login there cannot read it inside the sandbox. Claude Code is unaffected because it reads `~/.claude/.credentials.json` and the state directories stay readable, but a keychain-backed agent needs a token passed in with `--pass-env`.

CLI PR: https://github.com/Infisical/cli/pull/352

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
