### PR TITLE
improvement: revise access restricted display

### DIFF
--- a/frontend/src/pages/organization/ProjectsPage/ProjectTypePage/ProjectTypePage.tsx
+++ b/frontend/src/pages/organization/ProjectsPage/ProjectTypePage/ProjectTypePage.tsx
@@ -411,7 +411,7 @@ const MyProjectsForType = ({
         className={`group h-full cursor-pointer bg-container transition-all duration-200 ease-out ${tileStyle.cardHoverClassName}`}
       >
         <CardHeader>
-          <div className="flex items-start gap-3">
+          <div className="flex min-w-0 items-start gap-3">
             <div className="shrink-0 rounded-sm border border-border bg-muted/10 p-2 transition-colors duration-200 ease-out group-hover:border-project/20 group-hover:bg-gradient-to-br group-hover:from-project/5 group-hover:to-transparent">
               <WorkspaceIcon className="size-5.5 shrink-0 text-accent transition-colors duration-200 ease-out group-hover:text-project" />
             </div>

--- a/frontend/src/pages/public/ErrorPage/ErrorPage.tsx
+++ b/frontend/src/pages/public/ErrorPage/ErrorPage.tsx
@@ -1,25 +1,17 @@
-import { useLayoutEffect, useRef, useState } from "react";
 import { ErrorComponentProps, Link } from "@tanstack/react-router";
 import { AxiosError } from "axios";
 import {
-  ActivityIcon,
   BugIcon,
-  CheckIcon,
-  CopyIcon,
   HouseIcon,
-  MonitorCheckIcon,
   RefreshCwIcon,
   ServerCrashIcon,
-  ShieldCheckIcon,
   TriangleAlertIcon
 } from "lucide-react";
 
-import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
-import { Badge, Button, Card } from "@app/components/v3";
-import { useTimedReset } from "@app/hooks";
+import { Button } from "@app/components/v3";
 
 import { ForbiddenPage } from "../ForbiddenPage/ForbiddenPage";
-import { ProjectAccessError } from "./components";
+import { ErrorPageFrame, ProjectAccessError, useErrorPageTimestamp } from "./components";
 
 const isProjectAccessDeniedError = (error: unknown): error is AxiosError =>
   error instanceof AxiosError &&
@@ -39,29 +31,8 @@ const STATUS_LABELS: Record<number, string> = {
   504: "Gateway Timeout"
 };
 
-const TONES = {
-  warning: { chip: "bg-warning/10 text-warning", dot: "bg-warning", text: "text-warning" },
-  success: { chip: "bg-success/10 text-success", dot: "bg-success", text: "text-success" }
-};
-
 export const ErrorPage = ({ error }: ErrorComponentProps) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  // Errors thrown in nested routes render inside the app layout chrome (sidebar,
-  // header), where the full-screen vault backdrop doesn't fit
-  const [isFullScreen, setIsFullScreen] = useState(false);
-  const [occurredAt] = useState(
-    () => `${new Date().toISOString().slice(0, 19).replace("T", " ")} UTC`
-  );
-  const [copyLabel, isCopied, setCopyLabel] = useTimedReset<string>({
-    initialState: "Copy Report"
-  });
-
-  useLayoutEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    setIsFullScreen(rect.top < 2 && rect.left < 2 && window.innerWidth - rect.width < 4);
-  }, []);
+  const occurredAt = useErrorPageTimestamp();
 
   if (isProjectAccessDeniedError(error)) {
     return <ProjectAccessError />;
@@ -96,34 +67,6 @@ export const ErrorPage = ({ error }: ErrorComponentProps) => {
     causeSentence = "An unexpected error stopped this page from loading.";
   }
 
-  const statusRows = [
-    isAxios
-      ? {
-          icon: <ServerCrashIcon className="size-4" />,
-          label: isGatewayIssue ? "Secrets gateway" : "API request",
-          state: isGatewayIssue ? "Unavailable" : `Failed${status ? ` (${status})` : ""}`,
-          tone: TONES.warning
-        }
-      : {
-          icon: <BugIcon className="size-4" />,
-          label: "This page",
-          state: "Render error",
-          tone: TONES.warning
-        },
-    {
-      icon: <MonitorCheckIcon className="size-4" />,
-      label: "Dashboard",
-      state: "Operational",
-      tone: TONES.success
-    },
-    {
-      icon: <ShieldCheckIcon className="size-4" />,
-      label: "Your secrets",
-      state: "Encrypted & safe",
-      tone: TONES.success
-    }
-  ];
-
   const reqId =
     isAxios && typeof error.response?.data?.reqId === "string"
       ? error.response.data.reqId
@@ -151,110 +94,48 @@ export const ErrorPage = ({ error }: ErrorComponentProps) => {
     .join("\n");
 
   return (
-    <div
-      ref={containerRef}
-      className={`relative flex items-center justify-center p-4 ${
-        isFullScreen
-          ? "min-h-screen bg-linear-to-tr from-card via-bunker-900 to-card"
-          : "min-h-full"
-      }`}
-    >
-      {isFullScreen && <AuthPageBackground />}
-      <Card className="relative z-10 grid w-full max-w-4xl gap-0 overflow-hidden p-0 md:grid-cols-2">
-        <div className="flex flex-col p-8">
-          <img alt="Infisical" src="/images/logotransparent.png" className="h-5 self-start" />
-          <div className="mt-6 flex flex-col items-start gap-5">
-            <Badge variant="warning" className="h-6 px-2">
-              <TriangleAlertIcon />
-              {badgeText}
-            </Badge>
-            <h1 className="text-3xl font-semibold text-foreground md:text-4xl">
-              The page broke.
-              <br />
-              Your secrets didn&rsquo;t.
-            </h1>
-            <p className="max-w-md text-sm leading-relaxed text-accent">
-              {causeSentence} Retry, or head back home.
-            </p>
-            <div className="flex flex-wrap items-center gap-2.5">
-              <Button variant="project" asChild>
-                <Link to="/">
-                  <HouseIcon />
-                  Back to Home
-                </Link>
-              </Button>
-              <Button variant="outline" onClick={() => window.location.reload()}>
-                <RefreshCwIcon />
-                Retry
-              </Button>
-            </div>
-            <p className="text-xs text-muted">
-              Still stuck? Email{" "}
-              <a
-                className="underline underline-offset-4 hover:text-foreground"
-                href="mailto:support@infisical.com"
-              >
-                support@infisical.com
-              </a>{" "}
-              or{" "}
-              <a
-                className="underline underline-offset-4 hover:text-foreground"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://infisical.com/slack"
-              >
-                join us on Slack
-              </a>
-              .
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-col border-t border-border bg-bunker-800/50 md:border-t-0 md:border-l">
-          <div className="flex items-center justify-between gap-2 border-b border-border py-4 pr-5 pl-6">
-            <div className="flex items-center gap-2.5 text-muted">
-              <ActivityIcon className="size-4" />
-              <span className="text-xs font-medium tracking-[0.2em] uppercase">What We Know</span>
-            </div>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => {
-                navigator.clipboard.writeText(errorReport).then(() => {
-                  setCopyLabel("Copied");
-                });
-              }}
-            >
-              {isCopied ? <CheckIcon /> : <CopyIcon />}
-              {copyLabel}
-            </Button>
-          </div>
-          {statusRows.map((row) => (
-            <div
-              key={row.label}
-              className="flex items-center gap-3.5 border-b border-border px-6 py-4"
-            >
-              <div
-                className={`flex size-9 shrink-0 items-center justify-center rounded-md ${row.tone.chip}`}
-              >
-                {row.icon}
-              </div>
-              <span className="text-sm text-foreground">{row.label}</span>
-              <div className="ml-auto flex items-center gap-2">
-                <span className={`size-1.5 rounded-full ${row.tone.dot}`} />
-                <span className={`text-sm ${row.tone.text}`}>{row.state}</span>
-              </div>
-            </div>
-          ))}
-          <div className="mt-auto flex flex-col gap-1.5 px-6 py-6 pt-10">
-            {monoRows.map(([key, value]) => (
-              <div key={key} className="flex gap-4 font-mono text-xs">
-                <span className="w-14 shrink-0 text-muted">{key}</span>
-                <span className="break-all text-label">{value}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </Card>
-    </div>
+    <ErrorPageFrame
+      badgeIcon={<TriangleAlertIcon />}
+      badgeText={badgeText}
+      heading={
+        <>
+          The page broke.
+          <br />
+          <span className="text-2xl">Your secrets didn&rsquo;t.</span>
+        </>
+      }
+      description={`${causeSentence} Retry, or head back home.`}
+      actions={
+        <>
+          <Button variant="project" asChild>
+            <Link to="/">
+              <HouseIcon />
+              Back to Home
+            </Link>
+          </Button>
+          <Button variant="outline" onClick={() => window.location.reload()}>
+            <RefreshCwIcon />
+            Retry
+          </Button>
+        </>
+      }
+      statusRows={[
+        isAxios
+          ? {
+              icon: <ServerCrashIcon />,
+              label: isGatewayIssue ? "Secrets gateway" : "API request",
+              state: isGatewayIssue ? "Unavailable" : `Failed${status ? ` (${status})` : ""}`,
+              tone: "warning"
+            }
+          : {
+              icon: <BugIcon />,
+              label: "This page",
+              state: "Render error",
+              tone: "warning"
+            }
+      ]}
+      monoRows={monoRows}
+      report={errorReport}
+    />
   );
 };

--- a/frontend/src/pages/public/ErrorPage/components/ErrorPageFrame.tsx
+++ b/frontend/src/pages/public/ErrorPage/components/ErrorPageFrame.tsx
@@ -1,0 +1,190 @@
+import { ReactNode, useLayoutEffect, useRef, useState } from "react";
+import { Helmet } from "react-helmet";
+import { ActivityIcon, CheckIcon, CopyIcon, MonitorCheckIcon, ShieldCheckIcon } from "lucide-react";
+
+import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
+import { Badge, Button, Card } from "@app/components/v3";
+import { useTimedReset } from "@app/hooks";
+
+const TONES = {
+  warning: { chip: "bg-warning/10 text-warning", dot: "bg-warning", text: "text-warning" },
+  success: { chip: "bg-success/10 text-success", dot: "bg-success", text: "text-success" }
+};
+
+export type ErrorPageStatusRow = {
+  icon: ReactNode;
+  label: string;
+  state: string;
+  tone: keyof typeof TONES;
+};
+
+// The timestamp appears in both the mono rows and the copyable report, so the caller owns it
+// (via this hook) and passes it into both.
+export const useErrorPageTimestamp = () => {
+  const [occurredAt] = useState(
+    () => `${new Date().toISOString().slice(0, 19).replace("T", " ")} UTC`
+  );
+  return occurredAt;
+};
+
+type Props = {
+  helmetTitle?: string;
+  badgeIcon: ReactNode;
+  badgeText: string;
+  heading: ReactNode;
+  description: ReactNode;
+  actions: ReactNode;
+  // Page-specific rows; the frame appends the standard Dashboard / Your secrets reassurance rows
+  statusRows: ErrorPageStatusRow[];
+  monoRows: [string, string][];
+  report: string;
+  children?: ReactNode;
+};
+
+// Shared shell for the full-page error/status family (ErrorPage, ForbiddenPage, NotFoundPage,
+// ProjectAccessError): vault backdrop, two-column card, badge + heading + actions on the left,
+// "What We Know" status column on the right.
+export const ErrorPageFrame = ({
+  helmetTitle,
+  badgeIcon,
+  badgeText,
+  heading,
+  description,
+  actions,
+  statusRows,
+  monoRows,
+  report,
+  children
+}: Props) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // These pages render from the router's error/not-found boundaries, so they can appear
+  // full-screen at the root or nested inside the app layout chrome (sidebar, header), where
+  // the full-screen vault backdrop doesn't fit
+  const [isFullScreen, setIsFullScreen] = useState(false);
+  const [copyLabel, isCopied, setCopyLabel] = useTimedReset<string>({
+    initialState: "Copy Report"
+  });
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setIsFullScreen(rect.top < 2 && rect.left < 2 && window.innerWidth - rect.width < 4);
+  }, []);
+
+  const allStatusRows: ErrorPageStatusRow[] = [
+    ...statusRows,
+    {
+      icon: <MonitorCheckIcon />,
+      label: "Dashboard",
+      state: "Operational",
+      tone: "success"
+    },
+    {
+      icon: <ShieldCheckIcon />,
+      label: "Your secrets",
+      state: "Encrypted & safe",
+      tone: "success"
+    }
+  ];
+
+  return (
+    <div
+      ref={containerRef}
+      className={`relative flex items-center justify-center p-4 ${
+        isFullScreen
+          ? "min-h-screen bg-linear-to-tr from-card via-bunker-900 to-card"
+          : "min-h-full"
+      }`}
+    >
+      {helmetTitle && (
+        <Helmet>
+          <title>{helmetTitle}</title>
+        </Helmet>
+      )}
+      {isFullScreen && <AuthPageBackground />}
+      <Card className="relative z-10 grid w-full max-w-5xl gap-0 overflow-hidden p-0 lg:grid-cols-[1fr_26rem]">
+        <div className="flex flex-col p-8">
+          <img alt="Infisical" src="/images/logotransparent.png" className="h-5 self-start" />
+          <div className="mt-6 flex flex-col items-start gap-5">
+            <Badge variant="warning" className="h-6 px-2">
+              {badgeIcon}
+              {badgeText}
+            </Badge>
+            <h1 className="text-3xl font-semibold text-foreground">{heading}</h1>
+            <p className="max-w-md text-sm leading-relaxed text-accent">{description}</p>
+            <div className="flex flex-wrap items-center gap-2.5">{actions}</div>
+            <p className="text-xs text-muted">
+              Still stuck? Email{" "}
+              <a
+                className="underline underline-offset-4 hover:text-foreground"
+                href="mailto:support@infisical.com"
+              >
+                support@infisical.com
+              </a>{" "}
+              or{" "}
+              <a
+                className="underline underline-offset-4 hover:text-foreground"
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://infisical.com/slack"
+              >
+                join us on Slack
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col border-t border-border bg-bunker-800/50 lg:border-t-0 lg:border-l">
+          <div className="flex items-center justify-between gap-2 border-b border-border py-4 pr-5 pl-6">
+            <div className="flex items-center gap-2.5 text-muted">
+              <ActivityIcon className="size-4" />
+              <span className="text-xs font-medium tracking-[0.2em] uppercase">What We Know</span>
+            </div>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => {
+                navigator.clipboard.writeText(report).then(() => {
+                  setCopyLabel("Copied");
+                });
+              }}
+            >
+              {isCopied ? <CheckIcon /> : <CopyIcon />}
+              {copyLabel}
+            </Button>
+          </div>
+          {allStatusRows.map((row) => {
+            const tone = TONES[row.tone];
+            return (
+              <div
+                key={row.label}
+                className="flex items-center gap-3.5 border-b border-border px-6 py-4"
+              >
+                <div
+                  className={`flex size-9 shrink-0 items-center justify-center rounded-md [&>svg]:size-4 ${tone.chip}`}
+                >
+                  {row.icon}
+                </div>
+                <span className="text-sm text-foreground">{row.label}</span>
+                <div className="ml-auto flex items-center gap-2">
+                  <span className={`size-1.5 rounded-full ${tone.dot}`} />
+                  <span className={`text-sm whitespace-nowrap ${tone.text}`}>{row.state}</span>
+                </div>
+              </div>
+            );
+          })}
+          <div className="mt-auto flex flex-col gap-1.5 px-6 py-6 pt-10">
+            {monoRows.map(([key, value]) => (
+              <div key={key} className="flex gap-4 font-mono text-xs">
+                <span className="w-14 shrink-0 text-muted">{key}</span>
+                <span className="break-all text-label">{value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Card>
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
+++ b/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
@@ -1,34 +1,18 @@
-import { useLayoutEffect, useRef, useState } from "react";
-import { Helmet } from "react-helmet";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
-import {
-  ActivityIcon,
-  CheckIcon,
-  CopyIcon,
-  HouseIcon,
-  MonitorCheckIcon,
-  SendIcon,
-  ShieldCheckIcon,
-  UserPlusIcon,
-  UserXIcon
-} from "lucide-react";
+import { HouseIcon, SendIcon, UserPlusIcon, UserXIcon } from "lucide-react";
 
-import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
 import { RequestProjectAccessModal } from "@app/components/projects";
-import { Badge, Button, Card } from "@app/components/v3";
+import { Button } from "@app/components/v3";
 import { OrgPermissionSubjects, useOrgPermission } from "@app/context";
 import {
   OrgPermissionAdminConsoleAction,
   OrgPermissionProjectActions
 } from "@app/context/OrgPermissionContext/types";
-import { usePopUp, useTimedReset } from "@app/hooks";
+import { usePopUp } from "@app/hooks";
 import { useOrgAdminAccessProject, useSearchProjects } from "@app/hooks/api";
 import { useGetOrganizationById } from "@app/hooks/api/organization/queries";
 
-const TONES = {
-  warning: { chip: "bg-warning/10 text-warning", dot: "bg-warning", text: "text-warning" },
-  success: { chip: "bg-success/10 text-success", dot: "bg-success", text: "text-success" }
-};
+import { ErrorPageFrame, useErrorPageTimestamp } from "./ErrorPageFrame";
 
 type ProjectAccessErrorProps = {
   projectId?: string;
@@ -58,24 +42,7 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
 
   const navigate = useNavigate();
   const { permission } = useOrgPermission();
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  // Rendered by the error boundary, so it can appear full-screen at the root or nested inside
-  // the app layout chrome (sidebar, header), where the full-screen vault backdrop doesn't fit
-  const [isFullScreen, setIsFullScreen] = useState(false);
-  const [occurredAt] = useState(
-    () => `${new Date().toISOString().slice(0, 19).replace("T", " ")} UTC`
-  );
-  const [copyLabel, isCopied, setCopyLabel] = useTimedReset<string>({
-    initialState: "Copy Report"
-  });
-
-  useLayoutEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    setIsFullScreen(rect.top < 2 && rect.left < 2 && window.innerWidth - rect.width < 4);
-  }, []);
+  const occurredAt = useErrorPageTimestamp();
 
   const { popUp, handlePopUpToggle, handlePopUpOpen } = usePopUp([
     "requestAccessConfirmation"
@@ -132,27 +99,6 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
     ? `Requesting access to ${productName}. You may include an optional note for admins to review your request.`
     : undefined;
 
-  const statusRows = [
-    {
-      icon: <UserXIcon className="size-4" />,
-      label: "Membership",
-      state: "Not found (403)",
-      tone: TONES.warning
-    },
-    {
-      icon: <MonitorCheckIcon className="size-4" />,
-      label: "Dashboard",
-      state: "Operational",
-      tone: TONES.success
-    },
-    {
-      icon: <ShieldCheckIcon className="size-4" />,
-      label: "Your secrets",
-      state: "Encrypted & safe",
-      tone: TONES.success
-    }
-  ];
-
   const monoRows: [string, string][] = [
     ...(project ? ([["project", project.name]] as [string, string][]) : []),
     ["route", window.location.pathname],
@@ -169,136 +115,70 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
     .join("\n");
 
   return (
-    <div
-      ref={containerRef}
-      className={`relative flex items-center justify-center p-4 ${
-        isFullScreen
-          ? "min-h-screen bg-linear-to-tr from-card via-bunker-900 to-card"
-          : "min-h-full"
-      }`}
-    >
-      <Helmet>
-        <title>Infisical | Access Restricted</title>
-      </Helmet>
-      {isFullScreen && <AuthPageBackground />}
-      <Card className="relative z-10 grid w-full max-w-5xl gap-0 overflow-hidden p-0 lg:grid-cols-[1fr_26rem]">
-        <div className="flex flex-col p-8">
-          <img alt="Infisical" src="/images/logotransparent.png" className="h-5 self-start" />
-          <div className="mt-6 flex flex-col items-start gap-5">
-            <Badge variant="warning" className="h-6 px-2">
-              <UserXIcon />
-              403 · Access Restricted
-            </Badge>
-            <h1 className="text-3xl font-semibold text-foreground">
-              Members only.
-              <br />
-              <span className="text-2xl">You&rsquo;re not on the list yet.</span>
-            </h1>
-            <p className="max-w-md text-sm leading-relaxed text-accent">
-              You&rsquo;re not currently a member of {accessTargetName}.{" "}
-              {(() => {
-                if (canJoinAsAdmin)
-                  return "As an organization admin, you can join directly, or head back home.";
-                if (canRequestAccess)
-                  return "Send an access request for an admin to review, or head back home.";
-                return "Your organization role doesn't allow requesting access, so ask an organization admin to add you.";
-              })()}
-            </p>
-            <div className="flex flex-wrap items-center gap-2.5">
-              {canJoinAsAdmin && (
-                <Button
-                  variant="project"
-                  isPending={isProjectLoading || orgAdminAccessProject.isPending}
-                  onClick={() => handleAccessProject()}
-                >
-                  <UserPlusIcon />
-                  {joinButtonText}
-                </Button>
-              )}
-              {!canJoinAsAdmin && canRequestAccess && (
-                <Button
-                  variant="project"
-                  isPending={isProjectLoading}
-                  onClick={() => handlePopUpOpen("requestAccessConfirmation")}
-                >
-                  <SendIcon />
-                  {requestButtonText}
-                </Button>
-              )}
-              <Button variant={canJoinAsAdmin || canRequestAccess ? "outline" : "project"} asChild>
-                <Link to="/">
-                  <HouseIcon />
-                  Back to Home
-                </Link>
-              </Button>
-            </div>
-            <p className="text-xs text-muted">
-              Still stuck? Email{" "}
-              <a
-                className="underline underline-offset-4 hover:text-foreground"
-                href="mailto:support@infisical.com"
-              >
-                support@infisical.com
-              </a>{" "}
-              or{" "}
-              <a
-                className="underline underline-offset-4 hover:text-foreground"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://infisical.com/slack"
-              >
-                join us on Slack
-              </a>
-              .
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-col border-t border-border bg-bunker-800/50 lg:border-t-0 lg:border-l">
-          <div className="flex items-center justify-between gap-2 border-b border-border py-4 pr-5 pl-6">
-            <div className="flex items-center gap-2.5 text-muted">
-              <ActivityIcon className="size-4" />
-              <span className="text-xs font-medium tracking-[0.2em] uppercase">What We Know</span>
-            </div>
+    <ErrorPageFrame
+      helmetTitle="Infisical | Access Restricted"
+      badgeIcon={<UserXIcon />}
+      badgeText="403 · Access Restricted"
+      heading={
+        <>
+          Members only.
+          <br />
+          <span className="text-2xl">You&rsquo;re not on the list yet.</span>
+        </>
+      }
+      description={
+        <>
+          You&rsquo;re not currently a member of {accessTargetName}.{" "}
+          {(() => {
+            if (canJoinAsAdmin)
+              return "As an organization admin, you can join directly, or head back home.";
+            if (canRequestAccess)
+              return "Send an access request for an admin to review, or head back home.";
+            return "Your organization role doesn't allow requesting access, so ask an organization admin to add you.";
+          })()}
+        </>
+      }
+      actions={
+        <>
+          {canJoinAsAdmin && (
             <Button
-              variant="outline"
-              size="xs"
-              onClick={() => {
-                navigator.clipboard.writeText(report).then(() => {
-                  setCopyLabel("Copied");
-                });
-              }}
+              variant="project"
+              isPending={isProjectLoading || orgAdminAccessProject.isPending}
+              onClick={() => handleAccessProject()}
             >
-              {isCopied ? <CheckIcon /> : <CopyIcon />}
-              {copyLabel}
+              <UserPlusIcon />
+              {joinButtonText}
             </Button>
-          </div>
-          {statusRows.map((row) => (
-            <div
-              key={row.label}
-              className="flex items-center gap-3.5 border-b border-border px-6 py-4"
+          )}
+          {!canJoinAsAdmin && canRequestAccess && (
+            <Button
+              variant="project"
+              isPending={isProjectLoading}
+              onClick={() => handlePopUpOpen("requestAccessConfirmation")}
             >
-              <div
-                className={`flex size-9 shrink-0 items-center justify-center rounded-md ${row.tone.chip}`}
-              >
-                {row.icon}
-              </div>
-              <span className="text-sm text-foreground">{row.label}</span>
-              <div className="ml-auto flex items-center gap-2">
-                <span className={`size-1.5 rounded-full ${row.tone.dot}`} />
-                <span className={`text-sm whitespace-nowrap ${row.tone.text}`}>{row.state}</span>
-              </div>
-            </div>
-          ))}
-          <div className="mt-auto flex flex-col gap-1.5 px-6 py-6 pt-10">
-            {monoRows.map(([key, value]) => (
-              <div key={key} className="flex gap-4 font-mono text-xs">
-                <span className="w-14 shrink-0 text-muted">{key}</span>
-                <span className="break-all text-label">{value}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </Card>
+              <SendIcon />
+              {requestButtonText}
+            </Button>
+          )}
+          <Button variant={canJoinAsAdmin || canRequestAccess ? "outline" : "project"} asChild>
+            <Link to="/">
+              <HouseIcon />
+              Back to Home
+            </Link>
+          </Button>
+        </>
+      }
+      statusRows={[
+        {
+          icon: <UserXIcon />,
+          label: "Membership",
+          state: "Not found (403)",
+          tone: "warning"
+        }
+      ]}
+      monoRows={monoRows}
+      report={report}
+    >
       <RequestProjectAccessModal
         isOpen={popUp.requestAccessConfirmation.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("requestAccessConfirmation", isOpen)}
@@ -310,6 +190,6 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
           });
         }}
       />
-    </div>
+    </ErrorPageFrame>
   );
 };

--- a/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
+++ b/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
@@ -55,13 +55,13 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
   const productName = getProductNameFromPath();
   const needsPamFallback = !projectIdProp && !routeProjectId;
   const pamOrgId = needsPamFallback ? getPamOrgIdFromPath() : undefined;
-  const { data: pamOrg } = useGetOrganizationById(pamOrgId ?? "", {
+  const { data: pamOrg, isPending: isPamOrgPending } = useGetOrganizationById(pamOrgId ?? "", {
     enabled: Boolean(pamOrgId)
   });
 
   const projectId = projectIdProp ?? routeProjectId ?? pamOrg?.pamProjectId ?? undefined;
 
-  const { data, isPending: isProjectLoading } = useSearchProjects({
+  const { data, isPending: isProjectSearchPending } = useSearchProjects({
     projectIds: projectId ? [projectId] : [],
     options: {
       enabled: Boolean(projectId)
@@ -69,6 +69,17 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
   });
 
   const [project] = data?.projects ?? [];
+
+  // A disabled query reports isPending forever, so only an enabled query counts as in-flight
+  const isResolvingProjectId = Boolean(pamOrgId) && isPamOrgPending;
+  const isProjectResolving = isResolvingProjectId || (Boolean(projectId) && isProjectSearchPending);
+  // Nothing in flight and still no project: the search errored or returned nothing, or no id
+  // could be resolved. The request flow needs the resolved project (the modal renders nothing
+  // without it), so disable it rather than leave it enabled but inert.
+  const isProjectUnavailable = !isProjectResolving && !project;
+  // Joining only needs the id (the server re-validates it), so it survives a failed project
+  // lookup and is blocked only when no id could be resolved at all
+  const isJoinUnavailable = !projectId && !isResolvingProjectId;
 
   const canJoinAsAdmin = permission.can(
     OrgPermissionAdminConsoleAction.AccessAllProjects,
@@ -83,9 +94,9 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
   );
 
   const handleAccessProject = async () => {
-    if (!project) return;
+    if (!projectId) return;
     await orgAdminAccessProject.mutateAsync({
-      projectId: project.id
+      projectId
     });
     await navigate({
       to: "."
@@ -99,16 +110,25 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
     ? `Requesting access to ${productName}. You may include an optional note for admins to review your request.`
     : undefined;
 
+  const lookupFailedCopy = (action: string) =>
+    `We couldn't load its details, so ${action} isn't available right now. Refresh to try again, or head back home.`;
+
   const monoRows: [string, string][] = [
     ...(project ? ([["project", project.name]] as [string, string][]) : []),
     ["route", window.location.pathname],
     ["time", occurredAt]
   ];
 
+  const projectReportValue = (() => {
+    if (!projectId) return null;
+    if (project) return `${projectId} (${project.name})`;
+    return isProjectUnavailable ? `${projectId} (name lookup failed)` : projectId;
+  })();
+
   const report = [
     `route: ${window.location.pathname}`,
     "error: 403 ProjectMembershipNotFound",
-    projectId ? `project: ${projectId}${project ? ` (${project.name})` : ""}` : null,
+    projectReportValue ? `project: ${projectReportValue}` : null,
     `time: ${occurredAt}`
   ]
     .filter(Boolean)
@@ -130,10 +150,14 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
         <>
           You&rsquo;re not currently a member of {accessTargetName}.{" "}
           {(() => {
-            if (canJoinAsAdmin)
+            if (canJoinAsAdmin) {
+              if (isJoinUnavailable) return lookupFailedCopy("joining");
               return "As an organization admin, you can join directly, or head back home.";
-            if (canRequestAccess)
+            }
+            if (canRequestAccess) {
+              if (isProjectUnavailable) return lookupFailedCopy("requesting access");
               return "Send an access request for an admin to review, or head back home.";
+            }
             return "Your organization role doesn't allow requesting access, so ask an organization admin to add you.";
           })()}
         </>
@@ -143,7 +167,8 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
           {canJoinAsAdmin && (
             <Button
               variant="project"
-              isPending={isProjectLoading || orgAdminAccessProject.isPending}
+              isPending={isResolvingProjectId || orgAdminAccessProject.isPending}
+              isDisabled={isJoinUnavailable}
               onClick={() => handleAccessProject()}
             >
               <UserPlusIcon />
@@ -153,7 +178,8 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
           {!canJoinAsAdmin && canRequestAccess && (
             <Button
               variant="project"
-              isPending={isProjectLoading}
+              isPending={isProjectResolving}
+              isDisabled={isProjectUnavailable}
               onClick={() => handlePopUpOpen("requestAccessConfirmation")}
             >
               <SendIcon />

--- a/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
+++ b/frontend/src/pages/public/ErrorPage/components/ProjectAccessError.tsx
@@ -1,15 +1,34 @@
-import { faHome } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useLayoutEffect, useRef, useState } from "react";
+import { Helmet } from "react-helmet";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
+import {
+  ActivityIcon,
+  CheckIcon,
+  CopyIcon,
+  HouseIcon,
+  MonitorCheckIcon,
+  SendIcon,
+  ShieldCheckIcon,
+  UserPlusIcon,
+  UserXIcon
+} from "lucide-react";
 
-import { OrgPermissionCan } from "@app/components/permissions";
+import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
 import { RequestProjectAccessModal } from "@app/components/projects";
-import { AccessRestrictedBanner, Button } from "@app/components/v2";
-import { OrgPermissionSubjects } from "@app/context";
-import { OrgPermissionAdminConsoleAction } from "@app/context/OrgPermissionContext/types";
-import { usePopUp } from "@app/hooks";
+import { Badge, Button, Card } from "@app/components/v3";
+import { OrgPermissionSubjects, useOrgPermission } from "@app/context";
+import {
+  OrgPermissionAdminConsoleAction,
+  OrgPermissionProjectActions
+} from "@app/context/OrgPermissionContext/types";
+import { usePopUp, useTimedReset } from "@app/hooks";
 import { useOrgAdminAccessProject, useSearchProjects } from "@app/hooks/api";
 import { useGetOrganizationById } from "@app/hooks/api/organization/queries";
+
+const TONES = {
+  warning: { chip: "bg-warning/10 text-warning", dot: "bg-warning", text: "text-warning" },
+  success: { chip: "bg-success/10 text-success", dot: "bg-success", text: "text-success" }
+};
 
 type ProjectAccessErrorProps = {
   projectId?: string;
@@ -38,6 +57,25 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
   const orgAdminAccessProject = useOrgAdminAccessProject();
 
   const navigate = useNavigate();
+  const { permission } = useOrgPermission();
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Rendered by the error boundary, so it can appear full-screen at the root or nested inside
+  // the app layout chrome (sidebar, header), where the full-screen vault backdrop doesn't fit
+  const [isFullScreen, setIsFullScreen] = useState(false);
+  const [occurredAt] = useState(
+    () => `${new Date().toISOString().slice(0, 19).replace("T", " ")} UTC`
+  );
+  const [copyLabel, isCopied, setCopyLabel] = useTimedReset<string>({
+    initialState: "Copy Report"
+  });
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setIsFullScreen(rect.top < 2 && rect.left < 2 && window.innerWidth - rect.width < 4);
+  }, []);
 
   const { popUp, handlePopUpToggle, handlePopUpOpen } = usePopUp([
     "requestAccessConfirmation"
@@ -65,6 +103,18 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
 
   const [project] = data?.projects ?? [];
 
+  const canJoinAsAdmin = permission.can(
+    OrgPermissionAdminConsoleAction.AccessAllProjects,
+    OrgPermissionSubjects.AdminConsole
+  );
+
+  // Mirrors the org-level check requestProjectAccess enforces server-side; without it the
+  // request would only fail on submit, so don't offer the action at all.
+  const canRequestAccess = permission.can(
+    OrgPermissionProjectActions.RequestAccess,
+    OrgPermissionSubjects.Project
+  );
+
   const handleAccessProject = async () => {
     if (!project) return;
     await orgAdminAccessProject.mutateAsync({
@@ -82,60 +132,183 @@ export const ProjectAccessError = ({ projectId: projectIdProp }: ProjectAccessEr
     ? `Requesting access to ${productName}. You may include an optional note for admins to review your request.`
     : undefined;
 
+  const statusRows = [
+    {
+      icon: <UserXIcon className="size-4" />,
+      label: "Membership",
+      state: "Not found (403)",
+      tone: TONES.warning
+    },
+    {
+      icon: <MonitorCheckIcon className="size-4" />,
+      label: "Dashboard",
+      state: "Operational",
+      tone: TONES.success
+    },
+    {
+      icon: <ShieldCheckIcon className="size-4" />,
+      label: "Your secrets",
+      state: "Encrypted & safe",
+      tone: TONES.success
+    }
+  ];
+
+  const monoRows: [string, string][] = [
+    ...(project ? ([["project", project.name]] as [string, string][]) : []),
+    ["route", window.location.pathname],
+    ["time", occurredAt]
+  ];
+
+  const report = [
+    `route: ${window.location.pathname}`,
+    "error: 403 ProjectMembershipNotFound",
+    projectId ? `project: ${projectId}${project ? ` (${project.name})` : ""}` : null,
+    `time: ${occurredAt}`
+  ]
+    .filter(Boolean)
+    .join("\n");
+
   return (
-    <div className="flex min-h-screen w-full items-center justify-center bg-background p-4">
-      <AccessRestrictedBanner
-        body={
-          <>
-            You are not currently a member of {accessTargetName}. Request access to join.
-            <div className="mt-4 flex w-full justify-center gap-2">
-              <Link to="/">
-                <Button variant="outline_bg">
-                  <FontAwesomeIcon icon={faHome} className="mr-2" />
-                  Back To Home
+    <div
+      ref={containerRef}
+      className={`relative flex items-center justify-center p-4 ${
+        isFullScreen
+          ? "min-h-screen bg-linear-to-tr from-card via-bunker-900 to-card"
+          : "min-h-full"
+      }`}
+    >
+      <Helmet>
+        <title>Infisical | Access Restricted</title>
+      </Helmet>
+      {isFullScreen && <AuthPageBackground />}
+      <Card className="relative z-10 grid w-full max-w-5xl gap-0 overflow-hidden p-0 lg:grid-cols-[1fr_26rem]">
+        <div className="flex flex-col p-8">
+          <img alt="Infisical" src="/images/logotransparent.png" className="h-5 self-start" />
+          <div className="mt-6 flex flex-col items-start gap-5">
+            <Badge variant="warning" className="h-6 px-2">
+              <UserXIcon />
+              403 · Access Restricted
+            </Badge>
+            <h1 className="text-3xl font-semibold text-foreground">
+              Members only.
+              <br />
+              <span className="text-2xl">You&rsquo;re not on the list yet.</span>
+            </h1>
+            <p className="max-w-md text-sm leading-relaxed text-accent">
+              You&rsquo;re not currently a member of {accessTargetName}.{" "}
+              {(() => {
+                if (canJoinAsAdmin)
+                  return "As an organization admin, you can join directly, or head back home.";
+                if (canRequestAccess)
+                  return "Send an access request for an admin to review, or head back home.";
+                return "Your organization role doesn't allow requesting access, so ask an organization admin to add you.";
+              })()}
+            </p>
+            <div className="flex flex-wrap items-center gap-2.5">
+              {canJoinAsAdmin && (
+                <Button
+                  variant="project"
+                  isPending={isProjectLoading || orgAdminAccessProject.isPending}
+                  onClick={() => handleAccessProject()}
+                >
+                  <UserPlusIcon />
+                  {joinButtonText}
                 </Button>
-              </Link>
-              <OrgPermissionCan
-                I={OrgPermissionAdminConsoleAction.AccessAllProjects}
-                an={OrgPermissionSubjects.AdminConsole}
-              >
-                {(isAllowed) =>
-                  isAllowed ? (
-                    <Button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        e.preventDefault();
-                        handleAccessProject();
-                      }}
-                      disabled={orgAdminAccessProject.isPending}
-                      isLoading={isProjectLoading || orgAdminAccessProject.isPending}
-                    >
-                      {joinButtonText}
-                    </Button>
-                  ) : (
-                    <Button
-                      onClick={() => handlePopUpOpen("requestAccessConfirmation")}
-                      isLoading={isProjectLoading}
-                    >
-                      {requestButtonText}
-                    </Button>
-                  )
-                }
-              </OrgPermissionCan>
+              )}
+              {!canJoinAsAdmin && canRequestAccess && (
+                <Button
+                  variant="project"
+                  isPending={isProjectLoading}
+                  onClick={() => handlePopUpOpen("requestAccessConfirmation")}
+                >
+                  <SendIcon />
+                  {requestButtonText}
+                </Button>
+              )}
+              <Button variant={canJoinAsAdmin || canRequestAccess ? "outline" : "project"} asChild>
+                <Link to="/">
+                  <HouseIcon />
+                  Back to Home
+                </Link>
+              </Button>
             </div>
-            <RequestProjectAccessModal
-              isOpen={popUp.requestAccessConfirmation.isOpen}
-              onOpenChange={(isOpen) => handlePopUpToggle("requestAccessConfirmation", isOpen)}
-              project={project}
-              subTitle={modalSubTitle}
-              onComplete={() => {
-                navigate({
-                  to: "/"
+            <p className="text-xs text-muted">
+              Still stuck? Email{" "}
+              <a
+                className="underline underline-offset-4 hover:text-foreground"
+                href="mailto:support@infisical.com"
+              >
+                support@infisical.com
+              </a>{" "}
+              or{" "}
+              <a
+                className="underline underline-offset-4 hover:text-foreground"
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://infisical.com/slack"
+              >
+                join us on Slack
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col border-t border-border bg-bunker-800/50 lg:border-t-0 lg:border-l">
+          <div className="flex items-center justify-between gap-2 border-b border-border py-4 pr-5 pl-6">
+            <div className="flex items-center gap-2.5 text-muted">
+              <ActivityIcon className="size-4" />
+              <span className="text-xs font-medium tracking-[0.2em] uppercase">What We Know</span>
+            </div>
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() => {
+                navigator.clipboard.writeText(report).then(() => {
+                  setCopyLabel("Copied");
                 });
               }}
-            />
-          </>
-        }
+            >
+              {isCopied ? <CheckIcon /> : <CopyIcon />}
+              {copyLabel}
+            </Button>
+          </div>
+          {statusRows.map((row) => (
+            <div
+              key={row.label}
+              className="flex items-center gap-3.5 border-b border-border px-6 py-4"
+            >
+              <div
+                className={`flex size-9 shrink-0 items-center justify-center rounded-md ${row.tone.chip}`}
+              >
+                {row.icon}
+              </div>
+              <span className="text-sm text-foreground">{row.label}</span>
+              <div className="ml-auto flex items-center gap-2">
+                <span className={`size-1.5 rounded-full ${row.tone.dot}`} />
+                <span className={`text-sm whitespace-nowrap ${row.tone.text}`}>{row.state}</span>
+              </div>
+            </div>
+          ))}
+          <div className="mt-auto flex flex-col gap-1.5 px-6 py-6 pt-10">
+            {monoRows.map(([key, value]) => (
+              <div key={key} className="flex gap-4 font-mono text-xs">
+                <span className="w-14 shrink-0 text-muted">{key}</span>
+                <span className="break-all text-label">{value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Card>
+      <RequestProjectAccessModal
+        isOpen={popUp.requestAccessConfirmation.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("requestAccessConfirmation", isOpen)}
+        project={project}
+        subTitle={modalSubTitle}
+        onComplete={() => {
+          navigate({
+            to: "/"
+          });
+        }}
       />
     </div>
   );

--- a/frontend/src/pages/public/ErrorPage/components/index.ts
+++ b/frontend/src/pages/public/ErrorPage/components/index.ts
@@ -1,1 +1,2 @@
+export * from "./ErrorPageFrame";
 export * from "./ProjectAccessError";

--- a/frontend/src/pages/public/ForbiddenPage/ForbiddenPage.tsx
+++ b/frontend/src/pages/public/ForbiddenPage/ForbiddenPage.tsx
@@ -1,27 +1,10 @@
-import { useLayoutEffect, useRef, useState } from "react";
-import { Helmet } from "react-helmet";
 import { Link } from "@tanstack/react-router";
 import { AxiosError } from "axios";
-import {
-  ActivityIcon,
-  ArrowLeftIcon,
-  CheckIcon,
-  CopyIcon,
-  HouseIcon,
-  LockIcon,
-  MonitorCheckIcon,
-  ShieldCheckIcon,
-  ShieldXIcon
-} from "lucide-react";
+import { ArrowLeftIcon, HouseIcon, LockIcon, ShieldXIcon } from "lucide-react";
 
-import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
-import { Badge, Button, Card } from "@app/components/v3";
-import { useTimedReset } from "@app/hooks";
+import { Button } from "@app/components/v3";
 
-const TONES = {
-  warning: { chip: "bg-warning/10 text-warning", dot: "bg-warning", text: "text-warning" },
-  success: { chip: "bg-success/10 text-success", dot: "bg-success", text: "text-success" }
-};
+import { ErrorPageFrame, useErrorPageTimestamp } from "../ErrorPage/components";
 
 type Props = {
   // The 403 originates from an Axios request, so forward the error to preserve the backend
@@ -31,45 +14,7 @@ type Props = {
 };
 
 export const ForbiddenPage = ({ error }: Props = {}) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  // The 403 is rendered by the error boundary, so it can appear full-screen at the root or
-  // nested inside the app layout chrome (sidebar, header) for a forbidden sub-route, where
-  // the full-screen vault backdrop doesn't fit
-  const [isFullScreen, setIsFullScreen] = useState(false);
-  const [occurredAt] = useState(
-    () => `${new Date().toISOString().slice(0, 19).replace("T", " ")} UTC`
-  );
-  const [copyLabel, isCopied, setCopyLabel] = useTimedReset<string>({
-    initialState: "Copy Report"
-  });
-
-  useLayoutEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    setIsFullScreen(rect.top < 2 && rect.left < 2 && window.innerWidth - rect.width < 4);
-  }, []);
-
-  const statusRows = [
-    {
-      icon: <ShieldXIcon className="size-4" />,
-      label: "Access",
-      state: "Denied (403)",
-      tone: TONES.warning
-    },
-    {
-      icon: <MonitorCheckIcon className="size-4" />,
-      label: "Dashboard",
-      state: "Operational",
-      tone: TONES.success
-    },
-    {
-      icon: <ShieldCheckIcon className="size-4" />,
-      label: "Your secrets",
-      state: "Encrypted & safe",
-      tone: TONES.success
-    }
-  ];
+  const occurredAt = useErrorPageTimestamp();
 
   const isAxios = error instanceof AxiosError;
 
@@ -98,114 +43,47 @@ export const ForbiddenPage = ({ error }: Props = {}) => {
     .join("\n");
 
   return (
-    <div
-      ref={containerRef}
-      className={`relative flex items-center justify-center p-4 ${
-        isFullScreen
-          ? "min-h-screen bg-linear-to-tr from-card via-bunker-900 to-card"
-          : "min-h-full"
-      }`}
-    >
-      <Helmet>
-        <title>Infisical | Access Denied</title>
-      </Helmet>
-      {isFullScreen && <AuthPageBackground />}
-      <Card className="relative z-10 grid w-full max-w-5xl gap-0 overflow-hidden p-0 lg:grid-cols-[1fr_26rem]">
-        <div className="flex flex-col p-8">
-          <img alt="Infisical" src="/images/logotransparent.png" className="h-5 self-start" />
-          <div className="mt-6 flex flex-col items-start gap-5">
-            <Badge variant="warning" className="h-6 px-2">
-              <LockIcon />
-              403 · Access Denied
-            </Badge>
-            <h1 className="text-3xl font-semibold text-foreground">
-              You&rsquo;ve hit a wall.
-              <br />
-              <span className="text-2xl">Your secrets are behind it.</span>
-            </h1>
-            <p className="max-w-md text-sm leading-relaxed text-accent">
-              You don&rsquo;t have permission to view this page. Check with your admin, or head back
-              home.
-            </p>
-            <div className="flex flex-wrap items-center gap-2.5">
-              <Button variant="project" asChild>
-                <Link to="/">
-                  <HouseIcon />
-                  Back to Home
-                </Link>
-              </Button>
-              <Button variant="outline" onClick={() => window.history.back()}>
-                <ArrowLeftIcon />
-                Go Back
-              </Button>
-            </div>
-            <p className="text-xs text-muted">
-              Still stuck? Email{" "}
-              <a
-                className="underline underline-offset-4 hover:text-foreground"
-                href="mailto:support@infisical.com"
-              >
-                support@infisical.com
-              </a>{" "}
-              or{" "}
-              <a
-                className="underline underline-offset-4 hover:text-foreground"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://infisical.com/slack"
-              >
-                join us on Slack
-              </a>
-              .
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-col border-t border-border bg-bunker-800/50 md:border-t-0 md:border-l">
-          <div className="flex items-center justify-between gap-2 border-b border-border py-4 pr-5 pl-6">
-            <div className="flex items-center gap-2.5 text-muted">
-              <ActivityIcon className="size-4" />
-              <span className="text-xs font-medium tracking-[0.2em] uppercase">What We Know</span>
-            </div>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => {
-                navigator.clipboard.writeText(report).then(() => {
-                  setCopyLabel("Copied");
-                });
-              }}
-            >
-              {isCopied ? <CheckIcon /> : <CopyIcon />}
-              {copyLabel}
-            </Button>
-          </div>
-          {statusRows.map((row) => (
-            <div
-              key={row.label}
-              className="flex items-center gap-3.5 border-b border-border px-6 py-4"
-            >
-              <div
-                className={`flex size-9 shrink-0 items-center justify-center rounded-md ${row.tone.chip}`}
-              >
-                {row.icon}
-              </div>
-              <span className="text-sm text-foreground">{row.label}</span>
-              <div className="ml-auto flex items-center gap-2">
-                <span className={`size-1.5 rounded-full ${row.tone.dot}`} />
-                <span className={`text-sm whitespace-nowrap ${row.tone.text}`}>{row.state}</span>
-              </div>
-            </div>
-          ))}
-          <div className="mt-auto flex flex-col gap-1.5 px-6 py-6 pt-10">
-            {monoRows.map(([key, value]) => (
-              <div key={key} className="flex gap-4 font-mono text-xs">
-                <span className="w-14 shrink-0 text-muted">{key}</span>
-                <span className="break-all text-label">{value}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </Card>
-    </div>
+    <ErrorPageFrame
+      helmetTitle="Infisical | Access Denied"
+      badgeIcon={<LockIcon />}
+      badgeText="403 · Access Denied"
+      heading={
+        <>
+          You&rsquo;ve hit a wall.
+          <br />
+          <span className="text-2xl">Your secrets are behind it.</span>
+        </>
+      }
+      description={
+        <>
+          You don&rsquo;t have permission to view this page. Check with your admin, or head back
+          home.
+        </>
+      }
+      actions={
+        <>
+          <Button variant="project" asChild>
+            <Link to="/">
+              <HouseIcon />
+              Back to Home
+            </Link>
+          </Button>
+          <Button variant="outline" onClick={() => window.history.back()}>
+            <ArrowLeftIcon />
+            Go Back
+          </Button>
+        </>
+      }
+      statusRows={[
+        {
+          icon: <ShieldXIcon />,
+          label: "Access",
+          state: "Denied (403)",
+          tone: "warning"
+        }
+      ]}
+      monoRows={monoRows}
+      report={report}
+    />
   );
 };

--- a/frontend/src/pages/public/NotFoundPage/NotFoundPage.tsx
+++ b/frontend/src/pages/public/NotFoundPage/NotFoundPage.tsx
@@ -1,67 +1,12 @@
-import { useLayoutEffect, useRef, useState } from "react";
-import { Helmet } from "react-helmet";
 import { Link } from "@tanstack/react-router";
-import {
-  ActivityIcon,
-  ArrowLeftIcon,
-  CheckIcon,
-  CompassIcon,
-  CopyIcon,
-  HouseIcon,
-  MapPinOffIcon,
-  MonitorCheckIcon,
-  ShieldCheckIcon
-} from "lucide-react";
+import { ArrowLeftIcon, CompassIcon, HouseIcon, MapPinOffIcon } from "lucide-react";
 
-import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
-import { Badge, Button, Card } from "@app/components/v3";
-import { useTimedReset } from "@app/hooks";
+import { Button } from "@app/components/v3";
 
-const TONES = {
-  warning: { chip: "bg-warning/10 text-warning", dot: "bg-warning", text: "text-warning" },
-  success: { chip: "bg-success/10 text-success", dot: "bg-success", text: "text-success" }
-};
+import { ErrorPageFrame, useErrorPageTimestamp } from "../ErrorPage/components";
 
 export const NotFoundPage = () => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  // The 404 is the router's defaultNotFoundComponent, so it can render full-screen at
-  // the root or nested inside the app layout chrome (sidebar, header) for an unmatched
-  // sub-route, where the full-screen vault backdrop doesn't fit
-  const [isFullScreen, setIsFullScreen] = useState(false);
-  const [occurredAt] = useState(
-    () => `${new Date().toISOString().slice(0, 19).replace("T", " ")} UTC`
-  );
-  const [copyLabel, isCopied, setCopyLabel] = useTimedReset<string>({
-    initialState: "Copy Report"
-  });
-
-  useLayoutEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    const rect = el.getBoundingClientRect();
-    setIsFullScreen(rect.top < 2 && rect.left < 2 && window.innerWidth - rect.width < 4);
-  }, []);
-
-  const statusRows = [
-    {
-      icon: <MapPinOffIcon className="size-4" />,
-      label: "This page",
-      state: "Not found",
-      tone: TONES.warning
-    },
-    {
-      icon: <MonitorCheckIcon className="size-4" />,
-      label: "Dashboard",
-      state: "Operational",
-      tone: TONES.success
-    },
-    {
-      icon: <ShieldCheckIcon className="size-4" />,
-      label: "Your secrets",
-      state: "Encrypted & safe",
-      tone: TONES.success
-    }
-  ];
+  const occurredAt = useErrorPageTimestamp();
 
   const monoRows: [string, string][] = [
     ["route", window.location.pathname],
@@ -75,114 +20,47 @@ export const NotFoundPage = () => {
   ].join("\n");
 
   return (
-    <div
-      ref={containerRef}
-      className={`relative flex items-center justify-center p-4 ${
-        isFullScreen
-          ? "min-h-screen bg-linear-to-tr from-card via-bunker-900 to-card"
-          : "min-h-full"
-      }`}
-    >
-      <Helmet>
-        <title>Infisical | Page Not Found</title>
-      </Helmet>
-      {isFullScreen && <AuthPageBackground />}
-      <Card className="relative z-10 grid w-full max-w-5xl gap-0 overflow-hidden p-0 lg:grid-cols-[1fr_26rem]">
-        <div className="flex flex-col p-8">
-          <img alt="Infisical" src="/images/logotransparent.png" className="h-5 self-start" />
-          <div className="mt-6 flex flex-col items-start gap-5">
-            <Badge variant="warning" className="h-6 px-2">
-              <CompassIcon />
-              404 · Not Found
-            </Badge>
-            <h1 className="text-3xl font-semibold text-foreground">
-              Some things stay hidden on purpose.
-              <br />
-              <span className="text-2xl">This page isn&rsquo;t one of them.</span>
-            </h1>
-            <p className="max-w-md text-sm leading-relaxed text-accent">
-              We couldn&rsquo;t find the page you&rsquo;re looking for. It may have moved, or the
-              link may be broken.
-            </p>
-            <div className="flex flex-wrap items-center gap-2.5">
-              <Button variant="project" asChild>
-                <Link to="/">
-                  <HouseIcon />
-                  Back to Home
-                </Link>
-              </Button>
-              <Button variant="outline" onClick={() => window.history.back()}>
-                <ArrowLeftIcon />
-                Go Back
-              </Button>
-            </div>
-            <p className="text-xs text-muted">
-              Still stuck? Email{" "}
-              <a
-                className="underline underline-offset-4 hover:text-foreground"
-                href="mailto:support@infisical.com"
-              >
-                support@infisical.com
-              </a>{" "}
-              or{" "}
-              <a
-                className="underline underline-offset-4 hover:text-foreground"
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://infisical.com/slack"
-              >
-                join us on Slack
-              </a>
-              .
-            </p>
-          </div>
-        </div>
-        <div className="flex flex-col border-t border-border bg-bunker-800/50 md:border-t-0 md:border-l">
-          <div className="flex items-center justify-between gap-2 border-b border-border py-4 pr-5 pl-6">
-            <div className="flex items-center gap-2.5 text-muted">
-              <ActivityIcon className="size-4" />
-              <span className="text-xs font-medium tracking-[0.2em] uppercase">What We Know</span>
-            </div>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() => {
-                navigator.clipboard.writeText(report).then(() => {
-                  setCopyLabel("Copied");
-                });
-              }}
-            >
-              {isCopied ? <CheckIcon /> : <CopyIcon />}
-              {copyLabel}
-            </Button>
-          </div>
-          {statusRows.map((row) => (
-            <div
-              key={row.label}
-              className="flex items-center gap-3.5 border-b border-border px-6 py-4"
-            >
-              <div
-                className={`flex size-9 shrink-0 items-center justify-center rounded-md ${row.tone.chip}`}
-              >
-                {row.icon}
-              </div>
-              <span className="text-sm text-foreground">{row.label}</span>
-              <div className="ml-auto flex items-center gap-2">
-                <span className={`size-1.5 rounded-full ${row.tone.dot}`} />
-                <span className={`text-sm whitespace-nowrap ${row.tone.text}`}>{row.state}</span>
-              </div>
-            </div>
-          ))}
-          <div className="mt-auto flex flex-col gap-1.5 px-6 py-6 pt-10">
-            {monoRows.map(([key, value]) => (
-              <div key={key} className="flex gap-4 font-mono text-xs">
-                <span className="w-14 shrink-0 text-muted">{key}</span>
-                <span className="break-all text-label">{value}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </Card>
-    </div>
+    <ErrorPageFrame
+      helmetTitle="Infisical | Page Not Found"
+      badgeIcon={<CompassIcon />}
+      badgeText="404 · Not Found"
+      heading={
+        <>
+          Some things stay hidden on purpose.
+          <br />
+          <span className="text-2xl">This page isn&rsquo;t one of them.</span>
+        </>
+      }
+      description={
+        <>
+          We couldn&rsquo;t find the page you&rsquo;re looking for. It may have moved, or the link
+          may be broken.
+        </>
+      }
+      actions={
+        <>
+          <Button variant="project" asChild>
+            <Link to="/">
+              <HouseIcon />
+              Back to Home
+            </Link>
+          </Button>
+          <Button variant="outline" onClick={() => window.history.back()}>
+            <ArrowLeftIcon />
+            Go Back
+          </Button>
+        </>
+      }
+      statusRows={[
+        {
+          icon: <MapPinOffIcon />,
+          label: "This page",
+          state: "Not found",
+          tone: "warning"
+        }
+      ]}
+      monoRows={monoRows}
+      report={report}
+    />
   );
 };


### PR DESCRIPTION
## Context

this PR updates the project access / request page to use the same styling as our error page

## Screenshots

<img width="3456" height="1930" alt="CleanShot 2026-08-04 at 17 29 22@2x" src="https://github.com/user-attachments/assets/22125451-16f1-4fbb-b79d-c3440555d23b" />

## Steps to verify the change

- [ ] Org admin, non-member project: page shows "Join Project as Admin"; clicking it joins and lands on the project overview
- [ ] Org member (built-in role), non-member project: shows "Request Access to Project"; modal opens, submit sends the request and redirects home
- [ ] Custom org role without `request-access` on `project`: no Join/Request button, copy says to ask an org admin, "Back to Home" becomes the primary button
- [ ] Modal Cancel closes without submitting and stays on the page
- [ ] "Back to Home" navigates to the org home from any variant
- [ ] Product copy: cert-manager URL says "Certificate Manager", PAM URL says "Privileged Access Manager", secret-manager project says "this project"
- [ ] Right column shows the resolved project name plus route/time, and "Copy Report" copies the route, 403 error, project id/name, and timestamp
- [ ] Direct URL load renders full-screen with the vault backdrop; the same error thrown inside app chrome (sidebar/header) renders without it
- [ ] Permission cache: after being removed from a project, the page appears within ~10s (not instantly) and joining again clears it
- [ ] Regression: plain 403s still render ForbiddenPage and other errors still render ErrorPage (only `ProjectMembershipNotFound` hits this page)

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)