### PR TITLE
docs(assistant): hide floating bubble

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -2,6 +2,10 @@
   border-radius: 0 !important;
 }
 
+.chat-assistant-floating-input {
+  display: none !important;
+}
+
 #navbar .max-w-8xl {
   max-width: 100%;
   border-bottom: 1px solid #ebebeb;


### PR DESCRIPTION
## Context

Hides the floating input bubble that appears on docs pages when the Mintlify assistant is enabled.

## Screenshots

<img width="787" height="345" alt="Screenshot 2026-08-05 at 6 06 40 PM" src="https://github.com/user-attachments/assets/f14cfa8a-a5e6-4f8c-9e76-7d3cbf20209c" />

## Steps to verify the change

Visit any docs page and verify that the floating input bubble is invisible.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)