### PR TITLE
fix(ui): remove text balancing from dialog headers

### DIFF
--- a/frontend/src/components/v3/generic/Dialog/Dialog.tsx
+++ b/frontend/src/components/v3/generic/Dialog/Dialog.tsx
@@ -88,7 +88,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-left text-balance", className)}
+      className={cn("flex flex-col gap-2 text-left", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

The V3 `DialogHeader` applied `text-balance` at its root, causing both dialog titles and descriptions to inherit balanced text wrapping. This removes the root utility so dialog header text uses natural wrapping by default. Consumers can still opt into balanced wrapping through `className` when a specific surface needs it.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Run `git diff origin/main...HEAD --check`.
2. Open `frontend/src/components/v3/generic/Dialog/Dialog.tsx`.
3. Confirm the `DialogHeader` root contains `flex flex-col gap-2 text-left` without `text-balance`.
4. Optionally run the Storybook flow described above and compare header wrapping at narrow and desktop widths.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)