### PR TITLE
feat(dynamic-secrets): migrate managed-store provider forms

### DIFF
--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFields.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFields.tsx
@@ -1,0 +1,181 @@
+import { Controller, FieldValues, useFormContext } from "react-hook-form";
+
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch,
+  TextArea
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+
+import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
+import { TDynamicSecretProviderField } from "./types";
+
+type Props<TValues extends FieldValues> = {
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+const getFieldId = (name: string) => `dynamic-secret-${name.replaceAll(".", "-")}`;
+
+export const DynamicSecretProviderFields = <TValues extends FieldValues>({
+  fields
+}: Props<TValues>) => {
+  const { control } = useFormContext<TValues>();
+
+  return (
+    <div className="@container">
+      <div className="grid grid-cols-1 gap-3 @xl:grid-cols-2">
+        {fields.map((fieldDefinition) => {
+          const inputId = getFieldId(fieldDefinition.name);
+          const descriptionId = `${inputId}-description`;
+          const errorId = `${inputId}-error`;
+
+          return (
+            <Controller
+              key={fieldDefinition.name}
+              control={control}
+              name={fieldDefinition.name}
+              render={({ field, fieldState: { error } }) => {
+                const value =
+                  typeof field.value === "string" || typeof field.value === "number"
+                    ? field.value
+                    : "";
+                const describedBy = [
+                  fieldDefinition.description ? descriptionId : undefined,
+                  error?.message ? errorId : undefined
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                let input;
+
+                if (fieldDefinition.type === "switch") {
+                  input = (
+                    <Switch
+                      ref={field.ref}
+                      id={inputId}
+                      variant="project"
+                      checked={Boolean(field.value)}
+                      onBlur={field.onBlur}
+                      onCheckedChange={field.onChange}
+                      disabled={fieldDefinition.isDisabled}
+                      aria-describedby={describedBy || undefined}
+                      aria-invalid={Boolean(error)}
+                    />
+                  );
+                } else if (fieldDefinition.type === "select") {
+                  input = (
+                    <Select
+                      value={String(value)}
+                      disabled={fieldDefinition.isDisabled}
+                      onValueChange={(nextValue) => {
+                        // Radix Select can emit an empty change while options mount.
+                        if (!nextValue || nextValue === String(value)) return;
+                        field.onChange(nextValue);
+                      }}
+                    >
+                      <SelectTrigger
+                        ref={field.ref}
+                        id={inputId}
+                        onBlur={field.onBlur}
+                        isError={Boolean(error)}
+                        aria-describedby={describedBy || undefined}
+                        className="w-full"
+                      >
+                        <SelectValue placeholder={fieldDefinition.placeholder} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {fieldDefinition.options.map((option) => (
+                          <SelectItem key={option.value} value={option.value}>
+                            {option.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  );
+                } else if (fieldDefinition.type === "textarea") {
+                  input = (
+                    <TextArea
+                      ref={field.ref}
+                      id={inputId}
+                      name={field.name}
+                      value={value}
+                      onBlur={field.onBlur}
+                      onChange={field.onChange}
+                      rows={fieldDefinition.rows}
+                      placeholder={fieldDefinition.placeholder}
+                      disabled={fieldDefinition.isDisabled}
+                      isError={Boolean(error)}
+                      aria-describedby={describedBy || undefined}
+                    />
+                  );
+                } else {
+                  const isNumber = fieldDefinition.type === "number";
+                  let inputType = "text";
+                  if (isNumber) inputType = "number";
+                  if (fieldDefinition.type === "secret") inputType = "password";
+                  input = (
+                    <Input
+                      ref={field.ref}
+                      id={inputId}
+                      name={field.name}
+                      value={value}
+                      onBlur={field.onBlur}
+                      onChange={
+                        isNumber
+                          ? (event) =>
+                              field.onChange(
+                                parseDynamicSecretProviderNumberInput(event.currentTarget.value)
+                              )
+                          : field.onChange
+                      }
+                      type={inputType}
+                      autoComplete={
+                        fieldDefinition.type === "number" ? undefined : fieldDefinition.autoComplete
+                      }
+                      min={isNumber ? fieldDefinition.min : undefined}
+                      max={isNumber ? fieldDefinition.max : undefined}
+                      step={isNumber ? fieldDefinition.step : undefined}
+                      placeholder={fieldDefinition.placeholder}
+                      disabled={fieldDefinition.isDisabled}
+                      isError={Boolean(error)}
+                      aria-describedby={describedBy || undefined}
+                    />
+                  );
+                }
+
+                return (
+                  <Field
+                    data-invalid={Boolean(error)}
+                    className={cn(fieldDefinition.layout !== "half" && "@xl:col-span-2")}
+                  >
+                    <FieldLabel htmlFor={inputId}>
+                      {fieldDefinition.label}
+                      {fieldDefinition.isOptional && (
+                        <span className="font-normal text-muted">(optional)</span>
+                      )}
+                    </FieldLabel>
+                    {input}
+                    {fieldDefinition.description && (
+                      <FieldDescription id={descriptionId}>
+                        {fieldDefinition.description}
+                      </FieldDescription>
+                    )}
+                    {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+                  </Field>
+                );
+              }}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
@@ -23,6 +23,7 @@ import { cn } from "@app/components/v3/utils";
 import { useCreateDynamicSecret, useUpdateDynamicSecret } from "@app/hooks/api";
 import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
 
+import { submitDynamicSecretCreatePayloads } from "./createSubmission";
 import { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
 import {
   TCreateDynamicSecretProviderFormContext,
@@ -189,10 +190,21 @@ export const DynamicSecretProviderForm = <
         context as TCreateDynamicSecretProviderFormContext
       );
       const payloads = "provider" in payload ? [payload] : payload;
-      const results = await Promise.all(
-        payloads.map((item) => createDynamicSecret.mutateAsync(item))
+      const { successfulResults, failedCount } = await submitDynamicSecretCreatePayloads(
+        payloads,
+        (item) => createDynamicSecret.mutateAsync(item)
       );
-      onCompleted(results.length === 1 ? results[0] : results);
+
+      if (successfulResults.length === 0) return;
+
+      if (failedCount > 0) {
+        createNotification({
+          type: "warning",
+          text: `Created ${successfulResults.length} of ${payloads.length} dynamic secrets. Review the created secrets before retrying failed items.`
+        });
+      }
+
+      onCompleted(successfulResults.length === 1 ? successfulResults[0] : successfulResults);
       return;
     }
 

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderForm.tsx
@@ -1,0 +1,464 @@
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import {
+  Controller,
+  DefaultValues,
+  FormProvider,
+  Resolver,
+  SubmitHandler,
+  useForm
+} from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FilterableSelect,
+  Input
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+import { useCreateDynamicSecret, useUpdateDynamicSecret } from "@app/hooks/api";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
+import {
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretFormEnvironment,
+  TDynamicSecretProviderDefinition,
+  TDynamicSecretProviderFormItem,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+type TCreateProps<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = TCreateDynamicSecretProviderFormContext & {
+  mode: "create";
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  onCompleted: (result?: unknown) => void;
+  onCancel: () => void;
+  onBack?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  header?: ReactNode;
+};
+
+type TEditProps<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = TEditDynamicSecretProviderFormContext & {
+  mode: "edit";
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  onCompleted: (result?: unknown) => void;
+  onCancel: () => void;
+  onBack?: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  header?: ReactNode;
+};
+
+type Props<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> =
+  | TCreateProps<TProvider, TCreateValues, TEditValues>
+  | TEditProps<TProvider, TCreateValues, TEditValues>;
+
+const EMPTY_ENVIRONMENTS: TCreateDynamicSecretProviderFormContext["environments"] = [];
+
+export const DynamicSecretProviderForm = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+>(
+  props: Props<TProvider, TCreateValues, TEditValues>
+) => {
+  type TValues = TCreateValues | TEditValues;
+  const {
+    definition,
+    mode,
+    onCancel,
+    onBack,
+    onCompleted,
+    onDirtyChange,
+    projectSlug,
+    secretPath,
+    header
+  } = props;
+  const createDynamicSecret = useCreateDynamicSecret();
+  const updateDynamicSecret = useUpdateDynamicSecret();
+  const [providerSubmitState, setProviderSubmitState] = useState({
+    isDisabled: false,
+    isPending: false
+  });
+
+  let environments = EMPTY_ENVIRONMENTS;
+  let isSingleEnvironmentMode = false;
+  let editDynamicSecret: TEditDynamicSecretProviderFormContext["dynamicSecret"] | undefined;
+  let editEnvironment: string | undefined;
+
+  if (mode === "create") {
+    ({ environments, isSingleEnvironmentMode = false } = props);
+  } else {
+    const { dynamicSecret, environment } = props;
+    editDynamicSecret = dynamicSecret;
+    editEnvironment = environment;
+  }
+
+  const context = useMemo<
+    TCreateDynamicSecretProviderFormContext | TEditDynamicSecretProviderFormContext
+  >(
+    () =>
+      mode === "create"
+        ? { projectSlug, secretPath, environments, isSingleEnvironmentMode }
+        : {
+            projectSlug,
+            secretPath,
+            dynamicSecret:
+              editDynamicSecret as TEditDynamicSecretProviderFormContext["dynamicSecret"],
+            environment: editEnvironment as string
+          },
+    [
+      editDynamicSecret,
+      editEnvironment,
+      environments,
+      isSingleEnvironmentMode,
+      mode,
+      projectSlug,
+      secretPath
+    ]
+  );
+
+  const schema = mode === "create" ? definition.create.schema : definition.edit.schema;
+  const defaultValues = useMemo(
+    () =>
+      mode === "create"
+        ? definition.create.getDefaultValues(context as TCreateDynamicSecretProviderFormContext)
+        : definition.edit.getDefaultValues(context as TEditDynamicSecretProviderFormContext),
+    [context, definition, mode]
+  );
+
+  const form = useForm<TValues>({
+    resolver: zodResolver(schema) as Resolver<TValues>,
+    defaultValues: defaultValues as DefaultValues<TValues>,
+    values: mode === "edit" ? (defaultValues as TValues) : undefined,
+    shouldFocusError: true
+  });
+  const [hasDirtyBaseline, setHasDirtyBaseline] = useState(false);
+
+  // Re-baseline after mount-time controlled-input synchronization so prefills
+  // never trigger an unsaved-change guard.
+  useEffect(() => {
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      if (cancelled) return;
+      form.reset(form.getValues());
+      setHasDirtyBaseline(true);
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [form]);
+
+  useEffect(() => {
+    if (!hasDirtyBaseline) {
+      onDirtyChange?.(false);
+      return undefined;
+    }
+    onDirtyChange?.(form.formState.isDirty);
+    return () => onDirtyChange?.(false);
+  }, [hasDirtyBaseline, form.formState.isDirty, onDirtyChange]);
+
+  const isPending =
+    form.formState.isSubmitting ||
+    providerSubmitState.isPending ||
+    (mode === "create" ? createDynamicSecret.isPending : updateDynamicSecret.isPending);
+
+  const handleSubmit: SubmitHandler<TValues> = async (values) => {
+    if (isPending) return;
+
+    if (mode === "create") {
+      const payload = definition.create.toPayload(
+        values as TCreateValues,
+        context as TCreateDynamicSecretProviderFormContext
+      );
+      const payloads = "provider" in payload ? [payload] : payload;
+      const results = await Promise.all(
+        payloads.map((item) => createDynamicSecret.mutateAsync(item))
+      );
+      onCompleted(results.length === 1 ? results[0] : results);
+      return;
+    }
+
+    const payload = definition.edit.toPayload(
+      values as TEditValues,
+      context as TEditDynamicSecretProviderFormContext
+    );
+    const result = await updateDynamicSecret.mutateAsync(payload);
+    onCompleted(result);
+    createNotification({
+      type: "success",
+      text: definition.edit.successMessage
+    });
+  };
+
+  const modeDefinition = mode === "create" ? definition.create : definition.edit;
+  const fields = modeDefinition.fields ?? definition.fields;
+  const CustomRenderer = (modeDefinition.customRenderer ?? definition.customRenderer)?.Component;
+  const { commonFields } = modeDefinition;
+  const ttlFieldCount =
+    Number(commonFields?.defaultTTL?.isVisible !== false) +
+    Number(commonFields?.maxTTL?.isVisible !== false);
+  let commonFieldGrid = "@2xl:grid-cols-[minmax(0,1fr)_8rem_8rem]";
+  if (ttlFieldCount === 0) commonFieldGrid = "@2xl:grid-cols-1";
+  if (ttlFieldCount === 1) commonFieldGrid = "@2xl:grid-cols-[minmax(0,1fr)_8rem]";
+  const nameError = form.formState.errors.name;
+  const defaultTtlError = form.formState.errors.defaultTTL;
+  const maxTtlError = form.formState.errors.maxTTL;
+
+  return (
+    <FormProvider {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        autoComplete="off"
+        noValidate
+        data-slot="dynamic-secret-provider-form"
+        className="@container flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        <div className="flex min-h-0 thin-scrollbar flex-1 flex-col gap-5 overflow-y-auto px-4 py-5">
+          {header}
+          <section className="flex flex-col gap-4" aria-label="Dynamic secret details">
+            <div className={cn("grid grid-cols-1 gap-3", commonFieldGrid)}>
+              {commonFields?.name?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"name" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(nameError)}>
+                      <FieldLabel htmlFor="dynamic-secret-name">
+                        {commonFields?.name?.label ?? "Secret Name"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-name"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        placeholder="dynamic-secret"
+                        isError={Boolean(nameError)}
+                        aria-describedby={nameError ? "dynamic-secret-name-error" : undefined}
+                        disabled={commonFields?.name?.isDisabled}
+                      />
+                      {nameError?.message && (
+                        <FieldError id="dynamic-secret-name-error">
+                          {nameError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+              {commonFields?.defaultTTL?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"defaultTTL" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(defaultTtlError)}>
+                      <FieldLabel htmlFor="dynamic-secret-default-ttl">
+                        {commonFields?.defaultTTL?.label ?? "Default TTL"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-default-ttl"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        isError={Boolean(defaultTtlError)}
+                        aria-describedby={
+                          [
+                            commonFields?.defaultTTL?.description
+                              ? "dynamic-secret-default-ttl-description"
+                              : undefined,
+                            defaultTtlError ? "dynamic-secret-default-ttl-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                        disabled={commonFields?.defaultTTL?.isDisabled}
+                      />
+                      {commonFields?.defaultTTL?.description && (
+                        <FieldDescription id="dynamic-secret-default-ttl-description">
+                          {commonFields.defaultTTL.description}
+                        </FieldDescription>
+                      )}
+                      {defaultTtlError?.message && (
+                        <FieldError id="dynamic-secret-default-ttl-error">
+                          {defaultTtlError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+              {commonFields?.maxTTL?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"maxTTL" as never}
+                  render={({ field }) => (
+                    <Field data-invalid={Boolean(maxTtlError)}>
+                      <FieldLabel htmlFor="dynamic-secret-max-ttl">
+                        {commonFields?.maxTTL?.label ?? "Max TTL"}
+                      </FieldLabel>
+                      <Input
+                        ref={field.ref}
+                        id="dynamic-secret-max-ttl"
+                        name={field.name}
+                        value={typeof field.value === "string" ? field.value : ""}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        isError={Boolean(maxTtlError)}
+                        aria-describedby={
+                          [
+                            commonFields?.maxTTL?.description
+                              ? "dynamic-secret-max-ttl-description"
+                              : undefined,
+                            maxTtlError ? "dynamic-secret-max-ttl-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                        disabled={commonFields?.maxTTL?.isDisabled}
+                      />
+                      {commonFields?.maxTTL?.description && (
+                        <FieldDescription id="dynamic-secret-max-ttl-description">
+                          {commonFields.maxTTL.description}
+                        </FieldDescription>
+                      )}
+                      {maxTtlError?.message && (
+                        <FieldError id="dynamic-secret-max-ttl-error">
+                          {maxTtlError.message as string}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+            </div>
+            {mode === "create" &&
+              !isSingleEnvironmentMode &&
+              commonFields?.environment?.isVisible !== false && (
+                <Controller
+                  control={form.control}
+                  name={"environment" as never}
+                  render={({ field, fieldState: { error } }) => (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor="dynamic-secret-environment">
+                        {commonFields?.environment?.label ?? "Environment"}
+                      </FieldLabel>
+                      <FilterableSelect<TDynamicSecretFormEnvironment>
+                        inputId="dynamic-secret-environment"
+                        options={environments}
+                        value={(field.value as TDynamicSecretFormEnvironment | undefined) ?? null}
+                        onBlur={field.onBlur}
+                        onChange={field.onChange}
+                        getOptionLabel={(option) => option.name}
+                        getOptionValue={(option) => option.slug}
+                        placeholder="Select the environment to create the secret in..."
+                        isDisabled={commonFields?.environment?.isDisabled}
+                        isError={Boolean(error)}
+                        aria-describedby={
+                          [
+                            commonFields?.environment?.description
+                              ? "dynamic-secret-environment-description"
+                              : undefined,
+                            error ? "dynamic-secret-environment-error" : undefined
+                          ]
+                            .filter(Boolean)
+                            .join(" ") || undefined
+                        }
+                      />
+                      {commonFields?.environment?.description && (
+                        <FieldDescription id="dynamic-secret-environment-description">
+                          {commonFields.environment.description}
+                        </FieldDescription>
+                      )}
+                      {error?.message && (
+                        <FieldError id="dynamic-secret-environment-error">
+                          {error.message}
+                        </FieldError>
+                      )}
+                    </Field>
+                  )}
+                />
+              )}
+          </section>
+
+          <section
+            className="flex flex-col gap-4"
+            aria-labelledby={
+              commonFields?.configurationHeading !== false
+                ? "dynamic-secret-configuration-heading"
+                : undefined
+            }
+          >
+            {commonFields?.configurationHeading !== false && (
+              <h3 id="dynamic-secret-configuration-heading" className="text-base font-medium">
+                {commonFields?.configurationHeading ?? "Configuration"}
+              </h3>
+            )}
+            {fields && (
+              <DynamicSecretProviderFormItems
+                items={fields as readonly TDynamicSecretProviderFormItem<TValues>[]}
+              />
+            )}
+            {CustomRenderer && (
+              <CustomRenderer
+                mode={mode}
+                context={context}
+                setSubmitState={(state) =>
+                  setProviderSubmitState((current) => ({ ...current, ...state }))
+                }
+              />
+            )}
+          </section>
+        </div>
+
+        <div
+          data-slot="dynamic-secret-provider-form-footer"
+          className="flex shrink-0 flex-col-reverse gap-2 border-t border-border px-4 py-3 @sm:flex-row @sm:items-center @sm:justify-end"
+        >
+          {onBack && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="@sm:mr-auto"
+              onClick={onBack}
+              isDisabled={isPending}
+            >
+              Back
+            </Button>
+          )}
+          <Button type="button" variant="ghost" onClick={onCancel} isDisabled={isPending}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="project"
+            isPending={isPending}
+            isDisabled={providerSubmitState.isDisabled || isPending}
+          >
+            {mode === "create" ? definition.create.submitLabel : definition.edit.submitLabel}
+          </Button>
+        </div>
+      </form>
+    </FormProvider>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFormItems.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderFormItems.tsx
@@ -1,0 +1,102 @@
+import { FieldValues } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "./DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "./DynamicSecretProviderGroup";
+import {
+  isDynamicSecretProviderFieldGroup,
+  TDynamicSecretProviderField,
+  TDynamicSecretProviderFieldGroup,
+  TDynamicSecretProviderFormItem
+} from "./types";
+
+type Props<TValues extends FieldValues> = {
+  items: readonly TDynamicSecretProviderFormItem<TValues>[];
+};
+
+type FormSegment<TValues extends FieldValues> =
+  | { type: "fields"; fields: TDynamicSecretProviderField<TValues>[] }
+  | { type: "group"; group: TDynamicSecretProviderFieldGroup<TValues> };
+
+const segmentFormItems = <TValues extends FieldValues>(
+  items: readonly TDynamicSecretProviderFormItem<TValues>[]
+): FormSegment<TValues>[] => {
+  const segments: FormSegment<TValues>[] = [];
+  let fieldBuffer: TDynamicSecretProviderField<TValues>[] = [];
+
+  const flushFields = () => {
+    if (fieldBuffer.length === 0) return;
+    segments.push({ type: "fields", fields: fieldBuffer });
+    fieldBuffer = [];
+  };
+
+  items.forEach((item) => {
+    if (isDynamicSecretProviderFieldGroup(item)) {
+      flushFields();
+      segments.push({ type: "group", group: item });
+      return;
+    }
+    fieldBuffer.push(item);
+  });
+
+  flushFields();
+  return segments;
+};
+
+const FieldGroup = <TValues extends FieldValues>({
+  group
+}: {
+  group: TDynamicSecretProviderFieldGroup<TValues>;
+}) => {
+  const fields = <DynamicSecretProviderFields fields={group.fields} />;
+
+  if (group.presentation === "collapse") {
+    return (
+      <DynamicSecretProviderGroup
+        id={group.id}
+        presentation="collapse"
+        title={group.title}
+        description={group.description}
+      >
+        {fields}
+      </DynamicSecretProviderGroup>
+    );
+  }
+
+  return (
+    <DynamicSecretProviderGroup
+      id={group.id}
+      presentation="panel"
+      title={group.title}
+      description={group.description}
+      surface={group.surface ?? Boolean(group.title)}
+    >
+      {fields}
+    </DynamicSecretProviderGroup>
+  );
+};
+
+/** Renders a mix of flat fields and panel/collapse groups under Configuration. */
+export const DynamicSecretProviderFormItems = <TValues extends FieldValues>({
+  items
+}: Props<TValues>) => {
+  const segments = segmentFormItems(items);
+
+  return (
+    <>
+      {segments.map((segment, index) => {
+        if (segment.type === "fields") {
+          return (
+            <DynamicSecretProviderFields
+              // Consecutive flat fields share one grid; index is stable for a given items array.
+              // eslint-disable-next-line react/no-array-index-key
+              key={`fields-${index}`}
+              fields={segment.fields}
+            />
+          );
+        }
+
+        return <FieldGroup key={segment.group.id} group={segment.group} />;
+      })}
+    </>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderGroup.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/DynamicSecretProviderGroup.tsx
@@ -1,0 +1,116 @@
+import { ReactNode } from "react";
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+  FieldDescription,
+  FieldLegend,
+  FieldSet
+} from "@app/components/v3";
+import { cn } from "@app/components/v3/utils";
+
+import { TDynamicSecretProviderFieldGroupPresentation } from "./types";
+
+const GROUP_SURFACE_CLASSNAME = "rounded-md border border-border bg-container p-3 text-foreground";
+
+type PanelProps = {
+  presentation?: "panel";
+  title?: string;
+  description?: string;
+  id: string;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  surface?: boolean;
+};
+
+type CollapseProps = {
+  presentation: "collapse";
+  title: string;
+  description?: string;
+  id: string;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+export type DynamicSecretProviderGroupProps = PanelProps | CollapseProps;
+
+/** Sheet-agnostic field clustering for provider forms. */
+export const DynamicSecretProviderGroup = (props: DynamicSecretProviderGroupProps) => {
+  const { presentation } = props;
+
+  if (presentation === "collapse") {
+    const {
+      id,
+      title,
+      description,
+      children,
+      className,
+      contentClassName,
+      defaultOpen,
+      open,
+      onOpenChange
+    } = props;
+    const descriptionId = `${id}-description`;
+    const controlledProps =
+      open === undefined
+        ? { defaultValue: defaultOpen ? id : undefined }
+        : {
+            value: open ? id : "",
+            onValueChange: (value: string) => onOpenChange?.(value === id)
+          };
+
+    return (
+      <Accordion
+        type="single"
+        collapsible
+        variant="ghost"
+        className={className}
+        {...controlledProps}
+      >
+        <AccordionItem value={id}>
+          <AccordionTrigger aria-describedby={description ? descriptionId : undefined}>
+            {title}
+          </AccordionTrigger>
+          <AccordionContent className={cn("flex flex-col gap-4", contentClassName)}>
+            {description ? (
+              <FieldDescription id={descriptionId}>{description}</FieldDescription>
+            ) : null}
+            {children}
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+  }
+
+  const { id, title, description, children, className, contentClassName, surface = false } = props;
+  const descriptionId = `${id}-description`;
+  const hasHeading = Boolean(title || description);
+
+  return (
+    <div
+      data-slot="dynamic-secret-provider-group"
+      data-presentation={"panel" satisfies TDynamicSecretProviderFieldGroupPresentation}
+      data-surface={surface ? "true" : "false"}
+      className={cn(surface && GROUP_SURFACE_CLASSNAME, className)}
+    >
+      {hasHeading ? (
+        <FieldSet className={contentClassName}>
+          {title ? <FieldLegend>{title}</FieldLegend> : null}
+          {description ? (
+            <FieldDescription id={descriptionId}>{description}</FieldDescription>
+          ) : null}
+          {children}
+        </FieldSet>
+      ) : (
+        <div className={cn("flex flex-col gap-4", contentClassName)}>{children}</div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
@@ -40,6 +40,7 @@ export const dynamicSecretProviderRegistry = createDynamicSecretProviderRegistry
 
 - Scalar number controls convert the browser string to a finite number before React Hook Form and `z.number()` validation see it. Clearing a numeric field emits `undefined` rather than accidental zero.
 - Secret controls preserve the supplied value and mask it with `type="password"`; edit defaults and adapters decide whether a masked value is sent unchanged.
+- Multi-create adapters may return several payloads. The shell settles the full batch, closes after any partial success to prevent accidental duplicate retries, and reports the exact success count.
 - Groups are sheet-agnostic. Panels use fieldset semantics, and collapsible groups use the shared V3 Accordion.
 - A custom renderer must declare at least one objective reason such as `repeatable-fields`, `remote-options`, `permission-aware-fields`, or `non-scalar-value`.
 - A custom renderer reads and writes the surrounding `FormProvider`; the shared shell still validates and submits the definition's adapter.

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/README.md
@@ -1,0 +1,76 @@
+# Dynamic-secret provider form contract
+
+The shared contract keeps one create/edit form shell while leaving provider validation, defaults, hydration, and request adapters with each provider definition. The foundation is intentionally provider-neutral: legacy providers keep their existing forms until a rollout ticket registers a replacement.
+
+## Ownership boundaries
+
+| Boundary | Owns | Does not own |
+| --- | --- | --- |
+| Form shell | Name, TTL, environment, submit/cancel behavior, pending state, mutation wiring, and first-invalid-field focus | Provider queries, conditional behavior, or DTO semantics |
+| Provider definition | Mode-specific schemas, defaults, scalar fields, custom-renderer reasons, and payload adapters | A second form or mutation ownership |
+| Registry composition | Immutable definition lookup, picker order, documentation slugs, and duplicate rejection | Production provider definitions |
+| Scalar renderer | V3 text, secret, number, textarea, select, and switch controls | Repeaters, remote options, imports, gateways, or nested editors |
+| Custom renderer | Explicit non-scalar or context-aware interaction inside shared React Hook Form state | Submitting, bypassing schemas, or duplicating common fields |
+
+Create and edit values are deliberately separate. That distinction preserves masked edit values, editable names, nullable gateway detachment, create-time omission, and provider-specific hydration without weakening types across modes.
+
+## Registering a provider batch
+
+Each rollout ticket owns a batch-local module. It imports the concrete definitions it migrated and exports only the shared registration contract:
+
+```ts
+export const identityAccessDynamicSecretProviders = defineDynamicSecretProviderModule({
+  id: "identity-access",
+  definitions: [awsIamDynamicSecretProvider, gcpIamDynamicSecretProvider]
+});
+```
+
+The production composition root combines completed batches:
+
+```ts
+export const dynamicSecretProviderRegistry = createDynamicSecretProviderRegistry(
+  identityAccessDynamicSecretProviders,
+  managedStoresDynamicSecretProviders
+);
+```
+
+`getDefinition(provider)` returns `undefined` for an unmigrated provider so routers can retain the existing legacy path during incremental rollout. `requireDefinition(provider)` is for code paths that already proved registration. Duplicate module IDs and duplicate providers fail during composition instead of silently overriding a definition.
+
+## Field and renderer contract
+
+- Scalar number controls convert the browser string to a finite number before React Hook Form and `z.number()` validation see it. Clearing a numeric field emits `undefined` rather than accidental zero.
+- Secret controls preserve the supplied value and mask it with `type="password"`; edit defaults and adapters decide whether a masked value is sent unchanged.
+- Groups are sheet-agnostic. Panels use fieldset semantics, and collapsible groups use the shared V3 Accordion.
+- A custom renderer must declare at least one objective reason such as `repeatable-fields`, `remote-options`, `permission-aware-fields`, or `non-scalar-value`.
+- A custom renderer reads and writes the surrounding `FormProvider`; the shared shell still validates and submits the definition's adapter.
+
+## Shared normalization
+
+- `{{randomUsername}}` is omitted on create and sent as `null` on edit unless a provider deliberately overrides that behavior.
+- A cleared gateway normalizes to `undefined` on create and `null` on edit.
+- Standard TTL validation retains the existing one-minute minimum, ten-year maximum, and user-facing messages.
+- Single-environment create defaults belong in the provider's `getDefaultValues`; multi-environment create keeps the environment field visible. Edit uses its route environment.
+
+## Checkpoint provenance and departures
+
+This foundation adapts the core contract from checkpoint commit `2eca032d7dc` without merging or cherry-picking the checkpoint.
+
+| Checkpoint area | Disposition |
+| --- | --- |
+| `types.ts`, `schemas.ts`, scalar fields, form items, and shared controls | Adapted to current main |
+| `DynamicSecretProviderForm.tsx` | Rewritten as a sheet-agnostic shell; dynamic-secret sheet, lease, renew, and post-create overlay work remain out of scope |
+| `DynamicSecretProviderGroup.tsx` | Rewritten to compose the existing V3 Accordion rather than the checkpoint-only sheet section |
+| `providerDefinitions/registry.ts` | Rewritten as immutable module composition so rollout batches do not edit core architecture |
+| Number input handling | Rewritten to emit numbers before validation, resolving the unresolved PR #7529 finding |
+| Production provider definitions and provider-family tests | Rejected from this foundation; owned by ENG-5513 through ENG-5516 |
+| Route removal, Overview redesign, sheet/lease work, and unrelated primitive changes | Rejected as outside ENG-5518 |
+
+## Verification
+
+The reusable Node test harness lives in `providerContractTestHarness.ts`. The adjacent contract test uses only a test-local provider definition and covers scalar metadata, numeric parsing, masked edit defaults, environment and TTL defaults, validation, create/edit adapters, gateway and username-template normalization, nested values, registry composition, and a custom-renderer escape hatch.
+
+Run it from `frontend/`:
+
+```sh
+TSX_TSCONFIG_PATH=tsconfig.app.json ./node_modules/.bin/tsx --test src/components/dynamic-secrets/DynamicSecretProviderForm/*.test.ts
+```

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/createSubmission.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/createSubmission.ts
@@ -1,0 +1,23 @@
+export type TDynamicSecretCreateSubmissionResult<TResult> = {
+  successfulResults: TResult[];
+  failedCount: number;
+};
+
+/**
+ * Settle an entire provider-owned create batch so the form can distinguish a
+ * total failure from partial success and avoid resubmitting completed items.
+ */
+export const submitDynamicSecretCreatePayloads = async <TPayload, TResult>(
+  payloads: readonly TPayload[],
+  submit: (payload: TPayload) => Promise<TResult>
+): Promise<TDynamicSecretCreateSubmissionResult<TResult>> => {
+  const settledResults = await Promise.allSettled(payloads.map((payload) => submit(payload)));
+  const successfulResults = settledResults.flatMap((result) =>
+    result.status === "fulfilled" ? [result.value] : []
+  );
+
+  return {
+    successfulResults,
+    failedCount: settledResults.length - successfulResults.length
+  };
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { DynamicSecretProviders, SqlProviders } from "@app/hooks/api/dynamicSecret/types";
 
+import { submitDynamicSecretCreatePayloads } from "./createSubmission";
 import { testDynamicSecretProviderContract } from "./providerContractTestHarness";
 import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
 import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
@@ -371,11 +372,26 @@ describe("shared dynamic-secret scalar behavior", () => {
 
 describe("shared dynamic-secret normalization", () => {
   it("preserves TTL bounds and messages", () => {
+    const missingDefault = createFormSchema.safeParse({ ...createValues, defaultTTL: "" });
+    const malformedDefault = createFormSchema.safeParse({ ...createValues, defaultTTL: "abc" });
+    const malformedMaximum = createFormSchema.safeParse({ ...createValues, maxTTL: "abc" });
     const belowMinimum = createFormSchema.safeParse({ ...createValues, defaultTTL: "30s" });
     const aboveMaximum = createFormSchema.safeParse({ ...createValues, defaultTTL: "11y" });
 
+    assert.equal(missingDefault.success, false);
+    assert.equal(malformedDefault.success, false);
+    assert.equal(malformedMaximum.success, false);
     assert.equal(belowMinimum.success, false);
     assert.equal(aboveMaximum.success, false);
+    if (!missingDefault.success) {
+      assert.equal(missingDefault.error.issues[0]?.message, "TTL is required");
+    }
+    if (!malformedDefault.success) {
+      assert.equal(malformedDefault.error.issues[0]?.message, "TTL must be a valid duration");
+    }
+    if (!malformedMaximum.success) {
+      assert.equal(malformedMaximum.error.issues[0]?.message, "TTL must be a valid duration");
+    }
     if (!belowMinimum.success) {
       assert.equal(belowMinimum.error.issues[0]?.message, "TTL must be a greater than 1min");
     }
@@ -396,6 +412,23 @@ describe("shared dynamic-secret normalization", () => {
     assert.equal(normalizeDynamicSecretGatewayValueForMode("create", null), undefined);
     assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", null), null);
     assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", "gateway-id"), "gateway-id");
+  });
+});
+
+describe("shared dynamic-secret create submission", () => {
+  it("reports partial success without rejecting completed items", async () => {
+    const attemptedPayloads: number[] = [];
+    const result = await submitDynamicSecretCreatePayloads([1, 2, 3], async (payload) => {
+      attemptedPayloads.push(payload);
+      if (payload === 2) throw new Error("create failed");
+      return `created-${payload}`;
+    });
+
+    assert.deepEqual(attemptedPayloads, [1, 2, 3]);
+    assert.deepEqual(result, {
+      successfulResults: ["created-1", "created-3"],
+      failedCount: 1
+    });
   });
 });
 

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/dynamic-secret-provider-contract.test.ts
@@ -1,0 +1,436 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { z } from "zod";
+
+import { DynamicSecretProviders, SqlProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { testDynamicSecretProviderContract } from "./providerContractTestHarness";
+import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
+import { parseDynamicSecretProviderNumberInput } from "./scalarValues";
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretGatewayValueForMode,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "./schemas";
+import {
+  defineDynamicSecretProvider,
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+const createInputsSchema = z.object({
+  host: z.string().min(1, "Host is required"),
+  port: z.number().int().positive(),
+  password: z.string().min(1, "Password is required"),
+  engine: z.literal("postgres"),
+  enabled: z.boolean(),
+  connection: z.object({
+    gatewayId: z.string().optional(),
+    gatewayPoolId: z.string().optional()
+  }),
+  statements: z.object({
+    creation: z.string().min(1),
+    revocation: z.string().min(1)
+  })
+});
+
+const editInputsSchema = createInputsSchema.extend({
+  connection: z.object({
+    gatewayId: z.string().nullable().optional(),
+    gatewayPoolId: z.string().nullable().optional()
+  })
+});
+
+const createFormSchema = createDynamicSecretProviderFormSchema(createInputsSchema);
+const editFormSchema = editDynamicSecretProviderFormSchema(editInputsSchema);
+
+type TCreateFixtureValues = z.infer<typeof createFormSchema>;
+type TEditFixtureValues = z.infer<typeof editFormSchema>;
+
+const FixtureCustomRenderer = () => null;
+
+const fixtureDefinition = defineDynamicSecretProvider<
+  DynamicSecretProviders.SqlDatabase,
+  TCreateFixtureValues,
+  TEditFixtureValues
+>({
+  provider: DynamicSecretProviders.SqlDatabase,
+  label: "Test SQL",
+  fields: [
+    { name: "inputs.host", type: "text", label: "Host", layout: "half" },
+    { name: "inputs.port", type: "number", label: "Port", layout: "half", min: 1 },
+    {
+      name: "inputs.password",
+      type: "secret",
+      label: "Password",
+      autoComplete: "new-password"
+    },
+    {
+      name: "inputs.engine",
+      type: "select",
+      label: "Engine",
+      options: [{ label: "PostgreSQL", value: "postgres" }]
+    },
+    { name: "inputs.enabled", type: "switch", label: "Enabled" },
+    {
+      kind: "group",
+      id: "statements",
+      presentation: "collapse",
+      title: "Statements",
+      fields: [
+        { name: "inputs.statements.creation", type: "textarea", label: "Creation Statement" },
+        { name: "inputs.statements.revocation", type: "textarea", label: "Revocation Statement" }
+      ]
+    }
+  ],
+  customRenderer: {
+    reasons: ["remote-options", "non-scalar-value"],
+    Component: FixtureCustomRenderer
+  },
+  create: {
+    schema: createFormSchema,
+    getDefaultValues: (context) => ({
+      name: "",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: {
+        host: "",
+        port: 5432,
+        password: "",
+        engine: "postgres",
+        enabled: true,
+        connection: {
+          gatewayId: undefined,
+          gatewayPoolId: undefined
+        },
+        statements: {
+          creation: "CREATE USER",
+          revocation: "DROP USER"
+        }
+      }
+    }),
+    toPayload: (values, context) => {
+      const gatewayId = normalizeDynamicSecretGatewayValueForMode(
+        "create",
+        values.inputs.connection.gatewayId
+      );
+      const usernameTemplate = normalizeDynamicSecretUsernameTemplateForCreate(
+        values.usernameTemplate
+      );
+
+      return {
+        projectSlug: context.projectSlug,
+        path: context.secretPath,
+        name: values.name,
+        environmentSlug: values.environment.slug,
+        defaultTTL: values.defaultTTL,
+        ...(values.maxTTL ? { maxTTL: values.maxTTL } : {}),
+        ...(usernameTemplate ? { usernameTemplate } : {}),
+        provider: {
+          type: DynamicSecretProviders.SqlDatabase,
+          inputs: {
+            client: SqlProviders.Postgres,
+            host: values.inputs.host,
+            port: values.inputs.port,
+            database: "postgres",
+            username: "postgres",
+            password: values.inputs.password,
+            creationStatement: values.inputs.statements.creation,
+            revocationStatement: values.inputs.statements.revocation,
+            ...(gatewayId ? { gatewayId } : {})
+          }
+        }
+      };
+    },
+    submitLabel: "Create Dynamic Secret"
+  },
+  edit: {
+    schema: editFormSchema,
+    getDefaultValues: (context) => ({
+      name: context.dynamicSecret.name,
+      defaultTTL: context.dynamicSecret.defaultTTL,
+      maxTTL: context.dynamicSecret.maxTTL ?? null,
+      usernameTemplate:
+        context.dynamicSecret.usernameTemplate ?? DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: context.dynamicSecret.inputs as TEditFixtureValues["inputs"]
+    }),
+    toPayload: (values, context) => ({
+      projectSlug: context.projectSlug,
+      path: context.secretPath,
+      environmentSlug: context.environment,
+      name: context.dynamicSecret.name,
+      data: {
+        newName: values.name,
+        defaultTTL: values.defaultTTL,
+        maxTTL: values.maxTTL,
+        usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate),
+        inputs: {
+          ...values.inputs,
+          connection: {
+            gatewayId: normalizeDynamicSecretGatewayValueForMode(
+              "edit",
+              values.inputs.connection.gatewayId
+            ),
+            gatewayPoolId: normalizeDynamicSecretGatewayValueForMode(
+              "edit",
+              values.inputs.connection.gatewayPoolId
+            )
+          }
+        }
+      }
+    }),
+    submitLabel: "Save Changes",
+    successMessage: "Dynamic secret updated"
+  }
+});
+
+const environment = { id: "env-id", name: "Development", slug: "dev" };
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+const editInputs: TEditFixtureValues["inputs"] = {
+  host: "database.example.com",
+  port: 5432,
+  password: "********",
+  engine: "postgres",
+  enabled: true,
+  connection: { gatewayId: null, gatewayPoolId: null },
+  statements: { creation: "CREATE USER", revocation: "DROP USER" }
+};
+const editContext: TEditDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environment: "dev",
+  dynamicSecret: {
+    id: "dynamic-secret-id",
+    name: "existing-secret",
+    type: DynamicSecretProviders.SqlDatabase,
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    defaultTTL: "1h",
+    maxTTL: "24h",
+    usernameTemplate: null,
+    inputs: editInputs
+  }
+};
+const createValues: TCreateFixtureValues = {
+  name: "test-secret",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "database.example.com",
+    port: 5432,
+    password: "new-password",
+    engine: "postgres",
+    enabled: true,
+    connection: { gatewayId: undefined, gatewayPoolId: undefined },
+    statements: { creation: "CREATE USER", revocation: "DROP USER" }
+  }
+};
+const editValues: TEditFixtureValues = {
+  name: "renamed-secret",
+  defaultTTL: "2h",
+  maxTTL: null,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: editInputs
+};
+
+testDynamicSecretProviderContract({
+  name: "test-only SQL fixture",
+  definition: fixtureDefinition,
+  create: {
+    context: createContext,
+    defaultValues: {
+      name: "",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      environment,
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: {
+        host: "",
+        port: 5432,
+        password: "",
+        engine: "postgres",
+        enabled: true,
+        connection: { gatewayId: undefined, gatewayPoolId: undefined },
+        statements: { creation: "CREATE USER", revocation: "DROP USER" }
+      }
+    },
+    validValues: createValues,
+    payload: {
+      projectSlug: "project",
+      path: "/folder",
+      name: "test-secret",
+      environmentSlug: "dev",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      provider: {
+        type: DynamicSecretProviders.SqlDatabase,
+        inputs: {
+          client: SqlProviders.Postgres,
+          host: "database.example.com",
+          port: 5432,
+          database: "postgres",
+          username: "postgres",
+          password: "new-password",
+          creationStatement: "CREATE USER",
+          revocationStatement: "DROP USER"
+        }
+      }
+    },
+    invalidValues: [
+      {
+        name: "provider validation paths",
+        values: {
+          ...createValues,
+          inputs: { ...createValues.inputs, host: "", password: "" }
+        },
+        issuePaths: [
+          ["inputs", "host"],
+          ["inputs", "password"]
+        ]
+      }
+    ]
+  },
+  edit: {
+    context: editContext,
+    defaultValues: {
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+      inputs: editInputs
+    },
+    validValues: editValues,
+    payload: {
+      projectSlug: "project",
+      path: "/folder",
+      environmentSlug: "dev",
+      name: "existing-secret",
+      data: {
+        newName: "renamed-secret",
+        defaultTTL: "2h",
+        maxTTL: null,
+        usernameTemplate: null,
+        inputs: editInputs
+      }
+    },
+    maskedValues: [
+      {
+        name: "provider password",
+        expected: "********",
+        defaultValuePath: ["inputs", "password"],
+        payloadValuePath: ["data", "inputs", "password"]
+      }
+    ]
+  }
+});
+
+describe("shared dynamic-secret scalar behavior", () => {
+  it("emits numbers before z.number validation", () => {
+    const parsedPort = parseDynamicSecretProviderNumberInput("6432");
+
+    assert.equal(parsedPort, 6432);
+    assert.equal(typeof parsedPort, "number");
+    assert.equal(
+      createFormSchema.safeParse({
+        ...createValues,
+        inputs: { ...createValues.inputs, port: parsedPort }
+      }).success,
+      true
+    );
+    assert.equal(parseDynamicSecretProviderNumberInput(""), undefined);
+    assert.equal(parseDynamicSecretProviderNumberInput("not-a-number"), undefined);
+  });
+
+  it("keeps scalar and custom-renderer paths explicit", () => {
+    const fields = fixtureDefinition.fields ?? [];
+    const flatTypes = fields.flatMap((item) => ("kind" in item ? [] : [item.type]));
+
+    assert.deepEqual(flatTypes, ["text", "number", "secret", "select", "switch"]);
+    const groupedTypes = fields.flatMap((item) =>
+      "kind" in item ? item.fields.map((field) => field.type) : []
+    );
+    assert.deepEqual(groupedTypes, ["textarea", "textarea"]);
+    assert.deepEqual(fixtureDefinition.customRenderer?.reasons, [
+      "remote-options",
+      "non-scalar-value"
+    ]);
+  });
+});
+
+describe("shared dynamic-secret normalization", () => {
+  it("preserves TTL bounds and messages", () => {
+    const belowMinimum = createFormSchema.safeParse({ ...createValues, defaultTTL: "30s" });
+    const aboveMaximum = createFormSchema.safeParse({ ...createValues, defaultTTL: "11y" });
+
+    assert.equal(belowMinimum.success, false);
+    assert.equal(aboveMaximum.success, false);
+    if (!belowMinimum.success) {
+      assert.equal(belowMinimum.error.issues[0]?.message, "TTL must be a greater than 1min");
+    }
+    if (!aboveMaximum.success) {
+      assert.equal(aboveMaximum.error.issues[0]?.message, "TTL must be less than 10 years");
+    }
+  });
+
+  it("keeps username-template and gateway create/edit semantics distinct", () => {
+    assert.equal(
+      normalizeDynamicSecretUsernameTemplateForCreate(DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE),
+      undefined
+    );
+    assert.equal(
+      normalizeDynamicSecretUsernameTemplateForEdit(DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE),
+      null
+    );
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("create", null), undefined);
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", null), null);
+    assert.equal(normalizeDynamicSecretGatewayValueForMode("edit", "gateway-id"), "gateway-id");
+  });
+});
+
+describe("dynamic-secret provider registry composition", () => {
+  const fixtureModule = defineDynamicSecretProviderModule({
+    id: "test-only",
+    definitions: [fixtureDefinition]
+  });
+
+  it("composes batch modules without exposing mutable registry state", () => {
+    const registry = createDynamicSecretProviderRegistry(fixtureModule);
+
+    assert.deepEqual(registry.providers, [DynamicSecretProviders.SqlDatabase]);
+    assert.equal(registry.getDefinition(DynamicSecretProviders.SqlDatabase), fixtureDefinition);
+    assert.equal(registry.getDefinition(DynamicSecretProviders.Redis), undefined);
+    assert.equal(registry.getDocsSlug(DynamicSecretProviders.SqlDatabase), "postgresql");
+    assert.equal(Object.isFrozen(registry.providers), true);
+    assert.equal(Object.isFrozen(registry.definitions), true);
+  });
+
+  it("rejects duplicate modules and providers", () => {
+    assert.throws(
+      () => createDynamicSecretProviderRegistry(fixtureModule, fixtureModule),
+      /module "test-only" was registered more than once/
+    );
+    assert.throws(
+      () =>
+        createDynamicSecretProviderRegistry(
+          fixtureModule,
+          defineDynamicSecretProviderModule({
+            id: "duplicate-provider",
+            definitions: [fixtureDefinition]
+          })
+        ),
+      /provider "sql-database" was registered more than once/
+    );
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/index.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/index.ts
@@ -1,0 +1,9 @@
+export { DynamicSecretProviderFields } from "./DynamicSecretProviderFields";
+export { DynamicSecretProviderForm } from "./DynamicSecretProviderForm";
+export { DynamicSecretProviderFormItems } from "./DynamicSecretProviderFormItems";
+export { DynamicSecretProviderGroup } from "./DynamicSecretProviderGroup";
+export * from "./registry";
+export * from "./scalarValues";
+export * from "./schemas";
+export * from "./shared";
+export * from "./types";

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/managed-stores-contract.test.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/managed-stores-contract.test.ts
@@ -1,0 +1,776 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { AwsMemoryDbAuthType, DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  awsElastiCacheCreateFormSchema,
+  awsElastiCacheEditFormSchema,
+  awsMemoryDbCreateFormSchema,
+  awsMemoryDbEditFormSchema,
+  getAwsElastiCacheCreateDefaultValues,
+  getAwsElastiCacheCreatePayload,
+  getAwsElastiCacheEditDefaultValues,
+  getAwsElastiCacheEditPayload,
+  getAwsMemoryDbCreateDefaultValues,
+  getAwsMemoryDbCreatePayload,
+  getAwsMemoryDbEditDefaultValues,
+  getAwsMemoryDbEditPayload
+} from "./providerDefinitions/awsManagedStoresContract";
+import {
+  couchbaseCreateFormSchema,
+  couchbaseEditFormSchema,
+  getCouchbaseCreateDefaultValues,
+  getCouchbaseCreatePayload,
+  getCouchbaseEditDefaultValues,
+  getCouchbaseEditPayload
+} from "./providerDefinitions/couchbaseContract";
+import { MANAGED_STORE_DYNAMIC_SECRET_PROVIDERS } from "./providerDefinitions/managedStoresContract";
+import {
+  getMongoAtlasCreateDefaultValues,
+  getMongoAtlasCreatePayload,
+  getMongoAtlasEditDefaultValues,
+  getMongoAtlasEditPayload,
+  mongoAtlasCreateFormSchema,
+  mongoAtlasEditFormSchema
+} from "./providerDefinitions/mongoAtlasContract";
+import {
+  getMongoDbCreateDefaultValues,
+  getMongoDbCreatePayload,
+  getMongoDbEditDefaultValues,
+  getMongoDbEditPayload,
+  mongoDbCreateFormSchema,
+  mongoDbEditFormSchema
+} from "./providerDefinitions/mongoDbContract";
+import {
+  getRedisCreateDefaultValues,
+  getRedisCreatePayload,
+  getRedisEditDefaultValues,
+  getRedisEditPayload,
+  redisCreateFormSchema,
+  redisEditFormSchema
+} from "./providerDefinitions/redisContract";
+import { createDynamicSecretProviderRegistry, defineDynamicSecretProviderModule } from "./registry";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "./schemas";
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+import { defineDynamicSecretProvider } from "./types";
+
+const environment = { id: "env-id", name: "Development", slug: "dev", position: 1 };
+
+const createContext: TCreateDynamicSecretProviderFormContext = {
+  projectSlug: "project",
+  secretPath: "/folder",
+  environments: [environment],
+  isSingleEnvironmentMode: true
+};
+
+const multiEnvironmentContext: TCreateDynamicSecretProviderFormContext = {
+  ...createContext,
+  environments: [environment, { ...environment, id: "prod-id", name: "Production", slug: "prod" }],
+  isSingleEnvironmentMode: false
+};
+
+const editContext = (
+  provider: DynamicSecretProviders,
+  inputs: unknown,
+  options: {
+    metadata?: { key: string; value: string }[];
+    usernameTemplate?: string | null;
+  } = {}
+) =>
+  ({
+    projectSlug: "project",
+    secretPath: "/folder",
+    environment: "dev",
+    dynamicSecret: {
+      id: "dynamic-secret-id",
+      name: "existing-secret",
+      type: provider,
+      createdAt: "2026-08-01T00:00:00.000Z",
+      updatedAt: "2026-08-01T00:00:00.000Z",
+      defaultTTL: "1h",
+      maxTTL: "24h",
+      usernameTemplate: options.usernameTemplate ?? null,
+      metadata: options.metadata,
+      inputs
+    }
+  }) as TEditDynamicSecretProviderFormContext;
+
+const getIssuePaths = (result: {
+  success: boolean;
+  error?: { issues: { path: PropertyKey[] }[] };
+}) => (result.success ? [] : (result.error?.issues.map(({ path }) => path) ?? []));
+
+const getValidAwsElastiCacheCreateValues = () => {
+  const values = getAwsElastiCacheCreateDefaultValues(createContext);
+  values.name = "elasticache";
+  Object.assign(values.inputs, {
+    clusterName: "redis-cluster",
+    accessKeyId: "access-key",
+    secretAccessKey: "secret-key",
+    region: "us-east-1"
+  });
+  return values;
+};
+
+const getValidAwsMemoryDbCreateValues = () => {
+  const values = getAwsMemoryDbCreateDefaultValues(createContext);
+  values.name = "memorydb";
+  Object.assign(values.inputs, {
+    clusterName: "memory-cluster",
+    region: "us-east-1",
+    auth: {
+      type: AwsMemoryDbAuthType.IAM,
+      accessKeyId: "access-key",
+      secretAccessKey: "secret-key"
+    }
+  });
+  return values;
+};
+
+const getValidRedisCreateValues = () => {
+  const values = getRedisCreateDefaultValues(createContext);
+  values.name = "redis";
+  Object.assign(values.inputs, {
+    host: "REDIS.EXAMPLE.COM",
+    password: "secret",
+    sslRejectUnauthorized: false
+  });
+  return values;
+};
+
+const getValidMongoDbCreateValues = () => {
+  const values = getMongoDbCreateDefaultValues(createContext);
+  values.name = "mongodb";
+  Object.assign(values.inputs, {
+    host: "MONGO.EXAMPLE.COM",
+    database: "app",
+    username: "admin",
+    password: "secret",
+    ca: "certificate",
+    sslRejectUnauthorized: false,
+    roles: [{ roleName: "readWrite" }, { roleName: "dbAdmin" }]
+  });
+  return values;
+};
+
+const getValidMongoAtlasCreateValues = () => {
+  const values = getMongoAtlasCreateDefaultValues(createContext);
+  values.name = "atlas";
+  Object.assign(values.inputs, {
+    adminPublicKey: "public-key",
+    adminPrivateKey: "private-key",
+    groupId: "0123456789abcdef01234567",
+    roles: [{ databaseName: "app", collectionName: "users", roleName: "readWrite" }],
+    scopes: [{ name: "cluster-id", type: "CLUSTER" }]
+  });
+  return values;
+};
+
+const getValidCouchbaseCreateValues = () => {
+  const values = getCouchbaseCreateDefaultValues(createContext);
+  values.name = "couchbase";
+  Object.assign(values.inputs, {
+    orgId: "org",
+    projectId: "project",
+    clusterId: "cluster",
+    auth: { apiKey: "secret" }
+  });
+  return values;
+};
+
+const awsElastiCacheContractDefinition = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AwsElastiCache,
+  label: "AWS ElastiCache",
+  create: {
+    schema: awsElastiCacheCreateFormSchema,
+    getDefaultValues: getAwsElastiCacheCreateDefaultValues,
+    toPayload: getAwsElastiCacheCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: awsElastiCacheEditFormSchema,
+    getDefaultValues: getAwsElastiCacheEditDefaultValues,
+    toPayload: getAwsElastiCacheEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const awsMemoryDbContractDefinition = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AwsMemoryDb,
+  label: "AWS MemoryDB",
+  create: {
+    schema: awsMemoryDbCreateFormSchema,
+    getDefaultValues: getAwsMemoryDbCreateDefaultValues,
+    toPayload: getAwsMemoryDbCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: awsMemoryDbEditFormSchema,
+    getDefaultValues: getAwsMemoryDbEditDefaultValues,
+    toPayload: getAwsMemoryDbEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const redisContractDefinition = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Redis,
+  label: "Redis",
+  create: {
+    schema: redisCreateFormSchema,
+    getDefaultValues: getRedisCreateDefaultValues,
+    toPayload: getRedisCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: redisEditFormSchema,
+    getDefaultValues: getRedisEditDefaultValues,
+    toPayload: getRedisEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const mongoAtlasContractDefinition = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.MongoAtlas,
+  label: "MongoDB Atlas",
+  create: {
+    schema: mongoAtlasCreateFormSchema,
+    getDefaultValues: getMongoAtlasCreateDefaultValues,
+    toPayload: getMongoAtlasCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: mongoAtlasEditFormSchema,
+    getDefaultValues: getMongoAtlasEditDefaultValues,
+    toPayload: getMongoAtlasEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const mongoDbContractDefinition = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.MongoDB,
+  label: "MongoDB",
+  create: {
+    schema: mongoDbCreateFormSchema,
+    getDefaultValues: getMongoDbCreateDefaultValues,
+    toPayload: getMongoDbCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: mongoDbEditFormSchema,
+    getDefaultValues: getMongoDbEditDefaultValues,
+    toPayload: getMongoDbEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const couchbaseContractDefinition = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Couchbase,
+  label: "Couchbase",
+  create: {
+    schema: couchbaseCreateFormSchema,
+    getDefaultValues: getCouchbaseCreateDefaultValues,
+    toPayload: getCouchbaseCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: couchbaseEditFormSchema,
+    getDefaultValues: getCouchbaseEditDefaultValues,
+    toPayload: getCouchbaseEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+const managedStoreContractModule = defineDynamicSecretProviderModule({
+  id: "managed-stores-contract",
+  definitions: [
+    redisContractDefinition,
+    awsElastiCacheContractDefinition,
+    awsMemoryDbContractDefinition,
+    mongoAtlasContractDefinition,
+    mongoDbContractDefinition,
+    couchbaseContractDefinition
+  ]
+});
+
+describe("managed-store provider registration", () => {
+  it("registers all six providers with create and edit parity in picker order", () => {
+    const registry = createDynamicSecretProviderRegistry(managedStoreContractModule);
+
+    assert.deepEqual(registry.providers, MANAGED_STORE_DYNAMIC_SECRET_PROVIDERS);
+    assert.equal(registry.definitions.length, 6);
+    registry.definitions.forEach((definition) => {
+      assert.ok(definition.create.schema);
+      assert.ok(definition.edit.schema);
+      assert.equal(typeof definition.create.getDefaultValues, "function");
+      assert.equal(typeof definition.create.toPayload, "function");
+      assert.equal(typeof definition.edit.getDefaultValues, "function");
+      assert.equal(typeof definition.edit.toPayload, "function");
+    });
+    assert.equal(registry.getDocsSlug(DynamicSecretProviders.MongoAtlas), "mongo-atlas");
+  });
+
+  it("keeps environment selection visible for multi-environment create", () => {
+    const defaultFactories = [
+      getAwsElastiCacheCreateDefaultValues,
+      getAwsMemoryDbCreateDefaultValues,
+      getRedisCreateDefaultValues,
+      getMongoDbCreateDefaultValues,
+      getMongoAtlasCreateDefaultValues,
+      getCouchbaseCreateDefaultValues
+    ];
+
+    defaultFactories.forEach((getDefaultValues) => {
+      assert.equal(getDefaultValues(multiEnvironmentContext).environment, undefined);
+      assert.deepEqual(getDefaultValues(createContext).environment, environment);
+    });
+  });
+});
+
+describe("managed-store provider defaults and validation", () => {
+  it("preserves AWS statement, IAM, and TTL defaults", () => {
+    const elastiCache = getAwsElastiCacheCreateDefaultValues(createContext);
+    const memoryDb = getAwsMemoryDbCreateDefaultValues(createContext);
+
+    assert.equal(elastiCache.defaultTTL, "1h");
+    assert.equal(elastiCache.maxTTL, "24h");
+    assert.match(elastiCache.inputs.creationStatement, /AccessString/);
+    assert.match(elastiCache.inputs.revocationStatement, /UserId/);
+    assert.equal(memoryDb.inputs.auth.type, AwsMemoryDbAuthType.IAM);
+    assert.match(memoryDb.inputs.creationStatement, /AuthenticationMode/);
+    assert.match(memoryDb.inputs.revocationStatement, /UserName/);
+  });
+
+  it("preserves Redis, MongoDB, Atlas, and Couchbase defaults", () => {
+    const redis = getRedisCreateDefaultValues(createContext);
+    const mongoDb = getMongoDbCreateDefaultValues(createContext);
+    const atlas = getMongoAtlasCreateDefaultValues(createContext);
+    const couchbase = getCouchbaseCreateDefaultValues(createContext);
+
+    assert.equal(redis.inputs.port, 6379);
+    assert.equal(typeof redis.inputs.port, "number");
+    assert.equal(redis.inputs.sslRejectUnauthorized, true);
+    assert.match(redis.inputs.creationStatement, /ACL SETUSER/);
+    assert.equal(mongoDb.inputs.port, 27017);
+    assert.equal(typeof mongoDb.inputs.port, "number");
+    assert.equal(mongoDb.inputs.database, "default");
+    assert.deepEqual(mongoDb.inputs.roles, [{ roleName: "readWrite" }]);
+    assert.deepEqual(atlas.inputs.roles, [{ databaseName: "", roleName: "" }]);
+    assert.deepEqual(atlas.inputs.scopes, []);
+    assert.equal(couchbase.inputs.buckets, "*");
+    assert.deepEqual(couchbase.inputs.roles, ["read"]);
+    assert.equal(couchbase.inputs.passwordRequirements?.length, 12);
+    assert.equal(typeof couchbase.inputs.passwordRequirements?.length, "number");
+  });
+
+  it("reports provider-specific required field paths", () => {
+    const redisValues = getValidRedisCreateValues();
+    const mongoDbValues = getValidMongoDbCreateValues();
+    const atlasValues = getValidMongoAtlasCreateValues();
+
+    const invalidRedis = redisCreateFormSchema.safeParse({
+      ...redisValues,
+      inputs: { ...redisValues.inputs, host: "", creationStatement: "" }
+    });
+    const invalidMongoDb = mongoDbCreateFormSchema.safeParse({
+      ...mongoDbValues,
+      inputs: { ...mongoDbValues.inputs, password: "", roles: [] }
+    });
+    const invalidAtlas = mongoAtlasCreateFormSchema.safeParse({
+      ...atlasValues,
+      inputs: { ...atlasValues.inputs, groupId: "", scopes: [{ name: "", type: "" }] }
+    });
+
+    assert.deepEqual(getIssuePaths(invalidRedis), [
+      ["inputs", "host"],
+      ["inputs", "creationStatement"]
+    ]);
+    assert.deepEqual(getIssuePaths(invalidMongoDb), [
+      ["inputs", "password"],
+      ["inputs", "roles"]
+    ]);
+    assert.deepEqual(getIssuePaths(invalidAtlas), [
+      ["inputs", "groupId"],
+      ["inputs", "scopes", 0, "name"],
+      ["inputs", "scopes", 0, "type"]
+    ]);
+  });
+
+  it("validates AWS cluster credentials in both managed-store branches", () => {
+    const elastiCacheValues = getValidAwsElastiCacheCreateValues();
+    const memoryDbValues = getValidAwsMemoryDbCreateValues();
+    const invalidElastiCache = awsElastiCacheCreateFormSchema.safeParse({
+      ...elastiCacheValues,
+      inputs: {
+        ...elastiCacheValues.inputs,
+        clusterName: "",
+        accessKeyId: "",
+        secretAccessKey: ""
+      }
+    });
+    const invalidMemoryDb = awsMemoryDbCreateFormSchema.safeParse({
+      ...memoryDbValues,
+      inputs: {
+        ...memoryDbValues.inputs,
+        clusterName: "",
+        region: "",
+        auth: {
+          type: AwsMemoryDbAuthType.IAM,
+          accessKeyId: "",
+          secretAccessKey: ""
+        }
+      }
+    });
+
+    assert.deepEqual(getIssuePaths(invalidElastiCache), [
+      ["inputs", "clusterName"],
+      ["inputs", "accessKeyId"],
+      ["inputs", "secretAccessKey"]
+    ]);
+    assert.deepEqual(getIssuePaths(invalidMemoryDb), [
+      ["inputs", "clusterName"],
+      ["inputs", "region"],
+      ["inputs", "auth", "accessKeyId"],
+      ["inputs", "auth", "secretAccessKey"]
+    ]);
+  });
+
+  it("keeps Couchbase password values numeric and validates every requirement", () => {
+    const values = getValidCouchbaseCreateValues();
+    const validResult = couchbaseCreateFormSchema.safeParse(values);
+    assert.equal(validResult.success, true);
+    if (validResult.success) {
+      const requirements = validResult.data.inputs.passwordRequirements;
+      assert.equal(typeof requirements?.length, "number");
+      assert.equal(typeof requirements?.required.lowercase, "number");
+      assert.equal(typeof requirements?.required.uppercase, "number");
+      assert.equal(typeof requirements?.required.digits, "number");
+      assert.equal(typeof requirements?.required.symbols, "number");
+    }
+
+    const stringLength = couchbaseCreateFormSchema.safeParse({
+      ...values,
+      inputs: {
+        ...values.inputs,
+        passwordRequirements: { ...values.inputs.passwordRequirements, length: "12" }
+      }
+    });
+    const excessiveRequirements = couchbaseCreateFormSchema.safeParse({
+      ...values,
+      inputs: {
+        ...values.inputs,
+        passwordRequirements: {
+          length: 8,
+          required: { lowercase: 3, uppercase: 3, digits: 3, symbols: 3 },
+          allowedSymbols: "!@#"
+        }
+      }
+    });
+    const forbiddenSymbols = couchbaseCreateFormSchema.safeParse({
+      ...values,
+      inputs: {
+        ...values.inputs,
+        passwordRequirements: {
+          ...values.inputs.passwordRequirements,
+          allowedSymbols: "!@#&"
+        }
+      }
+    });
+
+    assert.deepEqual(getIssuePaths(stringLength), [["inputs", "passwordRequirements", "length"]]);
+    assert.deepEqual(getIssuePaths(excessiveRequirements), [["inputs", "passwordRequirements"]]);
+    assert.deepEqual(getIssuePaths(forbiddenSymbols), [
+      ["inputs", "passwordRequirements", "allowedSymbols"]
+    ]);
+  });
+
+  it("keeps Couchbase edit partial while validating metadata keys", () => {
+    const partialEdit = couchbaseEditFormSchema.safeParse({
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: null,
+      usernameTemplate: null,
+      inputs: { auth: { apiKey: "********" } },
+      metadata: [{ key: "owner", value: "platform" }]
+    });
+    const invalidMetadata = couchbaseEditFormSchema.safeParse({
+      name: "existing-secret",
+      defaultTTL: "1h",
+      maxTTL: null,
+      inputs: {},
+      metadata: [{ key: "", value: "platform" }]
+    });
+
+    assert.equal(partialEdit.success, true);
+    assert.deepEqual(getIssuePaths(invalidMetadata), [["metadata", 0, "key"]]);
+  });
+});
+
+describe("managed-store create payload adapters", () => {
+  it("adapts all provider payloads without sending the default username template", () => {
+    const payloads = [
+      getAwsElastiCacheCreatePayload(getValidAwsElastiCacheCreateValues(), createContext),
+      getAwsMemoryDbCreatePayload(getValidAwsMemoryDbCreateValues(), createContext),
+      getRedisCreatePayload(getValidRedisCreateValues(), createContext),
+      getMongoAtlasCreatePayload(getValidMongoAtlasCreateValues(), createContext),
+      getMongoDbCreatePayload(getValidMongoDbCreateValues(), createContext),
+      getCouchbaseCreatePayload(getValidCouchbaseCreateValues(), createContext)
+    ];
+
+    assert.deepEqual(
+      payloads.map(({ provider }) => provider.type),
+      [
+        DynamicSecretProviders.AwsElastiCache,
+        DynamicSecretProviders.AwsMemoryDb,
+        DynamicSecretProviders.Redis,
+        DynamicSecretProviders.MongoAtlas,
+        DynamicSecretProviders.MongoDB,
+        DynamicSecretProviders.Couchbase
+      ]
+    );
+    payloads.forEach((payload) => {
+      assert.equal(payload.projectSlug, "project");
+      assert.equal(payload.path, "/folder");
+      assert.equal(payload.environmentSlug, "dev");
+      assert.equal(payload.usernameTemplate, undefined);
+    });
+  });
+
+  it("preserves Redis statements and TLS fields without adding gateway properties", () => {
+    const payload = getRedisCreatePayload(getValidRedisCreateValues(), createContext);
+
+    assert.equal(payload.provider.inputs.host, "redis.example.com");
+    assert.equal(payload.provider.inputs.port, 6379);
+    assert.equal(typeof payload.provider.inputs.port, "number");
+    assert.equal(
+      (
+        payload.provider.inputs as typeof payload.provider.inputs & {
+          sslRejectUnauthorized: boolean;
+        }
+      ).sslRejectUnauthorized,
+      false
+    );
+    assert.match(payload.provider.inputs.creationStatement, /ACL SETUSER/);
+    assert.equal("gatewayId" in payload.provider.inputs, false);
+    assert.equal("gatewayPoolId" in payload.provider.inputs, false);
+  });
+
+  it("flattens MongoDB roles, preserves TLS, and omits a cleared port", () => {
+    const values = getValidMongoDbCreateValues();
+    values.inputs.port = 0;
+    const payload = getMongoDbCreatePayload(values, createContext);
+
+    assert.equal(payload.provider.inputs.host, "mongo.example.com");
+    assert.equal(payload.provider.inputs.port, undefined);
+    assert.deepEqual(payload.provider.inputs.roles, ["readWrite", "dbAdmin"]);
+    assert.equal(
+      (
+        payload.provider.inputs as typeof payload.provider.inputs & {
+          sslRejectUnauthorized: boolean;
+        }
+      ).sslRejectUnauthorized,
+      false
+    );
+    assert.equal("gatewayId" in payload.provider.inputs, false);
+  });
+
+  it("preserves MongoDB Atlas roles and provider-specific scopes", () => {
+    const payload = getMongoAtlasCreatePayload(getValidMongoAtlasCreateValues(), createContext);
+
+    assert.deepEqual(payload.provider.inputs.roles, [
+      { databaseName: "app", collectionName: "users", roleName: "readWrite" }
+    ]);
+    assert.deepEqual(payload.provider.inputs.scopes, [{ name: "cluster-id", type: "CLUSTER" }]);
+  });
+
+  it("keeps Couchbase simple and advanced bucket payloads distinct", () => {
+    const simpleValues = getValidCouchbaseCreateValues();
+    const simplePayload = getCouchbaseCreatePayload(simpleValues, createContext);
+    assert.equal(simplePayload.provider.inputs.buckets, "*");
+    assert.equal("useAdvancedBuckets" in simplePayload.provider.inputs, false);
+
+    const advancedValues = getValidCouchbaseCreateValues();
+    advancedValues.inputs.useAdvancedBuckets = true;
+    advancedValues.inputs.buckets = [
+      {
+        name: "inventory",
+        scopes: [{ name: "default", collections: ["items", "suppliers"] }]
+      }
+    ];
+    const advancedPayload = getCouchbaseCreatePayload(advancedValues, createContext);
+
+    assert.deepEqual(advancedPayload.provider.inputs.buckets, advancedValues.inputs.buckets);
+    assert.equal(advancedPayload.provider.inputs.passwordRequirements?.length, 12);
+    assert.equal(typeof advancedPayload.provider.inputs.passwordRequirements?.length, "number");
+  });
+});
+
+describe("managed-store edit hydration and payload adapters", () => {
+  it("preserves every masked provider credential through edit submission", () => {
+    const elastiCacheContext = editContext(DynamicSecretProviders.AwsElastiCache, {
+      clusterName: "redis-cluster",
+      accessKeyId: "access-key",
+      secretAccessKey: "********",
+      region: "us-east-1",
+      creationStatement: "create",
+      revocationStatement: "revoke"
+    });
+    const memoryDbContext = editContext(DynamicSecretProviders.AwsMemoryDb, {
+      clusterName: "memory-cluster",
+      region: "us-east-1",
+      auth: {
+        type: AwsMemoryDbAuthType.IAM,
+        accessKeyId: "access-key",
+        secretAccessKey: "********"
+      },
+      creationStatement: "create",
+      revocationStatement: "revoke"
+    });
+    const redisContext = editContext(DynamicSecretProviders.Redis, {
+      host: "redis.example.com",
+      port: 6379,
+      username: "default",
+      password: "********",
+      creationStatement: "create",
+      revocationStatement: "revoke",
+      sslRejectUnauthorized: true
+    });
+    const mongoDbContext = editContext(DynamicSecretProviders.MongoDB, {
+      host: "mongo.example.com",
+      port: 27017,
+      database: "app",
+      username: "admin",
+      password: "********",
+      roles: ["readWrite"],
+      sslRejectUnauthorized: true
+    });
+    const atlasContext = editContext(DynamicSecretProviders.MongoAtlas, {
+      adminPublicKey: "public-key",
+      adminPrivateKey: "********",
+      groupId: "0123456789abcdef01234567",
+      roles: [{ databaseName: "app", roleName: "readWrite" }],
+      scopes: []
+    });
+    const couchbaseContext = editContext(DynamicSecretProviders.Couchbase, {
+      url: "https://cloudapi.cloud.couchbase.com",
+      orgId: "org",
+      projectId: "project",
+      clusterId: "cluster",
+      roles: ["read"],
+      buckets: "*",
+      passwordRequirements: {
+        length: 12,
+        required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 1 }
+      },
+      auth: { apiKey: "********" }
+    });
+
+    const elastiCache = getAwsElastiCacheEditDefaultValues(elastiCacheContext);
+    const memoryDb = getAwsMemoryDbEditDefaultValues(memoryDbContext);
+    const redis = getRedisEditDefaultValues(redisContext);
+    const mongoDb = getMongoDbEditDefaultValues(mongoDbContext);
+    const atlas = getMongoAtlasEditDefaultValues(atlasContext);
+    const couchbase = getCouchbaseEditDefaultValues(couchbaseContext);
+
+    assert.equal(elastiCache.inputs.secretAccessKey, "********");
+    assert.equal(memoryDb.inputs.auth?.secretAccessKey, "********");
+    assert.equal(redis.inputs.password, "********");
+    assert.equal(mongoDb.inputs.password, "********");
+    assert.equal(atlas.inputs.adminPrivateKey, "********");
+    assert.equal(couchbase.inputs.auth?.apiKey, "********");
+    assert.equal(
+      (
+        getAwsElastiCacheEditPayload(elastiCache, elastiCacheContext).data.inputs as {
+          secretAccessKey: string;
+        }
+      ).secretAccessKey,
+      "********"
+    );
+    assert.equal(
+      (
+        getAwsMemoryDbEditPayload(memoryDb, memoryDbContext).data.inputs as {
+          auth: { secretAccessKey: string };
+        }
+      ).auth.secretAccessKey,
+      "********"
+    );
+    assert.equal(
+      (getRedisEditPayload(redis, redisContext).data.inputs as { password: string }).password,
+      "********"
+    );
+    assert.equal(
+      (getMongoDbEditPayload(mongoDb, mongoDbContext).data.inputs as { password: string }).password,
+      "********"
+    );
+    assert.equal(
+      (getMongoAtlasEditPayload(atlas, atlasContext).data.inputs as { adminPrivateKey: string })
+        .adminPrivateKey,
+      "********"
+    );
+    assert.equal(
+      (
+        getCouchbaseEditPayload(couchbase, couchbaseContext).data.inputs as {
+          auth: { apiKey: string };
+        }
+      ).auth.apiKey,
+      "********"
+    );
+  });
+
+  it("hydrates and flattens MongoDB role values on edit", () => {
+    const context = editContext(DynamicSecretProviders.MongoDB, {
+      host: "mongo.example.com",
+      password: "********",
+      roles: ["readWrite", "dbAdmin"]
+    });
+    const values = getMongoDbEditDefaultValues(context);
+    values.name = "renamed-secret";
+    values.maxTTL = null;
+    values.usernameTemplate = DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE;
+
+    assert.deepEqual(values.inputs.roles, [{ roleName: "readWrite" }, { roleName: "dbAdmin" }]);
+    const payload = getMongoDbEditPayload(values, context);
+    assert.deepEqual((payload.data.inputs as { roles: string[] }).roles, ["readWrite", "dbAdmin"]);
+    assert.equal(payload.data.newName, "renamed-secret");
+    assert.equal(payload.data.maxTTL, undefined);
+    assert.equal(payload.data.usernameTemplate, null);
+  });
+
+  it("hydrates Couchbase advanced buckets and preserves edit-only metadata", () => {
+    const buckets = [{ name: "inventory", scopes: [{ name: "default", collections: ["items"] }] }];
+    const context = editContext(
+      DynamicSecretProviders.Couchbase,
+      {
+        url: "https://cloudapi.cloud.couchbase.com",
+        orgId: "org",
+        projectId: "project",
+        clusterId: "cluster",
+        roles: ["read"],
+        buckets,
+        auth: { apiKey: "********" }
+      },
+      { metadata: [{ key: "owner", value: "platform" }] }
+    );
+    const values = getCouchbaseEditDefaultValues(context);
+    values.name = "renamed-secret";
+    values.usernameTemplate = DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE;
+
+    assert.equal(values.inputs.useAdvancedBuckets, true);
+    assert.deepEqual(values.metadata, [{ key: "owner", value: "platform" }]);
+    const payload = getCouchbaseEditPayload(values, context);
+    assert.deepEqual((payload.data.inputs as { buckets: unknown }).buckets, buckets);
+    assert.deepEqual(payload.data.metadata, [{ key: "owner", value: "platform" }]);
+    assert.equal(payload.data.newName, "renamed-secret");
+    assert.equal(payload.data.usernameTemplate, undefined);
+    assert.equal("useAdvancedBuckets" in (payload.data.inputs as object), false);
+  });
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerContractTestHarness.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerContractTestHarness.ts
@@ -1,0 +1,135 @@
+import type { DefaultValues } from "react-hook-form";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type {
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderDefinition,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "./types";
+
+type TInvalidValuesCase = {
+  name: string;
+  values: unknown;
+  issuePaths: readonly (readonly (string | number)[])[];
+};
+
+type TMaskedValueCase = {
+  name: string;
+  expected: unknown;
+  defaultValuePath: readonly (string | number)[];
+  payloadValuePath: readonly (string | number)[];
+};
+
+export type TDynamicSecretProviderContractFixture<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+> = {
+  name: string;
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>;
+  create: {
+    context: TCreateDynamicSecretProviderFormContext;
+    defaultValues: DefaultValues<TCreateValues>;
+    validValues: TCreateValues;
+    payload: unknown;
+    invalidValues?: readonly TInvalidValuesCase[];
+  };
+  edit: {
+    context: TEditDynamicSecretProviderFormContext;
+    defaultValues: DefaultValues<TEditValues>;
+    validValues: TEditValues;
+    payload: unknown;
+    invalidValues?: readonly TInvalidValuesCase[];
+    maskedValues?: readonly TMaskedValueCase[];
+  };
+};
+
+const getValueAtPath = (value: unknown, path: readonly (string | number)[]) =>
+  path.reduce<unknown>((current, segment) => {
+    if (current === null || typeof current !== "object") return undefined;
+    return (current as Record<string | number, unknown>)[segment];
+  }, value);
+
+const getIssuePaths = (result: {
+  success: boolean;
+  error?: { issues: { path: PropertyKey[] }[] };
+}) => (result.success ? [] : (result.error?.issues.map(({ path }) => path) ?? []));
+
+/**
+ * Reusable provider-contract suite. Rollout tickets supply their own fixture;
+ * the foundation does not import or register production provider definitions.
+ */
+export const testDynamicSecretProviderContract = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues
+>(
+  fixture: TDynamicSecretProviderContractFixture<TProvider, TCreateValues, TEditValues>
+) => {
+  describe(`${fixture.name} dynamic-secret provider contract`, () => {
+    it("declares provider-owned defaults", () => {
+      assert.deepEqual(
+        fixture.definition.create.getDefaultValues(fixture.create.context),
+        fixture.create.defaultValues
+      );
+      assert.deepEqual(
+        fixture.definition.edit.getDefaultValues(fixture.edit.context),
+        fixture.edit.defaultValues
+      );
+    });
+
+    it("accepts valid create and edit values", () => {
+      assert.equal(
+        fixture.definition.create.schema.safeParse(fixture.create.validValues).success,
+        true
+      );
+      assert.equal(
+        fixture.definition.edit.schema.safeParse(fixture.edit.validValues).success,
+        true
+      );
+    });
+
+    fixture.create.invalidValues?.forEach((invalidCase) => {
+      it(`rejects invalid create values: ${invalidCase.name}`, () => {
+        const result = fixture.definition.create.schema.safeParse(invalidCase.values);
+        assert.equal(result.success, false);
+        assert.deepEqual(getIssuePaths(result), invalidCase.issuePaths);
+      });
+    });
+
+    fixture.edit.invalidValues?.forEach((invalidCase) => {
+      it(`rejects invalid edit values: ${invalidCase.name}`, () => {
+        const result = fixture.definition.edit.schema.safeParse(invalidCase.values);
+        assert.equal(result.success, false);
+        assert.deepEqual(getIssuePaths(result), invalidCase.issuePaths);
+      });
+    });
+
+    it("adapts create and edit payloads", () => {
+      assert.deepEqual(
+        fixture.definition.create.toPayload(fixture.create.validValues, fixture.create.context),
+        fixture.create.payload
+      );
+      assert.deepEqual(
+        fixture.definition.edit.toPayload(fixture.edit.validValues, fixture.edit.context),
+        fixture.edit.payload
+      );
+    });
+
+    fixture.edit.maskedValues?.forEach((maskedValue) => {
+      it(`preserves masked edit values: ${maskedValue.name}`, () => {
+        const defaults = fixture.definition.edit.getDefaultValues(fixture.edit.context);
+        const payload = fixture.definition.edit.toPayload(
+          fixture.edit.validValues,
+          fixture.edit.context
+        );
+        assert.equal(getValueAtPath(defaults, maskedValue.defaultValuePath), maskedValue.expected);
+        assert.equal(getValueAtPath(payload, maskedValue.payloadValuePath), maskedValue.expected);
+      });
+    });
+  });
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsManagedStores.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsManagedStores.tsx
@@ -1,0 +1,112 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { buildStatementFields, StatementAccordion } from "../shared";
+import { defineDynamicSecretProvider } from "../types";
+import {
+  awsElastiCacheCreateFormSchema,
+  awsElastiCacheEditFormSchema,
+  awsMemoryDbCreateFormSchema,
+  awsMemoryDbEditFormSchema,
+  getAwsElastiCacheCreateDefaultValues,
+  getAwsElastiCacheCreatePayload,
+  getAwsElastiCacheEditDefaultValues,
+  getAwsElastiCacheEditPayload,
+  getAwsMemoryDbCreateDefaultValues,
+  getAwsMemoryDbCreatePayload,
+  getAwsMemoryDbEditDefaultValues,
+  getAwsMemoryDbEditPayload
+} from "./awsManagedStoresContract";
+
+const elastiCacheConnectionFields = [
+  { name: "inputs.clusterName", type: "text", label: "Cluster Name", layout: "half" },
+  { name: "inputs.region", type: "text", label: "Region", layout: "half" },
+  { name: "inputs.accessKeyId", type: "text", label: "Access Key ID", layout: "half" },
+  {
+    name: "inputs.secretAccessKey",
+    type: "secret",
+    label: "Secret Access Key",
+    autoComplete: "new-password",
+    layout: "half"
+  }
+] as const;
+
+const memoryDbConnectionFields = [
+  { name: "inputs.clusterName", type: "text", label: "Cluster Name", layout: "half" },
+  { name: "inputs.region", type: "text", label: "Region", layout: "half" },
+  { name: "inputs.auth.accessKeyId", type: "text", label: "Access Key ID", layout: "half" },
+  {
+    name: "inputs.auth.secretAccessKey",
+    type: "secret",
+    label: "Secret Access Key",
+    autoComplete: "new-password",
+    layout: "half"
+  }
+] as const;
+
+const statementFields = buildStatementFields({
+  includeRenew: false,
+  creationRows: 4
+});
+
+const AwsManagedStoreFields = ({ memoryDb = false }: { memoryDb?: boolean }) => (
+  <>
+    <DynamicSecretProviderGroup id="aws-managed-store-connection" presentation="panel">
+      <DynamicSecretProviderFields
+        fields={memoryDb ? memoryDbConnectionFields : elastiCacheConnectionFields}
+      />
+    </DynamicSecretProviderGroup>
+    <StatementAccordion
+      title={`Modify ${memoryDb ? "MemoryDB" : "ElastiCache"} Statements`}
+      fields={statementFields}
+    />
+  </>
+);
+
+const AwsElastiCacheFields = () => <AwsManagedStoreFields />;
+const AwsMemoryDbFields = () => <AwsManagedStoreFields memoryDb />;
+
+export const awsElastiCacheDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AwsElastiCache,
+  label: "AWS ElastiCache",
+  customRenderer: {
+    reasons: ["non-scalar-value"],
+    Component: AwsElastiCacheFields
+  },
+  create: {
+    schema: awsElastiCacheCreateFormSchema,
+    getDefaultValues: getAwsElastiCacheCreateDefaultValues,
+    toPayload: getAwsElastiCacheCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: awsElastiCacheEditFormSchema,
+    getDefaultValues: getAwsElastiCacheEditDefaultValues,
+    toPayload: getAwsElastiCacheEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});
+
+export const awsMemoryDbDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.AwsMemoryDb,
+  label: "AWS MemoryDB",
+  customRenderer: {
+    reasons: ["non-scalar-value"],
+    Component: AwsMemoryDbFields
+  },
+  create: {
+    schema: awsMemoryDbCreateFormSchema,
+    getDefaultValues: getAwsMemoryDbCreateDefaultValues,
+    toPayload: getAwsMemoryDbCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: awsMemoryDbEditFormSchema,
+    getDefaultValues: getAwsMemoryDbEditDefaultValues,
+    toPayload: getAwsMemoryDbEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsManagedStoresContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/awsManagedStoresContract.ts
@@ -1,0 +1,222 @@
+import { z } from "zod";
+
+import {
+  AwsMemoryDbAuthType,
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const ELASTICACHE_CREATION_STATEMENT = `{
+        "UserId": "{{username}}",
+        "UserName": "{{username}}",
+        "Engine": "redis",
+        "Passwords": ["{{password}}"],
+        "AccessString": "on ~* +@all"
+}`;
+
+export const ELASTICACHE_REVOCATION_STATEMENT = `{
+        "UserId": "{{username}}"
+}`;
+
+export const MEMORYDB_CREATION_STATEMENT = `{
+        "UserName": "{{username}}",
+        "AccessString": "on ~* +@all",
+        "AuthenticationMode": { "Type": "password", "Passwords": ["{{password}}"] }
+}`;
+
+export const MEMORYDB_REVOCATION_STATEMENT = `{
+        "UserName": "{{username}}"
+}`;
+
+export const awsElastiCacheCreateInputsSchema = z.object({
+  clusterName: z.string().trim().min(1),
+  accessKeyId: z.string().trim().min(1),
+  secretAccessKey: z.string().trim().min(1),
+  region: z.string().trim(),
+  creationStatement: z.string().trim(),
+  revocationStatement: z.string().trim()
+});
+
+export const awsElastiCacheEditInputsSchema = awsElastiCacheCreateInputsSchema.partial();
+
+export const awsMemoryDbCreateInputsSchema = z.object({
+  clusterName: z.string().trim().min(1),
+  region: z.string().trim().min(1),
+  auth: z.discriminatedUnion("type", [
+    z.object({
+      type: z.literal(AwsMemoryDbAuthType.IAM),
+      accessKeyId: z.string().trim().min(1),
+      secretAccessKey: z.string().trim().min(1)
+    })
+  ]),
+  creationStatement: z.string().trim(),
+  revocationStatement: z.string().trim()
+});
+
+export const awsMemoryDbEditInputsSchema = awsMemoryDbCreateInputsSchema.partial();
+
+export type TAwsElastiCacheCreateValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof awsElastiCacheCreateInputsSchema>
+>;
+export type TAwsElastiCacheEditValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof awsElastiCacheEditInputsSchema>
+>;
+export type TAwsMemoryDbCreateValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof awsMemoryDbCreateInputsSchema>
+>;
+export type TAwsMemoryDbEditValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof awsMemoryDbEditInputsSchema>
+>;
+
+export const awsElastiCacheCreateFormSchema = createDynamicSecretProviderFormSchema(
+  awsElastiCacheCreateInputsSchema
+) as z.ZodType<TAwsElastiCacheCreateValues>;
+export const awsElastiCacheEditFormSchema = editDynamicSecretProviderFormSchema(
+  awsElastiCacheEditInputsSchema,
+  { usernameTemplateSchema: z.string().trim().nullable().optional() }
+) as z.ZodType<TAwsElastiCacheEditValues>;
+export const awsMemoryDbCreateFormSchema = createDynamicSecretProviderFormSchema(
+  awsMemoryDbCreateInputsSchema
+) as z.ZodType<TAwsMemoryDbCreateValues>;
+export const awsMemoryDbEditFormSchema = editDynamicSecretProviderFormSchema(
+  awsMemoryDbEditInputsSchema,
+  { usernameTemplateSchema: z.string().trim().nullable().optional() }
+) as z.ZodType<TAwsMemoryDbEditValues>;
+
+const getCreateDefaults = (context: TCreateDynamicSecretProviderFormContext) => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+});
+
+export const getAwsElastiCacheCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TAwsElastiCacheCreateValues => ({
+  ...getCreateDefaults(context),
+  inputs: {
+    clusterName: "",
+    accessKeyId: "",
+    secretAccessKey: "",
+    region: "",
+    creationStatement: ELASTICACHE_CREATION_STATEMENT,
+    revocationStatement: ELASTICACHE_REVOCATION_STATEMENT
+  }
+});
+
+export const getAwsMemoryDbCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TAwsMemoryDbCreateValues => ({
+  ...getCreateDefaults(context),
+  inputs: {
+    clusterName: "",
+    region: "",
+    auth: {
+      type: AwsMemoryDbAuthType.IAM,
+      accessKeyId: "",
+      secretAccessKey: ""
+    },
+    creationStatement: MEMORYDB_CREATION_STATEMENT,
+    revocationStatement: MEMORYDB_REVOCATION_STATEMENT
+  }
+});
+
+const getEditDefaults = (context: TEditDynamicSecretProviderFormContext) => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  usernameTemplate:
+    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+});
+
+export const getAwsElastiCacheEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TAwsElastiCacheEditValues => ({
+  ...getEditDefaults(context),
+  inputs: { ...(context.dynamicSecret.inputs as TAwsElastiCacheEditValues["inputs"]) }
+});
+
+export const getAwsMemoryDbEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TAwsMemoryDbEditValues => ({
+  ...getEditDefaults(context),
+  inputs: { ...(context.dynamicSecret.inputs as TAwsMemoryDbEditValues["inputs"]) }
+});
+
+const getCreatePayloadBase = (
+  values: TDynamicSecretProviderFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+) => ({
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+
+export const getAwsElastiCacheCreatePayload = (
+  values: TAwsElastiCacheCreateValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.AwsElastiCache> => ({
+  ...getCreatePayloadBase(values, context),
+  provider: {
+    type: DynamicSecretProviders.AwsElastiCache,
+    inputs: awsElastiCacheCreateInputsSchema.parse(values.inputs)
+  }
+});
+
+export const getAwsMemoryDbCreatePayload = (
+  values: TAwsMemoryDbCreateValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.AwsMemoryDb> => ({
+  ...getCreatePayloadBase(values, context),
+  provider: {
+    type: DynamicSecretProviders.AwsMemoryDb,
+    inputs: awsMemoryDbCreateInputsSchema.parse(values.inputs)
+  }
+});
+
+const getEditPayload = (
+  values: TDynamicSecretProviderFormValues,
+  context: TEditDynamicSecretProviderFormContext,
+  inputs: unknown
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs,
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});
+
+export const getAwsElastiCacheEditPayload = (
+  values: TAwsElastiCacheEditValues,
+  context: TEditDynamicSecretProviderFormContext
+) => getEditPayload(values, context, awsElastiCacheEditInputsSchema.parse(values.inputs));
+
+export const getAwsMemoryDbEditPayload = (
+  values: TAwsMemoryDbEditValues,
+  context: TEditDynamicSecretProviderFormContext
+) => getEditPayload(values, context, awsMemoryDbEditInputsSchema.parse(values.inputs));

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/couchbase.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/couchbase.tsx
@@ -1,0 +1,599 @@
+/* eslint-disable react/no-array-index-key -- Couchbase bucket collections do not carry stable IDs. */
+import { Controller, useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import {
+  Button,
+  Checkbox,
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+  FieldTitle,
+  IconButton,
+  Input,
+  Switch
+} from "@app/components/v3";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import {
+  defineDynamicSecretProvider,
+  TDynamicSecretProviderField,
+  TDynamicSecretProviderRendererProps
+} from "../types";
+import {
+  couchbaseCreateFormSchema,
+  couchbaseEditFormSchema,
+  getCouchbaseCreateDefaultValues,
+  getCouchbaseCreatePayload,
+  getCouchbaseEditDefaultValues,
+  getCouchbaseEditPayload,
+  TCouchbaseCreateValues,
+  TCouchbaseEditValues
+} from "./couchbaseContract";
+
+type TCouchbaseValues = TCouchbaseCreateValues | TCouchbaseEditValues;
+
+const COUCHBASE_ROLES = [
+  { value: "read", label: "Read", description: "Read-only access to bucket data." },
+  { value: "write", label: "Write", description: "Full write access to bucket data." }
+] as const;
+
+const couchbaseConnectionFields = [
+  { name: "inputs.url", type: "text", label: "URL" },
+  { name: "inputs.orgId", type: "text", label: "Organization ID", layout: "half" },
+  { name: "inputs.projectId", type: "text", label: "Project ID", layout: "half" },
+  { name: "inputs.clusterId", type: "text", label: "Cluster ID" },
+  {
+    name: "inputs.auth.apiKey",
+    type: "secret",
+    label: "API Key",
+    autoComplete: "new-password"
+  }
+] satisfies readonly TDynamicSecretProviderField<TCouchbaseValues>[];
+
+const usernameTemplateField = [
+  {
+    name: "usernameTemplate",
+    type: "text",
+    label: "Username Template",
+    placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+  }
+] satisfies readonly TDynamicSecretProviderField<TCouchbaseValues>[];
+
+const passwordRequirementFields = [
+  {
+    name: "inputs.passwordRequirements.length",
+    type: "number",
+    label: "Password Length",
+    min: 8,
+    max: 128
+  },
+  {
+    name: "inputs.passwordRequirements.required.lowercase",
+    type: "number",
+    label: "Lowercase Count",
+    description: "Minimum lowercase letters (required: at least 1).",
+    min: 1,
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.uppercase",
+    type: "number",
+    label: "Uppercase Count",
+    description: "Minimum uppercase letters (required: at least 1).",
+    min: 1,
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.digits",
+    type: "number",
+    label: "Digit Count",
+    description: "Minimum digits (required: at least 1).",
+    min: 1,
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.required.symbols",
+    type: "number",
+    label: "Symbol Count",
+    description: "Minimum special characters (required: at least 1).",
+    min: 1,
+    layout: "half"
+  },
+  {
+    name: "inputs.passwordRequirements.allowedSymbols",
+    type: "text",
+    label: "Allowed Symbols",
+    description: "Cannot contain: < > ; . * & | £.",
+    isOptional: true
+  }
+] satisfies readonly TDynamicSecretProviderField<TCouchbaseValues>[];
+
+const CouchbaseRolesField = () => {
+  const { control } = useFormContext<TCouchbaseValues>();
+
+  return (
+    <Controller
+      control={control}
+      name="inputs.roles"
+      render={({ field, fieldState: { error } }) => {
+        const selectedRoles = field.value ?? [];
+
+        return (
+          <FieldSet>
+            <FieldLegend>Roles</FieldLegend>
+            <FieldDescription>Select one or more roles to assign to the user.</FieldDescription>
+            <FieldGroup>
+              {COUCHBASE_ROLES.map((role) => {
+                const id = `couchbase-role-${role.value}`;
+                const isChecked = selectedRoles.includes(role.value);
+
+                return (
+                  <Field key={role.value} orientation="horizontal">
+                    <Checkbox
+                      id={id}
+                      variant="project"
+                      isChecked={isChecked}
+                      isError={Boolean(error)}
+                      onCheckedChange={(checked) => {
+                        field.onChange(
+                          checked === true
+                            ? [...selectedRoles, role.value]
+                            : selectedRoles.filter((value) => value !== role.value)
+                        );
+                      }}
+                    />
+                    <FieldContent>
+                      <FieldTitle>
+                        <label htmlFor={id}>{role.label}</label>
+                      </FieldTitle>
+                      <FieldDescription>{role.description}</FieldDescription>
+                    </FieldContent>
+                  </Field>
+                );
+              })}
+            </FieldGroup>
+            {error?.message && <FieldError>{error.message}</FieldError>}
+          </FieldSet>
+        );
+      }}
+    />
+  );
+};
+
+const CouchbaseBucketFields = () => {
+  const { control, setValue } = useFormContext<TCouchbaseValues>();
+  const useAdvancedBuckets = useWatch({ control, name: "inputs.useAdvancedBuckets" });
+  const buckets = useWatch({ control, name: "inputs.buckets" });
+  const advancedBuckets = Array.isArray(buckets) ? buckets : [];
+
+  return (
+    <DynamicSecretProviderGroup id="couchbase-buckets" presentation="panel" surface title="Buckets">
+      <Controller
+        control={control}
+        name="inputs.useAdvancedBuckets"
+        render={({ field }) => (
+          <Field orientation="horizontal">
+            <FieldContent>
+              <FieldTitle>
+                <FieldLabel htmlFor="couchbase-advanced-buckets">
+                  Advanced Bucket Configuration
+                </FieldLabel>
+              </FieldTitle>
+              <FieldDescription>
+                Limit access by bucket, scope, and collection instead of using a bucket pattern.
+              </FieldDescription>
+            </FieldContent>
+            <Switch
+              ref={field.ref}
+              id="couchbase-advanced-buckets"
+              variant="project"
+              checked={Boolean(field.value)}
+              onBlur={field.onBlur}
+              onCheckedChange={(checked) => {
+                field.onChange(checked);
+                setValue("inputs.buckets", checked ? [] : "*", {
+                  shouldDirty: true
+                });
+              }}
+            />
+          </Field>
+        )}
+      />
+
+      {!useAdvancedBuckets ? (
+        <Controller
+          control={control}
+          name="inputs.buckets"
+          render={({ field, fieldState: { error } }) => (
+            <Field data-invalid={Boolean(error)}>
+              <FieldLabel htmlFor="couchbase-bucket-access">Bucket Access</FieldLabel>
+              <Input
+                id="couchbase-bucket-access"
+                value={typeof field.value === "string" ? field.value : "*"}
+                onChange={field.onChange}
+                onBlur={field.onBlur}
+                isError={Boolean(error)}
+              />
+              <FieldDescription>
+                Specify comma-separated bucket names, or use * for all buckets, scopes, and
+                collections.
+              </FieldDescription>
+              {error?.message && <FieldError>{error.message}</FieldError>}
+            </Field>
+          )}
+        />
+      ) : (
+        <div className="flex flex-col gap-3">
+          {advancedBuckets.map((bucket, bucketIndex) => (
+            <div
+              key={bucketIndex}
+              className="rounded-md border border-border bg-container p-3 text-foreground"
+            >
+              <div className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_auto]">
+                <Controller
+                  control={control}
+                  name={`inputs.buckets.${bucketIndex}.name`}
+                  render={({ field, fieldState: { error } }) => (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`couchbase-bucket-${bucketIndex}-name`}>
+                        Bucket Name
+                      </FieldLabel>
+                      <Input
+                        {...field}
+                        id={`couchbase-bucket-${bucketIndex}-name`}
+                        placeholder="Bucket name"
+                        isError={Boolean(error)}
+                      />
+                      {error?.message && <FieldError>{error.message}</FieldError>}
+                    </Field>
+                  )}
+                />
+                <div className="flex flex-col gap-2">
+                  <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                    &nbsp;
+                  </FieldLabel>
+                  <IconButton
+                    type="button"
+                    variant="outline"
+                    aria-label={`Remove bucket ${bucketIndex + 1}`}
+                    onClick={() =>
+                      setValue(
+                        "inputs.buckets",
+                        advancedBuckets.filter((_, index) => index !== bucketIndex),
+                        { shouldDirty: true }
+                      )
+                    }
+                  >
+                    <Trash2Icon />
+                  </IconButton>
+                </div>
+              </div>
+
+              <FieldSet className="mt-3">
+                <FieldLegend variant="label">Scopes</FieldLegend>
+                <FieldDescription>
+                  No scopes grants access to every scope in this bucket.
+                </FieldDescription>
+                <div className="flex flex-col gap-3">
+                  {(bucket.scopes ?? []).map((scope, scopeIndex) => (
+                    <div
+                      key={scopeIndex}
+                      className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+                    >
+                      <Controller
+                        control={control}
+                        name={`inputs.buckets.${bucketIndex}.scopes.${scopeIndex}.name`}
+                        render={({ field, fieldState: { error } }) => (
+                          <Field data-invalid={Boolean(error)}>
+                            <FieldLabel
+                              htmlFor={`couchbase-bucket-${bucketIndex}-scope-${scopeIndex}-name`}
+                            >
+                              Scope Name
+                            </FieldLabel>
+                            <Input
+                              {...field}
+                              id={`couchbase-bucket-${bucketIndex}-scope-${scopeIndex}-name`}
+                              placeholder="Scope name"
+                              isError={Boolean(error)}
+                            />
+                            {error?.message && <FieldError>{error.message}</FieldError>}
+                          </Field>
+                        )}
+                      />
+                      <div className="flex flex-col gap-2">
+                        <FieldLabel
+                          className="pointer-events-none invisible select-none"
+                          aria-hidden
+                        >
+                          &nbsp;
+                        </FieldLabel>
+                        <IconButton
+                          type="button"
+                          variant="outline"
+                          aria-label={`Remove scope ${scopeIndex + 1} from bucket ${bucketIndex + 1}`}
+                          onClick={() => {
+                            const nextBuckets = structuredClone(advancedBuckets);
+                            nextBuckets[bucketIndex].scopes = (
+                              nextBuckets[bucketIndex].scopes ?? []
+                            ).filter((_, index) => index !== scopeIndex);
+                            setValue("inputs.buckets", nextBuckets, { shouldDirty: true });
+                          }}
+                        >
+                          <Trash2Icon />
+                        </IconButton>
+                      </div>
+                      <FieldSet className="col-span-full">
+                        <FieldLegend variant="label">
+                          Collections <span className="font-normal text-muted">(optional)</span>
+                        </FieldLegend>
+                        <FieldDescription>
+                          No collections grants access to every collection in this scope.
+                        </FieldDescription>
+                        <div className="flex flex-col gap-3">
+                          {(scope.collections ?? []).map((_collection, collectionIndex) => (
+                            <div
+                              key={collectionIndex}
+                              className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+                            >
+                              <Controller
+                                control={control}
+                                name={`inputs.buckets.${bucketIndex}.scopes.${scopeIndex}.collections.${collectionIndex}`}
+                                render={({ field, fieldState: { error } }) => (
+                                  <Field data-invalid={Boolean(error)}>
+                                    <FieldLabel
+                                      htmlFor={`couchbase-bucket-${bucketIndex}-scope-${scopeIndex}-collection-${collectionIndex}`}
+                                    >
+                                      Collection Name
+                                    </FieldLabel>
+                                    <Input
+                                      {...field}
+                                      id={`couchbase-bucket-${bucketIndex}-scope-${scopeIndex}-collection-${collectionIndex}`}
+                                      placeholder="Collection name"
+                                      isError={Boolean(error)}
+                                    />
+                                    {error?.message && <FieldError>{error.message}</FieldError>}
+                                  </Field>
+                                )}
+                              />
+                              <div className="flex flex-col gap-2">
+                                <FieldLabel
+                                  className="pointer-events-none invisible select-none"
+                                  aria-hidden
+                                >
+                                  &nbsp;
+                                </FieldLabel>
+                                <IconButton
+                                  type="button"
+                                  variant="outline"
+                                  aria-label={`Remove collection ${collectionIndex + 1} from scope ${scopeIndex + 1}`}
+                                  onClick={() => {
+                                    const nextBuckets = structuredClone(advancedBuckets);
+                                    const currentScope =
+                                      nextBuckets[bucketIndex].scopes?.[scopeIndex];
+                                    if (currentScope) {
+                                      currentScope.collections = (
+                                        currentScope.collections ?? []
+                                      ).filter((_, index) => index !== collectionIndex);
+                                    }
+                                    setValue("inputs.buckets", nextBuckets, {
+                                      shouldDirty: true
+                                    });
+                                  }}
+                                >
+                                  <Trash2Icon />
+                                </IconButton>
+                              </div>
+                            </div>
+                          ))}
+                          <Button
+                            type="button"
+                            size="sm"
+                            className="self-start"
+                            onClick={() => {
+                              const nextBuckets = structuredClone(advancedBuckets);
+                              const currentScope = nextBuckets[bucketIndex].scopes?.[scopeIndex];
+                              if (currentScope) {
+                                currentScope.collections = [
+                                  ...(currentScope.collections ?? []),
+                                  ""
+                                ];
+                              }
+                              setValue("inputs.buckets", nextBuckets, { shouldDirty: true });
+                            }}
+                          >
+                            <PlusIcon />
+                            Add Collection
+                          </Button>
+                        </div>
+                      </FieldSet>
+                    </div>
+                  ))}
+                  <Button
+                    type="button"
+                    size="sm"
+                    className="self-start"
+                    onClick={() => {
+                      const nextBuckets = structuredClone(advancedBuckets);
+                      nextBuckets[bucketIndex].scopes = [
+                        ...(nextBuckets[bucketIndex].scopes ?? []),
+                        { name: "", collections: [] }
+                      ];
+                      setValue("inputs.buckets", nextBuckets, { shouldDirty: true });
+                    }}
+                  >
+                    <PlusIcon />
+                    Add Scope
+                  </Button>
+                </div>
+              </FieldSet>
+            </div>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            className="self-start"
+            onClick={() =>
+              setValue("inputs.buckets", [...advancedBuckets, { name: "", scopes: [] }], {
+                shouldDirty: true
+              })
+            }
+          >
+            <PlusIcon />
+            Add Bucket
+          </Button>
+        </div>
+      )}
+    </DynamicSecretProviderGroup>
+  );
+};
+
+const CouchbasePasswordFields = () => {
+  const { control } = useFormContext<TCouchbaseValues>();
+  const length = useWatch({ control, name: "inputs.passwordRequirements.length" });
+  const required = useWatch({ control, name: "inputs.passwordRequirements.required" });
+  const requiredCount = Object.values(required ?? {}).reduce(
+    (total, count) => total + Number(count ?? 0),
+    0
+  );
+  const exceedsLength = typeof length === "number" && requiredCount > length;
+
+  return (
+    <DynamicSecretProviderGroup
+      id="couchbase-password-requirements"
+      presentation="collapse"
+      title="Password Configuration (optional)"
+    >
+      <FieldDescription>
+        Set constraints on the generated Couchbase user password (8–128 characters). Forbidden
+        characters: &lt; &gt; ; . * &amp; | £.
+      </FieldDescription>
+      <DynamicSecretProviderFields fields={passwordRequirementFields} />
+      <FieldDescription className={exceedsLength ? "text-danger" : undefined}>
+        Total required characters: {requiredCount}
+        {exceedsLength ? ` (exceeds length of ${length})` : ""}
+      </FieldDescription>
+    </DynamicSecretProviderGroup>
+  );
+};
+
+const CouchbaseMetadataFields = () => {
+  const { control } = useFormContext<TCouchbaseEditValues>();
+  const metadata = useFieldArray({ control, name: "metadata" });
+
+  return (
+    <DynamicSecretProviderGroup
+      id="couchbase-metadata"
+      presentation="panel"
+      surface
+      title="Metadata"
+    >
+      <div className="flex flex-col gap-3">
+        {metadata.fields.map(({ id }, index) => (
+          <div
+            key={id}
+            className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+          >
+            <Controller
+              control={control}
+              name={`metadata.${index}.key`}
+              render={({ field, fieldState: { error } }) => (
+                <Field data-invalid={Boolean(error)}>
+                  <FieldLabel htmlFor={`couchbase-metadata-${index}-key`}>Key</FieldLabel>
+                  <Input
+                    {...field}
+                    id={`couchbase-metadata-${index}-key`}
+                    placeholder="Key"
+                    isError={Boolean(error)}
+                  />
+                  {error?.message && <FieldError>{error.message}</FieldError>}
+                </Field>
+              )}
+            />
+            <Controller
+              control={control}
+              name={`metadata.${index}.value`}
+              render={({ field, fieldState: { error } }) => (
+                <Field data-invalid={Boolean(error)}>
+                  <FieldLabel htmlFor={`couchbase-metadata-${index}-value`}>Value</FieldLabel>
+                  <Input
+                    {...field}
+                    id={`couchbase-metadata-${index}-value`}
+                    placeholder="Value"
+                    isError={Boolean(error)}
+                  />
+                  {error?.message && <FieldError>{error.message}</FieldError>}
+                </Field>
+              )}
+            />
+            <div className="flex flex-col gap-2">
+              <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                &nbsp;
+              </FieldLabel>
+              <IconButton
+                type="button"
+                variant="outline"
+                aria-label={`Remove metadata ${index + 1}`}
+                onClick={() => metadata.remove(index)}
+              >
+                <Trash2Icon />
+              </IconButton>
+            </div>
+          </div>
+        ))}
+        <Button
+          type="button"
+          size="sm"
+          className="self-start"
+          onClick={() => metadata.append({ key: "", value: "" })}
+        >
+          <PlusIcon />
+          Add Metadata
+        </Button>
+      </div>
+    </DynamicSecretProviderGroup>
+  );
+};
+
+const CouchbaseFields = ({ mode }: TDynamicSecretProviderRendererProps) => (
+  <>
+    <DynamicSecretProviderGroup id="couchbase-connection" presentation="panel">
+      <DynamicSecretProviderFields fields={couchbaseConnectionFields} />
+      <CouchbaseRolesField />
+      <DynamicSecretProviderFields fields={usernameTemplateField} />
+    </DynamicSecretProviderGroup>
+    <CouchbaseBucketFields />
+    <CouchbasePasswordFields />
+    {mode === "edit" && <CouchbaseMetadataFields />}
+  </>
+);
+
+export const couchbaseDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Couchbase,
+  label: "Couchbase",
+  customRenderer: {
+    reasons: ["conditional-fields", "repeatable-fields", "non-scalar-value"],
+    Component: CouchbaseFields
+  },
+  create: {
+    schema: couchbaseCreateFormSchema,
+    getDefaultValues: getCouchbaseCreateDefaultValues,
+    toPayload: getCouchbaseCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: couchbaseEditFormSchema,
+    getDefaultValues: getCouchbaseEditDefaultValues,
+    toPayload: getCouchbaseEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/couchbaseContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/couchbaseContract.ts
@@ -1,0 +1,209 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+const passwordRequirementsSchema = z
+  .object({
+    length: z.number().min(8, "Password must be at least 8 characters").max(128),
+    required: z
+      .object({
+        lowercase: z.number().min(1, "At least 1 lowercase character required"),
+        uppercase: z.number().min(1, "At least 1 uppercase character required"),
+        digits: z.number().min(1, "At least 1 digit required"),
+        symbols: z.number().min(1, "At least 1 special character required")
+      })
+      .refine(
+        (required) => Object.values(required).reduce((total, count) => total + count, 0) <= 128,
+        "Sum of required characters cannot exceed 128"
+      ),
+    allowedSymbols: z
+      .string()
+      .refine(
+        (symbols) =>
+          !["<", ">", ";", ".", "*", "&", "|", "£"].some((character) =>
+            symbols?.includes(character)
+          ),
+        "Cannot contain: < > ; . * & | £"
+      )
+      .optional()
+  })
+  .refine(
+    ({ length, required }) =>
+      Object.values(required).reduce((total, count) => total + count, 0) <= length,
+    "Sum of required characters cannot exceed the total length"
+  );
+
+const bucketSchema = z.object({
+  name: z.string().trim().min(1, "Bucket name is required"),
+  scopes: z
+    .array(
+      z.object({
+        name: z.string().trim().min(1, "Scope name is required"),
+        collections: z.array(z.string().trim().min(1)).optional()
+      })
+    )
+    .optional()
+});
+
+const couchbaseInputFields = {
+  url: z.string().url().trim().min(1),
+  orgId: z.string().trim().min(1),
+  projectId: z.string().trim().min(1),
+  clusterId: z.string().trim().min(1),
+  roles: z.array(z.string()).min(1, "At least one role must be selected"),
+  buckets: z.union([z.string().trim().min(1), z.array(bucketSchema)]),
+  useAdvancedBuckets: z.boolean().default(false),
+  passwordRequirements: passwordRequirementsSchema.optional(),
+  auth: z.object({ apiKey: z.string().trim().min(1) })
+};
+
+export const couchbaseCreateInputsSchema = z.object(couchbaseInputFields);
+export const couchbaseEditInputsSchema = z.object(couchbaseInputFields).partial();
+
+const couchbaseMetadataSchema = z
+  .object({
+    key: z.string().trim().min(1),
+    value: z.string().trim().default("")
+  })
+  .array()
+  .optional();
+
+export type TCouchbaseCreateValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof couchbaseCreateInputsSchema>
+>;
+export type TCouchbaseEditValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof couchbaseEditInputsSchema>
+> & {
+  metadata?: { key: string; value: string }[];
+};
+
+export const couchbaseCreateFormSchema = createDynamicSecretProviderFormSchema(
+  couchbaseCreateInputsSchema
+) as z.ZodType<TCouchbaseCreateValues>;
+
+export const couchbaseEditFormSchema = editDynamicSecretProviderFormSchema(
+  couchbaseEditInputsSchema,
+  { usernameTemplateSchema: z.string().trim().nullable().optional() }
+).extend({ metadata: couchbaseMetadataSchema }) as z.ZodType<TCouchbaseEditValues>;
+
+export const getCouchbaseCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TCouchbaseCreateValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    url: "https://cloudapi.cloud.couchbase.com",
+    orgId: "",
+    projectId: "",
+    clusterId: "",
+    roles: ["read"],
+    buckets: "*",
+    useAdvancedBuckets: false,
+    passwordRequirements: {
+      length: 12,
+      required: { lowercase: 1, uppercase: 1, digits: 1, symbols: 1 },
+      allowedSymbols: "!@#$%^()_+-=[]{}:,?/~`"
+    },
+    auth: { apiKey: "" }
+  }
+});
+
+export const getCouchbaseEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TCouchbaseEditValues => {
+  const inputs = context.dynamicSecret.inputs as Omit<
+    TCouchbaseCreateValues["inputs"],
+    "useAdvancedBuckets"
+  >;
+
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL || undefined,
+    metadata: context.dynamicSecret.metadata,
+    usernameTemplate: context.dynamicSecret.usernameTemplate,
+    inputs: {
+      ...inputs,
+      useAdvancedBuckets: Array.isArray(inputs.buckets)
+    }
+  };
+};
+
+const getCouchbaseCreateProviderInputs = (values: TCouchbaseCreateValues) => {
+  const { useAdvancedBuckets, ...inputs } = couchbaseCreateInputsSchema.parse(values.inputs);
+
+  return {
+    ...inputs,
+    buckets: useAdvancedBuckets ? inputs.buckets : (inputs.buckets as string)
+  };
+};
+
+const getCouchbaseEditProviderInputs = (values: TCouchbaseEditValues) => {
+  const { useAdvancedBuckets, ...inputs } = couchbaseEditInputsSchema.parse(values.inputs);
+
+  return {
+    ...inputs,
+    ...(inputs.buckets === undefined
+      ? {}
+      : { buckets: useAdvancedBuckets ? inputs.buckets : (inputs.buckets as string) })
+  };
+};
+
+const normalizeCouchbaseUsernameTemplateForEdit = (usernameTemplate?: string | null) =>
+  !usernameTemplate || usernameTemplate === DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+    ? undefined
+    : usernameTemplate;
+
+export const getCouchbaseCreatePayload = (
+  values: TCouchbaseCreateValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Couchbase> => ({
+  provider: {
+    type: DynamicSecretProviders.Couchbase,
+    inputs: getCouchbaseCreateProviderInputs(values)
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+
+export const getCouchbaseEditPayload = (
+  values: TCouchbaseEditValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: getCouchbaseEditProviderInputs(values),
+    metadata: values.metadata,
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    usernameTemplate: normalizeCouchbaseUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/managedStores.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/managedStores.ts
@@ -1,0 +1,32 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type { TRegisteredDynamicSecretProviderDefinition } from "../registry";
+import { defineDynamicSecretProviderModule } from "../registry";
+import {
+  awsElastiCacheDynamicSecretProvider,
+  awsMemoryDbDynamicSecretProvider
+} from "./awsManagedStores";
+import { couchbaseDynamicSecretProvider } from "./couchbase";
+import { MANAGED_STORE_DYNAMIC_SECRET_PROVIDERS } from "./managedStoresContract";
+import { mongoAtlasDynamicSecretProvider } from "./mongoAtlas";
+import { mongoDbDynamicSecretProvider } from "./mongoDb";
+import { redisDynamicSecretProvider } from "./redis";
+
+const definitionsByProvider = {
+  [DynamicSecretProviders.Redis]: redisDynamicSecretProvider,
+  [DynamicSecretProviders.AwsElastiCache]: awsElastiCacheDynamicSecretProvider,
+  [DynamicSecretProviders.AwsMemoryDb]: awsMemoryDbDynamicSecretProvider,
+  [DynamicSecretProviders.MongoAtlas]: mongoAtlasDynamicSecretProvider,
+  [DynamicSecretProviders.MongoDB]: mongoDbDynamicSecretProvider,
+  [DynamicSecretProviders.Couchbase]: couchbaseDynamicSecretProvider
+} satisfies Record<
+  (typeof MANAGED_STORE_DYNAMIC_SECRET_PROVIDERS)[number],
+  TRegisteredDynamicSecretProviderDefinition
+>;
+
+export const managedStoresDynamicSecretProviders = defineDynamicSecretProviderModule({
+  id: "managed-stores",
+  definitions: MANAGED_STORE_DYNAMIC_SECRET_PROVIDERS.map(
+    (provider) => definitionsByProvider[provider]
+  )
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/managedStoresContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/managedStoresContract.ts
@@ -1,0 +1,10 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+export const MANAGED_STORE_DYNAMIC_SECRET_PROVIDERS = [
+  DynamicSecretProviders.Redis,
+  DynamicSecretProviders.AwsElastiCache,
+  DynamicSecretProviders.AwsMemoryDb,
+  DynamicSecretProviders.MongoAtlas,
+  DynamicSecretProviders.MongoDB,
+  DynamicSecretProviders.Couchbase
+] as const;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/mongoAtlas.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/mongoAtlas.tsx
@@ -1,0 +1,351 @@
+import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import {
+  Button,
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldFeedback,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+  IconButton,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@app/components/v3";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import {
+  defineDynamicSecretProvider,
+  TDynamicSecretProviderField,
+  TDynamicSecretProviderFormItem
+} from "../types";
+import {
+  getMongoAtlasCreateDefaultValues,
+  getMongoAtlasCreatePayload,
+  getMongoAtlasEditDefaultValues,
+  getMongoAtlasEditPayload,
+  mongoAtlasCreateFormSchema,
+  mongoAtlasEditFormSchema,
+  TMongoAtlasCreateValues,
+  TMongoAtlasEditValues
+} from "./mongoAtlasContract";
+
+const MONGO_ATLAS_SCOPE_TYPES = [
+  { label: "Cluster", value: "CLUSTER" },
+  { label: "Data Lake", value: "DATA_LAKE" },
+  { label: "Stream", value: "STREAM" }
+] as const;
+
+type TMongoAtlasValues = TMongoAtlasCreateValues | TMongoAtlasEditValues;
+
+const mongoAtlasCredentialFields = [
+  {
+    name: "inputs.adminPublicKey",
+    type: "text",
+    label: "Admin Public Key",
+    layout: "half"
+  },
+  {
+    name: "inputs.adminPrivateKey",
+    type: "secret",
+    label: "Admin Private Key",
+    autoComplete: "new-password",
+    layout: "half"
+  },
+  {
+    name: "inputs.groupId",
+    type: "text",
+    label: "Group/Project ID",
+    description: "Unique 24-hexadecimal digit string that identifies your project."
+  }
+] satisfies readonly TDynamicSecretProviderField<TMongoAtlasValues>[];
+
+const mongoAtlasFields = [
+  {
+    kind: "group",
+    id: "mongo-atlas-credentials",
+    presentation: "panel",
+    fields: mongoAtlasCredentialFields
+  }
+] satisfies readonly TDynamicSecretProviderFormItem<TMongoAtlasValues>[];
+
+const usernameTemplateField = [
+  {
+    name: "usernameTemplate",
+    type: "text",
+    label: "Username Template",
+    placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+  }
+] satisfies readonly TDynamicSecretProviderField<TMongoAtlasValues>[];
+
+const MongoAtlasFields = () => {
+  const { control, getValues, setValue } = useFormContext<TMongoAtlasValues>();
+  const roleFields = useFieldArray({ control, name: "inputs.roles" });
+  const scopeFields = useFieldArray({ control, name: "inputs.scopes" });
+
+  return (
+    <>
+      <DynamicSecretProviderGroup
+        id="mongo-atlas-roles"
+        presentation="panel"
+        surface
+        title="Roles"
+        description="A role may be custom or built in: atlasAdmin, backup, clusterMonitor, dbAdmin, dbAdminAnyDatabase, enableSharding, read, readAnyDatabase, readWrite, or readWriteAnyDatabase."
+      >
+        <div className="flex flex-col gap-3">
+          {roleFields.fields.map(({ id }, index) => (
+            <div
+              key={id}
+              className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto]"
+            >
+              <Controller
+                control={control}
+                name={`inputs.roles.${index}.databaseName`}
+                render={({ field, fieldState: { error } }) => {
+                  const errorId = `mongo-atlas-role-${index}-database-error`;
+
+                  return (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`mongo-atlas-role-${index}-database`}>
+                        Database Name
+                      </FieldLabel>
+                      <Input
+                        {...field}
+                        id={`mongo-atlas-role-${index}-database`}
+                        isError={Boolean(error)}
+                        aria-describedby={error ? errorId : undefined}
+                      />
+                      {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+                    </Field>
+                  );
+                }}
+              />
+              <Controller
+                control={control}
+                name={`inputs.roles.${index}.collectionName`}
+                render={({ field, fieldState: { error } }) => {
+                  const errorId = `mongo-atlas-role-${index}-collection-error`;
+
+                  return (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`mongo-atlas-role-${index}-collection`}>
+                        Collection <span className="font-normal text-muted">(optional)</span>
+                      </FieldLabel>
+                      <Input
+                        {...field}
+                        value={field.value ?? ""}
+                        id={`mongo-atlas-role-${index}-collection`}
+                        isError={Boolean(error)}
+                        aria-describedby={error ? errorId : undefined}
+                      />
+                      {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+                    </Field>
+                  );
+                }}
+              />
+              <Controller
+                control={control}
+                name={`inputs.roles.${index}.roleName`}
+                render={({ field, fieldState: { error } }) => {
+                  const errorId = `mongo-atlas-role-${index}-role-error`;
+
+                  return (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`mongo-atlas-role-${index}-role`}>Role</FieldLabel>
+                      <Input
+                        {...field}
+                        id={`mongo-atlas-role-${index}-role`}
+                        isError={Boolean(error)}
+                        aria-describedby={[
+                          "mongo-atlas-roles-description",
+                          error ? errorId : undefined
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}
+                      />
+                      {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+                    </Field>
+                  );
+                }}
+              />
+              <div className="flex flex-col gap-2">
+                <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                  &nbsp;
+                </FieldLabel>
+                <IconButton
+                  type="button"
+                  variant="outline"
+                  aria-label={`Remove role ${index + 1}`}
+                  onClick={() => {
+                    const roles = getValues("inputs.roles");
+                    if (roles && roles.length > 1) {
+                      roleFields.remove(index);
+                    } else {
+                      setValue("inputs.roles", [{ databaseName: "", roleName: "" }], {
+                        shouldDirty: true
+                      });
+                    }
+                  }}
+                >
+                  <Trash2Icon />
+                </IconButton>
+              </div>
+            </div>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            className="self-start"
+            onClick={() => roleFields.append({ databaseName: "", roleName: "" })}
+          >
+            <PlusIcon />
+            Add Role
+          </Button>
+        </div>
+      </DynamicSecretProviderGroup>
+
+      <DynamicSecretProviderGroup
+        id="mongo-atlas-advanced"
+        presentation="collapse"
+        title="Advanced"
+      >
+        <DynamicSecretProviderFields fields={usernameTemplateField} />
+        <FieldSet>
+          <FieldLegend variant="label">
+            Scopes <span className="font-normal text-muted">(optional)</span>
+          </FieldLegend>
+          <FieldDescription id="mongo-atlas-scopes-description">
+            Limit this database user to selected clusters, MongoDB Atlas Data Lakes, or MongoDB
+            Atlas Streams instances. If omitted, MongoDB Cloud grants access to all of them in the
+            project.
+          </FieldDescription>
+          <div className="flex flex-col gap-3">
+            {scopeFields.fields.map(({ id }, index) => (
+              <div
+                key={id}
+                className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+              >
+                <Controller
+                  control={control}
+                  name={`inputs.scopes.${index}.name`}
+                  render={({ field, fieldState: { error } }) => (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`mongo-atlas-scope-${index}-name`}>Label</FieldLabel>
+                      <Input
+                        {...field}
+                        id={`mongo-atlas-scope-${index}-name`}
+                        placeholder="Cluster or data lake ID"
+                        isError={Boolean(error)}
+                        aria-describedby={`mongo-atlas-scope-${index}-name-feedback`}
+                      />
+                      <FieldFeedback
+                        id={`mongo-atlas-scope-${index}-name-feedback`}
+                        description="Human-readable label for the cluster or MongoDB Atlas Data Lake this user can access."
+                        error={error?.message}
+                      />
+                    </Field>
+                  )}
+                />
+                <Controller
+                  control={control}
+                  name={`inputs.scopes.${index}.type`}
+                  render={({ field, fieldState: { error } }) => {
+                    const errorId = `mongo-atlas-scope-${index}-type-error`;
+
+                    return (
+                      <Field data-invalid={Boolean(error)}>
+                        <FieldLabel htmlFor={`mongo-atlas-scope-${index}-type`}>Type</FieldLabel>
+                        <Select
+                          value={field.value}
+                          onValueChange={(value) => {
+                            if (!value || value === field.value) return;
+                            field.onChange(value);
+                          }}
+                        >
+                          <SelectTrigger
+                            ref={field.ref}
+                            id={`mongo-atlas-scope-${index}-type`}
+                            onBlur={field.onBlur}
+                            isError={Boolean(error)}
+                            aria-describedby={error ? errorId : undefined}
+                            className="w-full"
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {MONGO_ATLAS_SCOPE_TYPES.map((scopeType) => (
+                              <SelectItem key={scopeType.value} value={scopeType.value}>
+                                {scopeType.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+                      </Field>
+                    );
+                  }}
+                />
+                <div className="flex flex-col gap-2">
+                  <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                    &nbsp;
+                  </FieldLabel>
+                  <IconButton
+                    type="button"
+                    variant="outline"
+                    aria-label={`Remove scope ${index + 1}`}
+                    onClick={() => scopeFields.remove(index)}
+                  >
+                    <Trash2Icon />
+                  </IconButton>
+                </div>
+              </div>
+            ))}
+            <Button
+              type="button"
+              size="sm"
+              className="self-start"
+              onClick={() =>
+                scopeFields.append({ name: "", type: MONGO_ATLAS_SCOPE_TYPES[0].value })
+              }
+            >
+              <PlusIcon />
+              Add Scope
+            </Button>
+          </div>
+        </FieldSet>
+      </DynamicSecretProviderGroup>
+    </>
+  );
+};
+
+export const mongoAtlasDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.MongoAtlas,
+  label: "MongoDB Atlas",
+  fields: mongoAtlasFields,
+  customRenderer: {
+    reasons: ["repeatable-fields"],
+    Component: MongoAtlasFields
+  },
+  create: {
+    schema: mongoAtlasCreateFormSchema,
+    getDefaultValues: getMongoAtlasCreateDefaultValues,
+    toPayload: getMongoAtlasCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: mongoAtlasEditFormSchema,
+    getDefaultValues: getMongoAtlasEditDefaultValues,
+    toPayload: getMongoAtlasEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/mongoAtlasContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/mongoAtlasContract.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+const mongoAtlasRoleSchema = z.object({
+  collectionName: z.string().optional(),
+  databaseName: z.string().min(1),
+  roleName: z.string().min(1)
+});
+
+const mongoAtlasScopeSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1)
+});
+
+export const mongoAtlasCreateInputsSchema = z.object({
+  adminPublicKey: z.string().trim().min(1),
+  adminPrivateKey: z.string().trim().min(1),
+  groupId: z.string().trim().min(1),
+  roles: mongoAtlasRoleSchema.array().min(1),
+  scopes: mongoAtlasScopeSchema.array()
+});
+
+export const mongoAtlasEditInputsSchema = mongoAtlasCreateInputsSchema.partial();
+
+export type TMongoAtlasCreateValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof mongoAtlasCreateInputsSchema>
+>;
+export type TMongoAtlasEditValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof mongoAtlasEditInputsSchema>
+>;
+
+export const mongoAtlasCreateFormSchema = createDynamicSecretProviderFormSchema(
+  mongoAtlasCreateInputsSchema
+) as z.ZodType<TMongoAtlasCreateValues>;
+
+export const mongoAtlasEditFormSchema = editDynamicSecretProviderFormSchema(
+  mongoAtlasEditInputsSchema,
+  { usernameTemplateSchema: z.string().trim().nullable().optional() }
+) as z.ZodType<TMongoAtlasEditValues>;
+
+export const getMongoAtlasCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TMongoAtlasCreateValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    adminPublicKey: "",
+    adminPrivateKey: "",
+    groupId: "",
+    roles: [{ databaseName: "", roleName: "" }],
+    scopes: []
+  }
+});
+
+export const getMongoAtlasEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TMongoAtlasEditValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  usernameTemplate:
+    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    ...(context.dynamicSecret.inputs as TMongoAtlasEditValues["inputs"])
+  }
+});
+
+export const getMongoAtlasCreatePayload = (
+  values: TMongoAtlasCreateValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.MongoAtlas> => ({
+  provider: {
+    type: DynamicSecretProviders.MongoAtlas,
+    inputs: mongoAtlasCreateInputsSchema.parse(values.inputs)
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+
+export const getMongoAtlasEditPayload = (
+  values: TMongoAtlasEditValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: mongoAtlasEditInputsSchema.parse(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/mongoDb.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/mongoDb.tsx
@@ -1,0 +1,158 @@
+import { Controller, useFieldArray, useFormContext } from "react-hook-form";
+import { PlusIcon, Trash2Icon } from "lucide-react";
+
+import { Button, Field, FieldError, FieldLabel, IconButton, Input } from "@app/components/v3";
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import { SslRejectUnauthorizedField } from "../shared";
+import { defineDynamicSecretProvider, TDynamicSecretProviderField } from "../types";
+import {
+  getMongoDbCreateDefaultValues,
+  getMongoDbCreatePayload,
+  getMongoDbEditDefaultValues,
+  getMongoDbEditPayload,
+  mongoDbCreateFormSchema,
+  mongoDbEditFormSchema,
+  TMongoDbCreateValues,
+  TMongoDbEditValues
+} from "./mongoDbContract";
+
+const mongoDbConnectionFields = [
+  { name: "inputs.host", type: "text", label: "Host", layout: "half" },
+  { name: "inputs.port", type: "number", label: "Port", isOptional: true, layout: "half" },
+  { name: "inputs.username", type: "text", label: "User", layout: "half" },
+  {
+    name: "inputs.password",
+    type: "secret",
+    label: "Password",
+    autoComplete: "new-password",
+    layout: "half"
+  },
+  { name: "inputs.database", type: "text", label: "Database" },
+  { name: "inputs.ca", type: "secret", label: "CA (SSL)", isOptional: true }
+] satisfies readonly TDynamicSecretProviderField<TMongoDbCreateValues | TMongoDbEditValues>[];
+
+const usernameTemplateField = [
+  {
+    name: "usernameTemplate",
+    type: "text",
+    label: "Username Template",
+    placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+  }
+] satisfies readonly TDynamicSecretProviderField<TMongoDbCreateValues | TMongoDbEditValues>[];
+
+const MongoDbFields = () => {
+  const { control, getValues, setValue } = useFormContext<
+    TMongoDbCreateValues | TMongoDbEditValues
+  >();
+  const roles = useFieldArray({ control, name: "inputs.roles" });
+
+  return (
+    <>
+      <DynamicSecretProviderGroup id="mongodb-connection" presentation="panel">
+        <DynamicSecretProviderFields fields={mongoDbConnectionFields} />
+        <SslRejectUnauthorizedField
+          id="mongodb-ssl-reject-unauthorized"
+          fallbackChecked={false}
+          layout="labeled"
+        />
+      </DynamicSecretProviderGroup>
+
+      <DynamicSecretProviderGroup
+        id="mongodb-roles"
+        presentation="panel"
+        surface
+        title="Roles"
+        description="A role may be custom or built in: atlasAdmin, backup, clusterMonitor, dbAdmin, dbAdminAnyDatabase, enableSharding, read, readAnyDatabase, readWrite, or readWriteAnyDatabase."
+      >
+        <div className="flex flex-col gap-3">
+          {roles.fields.map(({ id }, index) => (
+            <div
+              key={id}
+              className="grid grid-cols-1 items-start gap-3 sm:grid-cols-[minmax(0,1fr)_auto]"
+            >
+              <Controller
+                control={control}
+                name={`inputs.roles.${index}.roleName`}
+                render={({ field, fieldState: { error } }) => {
+                  const errorId = `mongodb-role-${index}-error`;
+
+                  return (
+                    <Field data-invalid={Boolean(error)}>
+                      <FieldLabel htmlFor={`mongodb-role-${index}`}>Role</FieldLabel>
+                      <Input
+                        {...field}
+                        id={`mongodb-role-${index}`}
+                        isError={Boolean(error)}
+                        aria-describedby={error ? errorId : undefined}
+                      />
+                      {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+                    </Field>
+                  );
+                }}
+              />
+              <div className="flex flex-col gap-2">
+                <FieldLabel className="pointer-events-none invisible select-none" aria-hidden>
+                  &nbsp;
+                </FieldLabel>
+                <IconButton
+                  type="button"
+                  variant="outline"
+                  aria-label={`Remove role ${index + 1}`}
+                  onClick={() => {
+                    const currentRoles = getValues("inputs.roles");
+                    if (currentRoles && currentRoles.length > 1) {
+                      roles.remove(index);
+                    } else {
+                      setValue("inputs.roles", [{ roleName: "" }], { shouldDirty: true });
+                    }
+                  }}
+                >
+                  <Trash2Icon />
+                </IconButton>
+              </div>
+            </div>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            className="self-start"
+            onClick={() => roles.append({ roleName: "" })}
+          >
+            <PlusIcon />
+            Add Role
+          </Button>
+        </div>
+      </DynamicSecretProviderGroup>
+
+      <DynamicSecretProviderGroup id="mongodb-advanced" presentation="collapse" title="Advanced">
+        <DynamicSecretProviderFields fields={usernameTemplateField} />
+      </DynamicSecretProviderGroup>
+    </>
+  );
+};
+
+export const mongoDbDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.MongoDB,
+  label: "MongoDB",
+  customRenderer: {
+    reasons: ["repeatable-fields"],
+    Component: MongoDbFields
+  },
+  create: {
+    schema: mongoDbCreateFormSchema,
+    getDefaultValues: getMongoDbCreateDefaultValues,
+    toPayload: getMongoDbCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: mongoDbEditFormSchema,
+    getDefaultValues: getMongoDbEditDefaultValues,
+    toPayload: getMongoDbEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/mongoDbContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/mongoDbContract.ts
@@ -1,0 +1,138 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+const mongoDbRoleSchema = z.object({ roleName: z.string().min(1) });
+
+export const mongoDbCreateInputsSchema = z.object({
+  host: z.string().toLowerCase().min(1),
+  port: z.number().optional(),
+  database: z.string().min(1),
+  username: z.string().min(1),
+  password: z.string().min(1),
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true),
+  roles: mongoDbRoleSchema.array().min(1)
+});
+
+export const mongoDbEditInputsSchema = mongoDbCreateInputsSchema.partial();
+
+export type TMongoDbCreateValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof mongoDbCreateInputsSchema>
+>;
+export type TMongoDbEditValues = TDynamicSecretProviderFormValues<
+  z.infer<typeof mongoDbEditInputsSchema>
+>;
+
+export const mongoDbCreateFormSchema = createDynamicSecretProviderFormSchema(
+  mongoDbCreateInputsSchema
+) as z.ZodType<TMongoDbCreateValues>;
+
+export const mongoDbEditFormSchema = editDynamicSecretProviderFormSchema(mongoDbEditInputsSchema, {
+  usernameTemplateSchema: z.string().trim().nullable().optional()
+}) as z.ZodType<TMongoDbEditValues>;
+
+export const getMongoDbCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TMongoDbCreateValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "",
+    port: 27017,
+    database: "default",
+    username: "",
+    password: "",
+    ca: undefined,
+    sslRejectUnauthorized: true,
+    roles: [{ roleName: "readWrite" }]
+  }
+});
+
+export const getMongoDbEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TMongoDbEditValues => {
+  const inputs = context.dynamicSecret.inputs as { roles?: string[] } & Record<string, unknown>;
+
+  return {
+    name: context.dynamicSecret.name,
+    defaultTTL: context.dynamicSecret.defaultTTL,
+    maxTTL: context.dynamicSecret.maxTTL,
+    usernameTemplate:
+      context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+    inputs: {
+      ...inputs,
+      roles: inputs.roles?.map((roleName) => ({ roleName }))
+    } as TMongoDbEditValues["inputs"]
+  };
+};
+
+export const getMongoDbCreatePayload = (
+  values: TMongoDbCreateValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.MongoDB> => {
+  const inputs = mongoDbCreateInputsSchema.parse(values.inputs);
+
+  return {
+    provider: {
+      type: DynamicSecretProviders.MongoDB,
+      inputs: {
+        ...inputs,
+        port: inputs.port || undefined,
+        roles: inputs.roles.map(({ roleName }) => roleName)
+      }
+    },
+    maxTTL: values.maxTTL ?? undefined,
+    name: values.name,
+    path: context.secretPath,
+    defaultTTL: values.defaultTTL,
+    projectSlug: context.projectSlug,
+    environmentSlug: values.environment?.slug ?? "",
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+  };
+};
+
+export const getMongoDbEditPayload = (
+  values: TMongoDbEditValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => {
+  const inputs = mongoDbEditInputsSchema.parse(values.inputs);
+
+  return {
+    name: context.dynamicSecret.name,
+    path: context.secretPath,
+    projectSlug: context.projectSlug,
+    environmentSlug: context.environment,
+    data: {
+      maxTTL: values.maxTTL || undefined,
+      defaultTTL: values.defaultTTL,
+      inputs: {
+        ...inputs,
+        port: inputs.port || undefined,
+        roles: inputs.roles?.map(({ roleName }) => roleName)
+      },
+      newName: values.name === context.dynamicSecret.name ? undefined : values.name,
+      usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate)
+    }
+  };
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/redis.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/redis.tsx
@@ -1,0 +1,68 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { buildStatementFields, SslRejectUnauthorizedField, StatementAccordion } from "../shared";
+import { defineDynamicSecretProvider } from "../types";
+import {
+  getRedisCreateDefaultValues,
+  getRedisCreatePayload,
+  getRedisEditDefaultValues,
+  getRedisEditPayload,
+  redisCreateFormSchema,
+  redisEditFormSchema
+} from "./redisContract";
+
+const redisConnectionFields = [
+  { name: "inputs.host", type: "text", label: "Host", layout: "half" },
+  { name: "inputs.port", type: "number", label: "Port", layout: "half" },
+  { name: "inputs.username", type: "text", label: "User", layout: "half" },
+  {
+    name: "inputs.password",
+    type: "secret",
+    label: "Password",
+    description: "Required if your Redis instance is password protected.",
+    autoComplete: "new-password",
+    isOptional: true,
+    layout: "half"
+  },
+  { name: "inputs.ca", type: "secret", label: "CA (SSL)", isOptional: true }
+] as const;
+
+const redisStatementFields = buildStatementFields();
+
+const RedisFields = () => (
+  <>
+    <DynamicSecretProviderGroup id="redis-connection" presentation="panel">
+      <DynamicSecretProviderFields fields={redisConnectionFields} />
+      <SslRejectUnauthorizedField
+        id="redis-ssl-reject-unauthorized"
+        fallbackChecked={false}
+        layout="labeled"
+      />
+    </DynamicSecretProviderGroup>
+    <StatementAccordion title="Modify Redis Statements" fields={redisStatementFields} />
+  </>
+);
+
+export const redisDynamicSecretProvider = defineDynamicSecretProvider({
+  provider: DynamicSecretProviders.Redis,
+  label: "Redis",
+  customRenderer: {
+    reasons: ["non-scalar-value"],
+    Component: RedisFields
+  },
+  create: {
+    schema: redisCreateFormSchema,
+    getDefaultValues: getRedisCreateDefaultValues,
+    toPayload: getRedisCreatePayload,
+    submitLabel: "Submit"
+  },
+  edit: {
+    schema: redisEditFormSchema,
+    getDefaultValues: getRedisEditDefaultValues,
+    toPayload: getRedisEditPayload,
+    submitLabel: "Save",
+    successMessage: "Successfully updated dynamic secret"
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/redisContract.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/redisContract.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+import {
+  DynamicSecretProviders,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+
+import {
+  createDynamicSecretProviderFormSchema,
+  DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  editDynamicSecretProviderFormSchema,
+  normalizeDynamicSecretUsernameTemplateForCreate,
+  normalizeDynamicSecretUsernameTemplateForEdit
+} from "../schemas";
+import {
+  TCreateDynamicSecretProviderDTO,
+  TCreateDynamicSecretProviderFormContext,
+  TDynamicSecretProviderFormValues,
+  TEditDynamicSecretProviderFormContext
+} from "../types";
+
+export const REDIS_CREATION_STATEMENT = "ACL SETUSER {{username}} on >{{password}} ~* &* +@all";
+export const REDIS_REVOCATION_STATEMENT = "ACL DELUSER {{username}}";
+
+export const redisCreateInputsSchema = z.object({
+  host: z.string().toLowerCase().min(1),
+  port: z.number(),
+  username: z.string().min(1),
+  password: z.string().min(1).optional(),
+  creationStatement: z.string().min(1),
+  renewStatement: z.string().optional(),
+  revocationStatement: z.string().min(1),
+  ca: z.string().optional(),
+  sslRejectUnauthorized: z.boolean().default(true)
+});
+
+export const redisEditInputsSchema = redisCreateInputsSchema.partial();
+
+export type TRedisCreateInputs = z.infer<typeof redisCreateInputsSchema>;
+export type TRedisEditInputs = z.infer<typeof redisEditInputsSchema>;
+export type TRedisCreateFormValues = TDynamicSecretProviderFormValues<TRedisCreateInputs>;
+export type TRedisEditFormValues = TDynamicSecretProviderFormValues<TRedisEditInputs>;
+
+export const redisCreateFormSchema = createDynamicSecretProviderFormSchema(
+  redisCreateInputsSchema
+) as z.ZodType<TRedisCreateFormValues>;
+
+export const redisEditFormSchema = editDynamicSecretProviderFormSchema(redisEditInputsSchema, {
+  usernameTemplateSchema: z.string().trim().nullable().optional()
+}) as z.ZodType<TRedisEditFormValues>;
+
+export const getRedisCreateDefaultValues = (
+  context: TCreateDynamicSecretProviderFormContext
+): TRedisCreateFormValues => ({
+  name: "",
+  defaultTTL: "1h",
+  maxTTL: "24h",
+  environment: context.isSingleEnvironmentMode ? context.environments[0] : undefined,
+  usernameTemplate: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: {
+    host: "",
+    port: 6379,
+    username: "default",
+    password: undefined,
+    creationStatement: REDIS_CREATION_STATEMENT,
+    renewStatement: undefined,
+    revocationStatement: REDIS_REVOCATION_STATEMENT,
+    ca: undefined,
+    sslRejectUnauthorized: true
+  }
+});
+
+export const getRedisEditDefaultValues = (
+  context: TEditDynamicSecretProviderFormContext
+): TRedisEditFormValues => ({
+  name: context.dynamicSecret.name,
+  defaultTTL: context.dynamicSecret.defaultTTL,
+  maxTTL: context.dynamicSecret.maxTTL,
+  usernameTemplate:
+    context.dynamicSecret.usernameTemplate || DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE,
+  inputs: { ...(context.dynamicSecret.inputs as TRedisEditInputs) }
+});
+
+export const getRedisCreatePayload = (
+  values: TRedisCreateFormValues,
+  context: TCreateDynamicSecretProviderFormContext
+): TCreateDynamicSecretProviderDTO<DynamicSecretProviders.Redis> => ({
+  provider: {
+    type: DynamicSecretProviders.Redis,
+    inputs: redisCreateInputsSchema.parse(values.inputs)
+  },
+  maxTTL: values.maxTTL ?? undefined,
+  name: values.name,
+  path: context.secretPath,
+  defaultTTL: values.defaultTTL,
+  projectSlug: context.projectSlug,
+  environmentSlug: values.environment?.slug ?? "",
+  usernameTemplate: normalizeDynamicSecretUsernameTemplateForCreate(values.usernameTemplate)
+});
+
+export const getRedisEditPayload = (
+  values: TRedisEditFormValues,
+  context: TEditDynamicSecretProviderFormContext
+): TUpdateDynamicSecretDTO => ({
+  name: context.dynamicSecret.name,
+  path: context.secretPath,
+  projectSlug: context.projectSlug,
+  environmentSlug: context.environment,
+  data: {
+    usernameTemplate: normalizeDynamicSecretUsernameTemplateForEdit(values.usernameTemplate),
+    maxTTL: values.maxTTL || undefined,
+    defaultTTL: values.defaultTTL,
+    inputs: redisEditInputsSchema.parse(values.inputs),
+    newName: values.name === context.dynamicSecret.name ? undefined : values.name
+  }
+});

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/registry.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/registry.ts
@@ -1,0 +1,114 @@
+import { DynamicSecretProviders } from "@app/hooks/api/dynamicSecret/types";
+
+import type { TDynamicSecretProviderDefinition } from "./types";
+
+export type TRegisteredDynamicSecretProviderDefinition = TDynamicSecretProviderDefinition<
+  DynamicSecretProviders,
+  // Provider value types remain available from each concrete definition. The
+  // composition root intentionally erases them for heterogeneous lookup.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any
+>;
+
+export type TDynamicSecretProviderDefinitionModule = {
+  id: string;
+  definitions: readonly TRegisteredDynamicSecretProviderDefinition[];
+};
+
+export const defineDynamicSecretProviderModule = <
+  const TDefinitions extends readonly TRegisteredDynamicSecretProviderDefinition[]
+>(module: {
+  id: string;
+  definitions: TDefinitions;
+}) => module;
+
+/** Product picker order. Partially migrated registries expose only registered entries. */
+export const DYNAMIC_SECRET_PROVIDER_PICKER_ORDER = [
+  DynamicSecretProviders.SqlDatabase,
+  DynamicSecretProviders.Cassandra,
+  DynamicSecretProviders.Redis,
+  DynamicSecretProviders.AwsElastiCache,
+  DynamicSecretProviders.AwsMemoryDb,
+  DynamicSecretProviders.AwsIam,
+  DynamicSecretProviders.MongoAtlas,
+  DynamicSecretProviders.MongoDB,
+  DynamicSecretProviders.ElasticSearch,
+  DynamicSecretProviders.RabbitMq,
+  DynamicSecretProviders.AzureEntraId,
+  DynamicSecretProviders.AzureSqlDatabase,
+  DynamicSecretProviders.Ldap,
+  DynamicSecretProviders.SapHana,
+  DynamicSecretProviders.SapAse,
+  DynamicSecretProviders.Snowflake,
+  DynamicSecretProviders.Totp,
+  DynamicSecretProviders.Vertica,
+  DynamicSecretProviders.Kubernetes,
+  DynamicSecretProviders.GcpIam,
+  DynamicSecretProviders.Github,
+  DynamicSecretProviders.Couchbase,
+  DynamicSecretProviders.Milvus,
+  DynamicSecretProviders.Clickhouse,
+  DynamicSecretProviders.Ssh,
+  DynamicSecretProviders.IbmApiConnect,
+  DynamicSecretProviders.Tailscale
+] as const satisfies readonly DynamicSecretProviders[];
+
+const DYNAMIC_SECRET_PROVIDER_DOCS_SLUG: Partial<Record<DynamicSecretProviders, string>> = {
+  [DynamicSecretProviders.SqlDatabase]: "postgresql",
+  [DynamicSecretProviders.MongoAtlas]: "mongo-atlas"
+};
+
+export const createDynamicSecretProviderRegistry = (
+  ...modules: readonly TDynamicSecretProviderDefinitionModule[]
+) => {
+  const definitions = new Map<DynamicSecretProviders, TRegisteredDynamicSecretProviderDefinition>();
+  const moduleIds = new Set<string>();
+
+  modules.forEach((module) => {
+    if (moduleIds.has(module.id)) {
+      throw new Error(
+        `Dynamic-secret provider module "${module.id}" was registered more than once.`
+      );
+    }
+    moduleIds.add(module.id);
+
+    module.definitions.forEach((definition) => {
+      if (definitions.has(definition.provider)) {
+        throw new Error(
+          `Dynamic-secret provider "${definition.provider}" was registered more than once.`
+        );
+      }
+      definitions.set(definition.provider, definition);
+    });
+  });
+
+  const providers = Object.freeze(
+    DYNAMIC_SECRET_PROVIDER_PICKER_ORDER.filter((provider) => definitions.has(provider))
+  );
+  const registeredDefinitions = Object.freeze(
+    providers.map(
+      (provider) => definitions.get(provider) as TRegisteredDynamicSecretProviderDefinition
+    )
+  );
+
+  return Object.freeze({
+    providers,
+    definitions: registeredDefinitions,
+    hasDefinition: (provider: DynamicSecretProviders) => definitions.has(provider),
+    getDefinition: (provider: DynamicSecretProviders) => definitions.get(provider),
+    requireDefinition: (provider: DynamicSecretProviders) => {
+      const definition = definitions.get(provider);
+      if (!definition) {
+        throw new Error(`Dynamic-secret provider "${provider}" is not registered.`);
+      }
+      return definition;
+    },
+    getLabel: (provider: DynamicSecretProviders) => definitions.get(provider)?.label,
+    getDocsSlug: (provider: DynamicSecretProviders) =>
+      DYNAMIC_SECRET_PROVIDER_DOCS_SLUG[provider] ?? provider
+  });
+};
+
+export type TDynamicSecretProviderRegistry = ReturnType<typeof createDynamicSecretProviderRegistry>;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/scalarValues.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/scalarValues.ts
@@ -1,0 +1,10 @@
+/**
+ * HTML number inputs emit strings. Store finite numbers in React Hook Form so
+ * provider-owned `z.number()` schemas receive the value type they declare.
+ */
+export const parseDynamicSecretProviderNumberInput = (value: string) => {
+  if (value.trim() === "") return undefined;
+
+  const parsedValue = Number(value);
+  return Number.isFinite(parsedValue) ? parsedValue : undefined;
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
@@ -7,8 +7,16 @@ import type { TDynamicSecretProviderFormMode } from "./types";
 
 export const DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE = "{{randomUsername}}";
 
-export const dynamicSecretTtlSchema = z.string().superRefine((value, context) => {
+const validateDynamicSecretTtl = (value: string, context: z.RefinementCtx) => {
   const valueInMilliseconds = ms(value);
+
+  if (valueInMilliseconds === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be a valid duration"
+    });
+    return;
+  }
 
   if (valueInMilliseconds < 60 * 1000) {
     context.addIssue({
@@ -23,7 +31,15 @@ export const dynamicSecretTtlSchema = z.string().superRefine((value, context) =>
       message: "TTL must be less than 10 years"
     });
   }
-});
+};
+
+export const dynamicSecretTtlSchema = z
+  .string()
+  .min(1, "TTL is required")
+  .superRefine((value, context) => {
+    if (!value) return;
+    validateDynamicSecretTtl(value, context);
+  });
 
 export const optionalDynamicSecretTtlSchema = z
   .string()
@@ -31,21 +47,7 @@ export const optionalDynamicSecretTtlSchema = z
   .superRefine((value, context) => {
     if (!value) return;
 
-    const valueInMilliseconds = ms(value);
-
-    if (valueInMilliseconds < 60 * 1000) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "TTL must be a greater than 1min"
-      });
-    }
-
-    if (valueInMilliseconds > ms("10y")) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "TTL must be less than 10 years"
-      });
-    }
+    validateDynamicSecretTtl(value, context);
   });
 
 const environmentSchema = z.object({

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/schemas.ts
@@ -1,0 +1,102 @@
+import ms from "ms";
+import { z } from "zod";
+
+import { slugSchema } from "@app/lib/schemas";
+
+import type { TDynamicSecretProviderFormMode } from "./types";
+
+export const DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE = "{{randomUsername}}";
+
+export const dynamicSecretTtlSchema = z.string().superRefine((value, context) => {
+  const valueInMilliseconds = ms(value);
+
+  if (valueInMilliseconds < 60 * 1000) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be a greater than 1min"
+    });
+  }
+
+  if (valueInMilliseconds > ms("10y")) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TTL must be less than 10 years"
+    });
+  }
+});
+
+export const optionalDynamicSecretTtlSchema = z
+  .string()
+  .optional()
+  .superRefine((value, context) => {
+    if (!value) return;
+
+    const valueInMilliseconds = ms(value);
+
+    if (valueInMilliseconds < 60 * 1000) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "TTL must be a greater than 1min"
+      });
+    }
+
+    if (valueInMilliseconds > ms("10y")) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "TTL must be less than 10 years"
+      });
+    }
+  });
+
+const environmentSchema = z.object({
+  name: z.string(),
+  slug: z.string()
+});
+
+type TDynamicSecretFormSchemaOptions = {
+  usernameTemplateSchema?: z.ZodTypeAny;
+};
+
+export const createDynamicSecretProviderFormSchema = <TInputs extends z.ZodTypeAny>(
+  inputsSchema: TInputs,
+  options: TDynamicSecretFormSchemaOptions = {}
+) =>
+  z.object({
+    name: slugSchema(),
+    defaultTTL: dynamicSecretTtlSchema,
+    maxTTL: optionalDynamicSecretTtlSchema,
+    environment: environmentSchema,
+    usernameTemplate: options.usernameTemplateSchema ?? z.string().nullable().optional(),
+    inputs: inputsSchema
+  });
+
+export const editDynamicSecretProviderFormSchema = <TInputs extends z.ZodTypeAny>(
+  inputsSchema: TInputs,
+  options: TDynamicSecretFormSchemaOptions = {}
+) =>
+  z.object({
+    name: slugSchema(),
+    defaultTTL: dynamicSecretTtlSchema,
+    maxTTL: optionalDynamicSecretTtlSchema.nullable(),
+    environment: environmentSchema.optional(),
+    usernameTemplate: options.usernameTemplateSchema ?? z.string().nullable().optional(),
+    inputs: inputsSchema
+  });
+
+export const normalizeDynamicSecretUsernameTemplateForCreate = (
+  usernameTemplate?: string | null
+) =>
+  !usernameTemplate || usernameTemplate === DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+    ? undefined
+    : usernameTemplate;
+
+export const normalizeDynamicSecretUsernameTemplateForEdit = (usernameTemplate?: string | null) =>
+  !usernameTemplate || usernameTemplate === DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+    ? null
+    : usernameTemplate;
+
+/** Create omits a cleared gateway; edit sends null to detach an existing gateway. */
+export const normalizeDynamicSecretGatewayValueForMode = (
+  mode: TDynamicSecretProviderFormMode,
+  value?: string | null
+) => value || (mode === "create" ? undefined : null);

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/SslRejectUnauthorizedField.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/SslRejectUnauthorizedField.tsx
@@ -1,0 +1,68 @@
+import { Controller, FieldValues, Path, useFormContext } from "react-hook-form";
+
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  FieldTitle,
+  Switch
+} from "@app/components/v3";
+
+type Props<TValues extends FieldValues> = {
+  name?: Path<TValues>;
+  id?: string;
+  fallbackChecked?: boolean;
+  layout?: "labeled" | "content";
+};
+
+export const SslRejectUnauthorizedField = <TValues extends FieldValues>({
+  name = "inputs.sslRejectUnauthorized" as Path<TValues>,
+  id = "dynamic-secret-ssl-reject-unauthorized",
+  fallbackChecked = true,
+  layout = "content"
+}: Props<TValues>) => {
+  const { control } = useFormContext<TValues>();
+  const descriptionId = `${id}-description`;
+  const errorId = `${id}-error`;
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState: { error } }) => (
+        <Field data-invalid={Boolean(error)} orientation="horizontal">
+          {layout === "labeled" ? (
+            <div className="flex flex-1 flex-col gap-0.5">
+              <FieldLabel htmlFor={id}>SSL Reject Unauthorized</FieldLabel>
+              <FieldDescription id={descriptionId}>
+                Verify the server certificate against the supplied certificate authorities.
+              </FieldDescription>
+              {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+            </div>
+          ) : (
+            <FieldContent>
+              <FieldTitle>SSL Reject Unauthorized</FieldTitle>
+              <FieldDescription id={descriptionId}>
+                Verify the server certificate against the supplied certificate authorities.
+              </FieldDescription>
+              {error?.message && <FieldError id={errorId}>{error.message}</FieldError>}
+            </FieldContent>
+          )}
+          <Switch
+            ref={field.ref}
+            id={id}
+            variant="project"
+            checked={field.value ?? fallbackChecked}
+            onBlur={field.onBlur}
+            onCheckedChange={field.onChange}
+            aria-invalid={Boolean(error)}
+            aria-label="SSL Reject Unauthorized"
+            aria-describedby={`${descriptionId}${error?.message ? ` ${errorId}` : ""}`}
+          />
+        </Field>
+      )}
+    />
+  );
+};

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/StatementAccordion.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/StatementAccordion.tsx
@@ -1,0 +1,90 @@
+import { FieldValues, Path } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";
+import { TDynamicSecretProviderField } from "../types";
+import { usernameTemplateFieldDefinition } from "./UsernameTemplateField";
+
+type StatementCopy = {
+  creation?: string;
+  revocation?: string;
+  renew?: string;
+};
+
+type BuildOptions = {
+  includeUsernameTemplate?: boolean;
+  includeRenew?: boolean;
+  renewOptional?: boolean;
+  creationRows?: number;
+  copy?: StatementCopy;
+};
+
+const DEFAULT_COPY: Required<StatementCopy> = {
+  creation: "Username, password, and expiration are dynamically provisioned.",
+  revocation: "Username is dynamically provisioned.",
+  renew: "Username and expiration are dynamically provisioned."
+};
+
+export const buildStatementFields = <TValues extends FieldValues>(
+  options: BuildOptions = {}
+): TDynamicSecretProviderField<TValues>[] => {
+  const {
+    includeUsernameTemplate = true,
+    includeRenew = true,
+    renewOptional = true,
+    creationRows = 3,
+    copy = {}
+  } = options;
+  const resolvedCopy = { ...DEFAULT_COPY, ...copy };
+  const fields: TDynamicSecretProviderField<TValues>[] = [];
+
+  if (includeUsernameTemplate) {
+    fields.push(usernameTemplateFieldDefinition as TDynamicSecretProviderField<TValues>);
+  }
+
+  fields.push(
+    {
+      name: "inputs.creationStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Creation Statement",
+      ...(resolvedCopy.creation ? { description: resolvedCopy.creation } : {}),
+      rows: creationRows
+    },
+    {
+      name: "inputs.revocationStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Revocation Statement",
+      ...(resolvedCopy.revocation ? { description: resolvedCopy.revocation } : {}),
+      rows: 3
+    }
+  );
+
+  if (includeRenew) {
+    fields.push({
+      name: "inputs.renewStatement" as Path<TValues>,
+      type: "textarea",
+      label: "Renew Statement",
+      ...(resolvedCopy.renew ? { description: resolvedCopy.renew } : {}),
+      isOptional: renewOptional,
+      rows: 3
+    });
+  }
+
+  return fields;
+};
+
+type Props<TValues extends FieldValues> = {
+  title: string;
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+  value?: string;
+};
+
+export const StatementAccordion = <TValues extends FieldValues>({
+  title,
+  fields,
+  value = "statements"
+}: Props<TValues>) => (
+  <DynamicSecretProviderGroup id={value} presentation="collapse" title={title}>
+    <DynamicSecretProviderFields fields={fields} />
+  </DynamicSecretProviderGroup>
+);

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/UsernameTemplateField.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/UsernameTemplateField.tsx
@@ -1,0 +1,20 @@
+import { FieldValues } from "react-hook-form";
+
+import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
+import { DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE } from "../schemas";
+import { TDynamicSecretProviderField } from "../types";
+
+export const usernameTemplateFieldDefinition = {
+  name: "usernameTemplate",
+  type: "text",
+  label: "Username Template",
+  placeholder: DEFAULT_DYNAMIC_SECRET_USERNAME_TEMPLATE
+} as const;
+
+type Props<TValues extends FieldValues> = {
+  fields?: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+export const UsernameTemplateFields = <TValues extends FieldValues>({
+  fields = [usernameTemplateFieldDefinition as TDynamicSecretProviderField<TValues>]
+}: Props<TValues>) => <DynamicSecretProviderFields fields={fields} />;

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/index.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/shared/index.ts
@@ -1,0 +1,3 @@
+export { SslRejectUnauthorizedField } from "./SslRejectUnauthorizedField";
+export { buildStatementFields, StatementAccordion } from "./StatementAccordion";
+export { usernameTemplateFieldDefinition, UsernameTemplateFields } from "./UsernameTemplateField";

--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/types.ts
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/types.ts
@@ -1,0 +1,205 @@
+import type { ComponentType } from "react";
+import type { DefaultValues, FieldPath, FieldValues } from "react-hook-form";
+import type { z } from "zod";
+
+import type {
+  DynamicSecretProviders,
+  TCreateDynamicSecretDTO,
+  TDynamicSecret,
+  TDynamicSecretProvider,
+  TUpdateDynamicSecretDTO
+} from "@app/hooks/api/dynamicSecret/types";
+import type { ProjectEnv } from "@app/hooks/api/types";
+
+export const DYNAMIC_SECRET_CUSTOM_RENDERER_REASONS = [
+  "conditional-fields",
+  "repeatable-fields",
+  "permission-aware-fields",
+  "remote-options",
+  "import-workflow",
+  "non-scalar-value",
+  "multi-create",
+  "post-create-workflow",
+  "context-aware-fields"
+] as const;
+
+export type TDynamicSecretCustomRendererReason =
+  (typeof DYNAMIC_SECRET_CUSTOM_RENDERER_REASONS)[number];
+
+export type TDynamicSecretProviderFormMode = "create" | "edit";
+
+export type TDynamicSecretProviderCommonField = {
+  isVisible?: boolean;
+  isDisabled?: boolean;
+  label?: string;
+  description?: string;
+};
+
+export type TDynamicSecretProviderCommonFields = {
+  name?: TDynamicSecretProviderCommonField;
+  defaultTTL?: TDynamicSecretProviderCommonField;
+  maxTTL?: TDynamicSecretProviderCommonField;
+  environment?: TDynamicSecretProviderCommonField;
+  configurationHeading?: string | false;
+};
+
+export type TDynamicSecretFormEnvironment = Pick<ProjectEnv, "name" | "slug">;
+
+export type TDynamicSecretProviderFormValues<TInputs extends FieldValues = FieldValues> = {
+  name: string;
+  defaultTTL: string;
+  maxTTL?: string | null;
+  environment?: TDynamicSecretFormEnvironment;
+  usernameTemplate?: string | null;
+  inputs: TInputs;
+};
+
+type TDynamicSecretBaseField<TValues extends FieldValues> = {
+  name: FieldPath<TValues>;
+  label: string;
+  description?: string;
+  placeholder?: string;
+  isOptional?: boolean;
+  isDisabled?: boolean;
+  layout?: "full" | "half";
+};
+
+export type TDynamicSecretProviderField<TValues extends FieldValues> =
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "text" | "secret";
+      autoComplete?: string;
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "number";
+      min?: number;
+      max?: number;
+      step?: number | "any";
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "textarea";
+      rows?: number;
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "select";
+      options: readonly { label: string; value: string }[];
+    })
+  | (TDynamicSecretBaseField<TValues> & {
+      type: "switch";
+    });
+
+export type TDynamicSecretProviderFieldGroupPresentation = "panel" | "collapse";
+
+type TDynamicSecretProviderFieldGroupBase<TValues extends FieldValues> = {
+  kind: "group";
+  id: string;
+  description?: string;
+  fields: readonly TDynamicSecretProviderField<TValues>[];
+};
+
+export type TDynamicSecretProviderFieldGroup<TValues extends FieldValues> =
+  | (TDynamicSecretProviderFieldGroupBase<TValues> & {
+      presentation?: "panel";
+      title?: string;
+      surface?: boolean;
+    })
+  | (TDynamicSecretProviderFieldGroupBase<TValues> & {
+      presentation: "collapse";
+      title: string;
+    });
+
+export type TDynamicSecretProviderFormItem<TValues extends FieldValues> =
+  | TDynamicSecretProviderField<TValues>
+  | TDynamicSecretProviderFieldGroup<TValues>;
+
+export const isDynamicSecretProviderFieldGroup = <TValues extends FieldValues>(
+  item: TDynamicSecretProviderFormItem<TValues>
+): item is TDynamicSecretProviderFieldGroup<TValues> => "kind" in item && item.kind === "group";
+
+export type TDynamicSecretProviderOf<TProvider extends DynamicSecretProviders> = Extract<
+  TDynamicSecretProvider,
+  { type: TProvider }
+>;
+
+export type TCreateDynamicSecretProviderDTO<TProvider extends DynamicSecretProviders> = Omit<
+  TCreateDynamicSecretDTO,
+  "provider"
+> & {
+  provider: TDynamicSecretProviderOf<TProvider>;
+};
+
+export type TDynamicSecretWithInputs = TDynamicSecret & { inputs: unknown };
+
+export type TCreateDynamicSecretProviderFormContext = {
+  projectSlug: string;
+  secretPath: string;
+  environments: ProjectEnv[];
+  isSingleEnvironmentMode?: boolean;
+};
+
+export type TEditDynamicSecretProviderFormContext = {
+  projectSlug: string;
+  secretPath: string;
+  environment: string;
+  dynamicSecret: TDynamicSecretWithInputs;
+};
+
+export type TDynamicSecretProviderRendererProps = {
+  mode: TDynamicSecretProviderFormMode;
+  context: TCreateDynamicSecretProviderFormContext | TEditDynamicSecretProviderFormContext;
+  setSubmitState: (state: { isDisabled?: boolean; isPending?: boolean }) => void;
+};
+
+export type TDynamicSecretProviderCustomRenderer = {
+  reasons: readonly [TDynamicSecretCustomRendererReason, ...TDynamicSecretCustomRendererReason[]];
+  Component: ComponentType<TDynamicSecretProviderRendererProps>;
+};
+
+export type TDynamicSecretProviderDefinition<
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues = TCreateValues
+> = {
+  provider: TProvider;
+  label: string;
+  fields?: readonly TDynamicSecretProviderFormItem<TCreateValues & TEditValues>[];
+  customRenderer?: TDynamicSecretProviderCustomRenderer;
+  create: {
+    schema: z.ZodType<TCreateValues>;
+    getDefaultValues: (
+      context: TCreateDynamicSecretProviderFormContext
+    ) => DefaultValues<TCreateValues>;
+    toPayload: (
+      values: TCreateValues,
+      context: TCreateDynamicSecretProviderFormContext
+    ) =>
+      | TCreateDynamicSecretProviderDTO<TProvider>
+      | readonly TCreateDynamicSecretProviderDTO<TProvider>[];
+    fields?: readonly TDynamicSecretProviderFormItem<TCreateValues>[];
+    customRenderer?: TDynamicSecretProviderCustomRenderer;
+    commonFields?: TDynamicSecretProviderCommonFields;
+    submitLabel: string;
+  };
+  edit: {
+    schema: z.ZodType<TEditValues>;
+    getDefaultValues: (
+      context: TEditDynamicSecretProviderFormContext
+    ) => DefaultValues<TEditValues>;
+    toPayload: (
+      values: TEditValues,
+      context: TEditDynamicSecretProviderFormContext
+    ) => TUpdateDynamicSecretDTO;
+    fields?: readonly TDynamicSecretProviderFormItem<TEditValues>[];
+    customRenderer?: TDynamicSecretProviderCustomRenderer;
+    commonFields?: TDynamicSecretProviderCommonFields;
+    submitLabel: string;
+    successMessage: string;
+  };
+};
+
+export const defineDynamicSecretProvider = <
+  TProvider extends DynamicSecretProviders,
+  TCreateValues extends TDynamicSecretProviderFormValues,
+  TEditValues extends TDynamicSecretProviderFormValues = TCreateValues
+>(
+  definition: TDynamicSecretProviderDefinition<TProvider, TCreateValues, TEditValues>
+) => definition;

--- a/frontend/src/components/dynamic-secrets/index.ts
+++ b/frontend/src/components/dynamic-secrets/index.ts
@@ -1,0 +1,1 @@
+export * from "./DynamicSecretProviderForm";


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

[ENG-5514](https://linear.app/infisical/issue/ENG-5514/migrate-managed-store-dynamic-secret-provider-forms) migrates the managed-store dynamic-secret provider batch onto the shared provider form contract introduced by stacked parent [PR #7563](https://github.com/Infisical/infisical/pull/7563).

Previously, AWS ElastiCache, AWS MemoryDB, Redis, MongoDB, MongoDB Atlas, and Couchbase were represented only by their legacy create/edit forms. This PR adds batch-local provider definitions with create/edit parity:

- Provider-owned schemas, defaults, edit hydration, and API payload adapters.
- V3 renderers for statements, TLS controls, roles, Atlas scopes, Couchbase bucket hierarchy, metadata, and password requirements.
- Masked-secret preservation and the existing provider-specific username-template null/omission behavior.
- Numeric payload preservation, including Couchbase password length and required-character counts.
- A batch-local `managedStoresDynamicSecretProviders` module plus focused contract coverage.

Production routes remain on the existing legacy forms. This PR does not add the batch to a production composition root; production composition is intentionally deferred to later integration work after the migration batches land.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

Not applicable. The provider definitions are not wired to a user-visible production route in this PR.

## Steps to verify the change

From `frontend/`:

1. Run targeted lint:

   ```sh
   ./node_modules/.bin/eslint src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions src/components/dynamic-secrets/DynamicSecretProviderForm/managed-stores-contract.test.ts --max-warnings 0
   ```

2. Run the full frontend TypeScript check:

   ```sh
   ./node_modules/.bin/tsc --noEmit --project ./tsconfig.app.json
   ```

3. Run the focused managed-store contract suite:

   ```sh
   TSX_TSCONFIG_PATH=tsconfig.app.json ./node_modules/.bin/tsx --test src/components/dynamic-secrets/DynamicSecretProviderForm/managed-stores-contract.test.ts
   ```

4. Run the complete provider-form contract glob:

   ```sh
   TSX_TSCONFIG_PATH=tsconfig.app.json ./node_modules/.bin/tsx --test src/components/dynamic-secrets/DynamicSecretProviderForm/*.test.ts
   ```

Verified locally:

- Targeted ESLint: passed.
- Full frontend TypeScript check: passed.
- Focused managed-store suite: 16 tests across 4 suites passed.
- Complete provider-form contract glob: passed.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)