### PR TITLE
fix(ci): harden standalone docker release tag handling

### DIFF
--- a/.github/workflows/release-standalone-docker-img-postgres-offical.yml
+++ b/.github/workflows/release-standalone-docker-img-postgres-offical.yml
@@ -177,11 +177,13 @@ jobs:
       needs: [infisical-tests]
       steps:
         - name: Create tag if it doesn't exist
+          env:
+            GH_TOKEN: ${{ secrets.OMNIBUS_RELEASE_TOKEN }}
+            TAG_NAME: ${{ github.ref_name }}
           run: |
-            TAG_NAME="${{ github.ref_name }}"
             echo "Checking for tag: $TAG_NAME"
 
-            EXACT_MATCH=$(gh api repos/Infisical/infisical-omnibus/git/refs/tags/$TAG_NAME 2>/dev/null | jq -r 'if type == "array" then .[].ref else .ref end' | grep -x "refs/tags/$TAG_NAME" || true)
+            EXACT_MATCH=$(gh api "repos/Infisical/infisical-omnibus/git/refs/tags/$TAG_NAME" 2>/dev/null | jq -r 'if type == "array" then .[].ref else .ref end' | grep -x "refs/tags/$TAG_NAME" || true)
 
             if [ "$EXACT_MATCH" == "refs/tags/$TAG_NAME" ]; then
               echo "Tag $TAG_NAME already exists, skipping..."
@@ -197,8 +199,6 @@ jobs:
 
               echo "Successfully created tag $TAG_NAME"
             fi
-          env:
-            GH_TOKEN: ${{ secrets.OMNIBUS_RELEASE_TOKEN }}
 
     generate-upgrade-impact:
         name: Generate upgrade impact PR


### PR DESCRIPTION
## Summary
- CI hygiene for `.github/workflows/release-standalone-docker-img-postgres-offical.yml`.
- Bind `github.ref_name` under `env:` before the omnibus tag create `run:` script.
- Sibling of #7538. Privileged release path (`OMNIBUS_RELEASE_TOKEN`).
- Defense-in-depth / CI hygiene — not a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Sign CLA as @SashaMIT at https://cla.infisical.com/sign (covers both Infisical PRs)


Made with [Cursor](https://cursor.com)