### PR TITLE
docs(config): add contextual options

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -11,6 +11,16 @@
     "codeblocks": "dark"
   },
   "favicon": "/favicon.ico",
+  "contextual": {
+    "options": [
+      "assistant",
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "mcp"
+    ]
+  },
   "navigation": {
     "tabs": [
       {

--- a/docs/style.css
+++ b/docs/style.css
@@ -67,6 +67,10 @@
   padding-top: 10px;
 }
 
+#page-context-menu button:hover {
+  background-color: #F3F4F6;
+}
+
 #content-area .mt-8 .block{
   border-width: 1px;
   background-color: #FCFBFA;
@@ -138,6 +142,10 @@
 .dark #header {
   background-color: #292B16;
   border-left-color: #DCEB30;
+}
+
+.dark #page-context-menu button:hover {
+  background-color: #343434;
 }
 
 .dark #content-area .mt-8 .block {


### PR DESCRIPTION
## Context

Enables the [contextual menu](https://www.mintlify.com/docs/ai/contextual-menu) for docs pages.

## Screenshots

<img width="365" height="370" alt="Screenshot 2026-08-05 at 6 33 15 PM" src="https://github.com/user-attachments/assets/3b4b6f93-a267-4427-9db8-b7b01c7add81" />

## Steps to verify the change

Check a docs page to see if contextual options appear.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)