### PR TITLE
fix(aws-parameter-store-sync): stop deleting all params when path is "/"

### DIFF
--- a/backend/src/services/secret-sync/aws-parameter-store/aws-parameter-store-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-parameter-store/aws-parameter-store-sync-fns.ts
@@ -110,7 +110,7 @@ const getParametersByPath = async (
         parameters.Parameters.forEach((parameter) => {
           if (parameter.Name) {
             // no leading slash if path is '/'
-            const secKey = fullPath.length > 1 ? parameter.Name.substring(path.length) : parameter.Name;
+            const secKey = parameter.Name.substring(path.length);
             awsParameterStoreSecretsRecord[secKey] = parameter;
           }
         });
@@ -170,7 +170,7 @@ const getParameterMetadataByPath = async (
         parameters.Parameters.forEach((parameter) => {
           if (parameter.Name) {
             // no leading slash if path is '/'
-            const secKey = fullPath.length > 1 ? parameter.Name.substring(path.length) : parameter.Name;
+            const secKey = parameter.Name.substring(path.length);
             awsParameterStoreMetadataRecord[secKey] = parameter;
           }
         });


### PR DESCRIPTION
## Context

An AWS Parameter Store sync with `destinationConfig.path = "/"` deletes every parameter it manages on the second sync, and orphans them on sync deletion.

Root cause is the key-extraction line in `getParametersByPath` / `getParameterMetadataByPath` that doesn't respect the comment above it:

```ts
const secKey = fullPath.length > 1 ? parameter.Name.substring(path.length) : parameter.Name;
```

A sync with `path = "/"` deletes every managed param on the second sync. The key-extraction line keeps the leading slash on param names, so none match their Infisical-side keys and the deletion loop wipes them all.

Fix: strip the path prefix unconditionally. No-op for every other path.

## Steps to verify the change

1. Create an AWS Parameter Store sync with `path = "/"`, no keySchema.
2. Sync twice: before: all params vanish after the second sync; after: they persist.
3. Delete the sync: before: params orphaned; after: cleaned up.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)