### PR TITLE
fix(frontend): migrate Project Settings buttons from legacy v2 to v3

### DIFF
--- a/frontend/src/pages/project/SettingsPage/components/AuditLogsRetentionSection/AuditLogsRetentionSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/AuditLogsRetentionSection/AuditLogsRetentionSection.tsx
@@ -4,7 +4,8 @@ import { z } from "zod";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
-import { Button, FormControl, Input } from "@app/components/v2";
+import { FormControl, Input } from "@app/components/v2";
+import { Button } from "@app/components/v3";
 import { useProject, useProjectPermission, useSubscription } from "@app/context";
 import { usePopUp } from "@app/hooks";
 import { useUpdateWorkspaceAuditLogsRetention } from "@app/hooks/api/projects/queries";
@@ -102,10 +103,10 @@ export const AuditLogsRetentionSection = () => {
             />
           </div>
           <Button
-            colorSchema="secondary"
+            variant="project"
             type="submit"
-            isLoading={isSubmitting}
-            disabled={!isAdmin || !isDirty}
+            isPending={isSubmitting}
+            isDisabled={!isAdmin || !isDirty}
           >
             Save
           </Button>

--- a/frontend/src/pages/project/SettingsPage/components/DeleteProjectSection/DeleteProjectSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/DeleteProjectSection/DeleteProjectSection.tsx
@@ -2,8 +2,9 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { createNotification } from "@app/components/notifications";
 import { ProjectPermissionCan } from "@app/components/permissions";
-import { Button, DeleteActionModal, Tooltip } from "@app/components/v2";
+import { DeleteActionModal, Tooltip } from "@app/components/v2";
 import { LeaveProjectModal } from "@app/components/v2/LeaveProjectModal";
+import { Button } from "@app/components/v3";
 import {
   ProjectPermissionActions,
   ProjectPermissionSub,
@@ -82,11 +83,9 @@ export const DeleteProjectSection = () => {
         <ProjectPermissionCan I={ProjectPermissionActions.Delete} a={ProjectPermissionSub.Project}>
           {(isAllowed) => (
             <Button
-              isLoading={isDeleting}
+              isPending={isDeleting}
               isDisabled={!isAllowed || isDeleting}
-              colorSchema="danger"
-              variant="outline_bg"
-              type="submit"
+              variant="danger"
               onClick={() => handlePopUpOpen("deleteWorkspace")}
             >
               {`Delete ${currentProject?.name}`}
@@ -99,11 +98,9 @@ export const DeleteProjectSection = () => {
         >
           <span>
             <Button
-              isLoading={isLeaving}
+              isPending={isLeaving}
               isDisabled={!isDirectMember}
-              colorSchema="danger"
-              variant="outline_bg"
-              type="submit"
+              variant="danger"
               onClick={() => handlePopUpOpen("leaveWorkspace")}
             >
               {`Leave ${currentProject?.name}`}


### PR DESCRIPTION
## Context

Fixes #7127

Project Settings mixes two Button generations side by side. The Save button in Audit Logs Retention (`colorSchema="secondary"`) and both Danger Zone buttons (`colorSchema="danger" variant="outline_bg"`) use the legacy v2 Button, which is flat gray at rest and only shows color on hover. Sibling sections on the same page (for example Cross-Project Sharing) use the v3 Button, whose variants are tinted at rest.

This PR swaps the three buttons to v3, following the sibling sections' idiom:

- Audit Logs Retention "Save": `variant="project"`, the scope color for a primary action on a project page per DESIGN.md ("DO use scope colors ... a primary button")
- Danger Zone "Delete" / "Leave": `variant="danger"`
- `isLoading` becomes `isPending` per the v3 prop API

Two deliberate scope choices, flagging them for review:

1. The Danger Zone buttons carried `type="submit"` despite not being inside a form. The v3 default of `type="button"` is correct there, so the attribute is dropped rather than carried over. No behavior change since there is no surrounding form to submit.
2. Other v2 components in these files (`FormControl`, `Input`, `DeleteActionModal`, `Tooltip`) are left alone. The issue is specifically about Button styling; migrating the rest touches form and modal surfaces with their own v3 equivalents and felt like scope creep for one PR. Happy to follow up if wanted.

These were the only v2 Button usages left under `pages/project/SettingsPage` and `pages/secret-manager/SettingsPage`. The mix described in the issue also exists on other project pages (`IdentityDetailsByIDPage`, `RoleDetailsBySlugPage`, `GroupDetailsByIDPage`, `MemberDetailsByIDPage`); if this PR's direction is right I can do those as a follow-up.

## Screenshots

None yet: I verified the change statically (the swap maps to the same v3 variants already rendered by sibling sections on this page) but did not run the full self-hosted stack. If screenshots are required for merge I will spin it up and add them.

## Steps to verify the change

1. Open a project's Settings page
2. Audit Logs Retention: Save should be tinted with the project scope color at rest, matching the Share Secrets button in Cross-Project Sharing
3. Danger Zone: Delete and Leave should be tinted with the danger color at rest
4. Trigger a save / delete to confirm the pending state still shows (isPending)

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (`npm run type:check`, `eslint --max-warnings 0` on both files)
- [ ] Updated docs (not needed)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the contributing guide
