### PR TITLE
fix: send recovery email to user.email instead of username

### DIFF
--- a/backend/src/services/account-recovery/account-recovery-service.ts
+++ b/backend/src/services/account-recovery/account-recovery-service.ts
@@ -32,18 +32,19 @@ export const accountRecoveryServiceFactory = ({
   /*
    * Account recovery flow via email. Step 1: send recovery email
    */
-  const sendRecoveryEmail = async (unsanitizedEmail: string) => {
+  const sendRecoveryEmail = async (unsanitizedUsername: string) => {
     const sendEmail = async () => {
-      const email = sanitizeEmail(unsanitizedEmail);
-      const user = await userDAL.findOne({ username: email });
+      const username = sanitizeEmail(unsanitizedUsername);
+      const user = await userDAL.findOne({ username });
       if (!user) throw new BadRequestError({ message: "Failed to find user data" });
 
       if (user && user.isAccepted) {
         const cfg = getConfig();
 
+        const recipient = user.email ?? user.username;
         const hasEmailAuth = user.authMethods?.includes(AuthMethod.EMAIL);
         const substitutions: Record<string, unknown> = {
-          email,
+          username: user.username,
           isCloud: cfg.isCloud,
           siteUrl: cfg.SITE_URL || "",
           hasEmailAuth,
@@ -71,7 +72,7 @@ export const accountRecoveryServiceFactory = ({
         substitutions.token = token;
         await smtpService.sendMail({
           template: SmtpTemplates.ResetPassword,
-          recipients: [email],
+          recipients: [recipient],
           subjectLine: "Infisical account recovery",
           substitutions
         });
@@ -85,10 +86,10 @@ export const accountRecoveryServiceFactory = ({
   /*
    * Account recovery flow via email. Step 2: verify the token and inject a temp token to reset password
    */
-  const verifyRecoveryEmail = async (unsanitizedEmail: string, code: string) => {
+  const verifyRecoveryEmail = async (unsanitizedUsername: string, code: string) => {
     const cfg = getConfig();
-    const email = sanitizeEmail(unsanitizedEmail);
-    const user = await userDAL.findOne({ username: email });
+    const username = sanitizeEmail(unsanitizedUsername);
+    const user = await userDAL.findOne({ username });
 
     // Use a dummy userId when there's no valid user.
     const shouldReject = !user || (user && !user.isAccepted);

--- a/backend/src/services/smtp/emails/PasswordResetTemplate.tsx
+++ b/backend/src/services/smtp/emails/PasswordResetTemplate.tsx
@@ -5,7 +5,7 @@ import { BaseButton } from "./BaseButton";
 import { BaseEmailWrapper, BaseEmailWrapperProps } from "./BaseEmailWrapper";
 
 interface PasswordResetTemplateProps extends Omit<BaseEmailWrapperProps, "title" | "preview" | "children"> {
-  email: string;
+  username: string;
   callback_url: string;
   token: string;
   isCloud: boolean;
@@ -14,7 +14,7 @@ interface PasswordResetTemplateProps extends Omit<BaseEmailWrapperProps, "title"
 }
 
 export const PasswordResetTemplate = ({
-  email,
+  username,
   siteUrl,
   callback_url,
   token,
@@ -66,7 +66,9 @@ export const PasswordResetTemplate = ({
         </Text>
       </Section>
       <Section className="text-center">
-        <BaseButton href={`${callback_url}?token=${token}&to=${encodeURIComponent(email)}`}>Restore Access</BaseButton>
+        <BaseButton href={`${callback_url}?token=${token}&to=${encodeURIComponent(username)}`}>
+          Restore Access
+        </BaseButton>
       </Section>
     </BaseEmailWrapper>
   );
@@ -75,7 +77,7 @@ export const PasswordResetTemplate = ({
 export default PasswordResetTemplate;
 
 PasswordResetTemplate.PreviewProps = {
-  email: "kevin@infisical.com",
+  username: "kevin@infisical.com",
   callback_url: "https://app.infisical.com",
   isCloud: true,
   token: "preview-token",


### PR DESCRIPTION
## Context

Account recovery was sending the recovery email to the user's `username` instead of `user.email`.

`sendRecoveryEmail` looked up the account by `username` and then reused that same value as the SMTP recipient. It never read `user.email`. Today those values are always the same, so this isn't an issue in practice. However, we're moving toward allowing usernames to diverge from email addresses, which would cause recovery emails to be sent to a non-email username instead of the user's actual mailbox.

The recipient is now `user.email ?? user.username`, matching the behavior already used in `sendPasswordSetupEmail`.

## Steps to verify the change

### Normal

1. Sign up a user and complete the signup flow so `isAccepted` is `true`.
2. Go to `/account-recovery` and submit the account's email address.
3. Open MailHog at http://localhost:8025/ and verify the recovery email was received.
4. Click **Restore Access** and verify the confirm-email step succeeds and redirects you to the password reset flow.

### Username != Email

1. Sign up as `real@example.com` and complete the signup flow.
2. Make the username differ from the email. You can do this via pgAdmin at http://localhost:5050/ or by running:
   ```sql
   UPDATE users
   SET username = 'username@example.com'
   WHERE email = 'real@example.com';
   ```
3. Go to `/account-recovery` and submit `username@example.com`.
4. In MailHog at http://localhost:8025/, inspect the email's **To** header. Before this change, it was sent to the username. It should now be sent to `real@example.com`.
5. Click **Restore Access** and verify the link still works. The `to` query parameter in the URL should contain the username, not the email, and the confirm-email step should still succeed.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)