### PR TITLE
fix: move gcp sync regions to an advanced accordion

### DIFF
--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
@@ -1,10 +1,14 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { MultiValue, SingleValue } from "react-select";
 import { Info, TriangleAlert } from "lucide-react";
 
 import { SecretSyncConnectionField } from "@app/components/secret-syncs/forms/SecretSyncConnectionField";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Alert,
   AlertDescription,
   AlertTitle,
@@ -41,6 +45,8 @@ const formatOptionLabel = ({ displayName, locationId }: TGcpLocation) => (
   </div>
 );
 
+const ADVANCED_ITEM_VALUE = "gcp-secret-manager-advanced";
+
 export const GcpSyncFields = () => {
   const { control, setValue, formState } = useFormContext<
     TSecretSyncForm & { destination: SecretSync.GCPSecretManager }
@@ -69,6 +75,30 @@ export const GcpSyncFields = () => {
   const isGlobalScope = selectedScope === GcpSyncScope.Global;
   const isCommittedGlobalSync = committedReplicaLocationIds.length > 0;
   const lockReplicaRegions = isCommittedGlobalSync && isGlobalScope;
+
+  const hasConfiguredReplicaRegions = isGlobalScope && (userReplicaLocationIds?.length ?? 0) > 0;
+  const hasAccordionError = Boolean(
+    formState.errors.destinationConfig &&
+      "userReplicaLocationIds" in formState.errors.destinationConfig
+  );
+
+  const [openItem, setOpenItem] = useState<string>(
+    hasConfiguredReplicaRegions || hasAccordionError ? ADVANCED_ITEM_VALUE : ""
+  );
+
+  // Selects do not work well inside dynamic containers (e.g. Accordion)
+  // We use menuPortalTarget to ensure this is render correctly without
+  // hiding any option due to the container heigh.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setMenuPortalTarget(containerRef.current?.closest<HTMLElement>('[role="dialog"]') ?? null);
+  }, []);
+
+  useEffect(() => {
+    if (hasAccordionError) setOpenItem(ADVANCED_ITEM_VALUE);
+  }, [hasAccordionError, formState.submitCount]);
 
   const { data: projects, isPending } = useGcpConnectionListProjects(connectionId, {
     enabled: Boolean(connectionId)
@@ -108,7 +138,7 @@ export const GcpSyncFields = () => {
   ]);
 
   return (
-    <FieldGroup>
+    <FieldGroup ref={containerRef} className="min-h-0 flex-1">
       <SecretSyncConnectionField
         onChange={() => {
           setValue("destinationConfig.projectId", "");
@@ -238,60 +268,84 @@ export const GcpSyncFields = () => {
         />
       )}
       {selectedScope === GcpSyncScope.Global && (
-        <Controller
-          name="destinationConfig.userReplicaLocationIds"
-          control={control}
-          render={({ field: { value, onChange }, fieldState: { error } }) => (
-            <Field>
-              <FieldLabel>
-                Replica Regions
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Info />
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-md">
-                    Optionally specify one or more regions for user-managed replication. If none are
-                    set, automatic replication will be used.
-                  </TooltipContent>
-                </Tooltip>
-              </FieldLabel>
-              <FieldContent>
-                <FilterableSelect
-                  isMulti
-                  isLoading={areLocationsPending && Boolean(projectId)}
-                  isDisabled={!projectId || lockReplicaRegions}
-                  isClearable={!lockReplicaRegions}
-                  value={
-                    locations?.filter((option) => (value || []).includes(option.locationId)) ?? []
-                  }
-                  onChange={(option) =>
-                    onChange((option as MultiValue<TGcpLocation>).map((o) => o.locationId))
-                  }
-                  options={locations}
-                  placeholder="Automatic replication"
-                  getOptionValue={(option) => option.locationId}
-                  formatOptionLabel={formatOptionLabel}
-                />
+        <Accordion
+          type="single"
+          collapsible
+          variant="ghost"
+          value={openItem}
+          onValueChange={setOpenItem}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <AccordionItem
+            value={ADVANCED_ITEM_VALUE}
+            className="flex min-h-0 flex-1 flex-col [&>[data-slot=accordion-content]]:flex [&>[data-slot=accordion-content]]:min-h-0 [&>[data-slot=accordion-content]]:flex-1 [&>[data-slot=accordion-content]]:flex-col"
+          >
+            <AccordionTrigger>Advanced</AccordionTrigger>
+            <AccordionContent>
+              <Controller
+                name="destinationConfig.userReplicaLocationIds"
+                control={control}
+                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel>
+                      Replica Regions
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-md">
+                          When set, secrets are replicated only in the selected regions. When empty,
+                          GCP automatically manages replication.
+                        </TooltipContent>
+                      </Tooltip>
+                    </FieldLabel>
+                    <FieldContent>
+                      <FilterableSelect
+                        isMulti
+                        isLoading={areLocationsPending && Boolean(projectId)}
+                        isDisabled={!projectId || lockReplicaRegions}
+                        isClearable={!lockReplicaRegions}
+                        value={
+                          locations?.filter((option) =>
+                            (value || []).includes(option.locationId)
+                          ) ?? []
+                        }
+                        onChange={(option) =>
+                          onChange((option as MultiValue<TGcpLocation>).map((o) => o.locationId))
+                        }
+                        options={locations}
+                        placeholder="Automatic replication"
+                        getOptionValue={(option) => option.locationId}
+                        formatOptionLabel={formatOptionLabel}
+                        menuPortalTarget={menuPortalTarget ?? undefined}
+                        menuPosition="fixed"
+                        menuPlacement="auto"
+                      />
 
-                {(value?.length ?? 0) > 0 && (
-                  <Alert variant="warning">
-                    <TriangleAlert />
-                    <AlertTitle>Replica regions can&apos;t be changed after creation</AlertTitle>
-                    <AlertDescription>
-                      <p>
-                        Replica regions are fixed when the sync is created and cannot be changed
-                        later, since GCP does not support it. It is still possible to change the
-                        scope to <span className="font-medium">Region</span> and specify a region
-                        for the secret.
-                      </p>
-                    </AlertDescription>
-                  </Alert>
+                      {(value?.length ?? 0) > 0 && (
+                        <Alert variant="warning">
+                          <TriangleAlert />
+                          <AlertTitle>
+                            Replica regions can&apos;t be changed after creation
+                          </AlertTitle>
+                          <AlertDescription>
+                            <p>
+                              Replica regions are fixed when the sync is created and cannot be
+                              changed later, since GCP does not support it. It is still possible to
+                              change the scope to <span className="font-medium">Region</span> and
+                              specify a region for the secret.
+                            </p>
+                          </AlertDescription>
+                        </Alert>
+                      )}
+                      <FieldError errors={[error]} />
+                    </FieldContent>
+                  </Field>
                 )}
-                <FieldError errors={[error]} />
-              </FieldContent>
-            </Field>
-          )}
-        />
+              />
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       )}
     </FieldGroup>
   );

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
-import { MultiValue, SingleValue } from "react-select";
+import { FormatOptionLabelMeta, MultiValue, SingleValue } from "react-select";
 import { Info, TriangleAlert } from "lucide-react";
 
 import { SecretSyncConnectionField } from "@app/components/secret-syncs/forms/SecretSyncConnectionField";
@@ -39,11 +39,21 @@ import { GcpSyncScope } from "@app/hooks/api/secretSyncs/types/gcp-sync";
 
 import { TSecretSyncForm } from "../schemas";
 
-const formatOptionLabel = ({ displayName, locationId }: TGcpLocation) => (
-  <div className="flex w-full flex-row items-center gap-1">
-    <span>{displayName}</span> <Badge variant="info">{locationId}</Badge>
-  </div>
-);
+// The control renders selected values inside chips (isMulti), where a nested Badge reads as a
+// badge-in-badge; use plain parentheses there and keep the Badge for menu options.
+const formatOptionLabel = (
+  { displayName, locationId }: TGcpLocation,
+  { context }: FormatOptionLabelMeta<TGcpLocation>
+) =>
+  context === "value" ? (
+    <span>
+      {displayName} ({locationId})
+    </span>
+  ) : (
+    <div className="flex w-full flex-row items-center gap-1">
+      <span>{displayName}</span> <Badge variant="info">{locationId}</Badge>
+    </div>
+  );
 
 const ADVANCED_ITEM_VALUE = "gcp-secret-manager-advanced";
 
@@ -76,7 +86,10 @@ export const GcpSyncFields = () => {
   const isCommittedGlobalSync = committedReplicaLocationIds.length > 0;
   const lockReplicaRegions = isCommittedGlobalSync && isGlobalScope;
 
-  const hasConfiguredReplicaRegions = isGlobalScope && (userReplicaLocationIds?.length ?? 0) > 0;
+  // locationId counts as configured: legacy Global syncs store their replica region there, and it
+  // is seeded into userReplicaLocationIds after mount, too late for the accordion's initial state.
+  const hasConfiguredReplicaRegions =
+    isGlobalScope && ((userReplicaLocationIds?.length ?? 0) > 0 || Boolean(locationId));
   const hasAccordionError = Boolean(
     formState.errors.destinationConfig &&
       "userReplicaLocationIds" in formState.errors.destinationConfig
@@ -86,9 +99,10 @@ export const GcpSyncFields = () => {
     hasConfiguredReplicaRegions || hasAccordionError ? ADVANCED_ITEM_VALUE : ""
   );
 
-  // Selects do not work well inside dynamic containers (e.g. Accordion)
-  // We use menuPortalTarget to ensure this is render correctly without
-  // hiding any option due to the container heigh.
+  // The accordion content clips its children (overflow-hidden for the height animation), so the
+  // select menu is portaled to the enclosing sheet. The ref must sit on a plain, always-mounted
+  // element: v3 components don't forward refs on React 18, and the accordion content only exists
+  // in the DOM while open.
   const containerRef = useRef<HTMLDivElement>(null);
   const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(null);
 
@@ -138,215 +152,217 @@ export const GcpSyncFields = () => {
   ]);
 
   return (
-    <FieldGroup ref={containerRef} className="min-h-0 flex-1">
-      <SecretSyncConnectionField
-        onChange={() => {
-          setValue("destinationConfig.projectId", "");
-          setValue("destinationConfig.locationId", "");
-          setValue("destinationConfig.userReplicaLocationIds", []);
-        }}
-      />
-      <Controller
-        name="destinationConfig.projectId"
-        control={control}
-        render={({ field: { value, onChange }, fieldState: { error } }) => (
-          <Field>
-            <FieldLabel>
-              Project
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Info />
-                </TooltipTrigger>
-                <TooltipContent className="max-w-md">
-                  Ensure that you&apos;ve enabled the Secret Manager API, Cloud Resource Manager
-                  API, and Service Usage API on your GCP project. Additionally, make sure that the
-                  service account is assigned the appropriate GCP roles.
-                </TooltipContent>
-              </Tooltip>
-            </FieldLabel>
-            <FieldContent>
-              <FilterableSelect
-                isLoading={isPending && Boolean(connectionId)}
-                isDisabled={!connectionId}
-                value={projects?.find((project) => project.id === value) ?? null}
-                onChange={(option) => {
-                  setValue("destinationConfig.locationId", "");
-                  setValue("destinationConfig.userReplicaLocationIds", []);
-                  onChange((option as SingleValue<TGcpProject>)?.id ?? null);
-                }}
-                options={projects}
-                placeholder="Select a GCP project..."
-                getOptionLabel={(option) => option.name}
-                getOptionValue={(option) => option.id.toString()}
-              />
-              <FieldError errors={[error]} />
-            </FieldContent>
-          </Field>
-        )}
-      />
-      <Controller
-        name="destinationConfig.scope"
-        control={control}
-        render={({ field: { value, onChange }, fieldState: { error } }) => (
-          <Field>
-            <FieldLabel>
-              Scope
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Info />
-                </TooltipTrigger>
-                <TooltipContent className="max-w-lg">
-                  <div className="flex flex-col gap-3">
-                    <p>
-                      Specify how Infisical should sync secrets to GCP. The following options are
-                      available:
-                    </p>
-                    <ul className="flex list-disc flex-col gap-3 pl-4">
-                      {Object.values(GCP_SYNC_SCOPES).map(({ name, description }) => (
-                        <li key={name}>
-                          <p className="text-mineshaft-300">
-                            <span className="font-medium text-bunker-200">{name}</span>:{" "}
-                            {description}
-                          </p>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </TooltipContent>
-              </Tooltip>
-            </FieldLabel>
-            <FieldContent>
-              <Select
-                value={value}
-                onValueChange={(val) => {
-                  onChange(val);
-                  setValue("destinationConfig.locationId", "");
-                  setValue("destinationConfig.userReplicaLocationIds", []);
-                }}
-                disabled={!projectId}
-              >
-                <SelectTrigger className="w-full capitalize" isError={Boolean(error)}>
-                  <SelectValue placeholder="Select a scope..." />
-                </SelectTrigger>
-                <SelectContent position="popper">
-                  {Object.values(GcpSyncScope).map((scope) => (
-                    <SelectItem className="capitalize" value={scope} key={scope}>
-                      {scope}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FieldError errors={[error]} />
-            </FieldContent>
-          </Field>
-        )}
-      />
-      {selectedScope === GcpSyncScope.Region && (
+    <div ref={containerRef} className="contents">
+      <FieldGroup className="min-h-0 flex-1">
+        <SecretSyncConnectionField
+          onChange={() => {
+            setValue("destinationConfig.projectId", "");
+            setValue("destinationConfig.locationId", "");
+            setValue("destinationConfig.userReplicaLocationIds", []);
+          }}
+        />
         <Controller
-          name="destinationConfig.locationId"
+          name="destinationConfig.projectId"
           control={control}
           render={({ field: { value, onChange }, fieldState: { error } }) => (
             <Field>
-              <FieldLabel>Region</FieldLabel>
+              <FieldLabel>
+                Project
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-md">
+                    Ensure that you&apos;ve enabled the Secret Manager API, Cloud Resource Manager
+                    API, and Service Usage API on your GCP project. Additionally, make sure that the
+                    service account is assigned the appropriate GCP roles.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
               <FieldContent>
                 <FilterableSelect
-                  isLoading={areLocationsPending && Boolean(projectId)}
-                  isDisabled={!projectId}
-                  value={locations?.find((option) => option.locationId === value) ?? null}
-                  onChange={(option) =>
-                    onChange((option as SingleValue<TGcpLocation>)?.locationId ?? "")
-                  }
-                  options={locations}
-                  placeholder="Select a region..."
-                  getOptionValue={(option) => option.locationId}
-                  formatOptionLabel={formatOptionLabel}
+                  isLoading={isPending && Boolean(connectionId)}
+                  isDisabled={!connectionId}
+                  value={projects?.find((project) => project.id === value) ?? null}
+                  onChange={(option) => {
+                    setValue("destinationConfig.locationId", "");
+                    setValue("destinationConfig.userReplicaLocationIds", []);
+                    onChange((option as SingleValue<TGcpProject>)?.id ?? null);
+                  }}
+                  options={projects}
+                  placeholder="Select a GCP project..."
+                  getOptionLabel={(option) => option.name}
+                  getOptionValue={(option) => option.id.toString()}
                 />
                 <FieldError errors={[error]} />
               </FieldContent>
             </Field>
           )}
         />
-      )}
-      {selectedScope === GcpSyncScope.Global && (
-        <Accordion
-          type="single"
-          collapsible
-          variant="ghost"
-          value={openItem}
-          onValueChange={setOpenItem}
-          className="flex min-h-0 flex-1 flex-col"
-        >
-          <AccordionItem
-            value={ADVANCED_ITEM_VALUE}
-            className="flex min-h-0 flex-1 flex-col [&>[data-slot=accordion-content]]:flex [&>[data-slot=accordion-content]]:min-h-0 [&>[data-slot=accordion-content]]:flex-1 [&>[data-slot=accordion-content]]:flex-col"
-          >
-            <AccordionTrigger>Advanced</AccordionTrigger>
-            <AccordionContent>
-              <Controller
-                name="destinationConfig.userReplicaLocationIds"
-                control={control}
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
-                  <Field>
-                    <FieldLabel>
-                      Replica Regions
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Info />
-                        </TooltipTrigger>
-                        <TooltipContent className="max-w-md">
-                          When set, secrets are replicated only in the selected regions. When empty,
-                          GCP automatically manages replication.
-                        </TooltipContent>
-                      </Tooltip>
-                    </FieldLabel>
-                    <FieldContent>
-                      <FilterableSelect
-                        isMulti
-                        isLoading={areLocationsPending && Boolean(projectId)}
-                        isDisabled={!projectId || lockReplicaRegions}
-                        isClearable={!lockReplicaRegions}
-                        value={
-                          locations?.filter((option) =>
-                            (value || []).includes(option.locationId)
-                          ) ?? []
-                        }
-                        onChange={(option) =>
-                          onChange((option as MultiValue<TGcpLocation>).map((o) => o.locationId))
-                        }
-                        options={locations}
-                        placeholder="Automatic replication"
-                        getOptionValue={(option) => option.locationId}
-                        formatOptionLabel={formatOptionLabel}
-                        menuPortalTarget={menuPortalTarget ?? undefined}
-                        menuPosition="fixed"
-                        menuPlacement="auto"
-                      />
-
-                      {(value?.length ?? 0) > 0 && (
-                        <Alert variant="warning">
-                          <TriangleAlert />
-                          <AlertTitle>
-                            Replica regions can&apos;t be changed after creation
-                          </AlertTitle>
-                          <AlertDescription>
-                            <p>
-                              Replica regions are fixed when the sync is created and cannot be
-                              changed later, since GCP does not support it. It is still possible to
-                              change the scope to <span className="font-medium">Region</span> and
-                              specify a region for the secret.
+        <Controller
+          name="destinationConfig.scope"
+          control={control}
+          render={({ field: { value, onChange }, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel>
+                Scope
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-lg">
+                    <div className="flex flex-col gap-3">
+                      <p>
+                        Specify how Infisical should sync secrets to GCP. The following options are
+                        available:
+                      </p>
+                      <ul className="flex list-disc flex-col gap-3 pl-4">
+                        {Object.values(GCP_SYNC_SCOPES).map(({ name, description }) => (
+                          <li key={name}>
+                            <p className="text-mineshaft-300">
+                              <span className="font-medium text-bunker-200">{name}</span>:{" "}
+                              {description}
                             </p>
-                          </AlertDescription>
-                        </Alert>
-                      )}
-                      <FieldError errors={[error]} />
-                    </FieldContent>
-                  </Field>
-                )}
-              />
-            </AccordionContent>
-          </AccordionItem>
-        </Accordion>
-      )}
-    </FieldGroup>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <FieldContent>
+                <Select
+                  value={value}
+                  onValueChange={(val) => {
+                    onChange(val);
+                    setValue("destinationConfig.locationId", "");
+                    setValue("destinationConfig.userReplicaLocationIds", []);
+                  }}
+                  disabled={!projectId}
+                >
+                  <SelectTrigger className="w-full capitalize" isError={Boolean(error)}>
+                    <SelectValue placeholder="Select a scope..." />
+                  </SelectTrigger>
+                  <SelectContent position="popper">
+                    {Object.values(GcpSyncScope).map((scope) => (
+                      <SelectItem className="capitalize" value={scope} key={scope}>
+                        {scope}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FieldError errors={[error]} />
+              </FieldContent>
+            </Field>
+          )}
+        />
+        {selectedScope === GcpSyncScope.Region && (
+          <Controller
+            name="destinationConfig.locationId"
+            control={control}
+            render={({ field: { value, onChange }, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel>Region</FieldLabel>
+                <FieldContent>
+                  <FilterableSelect
+                    isLoading={areLocationsPending && Boolean(projectId)}
+                    isDisabled={!projectId}
+                    value={locations?.find((option) => option.locationId === value) ?? null}
+                    onChange={(option) =>
+                      onChange((option as SingleValue<TGcpLocation>)?.locationId ?? "")
+                    }
+                    options={locations}
+                    placeholder="Select a region..."
+                    getOptionValue={(option) => option.locationId}
+                    formatOptionLabel={formatOptionLabel}
+                  />
+                  <FieldError errors={[error]} />
+                </FieldContent>
+              </Field>
+            )}
+          />
+        )}
+        {selectedScope === GcpSyncScope.Global && (
+          <Accordion
+            type="single"
+            collapsible
+            variant="ghost"
+            value={openItem}
+            onValueChange={setOpenItem}
+            className="flex min-h-0 flex-1 flex-col"
+          >
+            <AccordionItem
+              value={ADVANCED_ITEM_VALUE}
+              className="flex min-h-0 flex-1 flex-col [&>[data-slot=accordion-content]]:flex [&>[data-slot=accordion-content]]:min-h-0 [&>[data-slot=accordion-content]]:flex-1 [&>[data-slot=accordion-content]]:flex-col"
+            >
+              <AccordionTrigger>Advanced</AccordionTrigger>
+              <AccordionContent>
+                <Controller
+                  name="destinationConfig.userReplicaLocationIds"
+                  control={control}
+                  render={({ field: { value, onChange }, fieldState: { error } }) => (
+                    <Field>
+                      <FieldLabel>
+                        Replica Regions
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Info />
+                          </TooltipTrigger>
+                          <TooltipContent className="max-w-md">
+                            When set, secrets are replicated only in the selected regions. When
+                            empty, GCP automatically manages replication.
+                          </TooltipContent>
+                        </Tooltip>
+                      </FieldLabel>
+                      <FieldContent>
+                        <FilterableSelect
+                          isMulti
+                          isLoading={areLocationsPending && Boolean(projectId)}
+                          isDisabled={!projectId || lockReplicaRegions}
+                          isClearable={!lockReplicaRegions}
+                          value={
+                            locations?.filter((option) =>
+                              (value || []).includes(option.locationId)
+                            ) ?? []
+                          }
+                          onChange={(option) =>
+                            onChange((option as MultiValue<TGcpLocation>).map((o) => o.locationId))
+                          }
+                          options={locations}
+                          placeholder="Automatic replication"
+                          getOptionValue={(option) => option.locationId}
+                          formatOptionLabel={formatOptionLabel}
+                          menuPortalTarget={menuPortalTarget ?? undefined}
+                          menuPosition="fixed"
+                          menuPlacement="auto"
+                        />
+
+                        {(value?.length ?? 0) > 0 && (
+                          <Alert variant="warning" className="mt-2">
+                            <TriangleAlert />
+                            <AlertTitle>
+                              Replica regions can&apos;t be changed after creation
+                            </AlertTitle>
+                            <AlertDescription>
+                              <p>
+                                Replica regions are fixed when the sync is created and cannot be
+                                changed later, since GCP does not support it. It is still possible
+                                to change the scope to <span className="font-medium">Region</span>{" "}
+                                and specify a region for the secret.
+                              </p>
+                            </AlertDescription>
+                          </Alert>
+                        )}
+                        <FieldError errors={[error]} />
+                      </FieldContent>
+                    </Field>
+                  )}
+                />
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        )}
+      </FieldGroup>
+    </div>
   );
 };


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

We got a feedback that users were confused by the region option, so we are hiding it behind an "advanced" accordion.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="1918" height="874" alt="CleanShot 2026-08-06 at 13 01 46" src="https://github.com/user-attachments/assets/5dbfa700-0a49-4f86-a054-3ee258f3ae70" />

<img width="1918" height="874" alt="CleanShot 2026-08-06 at 13 02 07" src="https://github.com/user-attachments/assets/5759fb48-8c1f-456d-a102-e88c3aaa2e18" />


## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)