### PR TITLE
improvement: add gateway support to chef app connection

### DIFF
--- a/backend/src/ee/services/app-connections/chef/chef-connection-fns.ts
+++ b/backend/src/ee/services/app-connections/chef/chef-connection-fns.ts
@@ -4,12 +4,13 @@ import https from "https";
 
 import { TGatewayServiceFactory } from "@app/ee/services/gateway/gateway-service";
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
+import { getConfig } from "@app/lib/config/env";
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 import { removeTrailingSlash } from "@app/lib/fn";
 import { GatewayProxyProtocol } from "@app/lib/gateway";
 import { withGatewayV2Proxy } from "@app/lib/gateway-v2/gateway-v2";
-import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
+import { blockLocalAndPrivateIpAddresses, safeRequest } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 
@@ -23,6 +24,9 @@ import {
   TGetChefDataBagItem,
   TUpdateChefDataBagItem
 } from "./chef-connection-types";
+
+const CHEF_REQUEST_TIMEOUT_MS = 30_000;
+const CHEF_MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
 
 export const getChefServerUrl = (serverUrl?: string) => {
   return serverUrl ? removeTrailingSlash(serverUrl) : IntegrationUrls.CHEF_API_URL;
@@ -169,6 +173,9 @@ export const requestWithChefGateway = async <T>(
             ...requestConfig.headers,
             Host: targetHost
           },
+          timeout: CHEF_REQUEST_TIMEOUT_MS,
+          maxContentLength: CHEF_MAX_RESPONSE_BYTES,
+          maxBodyLength: CHEF_MAX_RESPONSE_BYTES,
           ...(isHttps && {
             httpsAgent: new https.Agent({
               servername: targetHost
@@ -187,9 +194,16 @@ export const requestWithChefGateway = async <T>(
     );
   }
 
-  await blockLocalAndPrivateIpAddresses(url.toString(), false);
-
-  return request.request<T>(requestConfig);
+  // safeRequest validates the URL and pins the connection to the validated IPs,
+  // closing the DNS rebinding window between SSRF validation and connect
+  return safeRequest.request<T>({
+    ...requestConfig,
+    url: requestConfig.url as string,
+    allowPrivateIps: getConfig().ALLOW_INTERNAL_IP_CONNECTIONS,
+    timeout: CHEF_REQUEST_TIMEOUT_MS,
+    maxContentLength: CHEF_MAX_RESPONSE_BYTES,
+    maxBodyLength: CHEF_MAX_RESPONSE_BYTES
+  });
 };
 
 export const getChefConnectionListItem = () => {
@@ -221,13 +235,12 @@ export const validateChefConnectionCredentials = async (
       headers
     });
   } catch (error: unknown) {
-    if (error instanceof AxiosError) {
+    // withGatewayV2Proxy re-throws callback failures as BadRequestError, so wrap
+    // both error types to preserve the Chef operation context in the message
+    if (error instanceof AxiosError || error instanceof BadRequestError) {
       throw new BadRequestError({
         message: `Failed to validate Chef credentials: ${error.message || "Unknown error"}`
       });
-    }
-    if (error instanceof BadRequestError) {
-      throw error;
     }
     throw new BadRequestError({
       message: "Unable to validate Chef connection: verify credentials"
@@ -265,13 +278,10 @@ export const listChefDataBags = async (
       name
     }));
   } catch (error) {
-    if (error instanceof AxiosError) {
+    if (error instanceof AxiosError || error instanceof BadRequestError) {
       throw new BadRequestError({
         message: `Failed to list Chef data bags: ${error.message || "Unknown error"}`
       });
-    }
-    if (error instanceof BadRequestError) {
-      throw error;
     }
     throw new BadRequestError({
       message: "Unable to list Chef data bags"
@@ -308,13 +318,10 @@ export const listChefDataBagItems = async (
       name
     }));
   } catch (error) {
-    if (error instanceof AxiosError) {
+    if (error instanceof AxiosError || error instanceof BadRequestError) {
       throw new BadRequestError({
         message: `Failed to list Chef data bag items: ${error.message || "Unknown error"}`
       });
-    }
-    if (error instanceof BadRequestError) {
-      throw error;
     }
     throw new BadRequestError({
       message: "Unable to list Chef data bag items"
@@ -343,13 +350,10 @@ export const getChefDataBagItem = async (
 
     return res.data;
   } catch (error) {
-    if (error instanceof AxiosError) {
+    if (error instanceof AxiosError || error instanceof BadRequestError) {
       throw new BadRequestError({
         message: `Failed to get Chef data bag item: ${error.message || "Unknown error"}`
       });
-    }
-    if (error instanceof BadRequestError) {
-      throw error;
     }
     throw new BadRequestError({
       message: "Unable to get Chef data bag item"
@@ -385,13 +389,10 @@ export const createChefDataBagItem = async (
       headers
     });
   } catch (error) {
-    if (error instanceof AxiosError) {
+    if (error instanceof AxiosError || error instanceof BadRequestError) {
       throw new BadRequestError({
         message: `Failed to create Chef data bag item: ${error.message || "Unknown error"}`
       });
-    }
-    if (error instanceof BadRequestError) {
-      throw error;
     }
     throw new BadRequestError({
       message: "Unable to create Chef data bag item"
@@ -419,13 +420,10 @@ export const updateChefDataBagItem = async (
       headers
     });
   } catch (error) {
-    if (error instanceof AxiosError) {
+    if (error instanceof AxiosError || error instanceof BadRequestError) {
       throw new BadRequestError({
         message: `Failed to update Chef data bag item: ${error.message || "Unknown error"}`
       });
-    }
-    if (error instanceof BadRequestError) {
-      throw error;
     }
     throw new BadRequestError({
       message: "Unable to update Chef data bag item"
@@ -460,13 +458,10 @@ export const removeChefDataBagItem = async (
       headers
     });
   } catch (error) {
-    if (error instanceof AxiosError) {
+    if (error instanceof AxiosError || error instanceof BadRequestError) {
       throw new BadRequestError({
         message: `Failed to remove Chef data bag item: ${error.message || "Unknown error"}`
       });
-    }
-    if (error instanceof BadRequestError) {
-      throw error;
     }
     throw new BadRequestError({
       message: "Unable to remove Chef data bag item"

--- a/backend/src/ee/services/app-connections/chef/chef-connection-fns.ts
+++ b/backend/src/ee/services/app-connections/chef/chef-connection-fns.ts
@@ -1,9 +1,14 @@
-import { AxiosError } from "axios";
+import { AxiosError, AxiosRequestConfig, AxiosResponse } from "axios";
 import crypto from "crypto";
+import https from "https";
 
+import { TGatewayServiceFactory } from "@app/ee/services/gateway/gateway-service";
+import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 import { removeTrailingSlash } from "@app/lib/fn";
+import { GatewayProxyProtocol } from "@app/lib/gateway";
+import { withGatewayV2Proxy } from "@app/lib/gateway-v2/gateway-v2";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
@@ -19,12 +24,8 @@ import {
   TUpdateChefDataBagItem
 } from "./chef-connection-types";
 
-export const getChefServerUrl = async (serverUrl?: string) => {
-  const chefServerUrl = serverUrl ? removeTrailingSlash(serverUrl) : IntegrationUrls.CHEF_API_URL;
-
-  await blockLocalAndPrivateIpAddresses(chefServerUrl);
-
-  return chefServerUrl;
+export const getChefServerUrl = (serverUrl?: string) => {
+  return serverUrl ? removeTrailingSlash(serverUrl) : IntegrationUrls.CHEF_API_URL;
 };
 
 const buildSecureUrl = (baseUrl: string, path: string): string => {
@@ -131,6 +132,66 @@ const getChefAuthHeaders = (
   };
 };
 
+export const requestWithChefGateway = async <T>(
+  gatewayId: string | null | undefined,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId"> | undefined,
+  requestConfig: AxiosRequestConfig
+): Promise<AxiosResponse<T>> => {
+  const url = new URL(requestConfig.url as string);
+
+  if (gatewayId && gatewayV2Service) {
+    await blockLocalAndPrivateIpAddresses(url.toString(), true);
+
+    const targetHost = url.hostname;
+    // port is an empty string when the URL uses the protocol's default port (443 for https, 80 for http)
+    // eslint-disable-next-line no-nested-ternary
+    const targetPort = url.port ? Number(url.port) : url.protocol === "https:" ? 443 : 80;
+
+    const platformConnectionDetails = await gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
+      gatewayId,
+      targetHost,
+      targetPort
+    });
+
+    if (!platformConnectionDetails) {
+      throw new BadRequestError({ message: "Unable to connect to gateway, no platform connection details found" });
+    }
+
+    return withGatewayV2Proxy(
+      async (proxyPort) => {
+        const isHttps = url.protocol === "https:";
+        url.host = `localhost:${proxyPort}`;
+
+        const finalRequestConfig: AxiosRequestConfig = {
+          ...requestConfig,
+          url: url.toString(),
+          headers: {
+            ...requestConfig.headers,
+            Host: targetHost
+          },
+          ...(isHttps && {
+            httpsAgent: new https.Agent({
+              servername: targetHost
+            })
+          })
+        };
+
+        return request.request<T>(finalRequestConfig);
+      },
+      {
+        protocol: GatewayProxyProtocol.Tcp,
+        relayHost: platformConnectionDetails.relayHost,
+        gateway: platformConnectionDetails.gateway,
+        relay: platformConnectionDetails.relay
+      }
+    );
+  }
+
+  await blockLocalAndPrivateIpAddresses(url.toString(), false);
+
+  return request.request<T>(requestConfig);
+};
+
 export const getChefConnectionListItem = () => {
   return {
     name: "Chef" as const,
@@ -139,18 +200,24 @@ export const getChefConnectionListItem = () => {
   };
 };
 
-export const validateChefConnectionCredentials = async (config: TChefConnectionConfig) => {
-  const { credentials: inputCredentials } = config;
+export const validateChefConnectionCredentials = async (
+  config: TChefConnectionConfig,
+  _gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId"> | undefined
+) => {
+  const { credentials: inputCredentials, gatewayId } = config;
 
   try {
     const path = `/organizations/${inputCredentials.orgName}/users/${inputCredentials.userName}`;
 
-    const hostServerUrl = await getChefServerUrl(inputCredentials.serverUrl);
+    const hostServerUrl = getChefServerUrl(inputCredentials.serverUrl);
 
     const headers = getChefAuthHeaders("GET", path, "", inputCredentials.userName, inputCredentials.privateKey);
 
     const secureUrl = buildSecureUrl(hostServerUrl, path);
-    await request.get(secureUrl, {
+    await requestWithChefGateway(gatewayId, gatewayV2Service, {
+      method: "GET",
+      url: secureUrl,
       headers
     });
   } catch (error: unknown) {
@@ -158,6 +225,9 @@ export const validateChefConnectionCredentials = async (config: TChefConnectionC
       throw new BadRequestError({
         message: `Failed to validate Chef credentials: ${error.message || "Unknown error"}`
       });
+    }
+    if (error instanceof BadRequestError) {
+      throw error;
     }
     throw new BadRequestError({
       message: "Unable to validate Chef connection: verify credentials"
@@ -167,21 +237,27 @@ export const validateChefConnectionCredentials = async (config: TChefConnectionC
   return inputCredentials;
 };
 
-export const listChefDataBags = async (appConnection: TChefConnection): Promise<TChefDataBag[]> => {
+export const listChefDataBags = async (
+  appConnection: Pick<TChefConnection, "credentials" | "gatewayId">,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId"> | undefined
+): Promise<TChefDataBag[]> => {
   const {
-    credentials: { serverUrl, userName, privateKey, orgName }
+    credentials: { serverUrl, userName, privateKey, orgName },
+    gatewayId
   } = appConnection;
 
   try {
     const path = `/organizations/${orgName}/data`;
     const body = "";
 
-    const hostServerUrl = await getChefServerUrl(serverUrl);
+    const hostServerUrl = getChefServerUrl(serverUrl);
 
     const headers = getChefAuthHeaders("GET", path, body, userName, privateKey);
 
     const secureUrl = buildSecureUrl(hostServerUrl, path);
-    const res = await request.get<Record<string, string>>(secureUrl, {
+    const res = await requestWithChefGateway<Record<string, string>>(gatewayId, gatewayV2Service, {
+      method: "GET",
+      url: secureUrl,
       headers
     });
 
@@ -194,6 +270,9 @@ export const listChefDataBags = async (appConnection: TChefConnection): Promise<
         message: `Failed to list Chef data bags: ${error.message || "Unknown error"}`
       });
     }
+    if (error instanceof BadRequestError) {
+      throw error;
+    }
     throw new BadRequestError({
       message: "Unable to list Chef data bags"
     });
@@ -201,23 +280,27 @@ export const listChefDataBags = async (appConnection: TChefConnection): Promise<
 };
 
 export const listChefDataBagItems = async (
-  appConnection: TChefConnection,
-  dataBagName: string
+  appConnection: Pick<TChefConnection, "credentials" | "gatewayId">,
+  dataBagName: string,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId"> | undefined
 ): Promise<TChefDataBagItem[]> => {
   const {
-    credentials: { serverUrl, userName, privateKey, orgName }
+    credentials: { serverUrl, userName, privateKey, orgName },
+    gatewayId
   } = appConnection;
 
   try {
     const path = `/organizations/${orgName}/data/${dataBagName}`;
     const body = "";
 
-    const hostServerUrl = await getChefServerUrl(serverUrl);
+    const hostServerUrl = getChefServerUrl(serverUrl);
 
     const headers = getChefAuthHeaders("GET", path, body, userName, privateKey);
 
     const secureUrl = buildSecureUrl(hostServerUrl, path);
-    const res = await request.get<Record<string, string>>(secureUrl, {
+    const res = await requestWithChefGateway<Record<string, string>>(gatewayId, gatewayV2Service, {
+      method: "GET",
+      url: secureUrl,
       headers
     });
 
@@ -230,30 +313,31 @@ export const listChefDataBagItems = async (
         message: `Failed to list Chef data bag items: ${error.message || "Unknown error"}`
       });
     }
+    if (error instanceof BadRequestError) {
+      throw error;
+    }
     throw new BadRequestError({
       message: "Unable to list Chef data bag items"
     });
   }
 };
 
-export const getChefDataBagItem = async ({
-  serverUrl,
-  userName,
-  privateKey,
-  orgName,
-  dataBagName,
-  dataBagItemName
-}: TGetChefDataBagItem): Promise<TChefDataBagItemContent> => {
+export const getChefDataBagItem = async (
+  { serverUrl, userName, privateKey, orgName, dataBagName, dataBagItemName, gatewayId }: TGetChefDataBagItem,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId"> | undefined
+): Promise<TChefDataBagItemContent> => {
   try {
     const path = `/organizations/${orgName}/data/${dataBagName}/${dataBagItemName}`;
     const body = "";
 
-    const hostServerUrl = await getChefServerUrl(serverUrl);
+    const hostServerUrl = getChefServerUrl(serverUrl);
 
     const headers = getChefAuthHeaders("GET", path, body, userName, privateKey);
 
     const secureUrl = buildSecureUrl(hostServerUrl, path);
-    const res = await request.get<TChefDataBagItemContent>(secureUrl, {
+    const res = await requestWithChefGateway<TChefDataBagItemContent>(gatewayId, gatewayV2Service, {
+      method: "GET",
+      url: secureUrl,
       headers
     });
 
@@ -264,30 +348,40 @@ export const getChefDataBagItem = async ({
         message: `Failed to get Chef data bag item: ${error.message || "Unknown error"}`
       });
     }
+    if (error instanceof BadRequestError) {
+      throw error;
+    }
     throw new BadRequestError({
       message: "Unable to get Chef data bag item"
     });
   }
 };
 
-export const createChefDataBagItem = async ({
-  serverUrl,
-  userName,
-  privateKey,
-  orgName,
-  dataBagName,
-  data
-}: Omit<TUpdateChefDataBagItem, "dataBagItemName">): Promise<void> => {
+export const createChefDataBagItem = async (
+  {
+    serverUrl,
+    userName,
+    privateKey,
+    orgName,
+    dataBagName,
+    data,
+    gatewayId
+  }: Omit<TUpdateChefDataBagItem, "dataBagItemName">,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId"> | undefined
+): Promise<void> => {
   try {
     const path = `/organizations/${orgName}/data/${dataBagName}`;
     const body = JSON.stringify(data);
 
-    const hostServerUrl = await getChefServerUrl(serverUrl);
+    const hostServerUrl = getChefServerUrl(serverUrl);
 
     const headers = getChefAuthHeaders("POST", path, body, userName, privateKey);
 
     const secureUrl = buildSecureUrl(hostServerUrl, path);
-    await request.post(secureUrl, data, {
+    await requestWithChefGateway(gatewayId, gatewayV2Service, {
+      method: "POST",
+      url: secureUrl,
+      data,
       headers
     });
   } catch (error) {
@@ -296,31 +390,32 @@ export const createChefDataBagItem = async ({
         message: `Failed to create Chef data bag item: ${error.message || "Unknown error"}`
       });
     }
+    if (error instanceof BadRequestError) {
+      throw error;
+    }
     throw new BadRequestError({
       message: "Unable to create Chef data bag item"
     });
   }
 };
 
-export const updateChefDataBagItem = async ({
-  serverUrl,
-  userName,
-  privateKey,
-  orgName,
-  dataBagName,
-  dataBagItemName,
-  data
-}: TUpdateChefDataBagItem): Promise<void> => {
+export const updateChefDataBagItem = async (
+  { serverUrl, userName, privateKey, orgName, dataBagName, dataBagItemName, data, gatewayId }: TUpdateChefDataBagItem,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId"> | undefined
+): Promise<void> => {
   try {
     const path = `/organizations/${orgName}/data/${dataBagName}/${dataBagItemName}`;
     const body = JSON.stringify(data);
 
-    const hostServerUrl = await getChefServerUrl(serverUrl);
+    const hostServerUrl = getChefServerUrl(serverUrl);
 
     const headers = getChefAuthHeaders("PUT", path, body, userName, privateKey);
 
     const secureUrl = buildSecureUrl(hostServerUrl, path);
-    await request.put(secureUrl, data, {
+    await requestWithChefGateway(gatewayId, gatewayV2Service, {
+      method: "PUT",
+      url: secureUrl,
+      data,
       headers
     });
   } catch (error) {
@@ -329,30 +424,39 @@ export const updateChefDataBagItem = async ({
         message: `Failed to update Chef data bag item: ${error.message || "Unknown error"}`
       });
     }
+    if (error instanceof BadRequestError) {
+      throw error;
+    }
     throw new BadRequestError({
       message: "Unable to update Chef data bag item"
     });
   }
 };
 
-export const removeChefDataBagItem = async ({
-  serverUrl,
-  userName,
-  privateKey,
-  orgName,
-  dataBagName,
-  dataBagItemName
-}: Omit<TUpdateChefDataBagItem, "data">): Promise<void> => {
+export const removeChefDataBagItem = async (
+  {
+    serverUrl,
+    userName,
+    privateKey,
+    orgName,
+    dataBagName,
+    dataBagItemName,
+    gatewayId
+  }: Omit<TUpdateChefDataBagItem, "data">,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId"> | undefined
+): Promise<void> => {
   try {
     const path = `/organizations/${orgName}/data/${dataBagName}/${dataBagItemName}`;
     const body = "";
 
-    const hostServerUrl = await getChefServerUrl(serverUrl);
+    const hostServerUrl = getChefServerUrl(serverUrl);
 
     const headers = getChefAuthHeaders("DELETE", path, body, userName, privateKey);
 
     const secureUrl = buildSecureUrl(hostServerUrl, path);
-    await request.delete(secureUrl, {
+    await requestWithChefGateway(gatewayId, gatewayV2Service, {
+      method: "DELETE",
+      url: secureUrl,
       headers
     });
   } catch (error) {
@@ -360,6 +464,9 @@ export const removeChefDataBagItem = async ({
       throw new BadRequestError({
         message: `Failed to remove Chef data bag item: ${error.message || "Unknown error"}`
       });
+    }
+    if (error instanceof BadRequestError) {
+      throw error;
     }
     throw new BadRequestError({
       message: "Unable to remove Chef data bag item"

--- a/backend/src/ee/services/app-connections/chef/chef-connection-schemas.ts
+++ b/backend/src/ee/services/app-connections/chef/chef-connection-schemas.ts
@@ -60,7 +60,9 @@ export const ValidateChefConnectionCredentialsSchema = z.discriminatedUnion("met
 ]);
 
 export const CreateChefConnectionSchema = ValidateChefConnectionCredentialsSchema.and(
-  GenericCreateAppConnectionFieldsSchema(AppConnection.Chef)
+  GenericCreateAppConnectionFieldsSchema(AppConnection.Chef, {
+    supportsGateways: true
+  })
 );
 
 export const UpdateChefConnectionSchema = z
@@ -69,7 +71,11 @@ export const UpdateChefConnectionSchema = z
       AppConnections.UPDATE(AppConnection.Chef).credentials
     )
   })
-  .and(GenericUpdateAppConnectionFieldsSchema(AppConnection.Chef));
+  .and(
+    GenericUpdateAppConnectionFieldsSchema(AppConnection.Chef, {
+      supportsGateways: true
+    })
+  );
 
 export const ChefConnectionListItemSchema = z
   .object({

--- a/backend/src/ee/services/app-connections/chef/chef-connection-service.ts
+++ b/backend/src/ee/services/app-connections/chef/chef-connection-service.ts
@@ -2,6 +2,8 @@ import { BadRequestError, ForbiddenRequestError } from "@app/lib/errors";
 import { OrgServiceActor } from "@app/lib/types";
 
 import { AppConnection } from "../../../../services/app-connection/app-connection-enums";
+import { TGatewayPoolServiceFactory } from "../../gateway-pool/gateway-pool-service";
+import { TGatewayV2ServiceFactory } from "../../gateway-v2/gateway-v2-service";
 import { TLicenseServiceFactory } from "../../license/license-service";
 import { listChefDataBagItems, listChefDataBags } from "./chef-connection-fns";
 import { TChefConnection } from "./chef-connection-types";
@@ -24,30 +26,39 @@ export const checkPlan = async (licenseService: Pick<TLicenseServiceFactory, "ge
 
 export const chefConnectionService = (
   getAppConnection: TGetAppConnectionFunc,
-  licenseService: Pick<TLicenseServiceFactory, "getPlan">
+  licenseService: Pick<TLicenseServiceFactory, "getPlan">,
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">,
+  gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">
 ) => {
-  const listDataBags = async (appConnectionId: string, actor: OrgServiceActor) => {
-    await checkPlan(licenseService, actor.orgId);
-
+  const $getResolvedConnection = async (appConnectionId: string, actor: OrgServiceActor) => {
     const appConnection = await getAppConnection(AppConnection.Chef, appConnectionId, actor);
 
     if (!appConnection) {
       throw new ForbiddenRequestError({ message: "App connection not found" });
     }
 
-    return listChefDataBags(appConnection);
+    const effectiveGatewayId = await gatewayPoolService.resolveEffectiveGatewayId({
+      gatewayId: appConnection.gatewayId,
+      gatewayPoolId: appConnection.gatewayPoolId
+    });
+
+    return { ...appConnection, gatewayId: effectiveGatewayId, gatewayPoolId: null };
+  };
+
+  const listDataBags = async (appConnectionId: string, actor: OrgServiceActor) => {
+    await checkPlan(licenseService, actor.orgId);
+
+    const appConnection = await $getResolvedConnection(appConnectionId, actor);
+
+    return listChefDataBags(appConnection, gatewayV2Service);
   };
 
   const listDataBagItems = async (appConnectionId: string, dataBagName: string, actor: OrgServiceActor) => {
     await checkPlan(licenseService, actor.orgId);
 
-    const appConnection = await getAppConnection(AppConnection.Chef, appConnectionId, actor);
+    const appConnection = await $getResolvedConnection(appConnectionId, actor);
 
-    if (!appConnection) {
-      throw new ForbiddenRequestError({ message: "App connection not found" });
-    }
-
-    return listChefDataBagItems(appConnection, dataBagName);
+    return listChefDataBagItems(appConnection, dataBagName, gatewayV2Service);
   };
 
   return {

--- a/backend/src/ee/services/app-connections/chef/chef-connection-types.ts
+++ b/backend/src/ee/services/app-connections/chef/chef-connection-types.ts
@@ -18,8 +18,11 @@ export type TChefConnectionInput = z.infer<typeof CreateChefConnectionSchema> & 
 
 export type TValidateChefConnectionCredentialsSchema = typeof ValidateChefConnectionCredentialsSchema;
 
-export type TChefConnectionConfig = DiscriminativePick<TChefConnectionInput, "method" | "app" | "credentials"> & {
-  orgName: string;
+export type TChefConnectionConfig = DiscriminativePick<
+  TChefConnectionInput,
+  "method" | "app" | "credentials" | "gatewayId" | "gatewayPoolId"
+> & {
+  orgId: string;
 };
 
 export type TChefDataBag = {
@@ -37,6 +40,7 @@ export type TGetChefDataBagItem = {
   orgName: string;
   dataBagName: string;
   dataBagItemName: string;
+  gatewayId?: string | null;
 };
 
 export type TUpdateChefDataBagItem = {
@@ -47,4 +51,5 @@ export type TUpdateChefDataBagItem = {
   dataBagName: string;
   dataBagItemName: string;
   data: TChefDataBagItemContent;
+  gatewayId?: string | null;
 };

--- a/backend/src/ee/services/secret-sync/chef/chef-sync-fns.ts
+++ b/backend/src/ee/services/secret-sync/chef/chef-sync-fns.ts
@@ -1,4 +1,6 @@
 import { getChefDataBagItem, updateChefDataBagItem } from "@app/ee/services/app-connections/chef";
+import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
+import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
@@ -11,22 +13,35 @@ import {
   TGetChefSecrets
 } from "./chef-sync-types";
 
-const getChefSecretsRaw = async ({
-  serverUrl,
-  userName,
-  privateKey,
-  orgName,
-  dataBagName,
-  dataBagItemName
-}: TGetChefSecrets): Promise<TChefDataBagItemContent> => {
-  const dataBagItem = await getChefDataBagItem({
-    serverUrl,
-    userName,
-    privateKey,
-    orgName,
-    dataBagName,
-    dataBagItemName
+type TChefSyncGatewayV2Service = Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
+type TChefSyncGatewayPoolService = Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
+
+const resolveGatewayId = async (
+  secretSync: TChefSyncWithCredentials,
+  gatewayPoolService: TChefSyncGatewayPoolService
+) => {
+  return gatewayPoolService.resolveEffectiveGatewayId({
+    gatewayId: secretSync.connection.gatewayId,
+    gatewayPoolId: secretSync.connection.gatewayPoolId
   });
+};
+
+const getChefSecretsRaw = async (
+  { serverUrl, userName, privateKey, orgName, dataBagName, dataBagItemName, gatewayId }: TGetChefSecrets,
+  gatewayV2Service: TChefSyncGatewayV2Service
+): Promise<TChefDataBagItemContent> => {
+  const dataBagItem = await getChefDataBagItem(
+    {
+      serverUrl,
+      userName,
+      privateKey,
+      orgName,
+      dataBagName,
+      dataBagItemName,
+      gatewayId
+    },
+    gatewayV2Service
+  );
 
   // Ensure the data bag item has an id field
   if (!dataBagItem.id) {
@@ -36,7 +51,11 @@ const getChefSecretsRaw = async ({
   return dataBagItem;
 };
 
-const getChefSecrets = async (secretSync: TChefSyncWithCredentials): Promise<TChefSecrets> => {
+const getChefSecrets = async (
+  secretSync: TChefSyncWithCredentials,
+  gatewayId: string | null,
+  gatewayV2Service: TChefSyncGatewayV2Service
+): Promise<TChefSecrets> => {
   const {
     connection,
     destinationConfig: { dataBagName, dataBagItemName }
@@ -44,14 +63,18 @@ const getChefSecrets = async (secretSync: TChefSyncWithCredentials): Promise<TCh
 
   const { serverUrl, userName, privateKey, orgName } = connection.credentials;
 
-  const dataBagItem = await getChefSecretsRaw({
-    serverUrl,
-    orgName,
-    userName,
-    privateKey,
-    dataBagName,
-    dataBagItemName
-  });
+  const dataBagItem = await getChefSecretsRaw(
+    {
+      serverUrl,
+      orgName,
+      userName,
+      privateKey,
+      dataBagName,
+      dataBagItemName,
+      gatewayId
+    },
+    gatewayV2Service
+  );
 
   const { id, ...existingSecrets } = dataBagItem;
 
@@ -69,7 +92,9 @@ const getChefSecrets = async (secretSync: TChefSyncWithCredentials): Promise<TCh
 const updateChefSecrets = async (
   secretSync: TChefSyncWithCredentials,
   id: string,
-  secrets: Record<string, TChefSecret>
+  secrets: Record<string, TChefSecret>,
+  gatewayId: string | null,
+  gatewayV2Service: TChefSyncGatewayV2Service
 ) => {
   const {
     connection,
@@ -84,25 +109,36 @@ const updateChefSecrets = async (
     ...secrets
   };
 
-  await updateChefDataBagItem({
-    serverUrl,
-    orgName,
-    userName,
-    privateKey,
-    dataBagName,
-    dataBagItemName,
-    data: dataBagItemContent
-  });
+  await updateChefDataBagItem(
+    {
+      serverUrl,
+      orgName,
+      userName,
+      privateKey,
+      dataBagName,
+      dataBagItemName,
+      data: dataBagItemContent,
+      gatewayId
+    },
+    gatewayV2Service
+  );
 };
 
 export const ChefSyncFns = {
-  async syncSecrets(secretSync: TChefSyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(
+    secretSync: TChefSyncWithCredentials,
+    secretMap: TSecretMap,
+    gatewayV2Service: TChefSyncGatewayV2Service,
+    gatewayPoolService: TChefSyncGatewayPoolService
+  ) {
     const {
       environment,
       syncOptions: { disableSecretDeletion, keySchema }
     } = secretSync;
 
-    const { id, secrets } = await getChefSecrets(secretSync);
+    const gatewayId = await resolveGatewayId(secretSync, gatewayPoolService);
+
+    const { id, secrets } = await getChefSecrets(secretSync, gatewayId, gatewayV2Service);
 
     // Create a map of the existing secrets
     const updatedSecretsMap = new Map(secrets.map((secret) => [secret.key, secret.value]));
@@ -126,17 +162,30 @@ export const ChefSyncFns = {
     // Convert map to object for Chef API
     const updatedSecrets = Object.fromEntries(updatedSecretsMap.entries());
 
-    await updateChefSecrets(secretSync, id, updatedSecrets);
+    await updateChefSecrets(secretSync, id, updatedSecrets, gatewayId, gatewayV2Service);
   },
 
-  async getSecrets(secretSync: TChefSyncWithCredentials): Promise<TSecretMap> {
-    const { secrets } = await getChefSecrets(secretSync);
+  async getSecrets(
+    secretSync: TChefSyncWithCredentials,
+    gatewayV2Service: TChefSyncGatewayV2Service,
+    gatewayPoolService: TChefSyncGatewayPoolService
+  ): Promise<TSecretMap> {
+    const gatewayId = await resolveGatewayId(secretSync, gatewayPoolService);
+
+    const { secrets } = await getChefSecrets(secretSync, gatewayId, gatewayV2Service);
 
     return Object.fromEntries(secrets.map((secret) => [secret.key, { value: secret.value }]));
   },
 
-  async removeSecrets(secretSync: TChefSyncWithCredentials, secretMap: TSecretMap) {
-    const { id, secrets: existingSecrets } = await getChefSecrets(secretSync);
+  async removeSecrets(
+    secretSync: TChefSyncWithCredentials,
+    secretMap: TSecretMap,
+    gatewayV2Service: TChefSyncGatewayV2Service,
+    gatewayPoolService: TChefSyncGatewayPoolService
+  ) {
+    const gatewayId = await resolveGatewayId(secretSync, gatewayPoolService);
+
+    const { id, secrets: existingSecrets } = await getChefSecrets(secretSync, gatewayId, gatewayV2Service);
 
     const newSecrets = existingSecrets.filter((secret) => !Object.hasOwn(secretMap, secret.key));
 
@@ -146,6 +195,6 @@ export const ChefSyncFns = {
 
     const updatedSecrets = Object.fromEntries(newSecrets.map((secret) => [secret.key, secret.value]));
 
-    await updateChefSecrets(secretSync, id, updatedSecrets);
+    await updateChefSecrets(secretSync, id, updatedSecrets, gatewayId, gatewayV2Service);
   }
 };

--- a/backend/src/ee/services/secret-sync/chef/chef-sync-types.ts
+++ b/backend/src/ee/services/secret-sync/chef/chef-sync-types.ts
@@ -21,6 +21,7 @@ export type TGetChefSecrets = {
   orgName: string;
   dataBagName: string;
   dataBagItemName: string;
+  gatewayId?: string | null;
 };
 
 export type TChefSecret = string | number | boolean | null;

--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -1398,7 +1398,7 @@ export const appConnectionServiceFactory = ({
     datadog: datadogConnectionService(connectAppConnectionById),
     openai: openaiConnectionService(connectAppConnectionById),
     laravelForge: laravelForgeConnectionService(connectAppConnectionById),
-    chef: chefConnectionService(connectAppConnectionById, licenseService),
+    chef: chefConnectionService(connectAppConnectionById, licenseService, gatewayV2Service, gatewayPoolService),
     octopusDeploy: octopusDeployConnectionService(connectAppConnectionById),
     dbt: dbtConnectionService(connectAppConnectionById),
     circleci: circleciConnectionService(connectAppConnectionById),

--- a/backend/src/services/pki-sync/chef/chef-pki-sync-fns.ts
+++ b/backend/src/services/pki-sync/chef/chef-pki-sync-fns.ts
@@ -7,6 +7,8 @@ import {
   removeChefDataBagItem,
   updateChefDataBagItem
 } from "@app/ee/services/app-connections/chef";
+import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
+import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { TChefDataBagItemContent } from "@app/ee/services/secret-sync/chef";
 import { logger } from "@app/lib/logger";
 import { TCertificateDALFactory } from "@app/services/certificate/certificate-dal";
@@ -72,11 +74,28 @@ type TChefPkiSyncFactoryDeps = {
     | "findByPkiSyncId"
     | "updateSyncStatus"
   >;
+  gatewayV2Service?: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
+  gatewayPoolService?: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
 };
 
-export const chefPkiSyncFactory = ({ certificateDAL, certificateSyncDAL }: TChefPkiSyncFactoryDeps) => {
+export const chefPkiSyncFactory = ({
+  certificateDAL,
+  certificateSyncDAL,
+  gatewayV2Service,
+  gatewayPoolService
+}: TChefPkiSyncFactoryDeps) => {
+  const $resolveGateway = async (pkiSync: TChefPkiSyncWithCredentials): Promise<string | null> => {
+    return gatewayPoolService
+      ? gatewayPoolService.resolveEffectiveGatewayId({
+          gatewayId: pkiSync.connection.gatewayId,
+          gatewayPoolId: pkiSync.connection.gatewayPoolId
+        })
+      : (pkiSync.connection.gatewayId ?? null);
+  };
+
   const $getChefDataBagItems = async (
     pkiSync: TChefPkiSyncWithCredentials,
+    gatewayId: string | null,
     syncId = "unknown"
   ): Promise<Record<string, boolean>> => {
     const {
@@ -89,9 +108,11 @@ export const chefPkiSyncFactory = ({ certificateDAL, certificateSyncDAL }: TChef
       () =>
         listChefDataBagItems(
           {
-            credentials: { serverUrl, userName, privateKey, orgName }
-          } as Parameters<typeof listChefDataBagItems>[0],
-          dataBagName
+            credentials: { serverUrl, userName, privateKey, orgName },
+            gatewayId
+          },
+          dataBagName,
+          gatewayV2Service
         ),
       {
         operation: "list-chef-data-bag-items",
@@ -118,7 +139,9 @@ export const chefPkiSyncFactory = ({ certificateDAL, certificateSyncDAL }: TChef
     } = chefPkiSync;
     const { serverUrl, userName, privateKey, orgName } = connection.credentials;
 
-    const chefDataBagItems = await $getChefDataBagItems(chefPkiSync, pkiSync.id);
+    const effectiveGatewayId = await $resolveGateway(chefPkiSync);
+
+    const chefDataBagItems = await $getChefDataBagItems(chefPkiSync, effectiveGatewayId, pkiSync.id);
 
     const existingSyncRecords = await certificateSyncDAL.findByPkiSyncId(pkiSync.id);
     const syncRecordsByCertId = new Map<string, TCertificateSyncs>();
@@ -278,15 +301,19 @@ export const chefPkiSyncFactory = ({ certificateDAL, certificateSyncDAL }: TChef
         if (itemExists) {
           await withRateLimitRetry(
             () =>
-              updateChefDataBagItem({
-                serverUrl,
-                userName,
-                privateKey,
-                orgName,
-                dataBagName,
-                dataBagItemName: targetItemName,
-                data: chefDataBagItem as unknown as TChefDataBagItemContent
-              }),
+              updateChefDataBagItem(
+                {
+                  serverUrl,
+                  userName,
+                  privateKey,
+                  orgName,
+                  dataBagName,
+                  dataBagItemName: targetItemName,
+                  data: chefDataBagItem as unknown as TChefDataBagItemContent,
+                  gatewayId: effectiveGatewayId
+                },
+                gatewayV2Service
+              ),
             {
               operation: "update-chef-data-bag-item",
               syncId: pkiSync.id
@@ -295,14 +322,18 @@ export const chefPkiSyncFactory = ({ certificateDAL, certificateSyncDAL }: TChef
         } else {
           await withRateLimitRetry(
             () =>
-              createChefDataBagItem({
-                serverUrl,
-                userName,
-                privateKey,
-                orgName,
-                dataBagName,
-                data: chefDataBagItem as unknown as TChefDataBagItemContent
-              }),
+              createChefDataBagItem(
+                {
+                  serverUrl,
+                  userName,
+                  privateKey,
+                  orgName,
+                  dataBagName,
+                  data: chefDataBagItem as unknown as TChefDataBagItemContent,
+                  gatewayId: effectiveGatewayId
+                },
+                gatewayV2Service
+              ),
             {
               operation: "create-chef-data-bag-item",
               syncId: pkiSync.id
@@ -364,14 +395,18 @@ export const chefPkiSyncFactory = ({ certificateDAL, certificateSyncDAL }: TChef
           try {
             await withRateLimitRetry(
               () =>
-                removeChefDataBagItem({
-                  serverUrl,
-                  userName,
-                  privateKey,
-                  orgName,
-                  dataBagName,
-                  dataBagItemName: itemName
-                }),
+                removeChefDataBagItem(
+                  {
+                    serverUrl,
+                    userName,
+                    privateKey,
+                    orgName,
+                    dataBagName,
+                    dataBagItemName: itemName,
+                    gatewayId: effectiveGatewayId
+                  },
+                  gatewayV2Service
+                ),
               {
                 operation: "remove-chef-data-bag-item",
                 syncId: pkiSync.id
@@ -535,6 +570,8 @@ export const chefPkiSyncFactory = ({ certificateDAL, certificateSyncDAL }: TChef
     } = chefPkiSync;
     const { serverUrl, userName, privateKey, orgName } = connection.credentials;
 
+    const effectiveGatewayId = await $resolveGateway(chefPkiSync);
+
     const existingSyncRecords = await certificateSyncDAL.findByPkiSyncId(sync.id);
     const certificateIdsToRemove: string[] = [];
     const itemsToRemove: string[] = [];
@@ -563,14 +600,18 @@ export const chefPkiSyncFactory = ({ certificateDAL, certificateSyncDAL }: TChef
       try {
         await withRateLimitRetry(
           () =>
-            removeChefDataBagItem({
-              serverUrl,
-              userName,
-              privateKey,
-              orgName,
-              dataBagName,
-              dataBagItemName: itemName
-            }),
+            removeChefDataBagItem(
+              {
+                serverUrl,
+                userName,
+                privateKey,
+                orgName,
+                dataBagName,
+                dataBagItemName: itemName,
+                gatewayId: effectiveGatewayId
+              },
+              gatewayV2Service
+            ),
           {
             operation: "remove-chef-data-bag-item",
             syncId: sync.id

--- a/backend/src/services/pki-sync/pki-sync-fns.ts
+++ b/backend/src/services/pki-sync/pki-sync-fns.ts
@@ -253,7 +253,9 @@ export const PkiSyncFns = {
         checkPkiSyncDestination(pkiSync, PkiSync.Chef as PkiSync);
         const chefPkiSync = chefPkiSyncFactory({
           certificateDAL: dependencies.certificateDAL,
-          certificateSyncDAL: dependencies.certificateSyncDAL
+          certificateSyncDAL: dependencies.certificateSyncDAL,
+          gatewayV2Service: dependencies.gatewayV2Service,
+          gatewayPoolService: dependencies.gatewayPoolService
         });
         return chefPkiSync.syncCertificates(pkiSync, certificateMap);
       }
@@ -396,7 +398,9 @@ export const PkiSyncFns = {
         checkPkiSyncDestination(pkiSync, PkiSync.Chef as PkiSync);
         const chefPkiSync = chefPkiSyncFactory({
           certificateDAL: dependencies.certificateDAL,
-          certificateSyncDAL: dependencies.certificateSyncDAL
+          certificateSyncDAL: dependencies.certificateSyncDAL,
+          gatewayV2Service: dependencies.gatewayV2Service,
+          gatewayPoolService: dependencies.gatewayPoolService
         });
         await chefPkiSync.removeCertificates(pkiSync, certificateNames, {
           certificateSyncDAL: dependencies.certificateSyncDAL,

--- a/backend/src/services/secret-sync/secret-sync-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-fns.ts
@@ -424,7 +424,7 @@ export const SecretSyncFns = {
       case SecretSync.LaravelForge:
         return LaravelForgeSyncFns.syncSecrets(secretSync, schemaSecretMap);
       case SecretSync.Chef:
-        return ChefSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return ChefSyncFns.syncSecrets(secretSync, schemaSecretMap, gatewayV2Service, gatewayPoolService);
       case SecretSync.OctopusDeploy:
         return OctopusDeploySyncFns.syncSecrets(secretSync, schemaSecretMap);
       case SecretSync.CircleCI:
@@ -589,7 +589,7 @@ export const SecretSyncFns = {
         secretMap = await LaravelForgeSyncFns.getSecrets(secretSync);
         break;
       case SecretSync.Chef:
-        secretMap = await ChefSyncFns.getSecrets(secretSync);
+        secretMap = await ChefSyncFns.getSecrets(secretSync, gatewayV2Service, gatewayPoolService);
         break;
       case SecretSync.OctopusDeploy:
         secretMap = await OctopusDeploySyncFns.getSecrets(secretSync);
@@ -754,7 +754,7 @@ export const SecretSyncFns = {
       case SecretSync.LaravelForge:
         return LaravelForgeSyncFns.removeSecrets(secretSync, schemaSecretMap);
       case SecretSync.Chef:
-        return ChefSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return ChefSyncFns.removeSecrets(secretSync, schemaSecretMap, gatewayV2Service, gatewayPoolService);
       case SecretSync.OctopusDeploy:
         return OctopusDeploySyncFns.removeSecrets(secretSync, schemaSecretMap);
       case SecretSync.CircleCI:

--- a/docs/integrations/app-connections/chef.mdx
+++ b/docs/integrations/app-connections/chef.mdx
@@ -90,6 +90,8 @@ Please access your **starter kit** to get all the required information to create
         - User name
         - Private key: Your Chef user's private key (.pem file)
 
+        Optionally select a **Gateway** to route the connection through an Infisical Gateway for private network access.
+
         ![Chef Connection Modal](/images/app-connections/chef/app-connection-form.png)
       </Step>
       <Step title="Connection created">

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ChefConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/ChefConnectionForm.tsx
@@ -3,6 +3,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { Info } from "lucide-react";
 import { z } from "zod";
 
+import { OrgPermissionCan } from "@app/components/permissions";
 import {
   Field,
   FieldError,
@@ -18,6 +19,9 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
+import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
+import { OrgPermissionSubjects } from "@app/context";
+import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
 import { APP_CONNECTION_MAP, getAppConnectionMethodDetails } from "@app/helpers/appConnections";
 import { ChefConnectionMethod, TChefConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
@@ -58,16 +62,63 @@ export const ChefConnectionForm = ({ appConnection, onSubmit }: Props) => {
     resolver: zodResolver(formSchema),
     defaultValues: appConnection ?? {
       app: AppConnection.Chef,
-      method: ChefConnectionMethod.UserKey
+      method: ChefConnectionMethod.UserKey,
+      gatewayId: null,
+      gatewayPoolId: null
     }
   });
 
-  const { handleSubmit, control } = form;
+  const { handleSubmit, control, setValue, watch } = form;
+
+  const gatewayId = watch("gatewayId");
+  const gatewayPoolId = watch("gatewayPoolId");
 
   return (
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(onSubmit)}>
         {!isUpdate && <GenericAppConnectionsFields />}
+        <OrgPermissionCan
+          I={OrgGatewayPermissionActions.AttachGateways}
+          a={OrgPermissionSubjects.Gateway}
+        >
+          {(isAllowed) => (
+            <Field className="mb-4">
+              <FieldLabel>Gateway</FieldLabel>
+              {isAllowed ? (
+                <GatewayPicker
+                  isDisabled={!isAllowed}
+                  value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                  onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                    setValue("gatewayId", newGwId, { shouldDirty: true });
+                    setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                  }}
+                />
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <GatewayPicker
+                        isDisabled={!isAllowed}
+                        value={{
+                          gatewayId: gatewayId ?? null,
+                          gatewayPoolId: gatewayPoolId ?? null
+                        }}
+                        onChange={({ gatewayId: newGwId, gatewayPoolId: newPoolId }) => {
+                          setValue("gatewayId", newGwId, { shouldDirty: true });
+                          setValue("gatewayPoolId", newPoolId, { shouldDirty: true });
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Restricted access. You don&apos;t have permission to attach gateways to
+                    resources.
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </Field>
+          )}
+        </OrgPermissionCan>
         <Controller
           name="credentials.serverUrl"
           control={control}


### PR DESCRIPTION
## Context

Route all Chef server requests (connection validation, data bag listing, secret sync, PKI sync) through an Infisical Gateway when one is attached, following the NetScaler/Kemp gateway v2 pattern. Supports both direct gateways and gateway pools, and adds the GatewayPicker to the Chef connection form.

## Screenshots

N/A

## Steps to verify the change

## Chef gateway verification (ENG-5418)

Setup: use a Chef server reachable **only** through the gateway (e.g. chef-zero behind a private hostname) so success itself proves gateway routing.

- [ ] Create a Chef connection with a direct gateway attached and confirm credential validation succeeds.
- [ ] Create a Chef connection with a gateway pool and confirm validation succeeds via a picked healthy pool gateway.
- [ ] Edit the connection's credentials and confirm re-validation still routes through the gateway/pool.
- [ ] Without a gateway attached, confirm validation against a private address fails the SSRF block while a public Chef server still validates directly.
- [ ] Confirm the data bag and data bag item dropdowns populate when configuring a sync on the gatewayed connection.
- [ ] Run a Chef secret sync and confirm secrets land in the target data bag item.
- [ ] Run a secret import from the Chef sync and confirm values are pulled back into Infisical.
- [ ] Remove synced secrets (or delete the sync with removal enabled) and confirm the keys are deleted from the data bag item.
- [ ] Run a Chef PKI sync and confirm certificates are created/updated as data bag items.
- [ ] Remove a synced certificate and confirm its data bag item is deleted from the Chef server.
- [ ] Confirm the GatewayPicker appears in the Chef connection form and is disabled with a tooltip without the Attach Gateways permission.
- [ ] Stop the gateway and confirm syncs fail with a clear error instead of silently falling back to a direct connection.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)