### PR TITLE
feat(dynamic-secrets): migrate identity and access provider forms

### DIFF
--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/identity-access-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/identity-access-contract.test.ts
@@ -1,0 +1,1133 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { SshCertKeyAlgorithm } from "@app/hooks/api/dynamicSecret/constants";
+import {
+  DynamicSecretAwsIamAuth,
+  DynamicSecretAwsIamCredentialType,
+  DynamicSecretProviders,
+  TailscaleAuthMethod,
+  TailscaleKeyAuthType
+} from "@app/hooks/api/dynamicSecret/types";
+
+import type { TAwsIamFormValues } from "./providerDefinitions/awsIamContract";
+import {
+  AWS_IAM_CUSTOM_RENDERER_REASONS,
+  awsIamCreateFormSchema,
+  awsIamEditFormSchema,
+  getAwsIamCreateDefaultValues,
+  getAwsIamCreatePayload,
+  getAwsIamEditDefaultValues,
+  getAwsIamEditPayload
+} from "./providerDefinitions/awsIamContract";
+import {
+  AZURE_ENTRA_ID_CREATE_RENDERER_REASONS,
+  AZURE_ENTRA_ID_EDIT_RENDERER_REASONS,
+  azureEntraIdCreateFormSchema,
+  azureEntraIdEditFormSchema,
+  getAzureEntraIdCreateDefaultValues,
+  getAzureEntraIdCreatePayload,
+  getAzureEntraIdEditDefaultValues,
+  getAzureEntraIdEditPayload
+} from "./providerDefinitions/azureEntraIdContract";
+import {
+  GCP_IAM_CUSTOM_RENDERER_REASONS,
+  gcpIamCreateFormSchema,
+  gcpIamEditFormSchema,
+  getGcpIamCreateDefaultValues,
+  getGcpIamCreatePayload,
+  getGcpIamEditDefaultValues,
+  getGcpIamEditPayload
+} from "./providerDefinitions/gcpIamContract";
+import {
+  getGithubCreateDefaultValues,
+  getGithubCreatePayload,
+  getGithubEditDefaultValues,
+  getGithubEditPayload,
+  GITHUB_CUSTOM_RENDERER_REASONS,
+  githubCreateFormSchema,
+  githubEditFormSchema
+} from "./providerDefinitions/githubContract";
+import { IDENTITY_ACCESS_DYNAMIC_SECRET_PROVIDERS } from "./providerDefinitions/identityAccessContract";
+import {
+  getLdapCreateDefaultValues,
+  getLdapCreatePayload,
+  getLdapEditDefaultValues,
+  getLdapEditPayload,
+  getLdapVaultImportValues,
+  LDAP_CUSTOM_RENDERER_REASONS,
+  ldapCreateFormSchema,
+  LdapCredentialType,
+  ldapEditFormSchema
+} from "./providerDefinitions/ldapContract";
+import {
+  getSshCreateDefaultValues,
+  getSshCreatePayload,
+  getSshEditDefaultValues,
+  getSshEditPayload,
+  SSH_CREATE_WORKFLOW_BOUNDARY_REASONS,
+  SSH_CUSTOM_RENDERER_REASONS,
+  sshCreateFormSchema,
+  sshEditFormSchema
+} from "./providerDefinitions/sshContract";
+import {
+  getTailscaleCreateDefaultValues,
+  getTailscaleCreatePayload,
+  getTailscaleEditDefaultValues,
+  getTailscaleEditPayload,
+  TAILSCALE_CUSTOM_RENDERER_REASONS,
+  tailscaleCreateFormSchema,
+  tailscaleEditFormSchema
+} from "./providerDefinitions/tailscaleContract";
+import { testDynamicSecretProviderContract } from "./providerContractTestHarness";
+import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "./schemas";
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+import { defineDynamicSecretProvider } from "./types";
+
+const environment = { id: "env-id", name: "Development", slug: "dev", position: 1 };
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+
+const getEditContext = ({
+  provider,
+  inputs,
+  defaultTTL = "1h",
+  maxTTL = "24h",
+  usernameTemplate
+}: {
+  provider: DynamicSecretProviders;
+  inputs: unknown;
+  defaultTTL?: string;
+  maxTTL?: string;
+  usernameTemplate?: string | null;
+}): TEditDynamicSecretProviderFormContext => ({
+  projectSlug: "project",
+  secretPath: "/folder",
+  environment: "dev",
+  dynamicSecret: {
+    id: "dynamic-secret-id",
+    name: "existing-secret",
+    type: provider,
+    createdAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+    defaultTTL,
+    ...(maxTTL === undefined ? {} : { maxTTL }),
+    ...(usernameTemplate === undefined ? {} : { usernameTemplate }),
+    inputs
+  }
+});
+
+const privateKey = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----";
+const NoopRenderer = () => null;
+
+const awsIamDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AwsIam,
+  label: "AWS IAM",
+  customRenderer: {
+    reasons: AWS_IAM_CUSTOM_RENDERER_REASONS,
+    Component: NoopRenderer
+  },
+  create: {
+    schema: awsIamCreateFormSchema,
+    getDefaultValues: getAwsIamCreateDefaultValues,
+    toPayload: getAwsIamCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: awsIamEditFormSchema,
+    getDefaultValues: getAwsIamEditDefaultValues,
+    toPayload: getAwsIamEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const gcpIamDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.GcpIam,
+  label: "GCP IAM",
+  customRenderer: {
+    reasons: GCP_IAM_CUSTOM_RENDERER_REASONS,
+    Component: NoopRenderer
+  },
+  create: {
+    schema: gcpIamCreateFormSchema,
+    getDefaultValues: getGcpIamCreateDefaultValues,
+    toPayload: getGcpIamCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: gcpIamEditFormSchema,
+    getDefaultValues: getGcpIamEditDefaultValues,
+    toPayload: getGcpIamEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const azureEntraIdDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AzureEntraId,
+  label: "Azure Entra ID",
+  create: {
+    schema: azureEntraIdCreateFormSchema,
+    getDefaultValues: getAzureEntraIdCreateDefaultValues,
+    toPayload: getAzureEntraIdCreatePayload,
+    customRenderer: {
+      reasons: AZURE_ENTRA_ID_CREATE_RENDERER_REASONS,
+      Component: NoopRenderer
+    },
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: azureEntraIdEditFormSchema,
+    getDefaultValues: getAzureEntraIdEditDefaultValues,
+    toPayload: getAzureEntraIdEditPayload,
+    customRenderer: {
+      reasons: AZURE_ENTRA_ID_EDIT_RENDERER_REASONS,
+      Component: NoopRenderer
+    },
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const githubDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Github,
+  label: "GitHub",
+  create: {
+    schema: githubCreateFormSchema,
+    getDefaultValues: getGithubCreateDefaultValues,
+    toPayload: getGithubCreatePayload,
+    customRenderer: {
+      reasons: GITHUB_CUSTOM_RENDERER_REASONS,
+      Component: NoopRenderer
+    },
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: githubEditFormSchema,
+    getDefaultValues: getGithubEditDefaultValues,
+    toPayload: getGithubEditPayload,
+    customRenderer: {
+      reasons: GITHUB_CUSTOM_RENDERER_REASONS,
+      Component: NoopRenderer
+    },
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const tailscaleDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Tailscale,
+  label: "Tailscale",
+  customRenderer: {
+    reasons: TAILSCALE_CUSTOM_RENDERER_REASONS,
+    Component: NoopRenderer
+  },
+  create: {
+    schema: tailscaleCreateFormSchema,
+    getDefaultValues: getTailscaleCreateDefaultValues,
+    toPayload: getTailscaleCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: tailscaleEditFormSchema,
+    getDefaultValues: getTailscaleEditDefaultValues,
+    toPayload: getTailscaleEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const sshDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Ssh,
+  label: "SSH",
+  customRenderer: {
+    reasons: SSH_CUSTOM_RENDERER_REASONS,
+    Component: NoopRenderer
+  },
+  create: {
+    schema: sshCreateFormSchema,
+    getDefaultValues: getSshCreateDefaultValues,
+    toPayload: getSshCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: sshEditFormSchema,
+    getDefaultValues: getSshEditDefaultValues,
+    toPayload: getSshEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const ldapDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Ldap,
+  label: "LDAP",
+  customRenderer: {
+    reasons: LDAP_CUSTOM_RENDERER_REASONS,
+    Component: NoopRenderer
+  },
+  create: {
+    schema: ldapCreateFormSchema,
+    getDefaultValues: getLdapCreateDefaultValues,
+    toPayload: getLdapCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: ldapEditFormSchema,
+    getDefaultValues: getLdapEditDefaultValues,
+    toPayload: getLdapEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const identityAccessContractModule = defineDynamicSecretProviderModule({
+  id: "identity-access",
+  definitions: [
+    awsIamDynamicSecretProvider,
+    gcpIamDynamicSecretProvider,
+    azureEntraIdDynamicSecretProvider,
+    githubDynamicSecretProvider,
+    tailscaleDynamicSecretProvider,
+    sshDynamicSecretProvider,
+    ldapDynamicSecretProvider
+  ]
+});
+
+const awsCreateDefaults: TAwsIamFormValues = {
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    method: DynamicSecretAwsIamAuth.AssumeRole,
+    credentialType: DynamicSecretAwsIamCredentialType.IamUser,
+    roleArn: "",
+    region: "us-east-1",
+    awsPath: "/",
+    tags: []
+  }
+};
+const awsEditInputs: TAwsIamFormValues["inputs"] = {
+  method: DynamicSecretAwsIamAuth.AccessKey,
+  credentialType: DynamicSecretAwsIamCredentialType.IamUser,
+  accessKey: "AKIAEXAMPLE",
+  secretAccessKey: "********",
+  region: "us-east-1",
+  awsPath: "/",
+  // Existing tags can exceed the create-time AWS limits, so edits must preserve them.
+  tags: [{ key: "e".repeat(129), value: "platform" }]
+};
+const awsEditContext = getEditContext({
+  provider: DynamicSecretProviders.AwsIam,
+  inputs: awsEditInputs,
+  usernameTemplate: null
+});
+const awsCreateValues: TAwsIamFormValues = {
+  ...awsCreateDefaults,
+  name: "aws-secret",
+  inputs: {
+    method: DynamicSecretAwsIamAuth.AssumeRole,
+    credentialType: DynamicSecretAwsIamCredentialType.TemporaryCredentials,
+    roleArn: "arn:aws:iam::123:role/example",
+    region: "us-east-1",
+    policyArns: "must-clear",
+    policyDocument: "must-clear",
+    sessionPolicyArns: "session-policy"
+  }
+};
+const awsEditValues: TAwsIamFormValues = {
+  name: "renamed-aws-secret",
+  defaultTTL: "1h",
+  maxTTL: null,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: awsEditInputs
+};
+
+testDynamicSecretProviderContract({
+  name: "AWS IAM",
+  definition: awsIamDynamicSecretProvider,
+  create: {
+    context: createContext,
+    defaultValues: awsCreateDefaults,
+    validValues: awsCreateValues,
+    payload: {
+      provider: {
+        type: DynamicSecretProviders.AwsIam,
+        inputs: {
+          ...awsCreateValues.inputs,
+          policyArns: "",
+          policyDocument: ""
+        }
+      },
+      maxTTL: "24h",
+      name: "aws-secret",
+      path: "/folder",
+      defaultTTL: "1h",
+      projectSlug: "project",
+      environmentSlug: "dev",
+      usernameTemplate: undefined
+    },
+    invalidValues: [
+      {
+        name: "tag key exceeds the create limit",
+        values: {
+          ...awsCreateDefaults,
+          name: "aws-secret",
+          inputs: {
+            ...awsCreateDefaults.inputs,
+            roleArn: "arn:aws:iam::123:role/example",
+            tags: [{ key: "a".repeat(129), value: "value" }]
+          }
+        },
+        issuePaths: [["inputs", "tags", 0, "key"]]
+      }
+    ]
+  },
+  edit: {
+    context: awsEditContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: awsEditInputs
+    },
+    validValues: awsEditValues,
+    payload: {
+      name: "existing-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev",
+      data: {
+        maxTTL: undefined,
+        defaultTTL: "1h",
+        inputs: {
+          ...awsEditInputs,
+          sessionPolicyArns: "",
+          sessionPolicyDocument: ""
+        },
+        newName: "renamed-aws-secret",
+        usernameTemplate: null
+      }
+    },
+    maskedValues: [
+      {
+        name: "secret access key",
+        expected: "********",
+        defaultValuePath: ["inputs", "secretAccessKey"],
+        payloadValuePath: ["data", "inputs", "secretAccessKey"]
+      }
+    ]
+  }
+});
+
+const gcpDefaultScopes = [
+  { value: "https://www.googleapis.com/auth/iam" },
+  { value: "https://www.googleapis.com/auth/cloud-platform" }
+];
+const gcpCreateDefaults = {
+  name: "",
+  defaultTTL: "30m",
+  maxTTL: "1h",
+  environment,
+  inputs: { serviceAccountEmail: "", tokenScopes: gcpDefaultScopes }
+};
+const gcpEditContext = getEditContext({
+  provider: DynamicSecretProviders.GcpIam,
+  defaultTTL: "30m",
+  maxTTL: "1h",
+  inputs: { serviceAccountEmail: "service@example.com" }
+});
+const gcpCreateValues = {
+  ...gcpCreateDefaults,
+  name: "gcp-secret",
+  inputs: {
+    serviceAccountEmail: "service@example.com",
+    tokenScopes: [{ value: "scope-a" }, { value: "scope-a" }, { value: "scope-b" }]
+  }
+};
+const gcpEditValues = {
+  name: "renamed-gcp-secret",
+  defaultTTL: "30m",
+  maxTTL: "1h",
+  inputs: {
+    serviceAccountEmail: "service@example.com",
+    tokenScopes: gcpDefaultScopes
+  }
+};
+
+testDynamicSecretProviderContract({
+  name: "GCP IAM",
+  definition: gcpIamDynamicSecretProvider,
+  create: {
+    context: createContext,
+    defaultValues: gcpCreateDefaults,
+    validValues: gcpCreateValues,
+    payload: {
+      provider: {
+        type: DynamicSecretProviders.GcpIam,
+        inputs: {
+          serviceAccountEmail: "service@example.com",
+          tokenScopes: ["scope-a", "scope-b"]
+        }
+      },
+      maxTTL: "1h",
+      name: "gcp-secret",
+      path: "/folder",
+      defaultTTL: "30m",
+      projectSlug: "project",
+      environmentSlug: "dev"
+    },
+    invalidValues: [
+      {
+        name: "TTL exceeds one hour",
+        values: {
+          ...gcpCreateValues,
+          defaultTTL: "2h",
+          maxTTL: undefined
+        },
+        issuePaths: [["defaultTTL"]]
+      }
+    ]
+  },
+  edit: {
+    context: gcpEditContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "30m",
+      maxTTL: "1h",
+      inputs: {
+        serviceAccountEmail: "service@example.com",
+        tokenScopes: gcpDefaultScopes
+      }
+    },
+    validValues: gcpEditValues,
+    payload: {
+      name: "existing-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev",
+      data: {
+        inputs: {
+          serviceAccountEmail: "service@example.com",
+          tokenScopes: gcpDefaultScopes.map(({ value }) => value)
+        },
+        newName: "renamed-gcp-secret",
+        defaultTTL: "30m",
+        maxTTL: "1h"
+      }
+    }
+  }
+});
+
+const azureCreateDefaults = {
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment,
+  selectedUsers: [],
+  inputs: { tenantId: "", applicationId: "", clientSecret: "" }
+};
+const azureEditInputs = {
+  email: "alice@example.com",
+  userId: "user-id",
+  tenantId: "tenant-id",
+  applicationId: "application-id",
+  clientSecret: "********"
+};
+const azureEditContext = getEditContext({
+  provider: DynamicSecretProviders.AzureEntraId,
+  inputs: azureEditInputs
+});
+const azureCreateValues = {
+  ...azureCreateDefaults,
+  name: "entra",
+  inputs: { tenantId: "tenant", applicationId: "app", clientSecret: "secret" },
+  selectedUsers: [
+    { id: "1", name: "alice", email: "alice@example.com" },
+    { id: "2", name: "bob", email: "bob@example.com" }
+  ]
+};
+const azureEditValues = {
+  name: "renamed-entra-secret",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  inputs: azureEditInputs
+};
+
+testDynamicSecretProviderContract({
+  name: "Azure Entra ID",
+  definition: azureEntraIdDynamicSecretProvider,
+  create: {
+    context: createContext,
+    defaultValues: azureCreateDefaults,
+    validValues: azureCreateValues,
+    payload: azureCreateValues.selectedUsers.map((user) => ({
+      provider: {
+        type: DynamicSecretProviders.AzureEntraId,
+        inputs: {
+          ...azureCreateValues.inputs,
+          userId: user.id,
+          email: user.email
+        }
+      },
+      maxTTL: "24h",
+      name: `entra-${user.name}`,
+      path: "/folder",
+      defaultTTL: "1h",
+      projectSlug: "project",
+      environmentSlug: "dev"
+    })),
+    invalidValues: [
+      {
+        name: "selected user is missing an id",
+        values: {
+          ...azureCreateValues,
+          selectedUsers: [{ id: "", name: "alice", email: "alice@example.com" }]
+        },
+        issuePaths: [["selectedUsers", 0, "id"]]
+      }
+    ]
+  },
+  edit: {
+    context: azureEditContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      inputs: azureEditInputs
+    },
+    validValues: azureEditValues,
+    payload: {
+      name: "existing-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev",
+      data: {
+        maxTTL: "24h",
+        defaultTTL: "1h",
+        newName: "renamed-entra-secret",
+        inputs: azureEditInputs
+      }
+    },
+    maskedValues: [
+      {
+        name: "client secret",
+        expected: "********",
+        defaultValuePath: ["inputs", "clientSecret"],
+        payloadValuePath: ["data", "inputs", "clientSecret"]
+      }
+    ]
+  }
+});
+
+const githubCreateDefaults = {
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: undefined,
+  environment,
+  inputs: { appId: 0, installationId: 0, privateKey: "" }
+};
+const githubEditInputs = { appId: 1, installationId: 2, privateKey: "********" };
+const githubEditContext = getEditContext({
+  provider: DynamicSecretProviders.Github,
+  inputs: githubEditInputs,
+  maxTTL: undefined
+});
+const githubCreateValues = {
+  ...githubCreateDefaults,
+  name: "github-secret",
+  inputs: { appId: 1, installationId: 2, privateKey }
+};
+const githubEditValues = {
+  name: "renamed-github-secret",
+  defaultTTL: "1h",
+  maxTTL: undefined,
+  inputs: githubEditInputs
+};
+
+testDynamicSecretProviderContract({
+  name: "GitHub",
+  definition: githubDynamicSecretProvider,
+  create: {
+    context: createContext,
+    defaultValues: githubCreateDefaults,
+    validValues: githubCreateValues,
+    payload: {
+      provider: {
+        type: DynamicSecretProviders.Github,
+        inputs: githubCreateValues.inputs
+      },
+      defaultTTL: "1h",
+      name: "github-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev"
+    },
+    invalidValues: [
+      {
+        name: "private key is not PEM",
+        values: {
+          ...githubCreateValues,
+          inputs: { ...githubCreateValues.inputs, privateKey: "not-pem" }
+        },
+        issuePaths: [["inputs", "privateKey"]]
+      }
+    ]
+  },
+  edit: {
+    context: githubEditContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: undefined,
+      inputs: githubEditInputs
+    },
+    validValues: githubEditValues,
+    payload: {
+      name: "existing-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev",
+      data: {
+        inputs: githubEditInputs,
+        newName: "renamed-github-secret"
+      }
+    },
+    maskedValues: [
+      {
+        name: "private key",
+        expected: "********",
+        defaultValuePath: ["inputs", "privateKey"],
+        payloadValuePath: ["data", "inputs", "privateKey"]
+      }
+    ]
+  }
+});
+
+const tailscaleCreateDefaults = {
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment,
+  inputs: {
+    authType: TailscaleKeyAuthType.AuthKeys,
+    auth: { method: TailscaleAuthMethod.ApiKey, apiKey: "" },
+    tailnet: "-",
+    reusable: false,
+    preauthorized: false
+  }
+} as const;
+const tailscaleCreateValues = {
+  ...tailscaleCreateDefaults,
+  name: "tailscale-secret",
+  inputs: {
+    authType: TailscaleKeyAuthType.AuthKeys,
+    auth: {
+      method: TailscaleAuthMethod.OAuth,
+      clientId: "client-id",
+      clientSecret: "client-secret"
+    },
+    tailnet: "-",
+    description: "",
+    tags: "tag:ci, tag:prod",
+    reusable: true,
+    preauthorized: false
+  }
+} as const;
+const tailscaleEditRawInputs = {
+  authType: TailscaleKeyAuthType.OAuthKeys,
+  auth: {
+    method: TailscaleAuthMethod.OAuth,
+    clientId: "client-id",
+    clientSecret: "********"
+  },
+  tailnet: "example.com",
+  description: "automation",
+  tags: ["tag:ci"],
+  scopes: ["devices:core", "users:read"]
+} as const;
+const tailscaleEditContext = getEditContext({
+  provider: DynamicSecretProviders.Tailscale,
+  inputs: tailscaleEditRawInputs
+});
+const tailscaleEditValues = {
+  name: "renamed-tailscale-secret",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  inputs: {
+    authType: TailscaleKeyAuthType.OAuthKeys,
+    auth: tailscaleEditRawInputs.auth,
+    tailnet: "example.com",
+    description: "automation",
+    tags: "tag:ci",
+    scopes: "devices:core, users:read"
+  }
+} as const;
+
+testDynamicSecretProviderContract({
+  name: "Tailscale",
+  definition: tailscaleDynamicSecretProvider,
+  create: {
+    context: createContext,
+    defaultValues: tailscaleCreateDefaults,
+    validValues: tailscaleCreateValues,
+    payload: {
+      provider: {
+        type: DynamicSecretProviders.Tailscale,
+        inputs: {
+          authType: TailscaleKeyAuthType.AuthKeys,
+          auth: tailscaleCreateValues.inputs.auth,
+          tailnet: "-",
+          description: undefined,
+          tags: ["tag:ci", "tag:prod"],
+          reusable: true,
+          preauthorized: false
+        }
+      },
+      maxTTL: "24h",
+      name: "tailscale-secret",
+      path: "/folder",
+      defaultTTL: "1h",
+      projectSlug: "project",
+      environmentSlug: "dev"
+    },
+    invalidValues: [
+      {
+        name: "OAuth-created auth key has no tags",
+        values: {
+          ...tailscaleCreateValues,
+          inputs: { ...tailscaleCreateValues.inputs, tags: "" }
+        },
+        issuePaths: [["inputs", "tags"]]
+      },
+      {
+        name: "TTL is not a duration",
+        values: {
+          ...tailscaleCreateValues,
+          defaultTTL: "invalid",
+          maxTTL: undefined
+        },
+        issuePaths: [["defaultTTL"]]
+      }
+    ]
+  },
+  edit: {
+    context: tailscaleEditContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      inputs: {
+        authType: TailscaleKeyAuthType.OAuthKeys,
+        auth: tailscaleEditRawInputs.auth,
+        tailnet: "example.com",
+        description: "automation",
+        tags: "tag:ci",
+        scopes: "devices:core, users:read"
+      }
+    },
+    validValues: tailscaleEditValues,
+    payload: {
+      name: "existing-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev",
+      data: {
+        maxTTL: "24h",
+        defaultTTL: "1h",
+        inputs: tailscaleEditRawInputs,
+        newName: "renamed-tailscale-secret"
+      }
+    },
+    maskedValues: [
+      {
+        name: "OAuth client secret",
+        expected: "********",
+        defaultValuePath: ["inputs", "auth", "clientSecret"],
+        payloadValuePath: ["data", "inputs", "auth", "clientSecret"]
+      }
+    ]
+  }
+});
+
+const sshCreateDefaults = {
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment,
+  inputs: { principals: [], keyAlgorithm: SshCertKeyAlgorithm.ED25519 }
+};
+const sshCreateValues = {
+  ...sshCreateDefaults,
+  name: "ssh-secret",
+  inputs: {
+    principals: ["deploy", "root"],
+    keyAlgorithm: SshCertKeyAlgorithm.ED25519
+  }
+};
+const sshEditContext = getEditContext({
+  provider: DynamicSecretProviders.Ssh,
+  inputs: {
+    caPublicKey: "ignored",
+    principals: ["deploy"],
+    keyAlgorithm: SshCertKeyAlgorithm.ED25519
+  }
+});
+const sshEditValues = {
+  name: "renamed-ssh-secret",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  inputs: {
+    principals: ["deploy"],
+    keyAlgorithm: SshCertKeyAlgorithm.ED25519
+  }
+};
+
+testDynamicSecretProviderContract({
+  name: "SSH",
+  definition: sshDynamicSecretProvider,
+  create: {
+    context: createContext,
+    defaultValues: sshCreateDefaults,
+    validValues: sshCreateValues,
+    payload: {
+      provider: {
+        type: DynamicSecretProviders.Ssh,
+        inputs: sshCreateValues.inputs
+      },
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      name: "ssh-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev"
+    },
+    invalidValues: [
+      {
+        name: "no principals",
+        values: { ...sshCreateValues, inputs: { ...sshCreateValues.inputs, principals: [] } },
+        issuePaths: [["inputs", "principals"]]
+      }
+    ]
+  },
+  edit: {
+    context: sshEditContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      inputs: {
+        principals: ["deploy"],
+        keyAlgorithm: SshCertKeyAlgorithm.ED25519
+      }
+    },
+    validValues: sshEditValues,
+    payload: {
+      name: "existing-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev",
+      data: {
+        inputs: sshEditValues.inputs,
+        newName: "renamed-ssh-secret",
+        defaultTTL: "1h",
+        maxTTL: "24h"
+      }
+    }
+  }
+});
+
+const ldapCreateDefaults = {
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    url: "",
+    binddn: "",
+    bindpass: "",
+    ca: "",
+    sslRejectUnauthorized: true,
+    creationLdif: "",
+    revocationLdif: "",
+    rollbackLdif: "",
+    credentialType: LdapCredentialType.Dynamic
+  }
+} as const;
+const ldapCreateValues = {
+  ...ldapCreateDefaults,
+  name: "ldap-secret",
+  inputs: {
+    ...ldapCreateDefaults.inputs,
+    url: "ldaps://ldap.example.com",
+    binddn: "cn=admin",
+    bindpass: "secret",
+    creationLdif: "create",
+    revocationLdif: "revoke"
+  }
+} as const;
+const ldapEditInputs = {
+  url: "ldaps://ldap.example.com",
+  binddn: "cn=admin",
+  bindpass: "********",
+  ca: "certificate",
+  credentialType: LdapCredentialType.Static,
+  rotationLdif: "rotate"
+} as const;
+const ldapEditContext = getEditContext({
+  provider: DynamicSecretProviders.Ldap,
+  inputs: ldapEditInputs,
+  usernameTemplate: null
+});
+const ldapEditValues = {
+  name: "renamed-ldap-secret",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: ldapEditInputs
+};
+
+testDynamicSecretProviderContract({
+  name: "LDAP",
+  definition: ldapDynamicSecretProvider,
+  create: {
+    context: createContext,
+    defaultValues: ldapCreateDefaults,
+    validValues: ldapCreateValues,
+    payload: {
+      provider: {
+        type: DynamicSecretProviders.Ldap,
+        inputs: ldapCreateValues.inputs
+      },
+      maxTTL: "24h",
+      name: "ldap-secret",
+      path: "/folder",
+      defaultTTL: "1h",
+      projectSlug: "project",
+      usernameTemplate: undefined,
+      environmentSlug: "dev"
+    },
+    invalidValues: [
+      {
+        name: "static credentials have no rotation LDIF",
+        values: {
+          ...ldapCreateValues,
+          inputs: {
+            url: "ldaps://ldap.example.com",
+            binddn: "cn=admin",
+            bindpass: "secret",
+            credentialType: LdapCredentialType.Static
+          }
+        },
+        issuePaths: [["inputs", "rotationLdif"]]
+      }
+    ]
+  },
+  edit: {
+    context: ldapEditContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: ldapEditInputs
+    },
+    validValues: ldapEditValues,
+    payload: {
+      name: "existing-secret",
+      path: "/folder",
+      projectSlug: "project",
+      environmentSlug: "dev",
+      data: {
+        maxTTL: "24h",
+        defaultTTL: "1h",
+        inputs: ldapEditInputs,
+        newName: "renamed-ldap-secret",
+        usernameTemplate: null
+      }
+    },
+    maskedValues: [
+      {
+        name: "bind password",
+        expected: "********",
+        defaultValuePath: ["inputs", "bindpass"],
+        payloadValuePath: ["data", "inputs", "bindpass"]
+      }
+    ]
+  }
+});
+
+describe("identity and access provider registration", () => {
+  it("registers the seven-provider batch in product picker order", () => {
+    assert.deepEqual(
+      identityAccessContractModule.definitions.map(({ provider }) => provider),
+      IDENTITY_ACCESS_DYNAMIC_SECRET_PROVIDERS
+    );
+    const registry = createDynamicSecretProviderRegistry(identityAccessContractModule);
+
+    assert.deepEqual(registry.providers, [
+      DynamicSecretProviders.AwsIam,
+      DynamicSecretProviders.AzureEntraId,
+      DynamicSecretProviders.Ldap,
+      DynamicSecretProviders.GcpIam,
+      DynamicSecretProviders.Github,
+      DynamicSecretProviders.Ssh,
+      DynamicSecretProviders.Tailscale
+    ]);
+    registry.providers.forEach((provider) => {
+      assert.equal(registry.requireDefinition(provider).provider, provider);
+    });
+  });
+
+  it("declares every provider-specific renderer boundary", () => {
+    assert.ok(awsIamDynamicSecretProvider.customRenderer?.reasons.includes("conditional-fields"));
+    assert.ok(gcpIamDynamicSecretProvider.customRenderer?.reasons.includes("repeatable-fields"));
+    assert.ok(
+      azureEntraIdDynamicSecretProvider.create.customRenderer?.reasons.includes("multi-create")
+    );
+    assert.ok(
+      githubDynamicSecretProvider.edit.customRenderer?.reasons.includes("non-scalar-value")
+    );
+    assert.ok(
+      tailscaleDynamicSecretProvider.customRenderer?.reasons.includes("conditional-fields")
+    );
+    assert.ok(sshDynamicSecretProvider.customRenderer?.reasons.includes("repeatable-fields"));
+    assert.ok(SSH_CREATE_WORKFLOW_BOUNDARY_REASONS.includes("post-create-workflow"));
+    assert.ok(ldapDynamicSecretProvider.customRenderer?.reasons.includes("import-workflow"));
+  });
+
+  it("maps LDAP Vault roles without inventing a bind password", () => {
+    const imported = getLdapVaultImportValues({
+      name: "ldap-role",
+      config: { url: "ldaps://ldap.example.com", binddn: "cn=admin", certificate: "ca" },
+      creation_ldif: "create",
+      deletion_ldif: "delete",
+      default_ttl: 3600,
+      max_ttl: 7200
+    } as never);
+
+    assert.equal(imported.inputs?.bindpass, "");
+    assert.equal(imported.defaultTTL, "3600s");
+
+    const importWithoutOptionalValues = getLdapVaultImportValues({
+      name: "minimal-role",
+      config: {}
+    } as never);
+    assert.equal("defaultTTL" in importWithoutOptionalValues, false);
+    assert.equal("maxTTL" in importWithoutOptionalValues, false);
+    assert.equal("usernameTemplate" in importWithoutOptionalValues, false);
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/identity-access-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/identity-access-contract.test.ts
@@ -591,6 +591,11 @@ testDynamicSecretProviderContract({
     })),
     invalidValues: [
       {
+        name: "no users are selected",
+        values: { ...azureCreateValues, selectedUsers: [] },
+        issuePaths: [["selectedUsers"]]
+      },
+      {
         name: "selected user is missing an id",
         values: {
           ...azureCreateValues,
@@ -813,6 +818,36 @@ testDynamicSecretProviderContract({
         issuePaths: [["inputs", "tags"]]
       },
       {
+        name: "OAuth key has no tags",
+        values: {
+          ...tailscaleCreateValues,
+          inputs: {
+            authType: TailscaleKeyAuthType.OAuthKeys,
+            auth: tailscaleCreateValues.inputs.auth,
+            tailnet: "-",
+            tags: "",
+            scopes: "devices:core"
+          }
+        },
+        issuePaths: [["inputs", "tags"]]
+      },
+      {
+        name: "federated key has no tags",
+        values: {
+          ...tailscaleCreateValues,
+          inputs: {
+            authType: TailscaleKeyAuthType.FederatedKeys,
+            auth: tailscaleCreateValues.inputs.auth,
+            tailnet: "-",
+            tags: "",
+            scopes: "devices:core",
+            issuer: "https://issuer.example.com",
+            subject: "repo:example/project"
+          }
+        },
+        issuePaths: [["inputs", "tags"]]
+      },
+      {
         name: "TTL is not a duration",
         values: {
           ...tailscaleCreateValues,
@@ -839,6 +874,16 @@ testDynamicSecretProviderContract({
       }
     },
     validValues: tailscaleEditValues,
+    invalidValues: [
+      {
+        name: "OAuth key has no tags",
+        values: {
+          ...tailscaleEditValues,
+          inputs: { ...tailscaleEditValues.inputs, tags: "" }
+        },
+        issuePaths: [["inputs", "tags"]]
+      }
+    ],
     payload: {
       name: "existing-secret",
       path: "/folder",

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/identity-access-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/identity-access-contract.test.ts
@@ -343,6 +343,7 @@ const awsCreateValues: TAwsIamFormValues = {
     region: "us-east-1",
     policyArns: "must-clear",
     policyDocument: "must-clear",
+    userGroups: "must-clear",
     sessionPolicyArns: "session-policy"
   }
 };
@@ -367,7 +368,8 @@ testDynamicSecretProviderContract({
         inputs: {
           ...awsCreateValues.inputs,
           policyArns: "",
-          policyDocument: ""
+          policyDocument: "",
+          userGroups: ""
         }
       },
       maxTTL: "24h",
@@ -414,6 +416,7 @@ testDynamicSecretProviderContract({
         defaultTTL: "1h",
         inputs: {
           ...awsEditInputs,
+          roleArn: "",
           sessionPolicyArns: "",
           sessionPolicyDocument: ""
         },
@@ -430,6 +433,31 @@ testDynamicSecretProviderContract({
       }
     ]
   }
+});
+
+describe("AWS IAM payload sanitization", () => {
+  it("clears a retained role ARN when Assume Role is not selected", () => {
+    const payload = getAwsIamCreatePayload(
+      {
+        ...awsCreateDefaults,
+        name: "aws-secret",
+        inputs: {
+          method: DynamicSecretAwsIamAuth.AccessKey,
+          credentialType: DynamicSecretAwsIamCredentialType.IamUser,
+          accessKey: "AKIAEXAMPLE",
+          secretAccessKey: "secret",
+          roleArn: "arn:aws:iam::123:role/stale",
+          region: "us-east-1"
+        } as TAwsIamFormValues["inputs"]
+      },
+      createContext
+    );
+
+    assert.equal(
+      (payload.provider.inputs as typeof payload.provider.inputs & { roleArn?: string }).roleArn,
+      ""
+    );
+  });
 });
 
 const gcpDefaultScopes = [

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/index.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/index.ts
@@ -2,6 +2,7 @@ export { DynamicSecretProviderFields } from "./DynamicSecretProviderFields";
 export { DynamicSecretProviderForm } from "./DynamicSecretProviderForm";
 export { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
 export { DynamicSecretProviderGroup } from "./DynamicSecretProviderGroup";
+export * from "./providerDefinitions";
 export * from "./registry";
 export * from "./scalarValues";
 export * from "./schemas";

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsIam.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsIam.tsx
@@ -1,0 +1,230 @@
+import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import { Button, Field, FieldError, FieldLabel, IconButton, Input } from "@app/components/v3";
+import { useGetServerConfig } from "@app/hooks/api/admin";
+import {
+  DynamicSecretAwsIamAuth,
+  DynamicSecretAwsIamCredentialType,
+  DynamicSecretProviders
+} from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import { defineDynamicSecretProvider, TDynamicSecretProviderField } from "../types";
+import {
+  AWS_IAM_CUSTOM_RENDERER_REASONS,
+  awsIamCreateFormSchema,
+  awsIamEditFormSchema,
+  getAwsIamCreateDefaultValues,
+  getAwsIamCreatePayload,
+  getAwsIamEditDefaultValues,
+  getAwsIamEditPayload,
+  TAwsIamFormValues
+} from "./awsIamContract";
+
+const AwsIamFields = () => {
+  const { data: serverConfig } = useGetServerConfig();
+  const { control, watch } = useFormContext<TAwsIamFormValues>();
+  const tags = useFieldArray({ control, name: "inputs.tags" });
+  const method = watch("inputs.method");
+  const credentialType = watch("inputs.credentialType");
+  const isIamUser = credentialType !== DynamicSecretAwsIamCredentialType.TemporaryCredentials;
+  const sessionSupported = !isIamUser && method === DynamicSecretAwsIamAuth.AssumeRole;
+  const methodOptions = [
+    { label: "Assume Role", value: DynamicSecretAwsIamAuth.AssumeRole },
+    { label: "Access Key", value: DynamicSecretAwsIamAuth.AccessKey },
+    ...(serverConfig?.kubernetesAutoFetchServiceAccountToken
+      ? [{ label: "IRSA", value: DynamicSecretAwsIamAuth.IRSA }]
+      : [])
+  ];
+  const fields: TDynamicSecretProviderField<TAwsIamFormValues>[] = [
+    {
+      name: "inputs.method",
+      type: "select",
+      label: "Authentication Method",
+      options: methodOptions
+    },
+    {
+      name: "inputs.credentialType",
+      type: "select",
+      label: "Credential Type",
+      options: [
+        { label: "IAM User", value: DynamicSecretAwsIamCredentialType.IamUser },
+        {
+          label: "Temporary Credentials",
+          value: DynamicSecretAwsIamCredentialType.TemporaryCredentials
+        }
+      ]
+    },
+    ...(method === DynamicSecretAwsIamAuth.AccessKey
+      ? [
+          { name: "inputs.accessKey", type: "text", label: "Access Key", layout: "half" } as const,
+          {
+            name: "inputs.secretAccessKey",
+            type: "secret",
+            label: "Secret Access Key",
+            layout: "half",
+            autoComplete: "new-password"
+          } as const
+        ]
+      : []),
+    ...(method === DynamicSecretAwsIamAuth.AssumeRole
+      ? [{ name: "inputs.roleArn", type: "text", label: "Role ARN" } as const]
+      : []),
+    ...(!isIamUser
+      ? []
+      : [{ name: "inputs.awsPath", type: "text", label: "AWS Path", isOptional: true } as const]),
+    { name: "inputs.region", type: "text", label: "Region" },
+    {
+      name: "inputs.permissionBoundaryPolicyArn",
+      type: "text",
+      label: "Permission Boundary Policy ARN",
+      isOptional: true
+    },
+    ...(isIamUser
+      ? ([
+          { name: "inputs.userGroups", type: "text", label: "AWS IAM Groups", isOptional: true },
+          {
+            name: "inputs.policyArns",
+            type: "textarea",
+            label: "AWS Policy ARNs",
+            isOptional: true
+          },
+          {
+            name: "inputs.policyDocument",
+            type: "textarea",
+            label: "AWS IAM Policy Document",
+            isOptional: true
+          }
+        ] as const)
+      : []),
+    ...(sessionSupported
+      ? ([
+          {
+            name: "inputs.sessionPolicyArns",
+            type: "textarea",
+            label: "AWS Session Policy ARNs",
+            isOptional: true
+          },
+          {
+            name: "inputs.sessionPolicyDocument",
+            type: "textarea",
+            label: "AWS Session Policy Document",
+            isOptional: true
+          }
+        ] as const)
+      : []),
+    ...(isIamUser
+      ? ([
+          {
+            name: "usernameTemplate",
+            type: "text",
+            label: "Username Template",
+            placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+          }
+        ] as const)
+      : [])
+  ];
+  return (
+    <>
+      <DynamicSecretProviderGroup id="aws-iam-configuration" presentation="panel">
+        <DynamicSecretProviderFields fields={fields} />
+      </DynamicSecretProviderGroup>
+      {isIamUser && (
+        <DynamicSecretProviderGroup id="aws-iam-tags" presentation="panel" surface title="Tags">
+          <div className="flex flex-col gap-3">
+            {tags.fields.map(({ id }, index) => (
+              <div
+                key={id}
+                className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+              >
+                <Controller
+                  control={control}
+                  name={`inputs.tags.${index}.key`}
+                  render={({ field, fieldState: { error } }) => (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`aws-tag-key-${index}`} className="sr-only">
+                        Tag key {index + 1}
+                      </FieldLabel>
+                      <Input
+                        {...field}
+                        id={`aws-tag-key-${index}`}
+                        placeholder="Key"
+                        isError={Boolean(error)}
+                      />
+                      <FieldError>{error?.message}</FieldError>
+                    </Field>
+                  )}
+                />
+                <Controller
+                  control={control}
+                  name={`inputs.tags.${index}.value`}
+                  render={({ field, fieldState: { error } }) => (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`aws-tag-value-${index}`} className="sr-only">
+                        Tag value {index + 1}
+                      </FieldLabel>
+                      <Input
+                        {...field}
+                        id={`aws-tag-value-${index}`}
+                        placeholder="Value"
+                        isError={Boolean(error)}
+                      />
+                      <FieldError>{error?.message}</FieldError>
+                    </Field>
+                  )}
+                />
+                <div className="flex flex-col gap-2">
+                  <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                    &nbsp;
+                  </FieldLabel>
+                  <IconButton
+                    type="button"
+                    variant="outline"
+                    aria-label={`Remove tag ${index + 1}`}
+                    onClick={() => tags.remove(index)}
+                  >
+                    <Trash2Icon />
+                  </IconButton>
+                </div>
+              </div>
+            ))}
+            <Button
+              type="button"
+              size="sm"
+              className="self-start"
+              onClick={() => tags.append({ key: "", value: "" })}
+            >
+              <PlusIcon />
+              Add Tag
+            </Button>
+          </div>
+        </DynamicSecretProviderGroup>
+      )}
+    </>
+  );
+};
+
+export const awsIamDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AwsIam,
+  label: "AWS IAM",
+  customRenderer: {
+    reasons: AWS_IAM_CUSTOM_RENDERER_REASONS,
+    Component: AwsIamFields
+  },
+  create: {
+    schema: awsIamCreateFormSchema,
+    getDefaultValues: getAwsIamCreateDefaultValues,
+    toPayload: getAwsIamCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: awsIamEditFormSchema,
+    getDefaultValues: getAwsIamEditDefaultValues,
+    toPayload: getAwsIamEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsIamContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsIamContract.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretAwsIamAuth,
+  DynamicSecretAwsIamCredentialType,
+  DynamicSecretProviders,
+  TDynamicSecretProvider,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const AWS_IAM_CUSTOM_RENDERER_REASONS = [
+  "conditional-fields",
+  "repeatable-fields",
+  "context-aware-fields"
+] as const;
+
+const createTagsSchema = z
+  .array(
+    z.object({ key: z.string().trim().min(1).max(128), value: z.string().trim().min(1).max(256) })
+  )
+  .optional();
+const editTagsSchema = z
+  .array(z.object({ key: z.string().trim().min(1), value: z.string().trim().min(1) }))
+  .optional();
+
+const getCommonSchema = (tags: typeof createTagsSchema | typeof editTagsSchema) => ({
+  credentialType: z
+    .nativeEnum(DynamicSecretAwsIamCredentialType)
+    .default(DynamicSecretAwsIamCredentialType.IamUser),
+  region: z.string().trim().min(1),
+  awsPath: z.string().trim().optional(),
+  permissionBoundaryPolicyArn: z.string().trim().optional(),
+  policyDocument: z.string().trim().optional(),
+  userGroups: z.string().trim().optional(),
+  policyArns: z.string().trim().optional(),
+  tags
+});
+
+const getInputsSchema = (tags: typeof createTagsSchema | typeof editTagsSchema) =>
+  z.discriminatedUnion("method", [
+    z.object({
+      method: z.literal(DynamicSecretAwsIamAuth.AccessKey),
+      ...getCommonSchema(tags),
+      accessKey: z.string().trim().min(1),
+      secretAccessKey: z.string().trim().min(1)
+    }),
+    z.object({
+      method: z.literal(DynamicSecretAwsIamAuth.AssumeRole),
+      ...getCommonSchema(tags),
+      roleArn: z.string().trim().min(1),
+      sessionPolicyArns: z.string().trim().optional(),
+      sessionPolicyDocument: z.string().trim().optional()
+    }),
+    z.object({ method: z.literal(DynamicSecretAwsIamAuth.IRSA), ...getCommonSchema(tags) })
+  ]);
+
+const createInputsSchema = getInputsSchema(createTagsSchema);
+const editInputsSchema = getInputsSchema(editTagsSchema);
+export type TAwsIamFormValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof createInputsSchema>
+>;
+export const awsIamCreateFormSchema = createDynamicSecretProviderFormSchema(
+  createInputsSchema
+) as z.ZodType<TAwsIamFormValues>;
+export const awsIamEditFormSchema = editDynamicSecretProviderFormSchema(editInputsSchema, {
+  usernameTemplateSchema: z.string().trim().nullable().optional()
+}) as z.ZodType<TAwsIamFormValues>;
+
+export const getAwsIamCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TAwsIamFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    method: DynamicSecretAwsIamAuth.AssumeRole,
+    credentialType: DynamicSecretAwsIamCredentialType.IamUser,
+    roleArn: "",
+    region: "us-east-1",
+    awsPath: "/",
+    tags: []
+  }
+});
+export const getAwsIamEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TAwsIamFormValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  usernameTemplate:
+    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: context.dynamicSecret.inputs as TAwsIamFormValues["inputs"]
+});
+type TAwsInputs = Extract<
+  TDynamicSecretProvider,
+  { type: DynamicSecretProviders.AwsIam }
+>["inputs"];
+const sanitize = (inputs: TAwsIamFormValues["inputs"]): TAwsInputs => {
+  const isIamUser =
+    inputs.credentialType !== DynamicSecretAwsIamCredentialType.TemporaryCredentials;
+  const sessionSupported = !isIamUser && inputs.method === DynamicSecretAwsIamAuth.AssumeRole;
+  return {
+    ...inputs,
+    ...(!isIamUser && { policyArns: "", policyDocument: "" }),
+    ...(!sessionSupported && { sessionPolicyArns: "", sessionPolicyDocument: "" })
+  } as TAwsInputs;
+};
+export const getAwsIamCreatePayload = (
+  values: TAwsIamFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.AwsIam> => ({
+  provider: { type: DynamicSecretProviders.AwsIam, inputs: sanitize(values.inputs) },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+export const getAwsIamEditPayload = (
+  values: TAwsIamFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: sanitize(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsIamContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsIamContract.ts
@@ -117,7 +117,8 @@ const sanitize = (inputs: TAwsIamFormValues["inputs"]): TAwsInputs => {
   const sessionSupported = !isIamUser && inputs.method === DynamicSecretAwsIamAuth.AssumeRole;
   return {
     ...inputs,
-    ...(!isIamUser && { policyArns: "", policyDocument: "" }),
+    ...(!isIamUser && { policyArns: "", policyDocument: "", userGroups: "" }),
+    ...(inputs.method !== DynamicSecretAwsIamAuth.AssumeRole && { roleArn: "" }),
     ...(!sessionSupported && { sessionPolicyArns: "", sessionPolicyDocument: "" })
   } as TAwsInputs;
 };

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureEntraId.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureEntraId.tsx
@@ -36,13 +36,18 @@ const credentialLabels = {
 
 const EMPTY_USERS: { id: string; name: string; email: string }[] = [];
 
-const AzureEntraIdFields = ({ mode, setSubmitState }: TDynamicSecretProviderRendererProps) => {
+const AzureEntraIdFields = ({
+  context,
+  mode,
+  setSubmitState
+}: TDynamicSecretProviderRendererProps) => {
   const { control, watch } = useFormContext<TAzureEntraIdCreateValues & TAzureEntraIdEditValues>();
   const tenantId = watch("inputs.tenantId");
   const applicationId = watch("inputs.applicationId");
   const clientSecret = watch("inputs.clientSecret");
   const isConfigured = Boolean(tenantId && applicationId && clientSecret);
   const usersQuery = useGetDynamicSecretProviderData({
+    projectSlug: context.projectSlug,
     tenantId,
     applicationId,
     clientSecret,

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureEntraId.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureEntraId.tsx
@@ -1,0 +1,179 @@
+import { useEffect } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+
+import {
+  Field,
+  FieldError,
+  FieldFeedback,
+  FieldLabel,
+  FilterableSelect,
+  Input
+} from "@app/components/v3";
+import { SecretInput } from "@app/components/v3/platform";
+import { useGetDynamicSecretProviderData } from "@app/hooks/api/dynamicSecret/queries";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { defineDynamicSecretProvider, TDynamicSecretProviderRendererProps } from "../types";
+import {
+  AZURE_ENTRA_ID_CREATE_RENDERER_REASONS,
+  AZURE_ENTRA_ID_EDIT_RENDERER_REASONS,
+  azureEntraIdCreateFormSchema,
+  azureEntraIdEditFormSchema,
+  getAzureEntraIdCreateDefaultValues,
+  getAzureEntraIdCreatePayload,
+  getAzureEntraIdEditDefaultValues,
+  getAzureEntraIdEditPayload,
+  TAzureEntraIdCreateValues,
+  TAzureEntraIdEditValues
+} from "./azureEntraIdContract";
+
+const credentialLabels = {
+  tenantId: "Tenant ID",
+  applicationId: "Application ID",
+  clientSecret: "Client Secret"
+} as const;
+
+const EMPTY_USERS: { id: string; name: string; email: string }[] = [];
+
+const AzureEntraIdFields = ({ mode, setSubmitState }: TDynamicSecretProviderRendererProps) => {
+  const { control, watch } = useFormContext<TAzureEntraIdCreateValues & TAzureEntraIdEditValues>();
+  const tenantId = watch("inputs.tenantId");
+  const applicationId = watch("inputs.applicationId");
+  const clientSecret = watch("inputs.clientSecret");
+  const isConfigured = Boolean(tenantId && applicationId && clientSecret);
+  const usersQuery = useGetDynamicSecretProviderData({
+    tenantId,
+    applicationId,
+    clientSecret,
+    enabled: mode === "create" && isConfigured
+  });
+  const isLoading = mode === "create" && isConfigured && usersQuery.isFetching;
+  const isError = mode === "create" && isConfigured && !usersQuery.isFetching && usersQuery.isError;
+
+  useEffect(() => {
+    setSubmitState({
+      isDisabled: mode === "create" && (isLoading || isError),
+      isPending: isLoading
+    });
+  }, [isError, isLoading, mode, setSubmitState]);
+
+  if (mode === "edit") {
+    const fields = [
+      ["email", "Email", true],
+      ["userId", "User ID", true],
+      ["tenantId", "Tenant ID", true],
+      ["applicationId", "Application ID", false],
+      ["clientSecret", "Client Secret", false]
+    ] as const;
+    return (
+      <DynamicSecretProviderGroup id="azure-entra-credentials" presentation="panel">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {fields.map(([key, label, isReadOnly]) => (
+            <Controller
+              key={key}
+              control={control}
+              name={`inputs.${key}`}
+              render={({ field, fieldState: { error } }) => (
+                <Field data-invalid={Boolean(error)}>
+                  <FieldLabel htmlFor={`azure-entra-${key}`}>{label}</FieldLabel>
+                  <SecretInput
+                    {...field}
+                    id={`azure-entra-${key}`}
+                    isReadOnly={isReadOnly}
+                    aria-describedby={error ? `azure-entra-${key}-error` : undefined}
+                  />
+                  <FieldError id={`azure-entra-${key}-error`}>{error?.message}</FieldError>
+                </Field>
+              )}
+            />
+          ))}
+        </div>
+      </DynamicSecretProviderGroup>
+    );
+  }
+
+  return (
+    <DynamicSecretProviderGroup id="azure-entra-configuration" presentation="panel">
+      <div className="flex flex-col gap-4">
+        {(["tenantId", "applicationId", "clientSecret"] as const).map((key) => (
+          <Controller
+            key={key}
+            control={control}
+            name={`inputs.${key}`}
+            render={({ field, fieldState: { error } }) => (
+              <Field data-invalid={Boolean(error)}>
+                <FieldLabel htmlFor={`azure-entra-${key}`}>{credentialLabels[key]}</FieldLabel>
+                <Input
+                  {...field}
+                  id={`azure-entra-${key}`}
+                  type={key === "clientSecret" ? "password" : "text"}
+                  autoComplete={key === "clientSecret" ? "new-password" : "off"}
+                  isError={Boolean(error)}
+                  aria-describedby={error ? `azure-entra-${key}-error` : undefined}
+                />
+                <FieldError id={`azure-entra-${key}-error`}>{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+        ))}
+        <Controller
+          control={control}
+          name="selectedUsers"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="azure-entra-users">Users</FieldLabel>
+              <FilterableSelect
+                inputId="azure-entra-users"
+                isMulti
+                isDisabled={!isConfigured || isLoading || isError}
+                isLoading={isLoading}
+                options={usersQuery.data ?? EMPTY_USERS}
+                value={field.value ?? EMPTY_USERS}
+                onBlur={field.onBlur}
+                onChange={(next) => field.onChange(next ?? EMPTY_USERS)}
+                getOptionLabel={(user) => `${user.name} (${user.email})`}
+                getOptionValue={(user) => user.id}
+                placeholder="Select users..."
+                isError={Boolean(error)}
+                aria-describedby="azure-entra-users-feedback"
+              />
+              <FieldFeedback
+                id="azure-entra-users-feedback"
+                description="A unique dynamic secret is created for each selected user."
+                error={error?.message}
+              />
+            </Field>
+          )}
+        />
+      </div>
+    </DynamicSecretProviderGroup>
+  );
+};
+
+export const azureEntraIdDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AzureEntraId,
+  label: "Azure Entra ID",
+  create: {
+    schema: azureEntraIdCreateFormSchema,
+    getDefaultValues: getAzureEntraIdCreateDefaultValues,
+    toPayload: getAzureEntraIdCreatePayload,
+    customRenderer: {
+      reasons: AZURE_ENTRA_ID_CREATE_RENDERER_REASONS,
+      Component: AzureEntraIdFields
+    },
+    commonFields: { name: { label: "Secret Prefix" } },
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: azureEntraIdEditFormSchema,
+    getDefaultValues: getAzureEntraIdEditDefaultValues,
+    toPayload: getAzureEntraIdEditPayload,
+    customRenderer: {
+      reasons: AZURE_ENTRA_ID_EDIT_RENDERER_REASONS,
+      Component: AzureEntraIdFields
+    },
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureEntraIdContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureEntraIdContract.ts
@@ -56,7 +56,7 @@ export const azureEntraIdCreateFormSchema = createDynamicSecretProviderFormSchem
     .string()
     .min(1)
     .refine((value) => value.toLowerCase() === value, "Must be lowercase"),
-  selectedUsers: selectedUserSchema.array()
+  selectedUsers: selectedUserSchema.array().min(1, "Select at least one user")
 }) as z.ZodType<TAzureEntraIdCreateValues>;
 
 export const azureEntraIdEditFormSchema = editDynamicSecretProviderFormSchema(

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureEntraIdContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureEntraIdContract.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+import { slugSchema } from "@app/lib/schemas";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  editDynamicSecretProviderFormSchema
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const AZURE_ENTRA_ID_CREATE_RENDERER_REASONS = [
+  "remote-options",
+  "multi-create",
+  "conditional-fields"
+] as const;
+export const AZURE_ENTRA_ID_EDIT_RENDERER_REASONS = ["non-scalar-value"] as const;
+
+const selectedUserSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  email: z.string().min(1)
+});
+const createInputsSchema = z.object({
+  tenantId: z.string().min(1),
+  applicationId: z.string().min(1),
+  clientSecret: z.string().min(1)
+});
+const editInputsSchema = z.object({
+  email: z.string(),
+  userId: z.string(),
+  tenantId: z.string(),
+  applicationId: z.string(),
+  clientSecret: z.string()
+});
+
+export type TAzureEntraIdCreateValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof createInputsSchema>
+> & { selectedUsers: z.infer<typeof selectedUserSchema>[] };
+export type TAzureEntraIdEditValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof editInputsSchema>
+>;
+
+export const azureEntraIdCreateFormSchema = createDynamicSecretProviderFormSchema(
+  createInputsSchema
+).extend({
+  name: z
+    .string()
+    .min(1)
+    .refine((value) => value.toLowerCase() === value, "Must be lowercase"),
+  selectedUsers: selectedUserSchema.array()
+}) as z.ZodType<TAzureEntraIdCreateValues>;
+
+export const azureEntraIdEditFormSchema = editDynamicSecretProviderFormSchema(
+  editInputsSchema
+).extend({ name: slugSchema().optional().default("") }) as z.ZodType<TAzureEntraIdEditValues>;
+
+export const getAzureEntraIdCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TAzureEntraIdCreateValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  selectedUsers: [],
+  inputs: { tenantId: "", applicationId: "", clientSecret: "" }
+});
+
+export const getAzureEntraIdEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TAzureEntraIdEditValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  inputs: editInputsSchema.parse(context.dynamicSecret.inputs)
+});
+
+export const getAzureEntraIdCreatePayload = (
+  values: TAzureEntraIdCreateValues,
+  context: TCreateDynamicSecretProviderFormContext
+): readonly TCreateDynamicSecretProviderDTO<DynamicSecretProviders.AzureEntraId>[] =>
+  values.selectedUsers.map((user) => ({
+    provider: {
+      type: DynamicSecretProviders.AzureEntraId,
+      inputs: { ...values.inputs, userId: user.id, email: user.email }
+    },
+    maxTTL: values.maxTTL ?? undefined,
+    name: `${values.name}-${user.name}`,
+    path: context.secretPath,
+    defaultTTL: values.defaultTTL,
+    projectSlug: context.projectSlug,
+    environmentSlug: values.environment?.slug ?? ""
+  }));
+
+export const getAzureEntraIdEditPayload = (
+  values: TAzureEntraIdEditValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    inputs: values.inputs
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/gcpIam.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/gcpIam.tsx
@@ -1,0 +1,131 @@
+import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import {
+  Button,
+  Field,
+  FieldError,
+  FieldFeedback,
+  FieldLabel,
+  IconButton,
+  Input
+} from "@app/components/v3";
+import { useOrganization } from "@app/context";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { defineDynamicSecretProvider } from "../types";
+import {
+  GCP_IAM_CUSTOM_RENDERER_REASONS,
+  gcpIamCreateFormSchema,
+  gcpIamEditFormSchema,
+  getGcpIamCreateDefaultValues,
+  getGcpIamCreatePayload,
+  getGcpIamEditDefaultValues,
+  getGcpIamEditPayload,
+  TGcpIamFormValues
+} from "./gcpIamContract";
+
+const GcpIamFields = () => {
+  const { currentOrg } = useOrganization();
+  const suffix = currentOrg.id.split("-").slice(0, 2).join("-");
+  const { control } = useFormContext<TGcpIamFormValues>();
+  const scopes = useFieldArray({ control, name: "inputs.tokenScopes" });
+
+  return (
+    <DynamicSecretProviderGroup id="gcp-iam-configuration" presentation="panel">
+      <Controller
+        control={control}
+        name="inputs.serviceAccountEmail"
+        render={({ field, fieldState: { error } }) => (
+          <Field data-invalid={Boolean(error)}>
+            <FieldLabel htmlFor="gcp-service-account-email">Service Account Email</FieldLabel>
+            <Input
+              {...field}
+              id="gcp-service-account-email"
+              placeholder="example@project.iam.gserviceaccount.com"
+              isError={Boolean(error)}
+              aria-describedby="gcp-service-account-feedback"
+            />
+            <FieldFeedback
+              id="gcp-service-account-feedback"
+              description={`The service account ID (the part before "@") must end with the first two sections of your organization ID: "${suffix}". Example: my-service-account-${suffix}@my-project.iam.gserviceaccount.com`}
+              error={error?.message}
+            />
+          </Field>
+        )}
+      />
+      <Field>
+        <FieldLabel>Token Scopes</FieldLabel>
+        <div className="flex flex-col gap-3">
+          {scopes.fields.map(({ id }, index) => (
+            <Controller
+              key={id}
+              control={control}
+              name={`inputs.tokenScopes.${index}.value`}
+              render={({ field, fieldState: { error } }) => (
+                <div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+                  <Field data-invalid={Boolean(error)}>
+                    <FieldLabel htmlFor={`gcp-scope-${index}`}>Token Scope</FieldLabel>
+                    <Input
+                      {...field}
+                      id={`gcp-scope-${index}`}
+                      placeholder="https://www.googleapis.com/auth/cloud-platform"
+                      isError={Boolean(error)}
+                      aria-describedby={error ? `gcp-scope-${index}-error` : undefined}
+                    />
+                    <FieldError id={`gcp-scope-${index}-error`}>{error?.message}</FieldError>
+                  </Field>
+                  <div className="flex flex-col gap-2">
+                    <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                      &nbsp;
+                    </FieldLabel>
+                    <IconButton
+                      type="button"
+                      variant="outline"
+                      aria-label={`Remove scope ${index + 1}`}
+                      onClick={() => scopes.remove(index)}
+                    >
+                      <Trash2Icon />
+                    </IconButton>
+                  </div>
+                </div>
+              )}
+            />
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            className="self-start"
+            onClick={() => scopes.append({ value: "" })}
+          >
+            <PlusIcon />
+            Add Scope
+          </Button>
+        </div>
+      </Field>
+    </DynamicSecretProviderGroup>
+  );
+};
+
+export const gcpIamDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.GcpIam,
+  label: "GCP IAM",
+  customRenderer: {
+    reasons: GCP_IAM_CUSTOM_RENDERER_REASONS,
+    Component: GcpIamFields
+  },
+  create: {
+    schema: gcpIamCreateFormSchema,
+    getDefaultValues: getGcpIamCreateDefaultValues,
+    toPayload: getGcpIamCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: gcpIamEditFormSchema,
+    getDefaultValues: getGcpIamEditDefaultValues,
+    toPayload: getGcpIamEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/gcpIamContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/gcpIamContract.ts
@@ -1,0 +1,145 @@
+import ms from "ms";
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const GCP_IAM_CUSTOM_RENDERER_REASONS = [
+  "repeatable-fields",
+  "context-aware-fields"
+] as const;
+
+const validateGcpTtl = (value: string, context: z.RefinementCtx) => {
+  if (!value) return;
+  const valueMs = ms(value);
+  if (valueMs === undefined) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "Invalid TTL format" });
+    return;
+  }
+  if (valueMs < 1000) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be a greater than 1 second"
+    });
+  }
+  if (valueMs > 60 * 60 * 1000) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than 1 hour" });
+  }
+};
+
+const gcpIamInputsSchema = z.object({
+  serviceAccountEmail: z.string().email().trim().min(1, "Service account email required"),
+  tokenScopes: z
+    .array(z.object({ value: z.string().trim().min(1, "Scope is required") }))
+    .min(1, "At least one scope is required")
+});
+
+export type TGcpIamFormValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof gcpIamInputsSchema>
+>;
+
+const makeGcpIamSchema = (isCreate: boolean) =>
+  z
+    .object({
+      inputs: gcpIamInputsSchema,
+      defaultTTL: z.string().superRefine(validateGcpTtl),
+      maxTTL: z
+        .string()
+        .optional()
+        .nullable()
+        .superRefine((value, context) => {
+          if (value) validateGcpTtl(value, context);
+        }),
+      name: z.string().refine((value) => value.toLowerCase() === value, "Must be lowercase"),
+      environment: isCreate
+        ? z.object({ name: z.string(), slug: z.string() })
+        : z.object({ name: z.string(), slug: z.string() }).optional(),
+      usernameTemplate: z.string().nullable().optional()
+    })
+    .refine((data) => !data.maxTTL || ms(data.maxTTL)! >= ms(data.defaultTTL)!, {
+      path: ["maxTTL"],
+      message: "Max TTL must be greater than or equal to Default TTL"
+    });
+
+export const gcpIamCreateFormSchema = makeGcpIamSchema(true) as z.ZodType<TGcpIamFormValues>;
+export const gcpIamEditFormSchema = makeGcpIamSchema(false) as z.ZodType<TGcpIamFormValues>;
+
+const DEFAULT_SCOPES = [
+  { value: "https://www.googleapis.com/auth/iam" },
+  { value: "https://www.googleapis.com/auth/cloud-platform" }
+];
+
+export const getGcpIamCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TGcpIamFormValues => ({
+  name: "",
+  defaultTTL: "30m",
+  maxTTL: "1h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  inputs: { serviceAccountEmail: "", tokenScopes: DEFAULT_SCOPES }
+});
+
+export const getGcpIamEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TGcpIamFormValues => {
+  const inputs = context.dynamicSecret.inputs as {
+    serviceAccountEmail: string;
+    tokenScopes?: string[];
+  };
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL,
+    inputs: {
+      serviceAccountEmail: inputs.serviceAccountEmail,
+      tokenScopes: (inputs.tokenScopes ?? DEFAULT_SCOPES.map(({ value }) => value)).map(
+        (value) => ({
+          value
+        })
+      )
+    }
+  };
+};
+
+const normalizeInputs = (inputs: TGcpIamFormValues["inputs"]) => ({
+  serviceAccountEmail: inputs.serviceAccountEmail,
+  tokenScopes: [...new Set(inputs.tokenScopes.map(({ value }) => value))]
+});
+
+export const getGcpIamCreatePayload = (
+  values: TGcpIamFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.GcpIam> => ({
+  provider: { type: DynamicSecretProviders.GcpIam, inputs: normalizeInputs(values.inputs) },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? ""
+});
+
+export const getGcpIamEditPayload = (
+  values: TGcpIamFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    inputs: normalizeInputs(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    defaultTTL: values.defaultTTL,
+    maxTTL: values.maxTTL || undefined
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/github.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/github.tsx
@@ -1,0 +1,101 @@
+import { Controller, useFormContext } from "react-hook-form";
+
+import { Field, FieldError, FieldLabel, Input } from "@app/components/v3";
+import { SecretInput } from "@app/components/v3/platform";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { defineDynamicSecretProvider } from "../types";
+import {
+  getGithubCreateDefaultValues,
+  getGithubCreatePayload,
+  getGithubEditDefaultValues,
+  getGithubEditPayload,
+  GITHUB_CUSTOM_RENDERER_REASONS,
+  githubCreateFormSchema,
+  githubEditFormSchema,
+  TGithubFormValues
+} from "./githubContract";
+
+const GithubFields = () => {
+  const { control } = useFormContext<TGithubFormValues>();
+
+  return (
+    <DynamicSecretProviderGroup id="github-credentials" presentation="panel">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {(["appId", "installationId"] as const).map((key) => (
+          <Controller
+            key={key}
+            control={control}
+            name={`inputs.${key}`}
+            render={({ field, fieldState: { error } }) => (
+              <Field data-invalid={Boolean(error)}>
+                <FieldLabel htmlFor={`github-${key}`}>
+                  {key === "appId" ? "App ID" : "Installation ID"}
+                </FieldLabel>
+                <Input
+                  ref={field.ref}
+                  id={`github-${key}`}
+                  name={field.name}
+                  type="number"
+                  value={field.value || ""}
+                  onBlur={field.onBlur}
+                  onChange={(event) => field.onChange(Number(event.target.value))}
+                  placeholder={key === "appId" ? "0000000" : "00000000"}
+                  isError={Boolean(error)}
+                  aria-describedby={error ? `github-${key}-error` : undefined}
+                />
+                <FieldError id={`github-${key}-error`}>{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+        ))}
+        <Controller
+          control={control}
+          name="inputs.privateKey"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)} className="sm:col-span-2">
+              <FieldLabel htmlFor="github-private-key">App Private Key PEM</FieldLabel>
+              <SecretInput
+                {...field}
+                id="github-private-key"
+                aria-describedby={error ? "github-private-key-error" : undefined}
+              />
+              <FieldError id="github-private-key-error">{error?.message}</FieldError>
+            </Field>
+          )}
+        />
+      </div>
+    </DynamicSecretProviderGroup>
+  );
+};
+
+const fixedTtlFields = {
+  defaultTTL: {
+    isDisabled: true,
+    description: "GitHub token TTL is fixed to 1 hour"
+  },
+  maxTTL: { isVisible: false }
+} as const;
+
+export const githubDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Github,
+  label: "GitHub",
+  create: {
+    schema: githubCreateFormSchema,
+    getDefaultValues: getGithubCreateDefaultValues,
+    toPayload: getGithubCreatePayload,
+    customRenderer: { reasons: GITHUB_CUSTOM_RENDERER_REASONS, Component: GithubFields },
+    commonFields: fixedTtlFields,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: githubEditFormSchema,
+    getDefaultValues: getGithubEditDefaultValues,
+    toPayload: getGithubEditPayload,
+    customRenderer: { reasons: GITHUB_CUSTOM_RENDERER_REASONS, Component: GithubFields },
+    commonFields: fixedTtlFields,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/githubContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/githubContract.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const GITHUB_CUSTOM_RENDERER_REASONS = ["non-scalar-value"] as const;
+
+const privateKeySchema = z
+  .string()
+  .trim()
+  .min(1, "Required")
+  .refine(
+    (value) =>
+      /^-----BEGIN(?:(?: RSA| PGP| ENCRYPTED)? PRIVATE KEY)-----\s*[\s\S]*?-----END(?:(?: RSA| PGP| ENCRYPTED)? PRIVATE KEY)-----$/.test(
+        value
+      ),
+    "Invalid PEM format for private key"
+  );
+const maskedPrivateKeySchema = z
+  .string()
+  .trim()
+  .min(1, "Required")
+  .refine(
+    (value) => /^\*+$/.test(value) || privateKeySchema.safeParse(value).success,
+    "Invalid PEM format for private key"
+  );
+const githubInputFields = {
+  appId: z.coerce.number().min(1, "Required"),
+  installationId: z.coerce.number().min(1, "Required")
+};
+const githubCreateInputsSchema = z.object({ ...githubInputFields, privateKey: privateKeySchema });
+const githubEditInputsSchema = z.object({
+  ...githubInputFields,
+  privateKey: maskedPrivateKeySchema
+});
+
+export type TGithubFormValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof githubCreateInputsSchema>
+>;
+
+const getGithubBaseSchema = (
+  inputs: typeof githubCreateInputsSchema | typeof githubEditInputsSchema
+) =>
+  z.object({
+    name: z.string().refine((value) => value.toLowerCase() === value, "Must be lowercase"),
+    defaultTTL: z.literal("1h"),
+    maxTTL: z.string().nullable().optional(),
+    environment: z.object({ name: z.string(), slug: z.string() }).optional(),
+    usernameTemplate: z.string().nullable().optional(),
+    inputs
+  });
+
+export const githubCreateFormSchema = getGithubBaseSchema(githubCreateInputsSchema).extend({
+  environment: z.object({ name: z.string(), slug: z.string() })
+}) as z.ZodType<TGithubFormValues>;
+
+export const githubEditFormSchema = getGithubBaseSchema(
+  githubEditInputsSchema
+) as z.ZodType<TGithubFormValues>;
+
+export const getGithubCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TGithubFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: undefined,
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  inputs: { appId: 0, installationId: 0, privateKey: "" }
+});
+
+export const getGithubEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TGithubFormValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: "1h",
+  maxTTL: undefined,
+  inputs: context.dynamicSecret.inputs as TGithubFormValues["inputs"]
+});
+
+export const getGithubCreatePayload = (
+  values: TGithubFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Github> => ({
+  provider: {
+    type: DynamicSecretProviders.Github,
+    inputs: githubCreateInputsSchema.parse(values.inputs)
+  },
+  defaultTTL: "1h",
+  name: values.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? ""
+});
+
+export const getGithubEditPayload = (
+  values: TGithubFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    inputs: githubEditInputsSchema.parse(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/identityAccess.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/identityAccess.ts
@@ -1,0 +1,32 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type { TRegisteredDynamicSecretProviderDefinition } from "../registry";
+import { defineDynamicSecretProviderModule } from "../registry";
+import { awsIamDynamicSecretProvider } from "./awsIam";
+import { azureEntraIdDynamicSecretProvider } from "./azureEntraId";
+import { gcpIamDynamicSecretProvider } from "./gcpIam";
+import { githubDynamicSecretProvider } from "./github";
+import { IDENTITY_ACCESS_DYNAMIC_SECRET_PROVIDERS } from "./identityAccessContract";
+import { ldapDynamicSecretProvider } from "./ldap";
+import { sshDynamicSecretProvider } from "./ssh";
+import { tailscaleDynamicSecretProvider } from "./tailscale";
+
+const definitionsByProvider = {
+  [DynamicSecretProviders.AwsIam]: awsIamDynamicSecretProvider,
+  [DynamicSecretProviders.GcpIam]: gcpIamDynamicSecretProvider,
+  [DynamicSecretProviders.AzureEntraId]: azureEntraIdDynamicSecretProvider,
+  [DynamicSecretProviders.Github]: githubDynamicSecretProvider,
+  [DynamicSecretProviders.Tailscale]: tailscaleDynamicSecretProvider,
+  [DynamicSecretProviders.Ssh]: sshDynamicSecretProvider,
+  [DynamicSecretProviders.Ldap]: ldapDynamicSecretProvider
+} satisfies Record<
+  (typeof IDENTITY_ACCESS_DYNAMIC_SECRET_PROVIDERS)[number],
+  TRegisteredDynamicSecretProviderDefinition
+>;
+
+export const identityAccessDynamicSecretProviders = defineDynamicSecretProviderModule({
+  id: "identity-access",
+  definitions: IDENTITY_ACCESS_DYNAMIC_SECRET_PROVIDERS.map(
+    (provider) => definitionsByProvider[provider]
+  )
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/identityAccessContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/identityAccessContract.ts
@@ -1,0 +1,12 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+/** Providers owned by the identity/access rollout batch. */
+export const IDENTITY_ACCESS_DYNAMIC_SECRET_PROVIDERS = [
+  DynamicSecretProviders.AwsIam,
+  DynamicSecretProviders.GcpIam,
+  DynamicSecretProviders.AzureEntraId,
+  DynamicSecretProviders.Github,
+  DynamicSecretProviders.Tailscale,
+  DynamicSecretProviders.Ssh,
+  DynamicSecretProviders.Ldap
+] as const;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/index.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/index.ts
@@ -1,0 +1,10 @@
+export { awsIamDynamicSecretProvider } from "./awsIam";
+export { azureEntraIdDynamicSecretProvider } from "./azureEntraId";
+export { gcpIamDynamicSecretProvider } from "./gcpIam";
+export { githubDynamicSecretProvider } from "./github";
+export { identityAccessDynamicSecretProviders } from "./identityAccess";
+export { IDENTITY_ACCESS_DYNAMIC_SECRET_PROVIDERS } from "./identityAccessContract";
+export { ldapDynamicSecretProvider } from "./ldap";
+export { sshDynamicSecretProvider } from "./ssh";
+export { sshDynamicSecretCreateBoundary, SshDynamicSecretCreateForm } from "./sshCreateForm";
+export { tailscaleDynamicSecretProvider } from "./tailscale";

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/ldap.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/ldap.tsx
@@ -1,0 +1,232 @@
+import { useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { InfoIcon } from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  Field,
+  FieldContent,
+  FieldError,
+  FieldFeedback,
+  FieldLabel,
+  FieldTitle,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch
+} from "@app/components/v3";
+import { ProjectPermissionSub, useProject } from "@app/context";
+import { useCanUseProjectAppConnectionImport } from "@app/hooks";
+import { useListAvailableAppConnections } from "@app/hooks/api/appConnections";
+import { AppConnection } from "@app/hooks/api/appConnections/enums";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import type { VaultLdapRole } from "@app/hooks/api/migration/types";
+import { VaultLdapImportModal } from "@app/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/VaultLdapImportModal";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import {
+  defineDynamicSecretProvider,
+  TDynamicSecretProviderField,
+  TDynamicSecretProviderRendererProps
+} from "../types";
+import {
+  getLdapCreateDefaultValues,
+  getLdapCreatePayload,
+  getLdapEditDefaultValues,
+  getLdapEditPayload,
+  getLdapVaultImportValues,
+  LDAP_CUSTOM_RENDERER_REASONS,
+  ldapCreateFormSchema,
+  LdapCredentialType,
+  ldapEditFormSchema,
+  TLdapFormValues
+} from "./ldapContract";
+
+const LdapFields = ({ mode }: TDynamicSecretProviderRendererProps) => {
+  const [isImportOpen, setIsImportOpen] = useState(false);
+  const { projectId } = useProject();
+  const canImport = useCanUseProjectAppConnectionImport(ProjectPermissionSub.Secrets);
+  const { data: connections = [] } = useListAvailableAppConnections(
+    AppConnection.HCVault,
+    projectId,
+    { enabled: mode === "create" && canImport }
+  );
+  const { control, reset, setValue, watch } = useFormContext<TLdapFormValues>();
+  const credentialType = watch("inputs.credentialType");
+  const common = [
+    { name: "inputs.url", type: "text", label: "URL" },
+    { name: "inputs.binddn", type: "text", label: "Bind DN", layout: "half" },
+    {
+      name: "inputs.bindpass",
+      type: "secret",
+      label: "Bind Password",
+      layout: "half",
+      autoComplete: "new-password"
+    },
+    { name: "inputs.ca", type: "textarea", label: "CA", isOptional: true }
+  ] satisfies readonly TDynamicSecretProviderField<TLdapFormValues>[];
+  const handleImport = (role: VaultLdapRole) => {
+    try {
+      const currentInputs = watch("inputs");
+      const importedValues = getLdapVaultImportValues(role);
+      reset({
+        ...watch(),
+        ...importedValues,
+        inputs: {
+          ...currentInputs,
+          ...importedValues.inputs,
+          bindpass: currentInputs.bindpass
+        }
+      });
+      createNotification({
+        type: "info",
+        text: "Configuration loaded successfully from HashiCorp Vault"
+      });
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to load configuration from HashiCorp Vault"
+      });
+    }
+  };
+  return (
+    <>
+      {mode === "create" && canImport && connections.length > 0 && (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-info/20 bg-info/10 p-3">
+          <div className="flex items-center gap-2 text-sm">
+            <InfoIcon className="size-4 text-info" />
+            Load values from HashiCorp Vault.
+          </div>
+          <Button type="button" size="sm" variant="info" onClick={() => setIsImportOpen(true)}>
+            Load from Vault
+          </Button>
+        </div>
+      )}
+      <DynamicSecretProviderGroup id="ldap-connection" presentation="panel">
+        <DynamicSecretProviderFields fields={common} />
+        <Controller
+          control={control}
+          name="inputs.sslRejectUnauthorized"
+          render={({ field, fieldState: { error } }) => (
+            <Field orientation="horizontal" data-invalid={Boolean(error)}>
+              <FieldContent>
+                <FieldTitle>SSL Reject Unauthorized</FieldTitle>
+                <FieldFeedback
+                  id="ldap-ssl-reject-feedback"
+                  description="Verify the server certificate against the supplied certificate authorities."
+                  error={error?.message}
+                />
+              </FieldContent>
+              <Switch
+                ref={field.ref}
+                checked={field.value}
+                onBlur={field.onBlur}
+                onCheckedChange={field.onChange}
+                aria-label="SSL Reject Unauthorized"
+              />
+            </Field>
+          )}
+        />
+      </DynamicSecretProviderGroup>
+      <DynamicSecretProviderGroup id="ldap-configuration" presentation="panel">
+        <Controller
+          control={control}
+          name="inputs.credentialType"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="ldap-credential-type">Credential Type</FieldLabel>
+              <Select
+                value={field.value}
+                onValueChange={(value) => {
+                  // Radix Select can emit a spurious empty onValueChange while options mount.
+                  if (!value || value === field.value) return;
+                  field.onChange(value);
+                  if (value === LdapCredentialType.Dynamic) setValue("inputs.rotationLdif", "");
+                  else {
+                    setValue("inputs.creationLdif", "");
+                    setValue("inputs.revocationLdif", "");
+                    setValue("inputs.rollbackLdif", "");
+                  }
+                }}
+              >
+                <SelectTrigger
+                  ref={field.ref}
+                  id="ldap-credential-type"
+                  onBlur={field.onBlur}
+                  isError={Boolean(error)}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={LdapCredentialType.Dynamic}>Dynamic</SelectItem>
+                  <SelectItem value={LdapCredentialType.Static}>Static</SelectItem>
+                </SelectContent>
+              </Select>
+              <FieldError>{error?.message}</FieldError>
+            </Field>
+          )}
+        />
+        {credentialType === LdapCredentialType.Dynamic ? (
+          <DynamicSecretProviderFields
+            fields={[
+              { name: "inputs.creationLdif", type: "textarea", label: "Creation LDIF" },
+              { name: "inputs.revocationLdif", type: "textarea", label: "Revocation LDIF" },
+              {
+                name: "inputs.rollbackLdif",
+                type: "textarea",
+                label: "Rollback LDIF",
+                isOptional: true
+              }
+            ]}
+          />
+        ) : (
+          <DynamicSecretProviderFields
+            fields={[{ name: "inputs.rotationLdif", type: "textarea", label: "Rotation LDIF" }]}
+          />
+        )}
+        <DynamicSecretProviderFields
+          fields={[
+            {
+              name: "usernameTemplate",
+              type: "text",
+              label: "Username Template",
+              placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+            }
+          ]}
+        />
+      </DynamicSecretProviderGroup>
+      <VaultLdapImportModal
+        isOpen={isImportOpen}
+        onOpenChange={setIsImportOpen}
+        appConnections={connections}
+        onImport={handleImport}
+      />
+    </>
+  );
+};
+export const ldapDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Ldap,
+  label: "LDAP",
+  customRenderer: {
+    reasons: LDAP_CUSTOM_RENDERER_REASONS,
+    Component: LdapFields
+  },
+  create: {
+    schema: ldapCreateFormSchema,
+    getDefaultValues: getLdapCreateDefaultValues,
+    toPayload: getLdapCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: ldapEditFormSchema,
+    getDefaultValues: getLdapEditDefaultValues,
+    toPayload: getLdapEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/ldapContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/ldapContract.ts
@@ -1,0 +1,146 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+import type { VaultLdapRole } from "@app/hooks/api/migration/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const LDAP_CUSTOM_RENDERER_REASONS = [
+  "conditional-fields",
+  "import-workflow",
+  "remote-options"
+] as const;
+
+export enum LdapCredentialType {
+  Dynamic = "dynamic",
+  Static = "static"
+}
+const getSharedSchema = (sslRejectUnauthorized: z.ZodType<boolean | undefined>) => ({
+  url: z.string().trim().min(1),
+  binddn: z.string().trim().min(1),
+  bindpass: z.string().trim().min(1),
+  ca: z.string().optional(),
+  sslRejectUnauthorized
+});
+const getInputsSchema = (sslRejectUnauthorized: z.ZodType<boolean | undefined>) =>
+  z.discriminatedUnion("credentialType", [
+    z.object({
+      ...getSharedSchema(sslRejectUnauthorized),
+      credentialType: z.literal(LdapCredentialType.Dynamic),
+      creationLdif: z.string().min(1),
+      revocationLdif: z.string().min(1),
+      rollbackLdif: z.string().optional()
+    }),
+    z.object({
+      ...getSharedSchema(sslRejectUnauthorized),
+      credentialType: z.literal(LdapCredentialType.Static),
+      rotationLdif: z.string().min(1)
+    })
+  ]);
+const createInputsSchema = getInputsSchema(z.boolean().default(true));
+const editInputsSchema = getInputsSchema(z.boolean().optional());
+
+export type TLdapCreateFormValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof createInputsSchema>
+>;
+export type TLdapEditFormValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof editInputsSchema>
+>;
+export type TLdapFormValues = TLdapCreateFormValues & TLdapEditFormValues;
+export const ldapCreateFormSchema = createDynamicSecretProviderFormSchema(
+  createInputsSchema
+) as z.ZodType<TLdapCreateFormValues>;
+export const ldapEditFormSchema = editDynamicSecretProviderFormSchema(editInputsSchema, {
+  usernameTemplateSchema: z.string().trim().nullable().optional()
+}) as z.ZodType<TLdapEditFormValues>;
+export const getLdapCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TLdapCreateFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    url: "",
+    binddn: "",
+    bindpass: "",
+    ca: "",
+    sslRejectUnauthorized: true,
+    creationLdif: "",
+    revocationLdif: "",
+    rollbackLdif: "",
+    credentialType: LdapCredentialType.Dynamic
+  }
+});
+export const getLdapEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TLdapEditFormValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  usernameTemplate:
+    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: context.dynamicSecret.inputs as TLdapEditFormValues["inputs"]
+});
+export const getLdapVaultImportValues = (role: VaultLdapRole): Partial<TLdapCreateFormValues> => ({
+  name: role.name,
+  ...(role.default_ttl ? { defaultTTL: `${role.default_ttl}s` } : {}),
+  ...(role.max_ttl ? { maxTTL: `${role.max_ttl}s` } : {}),
+  ...(role.username_template ? { usernameTemplate: role.username_template } : {}),
+  inputs: {
+    url: role.config.url ?? "",
+    binddn: role.config.binddn ?? "",
+    bindpass: "",
+    ca: role.config.certificate ?? "",
+    sslRejectUnauthorized: true,
+    credentialType: LdapCredentialType.Dynamic,
+    creationLdif: role.creation_ldif ?? "",
+    revocationLdif: role.deletion_ldif ?? "",
+    rollbackLdif: role.rollback_ldif
+  }
+});
+export const getLdapCreatePayload = (
+  values: TLdapCreateFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Ldap> => ({
+  provider: { type: DynamicSecretProviders.Ldap, inputs: createInputsSchema.parse(values.inputs) },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate),
+  environmentSlug: values.environment?.slug ?? ""
+});
+export const getLdapEditPayload = (
+  values: TLdapEditFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: editInputsSchema.parse(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/ssh.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/ssh.tsx
@@ -1,0 +1,207 @@
+import { KeyboardEvent, useState } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import {
+  Button,
+  CopyButton,
+  Field,
+  FieldFeedback,
+  FieldLabel,
+  IconButton,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@app/components/v3";
+import { useGetSshCaPublicKey } from "@app/hooks/api";
+import { sshCertKeyAlgorithms } from "@app/hooks/api/dynamicSecret/constants";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+import { getAuthToken } from "@app/hooks/api/reactQuery";
+
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { defineDynamicSecretProvider, TDynamicSecretProviderRendererProps } from "../types";
+import {
+  getSshCreateDefaultValues,
+  getSshCreatePayload,
+  getSshEditDefaultValues,
+  getSshEditPayload,
+  SSH_CUSTOM_RENDERER_REASONS,
+  sshCreateFormSchema,
+  sshEditFormSchema,
+  TSshFormValues
+} from "./sshContract";
+
+const SshFields = ({ context, mode }: TDynamicSecretProviderRendererProps) => {
+  const { control, setValue, watch } = useFormContext<TSshFormValues>();
+  const [principal, setPrincipal] = useState("");
+  const principals = watch("inputs.principals");
+  const [isSetupOpen, setIsSetupOpen] = useState(false);
+  const dynamicSecretId =
+    mode === "edit" && "dynamicSecret" in context ? context.dynamicSecret.id : "";
+  const { data: caPublicKey } = useGetSshCaPublicKey({
+    dynamicSecretId,
+    enabled: mode === "edit" && isSetupOpen
+  });
+  const setupCommand = dynamicSecretId
+    ? `curl -H "Authorization: Bearer ${getAuthToken()}" "${window.location.origin}/api/v1/dynamic-secrets/ssh-ca-setup/${dynamicSecretId}" | sudo bash`
+    : "";
+  const addPrincipal = () => {
+    const value = principal.trim();
+    if (value && !principals.includes(value)) {
+      setValue("inputs.principals", [...principals, value], {
+        shouldValidate: true,
+        shouldDirty: true
+      });
+    }
+    setPrincipal("");
+  };
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      addPrincipal();
+    }
+  };
+
+  return (
+    <>
+      <DynamicSecretProviderGroup id="ssh-configuration" presentation="panel">
+        <Controller
+          control={control}
+          name="inputs.principals"
+          render={({ fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="ssh-principal">Allowed Principals</FieldLabel>
+              <div className="flex gap-2">
+                <Input
+                  id="ssh-principal"
+                  value={principal}
+                  onChange={(event) => setPrincipal(event.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Enter principal name..."
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={addPrincipal}
+                  isDisabled={!principal.trim()}
+                >
+                  <PlusIcon /> Add
+                </Button>
+              </div>
+              <FieldFeedback
+                id="ssh-principals-feedback"
+                description="The usernames this dynamic secret can issue certificates for."
+                error={error?.message}
+              />
+              <div className="flex flex-col gap-2">
+                {principals.map((value, index) => (
+                  <div key={value} className="flex items-center gap-2">
+                    <Input value={value} readOnly aria-label={`Principal ${value}`} />
+                    <IconButton
+                      type="button"
+                      variant="outline"
+                      aria-label={`Remove principal ${value}`}
+                      onClick={() =>
+                        setValue(
+                          "inputs.principals",
+                          principals.filter((_, itemIndex) => itemIndex !== index),
+                          { shouldValidate: true, shouldDirty: true }
+                        )
+                      }
+                    >
+                      <Trash2Icon />
+                    </IconButton>
+                  </div>
+                ))}
+              </div>
+            </Field>
+          )}
+        />
+        <Controller
+          control={control}
+          name="inputs.keyAlgorithm"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="ssh-key-algorithm">Key Algorithm</FieldLabel>
+              <Select
+                value={field.value}
+                onValueChange={(value) => {
+                  if (!value || value === field.value) return;
+                  field.onChange(value);
+                }}
+              >
+                <SelectTrigger
+                  ref={field.ref}
+                  id="ssh-key-algorithm"
+                  onBlur={field.onBlur}
+                  isError={Boolean(error)}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {sshCertKeyAlgorithms.map((algorithm) => (
+                    <SelectItem key={algorithm.value} value={algorithm.value}>
+                      {algorithm.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldFeedback
+                id="ssh-key-algorithm-feedback"
+                description="Algorithm for ephemeral key pairs generated per lease."
+                error={error?.message}
+              />
+            </Field>
+          )}
+        />
+      </DynamicSecretProviderGroup>
+
+      {mode === "edit" && (
+        <DynamicSecretProviderGroup
+          id="ssh-setup"
+          presentation="collapse"
+          title="Certificate-Based Authentication"
+          open={isSetupOpen}
+          onOpenChange={setIsSetupOpen}
+        >
+          <Field>
+            <FieldLabel htmlFor="ssh-setup-command">Setup Command</FieldLabel>
+            <div className="flex gap-2">
+              <Input id="ssh-setup-command" value={setupCommand} readOnly />
+              <CopyButton value={setupCommand} ariaLabel="Copy setup command" />
+            </div>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="ssh-ca-public-key">CA Public Key</FieldLabel>
+            <div className="flex gap-2">
+              <Input id="ssh-ca-public-key" type="password" value={caPublicKey ?? ""} readOnly />
+              <CopyButton value={caPublicKey ?? ""} ariaLabel="Copy CA public key" />
+            </div>
+          </Field>
+        </DynamicSecretProviderGroup>
+      )}
+    </>
+  );
+};
+
+export const sshDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Ssh,
+  label: "SSH",
+  customRenderer: { reasons: SSH_CUSTOM_RENDERER_REASONS, Component: SshFields },
+  create: {
+    schema: sshCreateFormSchema,
+    getDefaultValues: getSshCreateDefaultValues,
+    toPayload: getSshCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: sshEditFormSchema,
+    getDefaultValues: getSshEditDefaultValues,
+    toPayload: getSshEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sshContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sshContract.ts
@@ -1,0 +1,97 @@
+import ms from "ms";
+import { z } from "zod";
+
+import { SshCertKeyAlgorithm, sshCertKeyAlgorithms } from "@app/hooks/api/dynamicSecret/constants";
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  editDynamicSecretProviderFormSchema
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const SSH_CUSTOM_RENDERER_REASONS = ["repeatable-fields"] as const;
+export const SSH_CREATE_WORKFLOW_BOUNDARY_REASONS = ["post-create-workflow"] as const;
+
+const algorithmValues = sshCertKeyAlgorithms.map(({ value }) => value);
+const sshInputsSchema = z.object({
+  principals: z.array(z.string().trim().min(1)).min(1, "At least one principal is required"),
+  keyAlgorithm: z.enum(algorithmValues as [string, ...string[]])
+});
+
+export type TSshFormValues = TDynamicSecretProviderFormValues<z.infer<typeof sshInputsSchema>>;
+
+const withTtlOrder = <T extends z.ZodType<TSshFormValues>>(schema: T) =>
+  schema.refine((data) => !data.maxTTL || ms(data.maxTTL)! >= ms(data.defaultTTL)!, {
+    path: ["maxTTL"],
+    message: "Max TTL must be greater than or equal to Default TTL"
+  }) as z.ZodType<TSshFormValues>;
+
+export const sshCreateFormSchema = withTtlOrder(
+  createDynamicSecretProviderFormSchema(sshInputsSchema) as z.ZodType<TSshFormValues>
+);
+export const sshEditFormSchema = withTtlOrder(
+  editDynamicSecretProviderFormSchema(sshInputsSchema) as z.ZodType<TSshFormValues>
+);
+
+export const getSshCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TSshFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  inputs: { principals: [], keyAlgorithm: SshCertKeyAlgorithm.ED25519 }
+});
+
+export const getSshEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TSshFormValues => {
+  const inputs = context.dynamicSecret.inputs as Partial<TSshFormValues["inputs"]>;
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL,
+    inputs: {
+      principals: inputs.principals ?? [],
+      keyAlgorithm: inputs.keyAlgorithm ?? SshCertKeyAlgorithm.ED25519
+    }
+  };
+};
+
+export const getSshCreatePayload = (
+  values: TSshFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Ssh> => ({
+  provider: { type: DynamicSecretProviders.Ssh, inputs: sshInputsSchema.parse(values.inputs) },
+  defaultTTL: values.defaultTTL,
+  maxTTL: values.maxTTL || undefined,
+  name: values.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? ""
+});
+
+export const getSshEditPayload = (
+  values: TSshFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    inputs: sshInputsSchema.parse(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    defaultTTL: values.defaultTTL,
+    maxTTL: values.maxTTL || undefined
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sshCreateForm.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sshCreateForm.tsx
@@ -1,0 +1,104 @@
+import { ReactNode, useState } from "react";
+
+import {
+  Button,
+  CopyButton,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input
+} from "@app/components/v3";
+import { useGetSshCaPublicKey } from "@app/hooks/api";
+import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
+import { getAuthToken } from "@app/hooks/api/reactQuery";
+import { ProjectEnv } from "@app/hooks/api/types";
+
+import { DynamicSecretProviderForm } from "../DynamicSecretProviderForm";
+import { sshDynamicSecretProvider } from "./ssh";
+import { SSH_CREATE_WORKFLOW_BOUNDARY_REASONS } from "./sshContract";
+
+type Props = {
+  header?: ReactNode;
+  onCompleted: () => void;
+  onCancel: () => void;
+  onBack?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  secretPath: string;
+  projectSlug: string;
+  environments: ProjectEnv[];
+  isSingleEnvironmentMode?: boolean;
+};
+
+/** Create-only SSH wrapper for the post-create certificate setup disclosure. */
+export const SshDynamicSecretCreateForm = ({ onCompleted, ...props }: Props) => {
+  const [createdId, setCreatedId] = useState<string>();
+  const { data: caPublicKey } = useGetSshCaPublicKey({
+    dynamicSecretId: createdId ?? "",
+    enabled: Boolean(createdId)
+  });
+  const setupCommand = createdId
+    ? `curl -H "Authorization: Bearer ${getAuthToken()}" "${window.location.origin}/api/v1/dynamic-secrets/ssh-ca-setup/${createdId}" | sudo bash`
+    : "";
+  const closeSetup = () => {
+    setCreatedId(undefined);
+    onCompleted();
+  };
+
+  return (
+    <>
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <DynamicSecretProviderForm
+          mode="create"
+          definition={sshDynamicSecretProvider}
+          onCompleted={(result) => setCreatedId((result as TDynamicSecret).id)}
+          {...props}
+        />
+      </div>
+      <Dialog
+        open={Boolean(createdId)}
+        onOpenChange={(open) => {
+          if (!open) closeSetup();
+        }}
+      >
+        <DialogContent className="w-2xl">
+          <DialogHeader>
+            <DialogTitle>Certificate Authentication Setup</DialogTitle>
+            <DialogDescription>
+              Configure the target host to trust certificates issued by this dynamic secret.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-4">
+            <div>
+              <p className="mb-2 text-sm text-accent">Run this command on the target host:</p>
+              <div className="flex gap-2">
+                <Input value={setupCommand} readOnly />
+                <CopyButton value={setupCommand} ariaLabel="Copy setup command" />
+              </div>
+            </div>
+            <div>
+              <p className="mb-2 text-sm text-accent">Or install the CA public key manually:</p>
+              <div className="flex gap-2">
+                <Input type="password" value={caPublicKey ?? ""} readOnly />
+                <CopyButton value={caPublicKey ?? ""} ariaLabel="Copy CA public key" />
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button type="button" onClick={closeSetup}>
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+/** Explicit create boundary that owns SSH's post-create host setup disclosure. */
+export const sshDynamicSecretCreateBoundary = {
+  reasons: SSH_CREATE_WORKFLOW_BOUNDARY_REASONS,
+  Component: SshDynamicSecretCreateForm
+} as const;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/tailscale.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/tailscale.tsx
@@ -1,0 +1,175 @@
+import { Controller, useFormContext } from "react-hook-form";
+
+import { Field, FieldContent, FieldFeedback, FieldTitle, Switch } from "@app/components/v3";
+import {
+  DynamicSecretProviders,
+  TailscaleAuthMethod,
+  TailscaleKeyAuthType
+} from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { defineDynamicSecretProvider, TDynamicSecretProviderField } from "../types";
+import {
+  getTailscaleCreateDefaultValues,
+  getTailscaleCreatePayload,
+  getTailscaleEditDefaultValues,
+  getTailscaleEditPayload,
+  TAILSCALE_CUSTOM_RENDERER_REASONS,
+  tailscaleCreateFormSchema,
+  tailscaleEditFormSchema,
+  TTailscaleFormValues
+} from "./tailscaleContract";
+
+const TailscaleFields = () => {
+  const { control, watch } = useFormContext<TTailscaleFormValues>();
+  const authMethod = watch("inputs.auth.method");
+  const authType = watch("inputs.authType");
+  const common = [
+    {
+      name: "inputs.auth.method",
+      type: "select",
+      label: "Authentication Method",
+      options: [
+        { label: "API Key", value: TailscaleAuthMethod.ApiKey },
+        { label: "OAuth", value: TailscaleAuthMethod.OAuth }
+      ]
+    },
+    {
+      name: "inputs.authType",
+      type: "select",
+      label: "Key Type",
+      options: [
+        { label: "Auth Keys", value: TailscaleKeyAuthType.AuthKeys },
+        { label: "OAuth Keys", value: TailscaleKeyAuthType.OAuthKeys },
+        { label: "Federated Keys", value: TailscaleKeyAuthType.FederatedKeys }
+      ]
+    },
+    {
+      name: "inputs.tailnet",
+      type: "text",
+      label: "Tailnet",
+      description: "Use '-' for the token owner's default tailnet, or provide a tailnet name."
+    },
+    { name: "inputs.description", type: "text", label: "Description", isOptional: true },
+    {
+      name: "inputs.tags",
+      type: "text",
+      label: "Tags",
+      isOptional: true,
+      description: "Comma-separated ACL tags (for example, tag:ci, tag:prod)."
+    }
+  ] satisfies readonly TDynamicSecretProviderField<TTailscaleFormValues>[];
+  const authFields =
+    authMethod === TailscaleAuthMethod.ApiKey
+      ? ([
+          {
+            name: "inputs.auth.apiKey",
+            type: "secret",
+            label: "API Key",
+            autoComplete: "new-password"
+          }
+        ] as const)
+      : ([
+          { name: "inputs.auth.clientId", type: "text", label: "Client ID", layout: "half" },
+          {
+            name: "inputs.auth.clientSecret",
+            type: "secret",
+            label: "Client Secret",
+            autoComplete: "new-password",
+            layout: "half"
+          }
+        ] as const);
+  return (
+    <DynamicSecretProviderGroup id="tailscale-configuration" presentation="panel">
+      <DynamicSecretProviderFields
+        fields={
+          [
+            common[0],
+            ...authFields,
+            ...common.slice(1)
+          ] as readonly TDynamicSecretProviderField<TTailscaleFormValues>[]
+        }
+      />
+      {authType !== TailscaleKeyAuthType.AuthKeys && (
+        <DynamicSecretProviderFields
+          fields={[
+            {
+              name: "inputs.scopes",
+              type: "text",
+              label: "Scopes",
+              description: "Comma-separated OAuth scopes."
+            }
+          ]}
+        />
+      )}
+      {authType === TailscaleKeyAuthType.FederatedKeys && (
+        <DynamicSecretProviderFields
+          fields={[
+            {
+              name: "inputs.issuer",
+              type: "text",
+              label: "Issuer",
+              description: "HTTPS URL of the OIDC issuer trusted for token exchange."
+            },
+            { name: "inputs.subject", type: "text", label: "Subject" },
+            { name: "inputs.audience", type: "text", label: "Audience", isOptional: true }
+          ]}
+        />
+      )}
+      {authType === TailscaleKeyAuthType.AuthKeys &&
+        (["reusable", "preauthorized"] as const).map((key) => (
+          <Controller
+            key={key}
+            control={control}
+            name={`inputs.${key}`}
+            render={({ field, fieldState: { error } }) => (
+              <Field orientation="horizontal" data-invalid={Boolean(error)}>
+                <FieldContent>
+                  <FieldTitle>{key === "reusable" ? "Reusable" : "Preauthorized"}</FieldTitle>
+                  <FieldFeedback
+                    id={`tailscale-${key}-feedback`}
+                    description={
+                      key === "reusable"
+                        ? "Allow this auth key to be used more than once."
+                        : "Authorize devices without an approval step."
+                    }
+                    error={error?.message}
+                  />
+                </FieldContent>
+                <Switch
+                  ref={field.ref}
+                  checked={field.value}
+                  onBlur={field.onBlur}
+                  onCheckedChange={field.onChange}
+                  aria-label={key === "reusable" ? "Reusable" : "Preauthorized"}
+                />
+              </Field>
+            )}
+          />
+        ))}
+    </DynamicSecretProviderGroup>
+  );
+};
+
+export const tailscaleDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Tailscale,
+  label: "Tailscale",
+  customRenderer: {
+    reasons: TAILSCALE_CUSTOM_RENDERER_REASONS,
+    Component: TailscaleFields
+  },
+  create: {
+    schema: tailscaleCreateFormSchema,
+    getDefaultValues: getTailscaleCreateDefaultValues,
+    toPayload: getTailscaleCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: tailscaleEditFormSchema,
+    getDefaultValues: getTailscaleEditDefaultValues,
+    toPayload: getTailscaleEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/tailscaleContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/tailscaleContract.ts
@@ -1,0 +1,237 @@
+import ms from "ms";
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TailscaleAuthMethod,
+  TailscaleKeyAuthType,
+  TDynamicSecretProvider,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+import { slugSchema } from "@app/lib/schemas";
+
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const TAILSCALE_CUSTOM_RENDERER_REASONS = [
+  "conditional-fields",
+  "non-scalar-value"
+] as const;
+
+type TTailscaleInputs = Extract<
+  TDynamicSecretProvider,
+  { type: DynamicSecretProviders.Tailscale }
+>["inputs"];
+
+const validateTtl = (value: string, context: z.RefinementCtx) => {
+  const valueMs = ms(value);
+  if (valueMs === undefined) {
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be a valid duration" });
+    return;
+  }
+  if (valueMs < 60 * 1000)
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be greater than 1 minute" });
+  if (valueMs > ms("90d"))
+    context.addIssue({ code: z.ZodIssueCode.custom, message: "TTL must be less than 90 days" });
+};
+const authSchema = z.discriminatedUnion("method", [
+  z.object({
+    method: z.literal(TailscaleAuthMethod.ApiKey),
+    apiKey: z.string().trim().min(1, "API key is required")
+  }),
+  z.object({
+    method: z.literal(TailscaleAuthMethod.OAuth),
+    clientId: z.string().trim().min(1, "Client ID is required"),
+    clientSecret: z.string().trim().min(1, "Client secret is required")
+  })
+]);
+const inputsSchema = z.discriminatedUnion("authType", [
+  z.object({
+    authType: z.literal(TailscaleKeyAuthType.AuthKeys),
+    auth: authSchema,
+    tailnet: z.string().trim().min(1, "Tailnet is required"),
+    description: z.string().trim().max(50).optional(),
+    tags: z.string().trim().optional(),
+    reusable: z.boolean().default(false),
+    preauthorized: z.boolean().default(false)
+  }),
+  z.object({
+    authType: z.literal(TailscaleKeyAuthType.OAuthKeys),
+    auth: authSchema,
+    tailnet: z.string().trim().min(1, "Tailnet is required"),
+    description: z.string().trim().max(50).optional(),
+    tags: z.string().trim().optional(),
+    scopes: z.string().trim().min(1, "At least one scope is required")
+  }),
+  z.object({
+    authType: z.literal(TailscaleKeyAuthType.FederatedKeys),
+    auth: authSchema,
+    tailnet: z.string().trim().min(1, "Tailnet is required"),
+    description: z.string().trim().max(50).optional(),
+    tags: z.string().trim().optional(),
+    scopes: z.string().trim().min(1, "At least one scope is required"),
+    issuer: z.string().trim().min(1, "Issuer is required").url("Issuer must be a valid https URL"),
+    subject: z.string().trim().min(1, "Subject is required"),
+    audience: z.string().trim().optional()
+  })
+]);
+
+export type TTailscaleFormValues = TDynamicSecretProviderFormValues<z.infer<typeof inputsSchema>>;
+
+const makeSchema = (create: boolean) =>
+  z
+    .object({
+      inputs: inputsSchema,
+      defaultTTL: z.string().superRefine(validateTtl),
+      maxTTL: z
+        .string()
+        .optional()
+        .nullable()
+        .superRefine((value, context) => {
+          if (value) validateTtl(value, context);
+        }),
+      name: slugSchema(),
+      environment: create
+        ? z.object({ name: z.string(), slug: z.string() })
+        : z.object({ name: z.string(), slug: z.string() }).optional(),
+      usernameTemplate: z.string().nullable().optional()
+    })
+    .superRefine((value, context) => {
+      if (
+        value.inputs.authType === TailscaleKeyAuthType.AuthKeys &&
+        value.inputs.auth.method === TailscaleAuthMethod.OAuth &&
+        !value.inputs.tags?.trim()
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["inputs", "tags"],
+          message: "Tags are required when creating auth keys with OAuth authentication"
+        });
+      }
+    });
+
+export const tailscaleCreateFormSchema = makeSchema(true) as z.ZodType<TTailscaleFormValues>;
+export const tailscaleEditFormSchema = makeSchema(false) as z.ZodType<TTailscaleFormValues>;
+
+export const getTailscaleCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TTailscaleFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  inputs: {
+    authType: TailscaleKeyAuthType.AuthKeys,
+    auth: { method: TailscaleAuthMethod.ApiKey, apiKey: "" },
+    tailnet: "-",
+    reusable: false,
+    preauthorized: false
+  }
+});
+
+const splitCsv = (value?: string) =>
+  value
+    ? value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : [];
+const hydrate = (raw: TTailscaleInputs): TTailscaleFormValues["inputs"] => {
+  const base = {
+    auth: raw.auth,
+    tailnet: raw.tailnet,
+    description: raw.description,
+    tags: (raw.tags ?? []).join(", ")
+  };
+  if (raw.authType === TailscaleKeyAuthType.AuthKeys)
+    return {
+      ...base,
+      authType: raw.authType,
+      reusable: raw.reusable,
+      preauthorized: raw.preauthorized
+    };
+  if (raw.authType === TailscaleKeyAuthType.OAuthKeys)
+    return { ...base, authType: raw.authType, scopes: (raw.scopes ?? []).join(", ") };
+  return {
+    ...base,
+    authType: raw.authType,
+    scopes: (raw.scopes ?? []).join(", "),
+    issuer: raw.issuer,
+    subject: raw.subject,
+    audience: raw.audience
+  };
+};
+export const getTailscaleEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TTailscaleFormValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  inputs: hydrate(context.dynamicSecret.inputs as TTailscaleInputs)
+});
+
+const buildInputs = (input: TTailscaleFormValues["inputs"]): TTailscaleInputs => {
+  const auth =
+    input.auth.method === TailscaleAuthMethod.ApiKey
+      ? ({ method: TailscaleAuthMethod.ApiKey, apiKey: input.auth.apiKey } as const)
+      : ({
+          method: TailscaleAuthMethod.OAuth,
+          clientId: input.auth.clientId,
+          clientSecret: input.auth.clientSecret
+        } as const);
+  const base = {
+    auth,
+    tailnet: input.tailnet,
+    description: input.description || undefined,
+    tags: splitCsv(input.tags)
+  };
+  if (input.authType === TailscaleKeyAuthType.AuthKeys)
+    return {
+      ...base,
+      authType: input.authType,
+      reusable: input.reusable,
+      preauthorized: input.preauthorized
+    };
+  if (input.authType === TailscaleKeyAuthType.OAuthKeys)
+    return { ...base, authType: input.authType, scopes: splitCsv(input.scopes) };
+  return {
+    ...base,
+    authType: input.authType,
+    scopes: splitCsv(input.scopes),
+    issuer: input.issuer,
+    subject: input.subject,
+    audience: input.audience || undefined
+  };
+};
+
+export const getTailscaleCreatePayload = (
+  values: TTailscaleFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Tailscale> => ({
+  provider: { type: DynamicSecretProviders.Tailscale, inputs: buildInputs(values.inputs) },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? ""
+});
+export const getTailscaleEditPayload = (
+  values: TTailscaleFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: buildInputs(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/tailscaleContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/tailscaleContract.ts
@@ -101,15 +101,18 @@ const makeSchema = (create: boolean) =>
       usernameTemplate: z.string().nullable().optional()
     })
     .superRefine((value, context) => {
-      if (
-        value.inputs.authType === TailscaleKeyAuthType.AuthKeys &&
-        value.inputs.auth.method === TailscaleAuthMethod.OAuth &&
-        !value.inputs.tags?.trim()
-      ) {
+      const tagsRequired =
+        value.inputs.authType !== TailscaleKeyAuthType.AuthKeys ||
+        value.inputs.auth.method === TailscaleAuthMethod.OAuth;
+
+      if (tagsRequired && !value.inputs.tags?.trim()) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["inputs", "tags"],
-          message: "Tags are required when creating auth keys with OAuth authentication"
+          message:
+            value.inputs.authType === TailscaleKeyAuthType.AuthKeys
+              ? "Tags are required when creating auth keys with OAuth authentication"
+              : "Tags are required when the key type is OAuth or Federated Identity"
         });
       }
     });


### PR DESCRIPTION
## Context

[ENG-5513](https://linear.app/infisical/issue/ENG-5513/migrate-identity-and-access-dynamic-secret-provider-forms) migrates the AWS IAM, GCP IAM, Azure Entra ID, GitHub, Tailscale, SSH, and LDAP dynamic-secret provider forms onto the shared provider contract introduced by stacked parent PR [#7563](https://github.com/Infisical/infisical/pull/7563).

Previously, these providers existed only in the legacy create and edit form paths, and the shared registry had no identity/access rollout batch. This change adds provider-owned create/edit schemas, defaults, payload adapters, masked-edit handling, conditional custom renderers, and an immutable identity/access registration module. SSH retains an explicit create-only post-create host setup boundary instead of forcing that workflow through the generic scalar renderer.

Existing routes continue using the legacy forms, so current production behavior and API payloads remain unchanged until the new definitions are consumed by a later integration change.

## Screenshots

Not applicable. This stacked migration defines the replacement form contracts and renderers but intentionally does not wire them into a production route, so there is no user-visible route change to capture in this PR.

## Steps to verify the change

From `frontend/`:

1. Run targeted lint:
   ```sh
   ./node_modules/.bin/eslint 'src/components/dynamic-secrets/DynamicSecretProviderForm/**/*.{ts,tsx}'
   ```
2. Run the full frontend typecheck:
   ```sh
   ./node_modules/.bin/tsc --noEmit --project tsconfig.app.json
   ```
3. Run the shared and identity/access contract tests:
   ```sh
   TSX_TSCONFIG_PATH=tsconfig.app.json ./node_modules/.bin/tsx --test src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts src/components/dynamic-secrets/DynamicSecretProviderForm/identity-access-contract.test.ts
   ```
4. Confirm all 49 tests pass, including defaults, validation, create/edit payloads, masked edit values, renderer boundaries, LDAP Vault imports, SSH post-create ownership, and seven-provider registry composition.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)