### PR TITLE
fix(identity-aws-auth): honor configured STS endpoint instead of caller region override

### DIFF
--- a/backend/src/services/identity-aws-auth/identity-aws-auth-fns.test.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-fns.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+
+import { resolveStsLoginUrl, stsEndpointRegion } from "./identity-aws-auth-fns";
+
+describe("stsEndpointRegion", () => {
+  test("global endpoint carries no region", () => {
+    expect(stsEndpointRegion("https://sts.amazonaws.com")).toBeUndefined();
+  });
+
+  test("regional endpoint yields its region", () => {
+    expect(stsEndpointRegion("https://sts.eu-west-1.amazonaws.com")).toBe("eu-west-1");
+  });
+
+  test("fips endpoint yields its region", () => {
+    expect(stsEndpointRegion("https://sts-fips.us-east-1.amazonaws.com")).toBe("us-east-1");
+  });
+
+  test("GovCloud endpoint yields its region", () => {
+    expect(stsEndpointRegion("https://sts.us-gov-west-1.amazonaws.com.us")).toBe("us-gov-west-1");
+  });
+
+  test("VPC PrivateLink endpoint yields its region", () => {
+    expect(stsEndpointRegion("https://vpce-0abc.sts.eu-west-1.vpce.amazonaws.com")).toBe("eu-west-1");
+  });
+
+  test("non-AWS host (e.g. LocalStack) carries no region", () => {
+    expect(stsEndpointRegion("http://localhost:4566")).toBeUndefined();
+  });
+
+  test("unparseable endpoint carries no region", () => {
+    expect(stsEndpointRegion("not a url")).toBeUndefined();
+  });
+});
+
+describe("resolveStsLoginUrl", () => {
+  test("global endpoint routes by the caller's credential scope region", () => {
+    expect(resolveStsLoginUrl("https://sts.amazonaws.com", "eu-west-1")).toBe("https://sts.eu-west-1.amazonaws.com");
+  });
+
+  test("global endpoint falls back to the configured endpoint when no region parses", () => {
+    expect(resolveStsLoginUrl("https://sts.amazonaws.com", null)).toBe("https://sts.amazonaws.com");
+  });
+
+  test("non-AWS endpoint (e.g. LocalStack) is honored rather than overridden by the caller region", () => {
+    expect(resolveStsLoginUrl("http://localhost:4566", "us-east-1")).toBe("http://localhost:4566");
+  });
+
+  test("unparseable configured endpoint is honored as-is", () => {
+    expect(resolveStsLoginUrl("not a url", "us-east-1")).toBe("not a url");
+  });
+
+  test("pinned regional endpoint honors the configured endpoint when the region matches", () => {
+    expect(resolveStsLoginUrl("https://sts.eu-west-1.amazonaws.com", "eu-west-1")).toBe(
+      "https://sts.eu-west-1.amazonaws.com"
+    );
+  });
+
+  test("pinned regional endpoint rejects a mismatched caller region", () => {
+    expect(resolveStsLoginUrl("https://sts.eu-west-1.amazonaws.com", "us-east-1")).toBeNull();
+  });
+
+  test("GovCloud endpoint rejects a commercial caller region", () => {
+    expect(resolveStsLoginUrl("https://sts.us-gov-west-1.amazonaws.com.us", "us-east-1")).toBeNull();
+  });
+
+  test("VPC endpoint is honored instead of being overridden by the caller region", () => {
+    const vpce = "https://vpce-0abc.sts.eu-west-1.vpce.amazonaws.com";
+    expect(resolveStsLoginUrl(vpce, "eu-west-1")).toBe(vpce);
+    expect(resolveStsLoginUrl(vpce, "us-east-1")).toBeNull();
+  });
+});

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-fns.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-fns.ts
@@ -91,3 +91,42 @@ export const extractPrincipalArn = (arn: string, formatAsIamRole: boolean = fals
 
   return `arn:${entity.Partition}:${formatAsIamRole ? "iam" : entity.Service}::${entity.AccountNumber}:${entity.Type}/${entity.FriendlyName}`;
 };
