### PR TITLE
docs(style): fix icon color on card components

### DIFF
--- a/docs/documentation/platform/access-controls/overview.mdx
+++ b/docs/documentation/platform/access-controls/overview.mdx
@@ -11,7 +11,6 @@ To make sure that users and machine identities are only accessing the resources 
     title="Role-based Access Controls" 
     href="./role-based-access-controls" 
     icon="address-book" 
-    color="#000000"
   >
     Manage user and machine identitity permissions through predefined roles. 
   </Card>
@@ -20,7 +19,6 @@ To make sure that users and machine identities are only accessing the resources 
     title="Attribute-based Access Control" 
     href="/documentation/platform/access-controls/abac" 
     icon="address-book" 
-    color="#000000"
   >
     Manage user and machine identitity permissions based on their attributes.
   </Card>
@@ -28,7 +26,6 @@ To make sure that users and machine identities are only accessing the resources 
     title="Additional Privileges"
     href="./additional-privileges"
     icon="ballot-check"
-    color="#000000"
   >
     Add specific privileges to users and machines on top of their roles. 
   </Card>
@@ -36,7 +33,6 @@ To make sure that users and machine identities are only accessing the resources 
     title="Temporary Access" 
     href="./temporary-access" 
     icon="clock" 
-    color="#000000"
   >
     Grant timed access to roles and specific privileges. 
   </Card>
@@ -44,7 +40,6 @@ To make sure that users and machine identities are only accessing the resources 
     title="Audit Logs"
     href="/documentation/platform/audit-logs"
     icon="list"
-    color="#000000"
   >
     Track every action performed by user and machine identities in Infisical. 
   </Card>

--- a/docs/documentation/platform/admin-panel/overview.mdx
+++ b/docs/documentation/platform/admin-panel/overview.mdx
@@ -9,7 +9,6 @@ Infisical offers a server and organization level console for admins to customize
     title="Server Admin Console"
     href="./server-admin"
     icon="user-tie"
-    color="#000000"
   >
     Configure and manage server related features.
   </Card>
@@ -18,7 +17,6 @@ Infisical offers a server and organization level console for admins to customize
     title="Organization Admin Console"
     href="./org-admin-console"
     icon="sitemap"
-    color="#000000"
   >
     View and access resources across your organization.
   </Card>

--- a/docs/documentation/platform/identities/overview.mdx
+++ b/docs/documentation/platform/identities/overview.mdx
@@ -12,14 +12,13 @@ Identities can be of two types:
 Both people and machines are able to utilize corresponding clients (e.g., Dashboard UI, CLI, SDKs, API, Kubernetes Operator) together with allowed authentication methods (e.g., email & password, SAML SSO, LDAP, OIDC, Universal Auth).
 
 <CardGroup cols={2}>
-  <Card href="./user-identities" title="People (User Identities)" icon="people" color="#000000">
+  <Card href="./user-identities" title="People (User Identities)" icon="people" >
     Learn more about the concept on user identities in Infisical. 
   </Card>
   <Card
     title="Machine Identities"
     href="./machine-identities"
     icon="computer"
-    color="#000000"
   >
     Understand the concept of machine identities in Infisical. 
   </Card>

--- a/docs/internals/overview.mdx
+++ b/docs/internals/overview.mdx
@@ -18,18 +18,16 @@ This section covers the internals of Infisical including its technical underpinn
     href="./architecture/components"
     title="Components"
     icon="boxes-stacked"
-    color="#000000"
   >
     Learn about the fundamental parts of Infisical.
   </Card>
-  <Card href="./security" title="Security" icon="shield" color="#000000">
+  <Card href="./security" title="Security" icon="shield" >
     Read about most common security-related topics and questions.
   </Card>
   <Card
     href="./service-tokens"
     title="Service tokens"
     icon="ticket"
-    color="#000000"
   >
     Learn best practices for utilizing Infisical service tokens. Please note
     that service tokens are now deprecated and will be removed entirely in the

--- a/docs/self-hosting/overview.mdx
+++ b/docs/self-hosting/overview.mdx
@@ -16,7 +16,6 @@ Choose from a number of deployment options listed below to get started.
 <CardGroup cols={3}>
   <Card
     title="Docker"
-    color="#000000"
     icon="docker"
     href="./deployment-options/standalone-infisical"
   >
@@ -24,7 +23,6 @@ Choose from a number of deployment options listed below to get started.
   </Card>
   <Card
     title="Kubernetes"
-    color="#000000"
     icon="dharmachakra"
     href="./deployment-options/kubernetes-helm"
   >
@@ -32,7 +30,6 @@ Choose from a number of deployment options listed below to get started.
   </Card>
   <Card
     title="Docker Compose"
-    color="#000000"
     icon="docker"
     href="./deployment-options/docker-compose"
   >
@@ -40,7 +37,7 @@ Choose from a number of deployment options listed below to get started.
   </Card>
   <Card
     title="AWS"
-    color="#000000"
+    
     icon="aws"
     href="./deployment-options/aws-native"
   >
@@ -48,7 +45,6 @@ Choose from a number of deployment options listed below to get started.
   </Card>
   <Card
     title="GCP"
-    color="#000000"
     icon="google"
     href="./deployment-options/gcp-native"
   >
@@ -56,7 +52,6 @@ Choose from a number of deployment options listed below to get started.
   </Card>
   <Card
     title="Linux package"
-    color="#000000"
     icon="linux"
     href="./deployment-options/native/linux-package/installation"
   >


### PR DESCRIPTION
## Context

Removes hardcoded black icons from several instances of the `<Card />` component in the docs.

## Screenshots

Before:

<img width="855" height="565" alt="Screenshot 2026-08-04 at 3 15 45 PM" src="https://github.com/user-attachments/assets/8ff590d6-e670-475e-b2b7-001fa38322c4" />

After:

<img width="813" height="545" alt="Screenshot 2026-08-04 at 3 15 59 PM" src="https://github.com/user-attachments/assets/fcaf16a0-9d77-40ec-b55a-df32ea57ab4a" />

## Steps to verify the change

1. Run `mint dev` to spin up the docs locally.
2. Check the affected pages in both light/dark mode to make sure the icons are the right color.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)