### PR TITLE
feat(ui): add Modify Role action for project member role rows

### DIFF
--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { Button, IconButton, PageLoader } from "@app/components/v3";
+import { Button, IconButton, PageLoader, SheetFooter } from "@app/components/v3";
 import {
   ProjectPermissionActions,
   ProjectPermissionSub,
@@ -27,10 +27,10 @@ type TRoleForm = z.infer<typeof roleFormSchema>;
 type Props = {
   projectMember: TWorkspaceUser;
   onOpenUpgradeModal: () => void;
-  onSuccess?: () => void;
+  onClose: () => void;
 };
 
-export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuccess }: Props) => {
+export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onClose }: Props) => {
   const { subscription } = useSubscription();
   const { projectId, currentProject } = useProject();
   const { isRolesLoading, assignableRoleSlugs, getRolesForSelect, isEditDisabled } =
@@ -64,7 +64,7 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuc
       roles: sanitizedRoles
     });
     createNotification({ text: "Successfully updated roles", type: "success" });
-    onSuccess?.();
+    onClose();
   };
 
   if (isRolesLoading) {
@@ -76,8 +76,11 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuc
   }
 
   return (
-    <form onSubmit={roleForm.handleSubmit(handleRoleUpdate)}>
-      <div className="flex flex-col gap-3">
+    <form
+      onSubmit={roleForm.handleSubmit(handleRoleUpdate)}
+      className="flex flex-1 flex-col overflow-hidden"
+    >
+      <div className="flex thin-scrollbar flex-1 flex-col gap-3 overflow-y-auto p-4">
         {selectedRoleList.fields.map(({ id }, index) => (
           <RoleAssignmentRow
             key={id}
@@ -106,13 +109,12 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuc
             }
           />
         ))}
