### PR TITLE
fix: fix glob pattern test popover and update docs so glob match is clearer

### DIFF
--- a/docs/internals/permissions/overview.mdx
+++ b/docs/internals/permissions/overview.mdx
@@ -83,7 +83,14 @@ The following operators are available for conditions:
 | `$eq`    | Equal                              | `{ environment: { $eq: "production" } }`              |
 | `$ne`    | Not equal                          | `{ environment: { $ne: "development" } }`             |
 | `$in`    | Matches any value in array         | `{ environment: { $in: ["staging", "production"] } }` |
-| `$glob`  | [Glob pattern](https://www.malikbrowne.com/blog/a-beginners-guide-glob-patterns/) matching (supports `*`, `**`, `?`, and `{a,b}` wildcards) | `{ secretPath: { $glob: "/app/\*" } }`                |
+| `$glob`  | [Glob pattern](https://www.malikbrowne.com/blog/a-beginners-guide-glob-patterns/) matching (supports `*`, `**`, `?`, and `{a,b}` wildcards) | `{ secretPath: { $glob: "/app/**" } }`                |
+
+<Note>
+  A trailing `/*` matches only a folder's direct children: `/app/*` matches `/app/api` but not
+  `/app` itself, and not `/app/api/db`. To match a folder and everything under it, use a trailing
+  `/**`. See [condition operators](/internals/permissions/project-permissions#condition-operators)
+  for details.
+</Note>
 
 These details are especially useful if you're using the API to [create new project roles](/api-reference/endpoints/project-roles/create).
 The rules outlined on this page, also apply when using our Terraform Provider to manage your Infisical project roles, or any other of our clients that manage project roles.

--- a/docs/internals/permissions/project-permissions.mdx
+++ b/docs/internals/permissions/project-permissions.mdx
@@ -478,10 +478,12 @@ When defining conditions for permissions, you can use the following operators to
 <Note>
 When using `$glob`, note that `*` does **not** match across `/` boundaries. Use `**` to match across multiple path segments.
 
+A trailing `/*` also does **not** match the folder itself: `/app/*` matches secrets in `/app/config` but not secrets directly in `/app`. To grant access to a folder and everything under it, use a trailing `/**`.
+
 | Pattern | Matches | Does not match |
 |---------|---------|----------------|
-| `/app/*` | `/app/config`, `/app/secrets` | `/app/config/db` |
-| `/app/**` | `/app/config`, `/app/config/db`, `/app/config/db/primary` | `/other/config` |
+| `/app/*` | `/app/config`, `/app/secrets` | `/app` (the folder itself), `/app/config/db` |
+| `/app/**` | `/app`, `/app/config`, `/app/config/db/primary` | `/other/config` |
 | `/{dev,staging}/*` | `/dev/secrets`, `/staging/config` | `/prod/secrets` |
 </Note>
 

--- a/frontend/src/components/permissions/GlobPermissionInfo.tsx
+++ b/frontend/src/components/permissions/GlobPermissionInfo.tsx
@@ -1,8 +1,7 @@
-import { useState } from "react";
+import { useId, useState } from "react";
 import picomatch from "picomatch";
 
-import { FormControl } from "../v2/FormControl";
-import { Input } from "../v2/Input";
+import { Field, FieldDescription, FieldLabel, Input } from "../v3";
 
 export const GlobPatternTooltip = () => (
   <div className="space-y-1.5 text-left text-xs">
@@ -39,14 +38,19 @@ export const BashGlobPatternTooltip = () => (
 );
 
 export const GlobPermissionInfo = () => {
+  const id = useId();
   const [pattern, setPattern] = useState("");
   const [text, setText] = useState("");
 
+  const hasInput = Boolean(pattern && text);
+  // Must stay in sync with the backend's $glob evaluation (backend/src/lib/casl/index.ts)
+  const isMatch = hasInput && picomatch.isMatch(text, pattern, { strictSlashes: false });
+
   return (
-    <div>
-      <div className="mt-2 space-y-1">
+    <div className="space-y-4 text-xs">
+      <div className="space-y-2">
         <p>A glob pattern uses special wildcard characters to match resources or paths:</p>
-        <ul className="list-disc pl-4 text-xs text-mineshaft-300">
+        <ul className="list-disc space-y-0.5 pl-4 text-accent">
           <li>
             <code>*</code> — matches any characters except <code>/</code> (e.g., <code>dev-*</code>{" "}
             matches <code>dev-api</code>)
@@ -62,27 +66,40 @@ export const GlobPermissionInfo = () => {
             <code>{"{a,b}"}</code> — matches either alternative
           </li>
         </ul>
+        <p className="text-accent">
+          A trailing <code>{"/*"}</code> matches a folder&apos;s direct children only, not the
+          folder itself: <code>/app/*</code> does not match secrets directly in <code>/app</code>.
+          Use <code>/app/**</code> to match a folder and everything under it.
+        </p>
       </div>
-      <div>
-        <FormControl
-          label="Glob pattern"
-          helperText="Examples: dev-*, /services/**, config-?, {dev,staging}-*"
-        >
-          <Input value={pattern} onChange={(e) => setPattern(e.target.value)} />
-        </FormControl>
-      </div>
-      <div>
-        <FormControl
-          label="Test string"
-          helperText="Type a value to test glob match"
-          isError={
-            pattern && text ? !picomatch.isMatch(text, pattern, { strictSlashes: false }) : false
-          }
-          errorText="Invalid"
-        >
-          <Input value={text} onChange={(e) => setText(e.target.value)} />
-        </FormControl>
-      </div>
+      <Field>
+        <FieldLabel htmlFor={`${id}-pattern`}>Glob Pattern</FieldLabel>
+        <Input
+          id={`${id}-pattern`}
+          value={pattern}
+          onChange={(e) => setPattern(e.target.value)}
+          placeholder="/app/**"
+        />
+        <FieldDescription>
+          Examples: dev-*, /services/**, config-?, {"{dev,staging}"}-*
+        </FieldDescription>
+      </Field>
+      <Field>
+        <FieldLabel htmlFor={`${id}-test`}>Test String</FieldLabel>
+        <Input
+          id={`${id}-test`}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="/app/config"
+        />
+        {hasInput ? (
+          <p className={isMatch ? "text-success" : "text-danger"}>
+            {isMatch ? "Matches the pattern" : "Does not match the pattern"}
+          </p>
+        ) : (
+          <FieldDescription>Type a value to test the pattern against</FieldDescription>
+        )}
+      </Field>
     </div>
   );
 };

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/ConditionsFields.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/ConditionsFields.tsx
@@ -13,6 +13,9 @@ import {
   FieldError,
   IconButton,
   Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -452,16 +455,42 @@ export const ConditionsFields = ({
                               )}
                             />
                             <div>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <InfoIcon className="size-4 text-muted" />
-                                </TooltipTrigger>
-                                <TooltipContent className="max-w-xs text-wrap">
-                                  {getConditionOperatorHelperInfo(
-                                    condition?.operator as PermissionConditionOperators
-                                  )}
-                                </TooltipContent>
-                              </Tooltip>
+                              {condition?.operator === PermissionConditionOperators.$GLOB ? (
+                                // The glob helper contains inputs for testing patterns, so it
+                                // needs a container that stays open while interacting with it
+                                <Popover>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <PopoverTrigger asChild>
+                                        <IconButton
+                                          aria-label="Glob pattern reference"
+                                          variant="ghost-muted"
+                                          size="xs"
+                                        >
+                                          <InfoIcon />
+                                        </IconButton>
+                                      </PopoverTrigger>
+                                    </TooltipTrigger>
+                                    <TooltipContent>Glob pattern reference</TooltipContent>
+                                  </Tooltip>
+                                  <PopoverContent className="w-96">
+                                    {getConditionOperatorHelperInfo(
+                                      condition.operator as PermissionConditionOperators
+                                    )}
+                                  </PopoverContent>
+                                </Popover>
+                              ) : (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <InfoIcon className="size-4 text-muted" />
+                                  </TooltipTrigger>
+                                  <TooltipContent className="max-w-xs text-wrap">
+                                    {getConditionOperatorHelperInfo(
+                                      condition?.operator as PermissionConditionOperators
+                                    )}
+                                  </TooltipContent>
+                                </Tooltip>
+                              )}
                             </div>
                           </div>
                           <div className="grow">


### PR DESCRIPTION
## Context

This PR migrates the glob match pattern tester to a popover so it remains interactive and updates our docs for clearer glob match examples

## Screenshots

<img width="3456" height="1924" alt="CleanShot 2026-08-05 at 19 11 27@2x" src="https://github.com/user-attachments/assets/8da369ac-3859-476e-89c3-5912c824f43e" />

## Steps to verify the change

- [ ] read docs
- [ ] test glob match

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)