### PR TITLE
improvement(pki): show disabled certificate profiles for API enrollment

### DIFF
--- a/frontend/src/hooks/api/ca/mutations.tsx
+++ b/frontend/src/hooks/api/ca/mutations.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
 
+import { certificateProfileKeys } from "../certificateProfiles/queries";
 import { projectKeys } from "../projects";
 import { CaRenewalStatus, CaType } from "./enums";
 import { caKeys } from "./queries";
@@ -174,7 +175,7 @@ export const useCreateCertificateV3 = () => {
       });
 
       queryClient.invalidateQueries({
-        queryKey: ["certificate-profiles"]
+        queryKey: certificateProfileKeys.all
       });
     }
   });

--- a/frontend/src/hooks/api/certificateProfiles/mutations.tsx
+++ b/frontend/src/hooks/api/certificateProfiles/mutations.tsx
@@ -23,7 +23,7 @@ export const useCreateCertificateProfile = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["certificate-profiles", "list"]
+        queryKey: certificateProfileKeys.lists()
       });
       queryClient.invalidateQueries({ queryKey: pkiApplicationKeys.all });
     }
@@ -42,7 +42,7 @@ export const useUpdateCertificateProfile = () => {
     },
     onSuccess: (_, { profileId }) => {
       queryClient.invalidateQueries({
-        queryKey: ["certificate-profiles", "list"]
+        queryKey: certificateProfileKeys.lists()
       });
       queryClient.invalidateQueries({
         queryKey: certificateProfileKeys.getById(profileId)
@@ -64,7 +64,7 @@ export const useDeleteCertificateProfile = () => {
     },
     onSuccess: (_, { profileId }) => {
       queryClient.invalidateQueries({
-        queryKey: ["certificate-profiles", "list"]
+        queryKey: certificateProfileKeys.lists()
       });
       queryClient.removeQueries({
         queryKey: certificateProfileKeys.getById(profileId)

--- a/frontend/src/hooks/api/certificateProfiles/queries.tsx
+++ b/frontend/src/hooks/api/certificateProfiles/queries.tsx
@@ -15,6 +15,8 @@ import {
 } from "./types";
 
 export const certificateProfileKeys = {
+  all: ["certificate-profiles"] as const,
+  lists: () => [...certificateProfileKeys.all, "list"] as const,
   list: (params: {
     limit?: number;
     offset?: number;
@@ -23,23 +25,23 @@ export const certificateProfileKeys = {
     enrollmentType?: string;
     expiringDays?: number;
     applicationId?: string;
-  }) => ["certificate-profiles", "list", params],
-  getById: (profileId: string) => ["certificate-profiles", "get-by-id", profileId],
-  getBySlug: (slug: string) => ["certificate-profiles", "get-by-slug", slug],
+  }) => [...certificateProfileKeys.lists(), params],
+  getById: (profileId: string) => [...certificateProfileKeys.all, "get-by-id", profileId],
+  getBySlug: (slug: string) => [...certificateProfileKeys.all, "get-by-slug", slug],
   getCertificates: (profileId: string, params?: Omit<TGetProfileCertificatesDTO, "profileId">) => [
-    "certificate-profiles",
+    ...certificateProfileKeys.all,
     "certificates",
     profileId,
     params
   ],
   getMetrics: (profileId: string, params?: Omit<TGetProfileMetricsDTO, "profileId">) => [
-    "certificate-profiles",
+    ...certificateProfileKeys.all,
     "metrics",
     profileId,
     params
   ],
   revealAcmeEabSecret: (profileId: string) => [
-    "certificate-profiles",
+    ...certificateProfileKeys.all,
     "reveal-acme-eab-secret",
     profileId
   ]

--- a/frontend/src/hooks/api/certificates/mutations.tsx
+++ b/frontend/src/hooks/api/certificates/mutations.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
 
+import { certificateProfileKeys } from "../certificateProfiles/queries";
 import { pkiSubscriberKeys } from "../pkiSubscriber/queries";
 import { projectKeys } from "../projects";
 import { certKeys } from "./queries";
@@ -38,7 +39,7 @@ export const useDeleteCert = () => {
         queryKey: certKeys.getCertificateById(id)
       });
       queryClient.invalidateQueries({
-        queryKey: ["certificate-profiles", "list"]
+        queryKey: certificateProfileKeys.lists()
       });
       queryClient.invalidateQueries({
         queryKey: pkiSubscriberKeys.allPkiSubscriberCertificates()
@@ -72,7 +73,7 @@ export const useRevokeCert = () => {
         queryKey: certKeys.getCertificateById(id)
       });
       queryClient.invalidateQueries({
-        queryKey: ["certificate-profiles", "list"]
+        queryKey: certificateProfileKeys.lists()
       });
       queryClient.invalidateQueries({
         queryKey: pkiSubscriberKeys.allPkiSubscriberCertificates()
@@ -123,7 +124,7 @@ export const useRenewCertificate = () => {
         queryKey: certKeys.getCertificateById(certificateId)
       });
       queryClient.invalidateQueries({
-        queryKey: ["certificate-profiles", "list"]
+        queryKey: certificateProfileKeys.lists()
       });
       queryClient.invalidateQueries({
         queryKey: pkiSubscriberKeys.allPkiSubscriberCertificates()
@@ -242,7 +243,7 @@ export const useUnifiedCertificateIssuance = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["certificate-profiles", "list"]
+        queryKey: certificateProfileKeys.lists()
       });
       queryClient.invalidateQueries({
         queryKey: pkiSubscriberKeys.allPkiSubscriberCertificates()

--- a/frontend/src/hooks/api/pkiApplications/mutations.ts
+++ b/frontend/src/hooks/api/pkiApplications/mutations.ts
@@ -5,6 +5,7 @@ import { apiRequest } from "@app/config/request";
 import { approvalGrantQuery } from "../approvalGrants/queries";
 import { approvalPolicyQuery } from "../approvalPolicies/queries";
 import { approvalRequestQuery } from "../approvalRequests/queries";
+import { certificateProfileKeys } from "../certificateProfiles/queries";
 import { pkiApplicationKeys } from "./queries";
 import {
   TAddPkiApplicationMemberDTO,
@@ -31,7 +32,7 @@ const BASE_URL = "/api/v1/cert-manager/applications";
 
 const invalidateAll = (qc: ReturnType<typeof useQueryClient>) => {
   qc.invalidateQueries({ queryKey: pkiApplicationKeys.all });
-  qc.invalidateQueries({ queryKey: ["certificate-profiles", "list"] });
+  qc.invalidateQueries({ queryKey: certificateProfileKeys.lists() });
 };
 
 export const useCreatePkiApplication = () => {

--- a/frontend/src/hooks/api/pkiApplications/mutations.ts
+++ b/frontend/src/hooks/api/pkiApplications/mutations.ts
@@ -29,8 +29,10 @@ import {
 
 const BASE_URL = "/api/v1/cert-manager/applications";
 
-const invalidateAll = (qc: ReturnType<typeof useQueryClient>) =>
+const invalidateAll = (qc: ReturnType<typeof useQueryClient>) => {
   qc.invalidateQueries({ queryKey: pkiApplicationKeys.all });
+  qc.invalidateQueries({ queryKey: ["certificate-profiles", "list"] });
+};
 
 export const useCreatePkiApplication = () => {
   const qc = useQueryClient();

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
@@ -268,10 +268,16 @@ export const CertificateIssuanceModal = ({
     const apiEnabledProfileIds = new Set(
       (appProfiles ?? []).filter((p) => Boolean(p.apiConfigId)).map((p) => p.profileId)
     );
-    return allProfiles.map((profile) => ({
-      profile,
-      isApiEnabled: apiEnabledProfileIds.has(profile.id)
-    }));
+    return allProfiles
+      .map((profile) => ({
+        profile,
+        isApiEnabled: apiEnabledProfileIds.has(profile.id)
+      }))
+      .sort(
+        (a, b) =>
+          Number(b.isApiEnabled) - Number(a.isApiEnabled) ||
+          a.profile.slug.localeCompare(b.profile.slug)
+      );
   }, [profilesData?.certificateProfiles, appProfiles, applicationId]);
 
   const availableProfiles = useMemo(

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
@@ -262,14 +262,24 @@ export const CertificateIssuanceModal = ({
 
   const { data: appProfiles } = useListPkiApplicationProfiles(applicationId ?? "");
 
-  const availableProfiles = useMemo(() => {
+  const profileOptions = useMemo(() => {
     const allProfiles = profilesData?.certificateProfiles ?? [];
-    if (!applicationId) return allProfiles;
+    if (!applicationId) return allProfiles.map((profile) => ({ profile, isApiEnabled: true }));
     const apiEnabledProfileIds = new Set(
       (appProfiles ?? []).filter((p) => Boolean(p.apiConfigId)).map((p) => p.profileId)
     );
-    return allProfiles.filter((p) => apiEnabledProfileIds.has(p.id));
+    return allProfiles.map((profile) => ({
+      profile,
+      isApiEnabled: apiEnabledProfileIds.has(profile.id)
+    }));
   }, [profilesData?.certificateProfiles, appProfiles, applicationId]);
+
+  const availableProfiles = useMemo(
+    () => profileOptions.filter((option) => option.isApiEnabled).map((option) => option.profile),
+    [profileOptions]
+  );
+
+  const hasDisabledProfiles = profileOptions.some((option) => !option.isApiEnabled);
 
   const { mutateAsync: issueCertificate } = useUnifiedCertificateIssuance();
 
@@ -671,21 +681,34 @@ export const CertificateIssuanceModal = ({
                                   <SelectValue placeholder="Select a certificate profile" />
                                 </SelectTrigger>
                                 <SelectContent position="popper">
-                                  {availableProfiles.length === 0 && applicationId ? (
+                                  {profileOptions.length === 0 && applicationId ? (
                                     <div className="px-3 py-3 text-xs leading-snug whitespace-normal text-muted">
-                                      Only profiles with API enrollment configured on this
-                                      Application are listed here. Configure API enrollment under
-                                      this Application&apos;s Settings tab.
+                                      No certificate profiles are attached to this Application. Add
+                                      one under this Application&apos;s Settings tab.
                                     </div>
                                   ) : (
-                                    availableProfiles.map((profile) => (
-                                      <SelectItem key={profile.id} value={profile.id}>
+                                    profileOptions.map(({ profile, isApiEnabled }) => (
+                                      <SelectItem
+                                        key={profile.id}
+                                        value={profile.id}
+                                        disabled={!isApiEnabled}
+                                        description={
+                                          isApiEnabled ? undefined : "API enrollment not configured"
+                                        }
+                                      >
                                         {profile.slug}
                                       </SelectItem>
                                     ))
                                   )}
                                 </SelectContent>
                               </Select>
+                              {hasDisabledProfiles && (
+                                <FieldDescription>
+                                  Profiles without API enrollment configured can&apos;t be used
+                                  here. Configure API enrollment under this Application&apos;s
+                                  Settings tab.
+                                </FieldDescription>
+                              )}
                               {isAdcsProfile && (
                                 <FieldDescription>{externalCaHint}</FieldDescription>
                               )}


### PR DESCRIPTION
## Context

The certificate request dropdown on an Application only listed profiles that already had API enrollment configured, so a profile attached to the Application but not configured for API just silently vanished from the list with no explanation. Now every attached profile is listed, and the ones without API enrollment render as disabled rows with "API enrollment not configured" under them, plus a hint pointing at the Application's Settings tab. The empty state is narrowed to the case it actually describes: no profiles attached to the Application at all.

**Cache invalidation:** found while testing the above. The dropdown's items come from the `certificate-profiles / list` query scoped by `applicationId`, but the Application mutations only invalidated `pkiApplicationKeys.all`. With the global 60s `staleTime`, attaching a profile and returning to the request sheet within that window served the stale list, so the newly attached profile was missing (and a detached one lingered) until the query went stale and remounted. `invalidateAll` in `pkiApplications/mutations.ts` now also invalidates `["certificate-profiles", "list"]`, which covers attach, detach, and every enrollment set/clear path since they all route through it. Same cross-domain invalidation the reverse direction already does in `certificateProfiles/mutations.tsx` and `certificates/mutations.tsx`.

## Screenshots

<img width="1400" alt="Certificate profile dropdown showing a profile disabled because API enrollment is not configured" src="https://github.com/user-attachments/assets/130cd30d-a4b8-4539-95e7-85e985d6278a" />

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
