### PR TITLE
feat: add extraArgs to gateway helm chart

### DIFF
--- a/docs/self-hosting/helm-charts/gateway.mdx
+++ b/docs/self-hosting/helm-charts/gateway.mdx
@@ -94,6 +94,7 @@ helm uninstall infisical-gateway --namespace infisical-gateway
 | `affinity` | `{}` | Pod affinity rules. |
 | `extraEnv` | `[]` | Extra environment variables for the gateway container. |
 | `extraEnvFrom` | `[]` | Load environment variables from Secrets or ConfigMaps. |
+| `extraArgs` | `[]` | Extra arguments appended to the gateway container command. |
 | `extraObjects` | `[]` | Extra Kubernetes manifests to deploy with this chart. |
 
 ## Default Helm Values
@@ -213,6 +214,10 @@ extraEnvFrom: []
 #      name: my-secret
 #  - configMapRef:
 #      name: my-configmap
+
+# Extra arguments appended to the gateway container command
+extraArgs: []
+#  - --log-level=debug
 
 # Extra Kubernetes manifests to deploy with this chart
 extraObjects: []

--- a/helm-charts/infisical-gateway/CHANGELOG.md
+++ b/helm-charts/infisical-gateway/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.0 (August 5, 2026)
+* Added `extraArgs` for appending additional command-line arguments to the gateway container.
+
 ## 1.2.0 (July 17, 2026)
 * Added `extraEnv` for injecting additional environment variables into the gateway container.
 * Added `extraEnvFrom` for loading environment variables from Secrets or ConfigMaps.

--- a/helm-charts/infisical-gateway/Chart.yaml
+++ b/helm-charts/infisical-gateway/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical-gateway/ci/default-values.yaml
+++ b/helm-charts/infisical-gateway/ci/default-values.yaml
@@ -1,0 +1,6 @@
+# Values applied automatically by chart-testing (ct install) in CI.
+# The CI secret holds a dummy token, so without an explicit relay name the
+# gateway exits on the relay-lookup API call and the pod crash-loops. With a
+# relay name it enters its reconnect-retry loop and the pod stays Running.
+extraArgs:
+  - --target-relay-name=ci-test-relay

--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -109,6 +109,9 @@ spec:
             - --target-relay-name={{ .Values.gateway.relayName }}
             {{- end }}
             - --pam-session-recording-path={{ $sessionPath }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           volumeMounts:
             {{- if $usePVC }}
             - name: gateway-data
@@ -133,6 +136,9 @@ spec:
             - gateway
             - start
             - --pam-session-recording-path={{ $sessionPath }}
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           envFrom:
             - secretRef:
                 name: {{ .Values.secret.name }}

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -113,5 +113,9 @@ extraEnvFrom: []
 #  - configMapRef:
 #      name: my-configmap
 
+# -- Extra arguments appended to the gateway container command
+extraArgs: []
+#  - --log-level=debug
+
 # -- Extra Kubernetes manifests to deploy with this chart
 extraObjects: []


### PR DESCRIPTION
## Context

Adds an `extraArgs` value to the infisical-gateway helm chart that appends user-supplied command-line arguments to the gateway container in both the enrollment and legacy machine-identity flows, so extra CLI flags (e.g. `--log-level=debug`) can be passed without forking the chart.


## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)