### PR TITLE
docs(claude): add code comments house style to root CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,20 @@ It is a floor, not an exhaustive standard: user-understandable error messages an
 
 That list describes what the guide currently covers; it is **not** a test for whether the guide applies. Do not skip it because a change does not look like one of those topics. Read it, then decide which items are relevant.
 
+### Code Comments
+
+**Default to writing no comments.** This is house style across `backend/`, `backend-go/`, `frontend/`, and `wasm/`. Well-named identifiers already say what the code does, so a comment earns its place only by explaining *why*: a non-obvious constraint, a workaround for a specific bug, an ordering dependency the code cannot express, or logic that looks wrong until you know the reason.
+
+Do not write:
+- Narration that restates the next line (`// loop over the users`, `// set the flag`)
+- Section headers inside a function (`// --- validation ---`)
+- Change history or status (`// Added retry logic`, `// NEW`, `// now uses the alert registry`)
+- Process references. Plans, phases, Linear tickets, PR numbers, and reviewer names rot fast and mean nothing to the next reader. 
+- Docstrings or JSDoc that restate the signature
+- Commented-out code. Delete it; git remembers.
+
+Before calling the work done, re-read every comment you added and delete the ones that only describe what the code already says. When in doubt, match the density of the surrounding file: most of this codebase has none.
+
 ### Design System & Voice
 
 The v3 visual system (colors, typography, components, layout) and product voice/content tone are documented in [`DESIGN.md`](DESIGN.md). Read it before producing new UI or user-visible copy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,17 +66,11 @@ That list describes what the guide currently covers; it is **not** a test for wh
 
 ### Code Comments
 
-**Default to writing no comments.** This is house style across `backend/`, `backend-go/`, `frontend/`, and `wasm/`. Well-named identifiers already say what the code does, so a comment earns its place only by explaining *why*: a non-obvious constraint, a workaround for a specific bug, an ordering dependency the code cannot express, or logic that looks wrong until you know the reason.
+**Default to no comments.** One earns its place only by explaining *why*: a non-obvious constraint, a workaround, an ordering dependency, or logic that looks wrong until you know the reason.
 
-Do not write:
-- Narration that restates the next line (`// loop over the users`, `// set the flag`)
-- Section headers inside a function (`// --- validation ---`)
-- Change history or status (`// Added retry logic`, `// NEW`, `// now uses the alert registry`)
-- Process references. Plans, phases, Linear tickets, PR numbers, and reviewer names rot fast and mean nothing to the next reader. 
-- Docstrings or JSDoc that restate the signature
-- Commented-out code. Delete it; git remembers.
+Never write: narration restating the next line; section headers inside a function (`// --- validation ---`); change history (`// Added retry logic`, `// NEW`); references to plans, tickets, PRs, or reviewers; docstrings restating the signature; commented-out code.
 
-Before calling the work done, re-read every comment you added and delete the ones that only describe what the code already says. When in doubt, match the density of the surrounding file: most of this codebase has none.
+Before finishing, delete any comment you added that only says what the code says.
 
 ### Design System & Voice
 


### PR DESCRIPTION
## Context

Claude leaves a lot of narration comments in generated code (`// loop over the users`, `// Added retry logic`, `// --- validation ---` headers inside functions) and they end up as review noise. None of our seven CLAUDE.md files said anything about comments, so there was nothing to point at when it happened.

Adds a `### Code Comments` section under Cross-Cutting Patterns in the root CLAUDE.md: default to none, a comment earns its place only by explaining *why*, and an explicit list of the genres to never write. Kept to 5 lines since every CLAUDE.md line is loaded into context on every session.

The genre list is deliberately specific, as "comments explain why, not what" is too abstract to act on mid-edit. The closing line asks for a delete pass before finishing, since the up-front rule tends to be forgotten by the time code is actually being written.

Root file rather than `backend/CLAUDE.md` because it applies to every code tree.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
