### PR TITLE
improvement: update the access restricted banner to v3 components

### DIFF
--- a/frontend/src/components/v2/AccessRestrictedBanner/AccessRestrictedBanner.tsx
+++ b/frontend/src/components/v2/AccessRestrictedBanner/AccessRestrictedBanner.tsx
@@ -1,4 +1,7 @@
 import { ReactNode } from "react";
+import { LockIcon } from "lucide-react";
+
+import { Badge, Card } from "@app/components/v3";
 
 type Props = {
   title?: string;
@@ -7,20 +10,16 @@ type Props = {
 
 export const AccessRestrictedBanner = ({
   title = "Access Restricted",
-
-  body = (
-    <>
-      Your current role doesn&#39;t provide access to this feature.
-      <br /> Contact your administrator to request access.
-    </>
-  )
+  body = "Your current role doesn't provide access to this feature. Contact your administrator to request access."
 }: Props) => {
   return (
-    <div className="flex items-center rounded-md border border-mineshaft-500 bg-linear-to-br from-mineshaft-900 to-mineshaft-600 px-16 py-12 text-center text-bunker-300">
-      <div>
-        <div className="text-4xl font-medium text-bunker-100">{title}</div>
-        <div className="-mt-1 text-sm">{body}</div>
-      </div>
-    </div>
+    <Card className="w-full max-w-lg items-start gap-4 p-8">
+      <Badge variant="warning" className="h-6 px-2">
+        <LockIcon />
+        {title}
+      </Badge>
+      <div className="text-2xl font-semibold">This section is locked.</div>
+      <div className="text-sm leading-relaxed text-accent">{body}</div>
+    </Card>
   );
 };


### PR DESCRIPTION
## Context

This PR updates the access restricted component to use v3 foundation

## Screenshots

old: 
<img width="3456" height="1924" alt="CleanShot 2026-08-05 at 14 02 09@2x" src="https://github.com/user-attachments/assets/0a807375-9321-45fc-8bdc-01a3784a357f" />

new:
<img width="3456" height="1924" alt="CleanShot 2026-08-05 at 13 58 49@2x" src="https://github.com/user-attachments/assets/057312f4-b766-4fa4-9c8a-9c2784f115ef" />


## Steps to verify the change
- navigate to page/component with a user who doesn't have permission to view it

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)