### PR TITLE
fix(ci): harden upgrade-impact tag handling

### DIFF
--- a/.github/workflows/generate-upgrade-impact.yml
+++ b/.github/workflows/generate-upgrade-impact.yml
@@ -24,8 +24,9 @@ jobs:
     steps:
       - name: Resolve tag
         id: release
+        env:
+          TAG_NAME: ${{ inputs.tag || github.ref_name }}
         run: |
-          TAG_NAME="${{ inputs.tag || github.ref_name }}"
           if ! echo "$TAG_NAME" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Skipping non-stable release tag: $TAG_NAME"
             echo "stable=false" >> "$GITHUB_OUTPUT"
@@ -68,11 +69,12 @@ jobs:
 
       - name: Generate upgrade impact data
         if: steps.release.outputs.stable == 'true'
-        run: npm run generate -- --tag "${{ steps.release.outputs.tag }}"
         working-directory: upgrade-impact
         env:
+          TAG: ${{ steps.release.outputs.tag }}
           UPGRADE_TOOL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: npm run generate -- --tag "$TAG"
 
       - name: Validate upgrade impact data
         if: steps.release.outputs.stable == 'true'


### PR DESCRIPTION
## Summary
- CI hygiene for `.github/workflows/generate-upgrade-impact.yml`.
- Bind `inputs.tag` / `github.ref_name` and the resolved tag under `env:` before use in `run:` (quoted shell vars).
- Same class of fix as binding values before bash parses the script; privileged workflow with write permissions + API tokens on the runner.
- Defense-in-depth / CI hygiene — not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Optional `workflow_dispatch` with a stable `vX.Y.Z` tag when maintainers want


Made with [Cursor](https://cursor.com)