### PR TITLE
improvement(ui): show certificate ID with copy button on certificate details page

### DIFF
--- a/frontend/src/pages/cert-manager/CertificateDetailsByIDPage/components/CertificateOverviewSection.tsx
+++ b/frontend/src/pages/cert-manager/CertificateDetailsByIDPage/components/CertificateOverviewSection.tsx
@@ -102,6 +102,13 @@ export const CertificateOverviewSection = ({ certificateId }: Props) => {
               </DetailValue>
             </Detail>
             <Detail>
+              <DetailLabel>Certificate ID</DetailLabel>
+              <DetailValue className="flex items-center gap-2 font-mono text-xs">
+                {certificate.id}
+                <CopyButton value={certificate.id} size="xs" variant="plain" />
+              </DetailValue>
+            </Detail>
+            <Detail>
               <DetailLabel>Not Before</DetailLabel>
               <DetailValue>
                 {certificate.notBefore ? (


### PR DESCRIPTION
## Context

The API's cert-manager certificate endpoints identify certificates by their ID (UUID), but the dashboard never displays it: the certificate details page shows the serial number, fingerprints, and subject attributes, while the ID only appears in the page URL. A customer migrating from the deprecated serial-number-based endpoints (support request from 2026-08-07) had no way to find the ID for a certificate in the UI and asked for it to be shown next to the serial number with the same copy button.

This adds a "Certificate ID" row to the Overview card on the certificate details page, directly under Serial Number, rendered in the same mono style with the same copy-to-clipboard button.

## Screenshots

Not yet captured. The row is a clone of the adjacent Serial Number row.

## Steps to verify the change

1. Open Certificate Manager and click into any certificate to view its details.
2. The Overview card shows a "Certificate ID" row under "Serial Number" with the certificate's UUID and a copy button.
3. The copy button places the UUID on the clipboard.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)