-      </div>
-      <div className="mt-4 flex items-center justify-between gap-2">
         <ProjectPermissionCan I={ProjectPermissionActions.Edit} a={ProjectPermissionSub.Member}>
           {(isAllowed) => (
             <Button
               type="button"
               variant="outline"
+              className="self-start"
               isDisabled={!isAllowed || isEditDisabled}
               onClick={() =>
                 selectedRoleList.append({
@@ -126,6 +128,8 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuc
             </Button>
           )}
         </ProjectPermissionCan>
+      </div>
+      <SheetFooter className="border-t">
         <Button
           type="submit"
           variant="project"
@@ -134,7 +138,10 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuc
         >
           Save Roles
         </Button>
-      </div>
+        <Button type="button" variant="outline" onClick={onClose}>
+          Cancel
+        </Button>
+      </SheetFooter>
     </form>
   );
 };

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
@@ -71,7 +71,7 @@ type Props = {
   onOpenUpgradeModal: () => void;
 };
 
-export const MemberRoleModify = ({ projectMember, onOpenUpgradeModal }: Props) => {
+export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal }: Props) => {
   const { subscription } = useSubscription();
   const { projectId, currentProject } = useProject();
   const { data: projectRoles, isPending: isRolesLoading } = useGetProjectRoles(

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable no-nested-ternary */
 import { useMemo } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { faCaretDown, faClock, faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format, formatDistance } from "date-fns";
+import { ChevronDownIcon, ClockIcon, PlusIcon, TrashIcon } from "lucide-react";
 import ms from "ms";
 import picomatch from "picomatch";
 import { twMerge } from "tailwind-merge";
@@ -13,20 +12,27 @@ import { z } from "zod";
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
+import { Lottie } from "@app/components/v2";
 import {
+  Badge,
   Button,
-  FormControl,
+  Field,
+  FieldError,
+  FieldLabel,
   IconButton,
   Input,
   Popover,
   PopoverContent,
   PopoverTrigger,
   Select,
+  SelectContent,
   SelectItem,
-  Spinner,
-  Tag,
-  Tooltip
-} from "@app/components/v2";
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import {
   ProjectPermissionActions,
   ProjectPermissionMemberActions,
@@ -45,6 +51,14 @@ import {
   filterByGrantConditions,
   getMemberAssignRoleConditions
 } from "@app/lib/fn/permission";
+
+const TEMPORARY_RANGE_ERROR = "Only valid time values are accepted (1h, 20m, 2d).";
+
+const isValidTemporaryRange = (value?: string) => {
+  if (!value?.trim()) return false;
+  const parsedMs = ms(value);
+  return typeof parsedMs === "number" && Number.isFinite(parsedMs) && parsedMs > 0;
+};
 
 const roleFormSchema = z.object({
   roles: z
@@ -69,9 +83,14 @@ type TRoleForm = z.infer<typeof roleFormSchema>;
 type Props = {
   projectMember: TWorkspaceUser;
   onOpenUpgradeModal: () => void;
+  onSuccess?: () => void;
 };
 
-export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal }: Props) => {
+export const MemberMultiRoleModify = ({
+  projectMember,
+  onOpenUpgradeModal,
+  onSuccess
+}: Props) => {
   const { subscription } = useSubscription();
   const { projectId, currentProject } = useProject();
   const { data: projectRoles, isPending: isRolesLoading } = useGetProjectRoles(
@@ -129,6 +148,8 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal }: Pro
     return [currentRole, ...assignable];
   };
 
+  const isEditDisabled = isMemberEditDisabled || !canModifyMemberRoles;
+
   const roleForm = useForm<TRoleForm>({
     resolver: zodResolver(roleFormSchema),
     values: {
@@ -153,7 +174,6 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal }: Pro
   });
 
   const formRoleField = roleForm.watch("roles");
-
   const updateMembershipRole = useUpdateUserWorkspaceRole();
 
   const handleRoleUpdate = async (data: TRoleForm) => {
@@ -190,18 +210,20 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal }: Pro
       roles: sanitizedRoles
     });
     createNotification({ text: "Successfully updated roles", type: "success" });
+    onSuccess?.();
   };
 
-  if (isRolesLoading)
+  if (isRolesLoading) {
     return (
-      <div className="flex w-full items-center justify-center p-8">
-        <Spinner />
+      <div className="flex h-40 w-full items-center justify-center">
+        <Lottie icon="infisical_loading_white" isAutoPlay className="w-16" />
       </div>
     );
+  }
 
   return (
     <form onSubmit={roleForm.handleSubmit(handleRoleUpdate)}>
-      <div className="mt-2 flex flex-col space-y-2">
+      <div className="flex flex-col gap-3">
         {selectedRoleList.fields.map(({ id }, index) => {
           const { temporaryAccess } = formRoleField[index];
           const isTemporary = temporaryAccess?.isTemporary;
@@ -209,194 +231,238 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal }: Pro
             temporaryAccess.isTemporary &&
             new Date() > new Date(temporaryAccess.temporaryAccessEndTime || "");
 
+          let durationVariant: "outline" | "warning" | "danger" = "outline";
+          let text = "Permanent";
+          let toolTipText = "Non-Expiring Access";
+
+          if (isTemporary) {
+            if (isExpired) {
+              durationVariant = "danger";
+              text = "Access Expired";
+              toolTipText = "Timed Access Expired";
+            } else {
+              durationVariant = "warning";
+              text = formatDistance(
+                new Date(temporaryAccess.temporaryAccessEndTime || ""),
+                new Date()
+              );
+              toolTipText = `Until ${format(
+                new Date(temporaryAccess.temporaryAccessEndTime || ""),
+                "yyyy-MM-dd HH:mm:ss"
+              )}`;
+            }
+          }
+
           return (
-            <div key={id} className="flex items-center space-x-2">
+            <div key={id} className="flex items-end gap-2">
               <Controller
                 control={roleForm.control}
                 name={`roles.${index}.slug`}
-                render={({ field: { onChange, ...field } }) => {
+                render={({ field }) => {
                   const rolesForSelect = getRolesForSelect(field.value);
                   return (
-                    <Select
-                      defaultValue={field.value}
-                      {...field}
-                      isDisabled={isMemberEditDisabled || !canModifyMemberRoles}
-                      onValueChange={(e) => onChange(e)}
-                      className="w-full bg-mineshaft-600 duration-200 hover:bg-mineshaft-500"
-                      containerClassName="w-1/2"
-                    >
-                      {rolesForSelect.map(({ name, slug, id: projectRoleId }) => {
-                        const isAssignable = assignableRoleSlugs.has(slug);
-                        if (!isAssignable) {
-                          return (
-                            <Tooltip
-                              key={projectRoleId ?? slug}
-                              content="You don't have permission to assign this role"
-                            >
-                              <div>
-                                <SelectItem
-                                  value={slug}
-                                  isDisabled
-                                  className="cursor-not-allowed opacity-50"
-                                >
-                                  {name}
-                                </SelectItem>
-                              </div>
-                            </Tooltip>
-                          );
-                        }
-                        return (
-                          <SelectItem value={slug} key={projectRoleId}>
-                            {name}
-                          </SelectItem>
-                        );
-                      })}
-                    </Select>
+                    <Field className="min-w-0 flex-1">
+                      {index === 0 && <FieldLabel>Role</FieldLabel>}
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        disabled={isEditDisabled}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent position="popper" className="z-[70]">
+                          {rolesForSelect.map(({ name, slug, id: projectRoleId }) => {
+                            const isAssignable = assignableRoleSlugs.has(slug);
+                            return (
+                              <SelectItem
+                                value={slug}
+                                key={projectRoleId}
+                                disabled={!isAssignable}
+                                description={
+                                  isAssignable
+                                    ? undefined
+                                    : "You don't have permission to assign this role"
+                                }
+                              >
+                                {name}
+                              </SelectItem>
+                            );
+                          })}
+                        </SelectContent>
+                      </Select>
+                    </Field>
                   );
                 }}
               />
-              <Popover>
-                <PopoverTrigger disabled={isMemberEditDisabled || !canModifyMemberRoles} asChild>
-                  <div className="grow">
-                    <Tooltip
-                      content={
-                        temporaryAccess?.isTemporary
-                          ? isExpired
-                            ? "Timed Access Expired"
-                            : `Until ${format(
-                                new Date(temporaryAccess.temporaryAccessEndTime || ""),
-                                "yyyy-MM-dd HH:mm:ss"
-                              )}`
-                          : "Non-Expiring Access"
-                      }
-                    >
-                      <Button
-                        variant="outline_bg"
-                        leftIcon={isTemporary ? <FontAwesomeIcon icon={faClock} /> : undefined}
-                        rightIcon={<FontAwesomeIcon icon={faCaretDown} className="ml-2" />}
-                        isDisabled={isMemberEditDisabled || !canModifyMemberRoles}
-                        className={twMerge(
-                          "w-full border-none bg-mineshaft-600 py-2.5 text-xs capitalize hover:bg-mineshaft-500",
-                          isTemporary && "text-primary",
-                          isExpired && "text-red-600"
-                        )}
-                      >
-                        {temporaryAccess?.isTemporary
-                          ? isExpired
-                            ? "Access Expired"
-                            : formatDistance(
-                                new Date(temporaryAccess.temporaryAccessEndTime || ""),
-                                new Date()
-                              )
-                          : "Permanent"}
-                      </Button>
-                    </Tooltip>
-                  </div>
-                </PopoverTrigger>
-                <PopoverContent
-                  arrowClassName="fill-gray-600"
-                  side="right"
-                  sideOffset={12}
-                  hideCloseBtn
-                  className="border border-gray-600 pt-4"
-                >
-                  <div className="flex flex-col space-y-4">
-                    <div className="border-b border-b-gray-700 pb-2 text-sm text-mineshaft-300">
-                      Configure Timed Access
-                    </div>
-                    {isExpired && <Tag colorSchema="red">Expired</Tag>}
-                    <Controller
-                      control={roleForm.control}
-                      defaultValue="1h"
-                      name={`roles.${index}.temporaryAccess.temporaryRange`}
-                      render={({ field, fieldState: { error } }) => (
-                        <FormControl
-                          label={<TtlFormLabel label="Validity" />}
-                          isError={Boolean(error?.message)}
-                          errorText={error?.message}
+              <Field className="w-44 shrink-0">
+                {index === 0 && <FieldLabel>Duration</FieldLabel>}
+                <Popover>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <Button
+                          type="button"
+                          variant={durationVariant}
+                          isDisabled={isEditDisabled}
+                          className="w-full capitalize"
                         >
-                          <Input {...field} />
-                        </FormControl>
-                      )}
-                    />
-                    <div className="flex items-center space-x-2">
-                      <Button
-                        size="xs"
-                        onClick={() => {
-                          const temporaryRange = roleForm.getValues(
-                            `roles.${index}.temporaryAccess.temporaryRange`
-                          );
-                          if (!temporaryRange) {
-                            roleForm.setError(
-                              `roles.${index}.temporaryAccess.temporaryRange`,
-                              { type: "required", message: "Required" },
-                              { shouldFocus: true }
-                            );
-                            return;
-                          }
-                          roleForm.clearErrors(`roles.${index}.temporaryAccess.temporaryRange`);
-                          roleForm.setValue(
-                            `roles.${index}.temporaryAccess`,
-                            {
-                              isTemporary: true,
-                              temporaryAccessStartTime: new Date().toISOString(),
-                              temporaryRange,
-                              temporaryAccessEndTime: new Date(
-                                new Date().getTime() + ms(temporaryRange)
-                              ).toISOString()
-                            },
-                            { shouldDirty: true }
+                          {isTemporary && <ClockIcon />}
+                          {text}
+                          <ChevronDownIcon />
+                        </Button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>{toolTipText}</TooltipContent>
+                  </Tooltip>
+                  <PopoverContent
+                    side="right"
+                    className="z-[70]"
+                    onWheel={(e) => e.stopPropagation()}
+                    onOpenAutoFocus={(e) => e.preventDefault()}
+                  >
+                    <div className="flex flex-col space-y-4">
+                      <div className="border-b border-b-border pb-2 text-sm text-muted">
+                        Configure Timed Access
+                      </div>
+                      {isExpired && <Badge variant="danger">Expired</Badge>}
+                      <Controller
+                        control={roleForm.control}
+                        defaultValue="1h"
+                        name={`roles.${index}.temporaryAccess.temporaryRange`}
+                        render={({ field, fieldState: { error } }) => {
+                          const showInvalidError =
+                            Boolean(field.value) && !isValidTemporaryRange(field.value);
+                          const errorMessage = showInvalidError
+                            ? TEMPORARY_RANGE_ERROR
+                            : error?.message;
+                          const canGrant = isValidTemporaryRange(field.value);
+
+                          return (
+                            <>
+                              <Field>
+                                <FieldLabel>
+                                  <TtlFormLabel label="Validity" />
+                                </FieldLabel>
+                                <Input
+                                  {...field}
+                                  value={field.value ?? ""}
+                                  isError={Boolean(errorMessage)}
+                                  onChange={(e) => {
+                                    field.onChange(e);
+                                    const nextValue = e.target.value;
+                                    if (!nextValue) {
+                                      roleForm.setError(
+                                        `roles.${index}.temporaryAccess.temporaryRange`,
+                                        { type: "required", message: "Required" },
+                                        { shouldFocus: false }
+                                      );
+                                      return;
+                                    }
+                                    if (!isValidTemporaryRange(nextValue)) {
+                                      roleForm.setError(
+                                        `roles.${index}.temporaryAccess.temporaryRange`,
+                                        {
+                                          type: "validate",
+                                          message: TEMPORARY_RANGE_ERROR
+                                        },
+                                        { shouldFocus: false }
+                                      );
+                                      return;
+                                    }
+                                    roleForm.clearErrors(
+                                      `roles.${index}.temporaryAccess.temporaryRange`
+                                    );
+                                  }}
+                                />
+                                {errorMessage && <FieldError>{errorMessage}</FieldError>}
+                              </Field>
+                              <div className="flex items-center space-x-2">
+                                <Button
+                                  size="xs"
+                                  variant="outline"
+                                  isDisabled={!canGrant}
+                                  onClick={() => {
+                                    const temporaryRange = field.value;
+                                    if (!isValidTemporaryRange(temporaryRange)) {
+                                      roleForm.setError(
+                                        `roles.${index}.temporaryAccess.temporaryRange`,
+                                        {
+                                          type: "validate",
+                                          message: TEMPORARY_RANGE_ERROR
+                                        },
+                                        { shouldFocus: true }
+                                      );
+                                      return;
+                                    }
+                                    roleForm.clearErrors(
+                                      `roles.${index}.temporaryAccess.temporaryRange`
+                                    );
+                                    roleForm.setValue(
+                                      `roles.${index}.temporaryAccess`,
+                                      {
+                                        isTemporary: true,
+                                        temporaryAccessStartTime: new Date().toISOString(),
+                                        temporaryRange,
+                                        temporaryAccessEndTime: new Date(
+                                          new Date().getTime() + ms(temporaryRange)
+                                        ).toISOString()
+                                      },
+                                      { shouldDirty: true }
+                                    );
+                                  }}
+                                >
+                                  {isTemporary ? "Restart" : "Grant"}
+                                </Button>
+                                {isTemporary && (
+                                  <Button
+                                    size="xs"
+                                    variant="danger"
+                                    onClick={() => {
+                                      roleForm.setValue(
+                                        `roles.${index}.temporaryAccess`,
+                                        { isTemporary: false },
+                                        { shouldDirty: true }
+                                      );
+                                    }}
+                                  >
+                                    Revoke Access
+                                  </Button>
+                                )}
+                              </div>
+                            </>
                           );
                         }}
-                      >
-                        {temporaryAccess.isTemporary ? "Restart" : "Grant"}
-                      </Button>
-                      {temporaryAccess.isTemporary && (
-                        <Button
-                          size="xs"
-                          variant="outline_bg"
-                          colorSchema="danger"
-                          onClick={() => {
-                            roleForm.setValue(`roles.${index}.temporaryAccess`, {
-                              isTemporary: false
-                            });
-                          }}
-                        >
-                          Revoke Access
-                        </Button>
-                      )}
+                      />
                     </div>
-                  </div>
-                </PopoverContent>
-              </Popover>
+                  </PopoverContent>
+                </Popover>
+              </Field>
               <IconButton
-                variant="outline_bg"
-                className="border border-mineshaft-500 bg-mineshaft-600 py-3 hover:border-red/70 hover:bg-red/20"
-                ariaLabel="delete-role"
-                isDisabled={
-                  isMemberEditDisabled ||
-                  !canModifyMemberRoles ||
-                  selectedRoleList.fields.length === 1
-                }
+                size="md"
+                variant="outline"
+                aria-label="Remove role"
+                className="shrink-0 hover:border-danger/40 hover:bg-danger/10 hover:text-danger"
+                isDisabled={isEditDisabled || selectedRoleList.fields.length === 1}
                 onClick={() => {
                   if (selectedRoleList.fields.length > 1) {
                     selectedRoleList.remove(index);
                   }
                 }}
               >
-                <FontAwesomeIcon icon={faTrash} />
+                <TrashIcon />
               </IconButton>
             </div>
           );
         })}
       </div>
-      <div className="mt-4 flex justify-between space-x-2">
+      <div className="mt-4 flex items-center justify-between gap-2">
         <ProjectPermissionCan I={ProjectPermissionActions.Edit} a={ProjectPermissionSub.Member}>
           {(isAllowed) => (
             <Button
-              variant="outline_bg"
-              isDisabled={!isAllowed}
-              leftIcon={<FontAwesomeIcon icon={faPlus} />}
+              type="button"
+              variant="outline"
+              isDisabled={!isAllowed || isEditDisabled}
               onClick={() =>
                 selectedRoleList.append({
                   slug: ProjectMembershipRole.Member,
@@ -404,19 +470,21 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal }: Pro
                 })
               }
             >
+              <PlusIcon />
               Add Role
             </Button>
           )}
         </ProjectPermissionCan>
         <Button
           type="submit"
+          variant="project"
           className={twMerge(
             "transition-all",
             "cursor-default opacity-0",
             roleForm.formState.isDirty && "cursor-pointer opacity-100"
           )}
-          isDisabled={!roleForm.formState.isDirty}
-          isLoading={roleForm.formState.isSubmitting}
+          isDisabled={!roleForm.formState.isDirty || isEditDisabled}
+          isPending={roleForm.formState.isSubmitting}
         >
           Save Roles
         </Button>

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
@@ -12,7 +12,6 @@ import { z } from "zod";
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { Lottie } from "@app/components/v2";
 import {
   Badge,
   Button,
@@ -21,6 +20,7 @@ import {
   FieldLabel,
   IconButton,
   Input,
+  PageLoader,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -67,7 +67,10 @@ const roleFormSchema = z.object({
       temporaryAccess: z.discriminatedUnion("isTemporary", [
         z.object({
           isTemporary: z.literal(true),
-          temporaryRange: z.string().min(1),
+          temporaryRange: z
+            .string()
+            .min(1, "Required")
+            .refine(isValidTemporaryRange, TEMPORARY_RANGE_ERROR),
           temporaryAccessStartTime: z.string().datetime(),
           temporaryAccessEndTime: z.string().datetime().nullable().optional()
         }),
@@ -86,11 +89,7 @@ type Props = {
   onSuccess?: () => void;
 };
 
-export const MemberMultiRoleModify = ({
-  projectMember,
-  onOpenUpgradeModal,
-  onSuccess
-}: Props) => {
+export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuccess }: Props) => {
   const { subscription } = useSubscription();
   const { projectId, currentProject } = useProject();
   const { data: projectRoles, isPending: isRolesLoading } = useGetProjectRoles(
@@ -215,8 +214,8 @@ export const MemberMultiRoleModify = ({
 
   if (isRolesLoading) {
     return (
-      <div className="flex h-40 w-full items-center justify-center">
-        <Lottie icon="infisical_loading_white" isAutoPlay className="w-16" />
+      <div className="h-40">
+        <PageLoader lottieClassName="w-16" />
       </div>
     );
   }

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberMultiRoleModify.tsx
@@ -1,86 +1,27 @@
-/* eslint-disable no-nested-ternary */
-import { useMemo } from "react";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { format, formatDistance } from "date-fns";
-import { ChevronDownIcon, ClockIcon, PlusIcon, TrashIcon } from "lucide-react";
-import ms from "ms";
-import picomatch from "picomatch";
-import { twMerge } from "tailwind-merge";
+import { PlusIcon, TrashIcon } from "lucide-react";
 import { z } from "zod";
 
-import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import {
-  Badge,
-  Button,
-  Field,
-  FieldError,
-  FieldLabel,
-  IconButton,
-  Input,
-  PageLoader,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
-} from "@app/components/v3";
+import { Button, IconButton, PageLoader } from "@app/components/v3";
 import {
   ProjectPermissionActions,
-  ProjectPermissionMemberActions,
   ProjectPermissionSub,
   useProject,
-  useProjectPermission,
   useSubscription
 } from "@app/context";
-import { formatProjectRoleName } from "@app/helpers/roles";
-import { useGetProjectRoles, useUpdateUserWorkspaceRole } from "@app/hooks/api";
-import { ProjectType, ProjectUserMembershipTemporaryMode } from "@app/hooks/api/projects/types";
+import { useUpdateUserWorkspaceRole } from "@app/hooks/api";
+import { ProjectType } from "@app/hooks/api/projects/types";
 import { ProjectMembershipRole } from "@app/hooks/api/roles/types";
 import { TWorkspaceUser } from "@app/hooks/api/types";
-import {
-  canModifyByGrantConditions,
-  filterByGrantConditions,
-  getMemberAssignRoleConditions
-} from "@app/lib/fn/permission";
 
-const TEMPORARY_RANGE_ERROR = "Only valid time values are accepted (1h, 20m, 2d).";
+import { formRoleToPayload, roleAssignmentSchema, toFormAssignment } from "./roleAssignment";
+import { RoleAssignmentRow } from "./RoleAssignmentRow";
+import { useMemberRoleGrant } from "./useMemberRoleGrant";
 
-const isValidTemporaryRange = (value?: string) => {
-  if (!value?.trim()) return false;
-  const parsedMs = ms(value);
-  return typeof parsedMs === "number" && Number.isFinite(parsedMs) && parsedMs > 0;
-};
-
-const roleFormSchema = z.object({
-  roles: z
-    .object({
-      slug: z.string(),
-      temporaryAccess: z.discriminatedUnion("isTemporary", [
-        z.object({
-          isTemporary: z.literal(true),
-          temporaryRange: z
-            .string()
-            .min(1, "Required")
-            .refine(isValidTemporaryRange, TEMPORARY_RANGE_ERROR),
-          temporaryAccessStartTime: z.string().datetime(),
-          temporaryAccessEndTime: z.string().datetime().nullable().optional()
-        }),
-        z.object({
-          isTemporary: z.literal(false)
-        })
-      ])
-    })
-    .array()
-});
+const roleFormSchema = z.object({ roles: roleAssignmentSchema.array() });
 type TRoleForm = z.infer<typeof roleFormSchema>;
 
 type Props = {
@@ -92,106 +33,20 @@ type Props = {
 export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuccess }: Props) => {
   const { subscription } = useSubscription();
   const { projectId, currentProject } = useProject();
-  const { data: projectRoles, isPending: isRolesLoading } = useGetProjectRoles(
-    projectId,
-    currentProject?.type
-  );
-  const { permission } = useProjectPermission();
-  const isMemberEditDisabled = permission.cannot(
-    ProjectPermissionMemberActions.Edit,
-    ProjectPermissionSub.Member
-  );
-
-  const assignRoleConditions = useMemo(
-    () => getMemberAssignRoleConditions(permission),
-    [permission]
-  );
-
-  const canModifyMemberRoles = useMemo(() => {
-    const memberEmail = projectMember?.user?.email;
-    if (!memberEmail) return false;
-
-    return canModifyByGrantConditions({
-      targetValue: memberEmail,
-      allowed: assignRoleConditions?.emails,
-      forbidden: assignRoleConditions?.forbiddenEmails,
-      isMatch: (value, pattern) => picomatch.isMatch(value, pattern)
-    });
-  }, [assignRoleConditions, projectMember?.user?.email]);
-
-  const filteredRoles = useMemo(
-    () =>
-      filterByGrantConditions(projectRoles ?? [], {
-        getKey: (role) => role.slug,
-        allowed: assignRoleConditions?.roles,
-        forbidden: assignRoleConditions?.forbiddenRoles
-      }),
-    [projectRoles, assignRoleConditions]
-  );
-
-  const assignableRoleSlugs = useMemo(
-    () => new Set(filteredRoles.map((r) => r.slug)),
-    [filteredRoles]
-  );
-
-  const getRolesForSelect = (currentSlug: string) => {
-    const assignable = filteredRoles;
-    const currentInAssignable = assignableRoleSlugs.has(currentSlug);
-    if (currentInAssignable) return assignable;
-
-    const currentRole = projectRoles?.find((r) => r.slug === currentSlug) ?? {
-      slug: currentSlug,
-      name: formatProjectRoleName(currentSlug),
-      id: currentSlug
-    };
-    return [currentRole, ...assignable];
-  };
-
-  const isEditDisabled = isMemberEditDisabled || !canModifyMemberRoles;
+  const { isRolesLoading, assignableRoleSlugs, getRolesForSelect, isEditDisabled } =
+    useMemberRoleGrant(projectMember);
+  const updateMembershipRole = useUpdateUserWorkspaceRole();
 
   const roleForm = useForm<TRoleForm>({
     resolver: zodResolver(roleFormSchema),
-    values: {
-      roles: projectMember?.roles?.map(({ customRoleSlug, role, ...dto }) => ({
-        slug: customRoleSlug || role,
-        temporaryAccess: dto.isTemporary
-          ? {
-              isTemporary: true,
-              temporaryRange: dto.temporaryRange,
-              temporaryAccessEndTime: dto.temporaryAccessEndTime,
-              temporaryAccessStartTime: dto.temporaryAccessStartTime
-            }
-          : {
-              isTemporary: dto.isTemporary
-            }
-      }))
-    }
+    values: { roles: projectMember?.roles?.map(toFormAssignment) ?? [] }
   });
-  const selectedRoleList = useFieldArray({
-    name: "roles",
-    control: roleForm.control
-  });
-
-  const formRoleField = roleForm.watch("roles");
-  const updateMembershipRole = useUpdateUserWorkspaceRole();
+  const selectedRoleList = useFieldArray({ name: "roles", control: roleForm.control });
 
   const handleRoleUpdate = async (data: TRoleForm) => {
     if (updateMembershipRole.isPending) return;
 
-    const sanitizedRoles = data.roles.map((el) => {
-      const { isTemporary } = el.temporaryAccess;
-      if (!isTemporary) {
-        return { role: el.slug, isTemporary: false as const };
-      }
-      return {
-        role: el.slug,
-        isTemporary: true as const,
-        temporaryMode: ProjectUserMembershipTemporaryMode.Relative,
-        temporaryRange: el.temporaryAccess.temporaryRange,
-        temporaryAccessStartTime: el.temporaryAccess.temporaryAccessStartTime
-      };
-    });
-
+    const sanitizedRoles = data.roles.map(formRoleToPayload);
     const hasCustomRoleSelected = sanitizedRoles.some(
       (el) => !Object.values(ProjectMembershipRole).includes(el.role as ProjectMembershipRole)
     );
@@ -223,220 +78,17 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuc
   return (
     <form onSubmit={roleForm.handleSubmit(handleRoleUpdate)}>
       <div className="flex flex-col gap-3">
-        {selectedRoleList.fields.map(({ id }, index) => {
-          const { temporaryAccess } = formRoleField[index];
-          const isTemporary = temporaryAccess?.isTemporary;
-          const isExpired =
-            temporaryAccess.isTemporary &&
-            new Date() > new Date(temporaryAccess.temporaryAccessEndTime || "");
-
-          let durationVariant: "outline" | "warning" | "danger" = "outline";
-          let text = "Permanent";
-          let toolTipText = "Non-Expiring Access";
-
-          if (isTemporary) {
-            if (isExpired) {
-              durationVariant = "danger";
-              text = "Access Expired";
-              toolTipText = "Timed Access Expired";
-            } else {
-              durationVariant = "warning";
-              text = formatDistance(
-                new Date(temporaryAccess.temporaryAccessEndTime || ""),
-                new Date()
-              );
-              toolTipText = `Until ${format(
-                new Date(temporaryAccess.temporaryAccessEndTime || ""),
-                "yyyy-MM-dd HH:mm:ss"
-              )}`;
-            }
-          }
-
-          return (
-            <div key={id} className="flex items-end gap-2">
-              <Controller
-                control={roleForm.control}
-                name={`roles.${index}.slug`}
-                render={({ field }) => {
-                  const rolesForSelect = getRolesForSelect(field.value);
-                  return (
-                    <Field className="min-w-0 flex-1">
-                      {index === 0 && <FieldLabel>Role</FieldLabel>}
-                      <Select
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        disabled={isEditDisabled}
-                      >
-                        <SelectTrigger className="w-full">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent position="popper" className="z-[70]">
-                          {rolesForSelect.map(({ name, slug, id: projectRoleId }) => {
-                            const isAssignable = assignableRoleSlugs.has(slug);
-                            return (
-                              <SelectItem
-                                value={slug}
-                                key={projectRoleId}
-                                disabled={!isAssignable}
-                                description={
-                                  isAssignable
-                                    ? undefined
-                                    : "You don't have permission to assign this role"
-                                }
-                              >
-                                {name}
-                              </SelectItem>
-                            );
-                          })}
-                        </SelectContent>
-                      </Select>
-                    </Field>
-                  );
-                }}
-              />
-              <Field className="w-44 shrink-0">
-                {index === 0 && <FieldLabel>Duration</FieldLabel>}
-                <Popover>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <PopoverTrigger asChild>
-                        <Button
-                          type="button"
-                          variant={durationVariant}
-                          isDisabled={isEditDisabled}
-                          className="w-full capitalize"
-                        >
-                          {isTemporary && <ClockIcon />}
-                          {text}
-                          <ChevronDownIcon />
-                        </Button>
-                      </PopoverTrigger>
-                    </TooltipTrigger>
-                    <TooltipContent>{toolTipText}</TooltipContent>
-                  </Tooltip>
-                  <PopoverContent
-                    side="right"
-                    className="z-[70]"
-                    onWheel={(e) => e.stopPropagation()}
-                    onOpenAutoFocus={(e) => e.preventDefault()}
-                  >
-                    <div className="flex flex-col space-y-4">
-                      <div className="border-b border-b-border pb-2 text-sm text-muted">
-                        Configure Timed Access
-                      </div>
-                      {isExpired && <Badge variant="danger">Expired</Badge>}
-                      <Controller
-                        control={roleForm.control}
-                        defaultValue="1h"
-                        name={`roles.${index}.temporaryAccess.temporaryRange`}
-                        render={({ field, fieldState: { error } }) => {
-                          const showInvalidError =
-                            Boolean(field.value) && !isValidTemporaryRange(field.value);
-                          const errorMessage = showInvalidError
-                            ? TEMPORARY_RANGE_ERROR
-                            : error?.message;
-                          const canGrant = isValidTemporaryRange(field.value);
-
-                          return (
-                            <>
-                              <Field>
-                                <FieldLabel>
-                                  <TtlFormLabel label="Validity" />
-                                </FieldLabel>
-                                <Input
-                                  {...field}
-                                  value={field.value ?? ""}
-                                  isError={Boolean(errorMessage)}
-                                  onChange={(e) => {
-                                    field.onChange(e);
-                                    const nextValue = e.target.value;
-                                    if (!nextValue) {
-                                      roleForm.setError(
-                                        `roles.${index}.temporaryAccess.temporaryRange`,
-                                        { type: "required", message: "Required" },
-                                        { shouldFocus: false }
-                                      );
-                                      return;
-                                    }
-                                    if (!isValidTemporaryRange(nextValue)) {
-                                      roleForm.setError(
-                                        `roles.${index}.temporaryAccess.temporaryRange`,
-                                        {
-                                          type: "validate",
-                                          message: TEMPORARY_RANGE_ERROR
-                                        },
-                                        { shouldFocus: false }
-                                      );
-                                      return;
-                                    }
-                                    roleForm.clearErrors(
-                                      `roles.${index}.temporaryAccess.temporaryRange`
-                                    );
-                                  }}
-                                />
-                                {errorMessage && <FieldError>{errorMessage}</FieldError>}
-                              </Field>
-                              <div className="flex items-center space-x-2">
-                                <Button
-                                  size="xs"
-                                  variant="outline"
-                                  isDisabled={!canGrant}
-                                  onClick={() => {
-                                    const temporaryRange = field.value;
-                                    if (!isValidTemporaryRange(temporaryRange)) {
-                                      roleForm.setError(
-                                        `roles.${index}.temporaryAccess.temporaryRange`,
-                                        {
-                                          type: "validate",
-                                          message: TEMPORARY_RANGE_ERROR
-                                        },
-                                        { shouldFocus: true }
-                                      );
-                                      return;
-                                    }
-                                    roleForm.clearErrors(
-                                      `roles.${index}.temporaryAccess.temporaryRange`
-                                    );
-                                    roleForm.setValue(
-                                      `roles.${index}.temporaryAccess`,
-                                      {
-                                        isTemporary: true,
-                                        temporaryAccessStartTime: new Date().toISOString(),
-                                        temporaryRange,
-                                        temporaryAccessEndTime: new Date(
-                                          new Date().getTime() + ms(temporaryRange)
-                                        ).toISOString()
-                                      },
-                                      { shouldDirty: true }
-                                    );
-                                  }}
-                                >
-                                  {isTemporary ? "Restart" : "Grant"}
-                                </Button>
-                                {isTemporary && (
-                                  <Button
-                                    size="xs"
-                                    variant="danger"
-                                    onClick={() => {
-                                      roleForm.setValue(
-                                        `roles.${index}.temporaryAccess`,
-                                        { isTemporary: false },
-                                        { shouldDirty: true }
-                                      );
-                                    }}
-                                  >
-                                    Revoke Access
-                                  </Button>
-                                )}
-                              </div>
-                            </>
-                          );
-                        }}
-                      />
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              </Field>
+        {selectedRoleList.fields.map(({ id }, index) => (
+          <RoleAssignmentRow
+            key={id}
+            control={roleForm.control}
+            setValue={roleForm.setValue}
+            namePrefix={`roles.${index}.`}
+            showLabels={index === 0}
+            isEditDisabled={isEditDisabled}
+            assignableRoleSlugs={assignableRoleSlugs}
+            getRolesForSelect={getRolesForSelect}
+            action={
               <IconButton
                 size="md"
                 variant="outline"
@@ -451,9 +103,9 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuc
               >
                 <TrashIcon />
               </IconButton>
-            </div>
-          );
-        })}
+            }
+          />
+        ))}
       </div>
       <div className="mt-4 flex items-center justify-between gap-2">
         <ProjectPermissionCan I={ProjectPermissionActions.Edit} a={ProjectPermissionSub.Member}>
@@ -477,11 +129,6 @@ export const MemberMultiRoleModify = ({ projectMember, onOpenUpgradeModal, onSuc
         <Button
           type="submit"
           variant="project"
-          className={twMerge(
-            "transition-all",
-            "cursor-default opacity-0",
-            roleForm.formState.isDirty && "cursor-pointer opacity-100"
-          )}
           isDisabled={!roleForm.formState.isDirty || isEditDisabled}
           isPending={roleForm.formState.isSubmitting}
         >

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
@@ -393,21 +393,19 @@ export const MemberRoleDetailsSection = ({
         open={popUp.modifyManyRoles.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("modifyManyRoles", isOpen)}
       >
-        <SheetContent className="sm:max-w-xl">
-          <SheetHeader>
+        <SheetContent className="flex flex-col gap-0 sm:max-w-xl">
+          <SheetHeader className="border-b">
             <SheetTitle>Roles</SheetTitle>
             <SheetDescription>
               Select one or more of the pre-defined or custom roles to configure project
               permissions.
             </SheetDescription>
           </SheetHeader>
-          <div className="flex-1 overflow-y-auto p-4">
-            <MemberMultiRoleModify
-              projectMember={membershipDetails}
-              onOpenUpgradeModal={onOpenUpgradeModal}
-              onSuccess={() => handlePopUpClose("modifyManyRoles")}
-            />
-          </div>
+          <MemberMultiRoleModify
+            projectMember={membershipDetails}
+            onOpenUpgradeModal={onOpenUpgradeModal}
+            onClose={() => handlePopUpClose("modifyManyRoles")}
+          />
         </SheetContent>
       </Sheet>
       <Dialog

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
@@ -6,7 +6,7 @@ import picomatch from "picomatch";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { DeleteActionModal, Lottie, Modal, ModalContent } from "@app/components/v2";
+import { DeleteActionModal, Lottie } from "@app/components/v2";
 import {
   Badge,
   Button,
@@ -16,6 +16,11 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -52,7 +57,8 @@ import { TProjectRole } from "@app/hooks/api/roles/types";
 import { TWorkspaceUser } from "@app/hooks/api/types";
 import { canModifyByGrantConditions, getMemberAssignRoleConditions } from "@app/lib/fn/permission";
 
-import { MemberRoleModify } from "./MemberRoleModify";
+import { MemberMultiRoleModify } from "./MemberMultiRoleModify";
+import { MemberSingleRoleModify } from "./MemberSingleRoleModify";
 
 type Props = {
   membershipDetails: TWorkspaceUser;
@@ -90,6 +96,7 @@ export const MemberRoleDetailsSection = ({
 
   const { popUp, handlePopUpOpen, handlePopUpToggle, handlePopUpClose } = usePopUp([
     "deleteRole",
+    "modifyManyRoles",
     "modifyRole"
   ] as const);
   const { mutateAsync: updateUserWorkspaceRole } = useUpdateUserWorkspaceRole();
@@ -154,7 +161,7 @@ export const MemberRoleDetailsSection = ({
                       size="xs"
                       variant="outline"
                       onClick={() => {
-                        handlePopUpOpen("modifyRole");
+                        handlePopUpOpen("modifyManyRoles");
                       }}
                       isDisabled={isEditDisabled}
                     >
@@ -285,6 +292,22 @@ export const MemberRoleDetailsSection = ({
                                     <DropdownMenuItem
                                       onClick={(e) => {
                                         e.stopPropagation();
+                                        handlePopUpOpen("modifyRole", roleDetails);
+                                      }}
+                                      isDisabled={!isAllowed || !canModifyMemberRoles}
+                                    >
+                                      Modify Role
+                                    </DropdownMenuItem>
+                                  )}
+                                </ProjectPermissionCan>
+                                <ProjectPermissionCan
+                                  I={ProjectPermissionActions.Edit}
+                                  a={ProjectPermissionSub.Member}
+                                >
+                                  {(isAllowed) => (
+                                    <DropdownMenuItem
+                                      onClick={(e) => {
+                                        e.stopPropagation();
                                         handlePopUpOpen("deleteRole", {
                                           id: roleDetails?.id,
                                           slug: roleDetails?.customRoleName || roleDetails?.role
@@ -325,7 +348,7 @@ export const MemberRoleDetailsSection = ({
                           variant="project"
                           size="xs"
                           onClick={() => {
-                            handlePopUpOpen("modifyRole");
+                            handlePopUpOpen("modifyManyRoles");
                           }}
                           isDisabled={isEditDisabled}
                         >
@@ -361,20 +384,46 @@ export const MemberRoleDetailsSection = ({
         onChange={(isOpen) => handlePopUpToggle("deleteRole", isOpen)}
         onDeleteApproved={() => handleRoleDelete()}
       />
-      <Modal
-        isOpen={popUp.modifyRole.isOpen}
-        onOpenChange={(isOpen) => handlePopUpToggle("modifyRole", isOpen)}
+      <Dialog
+        open={popUp.modifyManyRoles.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("modifyManyRoles", isOpen)}
       >
-        <ModalContent
-          title="Roles"
-          subTitle="Select one or more of the pre-defined or custom roles to configure project permissions."
-        >
-          <MemberRoleModify
+        <DialogContent className="overflow-visible sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Roles</DialogTitle>
+            <DialogDescription>
+              Select one or more of the pre-defined or custom roles to configure project
+              permissions.
+            </DialogDescription>
+          </DialogHeader>
+          <MemberMultiRoleModify
             projectMember={membershipDetails}
             onOpenUpgradeModal={onOpenUpgradeModal}
+            onSuccess={() => handlePopUpClose("modifyManyRoles")}
           />
-        </ModalContent>
-      </Modal>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={popUp.modifyRole.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("modifyRole", isOpen)}
+      >
+        <DialogContent className="overflow-visible sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Edit Role</DialogTitle>
+            <DialogDescription>
+              Update this role assignment and its access duration.
+            </DialogDescription>
+          </DialogHeader>
+          {popUp.modifyRole.data && (
+            <MemberSingleRoleModify
+              projectMember={membershipDetails}
+              role={popUp.modifyRole.data as TWorkspaceUser["roles"][number]}
+              onOpenUpgradeModal={onOpenUpgradeModal}
+              onSuccess={() => handlePopUpClose("modifyRole")}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </>
   );
 };

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberRoleDetailsSection.tsx
@@ -31,6 +31,11 @@ import {
   EmptyHeader,
   EmptyTitle,
   IconButton,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
   Table,
   TableBody,
   TableCell,
@@ -384,25 +389,27 @@ export const MemberRoleDetailsSection = ({
         onChange={(isOpen) => handlePopUpToggle("deleteRole", isOpen)}
         onDeleteApproved={() => handleRoleDelete()}
       />
-      <Dialog
+      <Sheet
         open={popUp.modifyManyRoles.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("modifyManyRoles", isOpen)}
       >
-        <DialogContent className="overflow-visible sm:max-w-xl">
-          <DialogHeader>
-            <DialogTitle>Roles</DialogTitle>
-            <DialogDescription>
+        <SheetContent className="sm:max-w-xl">
+          <SheetHeader>
+            <SheetTitle>Roles</SheetTitle>
+            <SheetDescription>
               Select one or more of the pre-defined or custom roles to configure project
               permissions.
-            </DialogDescription>
-          </DialogHeader>
-          <MemberMultiRoleModify
-            projectMember={membershipDetails}
-            onOpenUpgradeModal={onOpenUpgradeModal}
-            onSuccess={() => handlePopUpClose("modifyManyRoles")}
-          />
-        </DialogContent>
-      </Dialog>
+            </SheetDescription>
+          </SheetHeader>
+          <div className="flex-1 overflow-y-auto p-4">
+            <MemberMultiRoleModify
+              projectMember={membershipDetails}
+              onOpenUpgradeModal={onOpenUpgradeModal}
+              onSuccess={() => handlePopUpClose("modifyManyRoles")}
+            />
+          </div>
+        </SheetContent>
+      </Sheet>
       <Dialog
         open={popUp.modifyRole.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("modifyRole", isOpen)}

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberSingleRoleModify.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberSingleRoleModify.tsx
@@ -10,7 +10,6 @@ import { z } from "zod";
 
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
-import { Lottie } from "@app/components/v2";
 import {
   Badge,
   Button,
@@ -18,6 +17,7 @@ import {
   FieldError,
   FieldLabel,
   Input,
+  PageLoader,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -48,8 +48,7 @@ import {
   getMemberAssignRoleConditions
 } from "@app/lib/fn/permission";
 
-const TEMPORARY_RANGE_ERROR =
-  "Only valid time values are accepted (1h, 20m, 2d).";
+const TEMPORARY_RANGE_ERROR = "Only valid time values are accepted (1h, 20m, 2d).";
 
 const isValidTemporaryRange = (value?: string) => {
   if (!value?.trim()) return false;
@@ -62,7 +61,10 @@ const roleFormSchema = z.object({
   temporaryAccess: z.discriminatedUnion("isTemporary", [
     z.object({
       isTemporary: z.literal(true),
-      temporaryRange: z.string().min(1),
+      temporaryRange: z
+        .string()
+        .min(1, "Required")
+        .refine(isValidTemporaryRange, TEMPORARY_RANGE_ERROR),
       temporaryAccessStartTime: z.string().datetime(),
       temporaryAccessEndTime: z.string().datetime().nullable().optional()
     }),
@@ -244,8 +246,8 @@ export const MemberSingleRoleModify = ({
 
   if (isRolesLoading) {
     return (
-      <div className="flex h-40 w-full items-center justify-center">
-        <Lottie icon="infisical_loading_white" isAutoPlay className="w-16" />
+      <div className="h-40">
+        <PageLoader lottieClassName="w-16" />
       </div>
     );
   }
@@ -331,9 +333,7 @@ export const MemberSingleRoleModify = ({
                   render={({ field, fieldState: { error } }) => {
                     const showInvalidError =
                       Boolean(field.value) && !isValidTemporaryRange(field.value);
-                    const errorMessage = showInvalidError
-                      ? TEMPORARY_RANGE_ERROR
-                      : error?.message;
+                    const errorMessage = showInvalidError ? TEMPORARY_RANGE_ERROR : error?.message;
 
                     return (
                       <>

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberSingleRoleModify.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberSingleRoleModify.tsx
@@ -1,0 +1,452 @@
+import { useMemo } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { format, formatDistance } from "date-fns";
+import { ChevronDownIcon, ClockIcon } from "lucide-react";
+import ms from "ms";
+import picomatch from "picomatch";
+import { twMerge } from "tailwind-merge";
+import { z } from "zod";
+
+import { TtlFormLabel } from "@app/components/features";
+import { createNotification } from "@app/components/notifications";
+import { Lottie } from "@app/components/v2";
+import {
+  Badge,
+  Button,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
+import {
+  ProjectPermissionMemberActions,
+  ProjectPermissionSub,
+  useProject,
+  useProjectPermission,
+  useSubscription
+} from "@app/context";
+import { formatProjectRoleName } from "@app/helpers/roles";
+import { useGetProjectRoles, useUpdateUserWorkspaceRole } from "@app/hooks/api";
+import { ProjectType, ProjectUserMembershipTemporaryMode } from "@app/hooks/api/projects/types";
+import { ProjectMembershipRole } from "@app/hooks/api/roles/types";
+import { TWorkspaceUser } from "@app/hooks/api/types";
+import {
+  canModifyByGrantConditions,
+  filterByGrantConditions,
+  getMemberAssignRoleConditions
+} from "@app/lib/fn/permission";
+
+const TEMPORARY_RANGE_ERROR =
+  "Only valid time values are accepted (1h, 20m, 2d).";
+
+const isValidTemporaryRange = (value?: string) => {
+  if (!value?.trim()) return false;
+  const parsedMs = ms(value);
+  return typeof parsedMs === "number" && Number.isFinite(parsedMs) && parsedMs > 0;
+};
+
+const roleFormSchema = z.object({
+  slug: z.string().min(1),
+  temporaryAccess: z.discriminatedUnion("isTemporary", [
+    z.object({
+      isTemporary: z.literal(true),
+      temporaryRange: z.string().min(1),
+      temporaryAccessStartTime: z.string().datetime(),
+      temporaryAccessEndTime: z.string().datetime().nullable().optional()
+    }),
+    z.object({
+      isTemporary: z.literal(false)
+    })
+  ])
+});
+type TRoleForm = z.infer<typeof roleFormSchema>;
+
+export type MemberRoleAssignment = TWorkspaceUser["roles"][number];
+
+type Props = {
+  projectMember: TWorkspaceUser;
+  role: MemberRoleAssignment;
+  onOpenUpgradeModal: () => void;
+  onSuccess?: () => void;
+};
+
+export const MemberSingleRoleModify = ({
+  projectMember,
+  role,
+  onOpenUpgradeModal,
+  onSuccess
+}: Props) => {
+  const { subscription } = useSubscription();
+  const { projectId, currentProject } = useProject();
+  const { data: projectRoles, isPending: isRolesLoading } = useGetProjectRoles(
+    projectId,
+    currentProject?.type
+  );
+  const { permission } = useProjectPermission();
+  const isMemberEditDisabled = permission.cannot(
+    ProjectPermissionMemberActions.Edit,
+    ProjectPermissionSub.Member
+  );
+
+  const assignRoleConditions = useMemo(
+    () => getMemberAssignRoleConditions(permission),
+    [permission]
+  );
+
+  const canModifyMemberRoles = useMemo(() => {
+    const memberEmail = projectMember?.user?.email;
+    if (!memberEmail) return false;
+
+    return canModifyByGrantConditions({
+      targetValue: memberEmail,
+      allowed: assignRoleConditions?.emails,
+      forbidden: assignRoleConditions?.forbiddenEmails,
+      isMatch: (value, pattern) => picomatch.isMatch(value, pattern)
+    });
+  }, [assignRoleConditions, projectMember?.user?.email]);
+
+  const filteredRoles = useMemo(
+    () =>
+      filterByGrantConditions(projectRoles ?? [], {
+        getKey: (r) => r.slug,
+        allowed: assignRoleConditions?.roles,
+        forbidden: assignRoleConditions?.forbiddenRoles
+      }),
+    [projectRoles, assignRoleConditions]
+  );
+
+  const assignableRoleSlugs = useMemo(
+    () => new Set(filteredRoles.map((r) => r.slug)),
+    [filteredRoles]
+  );
+
+  const getRolesForSelect = (currentSlug: string) => {
+    const assignable = filteredRoles;
+    const currentInAssignable = assignableRoleSlugs.has(currentSlug);
+    if (currentInAssignable) return assignable;
+
+    const currentRole = projectRoles?.find((r) => r.slug === currentSlug) ?? {
+      slug: currentSlug,
+      name: formatProjectRoleName(currentSlug),
+      id: currentSlug
+    };
+    return [currentRole, ...assignable];
+  };
+
+  const isEditDisabled = isMemberEditDisabled || !canModifyMemberRoles;
+
+  const roleForm = useForm<TRoleForm>({
+    resolver: zodResolver(roleFormSchema),
+    values: {
+      slug: role.customRoleSlug || role.role,
+      temporaryAccess: role.isTemporary
+        ? {
+            isTemporary: true,
+            temporaryRange: role.temporaryRange,
+            temporaryAccessEndTime: role.temporaryAccessEndTime,
+            temporaryAccessStartTime: role.temporaryAccessStartTime
+          }
+        : {
+            isTemporary: false
+          }
+    }
+  });
+
+  const temporaryAccess = roleForm.watch("temporaryAccess");
+  const updateMembershipRole = useUpdateUserWorkspaceRole();
+
+  const isTemporary = temporaryAccess?.isTemporary;
+  const isExpired =
+    temporaryAccess?.isTemporary &&
+    new Date() > new Date(temporaryAccess.temporaryAccessEndTime || "");
+
+  let durationVariant: "outline" | "warning" | "danger" = "outline";
+  let text = "Permanent";
+  let toolTipText = "Non-Expiring Access";
+
+  if (isTemporary) {
+    if (isExpired) {
+      durationVariant = "danger";
+      text = "Access Expired";
+      toolTipText = "Timed Access Expired";
+    } else {
+      durationVariant = "warning";
+      text = formatDistance(new Date(temporaryAccess.temporaryAccessEndTime || ""), new Date());
+      toolTipText = `Until ${format(
+        new Date(temporaryAccess.temporaryAccessEndTime || ""),
+        "yyyy-MM-dd HH:mm:ss"
+      )}`;
+    }
+  }
+
+  const handleRoleUpdate = async (data: TRoleForm) => {
+    if (updateMembershipRole.isPending) return;
+
+    const nextRolePayload = data.temporaryAccess.isTemporary
+      ? {
+          role: data.slug,
+          isTemporary: true as const,
+          temporaryMode: ProjectUserMembershipTemporaryMode.Relative,
+          temporaryRange: data.temporaryAccess.temporaryRange,
+          temporaryAccessStartTime: data.temporaryAccess.temporaryAccessStartTime
+        }
+      : { role: data.slug, isTemporary: false as const };
+
+    const hasCustomRoleSelected = !Object.values(ProjectMembershipRole).includes(
+      nextRolePayload.role as ProjectMembershipRole
+    );
+
+    if (hasCustomRoleSelected && subscription && !subscription?.rbac) {
+      onOpenUpgradeModal();
+      return;
+    }
+
+    const sanitizedRoles = projectMember.roles.map((existing) => {
+      if (existing.id !== role.id) {
+        return existing.isTemporary
+          ? {
+              role: existing.role === "custom" ? existing.customRoleSlug : existing.role,
+              isTemporary: true as const,
+              temporaryMode: existing.temporaryMode,
+              temporaryRange: existing.temporaryRange,
+              temporaryAccessStartTime: existing.temporaryAccessStartTime
+            }
+          : {
+              role: existing.role === "custom" ? existing.customRoleSlug : existing.role,
+              isTemporary: false as const
+            };
+      }
+      return nextRolePayload;
+    });
+
+    const isCertManager = currentProject?.type === ProjectType.CertificateManager;
+    await updateMembershipRole.mutateAsync({
+      projectId,
+      projectType: currentProject?.type,
+      membershipId: isCertManager ? projectMember.user.id : projectMember.id,
+      roles: sanitizedRoles
+    });
+    createNotification({ text: "Successfully updated role", type: "success" });
+    onSuccess?.();
+  };
+
+  if (isRolesLoading) {
+    return (
+      <div className="flex h-40 w-full items-center justify-center">
+        <Lottie icon="infisical_loading_white" isAutoPlay className="w-16" />
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={roleForm.handleSubmit(handleRoleUpdate)}>
+      <div className="mt-2 flex items-end gap-2">
+        <Controller
+          control={roleForm.control}
+          name="slug"
+          render={({ field }) => {
+            const rolesForSelect = getRolesForSelect(field.value);
+            return (
+              <Field className="min-w-0 flex-1">
+                <FieldLabel>Role</FieldLabel>
+                <Select
+                  value={field.value}
+                  onValueChange={field.onChange}
+                  disabled={isEditDisabled}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent position="popper" className="z-[70]">
+                    {rolesForSelect.map(({ name, slug, id: projectRoleId }) => {
+                      const isAssignable = assignableRoleSlugs.has(slug);
+                      return (
+                        <SelectItem
+                          value={slug}
+                          key={projectRoleId}
+                          disabled={!isAssignable}
+                          description={
+                            isAssignable
+                              ? undefined
+                              : "You don't have permission to assign this role"
+                          }
+                        >
+                          {name}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              </Field>
+            );
+          }}
+        />
+        <Field className="w-44 shrink-0">
+          <FieldLabel>Duration</FieldLabel>
+          <Popover>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant={durationVariant}
+                    isDisabled={isEditDisabled}
+                    className="w-full capitalize"
+                  >
+                    {isTemporary && <ClockIcon />}
+                    {text}
+                    <ChevronDownIcon />
+                  </Button>
+                </PopoverTrigger>
+              </TooltipTrigger>
+              <TooltipContent>{toolTipText}</TooltipContent>
+            </Tooltip>
+            <PopoverContent
+              side="right"
+              className="z-[70]"
+              onWheel={(e) => e.stopPropagation()}
+              onOpenAutoFocus={(e) => e.preventDefault()}
+            >
+              <div className="flex flex-col space-y-4">
+                <div className="border-b border-b-border pb-2 text-sm text-muted">
+                  Configure Timed Access
+                </div>
+                {isExpired && <Badge variant="danger">Expired</Badge>}
+                <Controller
+                  control={roleForm.control}
+                  defaultValue="1h"
+                  name="temporaryAccess.temporaryRange"
+                  render={({ field, fieldState: { error } }) => {
+                    const showInvalidError =
+                      Boolean(field.value) && !isValidTemporaryRange(field.value);
+                    const errorMessage = showInvalidError
+                      ? TEMPORARY_RANGE_ERROR
+                      : error?.message;
+
+                    return (
+                      <>
+                        <Field>
+                          <FieldLabel>
+                            <TtlFormLabel label="Validity" />
+                          </FieldLabel>
+                          <Input
+                            {...field}
+                            value={field.value ?? ""}
+                            isError={Boolean(errorMessage)}
+                            onChange={(e) => {
+                              field.onChange(e);
+                              const nextValue = e.target.value;
+                              if (!nextValue) {
+                                roleForm.setError(
+                                  "temporaryAccess.temporaryRange",
+                                  { type: "required", message: "Required" },
+                                  { shouldFocus: false }
+                                );
+                                return;
+                              }
+                              if (!isValidTemporaryRange(nextValue)) {
+                                roleForm.setError(
+                                  "temporaryAccess.temporaryRange",
+                                  {
+                                    type: "validate",
+                                    message: TEMPORARY_RANGE_ERROR
+                                  },
+                                  { shouldFocus: false }
+                                );
+                                return;
+                              }
+                              roleForm.clearErrors("temporaryAccess.temporaryRange");
+                            }}
+                          />
+                          {errorMessage && <FieldError>{errorMessage}</FieldError>}
+                        </Field>
+                        <div className="flex items-center space-x-2">
+                          <Button
+                            size="xs"
+                            variant="outline"
+                            isDisabled={!isValidTemporaryRange(field.value)}
+                            onClick={() => {
+                              const temporaryRange = field.value;
+                              if (!isValidTemporaryRange(temporaryRange)) {
+                                roleForm.setError(
+                                  "temporaryAccess.temporaryRange",
+                                  {
+                                    type: "validate",
+                                    message: TEMPORARY_RANGE_ERROR
+                                  },
+                                  { shouldFocus: true }
+                                );
+                                return;
+                              }
+                              roleForm.clearErrors("temporaryAccess.temporaryRange");
+                              roleForm.setValue(
+                                "temporaryAccess",
+                                {
+                                  isTemporary: true,
+                                  temporaryAccessStartTime: new Date().toISOString(),
+                                  temporaryRange,
+                                  temporaryAccessEndTime: new Date(
+                                    new Date().getTime() + ms(temporaryRange)
+                                  ).toISOString()
+                                },
+                                { shouldDirty: true }
+                              );
+                            }}
+                          >
+                            {isTemporary ? "Restart" : "Grant"}
+                          </Button>
+                          {isTemporary && (
+                            <Button
+                              size="xs"
+                              variant="danger"
+                              onClick={() => {
+                                roleForm.setValue(
+                                  "temporaryAccess",
+                                  { isTemporary: false },
+                                  { shouldDirty: true }
+                                );
+                              }}
+                            >
+                              Revoke Access
+                            </Button>
+                          )}
+                        </div>
+                      </>
+                    );
+                  }}
+                />
+              </div>
+            </PopoverContent>
+          </Popover>
+        </Field>
+      </div>
+      <div className="mt-4 flex justify-end">
+        <Button
+          type="submit"
+          variant="project"
+          className={twMerge(
+            "transition-all",
+            "cursor-default opacity-0",
+            roleForm.formState.isDirty && "cursor-pointer opacity-100"
+          )}
+          isDisabled={!roleForm.formState.isDirty || isEditDisabled}
+          isPending={roleForm.formState.isSubmitting}
+        >
+          Save Role
+        </Button>
+      </div>
+    </form>
+  );
+};

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberSingleRoleModify.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/MemberSingleRoleModify.tsx
@@ -1,81 +1,24 @@
-import { useMemo } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { format, formatDistance } from "date-fns";
-import { ChevronDownIcon, ClockIcon } from "lucide-react";
-import ms from "ms";
-import picomatch from "picomatch";
-import { twMerge } from "tailwind-merge";
-import { z } from "zod";
 
-import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
-import {
-  Badge,
-  Button,
-  Field,
-  FieldError,
-  FieldLabel,
-  Input,
-  PageLoader,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
-} from "@app/components/v3";
-import {
-  ProjectPermissionMemberActions,
-  ProjectPermissionSub,
-  useProject,
-  useProjectPermission,
-  useSubscription
-} from "@app/context";
-import { formatProjectRoleName } from "@app/helpers/roles";
-import { useGetProjectRoles, useUpdateUserWorkspaceRole } from "@app/hooks/api";
-import { ProjectType, ProjectUserMembershipTemporaryMode } from "@app/hooks/api/projects/types";
+import { Button, PageLoader } from "@app/components/v3";
+import { useProject, useSubscription } from "@app/context";
+import { useUpdateUserWorkspaceRole } from "@app/hooks/api";
+import { ProjectType } from "@app/hooks/api/projects/types";
 import { ProjectMembershipRole } from "@app/hooks/api/roles/types";
 import { TWorkspaceUser } from "@app/hooks/api/types";
+
 import {
-  canModifyByGrantConditions,
-  filterByGrantConditions,
-  getMemberAssignRoleConditions
-} from "@app/lib/fn/permission";
-
-const TEMPORARY_RANGE_ERROR = "Only valid time values are accepted (1h, 20m, 2d).";
-
-const isValidTemporaryRange = (value?: string) => {
-  if (!value?.trim()) return false;
-  const parsedMs = ms(value);
-  return typeof parsedMs === "number" && Number.isFinite(parsedMs) && parsedMs > 0;
-};
-
-const roleFormSchema = z.object({
-  slug: z.string().min(1),
-  temporaryAccess: z.discriminatedUnion("isTemporary", [
-    z.object({
-      isTemporary: z.literal(true),
-      temporaryRange: z
-        .string()
-        .min(1, "Required")
-        .refine(isValidTemporaryRange, TEMPORARY_RANGE_ERROR),
-      temporaryAccessStartTime: z.string().datetime(),
-      temporaryAccessEndTime: z.string().datetime().nullable().optional()
-    }),
-    z.object({
-      isTemporary: z.literal(false)
-    })
-  ])
-});
-type TRoleForm = z.infer<typeof roleFormSchema>;
-
-export type MemberRoleAssignment = TWorkspaceUser["roles"][number];
+  existingRoleToPayload,
+  formRoleToPayload,
+  MemberRoleAssignment,
+  roleAssignmentSchema,
+  toFormAssignment,
+  TRoleAssignment
+} from "./roleAssignment";
+import { RoleAssignmentRow } from "./RoleAssignmentRow";
+import { useMemberRoleGrant } from "./useMemberRoleGrant";
 
 type Props = {
   projectMember: TWorkspaceUser;
@@ -92,120 +35,19 @@ export const MemberSingleRoleModify = ({
 }: Props) => {
   const { subscription } = useSubscription();
   const { projectId, currentProject } = useProject();
-  const { data: projectRoles, isPending: isRolesLoading } = useGetProjectRoles(
-    projectId,
-    currentProject?.type
-  );
-  const { permission } = useProjectPermission();
-  const isMemberEditDisabled = permission.cannot(
-    ProjectPermissionMemberActions.Edit,
-    ProjectPermissionSub.Member
-  );
-
-  const assignRoleConditions = useMemo(
-    () => getMemberAssignRoleConditions(permission),
-    [permission]
-  );
-
-  const canModifyMemberRoles = useMemo(() => {
-    const memberEmail = projectMember?.user?.email;
-    if (!memberEmail) return false;
-
-    return canModifyByGrantConditions({
-      targetValue: memberEmail,
-      allowed: assignRoleConditions?.emails,
-      forbidden: assignRoleConditions?.forbiddenEmails,
-      isMatch: (value, pattern) => picomatch.isMatch(value, pattern)
-    });
-  }, [assignRoleConditions, projectMember?.user?.email]);
-
-  const filteredRoles = useMemo(
-    () =>
-      filterByGrantConditions(projectRoles ?? [], {
-        getKey: (r) => r.slug,
-        allowed: assignRoleConditions?.roles,
-        forbidden: assignRoleConditions?.forbiddenRoles
-      }),
-    [projectRoles, assignRoleConditions]
-  );
-
-  const assignableRoleSlugs = useMemo(
-    () => new Set(filteredRoles.map((r) => r.slug)),
-    [filteredRoles]
-  );
-
-  const getRolesForSelect = (currentSlug: string) => {
-    const assignable = filteredRoles;
-    const currentInAssignable = assignableRoleSlugs.has(currentSlug);
-    if (currentInAssignable) return assignable;
-
-    const currentRole = projectRoles?.find((r) => r.slug === currentSlug) ?? {
-      slug: currentSlug,
-      name: formatProjectRoleName(currentSlug),
-      id: currentSlug
-    };
-    return [currentRole, ...assignable];
-  };
-
-  const isEditDisabled = isMemberEditDisabled || !canModifyMemberRoles;
-
-  const roleForm = useForm<TRoleForm>({
-    resolver: zodResolver(roleFormSchema),
-    values: {
-      slug: role.customRoleSlug || role.role,
-      temporaryAccess: role.isTemporary
-        ? {
-            isTemporary: true,
-            temporaryRange: role.temporaryRange,
-            temporaryAccessEndTime: role.temporaryAccessEndTime,
-            temporaryAccessStartTime: role.temporaryAccessStartTime
-          }
-        : {
-            isTemporary: false
-          }
-    }
-  });
-
-  const temporaryAccess = roleForm.watch("temporaryAccess");
+  const { isRolesLoading, assignableRoleSlugs, getRolesForSelect, isEditDisabled } =
+    useMemberRoleGrant(projectMember);
   const updateMembershipRole = useUpdateUserWorkspaceRole();
 
-  const isTemporary = temporaryAccess?.isTemporary;
-  const isExpired =
-    temporaryAccess?.isTemporary &&
-    new Date() > new Date(temporaryAccess.temporaryAccessEndTime || "");
+  const roleForm = useForm<TRoleAssignment>({
+    resolver: zodResolver(roleAssignmentSchema),
+    values: toFormAssignment(role)
+  });
 
-  let durationVariant: "outline" | "warning" | "danger" = "outline";
-  let text = "Permanent";
-  let toolTipText = "Non-Expiring Access";
-
-  if (isTemporary) {
-    if (isExpired) {
-      durationVariant = "danger";
-      text = "Access Expired";
-      toolTipText = "Timed Access Expired";
-    } else {
-      durationVariant = "warning";
-      text = formatDistance(new Date(temporaryAccess.temporaryAccessEndTime || ""), new Date());
-      toolTipText = `Until ${format(
-        new Date(temporaryAccess.temporaryAccessEndTime || ""),
-        "yyyy-MM-dd HH:mm:ss"
-      )}`;
-    }
-  }
-
-  const handleRoleUpdate = async (data: TRoleForm) => {
+  const handleRoleUpdate = async (data: TRoleAssignment) => {
     if (updateMembershipRole.isPending) return;
 
-    const nextRolePayload = data.temporaryAccess.isTemporary
-      ? {
-          role: data.slug,
-          isTemporary: true as const,
-          temporaryMode: ProjectUserMembershipTemporaryMode.Relative,
-          temporaryRange: data.temporaryAccess.temporaryRange,
-          temporaryAccessStartTime: data.temporaryAccess.temporaryAccessStartTime
-        }
-      : { role: data.slug, isTemporary: false as const };
-
+    const nextRolePayload = formRoleToPayload(data);
     const hasCustomRoleSelected = !Object.values(ProjectMembershipRole).includes(
       nextRolePayload.role as ProjectMembershipRole
     );
@@ -215,30 +57,18 @@ export const MemberSingleRoleModify = ({
       return;
     }
 
-    const sanitizedRoles = projectMember.roles.map((existing) => {
-      if (existing.id !== role.id) {
-        return existing.isTemporary
-          ? {
-              role: existing.role === "custom" ? existing.customRoleSlug : existing.role,
-              isTemporary: true as const,
-              temporaryMode: existing.temporaryMode,
-              temporaryRange: existing.temporaryRange,
-              temporaryAccessStartTime: existing.temporaryAccessStartTime
-            }
-          : {
-              role: existing.role === "custom" ? existing.customRoleSlug : existing.role,
-              isTemporary: false as const
-            };
-      }
-      return nextRolePayload;
-    });
+    // The PATCH replaces the whole role set, so re-send every current assignment and swap in the
+    // edited one — otherwise the member's other roles would be dropped.
+    const roles = projectMember.roles.map((existing) =>
+      existing.id === role.id ? nextRolePayload : existingRoleToPayload(existing)
+    );
 
     const isCertManager = currentProject?.type === ProjectType.CertificateManager;
     await updateMembershipRole.mutateAsync({
       projectId,
       projectType: currentProject?.type,
       membershipId: isCertManager ? projectMember.user.id : projectMember.id,
-      roles: sanitizedRoles
+      roles
     });
     createNotification({ text: "Successfully updated role", type: "success" });
     onSuccess?.();
@@ -254,193 +84,17 @@ export const MemberSingleRoleModify = ({
 
   return (
     <form onSubmit={roleForm.handleSubmit(handleRoleUpdate)}>
-      <div className="mt-2 flex items-end gap-2">
-        <Controller
-          control={roleForm.control}
-          name="slug"
-          render={({ field }) => {
-            const rolesForSelect = getRolesForSelect(field.value);
-            return (
-              <Field className="min-w-0 flex-1">
-                <FieldLabel>Role</FieldLabel>
-                <Select
-                  value={field.value}
-                  onValueChange={field.onChange}
-                  disabled={isEditDisabled}
-                >
-                  <SelectTrigger className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent position="popper" className="z-[70]">
-                    {rolesForSelect.map(({ name, slug, id: projectRoleId }) => {
-                      const isAssignable = assignableRoleSlugs.has(slug);
-                      return (
-                        <SelectItem
-                          value={slug}
-                          key={projectRoleId}
-                          disabled={!isAssignable}
-                          description={
-                            isAssignable
-                              ? undefined
-                              : "You don't have permission to assign this role"
-                          }
-                        >
-                          {name}
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectContent>
-                </Select>
-              </Field>
-            );
-          }}
-        />
-        <Field className="w-44 shrink-0">
-          <FieldLabel>Duration</FieldLabel>
-          <Popover>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <PopoverTrigger asChild>
-                  <Button
-                    type="button"
-                    variant={durationVariant}
-                    isDisabled={isEditDisabled}
-                    className="w-full capitalize"
-                  >
-                    {isTemporary && <ClockIcon />}
-                    {text}
-                    <ChevronDownIcon />
-                  </Button>
-                </PopoverTrigger>
-              </TooltipTrigger>
-              <TooltipContent>{toolTipText}</TooltipContent>
-            </Tooltip>
-            <PopoverContent
-              side="right"
-              className="z-[70]"
-              onWheel={(e) => e.stopPropagation()}
-              onOpenAutoFocus={(e) => e.preventDefault()}
-            >
-              <div className="flex flex-col space-y-4">
-                <div className="border-b border-b-border pb-2 text-sm text-muted">
-                  Configure Timed Access
-                </div>
-                {isExpired && <Badge variant="danger">Expired</Badge>}
-                <Controller
-                  control={roleForm.control}
-                  defaultValue="1h"
-                  name="temporaryAccess.temporaryRange"
-                  render={({ field, fieldState: { error } }) => {
-                    const showInvalidError =
-                      Boolean(field.value) && !isValidTemporaryRange(field.value);
-                    const errorMessage = showInvalidError ? TEMPORARY_RANGE_ERROR : error?.message;
-
-                    return (
-                      <>
-                        <Field>
-                          <FieldLabel>
-                            <TtlFormLabel label="Validity" />
-                          </FieldLabel>
-                          <Input
-                            {...field}
-                            value={field.value ?? ""}
-                            isError={Boolean(errorMessage)}
-                            onChange={(e) => {
-                              field.onChange(e);
-                              const nextValue = e.target.value;
-                              if (!nextValue) {
-                                roleForm.setError(
-                                  "temporaryAccess.temporaryRange",
-                                  { type: "required", message: "Required" },
-                                  { shouldFocus: false }
-                                );
-                                return;
-                              }
-                              if (!isValidTemporaryRange(nextValue)) {
-                                roleForm.setError(
-                                  "temporaryAccess.temporaryRange",
-                                  {
-                                    type: "validate",
-                                    message: TEMPORARY_RANGE_ERROR
-                                  },
-                                  { shouldFocus: false }
-                                );
-                                return;
-                              }
-                              roleForm.clearErrors("temporaryAccess.temporaryRange");
-                            }}
-                          />
-                          {errorMessage && <FieldError>{errorMessage}</FieldError>}
-                        </Field>
-                        <div className="flex items-center space-x-2">
-                          <Button
-                            size="xs"
-                            variant="outline"
-                            isDisabled={!isValidTemporaryRange(field.value)}
-                            onClick={() => {
-                              const temporaryRange = field.value;
-                              if (!isValidTemporaryRange(temporaryRange)) {
-                                roleForm.setError(
-                                  "temporaryAccess.temporaryRange",
-                                  {
-                                    type: "validate",
-                                    message: TEMPORARY_RANGE_ERROR
-                                  },
-                                  { shouldFocus: true }
-                                );
-                                return;
-                              }
-                              roleForm.clearErrors("temporaryAccess.temporaryRange");
-                              roleForm.setValue(
-                                "temporaryAccess",
-                                {
-                                  isTemporary: true,
-                                  temporaryAccessStartTime: new Date().toISOString(),
-                                  temporaryRange,
-                                  temporaryAccessEndTime: new Date(
-                                    new Date().getTime() + ms(temporaryRange)
-                                  ).toISOString()
-                                },
-                                { shouldDirty: true }
-                              );
-                            }}
-                          >
-                            {isTemporary ? "Restart" : "Grant"}
-                          </Button>
-                          {isTemporary && (
-                            <Button
-                              size="xs"
-                              variant="danger"
-                              onClick={() => {
-                                roleForm.setValue(
-                                  "temporaryAccess",
-                                  { isTemporary: false },
-                                  { shouldDirty: true }
-                                );
-                              }}
-                            >
-                              Revoke Access
-                            </Button>
-                          )}
-                        </div>
-                      </>
-                    );
-                  }}
-                />
-              </div>
-            </PopoverContent>
-          </Popover>
-        </Field>
-      </div>
+      <RoleAssignmentRow
+        control={roleForm.control}
+        setValue={roleForm.setValue}
+        isEditDisabled={isEditDisabled}
+        assignableRoleSlugs={assignableRoleSlugs}
+        getRolesForSelect={getRolesForSelect}
+      />
       <div className="mt-4 flex justify-end">
         <Button
           type="submit"
           variant="project"
-          className={twMerge(
-            "transition-all",
-            "cursor-default opacity-0",
-            roleForm.formState.isDirty && "cursor-pointer opacity-100"
-          )}
           isDisabled={!roleForm.formState.isDirty || isEditDisabled}
           isPending={roleForm.formState.isSubmitting}
         >

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/RoleAssignmentRow.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/RoleAssignmentRow.tsx
@@ -1,0 +1,203 @@
+import { ReactNode } from "react";
+import { Control, Controller, UseFormSetValue, useWatch } from "react-hook-form";
+import { ChevronDownIcon, ClockIcon } from "lucide-react";
+import ms from "ms";
+
+import { TtlFormLabel } from "@app/components/features";
+import {
+  Badge,
+  Button,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
+
+import { getDurationDisplay, isValidTemporaryRange, TEMPORARY_RANGE_ERROR } from "./roleAssignment";
+
+type RoleForSelect = { slug: string; name: string; id: string };
+
+type Props = {
+  control: Control<any>;
+  setValue: UseFormSetValue<any>;
+  /** Field path prefix: "" for a flat single-role form, `roles.${index}.` for a multi-role array. */
+  namePrefix?: string;
+  /** Field editors stack rows; only the first row shows its labels. */
+  showLabels?: boolean;
+  isEditDisabled: boolean;
+  assignableRoleSlugs: Set<string>;
+  getRolesForSelect: (currentSlug: string) => RoleForSelect[];
+  /** Trailing control rendered after the duration field, e.g. a remove-row button. */
+  action?: ReactNode;
+};
+
+export const RoleAssignmentRow = ({
+  control,
+  setValue,
+  namePrefix = "",
+  showLabels = true,
+  isEditDisabled,
+  assignableRoleSlugs,
+  getRolesForSelect,
+  action
+}: Props) => {
+  const slugName = `${namePrefix}slug`;
+  const temporaryAccessName = `${namePrefix}temporaryAccess`;
+  const temporaryRangeName = `${namePrefix}temporaryAccess.temporaryRange`;
+
+  const temporaryAccess = useWatch({ control, name: temporaryAccessName });
+  const isTemporary = Boolean(temporaryAccess?.isTemporary);
+  const { variant, text, tooltip, isExpired } = getDurationDisplay(temporaryAccess);
+
+  return (
+    <div className="flex items-end gap-2">
+      <Controller
+        control={control}
+        name={slugName}
+        render={({ field }) => {
+          const rolesForSelect = getRolesForSelect(field.value);
+          return (
+            <Field className="min-w-0 flex-1">
+              {showLabels && <FieldLabel>Role</FieldLabel>}
+              <Select value={field.value} onValueChange={field.onChange} disabled={isEditDisabled}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent position="popper" className="z-[70]">
+                  {rolesForSelect.map(({ name, slug, id }) => {
+                    const isAssignable = assignableRoleSlugs.has(slug);
+                    return (
+                      <SelectItem
+                        value={slug}
+                        key={id}
+                        disabled={!isAssignable}
+                        description={
+                          isAssignable ? undefined : "You don't have permission to assign this role"
+                        }
+                      >
+                        {name}
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </Field>
+          );
+        }}
+      />
+      <Field className="w-44 shrink-0">
+        {showLabels && <FieldLabel>Duration</FieldLabel>}
+        <Popover>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  variant={variant}
+                  isDisabled={isEditDisabled}
+                  className="w-full capitalize"
+                >
+                  {isTemporary && <ClockIcon />}
+                  {text}
+                  <ChevronDownIcon />
+                </Button>
+              </PopoverTrigger>
+            </TooltipTrigger>
+            <TooltipContent>{tooltip}</TooltipContent>
+          </Tooltip>
+          <PopoverContent
+            side="right"
+            className="z-[70]"
+            onWheel={(e) => e.stopPropagation()}
+            onOpenAutoFocus={(e) => e.preventDefault()}
+          >
+            <div className="flex flex-col space-y-4">
+              <div className="border-b border-b-border pb-2 text-sm text-muted">
+                Configure Timed Access
+              </div>
+              {isExpired && <Badge variant="danger">Expired</Badge>}
+              <Controller
+                control={control}
+                defaultValue="1h"
+                name={temporaryRangeName}
+                render={({ field, fieldState: { error } }) => {
+                  // The schema blocks an invalid range on save; this surfaces the same message
+                  // while the user is still typing, before the value has been granted.
+                  const isInvalid = Boolean(field.value) && !isValidTemporaryRange(field.value);
+                  const errorMessage = isInvalid ? TEMPORARY_RANGE_ERROR : error?.message;
+
+                  return (
+                    <>
+                      <Field>
+                        <FieldLabel>
+                          <TtlFormLabel label="Validity" />
+                        </FieldLabel>
+                        <Input
+                          {...field}
+                          value={field.value ?? ""}
+                          isError={Boolean(errorMessage)}
+                        />
+                        {errorMessage && <FieldError>{errorMessage}</FieldError>}
+                      </Field>
+                      <div className="flex items-center space-x-2">
+                        <Button
+                          size="xs"
+                          variant="outline"
+                          isDisabled={!isValidTemporaryRange(field.value)}
+                          onClick={() => {
+                            const temporaryRange = field.value;
+                            setValue(
+                              temporaryAccessName,
+                              {
+                                isTemporary: true,
+                                temporaryAccessStartTime: new Date().toISOString(),
+                                temporaryRange,
+                                temporaryAccessEndTime: new Date(
+                                  new Date().getTime() + ms(temporaryRange)
+                                ).toISOString()
+                              },
+                              { shouldDirty: true }
+                            );
+                          }}
+                        >
+                          {isTemporary ? "Restart" : "Grant"}
+                        </Button>
+                        {isTemporary && (
+                          <Button
+                            size="xs"
+                            variant="danger"
+                            onClick={() =>
+                              setValue(
+                                temporaryAccessName,
+                                { isTemporary: false },
+                                { shouldDirty: true }
+                              )
+                            }
+                          >
+                            Revoke Access
+                          </Button>
+                        )}
+                      </div>
+                    </>
+                  );
+                }}
+              />
+            </div>
+          </PopoverContent>
+        </Popover>
+      </Field>
+      {action}
+    </div>
+  );
+};

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/RoleAssignmentRow.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/RoleAssignmentRow.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { Control, Controller, UseFormSetValue, useWatch } from "react-hook-form";
 import { ChevronDownIcon, ClockIcon } from "lucide-react";
 import ms from "ms";
@@ -28,6 +28,58 @@ import { getDurationDisplay, isValidTemporaryRange, TEMPORARY_RANGE_ERROR } from
 
 type RoleForSelect = { slug: string; name: string; id: string };
 
+type DurationEditorProps = {
+  committedRange?: string;
+  isTemporary: boolean;
+  isExpired: boolean;
+  onApply: (temporaryRange: string) => void;
+  onRemove: () => void;
+};
+
+// The Validity input is a local draft, not a registered form field. Only the Configure/Restart
+// button commits it to the form, and that button stays disabled while the value is invalid. This
+// keeps a half-typed range (eg "ab") out of the form state so it can't dirty the form or block save
+// from behind a closed popover.
+const DurationEditor = ({
+  committedRange,
+  isTemporary,
+  isExpired,
+  onApply,
+  onRemove
+}: DurationEditorProps) => {
+  const [draft, setDraft] = useState(committedRange ?? "1h");
+  const isValid = isValidTemporaryRange(draft);
+  const errorMessage = draft && !isValid ? TEMPORARY_RANGE_ERROR : undefined;
+
+  return (
+    <div className="flex flex-col space-y-4">
+      <div className="border-b border-b-border pb-2 text-sm text-muted">Configure Timed Access</div>
+      {isExpired && <Badge variant="danger">Expired</Badge>}
+      <Field>
+        <FieldLabel>
+          <TtlFormLabel label="Validity" />
+        </FieldLabel>
+        <Input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          isError={Boolean(errorMessage)}
+        />
+        {errorMessage && <FieldError>{errorMessage}</FieldError>}
+      </Field>
+      <div className="flex items-center space-x-2">
+        <Button size="xs" variant="outline" isDisabled={!isValid} onClick={() => onApply(draft)}>
+          {isTemporary ? "Restart" : "Configure"}
+        </Button>
+        {isTemporary && (
+          <Button size="xs" variant="danger" onClick={onRemove}>
+            Remove Duration
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
 type Props = {
   control: Control<any>;
   setValue: UseFormSetValue<any>;
@@ -54,7 +106,6 @@ export const RoleAssignmentRow = ({
 }: Props) => {
   const slugName = `${namePrefix}slug`;
   const temporaryAccessName = `${namePrefix}temporaryAccess`;
-  const temporaryRangeName = `${namePrefix}temporaryAccess.temporaryRange`;
 
   const temporaryAccess = useWatch({ control, name: temporaryAccessName });
   const isTemporary = Boolean(temporaryAccess?.isTemporary);
@@ -110,7 +161,7 @@ export const RoleAssignmentRow = ({
                 >
                   {isTemporary && <ClockIcon />}
                   {text}
-                  <ChevronDownIcon />
+                  <ChevronDownIcon className="ml-auto" />
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>
@@ -122,78 +173,30 @@ export const RoleAssignmentRow = ({
             onWheel={(e) => e.stopPropagation()}
             onOpenAutoFocus={(e) => e.preventDefault()}
           >
-            <div className="flex flex-col space-y-4">
-              <div className="border-b border-b-border pb-2 text-sm text-muted">
-                Configure Timed Access
-              </div>
-              {isExpired && <Badge variant="danger">Expired</Badge>}
-              <Controller
-                control={control}
-                defaultValue="1h"
-                name={temporaryRangeName}
-                render={({ field, fieldState: { error } }) => {
-                  // The schema blocks an invalid range on save; this surfaces the same message
-                  // while the user is still typing, before the value has been granted.
-                  const isInvalid = Boolean(field.value) && !isValidTemporaryRange(field.value);
-                  const errorMessage = isInvalid ? TEMPORARY_RANGE_ERROR : error?.message;
-
-                  return (
-                    <>
-                      <Field>
-                        <FieldLabel>
-                          <TtlFormLabel label="Validity" />
-                        </FieldLabel>
-                        <Input
-                          {...field}
-                          value={field.value ?? ""}
-                          isError={Boolean(errorMessage)}
-                        />
-                        {errorMessage && <FieldError>{errorMessage}</FieldError>}
-                      </Field>
-                      <div className="flex items-center space-x-2">
-                        <Button
-                          size="xs"
-                          variant="outline"
-                          isDisabled={!isValidTemporaryRange(field.value)}
-                          onClick={() => {
-                            const temporaryRange = field.value;
-                            setValue(
-                              temporaryAccessName,
-                              {
-                                isTemporary: true,
-                                temporaryAccessStartTime: new Date().toISOString(),
-                                temporaryRange,
-                                temporaryAccessEndTime: new Date(
-                                  new Date().getTime() + ms(temporaryRange)
-                                ).toISOString()
-                              },
-                              { shouldDirty: true }
-                            );
-                          }}
-                        >
-                          {isTemporary ? "Restart" : "Grant"}
-                        </Button>
-                        {isTemporary && (
-                          <Button
-                            size="xs"
-                            variant="danger"
-                            onClick={() =>
-                              setValue(
-                                temporaryAccessName,
-                                { isTemporary: false },
-                                { shouldDirty: true }
-                              )
-                            }
-                          >
-                            Revoke Access
-                          </Button>
-                        )}
-                      </div>
-                    </>
-                  );
-                }}
-              />
-            </div>
+            <DurationEditor
+              committedRange={
+                temporaryAccess?.isTemporary ? temporaryAccess.temporaryRange : undefined
+              }
+              isTemporary={isTemporary}
+              isExpired={isExpired}
+              onApply={(temporaryRange) =>
+                setValue(
+                  temporaryAccessName,
+                  {
+                    isTemporary: true,
+                    temporaryAccessStartTime: new Date().toISOString(),
+                    temporaryRange,
+                    temporaryAccessEndTime: new Date(
+                      new Date().getTime() + ms(temporaryRange)
+                    ).toISOString()
+                  },
+                  { shouldDirty: true }
+                )
+              }
+              onRemove={() =>
+                setValue(temporaryAccessName, { isTemporary: false }, { shouldDirty: true })
+              }
+            />
           </PopoverContent>
         </Popover>
       </Field>

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/roleAssignment.ts
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/roleAssignment.ts
@@ -1,0 +1,119 @@
+import { format, formatDistance } from "date-fns";
+import ms from "ms";
+import { z } from "zod";
+
+import {
+  ProjectUserMembershipTemporaryMode,
+  TUpdateWorkspaceUserRoleDTO
+} from "@app/hooks/api/projects/types";
+import { TWorkspaceUser } from "@app/hooks/api/types";
+
+export const TEMPORARY_RANGE_ERROR = "Only valid time values are accepted (1h, 20m, 2d).";
+
+export const isValidTemporaryRange = (value?: string) => {
+  if (!value?.trim()) return false;
+  const parsedMs = ms(value);
+  return typeof parsedMs === "number" && Number.isFinite(parsedMs) && parsedMs > 0;
+};
+
+// Shape of a single role assignment as edited in the form. The single-role editor uses this
+// directly; the multi-role editor nests it under `roles[]`. Pair the `temporaryRange` refine
+// with the Grant button's disabled state so an invalid duration can neither be granted nor saved.
+export const roleAssignmentSchema = z.object({
+  slug: z.string().min(1),
+  temporaryAccess: z.discriminatedUnion("isTemporary", [
+    z.object({
+      isTemporary: z.literal(true),
+      temporaryRange: z
+        .string()
+        .min(1, "Required")
+        .refine(isValidTemporaryRange, TEMPORARY_RANGE_ERROR),
+      temporaryAccessStartTime: z.string().datetime(),
+      temporaryAccessEndTime: z.string().datetime().nullable().optional()
+    }),
+    z.object({
+      isTemporary: z.literal(false)
+    })
+  ])
+});
+export type TRoleAssignment = z.infer<typeof roleAssignmentSchema>;
+export type TTemporaryAccess = TRoleAssignment["temporaryAccess"];
+
+export type MemberRoleAssignment = TWorkspaceUser["roles"][number];
+type TRolePayload = TUpdateWorkspaceUserRoleDTO["roles"][number];
+
+// A membership stores custom roles under `customRoleSlug` with `role === "custom"`; every other
+// role identifies itself by `role`.
+export const getRoleSlug = (assignment: Pick<MemberRoleAssignment, "role" | "customRoleSlug">) =>
+  assignment.role === "custom" ? (assignment.customRoleSlug ?? assignment.role) : assignment.role;
+
+export const toFormAssignment = (assignment: MemberRoleAssignment): TRoleAssignment => ({
+  slug: getRoleSlug(assignment),
+  temporaryAccess: assignment.isTemporary
+    ? {
+        isTemporary: true,
+        temporaryRange: assignment.temporaryRange,
+        temporaryAccessEndTime: assignment.temporaryAccessEndTime,
+        temporaryAccessStartTime: assignment.temporaryAccessStartTime
+      }
+    : { isTemporary: false }
+});
+
+export const formRoleToPayload = (assignment: TRoleAssignment): TRolePayload =>
+  assignment.temporaryAccess.isTemporary
+    ? {
+        role: assignment.slug,
+        isTemporary: true as const,
+        temporaryMode: ProjectUserMembershipTemporaryMode.Relative,
+        temporaryRange: assignment.temporaryAccess.temporaryRange,
+        temporaryAccessStartTime: assignment.temporaryAccess.temporaryAccessStartTime
+      }
+    : { role: assignment.slug, isTemporary: false as const };
+
+// An untouched assignment is re-sent as-is (preserving its own temporary mode) so a targeted
+// edit doesn't drop the member's other roles.
+export const existingRoleToPayload = (assignment: MemberRoleAssignment): TRolePayload =>
+  assignment.isTemporary
+    ? {
+        role: getRoleSlug(assignment),
+        isTemporary: true as const,
+        temporaryMode: assignment.temporaryMode,
+        temporaryRange: assignment.temporaryRange,
+        temporaryAccessStartTime: assignment.temporaryAccessStartTime
+      }
+    : { role: getRoleSlug(assignment), isTemporary: false as const };
+
+type TDurationDisplay = {
+  variant: "outline" | "warning" | "danger";
+  text: string;
+  tooltip: string;
+  isExpired: boolean;
+};
+
+export const getDurationDisplay = (temporaryAccess?: TTemporaryAccess): TDurationDisplay => {
+  if (!temporaryAccess?.isTemporary) {
+    return {
+      variant: "outline",
+      text: "Permanent",
+      tooltip: "Non-Expiring Access",
+      isExpired: false
+    };
+  }
+
+  const endTime = new Date(temporaryAccess.temporaryAccessEndTime || "");
+  if (new Date() > endTime) {
+    return {
+      variant: "danger",
+      text: "Access Expired",
+      tooltip: "Timed Access Expired",
+      isExpired: true
+    };
+  }
+
+  return {
+    variant: "warning",
+    text: formatDistance(endTime, new Date()),
+    tooltip: `Until ${format(endTime, "yyyy-MM-dd HH:mm:ss")}`,
+    isExpired: false
+  };
+};

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/useMemberRoleGrant.ts
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/useMemberRoleGrant.ts
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+import picomatch from "picomatch";
+
+import {
+  ProjectPermissionMemberActions,
+  ProjectPermissionSub,
+  useProject,
+  useProjectPermission
+} from "@app/context";
+import { formatProjectRoleName } from "@app/helpers/roles";
+import { useGetProjectRoles } from "@app/hooks/api";
+import { TWorkspaceUser } from "@app/hooks/api/types";
+import {
+  canModifyByGrantConditions,
+  filterByGrantConditions,
+  getMemberAssignRoleConditions
+} from "@app/lib/fn/permission";
+
+// Resolves which project roles the current user may assign to `projectMember`, honouring the
+// grant conditions on their own permission (allowed/forbidden roles and target emails). Shared by
+// the single- and multi-role editors so both gate role selection the same way.
+export const useMemberRoleGrant = (projectMember: TWorkspaceUser) => {
+  const { projectId, currentProject } = useProject();
+  const { data: projectRoles, isPending: isRolesLoading } = useGetProjectRoles(
+    projectId,
+    currentProject?.type
+  );
+  const { permission } = useProjectPermission();
+
+  const isMemberEditDisabled = permission.cannot(
+    ProjectPermissionMemberActions.Edit,
+    ProjectPermissionSub.Member
+  );
+
+  const assignRoleConditions = useMemo(
+    () => getMemberAssignRoleConditions(permission),
+    [permission]
+  );
+
+  const canModifyMemberRoles = useMemo(() => {
+    const memberEmail = projectMember?.user?.email;
+    if (!memberEmail) return false;
+
+    return canModifyByGrantConditions({
+      targetValue: memberEmail,
+      allowed: assignRoleConditions?.emails,
+      forbidden: assignRoleConditions?.forbiddenEmails,
+      isMatch: (value, pattern) => picomatch.isMatch(value, pattern)
+    });
+  }, [assignRoleConditions, projectMember?.user?.email]);
+
+  const filteredRoles = useMemo(
+    () =>
+      filterByGrantConditions(projectRoles ?? [], {
+        getKey: (role) => role.slug,
+        allowed: assignRoleConditions?.roles,
+        forbidden: assignRoleConditions?.forbiddenRoles
+      }),
+    [projectRoles, assignRoleConditions]
+  );
+
+  const assignableRoleSlugs = useMemo(
+    () => new Set(filteredRoles.map((role) => role.slug)),
+    [filteredRoles]
+  );
+
+  // The list to show in a role Select: the assignable roles, prepended with the currently
+  // assigned role when it isn't itself assignable (so it stays visible but disabled).
+  const getRolesForSelect = (currentSlug: string) => {
+    if (assignableRoleSlugs.has(currentSlug)) return filteredRoles;
+
+    const currentRole = projectRoles?.find((role) => role.slug === currentSlug) ?? {
+      slug: currentSlug,
+      name: formatProjectRoleName(currentSlug),
+      id: currentSlug
+    };
+    return [currentRole, ...filteredRoles];
+  };
+
+  return {
+    isRolesLoading,
+    assignableRoleSlugs,
+    getRolesForSelect,
+    isEditDisabled: isMemberEditDisabled || !canModifyMemberRoles
+  };
+};


### PR DESCRIPTION
## Context

On a project member’s details page, the Project Roles row menu only exposed **Remove Role**. Changing a role’s type or duration required the header **Edit Roles** flow, which opens a multi-role editor.

This adds a row-level **Modify Role** action that opens a single-role **Edit Role** dialog. The existing multi-role editor remains available from **Edit Roles**, and both modals now use v3 Dialog/components.

## Screenshots

New button
<img width="1052" height="275" alt="image" src="https://github.com/user-attachments/assets/265fad29-b76e-4b7c-a02f-3bb526316142" />
New Dialog
<img width="543" height="284" alt="image" src="https://github.com/user-attachments/assets/359bcce7-850c-421e-ba71-afad2ba995bb" />
New input validation
<img width="796" height="276" alt="image" src="https://github.com/user-attachments/assets/686d484c-c9fa-430b-9792-6eee072d1d09" />

Existing mutli-role edit now moved to a Screen rather than Modal/Dialog
<img width="1174" height="802" alt="image" src="https://github.com/user-attachments/assets/cb7fa90f-afde-43a3-9c8f-463ef0c9ab90" />


## Steps to verify the change

1. Open a project → Access Control → Members → open another user with at least one project role.
2. On Project Roles, open the row `⋯` menu — confirm **Modify Role** and **Remove Role** are present.
3. Click **Modify Role** — confirm a v3 **Edit Role** dialog opens for only that role (no Add Role / trash).
4. Change the role and/or duration (including an invalid Validity value like `abc` to confirm TTL validation), save, and confirm only that assignment updates and the dialog closes.
5. Click header **Edit Roles** — confirm the multi-role v3 dialog still works (add/remove roles, TTL validation, closes on save).

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)


Made with [Cursor](https://cursor.com)