### PR TITLE
feat(dynamic-secrets): add shared provider form contract

### DIFF
--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFields.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFields.tsx
@@ -1,0 +1,181 @@
+import { Controller, FieldValues, useFormContext } from "react-hook-form";
+
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  TextArea
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+
+import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
+import { TDynamicSecretProviderField } from "./types";
+
+type Props<TValues extends FieldValues> = {
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+const getFieldId = (name: string) => `dynamic-secret-${name.replaceAll(".", "-")}`;
+
+export const DynamicSecretProviderFields = <TValues extends FieldValues>({
+  fields
+}: Props<TValues>) => {
+  const { control } = useFormContext<TValues>();
+
+  return (
+    <div className="@container">
+      <div className="grid grid-cols-1 gap-3 @xl:grid-cols-2">
+        {fields.map((fieldDefinition) => {
+          const inputId = getFieldId(fieldDefinition.name);
+          const descriptionId = `${inputId}-description`;
+          const errorId = `${inputId}-error`;
+
+          return (
+            <Controller
+              key={fieldDefinition.name}
+              control={control}
+              name={fieldDefinition.name}
+              render={({ field, fieldState: { error } }) => {
+                const value =
+                  typeof field.value === "string" || typeof field.value === "number"
+                    ? field.value
+                    : "";
+                const describedBy = [
+                  fieldDefinition.description ? descriptionId : undefined,
+                  error?.message ? errorId : undefined
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                let input;
+
+                if (fieldDefinition.type === "switch") {
+                  input = (
+                    <Switch
+                      ref={field.ref}
+                      id={inputId}
+                      variant="project"
+                      checked={Boolean(field.value)}
+                      onBlur={field.onBlur}
+                      onCheckedChange={field.onChange}
+                      disabled={fieldDefinition.isDisabled}
+                      aria-describedby={describedBy || undefined}
+                      aria-invalid={Boolean(error)}
+                    />
+                  );
+                } else if (fieldDefinition.type === "select") {
+                  input = (
+                    <Select
+                      value={String(value)}
+                      disabled={fieldDefinition.isDisabled}
+                      onValueChange={(nextValue) => {
+                        // Radix Select can emit an empty change while options mount.
+                        if (!nextValue || nextValue === String(value)) return;
+                        field.onChange(nextValue);
+                      }}
+                    >
+                      <SelectTrigger
+                        ref={field.ref}
+                        id={inputId}
+                        onBlur={field.onBlur}
+                        isError={Boolean(error)}
+                        aria-describedby={describedBy || undefined}
+                        className="w-full"
+                      >
+                        <SelectValue placeholder={fieldDefinition.placeholder} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {fieldDefinition.options.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  );
+                } else if (fieldDefinition.type === "textarea") {
+                  input = (
+                    <TextArea
+                      ref={field.ref}
+                      id={inputId}
+                      name={field.name}
+                      value={value}
+                      onBlur={field.onBlur}
+                      onChange={field.onChange}
+                      rows={fieldDefinition.rows}
+                      placeholder={fieldDefinition.placeholder}
+                      disabled={fieldDefinition.isDisabled}
+                      isError={Boolean(error)}
+                      aria-describedby={describedBy || undefined}
+                    />
+                  );
+                } else {
+                  const isNumber = fieldDefinition.type === "number";
+                  let inputType = "text";
+                  if (isNumber) inputType = "number";
+                  if (fieldDefinition.type === "secret") inputType = "password";
+                  input = (
+                    <Input
+                      ref={field.ref}
+                      id={inputId}
+                      name={field.name}
+                      value={value}
+                      onBlur={field.onBlur}
+                      onChange={
+                        isNumber
+                          ? (event) =>
+                              field.onChange(
+                                parseDynamicSecretProviderNumberInput(event.currentTarget.value)
+                              )
+                          : field.onChange
+                      }
+                      type={inputType}
+                      autoComplete={
+                        fieldDefinition.type === "number" ? undefined : fieldDefinition.autoComplete
+                      }
+                      min={isNumber ? fieldDefinition.min : undefined}
+                      max={isNumber ? fieldDefinition.max : undefined}
+                      step={isNumber ? fieldDefinition.step : undefined}
+                      placeholder={fieldDefinition.placeholder}
+                      disabled={fieldDefinition.isDisabled}
+                      isError={Boolean(error)}
+                      aria-describedby={describedBy || undefined}
+                    />
+                  );
+                }
+
+                return (
+                  <Field
+                    data-invalid={Boolean(error)}
+                    className={cn(fieldDefinition.layout !== "half" && "@xl:col-span-2")}
+                  >
+                    <FieldLabel htmlFor={inputId}>
+                      {fieldDefinition.label}
+                      {fieldDefinition.isOptional && (
+                        <span className="font-normal text-muted">(optional)</span>
+                      )}
+                    </FieldLabel>
+                    {input}
+                    {fieldDefinition.description && (
+                      <FieldDescription id={descriptionId}>
+                        {fieldDefinition.description}
+                      </FieldDescription>
+                    )}
+                    {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+                  </Field>
+                );
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
@@ -23,6 +23,7 @@ import { cn } from "@app/components/v3/utils";
 import { useCreateDynamicSecret, useUpdateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
 
+import { submitDynamicSecretCreatePayloads } from "./createSubmission";
 import { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
 import {
   TCreateDynamicSecretProviderFormContext,
@@ -189,10 +190,21 @@ export const DynamicSecretProviderForm = <
         context as TCreateDynamicSecretProviderFormContext
       );
       const payloads = "provider" in payload ? [payload] : payload;
-      const results = await Promise.all(
-        payloads.map((item) => createDynamicSecret.mutateAsync(item))
+      const { successfulResults, failedCount } = await submitDynamicSecretCreatePayloads(
+        payloads,
+        (item) => createDynamicSecret.mutateAsync(item)
       );
-      onCompleted(results.length === 1 ? results[0] : results);
+
+      if (successfulResults.length === 0) return;
+
+      if (failedCount > 0) {
+        createNotification({
+          type: "warning",
+          text: `Created ${successfulResults.length} of ${payloads.length} dynamic secrets. Review the created secrets before retrying failed items.`
+        });
+      }
+
+      onCompleted(successfulResults.length === 1 ? successfulResults[0] : successfulResults);
       return;
     }
 

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
@@ -1,0 +1,464 @@
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import {
+  Controller,
+  DefaultValues,
+  FormProvider,
+  Resolver,
+  SubmitHandler,
+  useForm
+} from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FilterableSelect,
+  Input
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+import { useCreateDynamicSecret, useUpdateDynamicSecret } from "@app/hooks/api";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
+import {
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretFormEnvironment,
+  TDynamicSecretProviderDefinition,
+  TDynamicSecretProviderFormItem,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+type TCreateProps<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = TCreateDynamicSecretProviderFormContext & {
+  mode: "create";
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  onCompleted: (result?: unknown) => void;
+  onCancel: () => void;
+  onBack?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  header?: ReactNode;
+};
+
+type TEditProps<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = TEditDynamicSecretProviderFormContext & {
+  mode: "edit";
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  onCompleted: (result?: unknown) => void;
+  onCancel: () => void;
+  onBack?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  header?: ReactNode;
+};
+
+type Props<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> =
+  | TCreateProps<TProvider, TCreateValues, TEditValues>
+  | TEditProps<TProvider, TCreateValues, TEditValues>;
+
+const EMPTY_ENVIRONMENTS: TCreateDynamicSecretProviderFormContext["environments"] = [];
+
+export const DynamicSecretProviderForm = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+>(
+  props: Props<TProvider, TCreateValues, TEditValues>
+) => {
+  type TValues = TCreateValues | TEditValues;
+  const {
+    definition,
+    mode,
+    onCancel,
+    onBack,
+    onCompleted,
+    onDirtyChange,
+    projectSlug,
+    secretPath,
+    header
+  } = props;
+  const createDynamicSecret = useCreateDynamicSecret();
+  const updateDynamicSecret = useUpdateDynamicSecret();
+  const [providerSubmitState, setProviderSubmitState] = useState({
+    isDisabled: false,
+    isPending: false
+  });
+
+  let environments = EMPTY_ENVIRONMENTS;
+  let isSingleEnvironmentMode = false;
+  let editDynamicSecret: TEditDynamicSecretProviderFormContext["dynamicSecret"] | undefined;
+  let editEnvironment: string | undefined;
+
+  if (mode === "create") {
+    ({ environments, isSingleEnvironmentMode = false } = props);
+  } else {
+    const { dynamicSecret, environment } = props;
+    editDynamicSecret = dynamicSecret;
+    editEnvironment = environment;
+  }
+
+  const context = useMemo<
+    TCreateDynamicSecretProviderFormContext | TEditDynamicSecretProviderFormContext
+  >(
+    () =>
+      mode === "create"
+        ? { projectSlug, secretPath, environments, isSingleEnvironmentMode }
+        : {
+            projectSlug,
+            secretPath,
+            dynamicSecret:
+              editDynamicSecret as TEditDynamicSecretProviderFormContext["dynamicSecret"],
+            environment: editEnvironment as string
+          },
+    [
+      editDynamicSecret,
+      editEnvironment,
+      environments,
+      isSingleEnvironmentMode,
+      mode,
+      projectSlug,
+      secretPath
+    ]
+  );
+
+  const schema = mode === "create" ? definition.create.schema : definition.edit.schema;
+  const defaultValues = useMemo(
+    () =>
+      mode === "create"
+        ? definition.create.getDefaultValues(context as TCreateDynamicSecretProviderFormContext)
+        : definition.edit.getDefaultValues(context as TEditDynamicSecretProviderFormContext),
+    [context, definition, mode]
+  );
+
+  const form = useForm<TValues>({
+    resolver: zodResolver(schema) as Resolver<TValues>,
+    defaultValues: defaultValues as DefaultValues<TValues>,
+    values: mode === "edit" ? (defaultValues as TValues) : undefined,
+    shouldFocusError: true
+  });
+  const [hasDirtyBaseline, setHasDirtyBaseline] = useState(false);
+
+  // Re-baseline after mount-time controlled-input synchronization so prefills
+  // never trigger an unsaved-change guard.
+  useEffect(() => {
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      if (cancelled) return;
+      form.reset(form.getValues());
+      setHasDirtyBaseline(true);
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [form]);
+
+  useEffect(() => {
+    if (!hasDirtyBaseline) {
+      onDirtyChange?.(false);
+      return undefined;
+    }
+    onDirtyChange?.(form.formState.isDirty);
+    return () => onDirtyChange?.(false);
+  }, [hasDirtyBaseline, form.formState.isDirty, onDirtyChange]);
+
+  const isPending =
+    form.formState.isSubmitting ||
+    providerSubmitState.isPending ||
+    (mode === "create" ? createDynamicSecret.isPending : updateDynamicSecret.isPending);
+
+  const handleSubmit: SubmitHandler<TValues> = async (values) => {
+    if (isPending) return;
+
+    if (mode === "create") {
+      const payload = definition.create.toPayload(
+        values as TCreateValues,
+        context as TCreateDynamicSecretProviderFormContext
+      );
+      const payloads = "provider" in payload ? [payload] : payload;
+      const results = await Promise.all(
+        payloads.map((item) => createDynamicSecret.mutateAsync(item))
+      );
+      onCompleted(results.length === 1 ? results[0] : results);
+      return;
+    }
+
+    const payload = definition.edit.toPayload(
+      values as TEditValues,
+      context as TEditDynamicSecretProviderFormContext
+    );
+    const result = await updateDynamicSecret.mutateAsync(payload);
+    onCompleted(result);
+    createNotification({
+      type: "success",
+      text: definition.edit.successMessage
+    });
+  };
+
+  const modeDefinition = mode === "create" ? definition.create : definition.edit;
+  const fields = modeDefinition.fields ?? definition.fields;
+  const CustomRenderer = (modeDefinition.customRenderer ?? definition.customRenderer)?.Component;
+  const { commonFields } = modeDefinition;
+  const ttlFieldCount =
+    Number(commonFields?.defaultTTL?.isVisible !== false) +
+    Number(commonFields?.maxTTL?.isVisible !== false);
+  let commonFieldGrid = "@2xl:grid-cols-[minmax(0,1fr)_8rem_8rem]";
+  if (ttlFieldCount === 0) commonFieldGrid = "@2xl:grid-cols-1";
+  if (ttlFieldCount === 1) commonFieldGrid = "@2xl:grid-cols-[minmax(0,1fr)_8rem]";
+  const nameError = form.formState.errors.name;
+  const defaultTtlError = form.formState.errors.defaultTTL;
+  const maxTtlError = form.formState.errors.maxTTL;
+
+  return (
+    <FormProvider {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        autoComplete="off"
+        noValidate
+        data-slot="dynamic-secret-provider-form"
+        className="@container flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        <div className="flex min-h-0 thin-scrollbar flex-1 flex-col gap-5 overflow-y-auto px-4 py-5">
+          {header}
+          <section className="flex flex-col gap-4" aria-label="Dynamic secret details">
+            <div className={cn("grid grid-cols-1 gap-3", commonFieldGrid)}>
+              {commonFields?.name?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"name" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(nameError)}>
+                      <FieldLabel htmlFor="dynamic-secret-name">
+                        {commonFields?.name?.label ?? "Secret Name"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-name"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        placeholder="dynamic-secret"
+                        isError={Boolean(nameError)}
+                        aria-describedby={nameError ? "dynamic-secret-name-error" : undefined}
+                        disabled={commonFields?.name?.isDisabled}
+                      />
+                      {nameError?.message && (
+                        <FieldError id="dynamic-secret-name-error">
+                          {nameError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+              {commonFields?.defaultTTL?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"defaultTTL" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(defaultTtlError)}>
+                      <FieldLabel htmlFor="dynamic-secret-default-ttl">
+                        {commonFields?.defaultTTL?.label ?? "Default TTL"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-default-ttl"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        isError={Boolean(defaultTtlError)}
+                        aria-describedby={
+                          [
+                            commonFields?.defaultTTL?.description
+                              ? "dynamic-secret-default-ttl-description"
+                              : undefined,
+                            defaultTtlError ? "dynamic-secret-default-ttl-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                        disabled={commonFields?.defaultTTL?.isDisabled}
+                      />
+                      {commonFields?.defaultTTL?.description && (
+                        <FieldDescription id="dynamic-secret-default-ttl-description">
+                          {commonFields.defaultTTL.description}
+                        </FieldDescription>
+                      )}
+                      {defaultTtlError?.message && (
+                        <FieldError id="dynamic-secret-default-ttl-error">
+                          {defaultTtlError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+              {commonFields?.maxTTL?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"maxTTL" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(maxTtlError)}>
+                      <FieldLabel htmlFor="dynamic-secret-max-ttl">
+                        {commonFields?.maxTTL?.label ?? "Max TTL"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-max-ttl"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        isError={Boolean(maxTtlError)}
+                        aria-describedby={
+                          [
+                            commonFields?.maxTTL?.description
+                              ? "dynamic-secret-max-ttl-description"
+                              : undefined,
+                            maxTtlError ? "dynamic-secret-max-ttl-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                        disabled={commonFields?.maxTTL?.isDisabled}
+                      />
+                      {commonFields?.maxTTL?.description && (
+                        <FieldDescription id="dynamic-secret-max-ttl-description">
+                          {commonFields.maxTTL.description}
+                        </FieldDescription>
+                      )}
+                      {maxTtlError?.message && (
+                        <FieldError id="dynamic-secret-max-ttl-error">
+                          {maxTtlError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+            </div>
+            {mode === "create" &&
+              !isSingleEnvironmentMode &&
+              commonFields?.environment?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"environment" as never}
+                  render={({ field, fieldState: { error } }) => (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor="dynamic-secret-environment">
+                        {commonFields?.environment?.label ?? "Environment"}
+                      </FieldLabel>
+                      <FilterableSelect<TDynamicSecretFormEnvironment>
+                        inputId="dynamic-secret-environment"
+                        options={environments}
+                        value={(field.value as TDynamicSecretFormEnvironment | undefined) ?? null}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        getOptionLabel={(option) => option.name}
+                        getOptionValue={(option) => option.slug}
+                        placeholder="Select the environment to create the secret in..."
+                        isDisabled={commonFields?.environment?.isDisabled}
+                        isError={Boolean(error)}
+                        aria-describedby={
+                          [
+                            commonFields?.environment?.description
+                              ? "dynamic-secret-environment-description"
+                              : undefined,
+                            error ? "dynamic-secret-environment-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                      />
+                      {commonFields?.environment?.description && (
+                        <FieldDescription id="dynamic-secret-environment-description">
+                          {commonFields.environment.description}
+                        </FieldDescription>
+                      )}
+                      {error?.message && (
+                        <FieldError id="dynamic-secret-environment-error">
+                          {error.message}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+          </section>
+
+          <section
+            className="flex flex-col gap-4"
+            aria-labelledby={
+              commonFields?.configurationHeading !== false
+                ? "dynamic-secret-configuration-heading"
+                : undefined
+            }
+          >
+            {commonFields?.configurationHeading !== false && (
+              <h3 id="dynamic-secret-configuration-heading" className="text-base font-medium">
+                {commonFields?.configurationHeading ?? "Configuration"}
+              </h3>
+            )}
+            {fields && (
+              <DynamicSecretProviderFormItems
+                items={fields as readonly TDynamicSecretProviderFormItem<TValues>[]}
+              />
+            )}
+            {CustomRenderer && (
+              <CustomRenderer
+                mode={mode}
+                context={context}
+                setSubmitState={(state) =>
+                  setProviderSubmitState((current) => ({ ...current, ...state }))
+                }
+              />
+            )}
+          </section>
+        </div>
+
+        <div
+          data-slot="dynamic-secret-provider-form-footer"
+          className="flex shrink-0 flex-col-reverse gap-2 border-t border-border px-4 py-3 @sm:flex-row @sm:items-center @sm:justify-end"
+        >
+          {onBack && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="@sm:mr-auto"
+              onClick={onBack}
+              isDisabled={isPending}
+            >
+              Back
+            </Button>
+          )}
+          <Button type="button" variant="ghost" onClick={onCancel} isDisabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="project"
+            isPending={isPending}
+            isDisabled={providerSubmitState.isDisabled || isPending}
+          >
+            {mode === "create" ? definition.create.submitLabel : definition.edit.submitLabel}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFormItems.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFormItems.tsx
@@ -1,0 +1,102 @@
+import { FieldValues } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "./DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "./DynamicSecretProviderGroup";
+import {
+  isDynamicSecretProviderFieldGroup,
+  TDynamicSecretProviderField,
+  TDynamicSecretProviderFieldGroup,
+  TDynamicSecretProviderFormItem
+} from "./types";
+
+type Props<TValues extends FieldValues> = {
+  items: readonly TDynamicSecretProviderFormItem<TValues>[];
+};
+
+type FormSegment<TValues extends FieldValues> =
+  | { type: "fields"; fields: TDynamicSecretProviderField<TValues>[] }
+  | { type: "group"; group: TDynamicSecretProviderFieldGroup<TValues> };
+
+const segmentFormItems = <TValues extends FieldValues>(
+  items: readonly TDynamicSecretProviderFormItem<TValues>[]
+): FormSegment<TValues>[] => {
+  const segments: FormSegment<TValues>[] = [];
+  let fieldBuffer: TDynamicSecretProviderField<TValues>[] = [];
+
+  const flushFields = () => {
+    if (fieldBuffer.length === 0) return;
+    segments.push({ type: "fields", fields: fieldBuffer });
+    fieldBuffer = [];
+  };
+
+  items.forEach((item) => {
+    if (isDynamicSecretProviderFieldGroup(item)) {
+      flushFields();
+      segments.push({ type: "group", group: item });
+      return;
+    }
+    fieldBuffer.push(item);
+  });
+
+  flushFields();
+  return segments;
+};
+
+const FieldGroup = <TValues extends FieldValues>({
+  group
+}: {
+  group: TDynamicSecretProviderFieldGroup<TValues>;
+}) => {
+  const fields = <DynamicSecretProviderFields fields={group.fields} />;
+
+  if (group.presentation === "collapse") {
+    return (
+      <DynamicSecretProviderGroup
+        id={group.id}
+        presentation="collapse"
+        title={group.title}
+        description={group.description}
+      >
+        {fields}
+      </DynamicSecretProviderGroup>
+    );
+  }
+
+  return (
+    <DynamicSecretProviderGroup
+      id={group.id}
+      presentation="panel"
+      title={group.title}
+      description={group.description}
+      surface={group.surface ?? Boolean(group.title)}
+    >
+      {fields}
+    </DynamicSecretProviderGroup>
+  );
+};
+
+/** Renders a mix of flat fields and panel/collapse groups under Configuration. */
+export const DynamicSecretProviderFormItems = <TValues extends FieldValues>({
+  items
+}: Props<TValues>) => {
+  const segments = segmentFormItems(items);
+
+  return (
+    <>
+      {segments.map((segment, index) => {
+        if (segment.type === "fields") {
+          return (
+            <DynamicSecretProviderFields
+              // Consecutive flat fields share one grid; index is stable for a given items array.
+              // eslint-disable-next-line react/no-array-index-key
+              key={`fields-${index}`}
+              fields={segment.fields}
+            />
+          );
+        }
+
+        return <FieldGroup key={segment.group.id} group={segment.group} />;
+      })}
+    </>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderGroup.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderGroup.tsx
@@ -1,0 +1,116 @@
+import { ReactNode } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  FieldDescription,
+  FieldLegend,
+  FieldSet
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+
+import { TDynamicSecretProviderFieldGroupPresentation } from "./types";
+
+const GROUP_SURFACE_CLASSNAME = "rounded-md border border-border bg-container p-3 text-foreground";
+
+type PanelProps = {
+  presentation?: "panel";
+  title?: string;
+  description?: string;
+  id: string;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  surface?: boolean;
+};
+
+type CollapseProps = {
+  presentation: "collapse";
+  title: string;
+  description?: string;
+  id: string;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export type DynamicSecretProviderGroupProps = PanelProps | CollapseProps;
+
+/** Sheet-agnostic field clustering for provider forms. */
+export const DynamicSecretProviderGroup = (props: DynamicSecretProviderGroupProps) => {
+  const { presentation } = props;
+
+  if (presentation === "collapse") {
+    const {
+      id,
+      title,
+      description,
+      children,
+      className,
+      contentClassName,
+      defaultOpen,
+      open,
+      onOpenChange
+    } = props;
+    const descriptionId = `${id}-description`;
+    const controlledProps =
+      open === undefined
+        ? { defaultValue: defaultOpen ? id : undefined }
+        : {
+            value: open ? id : "",
+            onValueChange: (value: string) => onOpenChange?.(value === id)
+          };
+
+    return (
+      <Accordion
+        type="single"
+        collapsible
+        variant="ghost"
+        className={className}
+        {...controlledProps}
+      >
+        <AccordionItem value={id}>
+          <AccordionTrigger aria-describedby={description ? descriptionId : undefined}>
+            {title}
+          </AccordionTrigger>
+          <AccordionContent className={cn("flex flex-col gap-4", contentClassName)}>
+            {description ? (
+              <FieldDescription id={descriptionId}>{description}</FieldDescription>
+            ) : null}
+            {children}
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+  }
+
+  const { id, title, description, children, className, contentClassName, surface = false } = props;
+  const descriptionId = `${id}-description`;
+  const hasHeading = Boolean(title || description);
+
+  return (
+    <div
+      data-slot="dynamic-secret-provider-group"
+      data-presentation={"panel" satisfies TDynamicSecretProviderFieldGroupPresentation}
+      data-surface={surface ? "true" : "false"}
+      className={cn(surface && GROUP_SURFACE_CLASSNAME, className)}
+    >
+      {hasHeading ? (
+        <FieldSet className={contentClassName}>
+          {title ? <FieldLegend>{title}</FieldLegend> : null}
+          {description ? (
+            <FieldDescription id={descriptionId}>{description}</FieldDescription>
+          ) : null}
+          {children}
+        </FieldSet>
+      ) : (
+        <div className={cn("flex flex-col gap-4", contentClassName)}>{children}</div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
@@ -40,6 +40,7 @@ export const dynamicSecretProviderRegistry = createDynamicSecretProviderRegistry
 
 - Scalar number controls convert the browser string to a finite number before React Hook Form and `z.number()` validation see it. Clearing a numeric field emits `undefined` rather than accidental zero.
 - Secret controls preserve the supplied value and mask it with `type="password"`; edit defaults and adapters decide whether a masked value is sent unchanged.
+- Multi-create adapters may return several payloads. The shell settles the full batch, closes after any partial success to prevent accidental duplicate retries, and reports the exact success count.
 - Groups are sheet-agnostic. Panels use fieldset semantics, and collapsible groups use the shared V3 Accordion.
 - A custom renderer must declare at least one objective reason such as `repeatable-fields`, `remote-options`, `permission-aware-fields`, or `non-scalar-value`.
 - A custom renderer reads and writes the surrounding `FormProvider`; the shared shell still validates and submits the definition's adapter.

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
@@ -1,0 +1,76 @@
+# Dynamic-secret provider form contract
+
+The shared contract keeps one create/edit form shell while leaving provider validation, defaults, hydration, and request adapters with each provider definition. The foundation is intentionally provider-neutral: legacy providers keep their existing forms until a rollout ticket registers a replacement.
+
+## Ownership boundaries
+
+| Boundary | Owns | Does not own |
+| --- | --- | --- |
+| Form shell | Name, TTL, environment, submit/cancel behavior, pending state, mutation wiring, and first-invalid-field focus | Provider queries, conditional behavior, or DTO semantics |
+| Provider definition | Mode-specific schemas, defaults, scalar fields, custom-renderer reasons, and payload adapters | A second form or mutation ownership |
+| Registry composition | Immutable definition lookup, picker order, documentation slugs, and duplicate rejection | Production provider definitions |
+| Scalar renderer | V3 text, secret, number, textarea, select, and switch controls | Repeaters, remote options, imports, gateways, or nested editors |
+| Custom renderer | Explicit non-scalar or context-aware interaction inside shared React Hook Form state | Submitting, bypassing schemas, or duplicating common fields |
+
+Create and edit values are deliberately separate. That distinction preserves masked edit values, editable names, nullable gateway detachment, create-time omission, and provider-specific hydration without weakening types across modes.
+
+## Registering a provider batch
+
+Each rollout ticket owns a batch-local module. It imports the concrete definitions it migrated and exports only the shared registration contract:
+
+```ts
+export const identityAccessDynamicSecretProviders = defineDynamicSecretProviderModule({
+  id: "identity-access",
+  definitions: [awsIamDynamicSecretProvider, gcpIamDynamicSecretProvider]
+});
+```
+
+The production composition root combines completed batches:
+
+```ts
+export const dynamicSecretProviderRegistry = createDynamicSecretProviderRegistry(
+  identityAccessDynamicSecretProviders,
+  managedStoresDynamicSecretProviders
+);
+```
+
+`getDefinition(provider)` returns `undefined` for an unmigrated provider so routers can retain the existing legacy path during incremental rollout. `requireDefinition(provider)` is for code paths that already proved registration. Duplicate module IDs and duplicate providers fail during composition instead of silently overriding a definition.
+
+## Field and renderer contract
+
+- Scalar number controls convert the browser string to a finite number before React Hook Form and `z.number()` validation see it. Clearing a numeric field emits `undefined` rather than accidental zero.
+- Secret controls preserve the supplied value and mask it with `type="password"`; edit defaults and adapters decide whether a masked value is sent unchanged.
+- Groups are sheet-agnostic. Panels use fieldset semantics, and collapsible groups use the shared V3 Accordion.
+- A custom renderer must declare at least one objective reason such as `repeatable-fields`, `remote-options`, `permission-aware-fields`, or `non-scalar-value`.
+- A custom renderer reads and writes the surrounding `FormProvider`; the shared shell still validates and submits the definition's adapter.
+
+## Shared normalization
+
+- `{{randomUsername}}` is omitted on create and sent as `null` on edit unless a provider deliberately overrides that behavior.
+- A cleared gateway normalizes to `undefined` on create and `null` on edit.
+- Standard TTL validation retains the existing one-minute minimum, ten-year maximum, and user-facing messages.
+- Single-environment create defaults belong in the provider's `getDefaultValues`; multi-environment create keeps the environment field visible. Edit uses its route environment.
+
+## Checkpoint provenance and departures
+
+This foundation adapts the core contract from checkpoint commit `2eca032d7dc` without merging or cherry-picking the checkpoint.
+
+| Checkpoint area | Disposition |
+| --- | --- |
+| `types.ts`, `schemas.ts`, scalar fields, form items, and shared controls | Adapted to current main |
+| `DynamicSecretProviderForm.tsx` | Rewritten as a sheet-agnostic shell; dynamic-secret sheet, lease, renew, and post-create overlay work remain out of scope |
+| `DynamicSecretProviderGroup.tsx` | Rewritten to compose the existing V3 Accordion rather than the checkpoint-only sheet section |
+| `providerDefinitions/registry.ts` | Rewritten as immutable module composition so rollout batches do not edit core architecture |
+| Number input handling | Rewritten to emit numbers before validation, resolving the unresolved PR #7529 finding |
+| Production provider definitions and provider-family tests | Rejected from this foundation; owned by ENG-5513 through ENG-5516 |
+| Route removal, Overview redesign, sheet/lease work, and unrelated primitive changes | Rejected as outside ENG-5518 |
+
+## Verification
+
+The reusable Node test harness lives in `providerContractTestHarness.ts`. The adjacent contract test uses only a test-local provider definition and covers scalar metadata, numeric parsing, masked edit defaults, environment and TTL defaults, validation, create/edit adapters, gateway and username-template normalization, nested values, registry composition, and a custom-renderer escape hatch.
+
+Run it from `frontend/`:
+
+```sh
+TSX_TSCONFIG_PATH=tsconfig.app.json ./node_modules/.bin/tsx --test src/components/dynamic-secrets/DynamicSecretProviderForm/*.test.ts
+```

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/createSubmission.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/createSubmission.ts
@@ -1,0 +1,23 @@
+export type TDynamicSecretCreateSubmissionResult<TResult> = {
+  successfulResults: TResult[];
+  failedCount: number;
+};
+
+/**
+ * Settle an entire provider-owned create batch so the form can distinguish a
+ * total failure from partial success and avoid resubmitting completed items.
+ */
+export const submitDynamicSecretCreatePayloads = async <TPayload, TResult>(
+  payloads: readonly TPayload[],
+  submit: (payload: TPayload) => Promise<TResult>
+): Promise<TDynamicSecretCreateSubmissionResult<TResult>> => {
+  const settledResults = await Promise.allSettled(payloads.map((payload) => submit(payload)));
+  const successfulResults = settledResults.flatMap((result) =>
+    result.status === "fulfilled" ? [result.value] : []
+  );
+
+  return {
+    successfulResults,
+    failedCount: settledResults.length - successfulResults.length
+  };
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { DynamicSecretProviders, SqlProviders } from "@app/hooks/api/dynamicSecret/types";
 
+import { submitDynamicSecretCreatePayloads } from "./createSubmission";
 import { testDynamicSecretProviderContract } from "./providerContractTestHarness";
 import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
 import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
@@ -371,11 +372,26 @@ describe("shared dynamic-secret scalar behavior", () => {
 
 describe("shared dynamic-secret normalization", () => {
   it("preserves TTL bounds and messages", () => {
+    const missingDefault = createFormSchema.safeParse({ ...createValues, defaultTTL: "" });
+    const malformedDefault = createFormSchema.safeParse({ ...createValues, defaultTTL: "abc" });
+    const malformedMaximum = createFormSchema.safeParse({ ...createValues, maxTTL: "abc" });
     const belowMinimum = createFormSchema.safeParse({ ...createValues, defaultTTL: "30s" });
     const aboveMaximum = createFormSchema.safeParse({ ...createValues, defaultTTL: "11y" });
 
+    assert.equal(missingDefault.success, false);
+    assert.equal(malformedDefault.success, false);
+    assert.equal(malformedMaximum.success, false);
     assert.equal(belowMinimum.success, false);
     assert.equal(aboveMaximum.success, false);
+    if (!missingDefault.success) {
+      assert.equal(missingDefault.error.issues[0]?.message, "TTL is required");
+    }
+    if (!malformedDefault.success) {
+      assert.equal(malformedDefault.error.issues[0]?.message, "TTL must be a valid duration");
+    }
+    if (!malformedMaximum.success) {
+      assert.equal(malformedMaximum.error.issues[0]?.message, "TTL must be a valid duration");
+    }
     if (!belowMinimum.success) {
       assert.equal(belowMinimum.error.issues[0]?.message, "TTL must be a greater than 1min");
     }
@@ -396,6 +412,23 @@ describe("shared dynamic-secret normalization", () => {
     assert.equal(normalizeDynamicSecretGatewayValueForMode("create", null), undefined);
     assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", null), null);
     assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", "gateway-id"), "gateway-id");
+  });
+});
+
+describe("shared dynamic-secret create submission", () => {
+  it("reports partial success without rejecting completed items", async () => {
+    const attemptedPayloads: number[] = [];
+    const result = await submitDynamicSecretCreatePayloads([1, 2, 3], async (payload) => {
+      attemptedPayloads.push(payload);
+      if (payload === 2) throw new Error("create failed");
+      return `created-${payload}`;
+    });
+
+    assert.deepEqual(attemptedPayloads, [1, 2, 3]);
+    assert.deepEqual(result, {
+      successfulResults: ["created-1", "created-3"],
+      failedCount: 1
+    });
   });
 });
 

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
@@ -1,0 +1,436 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { z } from "zod";
+
+import { DynamicSecretProviders, SqlProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { testDynamicSecretProviderContract } from "./providerContractTestHarness";
+import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
+import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretGatewayValueForMode,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "./schemas";
+import {
+  defineDynamicSecretProvider,
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+const createInputsSchema = z.object({
+  host: z.string().min(1, "Host is required"),
+  port: z.number().int().positive(),
+  password: z.string().min(1, "Password is required"),
+  engine: z.literal("postgres"),
+  enabled: z.boolean(),
+  connection: z.object({
+    gatewayId: z.string().optional(),
+    gatewayPoolId: z.string().optional()
+  }),
+  statements: z.object({
+    creation: z.string().min(1),
+    revocation: z.string().min(1)
+  })
+});
+
+const editInputsSchema = createInputsSchema.extend({
+  connection: z.object({
+    gatewayId: z.string().nullable().optional(),
+    gatewayPoolId: z.string().nullable().optional()
+  })
+});
+
+const createFormSchema = createDynamicSecretProviderFormSchema(createInputsSchema);
+const editFormSchema = editDynamicSecretProviderFormSchema(editInputsSchema);
+
+type TCreateFixtureValues = z.infer<typeof createFormSchema>;
+type TEditFixtureValues = z.infer<typeof editFormSchema>;
+
+const FixtureCustomRenderer = () => null;
+
+const fixtureDefinition = defineDynamicSecretProvider<
+  DynamicSecretProviders.SqlDatabase,
+  TCreateFixtureValues,
+  TEditFixtureValues
+>({
+  provider: DynamicSecretProviders.SqlDatabase,
+  label: "Test SQL",
+  fields: [
+    { name: "inputs.host", type: "text", label: "Host", layout: "half" },
+    { name: "inputs.port", type: "number", label: "Port", layout: "half", min: 1 },
+    {
+      name: "inputs.password",
+      type: "secret",
+      label: "Password",
+      autoComplete: "new-password"
+    },
+    {
+      name: "inputs.engine",
+      type: "select",
+      label: "Engine",
+      options: [{ label: "PostgreSQL", value: "postgres" }]
+    },
+    { name: "inputs.enabled", type: "switch", label: "Enabled" },
+    {
+      kind: "group",
+      id: "statements",
+      presentation: "collapse",
+      title: "Statements",
+      fields: [
+        { name: "inputs.statements.creation", type: "textarea", label: "Creation Statement" },
+        { name: "inputs.statements.revocation", type: "textarea", label: "Revocation Statement" }
+      ]
+    }
+  ],
+  customRenderer: {
+    reasons: ["remote-options", "non-scalar-value"],
+    Component: FixtureCustomRenderer
+  },
+  create: {
+    schema: createFormSchema,
+    getDefaultValues: (context) => ({
+      name: "",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: {
+        host: "",
+        port: 5432,
+        password: "",
+        engine: "postgres",
+        enabled: true,
+        connection: {
+          gatewayId: undefined,
+          gatewayPoolId: undefined
+        },
+        statements: {
+          creation: "CREATE USER",
+          revocation: "DROP USER"
+        }
+      }
+    }),
+    toPayload: (values, context) => {
+      const gatewayId = normalizeDynamicSecretGatewayValueForMode(
+        "create",
+        values.inputs.connection.gatewayId
+      );
+      const usernameTemplate = normalizeDynamicSecretUsernameTemplateForCreate(
+        values.usernameTemplate
+      );
+
+      return {
+        projectSlug: context.projectSlug,
+        path: context.secretPath,
+        name: values.name,
+        environmentSlug: values.environment.slug,
+        defaultTTL: values.defaultTTL,
+        ...(values.maxTTL ? { maxTTL: values.maxTTL } : {}),
+        ...(usernameTemplate ? { usernameTemplate } : {}),
+        provider: {
+          type: DynamicSecretProviders.SqlDatabase,
+          inputs: {
+            client: SqlProviders.Postgres,
+            host: values.inputs.host,
+            port: values.inputs.port,
+            database: "postgres",
+            username: "postgres",
+            password: values.inputs.password,
+            creationStatement: values.inputs.statements.creation,
+            revocationStatement: values.inputs.statements.revocation,
+            ...(gatewayId ? { gatewayId } : {})
+          }
+        }
+      };
+    },
+    submitLabel: "Create Dynamic Secret"
+  },
+  edit: {
+    schema: editFormSchema,
+    getDefaultValues: (context) => ({
+      name: context.dynamicSecret.name,
+      defaultTTL: context.dynamicSecret.defaultTTL,
+      maxTTL: context.dynamicSecret.maxTTL ?? null,
+      usernameTemplate:
+        context.dynamicSecret.usernameTemplate ?? DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: context.dynamicSecret.inputs as TEditFixtureValues["inputs"]
+    }),
+    toPayload: (values, context) => ({
+      projectSlug: context.projectSlug,
+      path: context.secretPath,
+      environmentSlug: context.environment,
+      name: context.dynamicSecret.name,
+      data: {
+        newName: values.name,
+        defaultTTL: values.defaultTTL,
+        maxTTL: values.maxTTL,
+        usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate),
+        inputs: {
+          ...values.inputs,
+          connection: {
+            gatewayId: normalizeDynamicSecretGatewayValueForMode(
+              "edit",
+              values.inputs.connection.gatewayId
+            ),
+            gatewayPoolId: normalizeDynamicSecretGatewayValueForMode(
+              "edit",
+              values.inputs.connection.gatewayPoolId
+            )
+          }
+        }
+      }
+    }),
+    submitLabel: "Save Changes",
+    successMessage: "Dynamic secret updated"
+  }
+});
+
+const environment = { id: "env-id", name: "Development", slug: "dev" };
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+const editInputs: TEditFixtureValues["inputs"] = {
+  host: "database.example.com",
+  port: 5432,
+  password: "********",
+  engine: "postgres",
+  enabled: true,
+  connection: { gatewayId: null, gatewayPoolId: null },
+  statements: { creation: "CREATE USER", revocation: "DROP USER" }
+};
+const editContext: TEditDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environment: "dev",
+  dynamicSecret: {
+    id: "dynamic-secret-id",
+    name: "existing-secret",
+    type: DynamicSecretProviders.SqlDatabase,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    defaultTTL: "1h",
+    maxTTL: "24h",
+    usernameTemplate: null,
+    inputs: editInputs
+  }
+};
+const createValues: TCreateFixtureValues = {
+  name: "test-secret",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "database.example.com",
+    port: 5432,
+    password: "new-password",
+    engine: "postgres",
+    enabled: true,
+    connection: { gatewayId: undefined, gatewayPoolId: undefined },
+    statements: { creation: "CREATE USER", revocation: "DROP USER" }
+  }
+};
+const editValues: TEditFixtureValues = {
+  name: "renamed-secret",
+  defaultTTL: "2h",
+  maxTTL: null,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: editInputs
+};
+
+testDynamicSecretProviderContract({
+  name: "test-only SQL fixture",
+  definition: fixtureDefinition,
+  create: {
+    context: createContext,
+    defaultValues: {
+      name: "",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      environment,
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: {
+        host: "",
+        port: 5432,
+        password: "",
+        engine: "postgres",
+        enabled: true,
+        connection: { gatewayId: undefined, gatewayPoolId: undefined },
+        statements: { creation: "CREATE USER", revocation: "DROP USER" }
+      }
+    },
+    validValues: createValues,
+    payload: {
+      projectSlug: "project",
+      path: "/folder",
+      name: "test-secret",
+      environmentSlug: "dev",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      provider: {
+        type: DynamicSecretProviders.SqlDatabase,
+        inputs: {
+          client: SqlProviders.Postgres,
+          host: "database.example.com",
+          port: 5432,
+          database: "postgres",
+          username: "postgres",
+          password: "new-password",
+          creationStatement: "CREATE USER",
+          revocationStatement: "DROP USER"
+        }
+      }
+    },
+    invalidValues: [
+      {
+        name: "provider validation paths",
+        values: {
+          ...createValues,
+          inputs: { ...createValues.inputs, host: "", password: "" }
+        },
+        issuePaths: [
+          ["inputs", "host"],
+          ["inputs", "password"]
+        ]
+      }
+    ]
+  },
+  edit: {
+    context: editContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: editInputs
+    },
+    validValues: editValues,
+    payload: {
+      projectSlug: "project",
+      path: "/folder",
+      environmentSlug: "dev",
+      name: "existing-secret",
+      data: {
+        newName: "renamed-secret",
+        defaultTTL: "2h",
+        maxTTL: null,
+        usernameTemplate: null,
+        inputs: editInputs
+      }
+    },
+    maskedValues: [
+      {
+        name: "provider password",
+        expected: "********",
+        defaultValuePath: ["inputs", "password"],
+        payloadValuePath: ["data", "inputs", "password"]
+      }
+    ]
+  }
+});
+
+describe("shared dynamic-secret scalar behavior", () => {
+  it("emits numbers before z.number validation", () => {
+    const parsedPort = parseDynamicSecretProviderNumberInput("6432");
+
+    assert.equal(parsedPort, 6432);
+    assert.equal(typeof parsedPort, "number");
+    assert.equal(
+      createFormSchema.safeParse({
+        ...createValues,
+        inputs: { ...createValues.inputs, port: parsedPort }
+      }).success,
+      true
+    );
+    assert.equal(parseDynamicSecretProviderNumberInput(""), undefined);
+    assert.equal(parseDynamicSecretProviderNumberInput("not-a-number"), undefined);
+  });
+
+  it("keeps scalar and custom-renderer paths explicit", () => {
+    const fields = fixtureDefinition.fields ?? [];
+    const flatTypes = fields.flatMap((item) => ("kind" in item ? [] : [item.type]));
+
+    assert.deepEqual(flatTypes, ["text", "number", "secret", "select", "switch"]);
+    const groupedTypes = fields.flatMap((item) =>
+      "kind" in item ? item.fields.map((field) => field.type) : []
+    );
+    assert.deepEqual(groupedTypes, ["textarea", "textarea"]);
+    assert.deepEqual(fixtureDefinition.customRenderer?.reasons, [
+      "remote-options",
+      "non-scalar-value"
+    ]);
+  });
+});
+
+describe("shared dynamic-secret normalization", () => {
+  it("preserves TTL bounds and messages", () => {
+    const belowMinimum = createFormSchema.safeParse({ ...createValues, defaultTTL: "30s" });
+    const aboveMaximum = createFormSchema.safeParse({ ...createValues, defaultTTL: "11y" });
+
+    assert.equal(belowMinimum.success, false);
+    assert.equal(aboveMaximum.success, false);
+    if (!belowMinimum.success) {
+      assert.equal(belowMinimum.error.issues[0]?.message, "TTL must be a greater than 1min");
+    }
+    if (!aboveMaximum.success) {
+      assert.equal(aboveMaximum.error.issues[0]?.message, "TTL must be less than 10 years");
+    }
+  });
+
+  it("keeps username-template and gateway create/edit semantics distinct", () => {
+    assert.equal(
+      normalizeDynamicSecretUsernameTemplateForCreate(DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE),
+      undefined
+    );
+    assert.equal(
+      normalizeDynamicSecretUsernameTemplateForEdit(DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE),
+      null
+    );
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("create", null), undefined);
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", null), null);
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", "gateway-id"), "gateway-id");
+  });
+});
+
+describe("dynamic-secret provider registry composition", () => {
+  const fixtureModule = defineDynamicSecretProviderModule({
+    id: "test-only",
+    definitions: [fixtureDefinition]
+  });
+
+  it("composes batch modules without exposing mutable registry state", () => {
+    const registry = createDynamicSecretProviderRegistry(fixtureModule);
+
+    assert.deepEqual(registry.providers, [DynamicSecretProviders.SqlDatabase]);
+    assert.equal(registry.getDefinition(DynamicSecretProviders.SqlDatabase), fixtureDefinition);
+    assert.equal(registry.getDefinition(DynamicSecretProviders.Redis), undefined);
+    assert.equal(registry.getDocsSlug(DynamicSecretProviders.SqlDatabase), "postgresql");
+    assert.equal(Object.isFrozen(registry.providers), true);
+    assert.equal(Object.isFrozen(registry.definitions), true);
+  });
+
+  it("rejects duplicate modules and providers", () => {
+    assert.throws(
+      () => createDynamicSecretProviderRegistry(fixtureModule, fixtureModule),
+      /module "test-only" was registered more than once/
+    );
+    assert.throws(
+      () =>
+        createDynamicSecretProviderRegistry(
+          fixtureModule,
+          defineDynamicSecretProviderModule({
+            id: "duplicate-provider",
+            definitions: [fixtureDefinition]
+          })
+        ),
+      /provider "sql-database" was registered more than once/
+    );
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/index.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/index.ts
@@ -1,0 +1,9 @@
+export { DynamicSecretProviderFields } from "./DynamicSecretProviderFields";
+export { DynamicSecretProviderForm } from "./DynamicSecretProviderForm";
+export { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
+export { DynamicSecretProviderGroup } from "./DynamicSecretProviderGroup";
+export * from "./registry";
+export * from "./scalarValues";
+export * from "./schemas";
+export * from "./shared";
+export * from "./types";

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerContractTestHarness.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerContractTestHarness.ts
@@ -1,0 +1,135 @@
+import type { DefaultValues } from "react-hook-form";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderDefinition,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+type TInvalidValuesCase = {
+  name: string;
+  values: unknown;
+  issuePaths: readonly (readonly (string | number)[])[];
+};
+
+type TMaskedValueCase = {
+  name: string;
+  expected: unknown;
+  defaultValuePath: readonly (string | number)[];
+  payloadValuePath: readonly (string | number)[];
+};
+
+export type TDynamicSecretProviderContractFixture<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = {
+  name: string;
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  create: {
+    context: TCreateDynamicSecretProviderFormContext;
+    defaultValues: DefaultValues<TCreateValues>;
+    validValues: TCreateValues;
+    payload: unknown;
+    invalidValues?: readonly TInvalidValuesCase[];
+  };
+  edit: {
+    context: TEditDynamicSecretProviderFormContext;
+    defaultValues: DefaultValues<TEditValues>;
+    validValues: TEditValues;
+    payload: unknown;
+    invalidValues?: readonly TInvalidValuesCase[];
+    maskedValues?: readonly TMaskedValueCase[];
+  };
+};
+
+const getValueAtPath = (value: unknown, path: readonly (string | number)[]) =>
+  path.reduce<unknown>((current, segment) => {
+    if (current === null || typeof current !== "object") return undefined;
+    return (current as Record<string | number, unknown>)[segment];
+  }, value);
+
+const getIssuePaths = (result: {
+  success: boolean;
+  error?: { issues: { path: PropertyKey[] }[] };
+}) => (result.success ? [] : (result.error?.issues.map(({ path }) => path) ?? []));
+
+/**
+ * Reusable provider-contract suite. Rollout tickets supply their own fixture;
+ * the foundation does not import or register production provider definitions.
+ */
+export const testDynamicSecretProviderContract = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+>(
+  fixture: TDynamicSecretProviderContractFixture<TProvider, TCreateValues, TEditValues>
+) => {
+  describe(`${fixture.name} dynamic-secret provider contract`, () => {
+    it("declares provider-owned defaults", () => {
+      assert.deepEqual(
+        fixture.definition.create.getDefaultValues(fixture.create.context),
+        fixture.create.defaultValues
+      );
+      assert.deepEqual(
+        fixture.definition.edit.getDefaultValues(fixture.edit.context),
+        fixture.edit.defaultValues
+      );
+    });
+
+    it("accepts valid create and edit values", () => {
+      assert.equal(
+        fixture.definition.create.schema.safeParse(fixture.create.validValues).success,
+        true
+      );
+      assert.equal(
+        fixture.definition.edit.schema.safeParse(fixture.edit.validValues).success,
+        true
+      );
+    });
+
+    fixture.create.invalidValues?.forEach((invalidCase) => {
+      it(`rejects invalid create values: ${invalidCase.name}`, () => {
+        const result = fixture.definition.create.schema.safeParse(invalidCase.values);
+        assert.equal(result.success, false);
+        assert.deepEqual(getIssuePaths(result), invalidCase.issuePaths);
+      });
+    });
+
+    fixture.edit.invalidValues?.forEach((invalidCase) => {
+      it(`rejects invalid edit values: ${invalidCase.name}`, () => {
+        const result = fixture.definition.edit.schema.safeParse(invalidCase.values);
+        assert.equal(result.success, false);
+        assert.deepEqual(getIssuePaths(result), invalidCase.issuePaths);
+      });
+    });
+
+    it("adapts create and edit payloads", () => {
+      assert.deepEqual(
+        fixture.definition.create.toPayload(fixture.create.validValues, fixture.create.context),
+        fixture.create.payload
+      );
+      assert.deepEqual(
+        fixture.definition.edit.toPayload(fixture.edit.validValues, fixture.edit.context),
+        fixture.edit.payload
+      );
+    });
+
+    fixture.edit.maskedValues?.forEach((maskedValue) => {
+      it(`preserves masked edit values: ${maskedValue.name}`, () => {
+        const defaults = fixture.definition.edit.getDefaultValues(fixture.edit.context);
+        const payload = fixture.definition.edit.toPayload(
+          fixture.edit.validValues,
+          fixture.edit.context
+        );
+        assert.equal(getValueAtPath(defaults, maskedValue.defaultValuePath), maskedValue.expected);
+        assert.equal(getValueAtPath(payload, maskedValue.payloadValuePath), maskedValue.expected);
+      });
+    });
+  });
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/registry.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/registry.ts
@@ -1,0 +1,114 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type { TDynamicSecretProviderDefinition } from "./types";
+
+export type TRegisteredDynamicSecretProviderDefinition = TDynamicSecretProviderDefinition<
+  DynamicSecretProviders,
+  // Provider value types remain available from each concrete definition. The
+  // composition root intentionally erases them for heterogeneous lookup.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any
+>;
+
+export type TDynamicSecretProviderDefinitionModule = {
+  id: string;
+  definitions: readonly TRegisteredDynamicSecretProviderDefinition[];
+};
+
+export const defineDynamicSecretProviderModule = <
+  const TDefinitions extends readonly TRegisteredDynamicSecretProviderDefinition[]
+>(module: {
+  id: string;
+  definitions: TDefinitions;
+}) => module;
+
+/** Product picker order. Partially migrated registries expose only registered entries. */
+export const DYNAMIC_SECRET_PROVIDER_PICKER_ORDER = [
+  DynamicSecretProviders.SqlDatabase,
+  DynamicSecretProviders.Cassandra,
+  DynamicSecretProviders.Redis,
+  DynamicSecretProviders.AwsElastiCache,
+  DynamicSecretProviders.AwsMemoryDb,
+  DynamicSecretProviders.AwsIam,
+  DynamicSecretProviders.MongoAtlas,
+  DynamicSecretProviders.MongoDB,
+  DynamicSecretProviders.ElasticSearch,
+  DynamicSecretProviders.RabbitMq,
+  DynamicSecretProviders.AzureEntraId,
+  DynamicSecretProviders.AzureSqlDatabase,
+  DynamicSecretProviders.Ldap,
+  DynamicSecretProviders.SapHana,
+  DynamicSecretProviders.SapAse,
+  DynamicSecretProviders.Snowflake,
+  DynamicSecretProviders.Totp,
+  DynamicSecretProviders.Vertica,
+  DynamicSecretProviders.Kubernetes,
+  DynamicSecretProviders.GcpIam,
+  DynamicSecretProviders.Github,
+  DynamicSecretProviders.Couchbase,
+  DynamicSecretProviders.Milvus,
+  DynamicSecretProviders.Clickhouse,
+  DynamicSecretProviders.Ssh,
+  DynamicSecretProviders.IbmApiConnect,
+  DynamicSecretProviders.Tailscale
+] as const satisfies readonly DynamicSecretProviders[];
+
+const DYNAMIC_SECRET_PROVIDER_DOCS_SLUG: Partial<Record<DynamicSecretProviders, string>> = {
+  [DynamicSecretProviders.SqlDatabase]: "postgresql",
+  [DynamicSecretProviders.MongoAtlas]: "mongo-atlas"
+};
+
+export const createDynamicSecretProviderRegistry = (
+  ...modules: readonly TDynamicSecretProviderDefinitionModule[]
+) => {
+  const definitions = new Map<DynamicSecretProviders, TRegisteredDynamicSecretProviderDefinition>();
+  const moduleIds = new Set<string>();
+
+  modules.forEach((module) => {
+    if (moduleIds.has(module.id)) {
+      throw new Error(
+        `Dynamic-secret provider module "${module.id}" was registered more than once.`
+      );
+    }
+    moduleIds.add(module.id);
+
+    module.definitions.forEach((definition) => {
+      if (definitions.has(definition.provider)) {
+        throw new Error(
+          `Dynamic-secret provider "${definition.provider}" was registered more than once.`
+        );
+      }
+      definitions.set(definition.provider, definition);
+    });
+  });
+
+  const providers = Object.freeze(
+    DYNAMIC_SECRET_PROVIDER_PICKER_ORDER.filter((provider) => definitions.has(provider))
+  );
+  const registeredDefinitions = Object.freeze(
+    providers.map(
+      (provider) => definitions.get(provider) as TRegisteredDynamicSecretProviderDefinition
+    )
+  );
+
+  return Object.freeze({
+    providers,
+    definitions: registeredDefinitions,
+    hasDefinition: (provider: DynamicSecretProviders) => definitions.has(provider),
+    getDefinition: (provider: DynamicSecretProviders) => definitions.get(provider),
+    requireDefinition: (provider: DynamicSecretProviders) => {
+      const definition = definitions.get(provider);
+      if (!definition) {
+        throw new Error(`Dynamic-secret provider "${provider}" is not registered.`);
+      }
+      return definition;
+    },
+    getLabel: (provider: DynamicSecretProviders) => definitions.get(provider)?.label,
+    getDocsSlug: (provider: DynamicSecretProviders) =>
+      DYNAMIC_SECRET_PROVIDER_DOCS_SLUG[provider] ?? provider
+  });
+};
+
+export type TDynamicSecretProviderRegistry = ReturnType<typeof createDynamicSecretProviderRegistry>;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/scalarValues.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/scalarValues.ts
@@ -1,0 +1,10 @@
+/**
+ * HTML number inputs emit strings. Store finite numbers in React Hook Form so
+ * provider-owned `z.number()` schemas receive the value type they declare.
+ */
+export const parseDynamicSecretProviderNumberInput = (value: string) => {
+  if (value.trim() === "") return undefined;
+
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) ? parsedValue : undefined;
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
@@ -7,8 +7,16 @@ import type { TDynamicSecretProviderFormMode } from "./types";
 
 export const DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE = "{{randomUsername}}";
 
-export const dynamicSecretTtlSchema = z.string().superRefine((value, context) => {
+const validateDynamicSecretTtl = (value: string, context: z.RefinementCtx) => {
   const valueInMilliseconds = ms(value);
+
+  if (valueInMilliseconds === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be a valid duration"
+    });
+    return;
+  }
 
   if (valueInMilliseconds < 60 * 1000) {
     context.addIssue({
@@ -23,7 +31,15 @@ export const dynamicSecretTtlSchema = z.string().superRefine((value, context) =>
       message: "TTL must be less than 10 years"
     });
   }
-});
+};
+
+export const dynamicSecretTtlSchema = z
+  .string()
+  .min(1, "TTL is required")
+  .superRefine((value, context) => {
+    if (!value) return;
+    validateDynamicSecretTtl(value, context);
+  });
 
 export const optionalDynamicSecretTtlSchema = z
   .string()
@@ -31,21 +47,7 @@ export const optionalDynamicSecretTtlSchema = z
   .superRefine((value, context) => {
     if (!value) return;
 
-    const valueInMilliseconds = ms(value);
-
-    if (valueInMilliseconds < 60 * 1000) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "TTL must be a greater than 1min"
-      });
-    }
-
-    if (valueInMilliseconds > ms("10y")) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "TTL must be less than 10 years"
-      });
-    }
+    validateDynamicSecretTtl(value, context);
   });
 
 const environmentSchema = z.object({

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
@@ -1,0 +1,102 @@
+import ms from "ms";
+import { z } from "zod";
+
+import { slugSchema } from "@app/lib/schemas";
+
+import type { TDynamicSecretProviderFormMode } from "./types";
+
+export const DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE = "{{randomUsername}}";
+
+export const dynamicSecretTtlSchema = z.string().superRefine((value, context) => {
+  const valueInMilliseconds = ms(value);
+
+  if (valueInMilliseconds < 60 * 1000) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be a greater than 1min"
+    });
+  }
+
+  if (valueInMilliseconds > ms("10y")) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be less than 10 years"
+    });
+  }
+});
+
+export const optionalDynamicSecretTtlSchema = z
+  .string()
+  .optional()
+  .superRefine((value, context) => {
+    if (!value) return;
+
+    const valueInMilliseconds = ms(value);
+
+    if (valueInMilliseconds < 60 * 1000) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "TTL must be a greater than 1min"
+      });
+    }
+
+    if (valueInMilliseconds > ms("10y")) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "TTL must be less than 10 years"
+      });
+    }
+  });
+
+const environmentSchema = z.object({
+  name: z.string(),
+  slug: z.string()
+});
+
+type TDynamicSecretFormSchemaOptions = {
+  usernameTemplateSchema?: z.ZodTypeAny;
+};
+
+export const createDynamicSecretProviderFormSchema = <TInputs extends z.ZodTypeAny>(
+  inputsSchema: TInputs,
+  options: TDynamicSecretFormSchemaOptions = {}
+) =>
+  z.object({
+    name: slugSchema(),
+    defaultTTL: dynamicSecretTtlSchema,
+    maxTTL: optionalDynamicSecretTtlSchema,
+    environment: environmentSchema,
+    usernameTemplate: options.usernameTemplateSchema ?? z.string().nullable().optional(),
+    inputs: inputsSchema
+  });
+
+export const editDynamicSecretProviderFormSchema = <TInputs extends z.ZodTypeAny>(
+  inputsSchema: TInputs,
+  options: TDynamicSecretFormSchemaOptions = {}
+) =>
+  z.object({
+    name: slugSchema(),
+    defaultTTL: dynamicSecretTtlSchema,
+    maxTTL: optionalDynamicSecretTtlSchema.nullable(),
+    environment: environmentSchema.optional(),
+    usernameTemplate: options.usernameTemplateSchema ?? z.string().nullable().optional(),
+    inputs: inputsSchema
+  });
+
+export const normalizeDynamicSecretUsernameTemplateForCreate = (
+  usernameTemplate?: string | null
+) =>
+  !usernameTemplate || usernameTemplate === DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+    ? undefined
+    : usernameTemplate;
+
+export const normalizeDynamicSecretUsernameTemplateForEdit = (usernameTemplate?: string | null) =>
+  !usernameTemplate || usernameTemplate === DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+    ? null
+    : usernameTemplate;
+
+/** Create omits a cleared gateway; edit sends null to detach an existing gateway. */
+export const normalizeDynamicSecretGatewayValueForMode = (
+  mode: TDynamicSecretProviderFormMode,
+  value?: string | null
+) => value || (mode === "create" ? undefined : null);

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/SslRejectUnauthorizedField.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/SslRejectUnauthorizedField.tsx
@@ -1,0 +1,68 @@
+import { Controller, FieldValues, Path, useFormContext } from "react-hook-form";
+
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FieldTitle,
+  Switch
+} from "@app/components/v3";
+
+type Props<TValues extends FieldValues> = {
+  name?: Path<TValues>;
+  id?: string;
+  fallbackChecked?: boolean;
+  layout?: "labeled" | "content";
+};
+
+export const SslRejectUnauthorizedField = <TValues extends FieldValues>({
+  name = "inputs.sslRejectUnauthorized" as Path<TValues>,
+  id = "dynamic-secret-ssl-reject-unauthorized",
+  fallbackChecked = true,
+  layout = "content"
+}: Props<TValues>) => {
+  const { control } = useFormContext<TValues>();
+  const descriptionId = `${id}-description`;
+  const errorId = `${id}-error`;
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState: { error } }) => (
+        <Field data-invalid={Boolean(error)} orientation="horizontal">
+          {layout === "labeled" ? (
+            <div className="flex flex-1 flex-col gap-0.5">
+              <FieldLabel htmlFor={id}>SSL Reject Unauthorized</FieldLabel>
+              <FieldDescription id={descriptionId}>
+                Verify the server certificate against the supplied certificate authorities.
+              </FieldDescription>
+              {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+            </div>
+          ) : (
+            <FieldContent>
+              <FieldTitle>SSL Reject Unauthorized</FieldTitle>
+              <FieldDescription id={descriptionId}>
+                Verify the server certificate against the supplied certificate authorities.
+              </FieldDescription>
+              {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+            </FieldContent>
+          )}
+          <Switch
+            ref={field.ref}
+            id={id}
+            variant="project"
+            checked={field.value ?? fallbackChecked}
+            onBlur={field.onBlur}
+            onCheckedChange={field.onChange}
+            aria-invalid={Boolean(error)}
+            aria-label="SSL Reject Unauthorized"
+            aria-describedby={`${descriptionId}${error?.message ? ` ${errorId}` : ""}`}
+          />
+        </Field>
+      )}
+    />
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/StatementAccordion.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/StatementAccordion.tsx
@@ -1,0 +1,90 @@
+import { FieldValues, Path } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { TDynamicSecretProviderField } from "../types";
+import { usernameTemplateFieldDefinition } from "./UsernameTemplateField";
+
+type StatementCopy = {
+  creation?: string;
+  revocation?: string;
+  renew?: string;
+};
+
+type BuildOptions = {
+  includeUsernameTemplate?: boolean;
+  includeRenew?: boolean;
+  renewOptional?: boolean;
+  creationRows?: number;
+  copy?: StatementCopy;
+};
+
+const DEFAULT_COPY: Required<StatementCopy> = {
+  creation: "Username, password, and expiration are dynamically provisioned.",
+  revocation: "Username is dynamically provisioned.",
+  renew: "Username and expiration are dynamically provisioned."
+};
+
+export const buildStatementFields = <TValues extends FieldValues>(
+  options: BuildOptions = {}
+): TDynamicSecretProviderField<TValues>[] => {
+  const {
+    includeUsernameTemplate = true,
+    includeRenew = true,
+    renewOptional = true,
+    creationRows = 3,
+    copy = {}
+  } = options;
+  const resolvedCopy = { ...DEFAULT_COPY, ...copy };
+  const fields: TDynamicSecretProviderField<TValues>[] = [];
+
+  if (includeUsernameTemplate) {
+    fields.push(usernameTemplateFieldDefinition as TDynamicSecretProviderField<TValues>);
+  }
+
+  fields.push(
+    {
+      name: "inputs.creationStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Creation Statement",
+      ...(resolvedCopy.creation ? { description: resolvedCopy.creation } : {}),
+      rows: creationRows
+    },
+    {
+      name: "inputs.revocationStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Revocation Statement",
+      ...(resolvedCopy.revocation ? { description: resolvedCopy.revocation } : {}),
+      rows: 3
+    }
+  );
+
+  if (includeRenew) {
+    fields.push({
+      name: "inputs.renewStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Renew Statement",
+      ...(resolvedCopy.renew ? { description: resolvedCopy.renew } : {}),
+      isOptional: renewOptional,
+      rows: 3
+    });
+  }
+
+  return fields;
+};
+
+type Props<TValues extends FieldValues> = {
+  title: string;
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+  value?: string;
+};
+
+export const StatementAccordion = <TValues extends FieldValues>({
+  title,
+  fields,
+  value = "statements"
+}: Props<TValues>) => (
+  <DynamicSecretProviderGroup id={value} presentation="collapse" title={title}>
+    <DynamicSecretProviderFields fields={fields} />
+  </DynamicSecretProviderGroup>
+);

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/UsernameTemplateField.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/UsernameTemplateField.tsx
@@ -1,0 +1,20 @@
+import { FieldValues } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import { TDynamicSecretProviderField } from "../types";
+
+export const usernameTemplateFieldDefinition = {
+  name: "usernameTemplate",
+  type: "text",
+  label: "Username Template",
+  placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+} as const;
+
+type Props<TValues extends FieldValues> = {
+  fields?: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+export const UsernameTemplateFields = <TValues extends FieldValues>({
+  fields = [usernameTemplateFieldDefinition as TDynamicSecretProviderField<TValues>]
+}: Props<TValues>) => <DynamicSecretProviderFields fields={fields} />;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/index.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/index.ts
@@ -1,0 +1,3 @@
+export { SslRejectUnauthorizedField } from "./SslRejectUnauthorizedField";
+export { buildStatementFields, StatementAccordion } from "./StatementAccordion";
+export { usernameTemplateFieldDefinition, UsernameTemplateFields } from "./UsernameTemplateField";

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/types.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/types.ts
@@ -1,0 +1,205 @@
+import type { ComponentType } from "react";
+import type { DefaultValues, FieldPath, FieldValues } from "react-hook-form";
+import type { z } from "zod";
+
+import type {
+  DynamicSecretProviders,
+  TCreateDynamicSecretDTO,
+  TDynamicSecret,
+  TDynamicSecretProvider,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+import type { ProjectEnv } from "@app/hooks/api/types";
+
+export const DYNAMIC_SECRET_CUSTOM_RENDERER_REASONS = [
+  "conditional-fields",
+  "repeatable-fields",
+  "permission-aware-fields",
+  "remote-options",
+  "import-workflow",
+  "non-scalar-value",
+  "multi-create",
+  "post-create-workflow",
+  "context-aware-fields"
+] as const;
+
+export type TDynamicSecretCustomRendererReason =
+  (typeof DYNAMIC_SECRET_CUSTOM_RENDERER_REASONS)[number];
+
+export type TDynamicSecretProviderFormMode = "create" | "edit";
+
+export type TDynamicSecretProviderCommonField = {
+  isVisible?: boolean;
+  isDisabled?: boolean;
+  label?: string;
+  description?: string;
+};
+
+export type TDynamicSecretProviderCommonFields = {
+  name?: TDynamicSecretProviderCommonField;
+  defaultTTL?: TDynamicSecretProviderCommonField;
+  maxTTL?: TDynamicSecretProviderCommonField;
+  environment?: TDynamicSecretProviderCommonField;
+  configurationHeading?: string | false;
+};
+
+export type TDynamicSecretFormEnvironment = Pick<ProjectEnv, "name" | "slug">;
+
+export type TDynamicSecretProviderFormValues<TInputs extends FieldValues = FieldValues> = {
+  name: string;
+  defaultTTL: string;
+  maxTTL?: string | null;
+  environment?: TDynamicSecretFormEnvironment;
+  usernameTemplate?: string | null;
+  inputs: TInputs;
+};
+
+type TDynamicSecretBaseField<TValues extends FieldValues> = {
+  name: FieldPath<TValues>;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  isOptional?: boolean;
+  isDisabled?: boolean;
+  layout?: "full" | "half";
+};
+
+export type TDynamicSecretProviderField<TValues extends FieldValues> =
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "text" | "secret";
+      autoComplete?: string;
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "number";
+      min?: number;
+      max?: number;
+      step?: number | "any";
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "textarea";
+      rows?: number;
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "select";
+      options: readonly { label: string; value: string }[];
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "switch";
+    });
+
+export type TDynamicSecretProviderFieldGroupPresentation = "panel" | "collapse";
+
+type TDynamicSecretProviderFieldGroupBase<TValues extends FieldValues> = {
+  kind: "group";
+  id: string;
+  description?: string;
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+export type TDynamicSecretProviderFieldGroup<TValues extends FieldValues> =
+  | (TDynamicSecretProviderFieldGroupBase<TValues> & {
+      presentation?: "panel";
+      title?: string;
+      surface?: boolean;
+    })
+  | (TDynamicSecretProviderFieldGroupBase<TValues> & {
+      presentation: "collapse";
+      title: string;
+    });
+
+export type TDynamicSecretProviderFormItem<TValues extends FieldValues> =
+  | TDynamicSecretProviderField<TValues>
+  | TDynamicSecretProviderFieldGroup<TValues>;
+
+export const isDynamicSecretProviderFieldGroup = <TValues extends FieldValues>(
+  item: TDynamicSecretProviderFormItem<TValues>
+): item is TDynamicSecretProviderFieldGroup<TValues> => "kind" in item && item.kind === "group";
+
+export type TDynamicSecretProviderOf<TProvider extends DynamicSecretProviders> = Extract<
+  TDynamicSecretProvider,
+  { type: TProvider }
+>;
+
+export type TCreateDynamicSecretProviderDTO<TProvider extends DynamicSecretProviders> = Omit<
+  TCreateDynamicSecretDTO,
+  "provider"
+> & {
+  provider: TDynamicSecretProviderOf<TProvider>;
+};
+
+export type TDynamicSecretWithInputs = TDynamicSecret & { inputs: unknown };
+
+export type TCreateDynamicSecretProviderFormContext = {
+  projectSlug: string;
+  secretPath: string;
+  environments: ProjectEnv[];
+  isSingleEnvironmentMode?: boolean;
+};
+
+export type TEditDynamicSecretProviderFormContext = {
+  projectSlug: string;
+  secretPath: string;
+  environment: string;
+  dynamicSecret: TDynamicSecretWithInputs;
+};
+
+export type TDynamicSecretProviderRendererProps = {
+  mode: TDynamicSecretProviderFormMode;
+  context: TCreateDynamicSecretProviderFormContext | TEditDynamicSecretProviderFormContext;
+  setSubmitState: (state: { isDisabled?: boolean; isPending?: boolean }) => void;
+};
+
+export type TDynamicSecretProviderCustomRenderer = {
+  reasons: readonly [TDynamicSecretCustomRendererReason, ...TDynamicSecretCustomRendererReason[]];
+  Component: ComponentType<TDynamicSecretProviderRendererProps>;
+};
+
+export type TDynamicSecretProviderDefinition<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues = TCreateValues
+> = {
+  provider: TProvider;
+  label: string;
+  fields?: readonly TDynamicSecretProviderFormItem<TCreateValues & TEditValues>[];
+  customRenderer?: TDynamicSecretProviderCustomRenderer;
+  create: {
+    schema: z.ZodType<TCreateValues>;
+    getDefaultValues: (
+      context: TCreateDynamicSecretProviderFormContext
+    ) => DefaultValues<TCreateValues>;
+    toPayload: (
+      values: TCreateValues,
+      context: TCreateDynamicSecretProviderFormContext
+    ) =>
+      | TCreateDynamicSecretProviderDTO<TProvider>
+      | readonly TCreateDynamicSecretProviderDTO<TProvider>[];
+    fields?: readonly TDynamicSecretProviderFormItem<TCreateValues>[];
+    customRenderer?: TDynamicSecretProviderCustomRenderer;
+    commonFields?: TDynamicSecretProviderCommonFields;
+    submitLabel: string;
+  };
+  edit: {
+    schema: z.ZodType<TEditValues>;
+    getDefaultValues: (
+      context: TEditDynamicSecretProviderFormContext
+    ) => DefaultValues<TEditValues>;
+    toPayload: (
+      values: TEditValues,
+      context: TEditDynamicSecretProviderFormContext
+    ) => TUpdateDynamicSecretDTO;
+    fields?: readonly TDynamicSecretProviderFormItem<TEditValues>[];
+    customRenderer?: TDynamicSecretProviderCustomRenderer;
+    commonFields?: TDynamicSecretProviderCommonFields;
+    submitLabel: string;
+    successMessage: string;
+  };
+};
+
+export const defineDynamicSecretProvider = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues = TCreateValues
+>(
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>
+) => definition;

--- a/frontend/src/components/dynamic-secrets/index.ts
+++ b/frontend/src/components/dynamic-secrets/index.ts
@@ -1,0 +1,1 @@
+export * from "./DynamicSecretProviderForm";


### PR DESCRIPTION
## Context

[ENG-5518](https://linear.app/infisical/issue/ENG-5518/land-the-shared-dynamic-secret-provider-form-contract) establishes the provider-neutral foundation for the four dynamic-secret provider migration batches (ENG-5513 through ENG-5516).

Previously, current `main` had no shared provider form contract, registry extension point, or reusable contract harness. The exploratory checkpoint in [PR #7529](https://github.com/Infisical/infisical/pull/7529) contained useful source material, but it also mixed the shared foundation with provider rollouts and unrelated UI work, and its number controls emitted strings into `z.number()` schemas.

This PR adds:

- Distinct create/edit value contracts with provider-owned schemas, defaults, hydration, and payload adapters.
- A sheet-agnostic React Hook Form shell using V3 controls.
- Scalar text, secret, numeric, textarea, select, and switch rendering, plus grouped fields and explicit custom-renderer escape hatches.
- Immutable batch-module registry composition so later rollout tickets can register definitions without redefining the core architecture.
- Shared username-template, SSL validation, and statement controls.
- A reusable generic contract-test harness with a test-only provider fixture.
- Numeric input parsing before validation, preserving actual number values for `z.number()`.
- Documentation for ownership boundaries, registration, normalization semantics, and checkpoint provenance.

No production provider definitions are registered, so existing legacy dynamic-secret behavior remains unchanged.

### Immutable checkpoint provenance

The implementation selectively adapts checkpoint commit `2eca032d7dc` from PR #7529; the checkpoint branch and salvage worktree were not modified, merged, rebased, or cherry-picked.

| Checkpoint area | Treatment in this PR |
| --- | --- |
| Types, schemas, scalar fields, form items, and shared controls | Adapted to current `main` |
| Form shell | Rewritten to be sheet-agnostic |
| Field grouping | Rewritten around the existing V3 Accordion |
| Provider registry | Rewritten as immutable batch-module composition |
| Numeric field behavior | Rewritten to emit numbers before schema validation |
| Production provider definitions and family tests | Excluded for ENG-5513 through ENG-5516 |
| Sheet, lease, post-create overlay, route removal, Overview redesign, and unrelated primitives | Excluded as out of scope |

## Steps to verify the change

From `frontend/`:

1. Run the targeted lint:
   ```sh
   ./node_modules/.bin/eslint 'src/components/dynamic-secrets/**/*.{ts,tsx}'
   ```
2. Run the full frontend TypeScript check:
   ```sh
   npm run type:check
   ```
3. Run the focused provider-contract suite:
   ```sh
   ./node_modules/.bin/tsx --tsconfig tsconfig.app.json --test src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
   ```

Verified locally:

- Targeted ESLint: passed
- Full frontend TypeScript check: passed
- Focused contract suite: 11 tests across 4 suites passed

The focused suite covers scalar metadata, numeric coercion, create/edit defaults, validation failures, payload adapters, masked edits, create omission versus edit `null`, environment and TTL behavior, gateway and username-template normalization, nested values, registry composition, and the custom-renderer path.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