+
+// Regional, FIPS, and VPC PrivateLink STS endpoints reject SigV4 requests whose credential
+// scope region does not match the endpoint's region. In AWS STS hosts the region is the label
+// following the "sts" (or "sts-fips") service label (e.g. sts.eu-west-1.amazonaws.com,
+// vpce-0abc.sts.eu-west-1.vpce.amazonaws.com). The global endpoint (sts.amazonaws.com) and
+// non-AWS hosts (e.g. LocalStack) carry no region.
+export const stsEndpointRegion = (stsEndpoint: string): string | undefined => {
+  try {
+    const { hostname } = new URL(stsEndpoint);
+    const labels = hostname.split(".");
+    const stsLabelIndex = labels.findIndex((label) => label === "sts" || label === "sts-fips");
+    if (stsLabelIndex === -1) return undefined;
+    const region = labels[stsLabelIndex + 1];
+    // the global endpoint has the domain in the region position, not a region
+    return region === "amazonaws" ? undefined : region;
+  } catch {
+    return undefined;
+  }
+};
+
+// Picks the STS URL used to validate a login's signed GetCallerIdentity request.
+//
+// Only the AWS global endpoint follows the caller's credential scope region: it accepts any
+// region scope, and regional routing keeps validation close to the caller. Every other
+// configured endpoint is operator intent and is honored. Regional, FIPS, GovCloud, China, and
+// VPC endpoints additionally reject a mismatched caller region (returning null) instead of
+// silently re-routing validation to a commercial endpoint the operator never configured.
+export const resolveStsLoginUrl = (stsEndpoint: string, callerRegion: string | null): string | null => {
+  try {
+    if (new URL(stsEndpoint).hostname === "sts.amazonaws.com") {
+      return callerRegion ? `https://sts.${callerRegion}.amazonaws.com` : stsEndpoint;
+    }
+  } catch {
+    // fall through: honor the configured value as-is
+  }
+  const configuredRegion = stsEndpointRegion(stsEndpoint);
+  if (configuredRegion !== undefined && callerRegion !== configuredRegion) return null;
+  return stsEndpoint;
+};

--- a/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
+++ b/backend/src/services/identity-aws-auth/identity-aws-auth-service.ts
@@ -42,7 +42,7 @@ import { TMembershipIdentityDALFactory } from "../membership-identity/membership
 import { TOrgDALFactory } from "../org/org-dal";
 import { validateIdentityUpdateForSuperAdminPrivileges } from "../super-admin/super-admin-fns";
 import { TIdentityAwsAuthDALFactory } from "./identity-aws-auth-dal";
-import { extractPrincipalArn, extractPrincipalArnEntity } from "./identity-aws-auth-fns";
+import { extractPrincipalArn, extractPrincipalArnEntity, resolveStsLoginUrl } from "./identity-aws-auth-fns";
 import {
   TAttachAwsAuthDTO,
   TAwsGetCallerIdentityHeaders,
@@ -154,7 +154,10 @@ export const identityAwsAuthServiceFactory = ({
         throw new BadRequestError({ message: "Invalid AWS region" });
       }
 
-      const url = region ? `https://sts.${region}.amazonaws.com` : identityAwsAuth.stsEndpoint;
+      const url = resolveStsLoginUrl(identityAwsAuth.stsEndpoint, region);
+      if (!url) {
+        throw new BadRequestError({ message: "Signed STS region does not match the configured STS endpoint" });
+      }
 
       const {
         data: {


### PR DESCRIPTION
## Summary
In plain terms: when an operator configures a custom AWS STS endpoint for AWS-auth identities (GovCloud, China, VPC PrivateLink, or a test endpoint like LocalStack), the login path ignored it in practice. The region was parsed out of the caller's signed `Authorization` header — present in every well-formed SigV4 request — and validation was always routed to `sts.<region>.amazonaws.com`. The operator's `stsEndpoint` setting only took effect for malformed headers.

What that meant:
- An identity an operator believed was pinned to GovCloud/China/a VPC endpoint could be re-routed by the caller to **any commercial AWS region** — so with no account/ARN allowlist set, **any commercial AWS account could authenticate as that identity** (cross-partition expansion).
- GovCloud logins were sent to `sts.<gov-region>.amazonaws.com`, which does not exist in the commercial partition — GovCloud login was broken regardless.
- Egress-restricted deployments made unexpected outbound calls to caller-chosen regional endpoints.

## Fix
- New `resolveStsLoginUrl`/`stsEndpointRegion` helpers (in `identity-aws-auth-fns.ts`, next to the existing ARN helpers): only the AWS **global** endpoint (`sts.amazonaws.com`) follows the caller's credential-scope region. Every other configured endpoint is treated as operator intent and honored; a regional/FIPS/GovCloud/VPC endpoint additionally **rejects** a mismatched caller region with a 400 (regional endpoints reject mismatched SigV4 scope anyway, so this fails earlier and louder, never changes a working login into another working login).
- The one-line call site in `identity-aws-auth-service.ts` now uses the helper.
- Mirrors the semantics the app-connection code already documents in `aws-connection-fns.ts` (`getStsSigningRegion`).

## Behavior-change note
Callers that signed for a region different from a **custom** configured endpoint were previously validated against the commercial endpoint matching their signature; they are now rejected. That is the vulnerability being closed — those setups were never actually using the configured endpoint.

## Test plan
- [x] `npx vitest run -c vitest.unit.config.mts src/services/identity-aws-auth/identity-aws-auth-fns.test.ts` — 15 tests covering global/regional/FIPS/GovCloud/VPC/LocalStack/malformed endpoints and match/mismatch routing
- [x] `npx tsc --noEmit` — clean
- [ ] E2E: identity login against a GovCloud-configured endpoint succeeds with a GovCloud-signed request and is rejected for a commercial-signed request

Made with Cursor

Made with [Cursor](https://cursor.com)