### PR TITLE
fix: avoid interval overflow for expire alerts

### DIFF
--- a/backend/src/server/routes/v1/identity-universal-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-universal-auth-router.ts
@@ -559,7 +559,6 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
         numUsesLimit: z.number().min(0).default(0).describe(UNIVERSAL_AUTH.CREATE_CLIENT_SECRET.numUsesLimit),
         ttl: z
           .number()
-          .int()
           .min(0)
           .max(MAX_UA_CLIENT_SECRET_TTL_SECONDS)
           .default(0)

--- a/backend/src/server/routes/v1/identity-universal-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-universal-auth-router.ts
@@ -11,6 +11,7 @@ import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
 import { TIdentityTrustedIp } from "@app/services/identity/identity-types";
+import { MAX_UA_CLIENT_SECRET_TTL_SECONDS } from "@app/services/identity-ua/identity-ua-types";
 import { isSuperAdmin } from "@app/services/super-admin/super-admin-fns";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
@@ -556,7 +557,13 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
       body: z.object({
         description: z.string().trim().default("").describe(UNIVERSAL_AUTH.CREATE_CLIENT_SECRET.description),
         numUsesLimit: z.number().min(0).default(0).describe(UNIVERSAL_AUTH.CREATE_CLIENT_SECRET.numUsesLimit),
-        ttl: z.number().min(0).max(315360000).default(0).describe(UNIVERSAL_AUTH.CREATE_CLIENT_SECRET.ttl)
+        ttl: z
+          .number()
+          .int()
+          .min(0)
+          .max(MAX_UA_CLIENT_SECRET_TTL_SECONDS)
+          .default(0)
+          .describe(UNIVERSAL_AUTH.CREATE_CLIENT_SECRET.ttl)
       }),
       response: {
         200: z.object({

--- a/backend/src/services/alert/providers/identity-credential-alert-dal.test.ts
+++ b/backend/src/services/alert/providers/identity-credential-alert-dal.test.ts
@@ -98,6 +98,22 @@ describe("identity credential alert dal", () => {
     });
   });
 
+  test("the expiry expression clamps clientSecretTTL into a range interval arithmetic can hold", async () => {
+    const { dal, calls } = buildDAL();
+
+    await dal.findExpiringUaClientSecrets(scanArgs);
+
+    // Under a hash-join plan this predicate is a scan-level filter on the whole table, evaluated
+    // before the identity/org joins narrow it. An unclamped `clientSecretTTL * interval '1 second'`
+    // therefore overflows on any other tenant's out-of-range row and aborts the entire scan.
+    const expirySql = calls.whereRaw.map(([sql]) => sql as string).filter((sql) => sql.includes("clientSecretTTL"));
+    expect(expirySql.length).toBeGreaterThan(0);
+    expirySql.forEach((sql) => {
+      expect(sql).toContain(`LEAST(GREATEST(${TableName.IdentityUaClientSecret}."clientSecretTTL", 0), 315360000)`);
+      expect(sql).not.toContain("* interval '1 second'");
+    });
+  });
+
   test("a project-scoped scan keeps org-level identities but only its own project's identities", async () => {
     const { dal, calls } = buildDAL();
 

--- a/backend/src/services/alert/providers/identity-credential-alert-dal.ts
+++ b/backend/src/services/alert/providers/identity-credential-alert-dal.ts
@@ -36,10 +36,7 @@ export const identityCredentialAlertDALFactory = (db: TDbClient) => {
     tx?: Knex
   ): Promise<TExpiringUaClientSecret[]> => {
     try {
-      // The clamp has to live in the expression, not in a `clientSecretTTL > 0` style guard. Under a
-      // hash-join plan this predicate is a scan-level filter on the whole table, evaluated before the
-      // identity/org joins narrow it, so a single out-of-range TTL belonging to any other tenant
-      // aborts the scan and silently kills every identity credential alert.
+      // The clamp has to live in the expression, not in a `clientSecretTTL > 0` style guard to avoid overflow
       const expiresAtSql = `${TableName.IdentityUaClientSecret}."createdAt" + make_interval(secs => LEAST(GREATEST(${TableName.IdentityUaClientSecret}."clientSecretTTL", 0), ${MAX_UA_CLIENT_SECRET_TTL_SECONDS}))`;
 
       const query = (tx || db.replicaNode())(TableName.IdentityUaClientSecret)

--- a/backend/src/services/alert/providers/identity-credential-alert-dal.ts
+++ b/backend/src/services/alert/providers/identity-credential-alert-dal.ts
@@ -3,6 +3,7 @@ import { Knex } from "knex";
 import { TDbClient } from "@app/db";
 import { AccessScope, TableName } from "@app/db/schemas";
 import { DatabaseError } from "@app/lib/errors";
+import { MAX_UA_CLIENT_SECRET_TTL_SECONDS } from "@app/services/identity-ua/identity-ua-types";
 
 export type TIdentityCredentialAlertDALFactory = ReturnType<typeof identityCredentialAlertDALFactory>;
 
@@ -35,7 +36,11 @@ export const identityCredentialAlertDALFactory = (db: TDbClient) => {
     tx?: Knex
   ): Promise<TExpiringUaClientSecret[]> => {
     try {
-      const expiresAtSql = `${TableName.IdentityUaClientSecret}."createdAt" + (${TableName.IdentityUaClientSecret}."clientSecretTTL" * interval '1 second')`;
+      // The clamp has to live in the expression, not in a `clientSecretTTL > 0` style guard. Under a
+      // hash-join plan this predicate is a scan-level filter on the whole table, evaluated before the
+      // identity/org joins narrow it, so a single out-of-range TTL belonging to any other tenant
+      // aborts the scan and silently kills every identity credential alert.
+      const expiresAtSql = `${TableName.IdentityUaClientSecret}."createdAt" + make_interval(secs => LEAST(GREATEST(${TableName.IdentityUaClientSecret}."clientSecretTTL", 0), ${MAX_UA_CLIENT_SECRET_TTL_SECONDS}))`;
 
       const query = (tx || db.replicaNode())(TableName.IdentityUaClientSecret)
         .join(

--- a/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
+++ b/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
@@ -6,6 +6,8 @@ import { DatabaseError } from "@app/lib/errors";
 import { ormify } from "@app/lib/knex";
 import { logger } from "@app/lib/logger";
 
+import { MAX_UA_CLIENT_SECRET_TTL_SECONDS } from "./identity-ua-types";
+
 export type TIdentityUaClientSecretDALFactory = ReturnType<typeof identityUaClientSecretDALFactory>;
 
 export const identityUaClientSecretDALFactory = (db: TDbClient) => {
@@ -27,7 +29,6 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
   const removeExpiredClientSecrets = async (tx?: Knex) => {
     const BATCH_SIZE = 10000;
     const MAX_RETRY_ON_FAILURE = 3;
-    const MAX_TTL = 315_360_000; // Maximum TTL value in seconds (10 years)
 
     let deletedClientSecret: { id: string }[] = [];
     let numberOfRetryOnFailure = 0;
@@ -54,7 +55,7 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
               .where("clientSecretTTL", ">", 0)
               .andWhereRaw(
                 `"${TableName.IdentityUaClientSecret}"."createdAt" + make_interval(secs => LEAST("${TableName.IdentityUaClientSecret}"."clientSecretTTL", ?)) < NOW()`,
-                [MAX_TTL]
+                [MAX_UA_CLIENT_SECRET_TTL_SECONDS]
               );
           })
           .select("id")

--- a/backend/src/services/identity-ua/identity-ua-types.ts
+++ b/backend/src/services/identity-ua/identity-ua-types.ts
@@ -1,6 +1,8 @@
 import { UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import { TProjectPermission } from "@app/lib/types";
 
+export const MAX_UA_CLIENT_SECRET_TTL_SECONDS = 315_360_000; // 10 years
+
 export type TLoginUaDTO = {
   clientId: string;
   clientSecret: string;


### PR DESCRIPTION
## Context

- Fix PSQL overflow on negative and huge values.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)