### PR TITLE
improvement: truncate org name on invite and display disabled email field

### DIFF
--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -152,14 +152,17 @@ export default function UserInfoStep({
           <CardTitle
             role="heading"
             aria-level={1}
-            className="ml-0.5 font-alliance text-2xl font-normal break-words"
+            className="ml-0.5 min-w-0 flex-nowrap font-alliance text-2xl font-normal break-words"
           >
             {isInvite ? (
               <>
-                <span className="bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent opacity-70">
+                <span className="shrink-0 bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent opacity-70">
                   Join
                 </span>
-                <span className="bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent">
+                <span
+                  className="min-w-0 truncate bg-linear-to-b from-white to-bunker-200 bg-clip-text text-transparent"
+                  title={inviteOrganizationLabel}
+                >
                   {inviteOrganizationLabel}
                 </span>
               </>
@@ -210,6 +213,14 @@ export default function UserInfoStep({
               ) : null}
             </Field>
           </div>
+          {isInvite && (
+            <Field>
+              <FieldLabel className="sr-only" htmlFor="signup-email">
+                Email
+              </FieldLabel>
+              <Input variant="outlined" id="signup-email" type="email" value={email} disabled />
+            </Field>
+          )}
           {!isInvite && (
             <Field data-invalid={showOrganizationNameError}>
               <FieldLabel className="sr-only" htmlFor="signup-organization-name">


### PR DESCRIPTION
## Context

This PR adds truncation to the org name on the invite accept page and also displays the email of the user as a disabled field

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-08-05 at 13 38 06@2x" src="https://github.com/user-attachments/assets/a415b7de-8422-46fd-8c9d-fb72cdc6959e" />

## Steps to verify the change

- [ ] invite a new user to an org with a long name

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)