### PR TITLE
feat(dynamic-secrets): migrate relational and warehouse provider forms

### DIFF
--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFields.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFields.tsx
@@ -1,0 +1,181 @@
+import { Controller, FieldValues, useFormContext } from "react-hook-form";
+
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  TextArea
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+
+import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
+import { TDynamicSecretProviderField } from "./types";
+
+type Props<TValues extends FieldValues> = {
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+const getFieldId = (name: string) => `dynamic-secret-${name.replaceAll(".", "-")}`;
+
+export const DynamicSecretProviderFields = <TValues extends FieldValues>({
+  fields
+}: Props<TValues>) => {
+  const { control } = useFormContext<TValues>();
+
+  return (
+    <div className="@container">
+      <div className="grid grid-cols-1 gap-3 @xl:grid-cols-2">
+        {fields.map((fieldDefinition) => {
+          const inputId = getFieldId(fieldDefinition.name);
+          const descriptionId = `${inputId}-description`;
+          const errorId = `${inputId}-error`;
+
+          return (
+            <Controller
+              key={fieldDefinition.name}
+              control={control}
+              name={fieldDefinition.name}
+              render={({ field, fieldState: { error } }) => {
+                const value =
+                  typeof field.value === "string" || typeof field.value === "number"
+                    ? field.value
+                    : "";
+                const describedBy = [
+                  fieldDefinition.description ? descriptionId : undefined,
+                  error?.message ? errorId : undefined
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                let input;
+
+                if (fieldDefinition.type === "switch") {
+                  input = (
+                    <Switch
+                      ref={field.ref}
+                      id={inputId}
+                      variant="project"
+                      checked={Boolean(field.value)}
+                      onBlur={field.onBlur}
+                      onCheckedChange={field.onChange}
+                      disabled={fieldDefinition.isDisabled}
+                      aria-describedby={describedBy || undefined}
+                      aria-invalid={Boolean(error)}
+                    />
+                  );
+                } else if (fieldDefinition.type === "select") {
+                  input = (
+                    <Select
+                      value={String(value)}
+                      disabled={fieldDefinition.isDisabled}
+                      onValueChange={(nextValue) => {
+                        // Radix Select can emit an empty change while options mount.
+                        if (!nextValue || nextValue === String(value)) return;
+                        field.onChange(nextValue);
+                      }}
+                    >
+                      <SelectTrigger
+                        ref={field.ref}
+                        id={inputId}
+                        onBlur={field.onBlur}
+                        isError={Boolean(error)}
+                        aria-describedby={describedBy || undefined}
+                        className="w-full"
+                      >
+                        <SelectValue placeholder={fieldDefinition.placeholder} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {fieldDefinition.options.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  );
+                } else if (fieldDefinition.type === "textarea") {
+                  input = (
+                    <TextArea
+                      ref={field.ref}
+                      id={inputId}
+                      name={field.name}
+                      value={value}
+                      onBlur={field.onBlur}
+                      onChange={field.onChange}
+                      rows={fieldDefinition.rows}
+                      placeholder={fieldDefinition.placeholder}
+                      disabled={fieldDefinition.isDisabled}
+                      isError={Boolean(error)}
+                      aria-describedby={describedBy || undefined}
+                    />
+                  );
+                } else {
+                  const isNumber = fieldDefinition.type === "number";
+                  let inputType = "text";
+                  if (isNumber) inputType = "number";
+                  if (fieldDefinition.type === "secret") inputType = "password";
+                  input = (
+                    <Input
+                      ref={field.ref}
+                      id={inputId}
+                      name={field.name}
+                      value={value}
+                      onBlur={field.onBlur}
+                      onChange={
+                        isNumber
+                          ? (event) =>
+                              field.onChange(
+                                parseDynamicSecretProviderNumberInput(event.currentTarget.value)
+                              )
+                          : field.onChange
+                      }
+                      type={inputType}
+                      autoComplete={
+                        fieldDefinition.type === "number" ? undefined : fieldDefinition.autoComplete
+                      }
+                      min={isNumber ? fieldDefinition.min : undefined}
+                      max={isNumber ? fieldDefinition.max : undefined}
+                      step={isNumber ? fieldDefinition.step : undefined}
+                      placeholder={fieldDefinition.placeholder}
+                      disabled={fieldDefinition.isDisabled}
+                      isError={Boolean(error)}
+                      aria-describedby={describedBy || undefined}
+                    />
+                  );
+                }
+
+                return (
+                  <Field
+                    data-invalid={Boolean(error)}
+                    className={cn(fieldDefinition.layout !== "half" && "@xl:col-span-2")}
+                  >
+                    <FieldLabel htmlFor={inputId}>
+                      {fieldDefinition.label}
+                      {fieldDefinition.isOptional && (
+                        <span className="font-normal text-muted">(optional)</span>
+                      )}
+                    </FieldLabel>
+                    {input}
+                    {fieldDefinition.description && (
+                      <FieldDescription id={descriptionId}>
+                        {fieldDefinition.description}
+                      </FieldDescription>
+                    )}
+                    {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+                  </Field>
+                );
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
@@ -23,6 +23,7 @@ import { cn } from "@app/components/v3/utils";
 import { useCreateDynamicSecret, useUpdateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
 
+import { submitDynamicSecretCreatePayloads } from "./createSubmission";
 import { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
 import {
   TCreateDynamicSecretProviderFormContext,
@@ -189,10 +190,21 @@ export const DynamicSecretProviderForm = <
         context as TCreateDynamicSecretProviderFormContext
       );
       const payloads = "provider" in payload ? [payload] : payload;
-      const results = await Promise.all(
-        payloads.map((item) => createDynamicSecret.mutateAsync(item))
+      const { successfulResults, failedCount } = await submitDynamicSecretCreatePayloads(
+        payloads,
+        (item) => createDynamicSecret.mutateAsync(item)
       );
-      onCompleted(results.length === 1 ? results[0] : results);
+
+      if (successfulResults.length === 0) return;
+
+      if (failedCount > 0) {
+        createNotification({
+          type: "warning",
+          text: `Created ${successfulResults.length} of ${payloads.length} dynamic secrets. Review the created secrets before retrying failed items.`
+        });
+      }
+
+      onCompleted(successfulResults.length === 1 ? successfulResults[0] : successfulResults);
       return;
     }
 

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
@@ -1,0 +1,464 @@
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import {
+  Controller,
+  DefaultValues,
+  FormProvider,
+  Resolver,
+  SubmitHandler,
+  useForm
+} from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FilterableSelect,
+  Input
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+import { useCreateDynamicSecret, useUpdateDynamicSecret } from "@app/hooks/api";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
+import {
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretFormEnvironment,
+  TDynamicSecretProviderDefinition,
+  TDynamicSecretProviderFormItem,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+type TCreateProps<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = TCreateDynamicSecretProviderFormContext & {
+  mode: "create";
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  onCompleted: (result?: unknown) => void;
+  onCancel: () => void;
+  onBack?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  header?: ReactNode;
+};
+
+type TEditProps<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = TEditDynamicSecretProviderFormContext & {
+  mode: "edit";
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  onCompleted: (result?: unknown) => void;
+  onCancel: () => void;
+  onBack?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  header?: ReactNode;
+};
+
+type Props<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> =
+  | TCreateProps<TProvider, TCreateValues, TEditValues>
+  | TEditProps<TProvider, TCreateValues, TEditValues>;
+
+const EMPTY_ENVIRONMENTS: TCreateDynamicSecretProviderFormContext["environments"] = [];
+
+export const DynamicSecretProviderForm = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+>(
+  props: Props<TProvider, TCreateValues, TEditValues>
+) => {
+  type TValues = TCreateValues | TEditValues;
+  const {
+    definition,
+    mode,
+    onCancel,
+    onBack,
+    onCompleted,
+    onDirtyChange,
+    projectSlug,
+    secretPath,
+    header
+  } = props;
+  const createDynamicSecret = useCreateDynamicSecret();
+  const updateDynamicSecret = useUpdateDynamicSecret();
+  const [providerSubmitState, setProviderSubmitState] = useState({
+    isDisabled: false,
+    isPending: false
+  });
+
+  let environments = EMPTY_ENVIRONMENTS;
+  let isSingleEnvironmentMode = false;
+  let editDynamicSecret: TEditDynamicSecretProviderFormContext["dynamicSecret"] | undefined;
+  let editEnvironment: string | undefined;
+
+  if (mode === "create") {
+    ({ environments, isSingleEnvironmentMode = false } = props);
+  } else {
+    const { dynamicSecret, environment } = props;
+    editDynamicSecret = dynamicSecret;
+    editEnvironment = environment;
+  }
+
+  const context = useMemo<
+    TCreateDynamicSecretProviderFormContext | TEditDynamicSecretProviderFormContext
+  >(
+    () =>
+      mode === "create"
+        ? { projectSlug, secretPath, environments, isSingleEnvironmentMode }
+        : {
+            projectSlug,
+            secretPath,
+            dynamicSecret:
+              editDynamicSecret as TEditDynamicSecretProviderFormContext["dynamicSecret"],
+            environment: editEnvironment as string
+          },
+    [
+      editDynamicSecret,
+      editEnvironment,
+      environments,
+      isSingleEnvironmentMode,
+      mode,
+      projectSlug,
+      secretPath
+    ]
+  );
+
+  const schema = mode === "create" ? definition.create.schema : definition.edit.schema;
+  const defaultValues = useMemo(
+    () =>
+      mode === "create"
+        ? definition.create.getDefaultValues(context as TCreateDynamicSecretProviderFormContext)
+        : definition.edit.getDefaultValues(context as TEditDynamicSecretProviderFormContext),
+    [context, definition, mode]
+  );
+
+  const form = useForm<TValues>({
+    resolver: zodResolver(schema) as Resolver<TValues>,
+    defaultValues: defaultValues as DefaultValues<TValues>,
+    values: mode === "edit" ? (defaultValues as TValues) : undefined,
+    shouldFocusError: true
+  });
+  const [hasDirtyBaseline, setHasDirtyBaseline] = useState(false);
+
+  // Re-baseline after mount-time controlled-input synchronization so prefills
+  // never trigger an unsaved-change guard.
+  useEffect(() => {
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      if (cancelled) return;
+      form.reset(form.getValues());
+      setHasDirtyBaseline(true);
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [form]);
+
+  useEffect(() => {
+    if (!hasDirtyBaseline) {
+      onDirtyChange?.(false);
+      return undefined;
+    }
+    onDirtyChange?.(form.formState.isDirty);
+    return () => onDirtyChange?.(false);
+  }, [hasDirtyBaseline, form.formState.isDirty, onDirtyChange]);
+
+  const isPending =
+    form.formState.isSubmitting ||
+    providerSubmitState.isPending ||
+    (mode === "create" ? createDynamicSecret.isPending : updateDynamicSecret.isPending);
+
+  const handleSubmit: SubmitHandler<TValues> = async (values) => {
+    if (isPending) return;
+
+    if (mode === "create") {
+      const payload = definition.create.toPayload(
+        values as TCreateValues,
+        context as TCreateDynamicSecretProviderFormContext
+      );
+      const payloads = "provider" in payload ? [payload] : payload;
+      const results = await Promise.all(
+        payloads.map((item) => createDynamicSecret.mutateAsync(item))
+      );
+      onCompleted(results.length === 1 ? results[0] : results);
+      return;
+    }
+
+    const payload = definition.edit.toPayload(
+      values as TEditValues,
+      context as TEditDynamicSecretProviderFormContext
+    );
+    const result = await updateDynamicSecret.mutateAsync(payload);
+    onCompleted(result);
+    createNotification({
+      type: "success",
+      text: definition.edit.successMessage
+    });
+  };
+
+  const modeDefinition = mode === "create" ? definition.create : definition.edit;
+  const fields = modeDefinition.fields ?? definition.fields;
+  const CustomRenderer = (modeDefinition.customRenderer ?? definition.customRenderer)?.Component;
+  const { commonFields } = modeDefinition;
+  const ttlFieldCount =
+    Number(commonFields?.defaultTTL?.isVisible !== false) +
+    Number(commonFields?.maxTTL?.isVisible !== false);
+  let commonFieldGrid = "@2xl:grid-cols-[minmax(0,1fr)_8rem_8rem]";
+  if (ttlFieldCount === 0) commonFieldGrid = "@2xl:grid-cols-1";
+  if (ttlFieldCount === 1) commonFieldGrid = "@2xl:grid-cols-[minmax(0,1fr)_8rem]";
+  const nameError = form.formState.errors.name;
+  const defaultTtlError = form.formState.errors.defaultTTL;
+  const maxTtlError = form.formState.errors.maxTTL;
+
+  return (
+    <FormProvider {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        autoComplete="off"
+        noValidate
+        data-slot="dynamic-secret-provider-form"
+        className="@container flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        <div className="flex min-h-0 thin-scrollbar flex-1 flex-col gap-5 overflow-y-auto px-4 py-5">
+          {header}
+          <section className="flex flex-col gap-4" aria-label="Dynamic secret details">
+            <div className={cn("grid grid-cols-1 gap-3", commonFieldGrid)}>
+              {commonFields?.name?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"name" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(nameError)}>
+                      <FieldLabel htmlFor="dynamic-secret-name">
+                        {commonFields?.name?.label ?? "Secret Name"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-name"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        placeholder="dynamic-secret"
+                        isError={Boolean(nameError)}
+                        aria-describedby={nameError ? "dynamic-secret-name-error" : undefined}
+                        disabled={commonFields?.name?.isDisabled}
+                      />
+                      {nameError?.message && (
+                        <FieldError id="dynamic-secret-name-error">
+                          {nameError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+              {commonFields?.defaultTTL?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"defaultTTL" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(defaultTtlError)}>
+                      <FieldLabel htmlFor="dynamic-secret-default-ttl">
+                        {commonFields?.defaultTTL?.label ?? "Default TTL"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-default-ttl"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        isError={Boolean(defaultTtlError)}
+                        aria-describedby={
+                          [
+                            commonFields?.defaultTTL?.description
+                              ? "dynamic-secret-default-ttl-description"
+                              : undefined,
+                            defaultTtlError ? "dynamic-secret-default-ttl-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                        disabled={commonFields?.defaultTTL?.isDisabled}
+                      />
+                      {commonFields?.defaultTTL?.description && (
+                        <FieldDescription id="dynamic-secret-default-ttl-description">
+                          {commonFields.defaultTTL.description}
+                        </FieldDescription>
+                      )}
+                      {defaultTtlError?.message && (
+                        <FieldError id="dynamic-secret-default-ttl-error">
+                          {defaultTtlError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+              {commonFields?.maxTTL?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"maxTTL" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(maxTtlError)}>
+                      <FieldLabel htmlFor="dynamic-secret-max-ttl">
+                        {commonFields?.maxTTL?.label ?? "Max TTL"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-max-ttl"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        isError={Boolean(maxTtlError)}
+                        aria-describedby={
+                          [
+                            commonFields?.maxTTL?.description
+                              ? "dynamic-secret-max-ttl-description"
+                              : undefined,
+                            maxTtlError ? "dynamic-secret-max-ttl-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                        disabled={commonFields?.maxTTL?.isDisabled}
+                      />
+                      {commonFields?.maxTTL?.description && (
+                        <FieldDescription id="dynamic-secret-max-ttl-description">
+                          {commonFields.maxTTL.description}
+                        </FieldDescription>
+                      )}
+                      {maxTtlError?.message && (
+                        <FieldError id="dynamic-secret-max-ttl-error">
+                          {maxTtlError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+            </div>
+            {mode === "create" &&
+              !isSingleEnvironmentMode &&
+              commonFields?.environment?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"environment" as never}
+                  render={({ field, fieldState: { error } }) => (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor="dynamic-secret-environment">
+                        {commonFields?.environment?.label ?? "Environment"}
+                      </FieldLabel>
+                      <FilterableSelect<TDynamicSecretFormEnvironment>
+                        inputId="dynamic-secret-environment"
+                        options={environments}
+                        value={(field.value as TDynamicSecretFormEnvironment | undefined) ?? null}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        getOptionLabel={(option) => option.name}
+                        getOptionValue={(option) => option.slug}
+                        placeholder="Select the environment to create the secret in..."
+                        isDisabled={commonFields?.environment?.isDisabled}
+                        isError={Boolean(error)}
+                        aria-describedby={
+                          [
+                            commonFields?.environment?.description
+                              ? "dynamic-secret-environment-description"
+                              : undefined,
+                            error ? "dynamic-secret-environment-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                      />
+                      {commonFields?.environment?.description && (
+                        <FieldDescription id="dynamic-secret-environment-description">
+                          {commonFields.environment.description}
+                        </FieldDescription>
+                      )}
+                      {error?.message && (
+                        <FieldError id="dynamic-secret-environment-error">
+                          {error.message}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+          </section>
+
+          <section
+            className="flex flex-col gap-4"
+            aria-labelledby={
+              commonFields?.configurationHeading !== false
+                ? "dynamic-secret-configuration-heading"
+                : undefined
+            }
+          >
+            {commonFields?.configurationHeading !== false && (
+              <h3 id="dynamic-secret-configuration-heading" className="text-base font-medium">
+                {commonFields?.configurationHeading ?? "Configuration"}
+              </h3>
+            )}
+            {fields && (
+              <DynamicSecretProviderFormItems
+                items={fields as readonly TDynamicSecretProviderFormItem<TValues>[]}
+              />
+            )}
+            {CustomRenderer && (
+              <CustomRenderer
+                mode={mode}
+                context={context}
+                setSubmitState={(state) =>
+                  setProviderSubmitState((current) => ({ ...current, ...state }))
+                }
+              />
+            )}
+          </section>
+        </div>
+
+        <div
+          data-slot="dynamic-secret-provider-form-footer"
+          className="flex shrink-0 flex-col-reverse gap-2 border-t border-border px-4 py-3 @sm:flex-row @sm:items-center @sm:justify-end"
+        >
+          {onBack && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="@sm:mr-auto"
+              onClick={onBack}
+              isDisabled={isPending}
+            >
+              Back
+            </Button>
+          )}
+          <Button type="button" variant="ghost" onClick={onCancel} isDisabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="project"
+            isPending={isPending}
+            isDisabled={providerSubmitState.isDisabled || isPending}
+          >
+            {mode === "create" ? definition.create.submitLabel : definition.edit.submitLabel}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFormItems.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFormItems.tsx
@@ -1,0 +1,102 @@
+import { FieldValues } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "./DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "./DynamicSecretProviderGroup";
+import {
+  isDynamicSecretProviderFieldGroup,
+  TDynamicSecretProviderField,
+  TDynamicSecretProviderFieldGroup,
+  TDynamicSecretProviderFormItem
+} from "./types";
+
+type Props<TValues extends FieldValues> = {
+  items: readonly TDynamicSecretProviderFormItem<TValues>[];
+};
+
+type FormSegment<TValues extends FieldValues> =
+  | { type: "fields"; fields: TDynamicSecretProviderField<TValues>[] }
+  | { type: "group"; group: TDynamicSecretProviderFieldGroup<TValues> };
+
+const segmentFormItems = <TValues extends FieldValues>(
+  items: readonly TDynamicSecretProviderFormItem<TValues>[]
+): FormSegment<TValues>[] => {
+  const segments: FormSegment<TValues>[] = [];
+  let fieldBuffer: TDynamicSecretProviderField<TValues>[] = [];
+
+  const flushFields = () => {
+    if (fieldBuffer.length === 0) return;
+    segments.push({ type: "fields", fields: fieldBuffer });
+    fieldBuffer = [];
+  };
+
+  items.forEach((item) => {
+    if (isDynamicSecretProviderFieldGroup(item)) {
+      flushFields();
+      segments.push({ type: "group", group: item });
+      return;
+    }
+    fieldBuffer.push(item);
+  });
+
+  flushFields();
+  return segments;
+};
+
+const FieldGroup = <TValues extends FieldValues>({
+  group
+}: {
+  group: TDynamicSecretProviderFieldGroup<TValues>;
+}) => {
+  const fields = <DynamicSecretProviderFields fields={group.fields} />;
+
+  if (group.presentation === "collapse") {
+    return (
+      <DynamicSecretProviderGroup
+        id={group.id}
+        presentation="collapse"
+        title={group.title}
+        description={group.description}
+      >
+        {fields}
+      </DynamicSecretProviderGroup>
+    );
+  }
+
+  return (
+    <DynamicSecretProviderGroup
+      id={group.id}
+      presentation="panel"
+      title={group.title}
+      description={group.description}
+      surface={group.surface ?? Boolean(group.title)}
+    >
+      {fields}
+    </DynamicSecretProviderGroup>
+  );
+};
+
+/** Renders a mix of flat fields and panel/collapse groups under Configuration. */
+export const DynamicSecretProviderFormItems = <TValues extends FieldValues>({
+  items
+}: Props<TValues>) => {
+  const segments = segmentFormItems(items);
+
+  return (
+    <>
+      {segments.map((segment, index) => {
+        if (segment.type === "fields") {
+          return (
+            <DynamicSecretProviderFields
+              // Consecutive flat fields share one grid; index is stable for a given items array.
+              // eslint-disable-next-line react/no-array-index-key
+              key={`fields-${index}`}
+              fields={segment.fields}
+            />
+          );
+        }
+
+        return <FieldGroup key={segment.group.id} group={segment.group} />;
+      })}
+    </>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderGroup.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderGroup.tsx
@@ -1,0 +1,116 @@
+import { ReactNode } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  FieldDescription,
+  FieldLegend,
+  FieldSet
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+
+import { TDynamicSecretProviderFieldGroupPresentation } from "./types";
+
+const GROUP_SURFACE_CLASSNAME = "rounded-md border border-border bg-container p-3 text-foreground";
+
+type PanelProps = {
+  presentation?: "panel";
+  title?: string;
+  description?: string;
+  id: string;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  surface?: boolean;
+};
+
+type CollapseProps = {
+  presentation: "collapse";
+  title: string;
+  description?: string;
+  id: string;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export type DynamicSecretProviderGroupProps = PanelProps | CollapseProps;
+
+/** Sheet-agnostic field clustering for provider forms. */
+export const DynamicSecretProviderGroup = (props: DynamicSecretProviderGroupProps) => {
+  const { presentation } = props;
+
+  if (presentation === "collapse") {
+    const {
+      id,
+      title,
+      description,
+      children,
+      className,
+      contentClassName,
+      defaultOpen,
+      open,
+      onOpenChange
+    } = props;
+    const descriptionId = `${id}-description`;
+    const controlledProps =
+      open === undefined
+        ? { defaultValue: defaultOpen ? id : undefined }
+        : {
+            value: open ? id : "",
+            onValueChange: (value: string) => onOpenChange?.(value === id)
+          };
+
+    return (
+      <Accordion
+        type="single"
+        collapsible
+        variant="ghost"
+        className={className}
+        {...controlledProps}
+      >
+        <AccordionItem value={id}>
+          <AccordionTrigger aria-describedby={description ? descriptionId : undefined}>
+            {title}
+          </AccordionTrigger>
+          <AccordionContent className={cn("flex flex-col gap-4", contentClassName)}>
+            {description ? (
+              <FieldDescription id={descriptionId}>{description}</FieldDescription>
+            ) : null}
+            {children}
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+  }
+
+  const { id, title, description, children, className, contentClassName, surface = false } = props;
+  const descriptionId = `${id}-description`;
+  const hasHeading = Boolean(title || description);
+
+  return (
+    <div
+      data-slot="dynamic-secret-provider-group"
+      data-presentation={"panel" satisfies TDynamicSecretProviderFieldGroupPresentation}
+      data-surface={surface ? "true" : "false"}
+      className={cn(surface && GROUP_SURFACE_CLASSNAME, className)}
+    >
+      {hasHeading ? (
+        <FieldSet className={contentClassName}>
+          {title ? <FieldLegend>{title}</FieldLegend> : null}
+          {description ? (
+            <FieldDescription id={descriptionId}>{description}</FieldDescription>
+          ) : null}
+          {children}
+        </FieldSet>
+      ) : (
+        <div className={cn("flex flex-col gap-4", contentClassName)}>{children}</div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
@@ -40,6 +40,7 @@ export const dynamicSecretProviderRegistry = createDynamicSecretProviderRegistry
 
 - Scalar number controls convert the browser string to a finite number before React Hook Form and `z.number()` validation see it. Clearing a numeric field emits `undefined` rather than accidental zero.
 - Secret controls preserve the supplied value and mask it with `type="password"`; edit defaults and adapters decide whether a masked value is sent unchanged.
+- Multi-create adapters may return several payloads. The shell settles the full batch, closes after any partial success to prevent accidental duplicate retries, and reports the exact success count.
 - Groups are sheet-agnostic. Panels use fieldset semantics, and collapsible groups use the shared V3 Accordion.
 - A custom renderer must declare at least one objective reason such as `repeatable-fields`, `remote-options`, `permission-aware-fields`, or `non-scalar-value`.
 - A custom renderer reads and writes the surrounding `FormProvider`; the shared shell still validates and submits the definition's adapter.

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
@@ -1,0 +1,76 @@
+# Dynamic-secret provider form contract
+
+The shared contract keeps one create/edit form shell while leaving provider validation, defaults, hydration, and request adapters with each provider definition. The foundation is intentionally provider-neutral: legacy providers keep their existing forms until a rollout ticket registers a replacement.
+
+## Ownership boundaries
+
+| Boundary | Owns | Does not own |
+| --- | --- | --- |
+| Form shell | Name, TTL, environment, submit/cancel behavior, pending state, mutation wiring, and first-invalid-field focus | Provider queries, conditional behavior, or DTO semantics |
+| Provider definition | Mode-specific schemas, defaults, scalar fields, custom-renderer reasons, and payload adapters | A second form or mutation ownership |
+| Registry composition | Immutable definition lookup, picker order, documentation slugs, and duplicate rejection | Production provider definitions |
+| Scalar renderer | V3 text, secret, number, textarea, select, and switch controls | Repeaters, remote options, imports, gateways, or nested editors |
+| Custom renderer | Explicit non-scalar or context-aware interaction inside shared React Hook Form state | Submitting, bypassing schemas, or duplicating common fields |
+
+Create and edit values are deliberately separate. That distinction preserves masked edit values, editable names, nullable gateway detachment, create-time omission, and provider-specific hydration without weakening types across modes.
+
+## Registering a provider batch
+
+Each rollout ticket owns a batch-local module. It imports the concrete definitions it migrated and exports only the shared registration contract:
+
+```ts
+export const identityAccessDynamicSecretProviders = defineDynamicSecretProviderModule({
+  id: "identity-access",
+  definitions: [awsIamDynamicSecretProvider, gcpIamDynamicSecretProvider]
+});
+```
+
+The production composition root combines completed batches:
+
+```ts
+export const dynamicSecretProviderRegistry = createDynamicSecretProviderRegistry(
+  identityAccessDynamicSecretProviders,
+  managedStoresDynamicSecretProviders
+);
+```
+
+`getDefinition(provider)` returns `undefined` for an unmigrated provider so routers can retain the existing legacy path during incremental rollout. `requireDefinition(provider)` is for code paths that already proved registration. Duplicate module IDs and duplicate providers fail during composition instead of silently overriding a definition.
+
+## Field and renderer contract
+
+- Scalar number controls convert the browser string to a finite number before React Hook Form and `z.number()` validation see it. Clearing a numeric field emits `undefined` rather than accidental zero.
+- Secret controls preserve the supplied value and mask it with `type="password"`; edit defaults and adapters decide whether a masked value is sent unchanged.
+- Groups are sheet-agnostic. Panels use fieldset semantics, and collapsible groups use the shared V3 Accordion.
+- A custom renderer must declare at least one objective reason such as `repeatable-fields`, `remote-options`, `permission-aware-fields`, or `non-scalar-value`.
+- A custom renderer reads and writes the surrounding `FormProvider`; the shared shell still validates and submits the definition's adapter.
+
+## Shared normalization
+
+- `{{randomUsername}}` is omitted on create and sent as `null` on edit unless a provider deliberately overrides that behavior.
+- A cleared gateway normalizes to `undefined` on create and `null` on edit.
+- Standard TTL validation retains the existing one-minute minimum, ten-year maximum, and user-facing messages.
+- Single-environment create defaults belong in the provider's `getDefaultValues`; multi-environment create keeps the environment field visible. Edit uses its route environment.
+
+## Checkpoint provenance and departures
+
+This foundation adapts the core contract from checkpoint commit `2eca032d7dc` without merging or cherry-picking the checkpoint.
+
+| Checkpoint area | Disposition |
+| --- | --- |
+| `types.ts`, `schemas.ts`, scalar fields, form items, and shared controls | Adapted to current main |
+| `DynamicSecretProviderForm.tsx` | Rewritten as a sheet-agnostic shell; dynamic-secret sheet, lease, renew, and post-create overlay work remain out of scope |
+| `DynamicSecretProviderGroup.tsx` | Rewritten to compose the existing V3 Accordion rather than the checkpoint-only sheet section |
+| `providerDefinitions/registry.ts` | Rewritten as immutable module composition so rollout batches do not edit core architecture |
+| Number input handling | Rewritten to emit numbers before validation, resolving the unresolved PR #7529 finding |
+| Production provider definitions and provider-family tests | Rejected from this foundation; owned by ENG-5513 through ENG-5516 |
+| Route removal, Overview redesign, sheet/lease work, and unrelated primitive changes | Rejected as outside ENG-5518 |
+
+## Verification
+
+The reusable Node test harness lives in `providerContractTestHarness.ts`. The adjacent contract test uses only a test-local provider definition and covers scalar metadata, numeric parsing, masked edit defaults, environment and TTL defaults, validation, create/edit adapters, gateway and username-template normalization, nested values, registry composition, and a custom-renderer escape hatch.
+
+Run it from `frontend/`:
+
+```sh
+TSX_TSCONFIG_PATH=tsconfig.app.json ./node_modules/.bin/tsx --test src/components/dynamic-secrets/DynamicSecretProviderForm/*.test.ts
+```

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/azure-sql-database-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/azure-sql-database-contract.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  azureSqlCreateFormSchema,
+  getAzureSqlCreateDefaultValues,
+  getAzureSqlCreatePayload,
+  getAzureSqlEditDefaultValues,
+  getAzureSqlEditPayload,
+  normalizeAzureSqlGatewayValueForMode
+} from "./providerDefinitions/azureSqlDatabaseContract";
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+const environment = { id: "env-id", name: "Development", slug: "dev", position: 1 };
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+const inputs = {
+  host: "sql.example.com",
+  port: 1433,
+  database: "application",
+  username: "admin",
+  password: "masked-or-new-password",
+  masterCreationStatement: "create login",
+  creationStatement: "create user",
+  revocationStatement: "drop user",
+  renewStatement: "",
+  sslEnabled: true,
+  sslRejectUnauthorized: true,
+  ca: "certificate",
+  gatewayId: "gateway",
+  gatewayPoolId: "pool",
+  passwordRequirements: {
+    length: 12,
+    required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 1 },
+    allowedSymbols: "-_"
+  }
+};
+const editContext: TEditDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environment: "dev",
+  dynamicSecret: {
+    id: "dynamic-secret-id",
+    name: "azure-sql",
+    type: DynamicSecretProviders.AzureSqlDatabase,
+    createdAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+    defaultTTL: "1h",
+    maxTTL: "24h",
+    usernameTemplate: null,
+    metadata: [{ key: "owner", value: "platform" }],
+    inputs: {
+      ...inputs,
+      password: "********",
+      ca: "********",
+      gatewayId: null,
+      gatewayPoolId: null
+    }
+  }
+};
+
+describe("Azure SQL Database provider contract", () => {
+  it("hydrates defaults and preserves masked edit values", () => {
+    const create = getAzureSqlCreateDefaultValues(createContext);
+    assert.equal(create.inputs.port, 1433);
+    assert.equal(create.inputs.passwordRequirements?.length, 48);
+    assert.deepEqual(create.environment, environment);
+
+    const edit = getAzureSqlEditDefaultValues(editContext);
+    assert.equal(edit.inputs.password, "********");
+    assert.equal(edit.inputs.ca, "********");
+    assert.equal(edit.inputs.gatewayId, null);
+    assert.deepEqual(edit.metadata, [{ key: "owner", value: "platform" }]);
+  });
+
+  it("validates password requirement totals against the configured length", () => {
+    const defaults = getAzureSqlCreateDefaultValues(createContext);
+    const parsed = azureSqlCreateFormSchema.safeParse({
+      ...defaults,
+      name: "azure-sql",
+      inputs: {
+        ...inputs,
+        passwordRequirements: {
+          length: 2,
+          required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 0 }
+        }
+      }
+    });
+    assert.equal(parsed.success, false);
+    if (!parsed.success) {
+      assert.equal(
+        parsed.error.issues.at(-1)?.message,
+        "Sum of required characters cannot exceed the total length"
+      );
+    }
+  });
+
+  it("adds the master database and preserves metadata/template create semantics", () => {
+    const defaults = getAzureSqlCreateDefaultValues(createContext);
+    const payload = getAzureSqlCreatePayload(
+      { ...defaults, name: "azure-sql", metadata: [{ key: "owner", value: "platform" }], inputs },
+      createContext
+    );
+    assert.equal(payload.provider.inputs.masterDatabase, "master");
+    assert.equal(payload.usernameTemplate, undefined);
+    assert.deepEqual(payload.metadata, [{ key: "owner", value: "platform" }]);
+  });
+
+  it("keeps edit gateway nulls, rename behavior, and masked secrets", () => {
+    const values = getAzureSqlEditDefaultValues(editContext);
+    const payload = getAzureSqlEditPayload({ ...values, name: "renamed-azure-sql" }, editContext);
+    const payloadInputs = payload.data.inputs as {
+      masterDatabase: string;
+      password: string;
+      ca: string;
+      gatewayId: null;
+      gatewayPoolId: null;
+    };
+    assert.equal(payloadInputs.masterDatabase, "master");
+    assert.equal(payloadInputs.password, "********");
+    assert.equal(payloadInputs.ca, "********");
+    assert.equal(payloadInputs.gatewayId, null);
+    assert.equal(payloadInputs.gatewayPoolId, null);
+    assert.equal(payload.data.newName, "renamed-azure-sql");
+    assert.equal(payload.data.usernameTemplate, null);
+  });
+
+  it("normalizes cleared gateway values by mode", () => {
+    assert.equal(normalizeAzureSqlGatewayValueForMode("create", null), undefined);
+    assert.equal(normalizeAzureSqlGatewayValueForMode("edit", null), null);
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/clickhouse-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/clickhouse-contract.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  clickHouseCreateFormSchema,
+  getClickHouseCreateDefaultValues,
+  getClickHouseCreatePayload,
+  getClickHouseEditDefaultValues,
+  getClickHouseEditPayload
+} from "./providerDefinitions/clickHouseContract";
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+const environment = { id: "env-id", name: "Development", slug: "dev", position: 1 };
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+
+describe("ClickHouse dynamic-secret provider contract", () => {
+  it("preserves create defaults, metadata, and exact payload", () => {
+    const defaults = getClickHouseCreateDefaultValues(createContext);
+    assert.equal(defaults.inputs.port, 8123);
+    assert.equal(typeof defaults.inputs.port, "number");
+    assert.equal(defaults.inputs.database, "default");
+    assert.deepEqual(defaults.inputs.passwordRequirements?.required, {
+      lowercase: 1,
+      uppercase: 1,
+      digits: 1,
+      symbols: 1
+    });
+
+    const values = {
+      ...defaults,
+      name: "clickhouse-secret",
+      metadata: [{ key: "owner", value: "platform" }],
+      inputs: {
+        ...defaults.inputs,
+        host: "clickhouse.example.com",
+        username: "admin",
+        password: "password"
+      }
+    };
+    assert.equal(clickHouseCreateFormSchema.safeParse(values).success, true);
+    const payload = getClickHouseCreatePayload(values, createContext);
+    assert.equal(payload.provider.type, DynamicSecretProviders.Clickhouse);
+    assert.equal(payload.provider.inputs.port, 8123);
+    assert.equal(typeof payload.provider.inputs.port, "number");
+    assert.equal(payload.environmentSlug, "dev");
+    assert.deepEqual(payload.metadata, [{ key: "owner", value: "platform" }]);
+    assert.equal(payload.usernameTemplate, undefined);
+  });
+
+  it("rejects the browser string regression for numeric inputs", () => {
+    const defaults = getClickHouseCreateDefaultValues(createContext);
+    const result = clickHouseCreateFormSchema.safeParse({
+      ...defaults,
+      name: "clickhouse-secret",
+      inputs: {
+        ...defaults.inputs,
+        host: "clickhouse.example.com",
+        port: "8123",
+        username: "admin",
+        password: "password"
+      }
+    });
+
+    assert.equal(result.success, false);
+    if (!result.success) {
+      assert.deepEqual(result.error.issues[0]?.path, ["inputs", "port"]);
+    }
+  });
+
+  it("preserves password-policy messages", () => {
+    const defaults = getClickHouseCreateDefaultValues(createContext);
+    const result = clickHouseCreateFormSchema.safeParse({
+      ...defaults,
+      name: "clickhouse-secret",
+      inputs: {
+        ...defaults.inputs,
+        host: "clickhouse.example.com",
+        username: "admin",
+        password: "password",
+        passwordRequirements: {
+          ...defaults.inputs.passwordRequirements,
+          length: 2
+        }
+      }
+    });
+    assert.equal(result.success, false);
+    if (!result.success) {
+      assert.equal(
+        result.error.issues[0]?.message,
+        "Sum of required characters cannot exceed the total length"
+      );
+    }
+  });
+
+  it("hydrates masked credentials and normalizes cleared edit gateways to null", () => {
+    const context: TEditDynamicSecretProviderFormContext = {
+      projectSlug: "project",
+      secretPath: "/folder",
+      environment: "dev",
+      dynamicSecret: {
+        id: "dynamic-secret-id",
+        name: "existing-clickhouse",
+        type: DynamicSecretProviders.Clickhouse,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+        defaultTTL: "1h",
+        maxTTL: "24h",
+        usernameTemplate: null,
+        metadata: [{ key: "owner", value: "platform" }],
+        inputs: {
+          host: "clickhouse.example.com",
+          port: 8123,
+          database: "default",
+          username: "admin",
+          password: "********",
+          ca: "********",
+          creationStatement: "CREATE USER '{{username}}'",
+          revocationStatement: "DROP USER '{{username}}'"
+        }
+      }
+    };
+    const defaults = getClickHouseEditDefaultValues(context);
+    assert.equal(defaults.inputs.password, "********");
+    assert.equal(defaults.inputs.ca, "********");
+    const payload = getClickHouseEditPayload({ ...defaults, name: "renamed-clickhouse" }, context);
+    assert.equal(payload.data.newName, "renamed-clickhouse");
+    assert.equal((payload.data.inputs as { password: string }).password, "********");
+    assert.equal((payload.data.inputs as { ca: string }).ca, "********");
+    assert.equal((payload.data.inputs as { gatewayId: null }).gatewayId, null);
+    assert.equal((payload.data.inputs as { gatewayPoolId: null }).gatewayPoolId, null);
+    assert.equal(payload.data.usernameTemplate, null);
+    assert.deepEqual(payload.data.metadata, [{ key: "owner", value: "platform" }]);
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/createSubmission.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/createSubmission.ts
@@ -1,0 +1,23 @@
+export type TDynamicSecretCreateSubmissionResult<TResult> = {
+  successfulResults: TResult[];
+  failedCount: number;
+};
+
+/**
+ * Settle an entire provider-owned create batch so the form can distinguish a
+ * total failure from partial success and avoid resubmitting completed items.
+ */
+export const submitDynamicSecretCreatePayloads = async <TPayload, TResult>(
+  payloads: readonly TPayload[],
+  submit: (payload: TPayload) => Promise<TResult>
+): Promise<TDynamicSecretCreateSubmissionResult<TResult>> => {
+  const settledResults = await Promise.allSettled(payloads.map((payload) => submit(payload)));
+  const successfulResults = settledResults.flatMap((result) =>
+    result.status === "fulfilled" ? [result.value] : []
+  );
+
+  return {
+    successfulResults,
+    failedCount: settledResults.length - successfulResults.length
+  };
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { DynamicSecretProviders, SqlProviders } from "@app/hooks/api/dynamicSecret/types";
 
+import { submitDynamicSecretCreatePayloads } from "./createSubmission";
 import { testDynamicSecretProviderContract } from "./providerContractTestHarness";
 import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
 import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
@@ -371,11 +372,26 @@ describe("shared dynamic-secret scalar behavior", () => {
 
 describe("shared dynamic-secret normalization", () => {
   it("preserves TTL bounds and messages", () => {
+    const missingDefault = createFormSchema.safeParse({ ...createValues, defaultTTL: "" });
+    const malformedDefault = createFormSchema.safeParse({ ...createValues, defaultTTL: "abc" });
+    const malformedMaximum = createFormSchema.safeParse({ ...createValues, maxTTL: "abc" });
     const belowMinimum = createFormSchema.safeParse({ ...createValues, defaultTTL: "30s" });
     const aboveMaximum = createFormSchema.safeParse({ ...createValues, defaultTTL: "11y" });
 
+    assert.equal(missingDefault.success, false);
+    assert.equal(malformedDefault.success, false);
+    assert.equal(malformedMaximum.success, false);
     assert.equal(belowMinimum.success, false);
     assert.equal(aboveMaximum.success, false);
+    if (!missingDefault.success) {
+      assert.equal(missingDefault.error.issues[0]?.message, "TTL is required");
+    }
+    if (!malformedDefault.success) {
+      assert.equal(malformedDefault.error.issues[0]?.message, "TTL must be a valid duration");
+    }
+    if (!malformedMaximum.success) {
+      assert.equal(malformedMaximum.error.issues[0]?.message, "TTL must be a valid duration");
+    }
     if (!belowMinimum.success) {
       assert.equal(belowMinimum.error.issues[0]?.message, "TTL must be a greater than 1min");
     }
@@ -396,6 +412,23 @@ describe("shared dynamic-secret normalization", () => {
     assert.equal(normalizeDynamicSecretGatewayValueForMode("create", null), undefined);
     assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", null), null);
     assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", "gateway-id"), "gateway-id");
+  });
+});
+
+describe("shared dynamic-secret create submission", () => {
+  it("reports partial success without rejecting completed items", async () => {
+    const attemptedPayloads: number[] = [];
+    const result = await submitDynamicSecretCreatePayloads([1, 2, 3], async (payload) => {
+      attemptedPayloads.push(payload);
+      if (payload === 2) throw new Error("create failed");
+      return `created-${payload}`;
+    });
+
+    assert.deepEqual(attemptedPayloads, [1, 2, 3]);
+    assert.deepEqual(result, {
+      successfulResults: ["created-1", "created-3"],
+      failedCount: 1
+    });
   });
 });
 

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
@@ -1,0 +1,436 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { z } from "zod";
+
+import { DynamicSecretProviders, SqlProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { testDynamicSecretProviderContract } from "./providerContractTestHarness";
+import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
+import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretGatewayValueForMode,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "./schemas";
+import {
+  defineDynamicSecretProvider,
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+const createInputsSchema = z.object({
+  host: z.string().min(1, "Host is required"),
+  port: z.number().int().positive(),
+  password: z.string().min(1, "Password is required"),
+  engine: z.literal("postgres"),
+  enabled: z.boolean(),
+  connection: z.object({
+    gatewayId: z.string().optional(),
+    gatewayPoolId: z.string().optional()
+  }),
+  statements: z.object({
+    creation: z.string().min(1),
+    revocation: z.string().min(1)
+  })
+});
+
+const editInputsSchema = createInputsSchema.extend({
+  connection: z.object({
+    gatewayId: z.string().nullable().optional(),
+    gatewayPoolId: z.string().nullable().optional()
+  })
+});
+
+const createFormSchema = createDynamicSecretProviderFormSchema(createInputsSchema);
+const editFormSchema = editDynamicSecretProviderFormSchema(editInputsSchema);
+
+type TCreateFixtureValues = z.infer<typeof createFormSchema>;
+type TEditFixtureValues = z.infer<typeof editFormSchema>;
+
+const FixtureCustomRenderer = () => null;
+
+const fixtureDefinition = defineDynamicSecretProvider<
+  DynamicSecretProviders.SqlDatabase,
+  TCreateFixtureValues,
+  TEditFixtureValues
+>({
+  provider: DynamicSecretProviders.SqlDatabase,
+  label: "Test SQL",
+  fields: [
+    { name: "inputs.host", type: "text", label: "Host", layout: "half" },
+    { name: "inputs.port", type: "number", label: "Port", layout: "half", min: 1 },
+    {
+      name: "inputs.password",
+      type: "secret",
+      label: "Password",
+      autoComplete: "new-password"
+    },
+    {
+      name: "inputs.engine",
+      type: "select",
+      label: "Engine",
+      options: [{ label: "PostgreSQL", value: "postgres" }]
+    },
+    { name: "inputs.enabled", type: "switch", label: "Enabled" },
+    {
+      kind: "group",
+      id: "statements",
+      presentation: "collapse",
+      title: "Statements",
+      fields: [
+        { name: "inputs.statements.creation", type: "textarea", label: "Creation Statement" },
+        { name: "inputs.statements.revocation", type: "textarea", label: "Revocation Statement" }
+      ]
+    }
+  ],
+  customRenderer: {
+    reasons: ["remote-options", "non-scalar-value"],
+    Component: FixtureCustomRenderer
+  },
+  create: {
+    schema: createFormSchema,
+    getDefaultValues: (context) => ({
+      name: "",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: {
+        host: "",
+        port: 5432,
+        password: "",
+        engine: "postgres",
+        enabled: true,
+        connection: {
+          gatewayId: undefined,
+          gatewayPoolId: undefined
+        },
+        statements: {
+          creation: "CREATE USER",
+          revocation: "DROP USER"
+        }
+      }
+    }),
+    toPayload: (values, context) => {
+      const gatewayId = normalizeDynamicSecretGatewayValueForMode(
+        "create",
+        values.inputs.connection.gatewayId
+      );
+      const usernameTemplate = normalizeDynamicSecretUsernameTemplateForCreate(
+        values.usernameTemplate
+      );
+
+      return {
+        projectSlug: context.projectSlug,
+        path: context.secretPath,
+        name: values.name,
+        environmentSlug: values.environment.slug,
+        defaultTTL: values.defaultTTL,
+        ...(values.maxTTL ? { maxTTL: values.maxTTL } : {}),
+        ...(usernameTemplate ? { usernameTemplate } : {}),
+        provider: {
+          type: DynamicSecretProviders.SqlDatabase,
+          inputs: {
+            client: SqlProviders.Postgres,
+            host: values.inputs.host,
+            port: values.inputs.port,
+            database: "postgres",
+            username: "postgres",
+            password: values.inputs.password,
+            creationStatement: values.inputs.statements.creation,
+            revocationStatement: values.inputs.statements.revocation,
+            ...(gatewayId ? { gatewayId } : {})
+          }
+        }
+      };
+    },
+    submitLabel: "Create Dynamic Secret"
+  },
+  edit: {
+    schema: editFormSchema,
+    getDefaultValues: (context) => ({
+      name: context.dynamicSecret.name,
+      defaultTTL: context.dynamicSecret.defaultTTL,
+      maxTTL: context.dynamicSecret.maxTTL ?? null,
+      usernameTemplate:
+        context.dynamicSecret.usernameTemplate ?? DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: context.dynamicSecret.inputs as TEditFixtureValues["inputs"]
+    }),
+    toPayload: (values, context) => ({
+      projectSlug: context.projectSlug,
+      path: context.secretPath,
+      environmentSlug: context.environment,
+      name: context.dynamicSecret.name,
+      data: {
+        newName: values.name,
+        defaultTTL: values.defaultTTL,
+        maxTTL: values.maxTTL,
+        usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate),
+        inputs: {
+          ...values.inputs,
+          connection: {
+            gatewayId: normalizeDynamicSecretGatewayValueForMode(
+              "edit",
+              values.inputs.connection.gatewayId
+            ),
+            gatewayPoolId: normalizeDynamicSecretGatewayValueForMode(
+              "edit",
+              values.inputs.connection.gatewayPoolId
+            )
+          }
+        }
+      }
+    }),
+    submitLabel: "Save Changes",
+    successMessage: "Dynamic secret updated"
+  }
+});
+
+const environment = { id: "env-id", name: "Development", slug: "dev" };
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+const editInputs: TEditFixtureValues["inputs"] = {
+  host: "database.example.com",
+  port: 5432,
+  password: "********",
+  engine: "postgres",
+  enabled: true,
+  connection: { gatewayId: null, gatewayPoolId: null },
+  statements: { creation: "CREATE USER", revocation: "DROP USER" }
+};
+const editContext: TEditDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environment: "dev",
+  dynamicSecret: {
+    id: "dynamic-secret-id",
+    name: "existing-secret",
+    type: DynamicSecretProviders.SqlDatabase,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    defaultTTL: "1h",
+    maxTTL: "24h",
+    usernameTemplate: null,
+    inputs: editInputs
+  }
+};
+const createValues: TCreateFixtureValues = {
+  name: "test-secret",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "database.example.com",
+    port: 5432,
+    password: "new-password",
+    engine: "postgres",
+    enabled: true,
+    connection: { gatewayId: undefined, gatewayPoolId: undefined },
+    statements: { creation: "CREATE USER", revocation: "DROP USER" }
+  }
+};
+const editValues: TEditFixtureValues = {
+  name: "renamed-secret",
+  defaultTTL: "2h",
+  maxTTL: null,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: editInputs
+};
+
+testDynamicSecretProviderContract({
+  name: "test-only SQL fixture",
+  definition: fixtureDefinition,
+  create: {
+    context: createContext,
+    defaultValues: {
+      name: "",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      environment,
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: {
+        host: "",
+        port: 5432,
+        password: "",
+        engine: "postgres",
+        enabled: true,
+        connection: { gatewayId: undefined, gatewayPoolId: undefined },
+        statements: { creation: "CREATE USER", revocation: "DROP USER" }
+      }
+    },
+    validValues: createValues,
+    payload: {
+      projectSlug: "project",
+      path: "/folder",
+      name: "test-secret",
+      environmentSlug: "dev",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      provider: {
+        type: DynamicSecretProviders.SqlDatabase,
+        inputs: {
+          client: SqlProviders.Postgres,
+          host: "database.example.com",
+          port: 5432,
+          database: "postgres",
+          username: "postgres",
+          password: "new-password",
+          creationStatement: "CREATE USER",
+          revocationStatement: "DROP USER"
+        }
+      }
+    },
+    invalidValues: [
+      {
+        name: "provider validation paths",
+        values: {
+          ...createValues,
+          inputs: { ...createValues.inputs, host: "", password: "" }
+        },
+        issuePaths: [
+          ["inputs", "host"],
+          ["inputs", "password"]
+        ]
+      }
+    ]
+  },
+  edit: {
+    context: editContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: editInputs
+    },
+    validValues: editValues,
+    payload: {
+      projectSlug: "project",
+      path: "/folder",
+      environmentSlug: "dev",
+      name: "existing-secret",
+      data: {
+        newName: "renamed-secret",
+        defaultTTL: "2h",
+        maxTTL: null,
+        usernameTemplate: null,
+        inputs: editInputs
+      }
+    },
+    maskedValues: [
+      {
+        name: "provider password",
+        expected: "********",
+        defaultValuePath: ["inputs", "password"],
+        payloadValuePath: ["data", "inputs", "password"]
+      }
+    ]
+  }
+});
+
+describe("shared dynamic-secret scalar behavior", () => {
+  it("emits numbers before z.number validation", () => {
+    const parsedPort = parseDynamicSecretProviderNumberInput("6432");
+
+    assert.equal(parsedPort, 6432);
+    assert.equal(typeof parsedPort, "number");
+    assert.equal(
+      createFormSchema.safeParse({
+        ...createValues,
+        inputs: { ...createValues.inputs, port: parsedPort }
+      }).success,
+      true
+    );
+    assert.equal(parseDynamicSecretProviderNumberInput(""), undefined);
+    assert.equal(parseDynamicSecretProviderNumberInput("not-a-number"), undefined);
+  });
+
+  it("keeps scalar and custom-renderer paths explicit", () => {
+    const fields = fixtureDefinition.fields ?? [];
+    const flatTypes = fields.flatMap((item) => ("kind" in item ? [] : [item.type]));
+
+    assert.deepEqual(flatTypes, ["text", "number", "secret", "select", "switch"]);
+    const groupedTypes = fields.flatMap((item) =>
+      "kind" in item ? item.fields.map((field) => field.type) : []
+    );
+    assert.deepEqual(groupedTypes, ["textarea", "textarea"]);
+    assert.deepEqual(fixtureDefinition.customRenderer?.reasons, [
+      "remote-options",
+      "non-scalar-value"
+    ]);
+  });
+});
+
+describe("shared dynamic-secret normalization", () => {
+  it("preserves TTL bounds and messages", () => {
+    const belowMinimum = createFormSchema.safeParse({ ...createValues, defaultTTL: "30s" });
+    const aboveMaximum = createFormSchema.safeParse({ ...createValues, defaultTTL: "11y" });
+
+    assert.equal(belowMinimum.success, false);
+    assert.equal(aboveMaximum.success, false);
+    if (!belowMinimum.success) {
+      assert.equal(belowMinimum.error.issues[0]?.message, "TTL must be a greater than 1min");
+    }
+    if (!aboveMaximum.success) {
+      assert.equal(aboveMaximum.error.issues[0]?.message, "TTL must be less than 10 years");
+    }
+  });
+
+  it("keeps username-template and gateway create/edit semantics distinct", () => {
+    assert.equal(
+      normalizeDynamicSecretUsernameTemplateForCreate(DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE),
+      undefined
+    );
+    assert.equal(
+      normalizeDynamicSecretUsernameTemplateForEdit(DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE),
+      null
+    );
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("create", null), undefined);
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", null), null);
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", "gateway-id"), "gateway-id");
+  });
+});
+
+describe("dynamic-secret provider registry composition", () => {
+  const fixtureModule = defineDynamicSecretProviderModule({
+    id: "test-only",
+    definitions: [fixtureDefinition]
+  });
+
+  it("composes batch modules without exposing mutable registry state", () => {
+    const registry = createDynamicSecretProviderRegistry(fixtureModule);
+
+    assert.deepEqual(registry.providers, [DynamicSecretProviders.SqlDatabase]);
+    assert.equal(registry.getDefinition(DynamicSecretProviders.SqlDatabase), fixtureDefinition);
+    assert.equal(registry.getDefinition(DynamicSecretProviders.Redis), undefined);
+    assert.equal(registry.getDocsSlug(DynamicSecretProviders.SqlDatabase), "postgresql");
+    assert.equal(Object.isFrozen(registry.providers), true);
+    assert.equal(Object.isFrozen(registry.definitions), true);
+  });
+
+  it("rejects duplicate modules and providers", () => {
+    assert.throws(
+      () => createDynamicSecretProviderRegistry(fixtureModule, fixtureModule),
+      /module "test-only" was registered more than once/
+    );
+    assert.throws(
+      () =>
+        createDynamicSecretProviderRegistry(
+          fixtureModule,
+          defineDynamicSecretProviderModule({
+            id: "duplicate-provider",
+            definitions: [fixtureDefinition]
+          })
+        ),
+      /provider "sql-database" was registered more than once/
+    );
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/index.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/index.ts
@@ -1,0 +1,9 @@
+export { DynamicSecretProviderFields } from "./DynamicSecretProviderFields";
+export { DynamicSecretProviderForm } from "./DynamicSecretProviderForm";
+export { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
+export { DynamicSecretProviderGroup } from "./DynamicSecretProviderGroup";
+export * from "./registry";
+export * from "./scalarValues";
+export * from "./schemas";
+export * from "./shared";
+export * from "./types";

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerContractTestHarness.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerContractTestHarness.ts
@@ -1,0 +1,135 @@
+import type { DefaultValues } from "react-hook-form";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderDefinition,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+type TInvalidValuesCase = {
+  name: string;
+  values: unknown;
+  issuePaths: readonly (readonly (string | number)[])[];
+};
+
+type TMaskedValueCase = {
+  name: string;
+  expected: unknown;
+  defaultValuePath: readonly (string | number)[];
+  payloadValuePath: readonly (string | number)[];
+};
+
+export type TDynamicSecretProviderContractFixture<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = {
+  name: string;
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  create: {
+    context: TCreateDynamicSecretProviderFormContext;
+    defaultValues: DefaultValues<TCreateValues>;
+    validValues: TCreateValues;
+    payload: unknown;
+    invalidValues?: readonly TInvalidValuesCase[];
+  };
+  edit: {
+    context: TEditDynamicSecretProviderFormContext;
+    defaultValues: DefaultValues<TEditValues>;
+    validValues: TEditValues;
+    payload: unknown;
+    invalidValues?: readonly TInvalidValuesCase[];
+    maskedValues?: readonly TMaskedValueCase[];
+  };
+};
+
+const getValueAtPath = (value: unknown, path: readonly (string | number)[]) =>
+  path.reduce<unknown>((current, segment) => {
+    if (current === null || typeof current !== "object") return undefined;
+    return (current as Record<string | number, unknown>)[segment];
+  }, value);
+
+const getIssuePaths = (result: {
+  success: boolean;
+  error?: { issues: { path: PropertyKey[] }[] };
+}) => (result.success ? [] : (result.error?.issues.map(({ path }) => path) ?? []));
+
+/**
+ * Reusable provider-contract suite. Rollout tickets supply their own fixture;
+ * the foundation does not import or register production provider definitions.
+ */
+export const testDynamicSecretProviderContract = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+>(
+  fixture: TDynamicSecretProviderContractFixture<TProvider, TCreateValues, TEditValues>
+) => {
+  describe(`${fixture.name} dynamic-secret provider contract`, () => {
+    it("declares provider-owned defaults", () => {
+      assert.deepEqual(
+        fixture.definition.create.getDefaultValues(fixture.create.context),
+        fixture.create.defaultValues
+      );
+      assert.deepEqual(
+        fixture.definition.edit.getDefaultValues(fixture.edit.context),
+        fixture.edit.defaultValues
+      );
+    });
+
+    it("accepts valid create and edit values", () => {
+      assert.equal(
+        fixture.definition.create.schema.safeParse(fixture.create.validValues).success,
+        true
+      );
+      assert.equal(
+        fixture.definition.edit.schema.safeParse(fixture.edit.validValues).success,
+        true
+      );
+    });
+
+    fixture.create.invalidValues?.forEach((invalidCase) => {
+      it(`rejects invalid create values: ${invalidCase.name}`, () => {
+        const result = fixture.definition.create.schema.safeParse(invalidCase.values);
+        assert.equal(result.success, false);
+        assert.deepEqual(getIssuePaths(result), invalidCase.issuePaths);
+      });
+    });
+
+    fixture.edit.invalidValues?.forEach((invalidCase) => {
+      it(`rejects invalid edit values: ${invalidCase.name}`, () => {
+        const result = fixture.definition.edit.schema.safeParse(invalidCase.values);
+        assert.equal(result.success, false);
+        assert.deepEqual(getIssuePaths(result), invalidCase.issuePaths);
+      });
+    });
+
+    it("adapts create and edit payloads", () => {
+      assert.deepEqual(
+        fixture.definition.create.toPayload(fixture.create.validValues, fixture.create.context),
+        fixture.create.payload
+      );
+      assert.deepEqual(
+        fixture.definition.edit.toPayload(fixture.edit.validValues, fixture.edit.context),
+        fixture.edit.payload
+      );
+    });
+
+    fixture.edit.maskedValues?.forEach((maskedValue) => {
+      it(`preserves masked edit values: ${maskedValue.name}`, () => {
+        const defaults = fixture.definition.edit.getDefaultValues(fixture.edit.context);
+        const payload = fixture.definition.edit.toPayload(
+          fixture.edit.validValues,
+          fixture.edit.context
+        );
+        assert.equal(getValueAtPath(defaults, maskedValue.defaultValuePath), maskedValue.expected);
+        assert.equal(getValueAtPath(payload, maskedValue.payloadValuePath), maskedValue.expected);
+      });
+    });
+  });
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureSqlDatabase.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureSqlDatabase.tsx
@@ -1,0 +1,417 @@
+import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import { OrgPermissionCan } from "@app/components/permissions";
+import {
+  Button,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldFeedback,
+  FieldLabel,
+  FieldTitle,
+  IconButton,
+  Input,
+  Switch
+} from "@app/components/v3";
+import { GatewayPicker, SecretInput } from "@app/components/v3/platform";
+import {
+  OrgGatewayPermissionActions,
+  OrgPermissionSubjects
+} from "@app/context/OrgPermissionContext/types";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { parseDynamicSecretProviderNumberInput } from "../scalarValues";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import {
+  defineDynamicSecretProvider,
+  TDynamicSecretProviderField,
+  TDynamicSecretProviderRendererProps
+} from "../types";
+import {
+  AZURE_SQL_DATABASE_CUSTOM_RENDERER_REASONS,
+  azureSqlCreateFormSchema,
+  azureSqlEditFormSchema,
+  getAzureSqlCreateDefaultValues,
+  getAzureSqlCreatePayload,
+  getAzureSqlEditDefaultValues,
+  getAzureSqlEditPayload,
+  normalizeAzureSqlGatewayValueForMode,
+  TAzureSqlEditValues
+} from "./azureSqlDatabaseContract";
+
+const AzureSqlMetadataFields = () => {
+  const { control } = useFormContext<TAzureSqlEditValues>();
+  const metadata = useFieldArray({ control, name: "metadata" });
+  return (
+    <DynamicSecretProviderGroup
+      id="azure-sql-metadata"
+      presentation="panel"
+      surface
+      title="Metadata"
+    >
+      <div className="flex flex-col gap-3">
+        {metadata.fields.map(({ id }, index) => (
+          <div
+            key={id}
+            className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+          >
+            {(["key", "value"] as const).map((key) => (
+              <Controller
+                key={key}
+                control={control}
+                name={`metadata.${index}.${key}`}
+                render={({ field, fieldState: { error } }) => (
+                  <Field data-invalid={Boolean(error)}>
+                    <FieldLabel htmlFor={`azure-sql-metadata-${index}-${key}`}>
+                      {key === "key" ? "Key" : "Value"}
+                      {key === "value" && (
+                        <span className="font-normal text-muted"> (optional)</span>
+                      )}
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id={`azure-sql-metadata-${index}-${key}`}
+                      isError={Boolean(error)}
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+            ))}
+            <div className="flex flex-col gap-2">
+              <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                &nbsp;
+              </FieldLabel>
+              <IconButton
+                type="button"
+                variant="outline"
+                aria-label={`Remove metadata entry ${index + 1}`}
+                onClick={() => metadata.remove(index)}
+              >
+                <Trash2Icon />
+              </IconButton>
+            </div>
+          </div>
+        ))}
+        <Button
+          type="button"
+          size="sm"
+          className="self-start"
+          onClick={() => metadata.append({ key: "", value: "" })}
+        >
+          <PlusIcon /> Add metadata
+        </Button>
+      </div>
+    </DynamicSecretProviderGroup>
+  );
+};
+
+const AzureSqlPasswordRequirements = () => {
+  const { control } = useFormContext<TAzureSqlEditValues>();
+  const countFields = [
+    ["lowercase", "Lowercase Count", "Minimum number of lowercase letters"],
+    ["uppercase", "Uppercase Count", "Minimum number of uppercase letters"],
+    ["digits", "Digit Count", "Minimum number of digits"],
+    ["symbols", "Symbol Count", "Minimum number of symbols"]
+  ] as const;
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <Controller
+        control={control}
+        name="inputs.passwordRequirements.length"
+        render={({ field, fieldState: { error } }) => (
+          <Field data-invalid={Boolean(error)}>
+            <FieldLabel htmlFor="azure-sql-password-length">Password Length</FieldLabel>
+            <Input
+              ref={field.ref}
+              id="azure-sql-password-length"
+              name={field.name}
+              type="number"
+              min={1}
+              max={250}
+              value={field.value ?? ""}
+              onBlur={field.onBlur}
+              onChange={(event) =>
+                field.onChange(parseDynamicSecretProviderNumberInput(event.currentTarget.value))
+              }
+              isError={Boolean(error)}
+            />
+            <FieldError>{error?.message}</FieldError>
+          </Field>
+        )}
+      />
+      {countFields.map(([key, label, description]) => (
+        <Controller
+          key={key}
+          control={control}
+          name={`inputs.passwordRequirements.required.${key}`}
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor={`azure-sql-password-${key}`}>{label}</FieldLabel>
+              <Input
+                ref={field.ref}
+                id={`azure-sql-password-${key}`}
+                name={field.name}
+                type="number"
+                min={0}
+                value={field.value ?? ""}
+                onBlur={field.onBlur}
+                onChange={(event) =>
+                  field.onChange(parseDynamicSecretProviderNumberInput(event.currentTarget.value))
+                }
+                isError={Boolean(error)}
+              />
+              <FieldFeedback description={description} error={error?.message} />
+            </Field>
+          )}
+        />
+      ))}
+      <Controller
+        control={control}
+        name="inputs.passwordRequirements.allowedSymbols"
+        render={({ field, fieldState: { error } }) => (
+          <Field data-invalid={Boolean(error)} className="sm:col-span-2">
+            <FieldLabel htmlFor="azure-sql-allowed-symbols">Symbols to use in password</FieldLabel>
+            <Input
+              {...field}
+              value={field.value ?? ""}
+              id="azure-sql-allowed-symbols"
+              isError={Boolean(error)}
+            />
+            <FieldFeedback description="Default: -_.~!*" error={error?.message} />
+          </Field>
+        )}
+      />
+    </div>
+  );
+};
+
+const AzureSqlFields = ({ mode }: TDynamicSecretProviderRendererProps) => {
+  const { control, setValue, watch } = useFormContext<TAzureSqlEditValues>();
+  const sslEnabled = watch("inputs.sslEnabled");
+  const gatewayId = watch("inputs.gatewayId");
+  const gatewayPoolId = watch("inputs.gatewayPoolId");
+  const scalarFields = [
+    { name: "inputs.host", type: "text", label: "Host" },
+    { name: "inputs.username", type: "text", label: "User", layout: "half" },
+    { name: "inputs.database", type: "text", label: "Database", layout: "half" }
+  ] satisfies readonly TDynamicSecretProviderField<TAzureSqlEditValues>[];
+  const statementFields = [
+    {
+      name: "usernameTemplate",
+      type: "text",
+      label: "Username Template",
+      placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+    },
+    {
+      name: "inputs.masterCreationStatement",
+      type: "textarea",
+      label: "Master Creation Statement",
+      description: "Statement to create login in master database",
+      rows: 3
+    },
+    {
+      name: "inputs.creationStatement",
+      type: "textarea",
+      label: "Creation Statement",
+      description: "Statement to create user in target database and grant permissions",
+      rows: 3
+    },
+    {
+      name: "inputs.revocationStatement",
+      type: "textarea",
+      label: "Revocation Statement",
+      description: "Statement to drop user and login",
+      rows: 3
+    },
+    {
+      name: "inputs.renewStatement",
+      type: "textarea",
+      label: "Renew Statement",
+      description: "username and expiration are dynamically provisioned",
+      isOptional: true,
+      rows: 3
+    }
+  ] satisfies readonly TDynamicSecretProviderField<TAzureSqlEditValues>[];
+  return (
+    <>
+      <DynamicSecretProviderGroup id="azure-sql-connection" presentation="panel">
+        <OrgPermissionCan
+          I={OrgGatewayPermissionActions.AttachGateways}
+          a={OrgPermissionSubjects.Gateway}
+        >
+          {(isAllowed) => (
+            <Controller
+              control={control}
+              name="inputs.gatewayId"
+              render={({ field, fieldState: { error } }) => {
+                const description = !isAllowed
+                  ? "You don't have permission to attach gateways to resources."
+                  : undefined;
+                const hasFeedback = Boolean(description || error?.message);
+
+                return (
+                  <Field data-invalid={Boolean(error)} data-disabled={!isAllowed}>
+                    <FieldTitle>Gateway</FieldTitle>
+                    <GatewayPicker
+                      isDisabled={!isAllowed}
+                      isError={Boolean(error)}
+                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                      onChange={({ gatewayId: nextId, gatewayPoolId: nextPoolId }) => {
+                        field.onChange(normalizeAzureSqlGatewayValueForMode(mode, nextId));
+                        setValue(
+                          "inputs.gatewayPoolId",
+                          normalizeAzureSqlGatewayValueForMode(mode, nextPoolId),
+                          { shouldDirty: true }
+                        );
+                      }}
+                    />
+                    {hasFeedback && (
+                      <FieldFeedback
+                        id="azure-sql-gateway-feedback"
+                        description={description}
+                        error={error?.message}
+                      />
+                    )}
+                  </Field>
+                );
+              }}
+            />
+          )}
+        </OrgPermissionCan>
+        <DynamicSecretProviderFields fields={scalarFields} />
+        <Controller
+          control={control}
+          name="inputs.port"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="azure-sql-port">Port</FieldLabel>
+              <Input
+                ref={field.ref}
+                id="azure-sql-port"
+                name={field.name}
+                type="number"
+                value={field.value ?? ""}
+                onBlur={field.onBlur}
+                onChange={(event) =>
+                  field.onChange(parseDynamicSecretProviderNumberInput(event.currentTarget.value))
+                }
+                isError={Boolean(error)}
+              />
+              <FieldError>{error?.message}</FieldError>
+            </Field>
+          )}
+        />
+        <Controller
+          control={control}
+          name="inputs.password"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="azure-sql-password">Password</FieldLabel>
+              <SecretInput
+                {...field}
+                value={field.value ?? ""}
+                id="azure-sql-password"
+                aria-describedby={error ? "azure-sql-password-error" : undefined}
+              />
+              <FieldError id="azure-sql-password-error">{error?.message}</FieldError>
+            </Field>
+          )}
+        />
+        <Controller
+          control={control}
+          name="inputs.sslEnabled"
+          render={({ field }) => (
+            <Field orientation="horizontal">
+              <FieldContent>
+                <FieldTitle>Enable SSL</FieldTitle>
+                <FieldDescription>
+                  Configure a custom CA certificate for this connection.
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                ref={field.ref}
+                checked={field.value ?? false}
+                onBlur={field.onBlur}
+                onCheckedChange={field.onChange}
+                aria-label="Enable SSL"
+              />
+            </Field>
+          )}
+        />
+        {sslEnabled && (
+          <>
+            <DynamicSecretProviderFields
+              fields={[{ name: "inputs.ca", type: "secret", label: "CA (SSL)", isOptional: true }]}
+            />
+            <Controller
+              control={control}
+              name="inputs.sslRejectUnauthorized"
+              render={({ field }) => (
+                <Field orientation="horizontal">
+                  <FieldContent>
+                    <FieldTitle>SSL Reject Unauthorized</FieldTitle>
+                    <FieldDescription>
+                      Verify the server certificate against the supplied certificate authorities.
+                    </FieldDescription>
+                  </FieldContent>
+                  <Switch
+                    ref={field.ref}
+                    checked={field.value ?? true}
+                    onBlur={field.onBlur}
+                    onCheckedChange={field.onChange}
+                    aria-label="SSL Reject Unauthorized"
+                  />
+                </Field>
+              )}
+            />
+          </>
+        )}
+      </DynamicSecretProviderGroup>
+
+      <AzureSqlMetadataFields />
+
+      <DynamicSecretProviderGroup
+        id="azure-sql-statements"
+        presentation="collapse"
+        title="Statements and Username Template"
+      >
+        <DynamicSecretProviderFields fields={statementFields} />
+      </DynamicSecretProviderGroup>
+
+      <DynamicSecretProviderGroup
+        id="azure-sql-password"
+        presentation="collapse"
+        title="Password Configuration (optional)"
+      >
+        <AzureSqlPasswordRequirements />
+      </DynamicSecretProviderGroup>
+    </>
+  );
+};
+
+export const azureSqlDatabaseDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AzureSqlDatabase,
+  label: "Azure SQL Database",
+  customRenderer: {
+    reasons: AZURE_SQL_DATABASE_CUSTOM_RENDERER_REASONS,
+    Component: AzureSqlFields
+  },
+  create: {
+    schema: azureSqlCreateFormSchema,
+    getDefaultValues: getAzureSqlCreateDefaultValues,
+    toPayload: getAzureSqlCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: azureSqlEditFormSchema,
+    getDefaultValues: getAzureSqlEditDefaultValues,
+    toPayload: getAzureSqlEditPayload,
+    submitLabel: "Submit",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureSqlDatabaseContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/azureSqlDatabaseContract.ts
@@ -1,0 +1,196 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const AZURE_SQL_DATABASE_CUSTOM_RENDERER_REASONS = [
+  "conditional-fields",
+  "repeatable-fields",
+  "permission-aware-fields",
+  "non-scalar-value"
+] as const;
+
+export const azureSqlPasswordRequirementsSchema = z
+  .object({
+    length: z.number().min(1).max(250),
+    required: z
+      .object({
+        lowercase: z.number().min(0),
+        uppercase: z.number().min(0),
+        digits: z.number().min(0),
+        symbols: z.number().min(0)
+      })
+      .refine(
+        (value) => Object.values(value).reduce((sum, count) => sum + count, 0) <= 250,
+        "Sum of required characters cannot exceed 250"
+      ),
+    allowedSymbols: z.string().optional()
+  })
+  .refine(
+    (value) => Object.values(value.required).reduce((sum, count) => sum + count, 0) <= value.length,
+    "Sum of required characters cannot exceed the total length"
+  );
+
+const createInputsSchema = z.object({
+  host: z.string().toLowerCase().min(1),
+  port: z.number(),
+  database: z.string().min(1),
+  username: z.string().min(1),
+  password: z.string().min(1),
+  passwordRequirements: azureSqlPasswordRequirementsSchema.optional(),
+  masterCreationStatement: z.string().min(1),
+  creationStatement: z.string().min(1),
+  revocationStatement: z.string().min(1),
+  renewStatement: z.string().optional(),
+  sslEnabled: z.boolean().optional(),
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true),
+  gatewayId: z.string().optional(),
+  gatewayPoolId: z.string().optional()
+});
+const editInputsSchema = z
+  .object({
+    host: z.string().toLowerCase().min(1),
+    port: z.number(),
+    database: z.string().min(1),
+    username: z.string().min(1),
+    password: z.string().min(1),
+    passwordRequirements: azureSqlPasswordRequirementsSchema.optional(),
+    masterCreationStatement: z.string().min(1),
+    creationStatement: z.string().min(1),
+    revocationStatement: z.string().min(1),
+    renewStatement: z.string().optional(),
+    ca: z.string().optional(),
+    sslEnabled: z.boolean().optional(),
+    sslRejectUnauthorized: z.boolean().optional(),
+    gatewayId: z.string().optional().nullable(),
+    gatewayPoolId: z.string().optional().nullable()
+  })
+  .partial();
+const metadataSchema = z
+  .object({ key: z.string().trim().min(1), value: z.string().trim().default("") })
+  .array()
+  .optional();
+
+export type TAzureSqlCreateValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof createInputsSchema>
+> & { metadata?: z.infer<typeof metadataSchema> };
+export type TAzureSqlEditValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof editInputsSchema>
+> & { metadata?: z.infer<typeof metadataSchema> };
+
+export const azureSqlCreateFormSchema = createDynamicSecretProviderFormSchema(
+  createInputsSchema
+).extend({ metadata: metadataSchema }) as z.ZodType<TAzureSqlCreateValues>;
+export const azureSqlEditFormSchema = editDynamicSecretProviderFormSchema(editInputsSchema, {
+  usernameTemplateSchema: z.string().nullable().optional()
+}).extend({ metadata: metadataSchema }) as z.ZodType<TAzureSqlEditValues>;
+
+export const DEFAULT_AZURE_SQL_PASSWORD_REQUIREMENTS = {
+  length: 48,
+  required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 0 },
+  allowedSymbols: "-_.~!*"
+};
+export const DEFAULT_AZURE_SQL_STATEMENTS = {
+  masterCreationStatement: "CREATE LOGIN [{{username}}] WITH PASSWORD = '{{password}}';",
+  creationStatement:
+    "CREATE USER [{{username}}] FOR LOGIN [{{username}}];\nGRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA::dbo TO [{{username}}];",
+  renewStatement: "",
+  revocationStatement: "DROP USER [{{username}}];\nDROP LOGIN [{{username}}];"
+};
+
+export const getAzureSqlCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TAzureSqlCreateValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  metadata: [],
+  inputs: {
+    host: "",
+    port: 1433,
+    database: "",
+    username: "",
+    password: "",
+    ...DEFAULT_AZURE_SQL_STATEMENTS,
+    sslRejectUnauthorized: true,
+    passwordRequirements: DEFAULT_AZURE_SQL_PASSWORD_REQUIREMENTS
+  }
+});
+export const getAzureSqlEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TAzureSqlEditValues => {
+  const inputs = context.dynamicSecret.inputs as TAzureSqlEditValues["inputs"];
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL || "",
+    usernameTemplate:
+      context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+    metadata: context.dynamicSecret.metadata?.map(({ key, value }) => ({ key, value })) ?? [],
+    inputs: {
+      ...inputs,
+      passwordRequirements: inputs.passwordRequirements || DEFAULT_AZURE_SQL_PASSWORD_REQUIREMENTS
+    }
+  };
+};
+
+export const normalizeAzureSqlGatewayValueForMode = (
+  mode: "create" | "edit",
+  value: string | null
+) => (mode === "create" ? value || undefined : value);
+
+export const getAzureSqlCreatePayload = (
+  values: TAzureSqlCreateValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.AzureSqlDatabase> => ({
+  provider: {
+    type: DynamicSecretProviders.AzureSqlDatabase,
+    inputs: { ...createInputsSchema.parse(values.inputs), masterDatabase: "master" }
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  metadata: values.metadata,
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+export const getAzureSqlEditPayload = (
+  values: TAzureSqlEditValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: values.inputs
+      ? { ...editInputsSchema.parse(values.inputs), masterDatabase: "master" }
+      : undefined,
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    metadata: values.metadata,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/clickHouse.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/clickHouse.tsx
@@ -1,0 +1,287 @@
+import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import { OrgPermissionCan } from "@app/components/permissions";
+import {
+  Button,
+  Empty,
+  EmptyContent,
+  EmptyHeader,
+  EmptyTitle,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldFeedback,
+  FieldLabel,
+  FieldTitle,
+  IconButton,
+  Input
+} from "@app/components/v3";
+import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
+import { OrgPermissionSubjects } from "@app/context";
+import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { defineDynamicSecretProvider, TDynamicSecretProviderField } from "../types";
+import {
+  CLICKHOUSE_CUSTOM_RENDERER_REASONS,
+  clickHouseCreateFormSchema,
+  clickHouseEditFormSchema,
+  getClickHouseCreateDefaultValues,
+  getClickHouseCreatePayload,
+  getClickHouseEditDefaultValues,
+  getClickHouseEditPayload,
+  TClickHouseFormValues
+} from "./clickHouseContract";
+
+const connectionFields = [
+  { name: "inputs.host", type: "text", label: "Host", layout: "half" },
+  { name: "inputs.port", type: "number", label: "Port", layout: "half" },
+  { name: "inputs.username", type: "text", label: "User", autoComplete: "off", layout: "half" },
+  {
+    name: "inputs.password",
+    type: "secret",
+    label: "Password",
+    autoComplete: "new-password",
+    layout: "half"
+  },
+  { name: "inputs.database", type: "text", label: "Database" },
+  {
+    name: "inputs.ca",
+    type: "secret",
+    label: "CA (SSL)",
+    description: "Optionally needed for self-signed certificates.",
+    isOptional: true
+  }
+] satisfies readonly TDynamicSecretProviderField<TClickHouseFormValues>[];
+
+const statementFields = [
+  {
+    name: "usernameTemplate",
+    type: "text",
+    label: "Username Template",
+    placeholder: "{{randomUsername}}"
+  },
+  { name: "inputs.creationStatement", type: "textarea", label: "Creation Statement", rows: 3 },
+  { name: "inputs.revocationStatement", type: "textarea", label: "Revocation Statement", rows: 3 },
+  { name: "inputs.renewStatement", type: "textarea", label: "Renew Statement", rows: 3 }
+] satisfies readonly TDynamicSecretProviderField<TClickHouseFormValues>[];
+
+const passwordRequirementFields = [
+  { name: "inputs.passwordRequirements.length", type: "number", label: "Password Length" },
+  {
+    name: "inputs.passwordRequirements.required.lowercase",
+    type: "number",
+    label: "Lowercase Count",
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.uppercase",
+    type: "number",
+    label: "Uppercase Count",
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.digits",
+    type: "number",
+    label: "Digit Count",
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.symbols",
+    type: "number",
+    label: "Symbol Count",
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.allowedSymbols",
+    type: "text",
+    label: "Allowed Symbols",
+    isOptional: true
+  }
+] satisfies readonly TDynamicSecretProviderField<TClickHouseFormValues>[];
+
+const ClickHouseMetadataFields = () => {
+  const { control } = useFormContext<TClickHouseFormValues>();
+  const metadata = useFieldArray({ control, name: "metadata" });
+  return (
+    <DynamicSecretProviderGroup
+      id="clickhouse-metadata"
+      presentation="panel"
+      surface
+      title="Metadata"
+    >
+      {metadata.fields.length === 0 ? (
+        <Empty className="gap-2 border p-6 md:p-6">
+          <EmptyHeader>
+            <EmptyTitle>No metadata entries</EmptyTitle>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button type="button" size="sm" onClick={() => metadata.append({ key: "", value: "" })}>
+              <PlusIcon /> Add entry
+            </Button>
+          </EmptyContent>
+        </Empty>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {metadata.fields.map(({ id }, index) => (
+            <div
+              key={id}
+              className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+            >
+              <Controller
+                control={control}
+                name={`metadata.${index}.key`}
+                render={({ field, fieldState: { error } }) => (
+                  <Field data-invalid={Boolean(error)}>
+                    <FieldLabel htmlFor={`clickhouse-metadata-${index}-key`}>Key</FieldLabel>
+                    <Input
+                      {...field}
+                      id={`clickhouse-metadata-${index}-key`}
+                      isError={Boolean(error)}
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+              <Controller
+                control={control}
+                name={`metadata.${index}.value`}
+                render={({ field, fieldState: { error } }) => (
+                  <Field data-invalid={Boolean(error)}>
+                    <FieldLabel htmlFor={`clickhouse-metadata-${index}-value`}>
+                      Value <span className="font-normal text-muted">(optional)</span>
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id={`clickhouse-metadata-${index}-value`}
+                      isError={Boolean(error)}
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+              <div className="flex flex-col gap-2">
+                <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                  &nbsp;
+                </FieldLabel>
+                <IconButton
+                  type="button"
+                  variant="outline"
+                  aria-label={`Remove metadata entry ${index + 1}`}
+                  onClick={() => metadata.remove(index)}
+                >
+                  <Trash2Icon />
+                </IconButton>
+              </div>
+            </div>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            className="self-start"
+            onClick={() => metadata.append({ key: "", value: "" })}
+          >
+            <PlusIcon /> Add entry
+          </Button>
+        </div>
+      )}
+    </DynamicSecretProviderGroup>
+  );
+};
+
+const ClickHouseFields = () => {
+  const { control, setValue, watch } = useFormContext<TClickHouseFormValues>();
+  const gatewayId = watch("inputs.gatewayId");
+  const gatewayPoolId = watch("inputs.gatewayPoolId");
+  return (
+    <>
+      <DynamicSecretProviderGroup id="clickhouse-connection" presentation="panel">
+        <OrgPermissionCan
+          I={OrgGatewayPermissionActions.AttachGateways}
+          a={OrgPermissionSubjects.Gateway}
+        >
+          {(isAllowed) => (
+            <Controller
+              control={control}
+              name="inputs.gatewayId"
+              render={({ fieldState: { error } }) => {
+                const description = !isAllowed
+                  ? "You don't have permission to attach gateways to resources."
+                  : undefined;
+
+                return (
+                  <Field data-invalid={Boolean(error)} data-disabled={!isAllowed}>
+                    <FieldTitle>Gateway</FieldTitle>
+                    <GatewayPicker
+                      isDisabled={!isAllowed}
+                      isError={Boolean(error)}
+                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                      onChange={({ gatewayId: nextId, gatewayPoolId: nextPoolId }) => {
+                        setValue("inputs.gatewayId", nextId ?? undefined, { shouldDirty: true });
+                        setValue("inputs.gatewayPoolId", nextPoolId ?? undefined, {
+                          shouldDirty: true
+                        });
+                      }}
+                    />
+                    {(description || error?.message) && (
+                      <FieldFeedback
+                        id="clickhouse-gateway-feedback"
+                        description={description}
+                        error={error?.message}
+                      />
+                    )}
+                  </Field>
+                );
+              }}
+            />
+          )}
+        </OrgPermissionCan>
+        <DynamicSecretProviderFields fields={connectionFields} />
+      </DynamicSecretProviderGroup>
+
+      <DynamicSecretProviderGroup
+        id="clickhouse-statements"
+        presentation="collapse"
+        title="Modify SQL Statements"
+      >
+        <DynamicSecretProviderFields fields={statementFields} />
+      </DynamicSecretProviderGroup>
+
+      <DynamicSecretProviderGroup
+        id="clickhouse-password"
+        presentation="collapse"
+        title="Password Configuration (optional)"
+      >
+        <FieldDescription>Set constraints on the generated database password.</FieldDescription>
+        <DynamicSecretProviderFields fields={passwordRequirementFields} />
+      </DynamicSecretProviderGroup>
+
+      <ClickHouseMetadataFields />
+    </>
+  );
+};
+
+export const clickHouseDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Clickhouse,
+  label: "ClickHouse",
+  customRenderer: {
+    reasons: CLICKHOUSE_CUSTOM_RENDERER_REASONS,
+    Component: ClickHouseFields
+  },
+  create: {
+    schema: clickHouseCreateFormSchema,
+    getDefaultValues: getClickHouseCreateDefaultValues,
+    toPayload: getClickHouseCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: clickHouseEditFormSchema,
+    getDefaultValues: getClickHouseEditDefaultValues,
+    toPayload: getClickHouseEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/clickHouseContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/clickHouseContract.ts
@@ -1,0 +1,180 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const CLICKHOUSE_CUSTOM_RENDERER_REASONS = [
+  "permission-aware-fields",
+  "repeatable-fields",
+  "non-scalar-value"
+] as const;
+
+export const clickHousePasswordRequirementsSchema = z
+  .object({
+    length: z.number().min(1).max(250),
+    required: z
+      .object({
+        lowercase: z.number().min(0),
+        uppercase: z.number().min(0),
+        digits: z.number().min(0),
+        symbols: z.number().min(0)
+      })
+      .refine(
+        (required) => Object.values(required).reduce((sum, count) => sum + count, 0) <= 250,
+        "Sum of required characters cannot exceed 250"
+      ),
+    allowedSymbols: z.string().optional()
+  })
+  .refine(
+    ({ length, required }) =>
+      Object.values(required).reduce((sum, count) => sum + count, 0) <= length,
+    "Sum of required characters cannot exceed the total length"
+  );
+
+export const clickHouseCreateInputsSchema = z.object({
+  host: z.string().min(1),
+  port: z.number(),
+  database: z.string().min(1),
+  username: z.string().min(1),
+  password: z.string().min(1),
+  passwordRequirements: clickHousePasswordRequirementsSchema.optional(),
+  creationStatement: z.string().min(1),
+  revocationStatement: z.string().min(1),
+  renewStatement: z.string().optional(),
+  ca: z.string().optional(),
+  gatewayId: z.string().optional(),
+  gatewayPoolId: z.string().optional()
+});
+
+export const clickHouseEditInputsSchema = clickHouseCreateInputsSchema
+  .extend({
+    port: z.number(),
+    gatewayId: z.string().optional().nullable(),
+    gatewayPoolId: z.string().optional().nullable()
+  })
+  .partial();
+
+const metadataSchema = z
+  .array(z.object({ key: z.string().trim().min(1), value: z.string().trim().default("") }))
+  .optional();
+
+export type TClickHouseFormValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof clickHouseCreateInputsSchema>
+> & { metadata?: { key: string; value: string }[] };
+
+export const clickHouseCreateFormSchema = createDynamicSecretProviderFormSchema(
+  clickHouseCreateInputsSchema
+).extend({ metadata: metadataSchema }) as z.ZodType<TClickHouseFormValues>;
+
+export const clickHouseEditFormSchema = editDynamicSecretProviderFormSchema(
+  clickHouseEditInputsSchema,
+  { usernameTemplateSchema: z.string().trim().nullable().optional() }
+).extend({ metadata: metadataSchema }) as z.ZodType<TClickHouseFormValues>;
+
+export const getDefaultClickHousePasswordRequirements = () => ({
+  length: 48,
+  required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 1 },
+  allowedSymbols: "-_.~!*"
+});
+
+export const getClickHouseCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TClickHouseFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  metadata: undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "",
+    port: 8123,
+    database: "default",
+    username: "",
+    password: "",
+    creationStatement:
+      "CREATE USER '{{username}}' IDENTIFIED WITH sha256_password BY '{{password}}';\nGRANT SELECT ON {{database}}.* TO '{{username}}';",
+    revocationStatement: "DROP USER IF EXISTS '{{username}}';",
+    renewStatement: "",
+    ca: "",
+    passwordRequirements: getDefaultClickHousePasswordRequirements()
+  }
+});
+
+export const getClickHouseEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TClickHouseFormValues => {
+  const inputs = context.dynamicSecret.inputs as TClickHouseFormValues["inputs"];
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL,
+    metadata: context.dynamicSecret.metadata,
+    usernameTemplate:
+      context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+    inputs: {
+      ...inputs,
+      passwordRequirements:
+        inputs.passwordRequirements || getDefaultClickHousePasswordRequirements()
+    }
+  };
+};
+
+export const getClickHouseCreatePayload = (
+  values: TClickHouseFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Clickhouse> => ({
+  provider: {
+    type: DynamicSecretProviders.Clickhouse,
+    inputs: clickHouseCreateInputsSchema.parse(values.inputs)
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  metadata: values.metadata,
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+
+export const getClickHouseEditPayload = (
+  values: TClickHouseFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => {
+  const inputs = clickHouseEditInputsSchema.parse(values.inputs);
+  return {
+    name: context.dynamicSecret.name,
+    path: context.secretPath,
+    projectSlug: context.projectSlug,
+    environmentSlug: context.environment,
+    data: {
+      maxTTL: values.maxTTL || undefined,
+      defaultTTL: values.defaultTTL,
+      inputs: {
+        ...inputs,
+        gatewayId: inputs.gatewayId ?? null,
+        gatewayPoolId: inputs.gatewayPoolId ?? null
+      },
+      newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+      metadata: values.metadata,
+      usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+    }
+  };
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/relationalWarehouse.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/relationalWarehouse.ts
@@ -1,0 +1,32 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type { TRegisteredDynamicSecretProviderDefinition } from "../registry";
+import { defineDynamicSecretProviderModule } from "../registry";
+import { azureSqlDatabaseDynamicSecretProvider } from "./azureSqlDatabase";
+import { clickHouseDynamicSecretProvider } from "./clickHouse";
+import { RELATIONAL_WAREHOUSE_DYNAMIC_SECRET_PROVIDERS } from "./relationalWarehouseContract";
+import { sapAseDynamicSecretProvider } from "./sapAse";
+import { sapHanaDynamicSecretProvider } from "./sapHana";
+import { snowflakeDynamicSecretProvider } from "./snowflake";
+import { sqlDatabaseDynamicSecretProvider } from "./sqlDatabase";
+import { verticaDynamicSecretProvider } from "./vertica";
+
+const definitionsByProvider = {
+  [DynamicSecretProviders.SqlDatabase]: sqlDatabaseDynamicSecretProvider,
+  [DynamicSecretProviders.AzureSqlDatabase]: azureSqlDatabaseDynamicSecretProvider,
+  [DynamicSecretProviders.Clickhouse]: clickHouseDynamicSecretProvider,
+  [DynamicSecretProviders.Snowflake]: snowflakeDynamicSecretProvider,
+  [DynamicSecretProviders.Vertica]: verticaDynamicSecretProvider,
+  [DynamicSecretProviders.SapAse]: sapAseDynamicSecretProvider,
+  [DynamicSecretProviders.SapHana]: sapHanaDynamicSecretProvider
+} satisfies Record<
+  (typeof RELATIONAL_WAREHOUSE_DYNAMIC_SECRET_PROVIDERS)[number],
+  TRegisteredDynamicSecretProviderDefinition
+>;
+
+export const relationalWarehouseDynamicSecretProviders = defineDynamicSecretProviderModule({
+  id: "relational-warehouse",
+  definitions: RELATIONAL_WAREHOUSE_DYNAMIC_SECRET_PROVIDERS.map(
+    (provider) => definitionsByProvider[provider]
+  )
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/relationalWarehouseContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/relationalWarehouseContract.ts
@@ -1,0 +1,11 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+export const RELATIONAL_WAREHOUSE_DYNAMIC_SECRET_PROVIDERS = [
+  DynamicSecretProviders.SqlDatabase,
+  DynamicSecretProviders.AzureSqlDatabase,
+  DynamicSecretProviders.Clickhouse,
+  DynamicSecretProviders.Snowflake,
+  DynamicSecretProviders.Vertica,
+  DynamicSecretProviders.SapAse,
+  DynamicSecretProviders.SapHana
+] as const;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapAse.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapAse.tsx
@@ -1,0 +1,88 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { buildStatementFields, StatementAccordion } from "../shared";
+import { defineDynamicSecretProvider } from "../types";
+import {
+  getSapAseCreateDefaultValues,
+  getSapAseCreatePayload,
+  getSapAseEditDefaultValues,
+  getSapAseEditPayload,
+  SAP_ASE_CUSTOM_RENDERER_REASONS,
+  sapAseCreateFormSchema,
+  sapAseEditFormSchema
+} from "./sapAseContract";
+
+const sapAseCreateConnectionFields = [
+  { name: "inputs.host", type: "text", label: "Host", layout: "half" },
+  { name: "inputs.port", type: "number", label: "Port", layout: "half" },
+  { name: "inputs.database", type: "text", label: "Database" },
+  { name: "inputs.username", type: "text", label: "User", layout: "half" },
+  {
+    name: "inputs.password",
+    type: "secret",
+    label: "Password",
+    autoComplete: "new-password",
+    layout: "half"
+  }
+] as const;
+
+const sapAseEditConnectionFields = [
+  ...sapAseCreateConnectionFields,
+  { name: "inputs.ca", type: "secret", label: "CA (SSL)", isOptional: true }
+] as const;
+
+const sapAseAdvancedFields = buildStatementFields({
+  includeRenew: false,
+  copy: {
+    creation:
+      "Username and password are dynamically provisioned. The sp_addlogin statement runs against the master database; other statements run against the selected database.",
+    revocation:
+      "Username is dynamically provisioned. The sp_droplogin statement runs against the master database; other statements run against the selected database."
+  }
+});
+
+const SapAseCreateFields = () => (
+  <>
+    <DynamicSecretProviderGroup id="sap-ase-connection" presentation="panel">
+      <DynamicSecretProviderFields fields={sapAseCreateConnectionFields} />
+    </DynamicSecretProviderGroup>
+    <StatementAccordion title="Modify SQL Statements" fields={sapAseAdvancedFields} />
+  </>
+);
+
+const SapAseEditFields = () => (
+  <>
+    <DynamicSecretProviderGroup id="sap-ase-connection" presentation="panel">
+      <DynamicSecretProviderFields fields={sapAseEditConnectionFields} />
+    </DynamicSecretProviderGroup>
+    <StatementAccordion title="Modify SQL Statements" fields={sapAseAdvancedFields} />
+  </>
+);
+
+export const sapAseDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.SapAse,
+  label: "SAP ASE",
+  create: {
+    schema: sapAseCreateFormSchema,
+    getDefaultValues: getSapAseCreateDefaultValues,
+    toPayload: getSapAseCreatePayload,
+    customRenderer: {
+      reasons: SAP_ASE_CUSTOM_RENDERER_REASONS,
+      Component: SapAseCreateFields
+    },
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: sapAseEditFormSchema,
+    getDefaultValues: getSapAseEditDefaultValues,
+    toPayload: getSapAseEditPayload,
+    customRenderer: {
+      reasons: SAP_ASE_CUSTOM_RENDERER_REASONS,
+      Component: SapAseEditFields
+    },
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapAse.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapAse.tsx
@@ -28,11 +28,6 @@ const sapAseCreateConnectionFields = [
   }
 ] as const;
 
-const sapAseEditConnectionFields = [
-  ...sapAseCreateConnectionFields,
-  { name: "inputs.ca", type: "secret", label: "CA (SSL)", isOptional: true }
-] as const;
-
 const sapAseAdvancedFields = buildStatementFields({
   includeRenew: false,
   copy: {
@@ -55,7 +50,7 @@ const SapAseCreateFields = () => (
 const SapAseEditFields = () => (
   <>
     <DynamicSecretProviderGroup id="sap-ase-connection" presentation="panel">
-      <DynamicSecretProviderFields fields={sapAseEditConnectionFields} />
+      <DynamicSecretProviderFields fields={sapAseCreateConnectionFields} />
     </DynamicSecretProviderGroup>
     <StatementAccordion title="Modify SQL Statements" fields={sapAseAdvancedFields} />
   </>

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapAseContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapAseContract.ts
@@ -37,10 +37,7 @@ export const sapAseCreateInputsSchema = z.object({
   revocationStatement: z.string().min(1)
 });
 
-// Existing SAP ASE records may expose a CA during edit even though create does not accept one.
-export const sapAseEditInputsSchema = sapAseCreateInputsSchema
-  .extend({ ca: z.string().optional() })
-  .partial();
+export const sapAseEditInputsSchema = sapAseCreateInputsSchema.partial();
 
 export type TSapAseCreateInputs = z.infer<typeof sapAseCreateInputsSchema>;
 export type TSapAseEditInputs = z.infer<typeof sapAseEditInputsSchema>;
@@ -81,7 +78,7 @@ export const getSapAseEditDefaultValues = (
   maxTTL: context.dynamicSecret.maxTTL,
   usernameTemplate:
     context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
-  inputs: { ...(context.dynamicSecret.inputs as TSapAseEditInputs) }
+  inputs: sapAseEditInputsSchema.parse(context.dynamicSecret.inputs)
 });
 
 export const getSapAseCreatePayload = (

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapAseContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapAseContract.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const SAP_ASE_CUSTOM_RENDERER_REASONS = ["non-scalar-value"] as const;
+
+export const SAP_ASE_CREATION_STATEMENT = `sp_addlogin '{{username}}', '{{password}}';
+sp_adduser '{{username}}', '{{username}}', null;
+sp_role 'grant', 'mon_role', '{{username}}';`;
+export const SAP_ASE_REVOCATION_STATEMENT = `sp_dropuser '{{username}}';
+sp_droplogin '{{username}}';`;
+
+export const sapAseCreateInputsSchema = z.object({
+  host: z.string().toLowerCase().min(1),
+  port: z.number(),
+  database: z.string().min(1),
+  username: z.string().min(1),
+  password: z.string().min(1),
+  creationStatement: z.string().min(1),
+  revocationStatement: z.string().min(1)
+});
+
+// Existing SAP ASE records may expose a CA during edit even though create does not accept one.
+export const sapAseEditInputsSchema = sapAseCreateInputsSchema
+  .extend({ ca: z.string().optional() })
+  .partial();
+
+export type TSapAseCreateInputs = z.infer<typeof sapAseCreateInputsSchema>;
+export type TSapAseEditInputs = z.infer<typeof sapAseEditInputsSchema>;
+export type TSapAseCreateFormValues = TDynamicSecretProviderFormValues<TSapAseCreateInputs>;
+export type TSapAseEditFormValues = TDynamicSecretProviderFormValues<TSapAseEditInputs>;
+
+export const sapAseCreateFormSchema = createDynamicSecretProviderFormSchema(
+  sapAseCreateInputsSchema
+) as z.ZodType<TSapAseCreateFormValues>;
+export const sapAseEditFormSchema = editDynamicSecretProviderFormSchema(sapAseEditInputsSchema, {
+  usernameTemplateSchema: z.string().trim().nullable().optional()
+}) as z.ZodType<TSapAseEditFormValues>;
+
+export const getSapAseCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TSapAseCreateFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "",
+    port: 5000,
+    database: "master",
+    username: "",
+    password: "",
+    creationStatement: SAP_ASE_CREATION_STATEMENT,
+    revocationStatement: SAP_ASE_REVOCATION_STATEMENT
+  }
+});
+
+export const getSapAseEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TSapAseEditFormValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  usernameTemplate:
+    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: { ...(context.dynamicSecret.inputs as TSapAseEditInputs) }
+});
+
+export const getSapAseCreatePayload = (
+  values: TSapAseCreateFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.SapAse> => ({
+  provider: {
+    type: DynamicSecretProviders.SapAse,
+    inputs: sapAseCreateInputsSchema.parse(values.inputs)
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+
+export const getSapAseEditPayload = (
+  values: TSapAseEditFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: sapAseEditInputsSchema.parse(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapHana.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapHana.tsx
@@ -36,7 +36,7 @@ const SapHanaFields = () => (
       <DynamicSecretProviderFields fields={sapHanaConnectionFields} />
       <SslRejectUnauthorizedField
         id="sap-hana-ssl-reject-unauthorized"
-        fallbackChecked={false}
+        fallbackChecked
         layout="labeled"
       />
     </DynamicSecretProviderGroup>

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapHana.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapHana.tsx
@@ -1,0 +1,67 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { buildStatementFields, SslRejectUnauthorizedField, StatementAccordion } from "../shared";
+import { defineDynamicSecretProvider } from "../types";
+import {
+  getSapHanaCreateDefaultValues,
+  getSapHanaCreatePayload,
+  getSapHanaEditDefaultValues,
+  getSapHanaEditPayload,
+  SAP_HANA_CUSTOM_RENDERER_REASONS,
+  sapHanaCreateFormSchema,
+  sapHanaEditFormSchema
+} from "./sapHanaContract";
+
+const sapHanaConnectionFields = [
+  { name: "inputs.host", type: "text", label: "Host", layout: "half" },
+  { name: "inputs.port", type: "number", label: "Port", layout: "half" },
+  { name: "inputs.username", type: "text", label: "User", layout: "half" },
+  {
+    name: "inputs.password",
+    type: "secret",
+    label: "Password",
+    autoComplete: "new-password",
+    layout: "half"
+  },
+  { name: "inputs.ca", type: "secret", label: "CA (SSL)", isOptional: true }
+] as const;
+
+const sapHanaAdvancedFields = buildStatementFields();
+
+const SapHanaFields = () => (
+  <>
+    <DynamicSecretProviderGroup id="sap-hana-connection" presentation="panel">
+      <DynamicSecretProviderFields fields={sapHanaConnectionFields} />
+      <SslRejectUnauthorizedField
+        id="sap-hana-ssl-reject-unauthorized"
+        fallbackChecked={false}
+        layout="labeled"
+      />
+    </DynamicSecretProviderGroup>
+    <StatementAccordion title="Modify SQL Statements" fields={sapHanaAdvancedFields} />
+  </>
+);
+
+export const sapHanaDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.SapHana,
+  label: "SAP HANA",
+  customRenderer: {
+    reasons: SAP_HANA_CUSTOM_RENDERER_REASONS,
+    Component: SapHanaFields
+  },
+  create: {
+    schema: sapHanaCreateFormSchema,
+    getDefaultValues: getSapHanaCreateDefaultValues,
+    toPayload: getSapHanaCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: sapHanaEditFormSchema,
+    getDefaultValues: getSapHanaEditDefaultValues,
+    toPayload: getSapHanaEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapHanaContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapHanaContract.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const SAP_HANA_CUSTOM_RENDERER_REASONS = ["non-scalar-value"] as const;
+
+export const SAP_HANA_CREATION_STATEMENT = `CREATE USER {{username}} PASSWORD {{password}} NO FORCE_FIRST_PASSWORD_CHANGE VALID UNTIL '{{expiration}}';
+GRANT "MONITORING" TO {{username}};`;
+export const SAP_HANA_REVOCATION_STATEMENT = `REVOKE "MONITORING" FROM {{username}};
+DROP USER {{username}};`;
+export const SAP_HANA_RENEW_STATEMENT = "ALTER USER {{username}} VALID UNTIL '{{expiration}}';";
+
+export const sapHanaCreateInputsSchema = z.object({
+  host: z.string().toLowerCase().min(1),
+  port: z.number(),
+  username: z.string().min(1),
+  password: z.string().min(1),
+  creationStatement: z.string().min(1),
+  revocationStatement: z.string().min(1),
+  renewStatement: z.string().optional(),
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true)
+});
+
+export const sapHanaEditInputsSchema = sapHanaCreateInputsSchema.partial();
+
+export type TSapHanaCreateInputs = z.infer<typeof sapHanaCreateInputsSchema>;
+export type TSapHanaEditInputs = z.infer<typeof sapHanaEditInputsSchema>;
+export type TSapHanaCreateFormValues = TDynamicSecretProviderFormValues<TSapHanaCreateInputs>;
+export type TSapHanaEditFormValues = TDynamicSecretProviderFormValues<TSapHanaEditInputs>;
+
+export const sapHanaCreateFormSchema = createDynamicSecretProviderFormSchema(
+  sapHanaCreateInputsSchema
+) as z.ZodType<TSapHanaCreateFormValues>;
+export const sapHanaEditFormSchema = editDynamicSecretProviderFormSchema(sapHanaEditInputsSchema, {
+  usernameTemplateSchema: z.string().trim().nullable().optional()
+}) as z.ZodType<TSapHanaEditFormValues>;
+
+export const getSapHanaCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TSapHanaCreateFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "",
+    port: 443,
+    username: "",
+    password: "",
+    creationStatement: SAP_HANA_CREATION_STATEMENT,
+    revocationStatement: SAP_HANA_REVOCATION_STATEMENT,
+    renewStatement: SAP_HANA_RENEW_STATEMENT,
+    ca: undefined,
+    sslRejectUnauthorized: true
+  }
+});
+
+export const getSapHanaEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TSapHanaEditFormValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  usernameTemplate:
+    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: { ...(context.dynamicSecret.inputs as TSapHanaEditInputs) }
+});
+
+export const getSapHanaCreatePayload = (
+  values: TSapHanaCreateFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.SapHana> => ({
+  provider: {
+    type: DynamicSecretProviders.SapHana,
+    inputs: sapHanaCreateInputsSchema.parse(values.inputs)
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate),
+  environmentSlug: values.environment?.slug ?? ""
+});
+
+export const getSapHanaEditPayload = (
+  values: TSapHanaEditFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: sapHanaEditInputsSchema.parse(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapHanaContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sapHanaContract.ts
@@ -76,14 +76,21 @@ export const getSapHanaCreateDefaultValues = (
 
 export const getSapHanaEditDefaultValues = (
   context: TEditDynamicSecretProviderFormContext
-): TSapHanaEditFormValues => ({
-  name: context.dynamicSecret.name,
-  defaultTTL: context.dynamicSecret.defaultTTL,
-  maxTTL: context.dynamicSecret.maxTTL,
-  usernameTemplate:
-    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
-  inputs: { ...(context.dynamicSecret.inputs as TSapHanaEditInputs) }
-});
+): TSapHanaEditFormValues => {
+  const inputs = context.dynamicSecret.inputs as TSapHanaEditInputs;
+
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL,
+    usernameTemplate:
+      context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+    inputs: {
+      ...inputs,
+      sslRejectUnauthorized: inputs.sslRejectUnauthorized ?? true
+    }
+  };
+};
 
 export const getSapHanaCreatePayload = (
   values: TSapHanaCreateFormValues,

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/snowflake.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/snowflake.tsx
@@ -1,0 +1,68 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { buildStatementFields, StatementAccordion } from "../shared";
+import { defineDynamicSecretProvider } from "../types";
+import {
+  getSnowflakeCreateDefaultValues,
+  getSnowflakeCreatePayload,
+  getSnowflakeEditDefaultValues,
+  getSnowflakeEditPayload,
+  SNOWFLAKE_CUSTOM_RENDERER_REASONS,
+  snowflakeCreateFormSchema,
+  snowflakeEditFormSchema
+} from "./snowflakeContract";
+
+const snowflakeConnectionFields = [
+  { name: "inputs.accountId", type: "text", label: "Account Identifier", layout: "half" },
+  {
+    name: "inputs.orgId",
+    type: "text",
+    label: "Organization Identifier",
+    layout: "half"
+  },
+  { name: "inputs.username", type: "text", label: "User", layout: "half" },
+  {
+    name: "inputs.password",
+    type: "secret",
+    label: "Programmatic Access Token",
+    description:
+      "The programmatic access token used to authenticate with Snowflake. A user password is still accepted, but Snowflake is phasing out password authentication.",
+    autoComplete: "new-password",
+    layout: "half"
+  }
+] as const;
+
+const snowflakeAdvancedFields = buildStatementFields();
+
+const SnowflakeFields = () => (
+  <>
+    <DynamicSecretProviderGroup id="snowflake-connection" presentation="panel">
+      <DynamicSecretProviderFields fields={snowflakeConnectionFields} />
+    </DynamicSecretProviderGroup>
+    <StatementAccordion title="Modify SQL Statements" fields={snowflakeAdvancedFields} />
+  </>
+);
+
+export const snowflakeDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Snowflake,
+  label: "Snowflake",
+  customRenderer: {
+    reasons: SNOWFLAKE_CUSTOM_RENDERER_REASONS,
+    Component: SnowflakeFields
+  },
+  create: {
+    schema: snowflakeCreateFormSchema,
+    getDefaultValues: getSnowflakeCreateDefaultValues,
+    toPayload: getSnowflakeCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: snowflakeEditFormSchema,
+    getDefaultValues: getSnowflakeEditDefaultValues,
+    toPayload: getSnowflakeEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/snowflakeContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/snowflakeContract.ts
@@ -1,0 +1,117 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const SNOWFLAKE_CUSTOM_RENDERER_REASONS = ["non-scalar-value"] as const;
+
+export const SNOWFLAKE_CREATION_STATEMENT =
+  "CREATE USER {{username}} PASSWORD = '{{password}}' DEFAULT_ROLE = public DEFAULT_SECONDARY_ROLES = ('ALL') MUST_CHANGE_PASSWORD = FALSE DAYS_TO_EXPIRY = {{expiration}};";
+export const SNOWFLAKE_REVOCATION_STATEMENT = "DROP USER {{username}};";
+export const SNOWFLAKE_RENEW_STATEMENT =
+  "ALTER USER {{username}} SET DAYS_TO_EXPIRY = {{expiration}};";
+
+export const snowflakeCreateInputsSchema = z.object({
+  accountId: z.string().trim().min(1),
+  orgId: z.string().trim().min(1),
+  username: z.string().trim().min(1),
+  password: z.string().trim().min(1),
+  creationStatement: z.string().trim().min(1),
+  revocationStatement: z.string().trim().min(1),
+  renewStatement: z.string().trim().optional()
+});
+
+export const snowflakeEditInputsSchema = snowflakeCreateInputsSchema.partial();
+
+export type TSnowflakeCreateInputs = z.infer<typeof snowflakeCreateInputsSchema>;
+export type TSnowflakeEditInputs = z.infer<typeof snowflakeEditInputsSchema>;
+export type TSnowflakeCreateFormValues = TDynamicSecretProviderFormValues<TSnowflakeCreateInputs>;
+export type TSnowflakeEditFormValues = TDynamicSecretProviderFormValues<TSnowflakeEditInputs>;
+
+export const snowflakeCreateFormSchema = createDynamicSecretProviderFormSchema(
+  snowflakeCreateInputsSchema
+) as z.ZodType<TSnowflakeCreateFormValues>;
+export const snowflakeEditFormSchema = editDynamicSecretProviderFormSchema(
+  snowflakeEditInputsSchema,
+  { usernameTemplateSchema: z.string().trim().nullable().optional() }
+) as z.ZodType<TSnowflakeEditFormValues>;
+
+export const getSnowflakeCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TSnowflakeCreateFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    accountId: "",
+    orgId: "",
+    username: "",
+    password: "",
+    creationStatement: SNOWFLAKE_CREATION_STATEMENT,
+    revocationStatement: SNOWFLAKE_REVOCATION_STATEMENT,
+    renewStatement: SNOWFLAKE_RENEW_STATEMENT
+  }
+});
+
+export const getSnowflakeEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TSnowflakeEditFormValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  usernameTemplate:
+    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: { ...(context.dynamicSecret.inputs as TSnowflakeEditInputs) }
+});
+
+export const getSnowflakeCreatePayload = (
+  values: TSnowflakeCreateFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Snowflake> => ({
+  provider: {
+    type: DynamicSecretProviders.Snowflake,
+    inputs: snowflakeCreateInputsSchema.parse(values.inputs)
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+
+export const getSnowflakeEditPayload = (
+  values: TSnowflakeEditFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: snowflakeEditInputsSchema.parse(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sqlDatabase.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sqlDatabase.tsx
@@ -1,0 +1,676 @@
+import { useState } from "react";
+import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { InfoIcon, PlusIcon, Trash2Icon } from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import { OrgPermissionCan } from "@app/components/permissions";
+import { ValidationRuleOverrideNotice } from "@app/components/secret-validation/ValidationRuleOverrideNotice";
+import {
+  Button,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldFeedback,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+  FieldTitle,
+  IconButton,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  TextArea
+} from "@app/components/v3";
+import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
+import { SecretInput } from "@app/components/v3/platform/SecretInput";
+import { ProjectPermissionSub, useProject } from "@app/context";
+import { OrgPermissionSubjects } from "@app/context/OrgPermissionContext";
+import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
+import { useCanUseProjectAppConnectionImport } from "@app/hooks";
+import { useListAvailableAppConnections } from "@app/hooks/api/appConnections";
+import { AppConnection } from "@app/hooks/api/appConnections/enums";
+import { DynamicSecretProviders, SqlProviders } from "@app/hooks/api/dynamicSecret/types";
+import type { VaultDatabaseRole } from "@app/hooks/api/migration/types";
+import {
+  DynamicSecretRuleProvider,
+  SecretValidationRuleType
+} from "@app/hooks/api/secretValidationRules";
+import { VaultSqlDatabaseImportModal } from "@app/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/VaultSqlDatabaseImportModal";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { parseDynamicSecretProviderNumberInput } from "../scalarValues";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import {
+  defineDynamicSecretProvider,
+  TDynamicSecretProviderField,
+  TDynamicSecretProviderRendererProps
+} from "../types";
+import {
+  getSqlClientResetValues,
+  getSqlDatabaseCreateDefaultValues,
+  getSqlDatabaseCreatePayload,
+  getSqlDatabaseEditDefaultValues,
+  getSqlDatabaseEditPayload,
+  getSqlDatabaseVaultImportValues,
+  normalizeSqlGatewayValueForMode,
+  SQL_DATABASE_CUSTOM_RENDERER_REASONS,
+  sqlDatabaseCreateFormSchema,
+  sqlDatabaseEditFormSchema,
+  TSqlDatabaseFormValues
+} from "./sqlDatabaseContract";
+
+const sqlConnectionFields = [
+  { name: "inputs.host", type: "text", label: "Host" },
+  {
+    name: "inputs.username",
+    type: "text",
+    label: "User",
+    autoComplete: "off",
+    layout: "half"
+  },
+  {
+    name: "inputs.password",
+    type: "secret",
+    label: "Password",
+    autoComplete: "new-password",
+    layout: "half"
+  },
+  { name: "inputs.database", type: "text", label: "Database Name", layout: "half" }
+] satisfies readonly TDynamicSecretProviderField<TSqlDatabaseFormValues>[];
+
+const usernameTemplateField = [
+  {
+    name: "usernameTemplate",
+    type: "text",
+    label: "Username Template",
+    placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+  }
+] satisfies readonly TDynamicSecretProviderField<TSqlDatabaseFormValues>[];
+
+const SqlVaultImport = ({ onImport }: { onImport: (role: VaultDatabaseRole) => void }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { projectId } = useProject();
+  const canUseAppConnectionImport = useCanUseProjectAppConnectionImport(
+    ProjectPermissionSub.Secrets
+  );
+  const { data: vaultAppConnections = [] } = useListAvailableAppConnections(
+    AppConnection.HCVault,
+    projectId,
+    { enabled: canUseAppConnectionImport }
+  );
+
+  if (!canUseAppConnectionImport || vaultAppConnections.length === 0) return null;
+
+  return (
+    <>
+      <div className="flex flex-col gap-3 rounded-md border border-info/20 bg-info/10 p-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2 text-sm text-foreground">
+          <InfoIcon className="size-4 text-info" />
+          <span>Load values from HashiCorp Vault.</span>
+        </div>
+        <Button type="button" size="sm" variant="info" onClick={() => setIsOpen(true)}>
+          <img src="/images/integrations/Vault.png" alt="" className="size-4" />
+          Load from Vault
+        </Button>
+      </div>
+      <VaultSqlDatabaseImportModal
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        appConnections={vaultAppConnections}
+        onImport={onImport}
+      />
+    </>
+  );
+};
+
+const SqlMetadataFields = () => {
+  const { control } = useFormContext<TSqlDatabaseFormValues>();
+  const metadataFields = useFieldArray({ control, name: "metadata" });
+
+  return (
+    <DynamicSecretProviderGroup id="sql-metadata" presentation="panel" surface title="Metadata">
+      {metadataFields.fields.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border p-5 text-center">
+          <FieldDescription>No metadata entries</FieldDescription>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => metadataFields.append({ key: "", value: "" })}
+          >
+            <PlusIcon />
+            Add entry
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {metadataFields.fields.map((metadataField, index) => (
+            <div
+              key={metadataField.id}
+              className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+            >
+              {(["key", "value"] as const).map((key) => (
+                <Controller
+                  key={key}
+                  control={control}
+                  name={`metadata.${index}.${key}`}
+                  render={({ field, fieldState: { error } }) => (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`sql-metadata-${index}-${key}`}>
+                        {key === "key" ? "Key" : "Value"}
+                        {key === "value" && (
+                          <span className="font-normal text-muted">(optional)</span>
+                        )}
+                      </FieldLabel>
+                      <Input
+                        {...field}
+                        id={`sql-metadata-${index}-${key}`}
+                        isError={Boolean(error)}
+                        aria-describedby={error ? `sql-metadata-${index}-${key}-error` : undefined}
+                      />
+                      <FieldError id={`sql-metadata-${index}-${key}-error`}>
+                        {error?.message}
+                      </FieldError>
+                    </Field>
+                  )}
+                />
+              ))}
+              <div className="flex flex-col gap-2">
+                <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                  &nbsp;
+                </FieldLabel>
+                <IconButton
+                  type="button"
+                  variant="outline"
+                  aria-label={`Remove metadata entry ${index + 1}`}
+                  onClick={() => metadataFields.remove(index)}
+                >
+                  <Trash2Icon />
+                </IconButton>
+              </div>
+            </div>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="self-start"
+            onClick={() => metadataFields.append({ key: "", value: "" })}
+          >
+            <PlusIcon />
+            Add entry
+          </Button>
+        </div>
+      )}
+    </DynamicSecretProviderGroup>
+  );
+};
+
+type NumericRequirement = "length" | "lowercase" | "uppercase" | "digits" | "symbols";
+
+const SqlPasswordNumberField = ({ fieldName }: { fieldName: NumericRequirement }) => {
+  const { control } = useFormContext<TSqlDatabaseFormValues>();
+  const isLength = fieldName === "length";
+  const name = isLength
+    ? ("inputs.passwordRequirements.length" as const)
+    : (`inputs.passwordRequirements.required.${fieldName}` as const);
+  const labels: Record<NumericRequirement, string> = {
+    length: "Password Length",
+    lowercase: "Lowercase Count",
+    uppercase: "Uppercase Count",
+    digits: "Digit Count",
+    symbols: "Symbol Count"
+  };
+  const descriptions: Partial<Record<NumericRequirement, string>> = {
+    lowercase: "Minimum number of lowercase letters",
+    uppercase: "Minimum number of uppercase letters",
+    digits: "Minimum number of digits",
+    symbols: "Minimum number of symbols"
+  };
+  const feedbackId = descriptions[fieldName]
+    ? `sql-password-${fieldName}-feedback`
+    : `sql-password-${fieldName}-error`;
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState: { error } }) => (
+        <Field data-invalid={Boolean(error)}>
+          <FieldLabel htmlFor={`sql-password-${fieldName}`}>{labels[fieldName]}</FieldLabel>
+          <Input
+            ref={field.ref}
+            id={`sql-password-${fieldName}`}
+            name={field.name}
+            type="number"
+            min={isLength ? 1 : 0}
+            max={isLength ? 250 : undefined}
+            value={field.value ?? ""}
+            onBlur={field.onBlur}
+            onChange={(event) =>
+              field.onChange(parseDynamicSecretProviderNumberInput(event.currentTarget.value))
+            }
+            isError={Boolean(error)}
+            aria-describedby={feedbackId}
+          />
+          {descriptions[fieldName] ? (
+            <FieldFeedback
+              id={feedbackId}
+              description={descriptions[fieldName]}
+              error={error?.message}
+            />
+          ) : (
+            <FieldError id={feedbackId}>{error?.message}</FieldError>
+          )}
+        </Field>
+      )}
+    />
+  );
+};
+
+const SqlPasswordConfiguration = ({
+  mode,
+  secretPath
+}: {
+  mode: TDynamicSecretProviderRendererProps["mode"];
+  secretPath: string;
+}) => {
+  const { control, formState, watch } = useFormContext<TSqlDatabaseFormValues>();
+  const required = watch("inputs.passwordRequirements.required");
+  const length = watch("inputs.passwordRequirements.length") ?? 0;
+  const total = Object.values(required ?? {}).reduce((sum, count) => sum + Number(count || 0), 0);
+  const requirementsError = (
+    formState.errors.inputs?.passwordRequirements as { message?: string } | undefined
+  )?.message;
+
+  return (
+    <DynamicSecretProviderGroup
+      id="sql-password-config"
+      presentation="collapse"
+      title="Password Configuration (optional)"
+    >
+      {mode === "create" && (
+        <ValidationRuleOverrideNotice
+          type={SecretValidationRuleType.DynamicSecrets}
+          provider={DynamicSecretRuleProvider.SqlDatabase}
+          environmentSlug={watch("environment")?.slug}
+          secretPath={secretPath}
+        />
+      )}
+      <FieldDescription>Set constraints on the generated database password.</FieldDescription>
+      <SqlPasswordNumberField fieldName="length" />
+      <FieldSet>
+        <FieldLegend variant="label">Minimum Required Character Counts</FieldLegend>
+        <FieldDescription className={total > length ? "text-danger" : undefined}>
+          Total required characters: {total} {total > length ? `(exceeds length of ${length})` : ""}
+        </FieldDescription>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <SqlPasswordNumberField fieldName="lowercase" />
+          <SqlPasswordNumberField fieldName="uppercase" />
+          <SqlPasswordNumberField fieldName="digits" />
+          <SqlPasswordNumberField fieldName="symbols" />
+        </div>
+        <FieldError>{requirementsError}</FieldError>
+      </FieldSet>
+      <Controller
+        control={control}
+        name="inputs.passwordRequirements.allowedSymbols"
+        render={({ field, fieldState: { error } }) => (
+          <Field data-invalid={Boolean(error)}>
+            <FieldLabel htmlFor="sql-password-allowed-symbols">
+              Symbols to use in password
+            </FieldLabel>
+            <Input
+              {...field}
+              value={field.value ?? ""}
+              id="sql-password-allowed-symbols"
+              placeholder="-_.~!*"
+              isError={Boolean(error)}
+              aria-describedby="sql-password-allowed-symbols-feedback"
+            />
+            <FieldFeedback
+              id="sql-password-allowed-symbols-feedback"
+              description="Default: -_.~!*"
+              error={error?.message}
+            />
+          </Field>
+        )}
+      />
+    </DynamicSecretProviderGroup>
+  );
+};
+
+const SqlAdvancedConfiguration = () => {
+  const { control } = useFormContext<TSqlDatabaseFormValues>();
+  const statements = [
+    {
+      name: "inputs.creationStatement" as const,
+      label: "Creation Statement",
+      description: "username, password and expiration are dynamically provisioned"
+    },
+    {
+      name: "inputs.revocationStatement" as const,
+      label: "Revocation Statement",
+      description: "username is dynamically provisioned"
+    },
+    {
+      name: "inputs.renewStatement" as const,
+      label: "Renew Statement",
+      description: "username and expiration are dynamically provisioned"
+    }
+  ];
+
+  return (
+    <DynamicSecretProviderGroup
+      id="sql-statements"
+      presentation="collapse"
+      title="Creation, Revocation & Renew Statements (optional)"
+    >
+      <DynamicSecretProviderFields fields={usernameTemplateField} />
+      <FieldDescription>
+        Customize SQL statements for managing database user lifecycle.
+      </FieldDescription>
+      {statements.map(({ name, label, description }) => (
+        <Controller
+          key={name}
+          control={control}
+          name={name}
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor={`sql-${name.split(".").at(-1)}`}>{label}</FieldLabel>
+              <TextArea
+                {...field}
+                value={field.value ?? ""}
+                id={`sql-${name.split(".").at(-1)}`}
+                rows={3}
+                isError={Boolean(error)}
+                aria-describedby={`sql-${name.split(".").at(-1)}-feedback`}
+              />
+              <FieldFeedback
+                id={`sql-${name.split(".").at(-1)}-feedback`}
+                description={description}
+                error={error?.message}
+              />
+            </Field>
+          )}
+        />
+      ))}
+    </DynamicSecretProviderGroup>
+  );
+};
+
+const SqlDatabaseFields = ({
+  mode,
+  context
+}: Pick<TDynamicSecretProviderRendererProps, "mode" | "context">) => {
+  const { control, setValue, watch } = useFormContext<TSqlDatabaseFormValues>();
+  const selectedClient = watch("inputs.client") ?? SqlProviders.Postgres;
+  const gatewayPoolId = watch("inputs.gatewayPoolId");
+
+  const handleVaultImport = (role: VaultDatabaseRole) => {
+    try {
+      const imported = getSqlDatabaseVaultImportValues(role);
+      setValue("name", imported.name);
+      setValue("inputs.client", imported.inputs.client);
+
+      const importableInputKeys = [
+        "host",
+        "port",
+        "database",
+        "username",
+        "ca",
+        "creationStatement",
+        "revocationStatement",
+        "renewStatement"
+      ] as const;
+      importableInputKeys.forEach((key) => {
+        const value = imported.inputs[key];
+        if (value !== undefined) setValue(`inputs.${key}`, value);
+      });
+      if (imported.defaultTTL) setValue("defaultTTL", imported.defaultTTL);
+      if (imported.maxTTL) setValue("maxTTL", imported.maxTTL);
+
+      if (imported.connectionUrlParseFailed) {
+        createNotification({
+          type: "info",
+          text: "Could not parse connection URL. Host, port, and database fields may need to be filled manually."
+        });
+      }
+      createNotification({
+        type: "info",
+        text: "Configuration loaded successfully from HashiCorp Vault"
+      });
+    } catch {
+      createNotification({
+        type: "error",
+        text: "Failed to load configuration from HashiCorp Vault"
+      });
+    }
+  };
+
+  return (
+    <>
+      {mode === "create" && <SqlVaultImport onImport={handleVaultImport} />}
+      <DynamicSecretProviderGroup id="sql-database-connection" presentation="panel">
+        <OrgPermissionCan
+          I={OrgGatewayPermissionActions.AttachGateways}
+          a={OrgPermissionSubjects.Gateway}
+        >
+          {(isAllowed) => (
+            <Controller
+              control={control}
+              name="inputs.gatewayId"
+              render={({ field, fieldState: { error } }) => {
+                const description = !isAllowed
+                  ? "You don't have permission to attach gateways to resources."
+                  : undefined;
+                const hasFeedback = Boolean(description || error?.message);
+
+                return (
+                  <Field data-invalid={Boolean(error)} data-disabled={!isAllowed}>
+                    <FieldTitle>Gateway</FieldTitle>
+                    <GatewayPicker
+                      isDisabled={!isAllowed}
+                      isError={Boolean(error)}
+                      value={{
+                        gatewayId: field.value ?? null,
+                        gatewayPoolId: gatewayPoolId ?? null
+                      }}
+                      onChange={({ gatewayId, gatewayPoolId: nextGatewayPoolId }) => {
+                        field.onChange(normalizeSqlGatewayValueForMode(mode, gatewayId));
+                        setValue(
+                          "inputs.gatewayPoolId",
+                          normalizeSqlGatewayValueForMode(mode, nextGatewayPoolId),
+                          { shouldDirty: true }
+                        );
+                      }}
+                    />
+                    {hasFeedback && (
+                      <FieldFeedback
+                        id="sql-database-gateway-feedback"
+                        description={description}
+                        error={error?.message}
+                      />
+                    )}
+                  </Field>
+                );
+              }}
+            />
+          )}
+        </OrgPermissionCan>
+
+        <Controller
+          control={control}
+          name="inputs.client"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)} data-disabled={mode === "edit"}>
+              <FieldLabel htmlFor="sql-database-service">Service</FieldLabel>
+              <Select
+                value={field.value ?? SqlProviders.Postgres}
+                disabled={mode === "edit"}
+                onValueChange={(value) => {
+                  // Radix Select can emit a spurious empty onValueChange while options mount
+                  // (esp. inside a <form>). Ignore it so create defaults don't trip the dirty guard.
+                  if (!value || value === field.value) return;
+                  const client = value as SqlProviders;
+                  field.onChange(client);
+                  const resetValues = getSqlClientResetValues(client);
+                  setValue("inputs.creationStatement", resetValues.creationStatement);
+                  setValue("inputs.renewStatement", resetValues.renewStatement);
+                  setValue("inputs.revocationStatement", resetValues.revocationStatement);
+                  setValue("inputs.port", resetValues.port);
+                  setValue("inputs.passwordRequirements.length", resetValues.passwordLength);
+                }}
+              >
+                <SelectTrigger
+                  ref={field.ref}
+                  id="sql-database-service"
+                  className="w-full"
+                  isError={Boolean(error)}
+                  onBlur={field.onBlur}
+                  aria-describedby={error ? "sql-database-service-error" : undefined}
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={SqlProviders.Postgres}>PostgreSQL</SelectItem>
+                  <SelectItem value={SqlProviders.MySql}>MySQL</SelectItem>
+                  <SelectItem value={SqlProviders.Oracle}>Oracle</SelectItem>
+                  <SelectItem value={SqlProviders.MsSQL}>Microsoft SQL Server</SelectItem>
+                </SelectContent>
+              </Select>
+              <FieldError id="sql-database-service-error">{error?.message}</FieldError>
+            </Field>
+          )}
+        />
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-[minmax(0,1fr)_8rem]">
+          <DynamicSecretProviderFields fields={sqlConnectionFields.slice(0, 1)} />
+          <Controller
+            control={control}
+            name="inputs.port"
+            render={({ field, fieldState: { error } }) => (
+              <Field data-invalid={Boolean(error)}>
+                <FieldLabel htmlFor="sql-database-port">Port</FieldLabel>
+                <Input
+                  ref={field.ref}
+                  id="sql-database-port"
+                  name={field.name}
+                  type="number"
+                  value={field.value ?? ""}
+                  onBlur={field.onBlur}
+                  onChange={(event) =>
+                    field.onChange(parseDynamicSecretProviderNumberInput(event.currentTarget.value))
+                  }
+                  isError={Boolean(error)}
+                  aria-describedby={error ? "sql-database-port-error" : undefined}
+                />
+                <FieldError id="sql-database-port-error">{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+        </div>
+        <DynamicSecretProviderFields fields={sqlConnectionFields.slice(1)} />
+
+        {selectedClient === SqlProviders.MsSQL && (
+          <Controller
+            control={control}
+            name="inputs.sslEnabled"
+            render={({ field, fieldState: { error } }) => (
+              <Field orientation="horizontal" data-invalid={Boolean(error)}>
+                <FieldContent>
+                  <FieldTitle>Encrypt Connection (SSL)</FieldTitle>
+                  <FieldError id="sql-database-ssl-enabled-error">{error?.message}</FieldError>
+                </FieldContent>
+                <Switch
+                  ref={field.ref}
+                  checked={field.value ?? false}
+                  onBlur={field.onBlur}
+                  onCheckedChange={field.onChange}
+                  aria-label="Encrypt Connection (SSL)"
+                  aria-describedby={error ? "sql-database-ssl-enabled-error" : undefined}
+                />
+              </Field>
+            )}
+          />
+        )}
+
+        <Controller
+          control={control}
+          name="inputs.ca"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="sql-database-ca">
+                CA (SSL) <span className="font-normal text-muted">(optional)</span>
+              </FieldLabel>
+              <SecretInput
+                {...field}
+                value={field.value ?? ""}
+                id="sql-database-ca"
+                aria-describedby={error ? "sql-database-ca-error" : undefined}
+              />
+              <FieldError id="sql-database-ca-error">{error?.message}</FieldError>
+            </Field>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="inputs.sslRejectUnauthorized"
+          render={({ field, fieldState: { error } }) => (
+            <Field orientation="horizontal" data-invalid={Boolean(error)}>
+              <FieldContent>
+                <FieldTitle>SSL Reject Unauthorized</FieldTitle>
+                <FieldFeedback
+                  id="sql-database-ssl-reject-feedback"
+                  description="Verify the server certificate against the supplied certificate authorities. Disable this option when using a self-signed certificate."
+                  error={error?.message}
+                />
+              </FieldContent>
+              <Switch
+                ref={field.ref}
+                checked={field.value ?? true}
+                onBlur={field.onBlur}
+                onCheckedChange={field.onChange}
+                aria-label="SSL Reject Unauthorized"
+                aria-describedby="sql-database-ssl-reject-feedback"
+              />
+            </Field>
+          )}
+        />
+      </DynamicSecretProviderGroup>
+
+      <SqlMetadataFields />
+      <SqlAdvancedConfiguration />
+      <SqlPasswordConfiguration mode={mode} secretPath={context.secretPath} />
+    </>
+  );
+};
+
+export const sqlDatabaseDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.SqlDatabase,
+  label: "SQL Database",
+  customRenderer: {
+    reasons: SQL_DATABASE_CUSTOM_RENDERER_REASONS,
+    Component: SqlDatabaseFields
+  },
+  create: {
+    schema: sqlDatabaseCreateFormSchema,
+    getDefaultValues: getSqlDatabaseCreateDefaultValues,
+    toPayload: getSqlDatabaseCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: sqlDatabaseEditFormSchema,
+    getDefaultValues: getSqlDatabaseEditDefaultValues,
+    toPayload: getSqlDatabaseEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sqlDatabaseContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sqlDatabaseContract.ts
@@ -1,0 +1,394 @@
+import type { FieldValues } from "react-hook-form";
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  SqlProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+import type { VaultDatabaseRole } from "@app/hooks/api/migration/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import type {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormMode,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const SQL_DATABASE_CUSTOM_RENDERER_REASONS = [
+  "conditional-fields",
+  "repeatable-fields",
+  "permission-aware-fields",
+  "import-workflow",
+  "non-scalar-value",
+  "context-aware-fields"
+] as const;
+
+export type TSqlPasswordRequirements = {
+  length: number;
+  required: {
+    lowercase: number;
+    uppercase: number;
+    digits: number;
+    symbols: number;
+  };
+  allowedSymbols?: string;
+};
+
+export type TSqlDatabaseInputs = {
+  client?: SqlProviders;
+  host?: string;
+  port?: number;
+  database?: string;
+  username?: string;
+  password?: string;
+  passwordRequirements?: TSqlPasswordRequirements;
+  creationStatement?: string;
+  revocationStatement?: string;
+  renewStatement?: string;
+  sslEnabled?: boolean;
+  ca?: string;
+  sslRejectUnauthorized?: boolean;
+  gatewayId?: string | null;
+  gatewayPoolId?: string | null;
+};
+
+export type TSqlDatabaseFormValues = TDynamicSecretProviderFormValues<TSqlDatabaseInputs> &
+  FieldValues & {
+    metadata?: { key: string; value: string }[];
+  };
+
+export const sqlPasswordRequirementsSchema = z
+  .object({
+    length: z.number().min(1).max(250),
+    required: z
+      .object({
+        lowercase: z.number().min(0),
+        uppercase: z.number().min(0),
+        digits: z.number().min(0),
+        symbols: z.number().min(0)
+      })
+      .refine(
+        (required) => Object.values(required).reduce((sum, count) => sum + count, 0) <= 250,
+        "Sum of required characters cannot exceed 250"
+      ),
+    allowedSymbols: z.string().optional()
+  })
+  .refine(
+    ({ length, required }) =>
+      Object.values(required).reduce((sum, count) => sum + count, 0) <= length,
+    "Sum of required characters cannot exceed the total length"
+  );
+
+const metadataSchema = z
+  .array(
+    z.object({
+      key: z.string().trim().min(1),
+      value: z.string().trim().default("")
+    })
+  )
+  .optional();
+
+export const sqlDatabaseCreateInputsSchema = z.object({
+  client: z.nativeEnum(SqlProviders),
+  host: z.string().toLowerCase().min(1),
+  port: z.number(),
+  database: z.string().min(1),
+  username: z.string().min(1),
+  password: z.string().min(1),
+  passwordRequirements: sqlPasswordRequirementsSchema.optional(),
+  creationStatement: z.string().min(1),
+  revocationStatement: z.string().min(1),
+  renewStatement: z.string().optional(),
+  sslEnabled: z.boolean().optional(),
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true),
+  gatewayId: z.string().optional(),
+  gatewayPoolId: z.string().optional()
+});
+
+export const sqlDatabaseEditInputsSchema = z
+  .object({
+    client: z.nativeEnum(SqlProviders),
+    host: z.string().toLowerCase().min(1),
+    port: z.number(),
+    database: z.string().min(1),
+    username: z.string().min(1),
+    password: z.string().min(1),
+    passwordRequirements: sqlPasswordRequirementsSchema.optional(),
+    creationStatement: z.string().min(1),
+    revocationStatement: z.string().min(1),
+    renewStatement: z.string().optional(),
+    sslEnabled: z.boolean().optional(),
+    ca: z.string().optional(),
+    sslRejectUnauthorized: z.boolean().optional(),
+    gatewayId: z.string().optional().nullable(),
+    gatewayPoolId: z.string().optional().nullable()
+  })
+  .partial();
+
+export const sqlDatabaseCreateFormSchema = createDynamicSecretProviderFormSchema(
+  sqlDatabaseCreateInputsSchema
+).extend({ metadata: metadataSchema }) as z.ZodType<TSqlDatabaseFormValues>;
+
+export const sqlDatabaseEditFormSchema = editDynamicSecretProviderFormSchema(
+  sqlDatabaseEditInputsSchema,
+  { usernameTemplateSchema: z.string().trim().nullable().optional() }
+).extend({ metadata: metadataSchema }) as z.ZodType<TSqlDatabaseFormValues>;
+
+export const getSqlStatements = (provider: SqlProviders) => {
+  if (provider === SqlProviders.MySql) {
+    return {
+      creationStatement:
+        "CREATE USER \"{{username}}\"@'%' IDENTIFIED BY '{{password}}';\nGRANT ALL ON \"{{database}}\".* TO \"{{username}}\"@'%';",
+      renewStatement: "",
+      revocationStatement:
+        'REVOKE ALL PRIVILEGES ON "{{database}}".* FROM "{{username}}"@\'%\';\nDROP USER "{{username}}"@\'%\';'
+    };
+  }
+
+  if (provider === SqlProviders.Oracle) {
+    return {
+      creationStatement:
+        'CREATE USER "{{username}}" IDENTIFIED BY "{{password}}";\nGRANT CONNECT TO "{{username}}";\nGRANT CREATE SESSION TO "{{username}}";',
+      renewStatement: "",
+      revocationStatement:
+        'REVOKE CONNECT FROM "{{username}}";\nREVOKE CREATE SESSION FROM "{{username}}";\nDROP USER "{{username}}";'
+    };
+  }
+
+  if (provider === SqlProviders.MsSQL) {
+    return {
+      creationStatement:
+        "CREATE LOGIN [{{username}}] WITH PASSWORD =  '{{password}}';\nCREATE USER [{{username}}] FOR LOGIN [{{username}}];\nGRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA::dbo TO [{{username}}];",
+      renewStatement: "",
+      revocationStatement: "DROP USER [{{username}}];\nDROP LOGIN [{{username}}];"
+    };
+  }
+
+  return {
+    creationStatement:
+      "CREATE USER \"{{username}}\" WITH ENCRYPTED PASSWORD '{{password}}' VALID UNTIL '{{expiration}}';\nGRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO \"{{username}}\";",
+    renewStatement: "ALTER ROLE \"{{username}}\" VALID UNTIL '{{expiration}}';",
+    revocationStatement:
+      'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM "{{username}}";\nDROP ROLE "{{username}}";'
+  };
+};
+
+export const getSqlDefaultPort = (provider: SqlProviders) => {
+  switch (provider) {
+    case SqlProviders.MySql:
+      return 3306;
+    case SqlProviders.Oracle:
+      return 1521;
+    case SqlProviders.MsSQL:
+      return 1433;
+    default:
+      return 5432;
+  }
+};
+
+export const getDefaultSqlPasswordRequirements = (
+  provider: SqlProviders
+): TSqlPasswordRequirements => ({
+  length: provider === SqlProviders.Oracle ? 30 : 48,
+  required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 0 },
+  allowedSymbols: "-_.~!*"
+});
+
+export const getSqlClientResetValues = (provider: SqlProviders) => ({
+  ...getSqlStatements(provider),
+  port: getSqlDefaultPort(provider),
+  passwordLength: getDefaultSqlPasswordRequirements(provider).length
+});
+
+export const normalizeSqlGatewayValueForMode = (
+  mode: TDynamicSecretProviderFormMode,
+  value: string | null
+) => (mode === "create" ? (value ?? undefined) : value);
+
+export const getSqlDatabaseCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TSqlDatabaseFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  metadata: [],
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    client: SqlProviders.Postgres,
+    host: "",
+    port: getSqlDefaultPort(SqlProviders.Postgres),
+    database: "default",
+    username: "",
+    password: "",
+    ...getSqlStatements(SqlProviders.Postgres),
+    sslRejectUnauthorized: true,
+    gatewayId: undefined,
+    gatewayPoolId: undefined,
+    passwordRequirements: getDefaultSqlPasswordRequirements(SqlProviders.Postgres)
+  }
+});
+
+export const getSqlDatabaseEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TSqlDatabaseFormValues => {
+  const inputs = context.dynamicSecret.inputs as TSqlDatabaseInputs;
+  const client = inputs.client ?? SqlProviders.Postgres;
+
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL,
+    metadata: context.dynamicSecret.metadata,
+    usernameTemplate:
+      context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+    inputs: {
+      ...inputs,
+      passwordRequirements: inputs.passwordRequirements ?? getDefaultSqlPasswordRequirements(client)
+    }
+  };
+};
+
+export const getSqlDatabaseCreatePayload = (
+  values: TSqlDatabaseFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.SqlDatabase> => {
+  const inputs = sqlDatabaseCreateInputsSchema.parse(values.inputs);
+
+  return {
+    provider: { type: DynamicSecretProviders.SqlDatabase, inputs },
+    maxTTL: values.maxTTL ?? undefined,
+    name: values.name,
+    path: context.secretPath,
+    defaultTTL: values.defaultTTL,
+    projectSlug: context.projectSlug,
+    environmentSlug: values.environment?.slug ?? "",
+    metadata: values.metadata,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+  };
+};
+
+export const getSqlDatabaseEditPayload = (
+  values: TSqlDatabaseFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => {
+  const inputs = sqlDatabaseEditInputsSchema.parse(values.inputs);
+
+  return {
+    name: context.dynamicSecret.name,
+    path: context.secretPath,
+    projectSlug: context.projectSlug,
+    environmentSlug: context.environment,
+    data: {
+      maxTTL: values.maxTTL || undefined,
+      defaultTTL: values.defaultTTL,
+      inputs: {
+        ...inputs,
+        gatewayId: inputs.gatewayId ?? null,
+        gatewayPoolId: inputs.gatewayPoolId ?? null
+      },
+      newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+      metadata: values.metadata,
+      usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+    }
+  };
+};
+
+const getSqlProviderFromVaultPlugin = (pluginName?: string) => {
+  const normalizedPluginName = pluginName?.toLowerCase() ?? "";
+  if (normalizedPluginName.includes("mysql")) return SqlProviders.MySql;
+  if (normalizedPluginName.includes("oracle")) return SqlProviders.Oracle;
+  if (normalizedPluginName.includes("mssql")) return SqlProviders.MsSQL;
+  return SqlProviders.Postgres;
+};
+
+const convertVaultVariables = (statement: string) =>
+  statement.replace(/\{\{name\}\}/g, "{{username}}");
+
+export const getSqlDatabaseVaultImportValues = (role: VaultDatabaseRole) => {
+  const client = getSqlProviderFromVaultPlugin(role.config.plugin_name);
+  const inputs: Partial<TSqlDatabaseInputs> = { client };
+  const connectionUrl = role.config.connection_details.connection_url ?? "";
+  let connectionUrlParseFailed = false;
+
+  try {
+    const trimmedUrl = connectionUrl.trim();
+    if (!trimmedUrl) throw new Error("Empty URL");
+
+    const setConnectionDetails = (host: string, port: number | undefined, database: string) => {
+      if (host) inputs.host = host;
+      const parsedPort = port ?? getSqlDefaultPort(client);
+      inputs.port = Number.isNaN(parsedPort) ? getSqlDefaultPort(client) : parsedPort;
+      if (database) inputs.database = database;
+    };
+    const parseStandardUrl = (url: URL, dbFromParams?: string) => {
+      if (url.username) inputs.username = url.username;
+      const port = url.port ? parseInt(url.port, 10) : undefined;
+      setConnectionDetails(url.hostname, port, dbFromParams || url.pathname.replace(/^\//, ""));
+    };
+
+    if (client === SqlProviders.MySql) {
+      const tcpMatch = trimmedUrl.match(/@tcp\(([^:]+):?(\d+)?\)\/([^?#]+)/);
+      if (tcpMatch) {
+        setConnectionDetails(
+          tcpMatch[1],
+          tcpMatch[2] ? parseInt(tcpMatch[2], 10) : undefined,
+          tcpMatch[3]
+        );
+      } else if (trimmedUrl.includes("://")) {
+        parseStandardUrl(new URL(trimmedUrl));
+      }
+    } else if (client === SqlProviders.Oracle) {
+      const oracleMatch = trimmedUrl.match(/@(?:\/\/)?([^:/]+):?(\d+)?\/(.+)/);
+      if (oracleMatch) {
+        setConnectionDetails(
+          oracleMatch[1],
+          oracleMatch[2] ? parseInt(oracleMatch[2], 10) : undefined,
+          oracleMatch[3]
+        );
+      }
+    } else if (client === SqlProviders.MsSQL) {
+      const url = new URL(trimmedUrl);
+      parseStandardUrl(
+        url,
+        url.searchParams.get("database") || url.searchParams.get("databaseName") || ""
+      );
+    } else {
+      parseStandardUrl(new URL(trimmedUrl));
+    }
+  } catch {
+    connectionUrlParseFailed = true;
+  }
+
+  if (role.config.connection_details.username) {
+    inputs.username = role.config.connection_details.username;
+  }
+  if (role.config.connection_details.tls_ca) inputs.ca = role.config.connection_details.tls_ca;
+  if (role.creation_statements?.length) {
+    inputs.creationStatement = role.creation_statements.map(convertVaultVariables).join("\n");
+  }
+  if (role.revocation_statements?.length) {
+    inputs.revocationStatement = role.revocation_statements.map(convertVaultVariables).join("\n");
+  }
+  if (role.renew_statements?.length) {
+    inputs.renewStatement = role.renew_statements.map(convertVaultVariables).join("\n");
+  }
+
+  return {
+    name: role.name,
+    defaultTTL: role.default_ttl ? `${role.default_ttl}s` : undefined,
+    maxTTL: role.max_ttl ? `${role.max_ttl}s` : undefined,
+    inputs,
+    connectionUrlParseFailed
+  };
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/vertica.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/vertica.tsx
@@ -1,0 +1,204 @@
+import { Controller, useFormContext } from "react-hook-form";
+
+import { OrgPermissionCan } from "@app/components/permissions";
+import { Field, FieldDescription, FieldFeedback, FieldTitle } from "@app/components/v3";
+import { GatewayPicker } from "@app/components/v3/platform/GatewayPicker";
+import { OrgPermissionSubjects } from "@app/context";
+import { OrgGatewayPermissionActions } from "@app/context/OrgPermissionContext/types";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { normalizeDynamicSecretGatewayValueForMode } from "../schemas";
+import { defineDynamicSecretProvider, TDynamicSecretProviderRendererProps } from "../types";
+import {
+  getVerticaCreateDefaultValues,
+  getVerticaCreatePayload,
+  getVerticaEditDefaultValues,
+  getVerticaEditPayload,
+  TVerticaCreateFormValues,
+  TVerticaEditFormValues,
+  VERTICA_CUSTOM_RENDERER_REASONS,
+  verticaCreateFormSchema,
+  verticaEditFormSchema
+} from "./verticaContract";
+
+const connectionFields = [
+  { name: "inputs.host", type: "text", label: "Host", placeholder: "Vertica Host", layout: "half" },
+  { name: "inputs.port", type: "number", label: "Port", layout: "half" },
+  { name: "inputs.database", type: "text", label: "Database", layout: "half" },
+  { name: "inputs.username", type: "text", label: "User", autoComplete: "off", layout: "half" },
+  {
+    name: "inputs.password",
+    type: "secret",
+    label: "Password",
+    autoComplete: "new-password",
+    layout: "half"
+  }
+] as const;
+
+const statementFields = [
+  {
+    name: "usernameTemplate",
+    type: "text",
+    label: "Username Template",
+    placeholder: "{{randomUsername}}"
+  },
+  { name: "inputs.creationStatement", type: "textarea", label: "Creation Statement", rows: 3 },
+  {
+    name: "inputs.revocationStatement",
+    type: "textarea",
+    label: "Revocation Statement",
+    rows: 3
+  }
+] as const;
+
+const passwordRequirementFields = [
+  {
+    name: "inputs.passwordRequirements.length",
+    type: "number",
+    label: "Password Length",
+    description: "Total generated password length."
+  },
+  {
+    name: "inputs.passwordRequirements.required.lowercase",
+    type: "number",
+    label: "Lowercase Count",
+    description: "Minimum number of lowercase letters.",
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.uppercase",
+    type: "number",
+    label: "Uppercase Count",
+    description: "Minimum number of uppercase letters.",
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.digits",
+    type: "number",
+    label: "Digit Count",
+    description: "Minimum number of digits.",
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.symbols",
+    type: "number",
+    label: "Symbol Count",
+    description: "Minimum number of symbols.",
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.allowedSymbols",
+    type: "text",
+    label: "Allowed Symbols",
+    description: "Symbols available to the password generator.",
+    isOptional: true
+  }
+] as const;
+
+const VerticaFields = ({ mode }: TDynamicSecretProviderRendererProps) => {
+  const { control, setValue, watch } = useFormContext<
+    TVerticaCreateFormValues | TVerticaEditFormValues
+  >();
+  const gatewayId = watch("inputs.gatewayId");
+  const gatewayPoolId = watch("inputs.gatewayPoolId");
+
+  return (
+    <>
+      <DynamicSecretProviderGroup id="vertica-connection" presentation="panel">
+        <OrgPermissionCan
+          I={OrgGatewayPermissionActions.AttachGateways}
+          a={OrgPermissionSubjects.Gateway}
+        >
+          {(isAllowed) => (
+            <Controller
+              control={control}
+              name="inputs.gatewayId"
+              render={({ fieldState: { error } }) => {
+                const description = !isAllowed
+                  ? "You don't have permission to attach gateways to resources."
+                  : undefined;
+                const hasFeedback = Boolean(description || error?.message);
+
+                return (
+                  <Field data-invalid={Boolean(error)} data-disabled={!isAllowed}>
+                    <FieldTitle>Gateway</FieldTitle>
+                    <GatewayPicker
+                      isDisabled={!isAllowed}
+                      isError={Boolean(error)}
+                      value={{ gatewayId: gatewayId ?? null, gatewayPoolId: gatewayPoolId ?? null }}
+                      onChange={({
+                        gatewayId: nextGatewayId,
+                        gatewayPoolId: nextGatewayPoolId
+                      }) => {
+                        setValue(
+                          "inputs.gatewayId",
+                          normalizeDynamicSecretGatewayValueForMode(mode, nextGatewayId),
+                          { shouldDirty: true }
+                        );
+                        setValue(
+                          "inputs.gatewayPoolId",
+                          normalizeDynamicSecretGatewayValueForMode(mode, nextGatewayPoolId),
+                          { shouldDirty: true }
+                        );
+                      }}
+                    />
+                    {hasFeedback && (
+                      <FieldFeedback
+                        id="vertica-gateway-feedback"
+                        description={description}
+                        error={error?.message}
+                      />
+                    )}
+                  </Field>
+                );
+              }}
+            />
+          )}
+        </OrgPermissionCan>
+
+        <DynamicSecretProviderFields fields={connectionFields} />
+      </DynamicSecretProviderGroup>
+
+      <DynamicSecretProviderGroup
+        id="vertica-statements"
+        presentation="collapse"
+        title="Modify SQL Statements"
+      >
+        <DynamicSecretProviderFields fields={statementFields} />
+      </DynamicSecretProviderGroup>
+
+      <DynamicSecretProviderGroup
+        id="vertica-password"
+        presentation="collapse"
+        title="Password Configuration (optional)"
+      >
+        <FieldDescription>Set constraints on the generated database password.</FieldDescription>
+        <DynamicSecretProviderFields fields={passwordRequirementFields} />
+      </DynamicSecretProviderGroup>
+    </>
+  );
+};
+
+export const verticaDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Vertica,
+  label: "Vertica",
+  customRenderer: {
+    reasons: VERTICA_CUSTOM_RENDERER_REASONS,
+    Component: VerticaFields
+  },
+  create: {
+    schema: verticaCreateFormSchema,
+    getDefaultValues: getVerticaCreateDefaultValues,
+    toPayload: getVerticaCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: verticaEditFormSchema,
+    getDefaultValues: getVerticaEditDefaultValues,
+    toPayload: getVerticaEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/verticaContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/verticaContract.ts
@@ -1,0 +1,173 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const VERTICA_CUSTOM_RENDERER_REASONS = [
+  "permission-aware-fields",
+  "non-scalar-value",
+  "context-aware-fields"
+] as const;
+
+const buildVerticaPasswordRequirementsSchema = (minimumLength: number) =>
+  z
+    .object({
+      length: z.number().min(minimumLength).max(250),
+      required: z
+        .object({
+          lowercase: z.number().min(0),
+          uppercase: z.number().min(0),
+          digits: z.number().min(0),
+          symbols: z.number().min(0)
+        })
+        .refine(
+          (required) => Object.values(required).reduce((sum, count) => sum + count, 0) <= 250,
+          "Sum of required characters cannot exceed 250"
+        ),
+      allowedSymbols: z.string().optional()
+    })
+    .refine(
+      ({ length, required }) =>
+        Object.values(required).reduce((sum, count) => sum + count, 0) <= length,
+      "Sum of required characters cannot exceed the total length"
+    );
+
+export const verticaCreatePasswordRequirementsSchema = buildVerticaPasswordRequirementsSchema(8);
+export const verticaEditPasswordRequirementsSchema = buildVerticaPasswordRequirementsSchema(1);
+
+export const verticaCreateInputsSchema = z.object({
+  host: z.string().toLowerCase().min(1),
+  port: z.number(),
+  database: z.string().min(1),
+  username: z.string().min(1),
+  password: z.string().min(1),
+  passwordRequirements: verticaCreatePasswordRequirementsSchema.optional(),
+  creationStatement: z.string().min(1),
+  revocationStatement: z.string().min(1),
+  gatewayId: z.string().optional(),
+  gatewayPoolId: z.string().optional()
+});
+
+export const verticaEditInputsSchema = verticaCreateInputsSchema
+  .extend({
+    passwordRequirements: verticaEditPasswordRequirementsSchema.optional(),
+    gatewayId: z.string().optional().nullable(),
+    gatewayPoolId: z.string().optional().nullable()
+  })
+  .partial();
+
+export type TVerticaCreateFormValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof verticaCreateInputsSchema>
+>;
+export type TVerticaEditFormValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof verticaEditInputsSchema>
+>;
+
+export const verticaCreateFormSchema = createDynamicSecretProviderFormSchema(
+  verticaCreateInputsSchema
+) as z.ZodType<TVerticaCreateFormValues>;
+
+export const verticaEditFormSchema = editDynamicSecretProviderFormSchema(verticaEditInputsSchema, {
+  usernameTemplateSchema: z.string().trim().nullable().optional()
+}) as z.ZodType<TVerticaEditFormValues>;
+
+export const getDefaultVerticaPasswordRequirements = () => ({
+  length: 48,
+  required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 0 },
+  allowedSymbols: "-_.~!*"
+});
+
+export const getVerticaCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TVerticaCreateFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "",
+    port: 5433,
+    database: "",
+    username: "",
+    password: "",
+    passwordRequirements: getDefaultVerticaPasswordRequirements(),
+    creationStatement:
+      "CREATE USER {{username}} IDENTIFIED BY '{{password}}';\nGRANT CREATE ON SCHEMA public TO {{username}};",
+    revocationStatement: "DROP USER {{username}} CASCADE;"
+  }
+});
+
+export const getVerticaEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TVerticaEditFormValues => {
+  const inputs = context.dynamicSecret.inputs as TVerticaEditFormValues["inputs"];
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL,
+    usernameTemplate:
+      context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+    inputs: {
+      ...inputs,
+      passwordRequirements: inputs.passwordRequirements || getDefaultVerticaPasswordRequirements()
+    }
+  };
+};
+
+export const getVerticaCreatePayload = (
+  values: TVerticaCreateFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Vertica> => ({
+  provider: {
+    type: DynamicSecretProviders.Vertica,
+    inputs: verticaCreateInputsSchema.parse(values.inputs)
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+
+export const getVerticaEditPayload = (
+  values: TVerticaEditFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => {
+  const inputs = verticaEditInputsSchema.parse(values.inputs);
+  return {
+    name: context.dynamicSecret.name,
+    path: context.secretPath,
+    projectSlug: context.projectSlug,
+    environmentSlug: context.environment,
+    data: {
+      maxTTL: values.maxTTL || undefined,
+      defaultTTL: values.defaultTTL,
+      inputs: {
+        ...inputs,
+        gatewayId: inputs.gatewayId ?? null,
+        gatewayPoolId: inputs.gatewayPoolId ?? null
+      },
+      newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+      usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+    }
+  };
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/registry.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/registry.ts
@@ -1,0 +1,114 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type { TDynamicSecretProviderDefinition } from "./types";
+
+export type TRegisteredDynamicSecretProviderDefinition = TDynamicSecretProviderDefinition<
+  DynamicSecretProviders,
+  // Provider value types remain available from each concrete definition. The
+  // composition root intentionally erases them for heterogeneous lookup.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any
+>;
+
+export type TDynamicSecretProviderDefinitionModule = {
+  id: string;
+  definitions: readonly TRegisteredDynamicSecretProviderDefinition[];
+};
+
+export const defineDynamicSecretProviderModule = <
+  const TDefinitions extends readonly TRegisteredDynamicSecretProviderDefinition[]
+>(module: {
+  id: string;
+  definitions: TDefinitions;
+}) => module;
+
+/** Product picker order. Partially migrated registries expose only registered entries. */
+export const DYNAMIC_SECRET_PROVIDER_PICKER_ORDER = [
+  DynamicSecretProviders.SqlDatabase,
+  DynamicSecretProviders.Cassandra,
+  DynamicSecretProviders.Redis,
+  DynamicSecretProviders.AwsElastiCache,
+  DynamicSecretProviders.AwsMemoryDb,
+  DynamicSecretProviders.AwsIam,
+  DynamicSecretProviders.MongoAtlas,
+  DynamicSecretProviders.MongoDB,
+  DynamicSecretProviders.ElasticSearch,
+  DynamicSecretProviders.RabbitMq,
+  DynamicSecretProviders.AzureEntraId,
+  DynamicSecretProviders.AzureSqlDatabase,
+  DynamicSecretProviders.Ldap,
+  DynamicSecretProviders.SapHana,
+  DynamicSecretProviders.SapAse,
+  DynamicSecretProviders.Snowflake,
+  DynamicSecretProviders.Totp,
+  DynamicSecretProviders.Vertica,
+  DynamicSecretProviders.Kubernetes,
+  DynamicSecretProviders.GcpIam,
+  DynamicSecretProviders.Github,
+  DynamicSecretProviders.Couchbase,
+  DynamicSecretProviders.Milvus,
+  DynamicSecretProviders.Clickhouse,
+  DynamicSecretProviders.Ssh,
+  DynamicSecretProviders.IbmApiConnect,
+  DynamicSecretProviders.Tailscale
+] as const satisfies readonly DynamicSecretProviders[];
+
+const DYNAMIC_SECRET_PROVIDER_DOCS_SLUG: Partial<Record<DynamicSecretProviders, string>> = {
+  [DynamicSecretProviders.SqlDatabase]: "postgresql",
+  [DynamicSecretProviders.MongoAtlas]: "mongo-atlas"
+};
+
+export const createDynamicSecretProviderRegistry = (
+  ...modules: readonly TDynamicSecretProviderDefinitionModule[]
+) => {
+  const definitions = new Map<DynamicSecretProviders, TRegisteredDynamicSecretProviderDefinition>();
+  const moduleIds = new Set<string>();
+
+  modules.forEach((module) => {
+    if (moduleIds.has(module.id)) {
+      throw new Error(
+        `Dynamic-secret provider module "${module.id}" was registered more than once.`
+      );
+    }
+    moduleIds.add(module.id);
+
+    module.definitions.forEach((definition) => {
+      if (definitions.has(definition.provider)) {
+        throw new Error(
+          `Dynamic-secret provider "${definition.provider}" was registered more than once.`
+        );
+      }
+      definitions.set(definition.provider, definition);
+    });
+  });
+
+  const providers = Object.freeze(
+    DYNAMIC_SECRET_PROVIDER_PICKER_ORDER.filter((provider) => definitions.has(provider))
+  );
+  const registeredDefinitions = Object.freeze(
+    providers.map(
+      (provider) => definitions.get(provider) as TRegisteredDynamicSecretProviderDefinition
+    )
+  );
+
+  return Object.freeze({
+    providers,
+    definitions: registeredDefinitions,
+    hasDefinition: (provider: DynamicSecretProviders) => definitions.has(provider),
+    getDefinition: (provider: DynamicSecretProviders) => definitions.get(provider),
+    requireDefinition: (provider: DynamicSecretProviders) => {
+      const definition = definitions.get(provider);
+      if (!definition) {
+        throw new Error(`Dynamic-secret provider "${provider}" is not registered.`);
+      }
+      return definition;
+    },
+    getLabel: (provider: DynamicSecretProviders) => definitions.get(provider)?.label,
+    getDocsSlug: (provider: DynamicSecretProviders) =>
+      DYNAMIC_SECRET_PROVIDER_DOCS_SLUG[provider] ?? provider
+  });
+};
+
+export type TDynamicSecretProviderRegistry = ReturnType<typeof createDynamicSecretProviderRegistry>;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/relational-gateway-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/relational-gateway-contract.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  getVerticaCreateDefaultValues,
+  getVerticaCreatePayload,
+  getVerticaEditDefaultValues,
+  getVerticaEditPayload,
+  verticaCreateFormSchema
+} from "./providerDefinitions/verticaContract";
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+const environment = { id: "env-id", name: "Development", slug: "dev", position: 1 };
+
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+
+const getEditContext = (inputs: unknown) =>
+  ({
+    projectSlug: "project",
+    secretPath: "/folder",
+    environment: "dev",
+    dynamicSecret: {
+      name: "vertica-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      usernameTemplate: null,
+      inputs
+    }
+  }) as TEditDynamicSecretProviderFormContext;
+
+describe("relational gateway dynamic-secret contracts", () => {
+  it("retains Vertica defaults and validates required connection fields", () => {
+    const values = getVerticaCreateDefaultValues(createContext);
+    assert.equal(values.inputs.port, 5433);
+    assert.equal(values.inputs.passwordRequirements?.length, 48);
+    assert.match(values.inputs.creationStatement, /CREATE USER/);
+    assert.equal(verticaCreateFormSchema.safeParse(values).success, false);
+  });
+
+  it("builds the Vertica create DTO without inventing cleared gateways", () => {
+    const values = getVerticaCreateDefaultValues(createContext);
+    Object.assign(values, { name: "vertica-secret" });
+    Object.assign(values.inputs, {
+      host: "vertica.example.com",
+      database: "analytics",
+      username: "admin",
+      password: "secret"
+    });
+
+    const payload = getVerticaCreatePayload(values, createContext);
+    assert.equal(payload.provider.type, DynamicSecretProviders.Vertica);
+    assert.equal(payload.environmentSlug, "dev");
+    assert.equal(payload.usernameTemplate, undefined);
+    assert.equal((payload.provider.inputs as { gatewayId?: string }).gatewayId, undefined);
+  });
+
+  it("passes masked edit credentials through and clears both gateway selectors with null", () => {
+    const context = getEditContext({
+      host: "vertica.example.com",
+      port: 5433,
+      database: "analytics",
+      username: "admin",
+      password: "********",
+      creationStatement: "create",
+      revocationStatement: "revoke"
+    });
+    const values = getVerticaEditDefaultValues(context);
+    const payload = getVerticaEditPayload(values, context);
+    const inputs = payload.data.inputs as {
+      password?: string;
+      gatewayId?: string | null;
+      gatewayPoolId?: string | null;
+    };
+
+    assert.equal(values.inputs.password, "********");
+    assert.equal(inputs.password, "********");
+    assert.equal(inputs.gatewayId, null);
+    assert.equal(inputs.gatewayPoolId, null);
+    assert.equal(payload.data.usernameTemplate, null);
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/relational-warehouse-registration.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/relational-warehouse-registration.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { AZURE_SQL_DATABASE_CUSTOM_RENDERER_REASONS } from "./providerDefinitions/azureSqlDatabaseContract";
+import { CLICKHOUSE_CUSTOM_RENDERER_REASONS } from "./providerDefinitions/clickHouseContract";
+import { RELATIONAL_WAREHOUSE_DYNAMIC_SECRET_PROVIDERS } from "./providerDefinitions/relationalWarehouseContract";
+import { SAP_ASE_CUSTOM_RENDERER_REASONS } from "./providerDefinitions/sapAseContract";
+import { SAP_HANA_CUSTOM_RENDERER_REASONS } from "./providerDefinitions/sapHanaContract";
+import { SNOWFLAKE_CUSTOM_RENDERER_REASONS } from "./providerDefinitions/snowflakeContract";
+import { SQL_DATABASE_CUSTOM_RENDERER_REASONS } from "./providerDefinitions/sqlDatabaseContract";
+import { VERTICA_CUSTOM_RENDERER_REASONS } from "./providerDefinitions/verticaContract";
+import type { TRegisteredDynamicSecretProviderDefinition } from "./registry";
+import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
+
+const definitions = RELATIONAL_WAREHOUSE_DYNAMIC_SECRET_PROVIDERS.map(
+  (provider) =>
+    ({
+      provider,
+      label: provider,
+      create: {
+        getDefaultValues: () => ({}),
+        toPayload: () => ({}),
+        submitLabel: "Submit"
+      },
+      edit: {
+        getDefaultValues: () => ({}),
+        toPayload: () => ({}),
+        submitLabel: "Save",
+        successMessage: "Updated"
+      }
+    }) as unknown as TRegisteredDynamicSecretProviderDefinition
+);
+
+const relationalWarehouseContractModule = defineDynamicSecretProviderModule({
+  id: "relational-warehouse-contract",
+  definitions
+});
+
+describe("relational and warehouse dynamic-secret provider registration", () => {
+  it("registers the seven-provider batch with create/edit parity", () => {
+    assert.deepEqual(
+      relationalWarehouseContractModule.definitions.map(({ provider }) => provider),
+      RELATIONAL_WAREHOUSE_DYNAMIC_SECRET_PROVIDERS
+    );
+
+    relationalWarehouseContractModule.definitions.forEach((definition) => {
+      assert.equal(typeof definition.create.getDefaultValues, "function");
+      assert.equal(typeof definition.create.toPayload, "function");
+      assert.equal(typeof definition.edit.getDefaultValues, "function");
+      assert.equal(typeof definition.edit.toPayload, "function");
+    });
+  });
+
+  it("composes the batch in product picker order", () => {
+    const registry = createDynamicSecretProviderRegistry(relationalWarehouseContractModule);
+
+    assert.deepEqual(registry.providers, [
+      DynamicSecretProviders.SqlDatabase,
+      DynamicSecretProviders.AzureSqlDatabase,
+      DynamicSecretProviders.SapHana,
+      DynamicSecretProviders.SapAse,
+      DynamicSecretProviders.Snowflake,
+      DynamicSecretProviders.Vertica,
+      DynamicSecretProviders.Clickhouse
+    ]);
+    registry.providers.forEach((provider) => {
+      assert.equal(registry.requireDefinition(provider).provider, provider);
+    });
+  });
+
+  it("keeps provider-specific renderers explicit", () => {
+    assert.ok(SQL_DATABASE_CUSTOM_RENDERER_REASONS.includes("import-workflow"));
+    assert.ok(AZURE_SQL_DATABASE_CUSTOM_RENDERER_REASONS.includes("conditional-fields"));
+    assert.ok(CLICKHOUSE_CUSTOM_RENDERER_REASONS.includes("repeatable-fields"));
+    assert.ok(VERTICA_CUSTOM_RENDERER_REASONS.includes("permission-aware-fields"));
+    assert.ok(SAP_ASE_CUSTOM_RENDERER_REASONS.includes("non-scalar-value"));
+    assert.ok(SAP_HANA_CUSTOM_RENDERER_REASONS.includes("non-scalar-value"));
+    assert.ok(SNOWFLAKE_CUSTOM_RENDERER_REASONS.includes("non-scalar-value"));
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/scalarValues.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/scalarValues.ts
@@ -1,0 +1,10 @@
+/**
+ * HTML number inputs emit strings. Store finite numbers in React Hook Form so
+ * provider-owned `z.number()` schemas receive the value type they declare.
+ */
+export const parseDynamicSecretProviderNumberInput = (value: string) => {
+  if (value.trim() === "") return undefined;
+
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) ? parsedValue : undefined;
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
@@ -7,8 +7,16 @@ import type { TDynamicSecretProviderFormMode } from "./types";
 
 export const DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE = "{{randomUsername}}";
 
-export const dynamicSecretTtlSchema = z.string().superRefine((value, context) => {
+const validateDynamicSecretTtl = (value: string, context: z.RefinementCtx) => {
   const valueInMilliseconds = ms(value);
+
+  if (valueInMilliseconds === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be a valid duration"
+    });
+    return;
+  }
 
   if (valueInMilliseconds < 60 * 1000) {
     context.addIssue({
@@ -23,7 +31,15 @@ export const dynamicSecretTtlSchema = z.string().superRefine((value, context) =>
       message: "TTL must be less than 10 years"
     });
   }
-});
+};
+
+export const dynamicSecretTtlSchema = z
+  .string()
+  .min(1, "TTL is required")
+  .superRefine((value, context) => {
+    if (!value) return;
+    validateDynamicSecretTtl(value, context);
+  });
 
 export const optionalDynamicSecretTtlSchema = z
   .string()
@@ -31,21 +47,7 @@ export const optionalDynamicSecretTtlSchema = z
   .superRefine((value, context) => {
     if (!value) return;
 
-    const valueInMilliseconds = ms(value);
-
-    if (valueInMilliseconds < 60 * 1000) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "TTL must be a greater than 1min"
-      });
-    }
-
-    if (valueInMilliseconds > ms("10y")) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "TTL must be less than 10 years"
-      });
-    }
+    validateDynamicSecretTtl(value, context);
   });
 
 const environmentSchema = z.object({

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
@@ -1,0 +1,102 @@
+import ms from "ms";
+import { z } from "zod";
+
+import { slugSchema } from "@app/lib/schemas";
+
+import type { TDynamicSecretProviderFormMode } from "./types";
+
+export const DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE = "{{randomUsername}}";
+
+export const dynamicSecretTtlSchema = z.string().superRefine((value, context) => {
+  const valueInMilliseconds = ms(value);
+
+  if (valueInMilliseconds < 60 * 1000) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be a greater than 1min"
+    });
+  }
+
+  if (valueInMilliseconds > ms("10y")) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be less than 10 years"
+    });
+  }
+});
+
+export const optionalDynamicSecretTtlSchema = z
+  .string()
+  .optional()
+  .superRefine((value, context) => {
+    if (!value) return;
+
+    const valueInMilliseconds = ms(value);
+
+    if (valueInMilliseconds < 60 * 1000) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "TTL must be a greater than 1min"
+      });
+    }
+
+    if (valueInMilliseconds > ms("10y")) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "TTL must be less than 10 years"
+      });
+    }
+  });
+
+const environmentSchema = z.object({
+  name: z.string(),
+  slug: z.string()
+});
+
+type TDynamicSecretFormSchemaOptions = {
+  usernameTemplateSchema?: z.ZodTypeAny;
+};
+
+export const createDynamicSecretProviderFormSchema = <TInputs extends z.ZodTypeAny>(
+  inputsSchema: TInputs,
+  options: TDynamicSecretFormSchemaOptions = {}
+) =>
+  z.object({
+    name: slugSchema(),
+    defaultTTL: dynamicSecretTtlSchema,
+    maxTTL: optionalDynamicSecretTtlSchema,
+    environment: environmentSchema,
+    usernameTemplate: options.usernameTemplateSchema ?? z.string().nullable().optional(),
+    inputs: inputsSchema
+  });
+
+export const editDynamicSecretProviderFormSchema = <TInputs extends z.ZodTypeAny>(
+  inputsSchema: TInputs,
+  options: TDynamicSecretFormSchemaOptions = {}
+) =>
+  z.object({
+    name: slugSchema(),
+    defaultTTL: dynamicSecretTtlSchema,
+    maxTTL: optionalDynamicSecretTtlSchema.nullable(),
+    environment: environmentSchema.optional(),
+    usernameTemplate: options.usernameTemplateSchema ?? z.string().nullable().optional(),
+    inputs: inputsSchema
+  });
+
+export const normalizeDynamicSecretUsernameTemplateForCreate = (
+  usernameTemplate?: string | null
+) =>
+  !usernameTemplate || usernameTemplate === DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+    ? undefined
+    : usernameTemplate;
+
+export const normalizeDynamicSecretUsernameTemplateForEdit = (usernameTemplate?: string | null) =>
+  !usernameTemplate || usernameTemplate === DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+    ? null
+    : usernameTemplate;
+
+/** Create omits a cleared gateway; edit sends null to detach an existing gateway. */
+export const normalizeDynamicSecretGatewayValueForMode = (
+  mode: TDynamicSecretProviderFormMode,
+  value?: string | null
+) => value || (mode === "create" ? undefined : null);

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/SslRejectUnauthorizedField.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/SslRejectUnauthorizedField.tsx
@@ -1,0 +1,68 @@
+import { Controller, FieldValues, Path, useFormContext } from "react-hook-form";
+
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FieldTitle,
+  Switch
+} from "@app/components/v3";
+
+type Props<TValues extends FieldValues> = {
+  name?: Path<TValues>;
+  id?: string;
+  fallbackChecked?: boolean;
+  layout?: "labeled" | "content";
+};
+
+export const SslRejectUnauthorizedField = <TValues extends FieldValues>({
+  name = "inputs.sslRejectUnauthorized" as Path<TValues>,
+  id = "dynamic-secret-ssl-reject-unauthorized",
+  fallbackChecked = true,
+  layout = "content"
+}: Props<TValues>) => {
+  const { control } = useFormContext<TValues>();
+  const descriptionId = `${id}-description`;
+  const errorId = `${id}-error`;
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState: { error } }) => (
+        <Field data-invalid={Boolean(error)} orientation="horizontal">
+          {layout === "labeled" ? (
+            <div className="flex flex-1 flex-col gap-0.5">
+              <FieldLabel htmlFor={id}>SSL Reject Unauthorized</FieldLabel>
+              <FieldDescription id={descriptionId}>
+                Verify the server certificate against the supplied certificate authorities.
+              </FieldDescription>
+              {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+            </div>
+          ) : (
+            <FieldContent>
+              <FieldTitle>SSL Reject Unauthorized</FieldTitle>
+              <FieldDescription id={descriptionId}>
+                Verify the server certificate against the supplied certificate authorities.
+              </FieldDescription>
+              {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+            </FieldContent>
+          )}
+          <Switch
+            ref={field.ref}
+            id={id}
+            variant="project"
+            checked={field.value ?? fallbackChecked}
+            onBlur={field.onBlur}
+            onCheckedChange={field.onChange}
+            aria-invalid={Boolean(error)}
+            aria-label="SSL Reject Unauthorized"
+            aria-describedby={`${descriptionId}${error?.message ? ` ${errorId}` : ""}`}
+          />
+        </Field>
+      )}
+    />
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/StatementAccordion.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/StatementAccordion.tsx
@@ -1,0 +1,90 @@
+import { FieldValues, Path } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { TDynamicSecretProviderField } from "../types";
+import { usernameTemplateFieldDefinition } from "./UsernameTemplateField";
+
+type StatementCopy = {
+  creation?: string;
+  revocation?: string;
+  renew?: string;
+};
+
+type BuildOptions = {
+  includeUsernameTemplate?: boolean;
+  includeRenew?: boolean;
+  renewOptional?: boolean;
+  creationRows?: number;
+  copy?: StatementCopy;
+};
+
+const DEFAULT_COPY: Required<StatementCopy> = {
+  creation: "Username, password, and expiration are dynamically provisioned.",
+  revocation: "Username is dynamically provisioned.",
+  renew: "Username and expiration are dynamically provisioned."
+};
+
+export const buildStatementFields = <TValues extends FieldValues>(
+  options: BuildOptions = {}
+): TDynamicSecretProviderField<TValues>[] => {
+  const {
+    includeUsernameTemplate = true,
+    includeRenew = true,
+    renewOptional = true,
+    creationRows = 3,
+    copy = {}
+  } = options;
+  const resolvedCopy = { ...DEFAULT_COPY, ...copy };
+  const fields: TDynamicSecretProviderField<TValues>[] = [];
+
+  if (includeUsernameTemplate) {
+    fields.push(usernameTemplateFieldDefinition as TDynamicSecretProviderField<TValues>);
+  }
+
+  fields.push(
+    {
+      name: "inputs.creationStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Creation Statement",
+      ...(resolvedCopy.creation ? { description: resolvedCopy.creation } : {}),
+      rows: creationRows
+    },
+    {
+      name: "inputs.revocationStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Revocation Statement",
+      ...(resolvedCopy.revocation ? { description: resolvedCopy.revocation } : {}),
+      rows: 3
+    }
+  );
+
+  if (includeRenew) {
+    fields.push({
+      name: "inputs.renewStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Renew Statement",
+      ...(resolvedCopy.renew ? { description: resolvedCopy.renew } : {}),
+      isOptional: renewOptional,
+      rows: 3
+    });
+  }
+
+  return fields;
+};
+
+type Props<TValues extends FieldValues> = {
+  title: string;
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+  value?: string;
+};
+
+export const StatementAccordion = <TValues extends FieldValues>({
+  title,
+  fields,
+  value = "statements"
+}: Props<TValues>) => (
+  <DynamicSecretProviderGroup id={value} presentation="collapse" title={title}>
+    <DynamicSecretProviderFields fields={fields} />
+  </DynamicSecretProviderGroup>
+);

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/UsernameTemplateField.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/UsernameTemplateField.tsx
@@ -1,0 +1,20 @@
+import { FieldValues } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import { TDynamicSecretProviderField } from "../types";
+
+export const usernameTemplateFieldDefinition = {
+  name: "usernameTemplate",
+  type: "text",
+  label: "Username Template",
+  placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+} as const;
+
+type Props<TValues extends FieldValues> = {
+  fields?: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+export const UsernameTemplateFields = <TValues extends FieldValues>({
+  fields = [usernameTemplateFieldDefinition as TDynamicSecretProviderField<TValues>]
+}: Props<TValues>) => <DynamicSecretProviderFields fields={fields} />;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/index.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/index.ts
@@ -1,0 +1,3 @@
+export { SslRejectUnauthorizedField } from "./SslRejectUnauthorizedField";
+export { buildStatementFields, StatementAccordion } from "./StatementAccordion";
+export { usernameTemplateFieldDefinition, UsernameTemplateFields } from "./UsernameTemplateField";

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/simple-sql-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/simple-sql-contract.test.ts
@@ -134,16 +134,21 @@ describe("simple SQL dynamic-secret contracts", () => {
 
     assert.equal(hanaValues.inputs.password, "********");
     assert.equal(hanaValues.inputs.ca, "********");
+    assert.equal(hanaValues.inputs.sslRejectUnauthorized, true);
     assert.equal(snowflakeValues.inputs.password, "********");
     assert.equal((hanaPayload.data.inputs as { password?: string }).password, "********");
     assert.equal((hanaPayload.data.inputs as { ca?: string }).ca, "********");
+    assert.equal(
+      (hanaPayload.data.inputs as { sslRejectUnauthorized?: boolean }).sslRejectUnauthorized,
+      true
+    );
     assert.equal((snowflakePayload.data.inputs as { password?: string }).password, "********");
     assert.equal(hanaPayload.data.newName, "renamed-hana-secret");
     assert.equal(hanaPayload.data.usernameTemplate, null);
     assert.equal(snowflakePayload.data.usernameTemplate, null);
   });
 
-  it("preserves the SAP ASE create/edit CA asymmetry", () => {
+  it("strips the unsupported SAP ASE CA from edit values and payloads", () => {
     const createValues = getSapAseCreateDefaultValues(createContext);
     assert.equal("ca" in createValues.inputs, false);
 
@@ -158,10 +163,35 @@ describe("simple SQL dynamic-secret contracts", () => {
       ca: "********"
     });
     const editValues = getSapAseEditDefaultValues(editContext);
-    assert.equal(editValues.inputs.ca, "********");
+    assert.equal("ca" in editValues.inputs, false);
     assert.equal(sapAseEditFormSchema.safeParse(editValues).success, true);
 
     const payload = getSapAseEditPayload(editValues, editContext);
-    assert.equal((payload.data.inputs as { ca?: string }).ca, "********");
+    assert.equal("ca" in (payload.data.inputs as Record<string, unknown>), false);
+  });
+
+  it("defaults missing SAP HANA TLS verification to true and preserves explicit false", () => {
+    const enabledContext = getEditContext({ host: "hana.example.com" });
+    const enabledValues = getSapHanaEditDefaultValues(enabledContext);
+    const enabledPayload = getSapHanaEditPayload(enabledValues, enabledContext);
+
+    assert.equal(enabledValues.inputs.sslRejectUnauthorized, true);
+    assert.equal(
+      (enabledPayload.data.inputs as { sslRejectUnauthorized?: boolean }).sslRejectUnauthorized,
+      true
+    );
+
+    const disabledContext = getEditContext({
+      host: "hana.example.com",
+      sslRejectUnauthorized: false
+    });
+    const disabledValues = getSapHanaEditDefaultValues(disabledContext);
+    const disabledPayload = getSapHanaEditPayload(disabledValues, disabledContext);
+
+    assert.equal(disabledValues.inputs.sslRejectUnauthorized, false);
+    assert.equal(
+      (disabledPayload.data.inputs as { sslRejectUnauthorized?: boolean }).sslRejectUnauthorized,
+      false
+    );
   });
 });

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/simple-sql-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/simple-sql-contract.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  getSapAseCreateDefaultValues,
+  getSapAseCreatePayload,
+  getSapAseEditDefaultValues,
+  getSapAseEditPayload,
+  sapAseCreateFormSchema,
+  sapAseEditFormSchema
+} from "./providerDefinitions/sapAseContract";
+import {
+  getSapHanaCreateDefaultValues,
+  getSapHanaCreatePayload,
+  getSapHanaEditDefaultValues,
+  getSapHanaEditPayload,
+  sapHanaCreateFormSchema
+} from "./providerDefinitions/sapHanaContract";
+import {
+  getSnowflakeCreateDefaultValues,
+  getSnowflakeCreatePayload,
+  getSnowflakeEditDefaultValues,
+  getSnowflakeEditPayload,
+  snowflakeCreateFormSchema
+} from "./providerDefinitions/snowflakeContract";
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+const environment = { id: "env-id", name: "Development", slug: "dev", position: 1 };
+
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+
+const getEditContext = (
+  inputs: unknown,
+  overrides: Partial<TEditDynamicSecretProviderFormContext["dynamicSecret"]> = {}
+) =>
+  ({
+    projectSlug: "project",
+    secretPath: "/folder",
+    environment: "dev",
+    dynamicSecret: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      usernameTemplate: null,
+      inputs,
+      ...overrides
+    }
+  }) as TEditDynamicSecretProviderFormContext;
+
+describe("simple SQL dynamic-secret contracts", () => {
+  it("preserves provider-specific defaults and validates required connection inputs", () => {
+    const sapHana = getSapHanaCreateDefaultValues(createContext);
+    const sapAse = getSapAseCreateDefaultValues(createContext);
+    const snowflake = getSnowflakeCreateDefaultValues(createContext);
+
+    assert.equal(sapHana.inputs.port, 443);
+    assert.equal(sapHana.inputs.sslRejectUnauthorized, true);
+    assert.match(sapHana.inputs.creationStatement, /CREATE USER/);
+    assert.match(sapHana.inputs.revocationStatement, /DROP USER/);
+    assert.match(sapHana.inputs.renewStatement ?? "", /ALTER USER/);
+    assert.equal(sapAse.inputs.port, 5000);
+    assert.equal(sapAse.inputs.database, "master");
+    assert.match(sapAse.inputs.creationStatement, /sp_addlogin/);
+    assert.match(sapAse.inputs.revocationStatement, /sp_droplogin/);
+    assert.match(snowflake.inputs.creationStatement, /DAYS_TO_EXPIRY/);
+    assert.match(snowflake.inputs.revocationStatement, /DROP USER/);
+    assert.match(snowflake.inputs.renewStatement ?? "", /ALTER USER/);
+
+    assert.equal(sapHanaCreateFormSchema.safeParse(sapHana).success, false);
+    assert.equal(sapAseCreateFormSchema.safeParse(sapAse).success, false);
+    assert.equal(snowflakeCreateFormSchema.safeParse(snowflake).success, false);
+  });
+
+  it("builds create payloads with exact provider discriminators and username normalization", () => {
+    const sapHanaValues = getSapHanaCreateDefaultValues(createContext);
+    Object.assign(sapHanaValues.inputs, {
+      host: "hana.example.com",
+      username: "admin",
+      password: "secret"
+    });
+    const sapAseValues = getSapAseCreateDefaultValues(createContext);
+    Object.assign(sapAseValues.inputs, {
+      host: "ase.example.com",
+      username: "admin",
+      password: "secret"
+    });
+    const snowflakeValues = getSnowflakeCreateDefaultValues(createContext);
+    Object.assign(snowflakeValues.inputs, {
+      accountId: "account",
+      orgId: "organization",
+      username: "admin",
+      password: "token"
+    });
+
+    sapHanaValues.name = "hana-secret";
+    sapAseValues.name = "ase-secret";
+    snowflakeValues.name = "snowflake-secret";
+
+    const sapHanaPayload = getSapHanaCreatePayload(sapHanaValues, createContext);
+    const sapAsePayload = getSapAseCreatePayload(sapAseValues, createContext);
+    const snowflakePayload = getSnowflakeCreatePayload(snowflakeValues, createContext);
+
+    assert.equal(sapHanaPayload.provider.type, DynamicSecretProviders.SapHana);
+    assert.equal(sapAsePayload.provider.type, DynamicSecretProviders.SapAse);
+    assert.equal(snowflakePayload.provider.type, DynamicSecretProviders.Snowflake);
+    assert.equal(sapHanaPayload.environmentSlug, "dev");
+    assert.equal(sapHanaPayload.usernameTemplate, undefined);
+  });
+
+  it("retains masked edit secrets and existing rename/template semantics", () => {
+    const hanaContext = getEditContext({
+      host: "hana.example.com",
+      password: "********",
+      ca: "********"
+    });
+    const hanaValues = getSapHanaEditDefaultValues(hanaContext);
+    const hanaPayload = getSapHanaEditPayload(
+      { ...hanaValues, name: "renamed-hana-secret" },
+      hanaContext
+    );
+    const snowflakeContext = getEditContext({ accountId: "account", password: "********" });
+    const snowflakeValues = getSnowflakeEditDefaultValues(snowflakeContext);
+    const snowflakePayload = getSnowflakeEditPayload(snowflakeValues, snowflakeContext);
+
+    assert.equal(hanaValues.inputs.password, "********");
+    assert.equal(hanaValues.inputs.ca, "********");
+    assert.equal(snowflakeValues.inputs.password, "********");
+    assert.equal((hanaPayload.data.inputs as { password?: string }).password, "********");
+    assert.equal((hanaPayload.data.inputs as { ca?: string }).ca, "********");
+    assert.equal((snowflakePayload.data.inputs as { password?: string }).password, "********");
+    assert.equal(hanaPayload.data.newName, "renamed-hana-secret");
+    assert.equal(hanaPayload.data.usernameTemplate, null);
+    assert.equal(snowflakePayload.data.usernameTemplate, null);
+  });
+
+  it("preserves the SAP ASE create/edit CA asymmetry", () => {
+    const createValues = getSapAseCreateDefaultValues(createContext);
+    assert.equal("ca" in createValues.inputs, false);
+
+    const editContext = getEditContext({
+      host: "ase.example.com",
+      port: 5000,
+      database: "master",
+      username: "admin",
+      password: "********",
+      creationStatement: "create",
+      revocationStatement: "revoke",
+      ca: "********"
+    });
+    const editValues = getSapAseEditDefaultValues(editContext);
+    assert.equal(editValues.inputs.ca, "********");
+    assert.equal(sapAseEditFormSchema.safeParse(editValues).success, true);
+
+    const payload = getSapAseEditPayload(editValues, editContext);
+    assert.equal((payload.data.inputs as { ca?: string }).ca, "********");
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/sql-database-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/sql-database-contract.test.ts
@@ -1,0 +1,236 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { DynamicSecretProviders, SqlProviders } from "@app/hooks/api/dynamicSecret/types";
+import type { VaultDatabaseRole } from "@app/hooks/api/migration/types";
+
+import {
+  getDefaultSqlPasswordRequirements,
+  getSqlClientResetValues,
+  getSqlDatabaseCreateDefaultValues,
+  getSqlDatabaseCreatePayload,
+  getSqlDatabaseEditDefaultValues,
+  getSqlDatabaseEditPayload,
+  getSqlDatabaseVaultImportValues,
+  getSqlDefaultPort,
+  normalizeSqlGatewayValueForMode,
+  sqlDatabaseCreateFormSchema
+} from "./providerDefinitions/sqlDatabaseContract";
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+const environment = { id: "env-id", name: "Development", slug: "dev", position: 1 };
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+
+const validInputs = {
+  client: SqlProviders.Postgres,
+  host: "sql.example.com",
+  port: 5432,
+  database: "application",
+  username: "admin",
+  password: "new-password",
+  creationStatement: "create user",
+  revocationStatement: "drop user",
+  renewStatement: "alter user",
+  sslEnabled: false,
+  sslRejectUnauthorized: true,
+  ca: "certificate",
+  gatewayId: "gateway",
+  gatewayPoolId: "pool",
+  passwordRequirements: getDefaultSqlPasswordRequirements(SqlProviders.Postgres)
+};
+
+const editContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environment: "dev",
+  dynamicSecret: {
+    id: "dynamic-secret-id",
+    name: "sql-secret",
+    type: DynamicSecretProviders.SqlDatabase,
+    createdAt: "2026-01-01",
+    updatedAt: "2026-01-01",
+    defaultTTL: "1h",
+    maxTTL: "24h",
+    usernameTemplate: null,
+    metadata: [{ key: "owner", value: "platform" }],
+    inputs: {
+      ...validInputs,
+      password: "********",
+      ca: "********",
+      gatewayId: null,
+      gatewayPoolId: null
+    }
+  }
+} satisfies TEditDynamicSecretProviderFormContext;
+
+const getVaultRole = (
+  pluginName: string,
+  connectionUrl: string,
+  overrides: Partial<VaultDatabaseRole> = {}
+): VaultDatabaseRole => ({
+  name: "vault-role",
+  mountPath: "database",
+  db_name: "database-config",
+  config: {
+    plugin_name: pluginName,
+    connection_details: { connection_url: connectionUrl }
+  },
+  ...overrides
+});
+
+describe("SQL Database provider contract", () => {
+  it("preserves each SQL discriminator, default port, statements, and password length reset", () => {
+    const expected = [
+      [SqlProviders.Postgres, 5432, 48, "CREATE USER"],
+      [SqlProviders.MySql, 3306, 48, "CREATE USER"],
+      [SqlProviders.Oracle, 1521, 30, "CREATE USER"],
+      [SqlProviders.MsSQL, 1433, 48, "CREATE LOGIN"]
+    ] as const;
+
+    expected.forEach(([client, port, passwordLength, statementPrefix]) => {
+      const reset = getSqlClientResetValues(client);
+      assert.equal(getSqlDefaultPort(client), port);
+      assert.equal(reset.port, port);
+      assert.equal(reset.passwordLength, passwordLength);
+      assert.match(reset.creationStatement, new RegExp(`^${statementPrefix}`));
+      assert.equal(typeof reset.revocationStatement, "string");
+    });
+  });
+
+  it("builds the exact create discriminator, metadata, gateway, and template semantics", () => {
+    const defaults = getSqlDatabaseCreateDefaultValues(createContext);
+    assert.equal(defaults.inputs.client, SqlProviders.Postgres);
+    assert.equal(defaults.inputs.port, 5432);
+    assert.deepEqual(defaults.environment, environment);
+
+    const payload = getSqlDatabaseCreatePayload(
+      {
+        ...defaults,
+        name: "sql-secret",
+        metadata: [{ key: "owner", value: "platform" }],
+        inputs: validInputs
+      },
+      createContext
+    );
+
+    assert.equal(payload.provider.type, DynamicSecretProviders.SqlDatabase);
+    assert.equal(payload.provider.inputs.client, SqlProviders.Postgres);
+    assert.equal(payload.provider.inputs.gatewayId, "gateway");
+    assert.equal(payload.environmentSlug, "dev");
+    assert.equal(payload.usernameTemplate, undefined);
+    assert.deepEqual(payload.metadata, [{ key: "owner", value: "platform" }]);
+  });
+
+  it("hydrates masked edit secrets and preserves rename, null gateway, and template semantics", () => {
+    const values = getSqlDatabaseEditDefaultValues(editContext);
+    assert.equal(values.inputs.password, "********");
+    assert.equal(values.inputs.ca, "********");
+    assert.equal(values.inputs.gatewayId, null);
+    assert.deepEqual(values.metadata, [{ key: "owner", value: "platform" }]);
+
+    const payload = getSqlDatabaseEditPayload(
+      { ...values, name: "renamed-sql-secret", maxTTL: "" },
+      editContext
+    );
+    const inputs = payload.data.inputs as {
+      password: string;
+      ca: string;
+      gatewayId: null;
+      gatewayPoolId: null;
+    };
+    assert.equal(inputs.password, "********");
+    assert.equal(inputs.ca, "********");
+    assert.equal(inputs.gatewayId, null);
+    assert.equal(inputs.gatewayPoolId, null);
+    assert.equal(payload.data.newName, "renamed-sql-secret");
+    assert.equal(payload.data.maxTTL, undefined);
+    assert.equal(payload.data.usernameTemplate, null);
+  });
+
+  it("keeps validation messages and mode-specific cleared gateway values", () => {
+    const defaults = getSqlDatabaseCreateDefaultValues(createContext);
+    const result = sqlDatabaseCreateFormSchema.safeParse({
+      ...defaults,
+      name: "sql-secret",
+      inputs: {
+        ...validInputs,
+        passwordRequirements: {
+          length: 2,
+          required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 0 }
+        }
+      }
+    });
+    assert.equal(result.success, false);
+    if (!result.success) {
+      assert.equal(
+        result.error.issues.at(-1)?.message,
+        "Sum of required characters cannot exceed the total length"
+      );
+    }
+    assert.equal(normalizeSqlGatewayValueForMode("create", null), undefined);
+    assert.equal(normalizeSqlGatewayValueForMode("edit", null), null);
+  });
+
+  it("maps Vault connection formats, explicit usernames, statements, CA, and TTLs", () => {
+    const mysql = getSqlDatabaseVaultImportValues(
+      getVaultRole("mysql-database-plugin", "user:pass@tcp(mysql.internal:3307)/app")
+    );
+    assert.deepEqual(mysql.inputs, {
+      client: SqlProviders.MySql,
+      host: "mysql.internal",
+      port: 3307,
+      database: "app"
+    });
+
+    const oracle = getSqlDatabaseVaultImportValues(
+      getVaultRole("oracle-database-plugin", "user/pass@//oracle.internal:1522/service")
+    );
+    assert.equal(oracle.inputs.client, SqlProviders.Oracle);
+    assert.equal(oracle.inputs.host, "oracle.internal");
+    assert.equal(oracle.inputs.port, 1522);
+    assert.equal(oracle.inputs.database, "service");
+
+    const mssqlRole = getVaultRole(
+      "mssql-database-plugin",
+      "sqlserver://url-user:pass@mssql.internal:1434?databaseName=app",
+      {
+        default_ttl: 3600,
+        max_ttl: 86400,
+        creation_statements: ["CREATE LOGIN {{name}}"],
+        revocation_statements: ["DROP LOGIN {{name}}"],
+        renew_statements: ["ALTER LOGIN {{name}}"],
+        config: {
+          plugin_name: "mssql-database-plugin",
+          connection_details: {
+            connection_url: "sqlserver://url-user:pass@mssql.internal:1434?databaseName=app",
+            username: "explicit-user",
+            tls_ca: "vault-ca"
+          }
+        }
+      }
+    );
+    const mssql = getSqlDatabaseVaultImportValues(mssqlRole);
+    assert.equal(mssql.inputs.client, SqlProviders.MsSQL);
+    assert.equal(mssql.inputs.username, "explicit-user");
+    assert.equal(mssql.inputs.ca, "vault-ca");
+    assert.equal(mssql.inputs.creationStatement, "CREATE LOGIN {{username}}");
+    assert.equal(mssql.inputs.revocationStatement, "DROP LOGIN {{username}}");
+    assert.equal(mssql.inputs.renewStatement, "ALTER LOGIN {{username}}");
+    assert.equal(mssql.defaultTTL, "3600s");
+    assert.equal(mssql.maxTTL, "86400s");
+    assert.equal(mssql.connectionUrlParseFailed, false);
+
+    const invalid = getSqlDatabaseVaultImportValues(
+      getVaultRole("postgresql-database-plugin", "not a URL")
+    );
+    assert.equal(invalid.connectionUrlParseFailed, true);
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/types.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/types.ts
@@ -1,0 +1,205 @@
+import type { ComponentType } from "react";
+import type { DefaultValues, FieldPath, FieldValues } from "react-hook-form";
+import type { z } from "zod";
+
+import type {
+  DynamicSecretProviders,
+  TCreateDynamicSecretDTO,
+  TDynamicSecret,
+  TDynamicSecretProvider,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+import type { ProjectEnv } from "@app/hooks/api/types";
+
+export const DYNAMIC_SECRET_CUSTOM_RENDERER_REASONS = [
+  "conditional-fields",
+  "repeatable-fields",
+  "permission-aware-fields",
+  "remote-options",
+  "import-workflow",
+  "non-scalar-value",
+  "multi-create",
+  "post-create-workflow",
+  "context-aware-fields"
+] as const;
+
+export type TDynamicSecretCustomRendererReason =
+  (typeof DYNAMIC_SECRET_CUSTOM_RENDERER_REASONS)[number];
+
+export type TDynamicSecretProviderFormMode = "create" | "edit";
+
+export type TDynamicSecretProviderCommonField = {
+  isVisible?: boolean;
+  isDisabled?: boolean;
+  label?: string;
+  description?: string;
+};
+
+export type TDynamicSecretProviderCommonFields = {
+  name?: TDynamicSecretProviderCommonField;
+  defaultTTL?: TDynamicSecretProviderCommonField;
+  maxTTL?: TDynamicSecretProviderCommonField;
+  environment?: TDynamicSecretProviderCommonField;
+  configurationHeading?: string | false;
+};
+
+export type TDynamicSecretFormEnvironment = Pick<ProjectEnv, "name" | "slug">;
+
+export type TDynamicSecretProviderFormValues<TInputs extends FieldValues = FieldValues> = {
+  name: string;
+  defaultTTL: string;
+  maxTTL?: string | null;
+  environment?: TDynamicSecretFormEnvironment;
+  usernameTemplate?: string | null;
+  inputs: TInputs;
+};
+
+type TDynamicSecretBaseField<TValues extends FieldValues> = {
+  name: FieldPath<TValues>;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  isOptional?: boolean;
+  isDisabled?: boolean;
+  layout?: "full" | "half";
+};
+
+export type TDynamicSecretProviderField<TValues extends FieldValues> =
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "text" | "secret";
+      autoComplete?: string;
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "number";
+      min?: number;
+      max?: number;
+      step?: number | "any";
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "textarea";
+      rows?: number;
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "select";
+      options: readonly { label: string; value: string }[];
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "switch";
+    });
+
+export type TDynamicSecretProviderFieldGroupPresentation = "panel" | "collapse";
+
+type TDynamicSecretProviderFieldGroupBase<TValues extends FieldValues> = {
+  kind: "group";
+  id: string;
+  description?: string;
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+export type TDynamicSecretProviderFieldGroup<TValues extends FieldValues> =
+  | (TDynamicSecretProviderFieldGroupBase<TValues> & {
+      presentation?: "panel";
+      title?: string;
+      surface?: boolean;
+    })
+  | (TDynamicSecretProviderFieldGroupBase<TValues> & {
+      presentation: "collapse";
+      title: string;
+    });
+
+export type TDynamicSecretProviderFormItem<TValues extends FieldValues> =
+  | TDynamicSecretProviderField<TValues>
+  | TDynamicSecretProviderFieldGroup<TValues>;
+
+export const isDynamicSecretProviderFieldGroup = <TValues extends FieldValues>(
+  item: TDynamicSecretProviderFormItem<TValues>
+): item is TDynamicSecretProviderFieldGroup<TValues> => "kind" in item && item.kind === "group";
+
+export type TDynamicSecretProviderOf<TProvider extends DynamicSecretProviders> = Extract<
+  TDynamicSecretProvider,
+  { type: TProvider }
+>;
+
+export type TCreateDynamicSecretProviderDTO<TProvider extends DynamicSecretProviders> = Omit<
+  TCreateDynamicSecretDTO,
+  "provider"
+> & {
+  provider: TDynamicSecretProviderOf<TProvider>;
+};
+
+export type TDynamicSecretWithInputs = TDynamicSecret & { inputs: unknown };
+
+export type TCreateDynamicSecretProviderFormContext = {
+  projectSlug: string;
+  secretPath: string;
+  environments: ProjectEnv[];
+  isSingleEnvironmentMode?: boolean;
+};
+
+export type TEditDynamicSecretProviderFormContext = {
+  projectSlug: string;
+  secretPath: string;
+  environment: string;
+  dynamicSecret: TDynamicSecretWithInputs;
+};
+
+export type TDynamicSecretProviderRendererProps = {
+  mode: TDynamicSecretProviderFormMode;
+  context: TCreateDynamicSecretProviderFormContext | TEditDynamicSecretProviderFormContext;
+  setSubmitState: (state: { isDisabled?: boolean; isPending?: boolean }) => void;
+};
+
+export type TDynamicSecretProviderCustomRenderer = {
+  reasons: readonly [TDynamicSecretCustomRendererReason, ...TDynamicSecretCustomRendererReason[]];
+  Component: ComponentType<TDynamicSecretProviderRendererProps>;
+};
+
+export type TDynamicSecretProviderDefinition<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues = TCreateValues
+> = {
+  provider: TProvider;
+  label: string;
+  fields?: readonly TDynamicSecretProviderFormItem<TCreateValues & TEditValues>[];
+  customRenderer?: TDynamicSecretProviderCustomRenderer;
+  create: {
+    schema: z.ZodType<TCreateValues>;
+    getDefaultValues: (
+      context: TCreateDynamicSecretProviderFormContext
+    ) => DefaultValues<TCreateValues>;
+    toPayload: (
+      values: TCreateValues,
+      context: TCreateDynamicSecretProviderFormContext
+    ) =>
+      | TCreateDynamicSecretProviderDTO<TProvider>
+      | readonly TCreateDynamicSecretProviderDTO<TProvider>[];
+    fields?: readonly TDynamicSecretProviderFormItem<TCreateValues>[];
+    customRenderer?: TDynamicSecretProviderCustomRenderer;
+    commonFields?: TDynamicSecretProviderCommonFields;
+    submitLabel: string;
+  };
+  edit: {
+    schema: z.ZodType<TEditValues>;
+    getDefaultValues: (
+      context: TEditDynamicSecretProviderFormContext
+    ) => DefaultValues<TEditValues>;
+    toPayload: (
+      values: TEditValues,
+      context: TEditDynamicSecretProviderFormContext
+    ) => TUpdateDynamicSecretDTO;
+    fields?: readonly TDynamicSecretProviderFormItem<TEditValues>[];
+    customRenderer?: TDynamicSecretProviderCustomRenderer;
+    commonFields?: TDynamicSecretProviderCommonFields;
+    submitLabel: string;
+    successMessage: string;
+  };
+};
+
+export const defineDynamicSecretProvider = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues = TCreateValues
+>(
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>
+) => definition;

--- a/frontend/src/components/dynamic-secrets/index.ts
+++ b/frontend/src/components/dynamic-secrets/index.ts
@@ -1,0 +1,1 @@
+export * from "./DynamicSecretProviderForm";


### PR DESCRIPTION
## Context

[ENG-5515](https://linear.app/infisical/issue/ENG-5515/migrate-relational-and-warehouse-dynamic-secret-provider-forms) migrates the SQL Database, Azure SQL Database, ClickHouse, Snowflake, Vertica, SAP ASE, and SAP HANA dynamic-secret provider forms onto the shared provider contract introduced by stacked parent PR [#7563](https://github.com/Infisical/infisical/pull/7563).

Previously, these providers existed only in the legacy create and edit form paths, and the shared registry had no relational/warehouse rollout batch. This change adds provider-owned create/edit schemas, defaults, payload adapters, explicit custom renderers, gateway and TLS normalization, statement handling, username-template handling, masked edit behavior, and an immutable seven-provider batch module. Numeric form values remain numbers through validation and payload construction, including focused ClickHouse regression coverage.

Production routes remain on the legacy forms, so current user-visible behavior and API payloads are unchanged. Production composition of completed provider batches is intentionally deferred to a later integration change.

## Screenshots

Not applicable. This PR defines replacement form contracts and renderers but does not wire them into a user-visible production route.

## Steps to verify the change

From `frontend/`:

1. Run targeted lint:
   ```sh
   node ./node_modules/eslint/bin/eslint.js 'src/components/dynamic-secrets/DynamicSecretProviderForm/**/*.{ts,tsx}'
   ```
2. Run the full frontend typecheck:
   ```sh
   node ./node_modules/typescript/bin/tsc --noEmit --project tsconfig.app.json
   ```
3. Run the scoped and shared-foundation contract suite:
   ```sh
   node ./node_modules/tsx/dist/cli.mjs --tsconfig tsconfig.app.json --test src/components/dynamic-secrets/DynamicSecretProviderForm/*.test.ts
   ```

Verified locally:

- Targeted ESLint: passed
- Full frontend TypeScript check: passed
- Scoped/foundation contract suite: 36 tests across 11 suites passed

The focused coverage includes defaults, validation, create/edit payload parity, gateway behavior, TLS and statement fields, username templates, masked values, omission versus null semantics, provider-specific branches, numeric payload values, explicit renderer boundaries, and immutable seven-provider registration.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)