### PR TITLE
feat: removed deprecation banner for self serve customers

### DIFF
--- a/frontend/src/pages/organization/BillingV2Page/components/cards/ProductsCard.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/cards/ProductsCard.tsx
@@ -56,10 +56,7 @@ const ActiveProductCard = ({
   // "Commit annually and save" nudge: shown when the org holds this product monthly but hasn't set the
   // available commitment. Clicking opens the set-commitment flow. Hidden for enterprise-managed orgs.
   const commitNudge = readOnly || !selfServe ? null : commitSavingsNudge(entitlement);
-  // Every deprecation is presented as a retiring plan for now (see asPlanDeprecation).
-  const deprecation = !entitlement?.planTier?.includes("enterprise")
-    ? asPlanDeprecation(entitlement?.deprecation)
-    : null;
+  const deprecation = selfServe ? asPlanDeprecation(entitlement?.deprecation) : null;
   const isProductDeprecated = deprecation?.kind === "product";
   const isPlanDeprecated = deprecation?.kind === "plan";
 

--- a/frontend/src/pages/organization/BillingV2Page/components/deprecation/DeprecationBanners.tsx
+++ b/frontend/src/pages/organization/BillingV2Page/components/deprecation/DeprecationBanners.tsx
@@ -48,7 +48,7 @@ export const DeprecationBanners = ({
       return (a.deprecation.daysLeft ?? Infinity) - (b.deprecation.daysLeft ?? Infinity);
     });
 
-  if (entries.length === 0) {
+  if (entries.length === 0 || !overview.selfServe) {
     return null;
   }
 


### PR DESCRIPTION
## Context

This PR removes the deprecation banner or any deprecation notice in usage and billing for custom contract plans

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)