### PR TITLE
fix: correct project highlight when projects share name

### DIFF
--- a/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ProjectSelect.tsx
+++ b/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ProjectSelect.tsx
@@ -139,7 +139,8 @@ const ProjectSelectInner = () => {
                 {projectsSortedByFav.map((workspace) => (
                   <CommandItem
                     key={workspace.id}
-                    value={workspace.name}
+                    value={workspace.id}
+                    keywords={[workspace.name]}
                     onSelect={() => handleSelectProject(workspace.id)}
                     className="gap-2"
                   >


### PR DESCRIPTION
## Context

This PR fixes the visual bug where projects with the same name where both shown as selected in the project select

## Screenshots

<img width="768" height="538" alt="CleanShot 2026-08-06 at 17 13 16@2x" src="https://github.com/user-attachments/assets/3500ebee-59f5-4335-b603-4fa47fd8f415" />

## Steps to verify the change

- [ ] create two projects with the same name and open the project select

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)