### PR TITLE
feat(helm): make infisical-standalone Service port and targetPort configurable

### DIFF
--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -43,6 +43,8 @@ A helm chart to deploy Infisical
 | infisical.resources.requests.cpu | string | `"350m"` | CPU request for Infisical container |
 | infisical.service.annotations | object | `{}` | Custom annotations for Infisical service |
 | infisical.service.nodePort | string | `""` | Optional node port for service when using NodePort type |
+| infisical.service.port | int | `8080` | Port the service listens on. The ingress backends and the auto-bootstrap job follow this value. |
+| infisical.service.targetPort | string | `""` | Pod port the service forwards to. Defaults to 8080, the port the Infisical container listens on, and should stay there unless a sidecar (e.g. a TLS-terminating proxy injected via `infisical.extraContainers`) fronts the Infisical container on a different port. |
 | infisical.service.type | string | `"ClusterIP"` | Service type, can be changed based on exposure needs (e.g., LoadBalancer) |
 | infisical.serviceAccount.annotations | object | `{}` | Custom annotations for the auto-created service account |
 | infisical.serviceAccount.create | bool | `true` | Creates a new service account if true, with necessary permissions for this chart. If false and `serviceAccount.name` is not defined, the chart will attempt to use the Default service account |

--- a/helm-charts/infisical-standalone-postgres/templates/bootstrap-job.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/bootstrap-job.yaml
@@ -39,7 +39,7 @@ spec:
         args:
         - |
           echo "Waiting for Infisical to be ready..."
-          until curl -f http://{{ include "infisical.fullname" . }}:8080/api/status; do
+          until curl -f http://{{ include "infisical.fullname" . }}:{{ $infisicalValues.service.port | default 8080 }}/api/status; do
             echo "Infisical not ready yet, retrying in 10 seconds..."
             sleep 10
           done
@@ -53,7 +53,7 @@ spec:
           {{- end }}
           args:
             - bootstrap
-            - --domain=http://{{ include "infisical.fullname" . }}:8080
+            - --domain=http://{{ include "infisical.fullname" . }}:{{ $infisicalValues.service.port | default 8080 }}
             - --output=k8-secret
             - --k8-secret-name={{ $infisicalValues.autoBootstrap.secretDestination.name }}
             - --k8-secret-namespace={{ $infisicalValues.autoBootstrap.secretDestination.namespace | default .Release.Namespace }}

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -122,8 +122,8 @@ spec:
     {{- include "infisical.matchLabels" . | nindent 8 }}
   ports:
     - protocol: TCP
-      port: 8080
-      targetPort: 8080
+      port: {{ $infisicalValues.service.port | default 8080 }}
+      targetPort: {{ $infisicalValues.service.targetPort | default 8080 }}
       {{- if eq $infisicalValues.service.type "NodePort" }}
       nodePort: {{ $infisicalValues.service.nodePort }}
       {{- end }}

--- a/helm-charts/infisical-standalone-postgres/templates/ingress.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/ingress.yaml
@@ -36,14 +36,14 @@ spec:
             service:
               name: {{ include "infisical.fullname" . }}
               port:
-                number: 8080
+                number: {{ .Values.infisical.service.port | default 8080 }}
         - path: /ss-webhook
           pathType: Exact
           backend:
             service:
               name: {{ include "infisical.fullname" . }}
               port:
-                number: 8080
+                number: {{ .Values.infisical.service.port | default 8080 }}
       {{- if $ingress.hostName }}
       host: {{ $ingress.hostName }}
       {{- end }}

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -91,6 +91,14 @@ infisical:
     type: ClusterIP
     # -- Optional node port for service when using NodePort type
     nodePort: ""
+    # -- Port the service listens on. The ingress backends and the auto-bootstrap
+    # -- job follow this value.
+    port: 8080
+    # -- Pod port the service forwards to. Defaults to 8080, the port the Infisical
+    # -- container listens on, and should stay there unless a sidecar (e.g. a
+    # -- TLS-terminating proxy injected via `infisical.extraContainers`) fronts the
+    # -- Infisical container on a different port.
+    targetPort: ""
 
   # -- Extra environment variables to set on the Infisical container. Useful for setting variables like NODE_EXTRA_CA_CERTS.
   # -- Example:


### PR DESCRIPTION
## Motivation

In `infisical-standalone-postgres`, the Service's `port` and `targetPort` are hardcoded to `8080`:

```yaml
  ports:
    - protocol: TCP
      port: 8080
      targetPort: 8080
```

Deployments that front the Infisical container with a TLS-terminating sidecar — injected through the chart's existing `infisical.extraContainers` / `infisical.extraVolumes` hooks — need the Service to address the sidecar's listener instead, so that plain HTTP `:8080` stays pod-local. Today that requires patching the rendered Service after the fact.

## Change

Two new values, in the same style the chart already uses for `infisical.service.type` / `nodePort` / `annotations`:

| Key | Default | Meaning |
|---|---|---|
| `infisical.service.port` | `8080` | Port the Service listens on |
| `infisical.service.targetPort` | `""` → `8080` | Pod port the Service forwards to — the Infisical container's listener |

```yaml
      port: {{ $infisicalValues.service.port | default 8080 }}
      targetPort: {{ $infisicalValues.service.targetPort | default 8080 }}
```

`targetPort` deliberately falls back to the fixed `8080` and **not** to `service.port`: the app container and its readiness probe always listen on 8080, so changing only `service.port` must keep traffic reaching the container. `targetPort` is for sidecar-remapping deployments only.

Everything else in the chart that addresses the *Service* follows `service.port` too:

- `templates/ingress.yaml` — both backend `port.number`s
- `templates/bootstrap-job.yaml` — the readiness `curl` and the CLI `--domain`

The container port and the readiness probe stay on `8080` unconditionally — they describe the app's listener, not the Service.

`README.md`'s values table is updated to match. No chart version bump — happy to add one plus a `CHANGELOG.md` entry if that is the expected contributor flow here.

## Proof: byte-identical at default values

`helm template` of the chart before and after this change, no `--set`, no values file:

```
$ diff -u render-upstream-main.yaml render-branch.yaml
$ echo $?
0
```

(The chart renders two values that differ between *any* two runs regardless of chart content — the bundled `postgresql` subchart's random `postgres-password`, and the Deployment's `updatedAt` timestamp. Both were pinned to a constant in each render before diffing; nothing else was touched.)

## Proof: `service.port` propagates, listener does not move

`--set infisical.service.port=8443 --set infisical.service.targetPort=8443` (ingress enabled, i.e. chart defaults) against the default render:

```diff
# Service
   ports:
     - protocol: TCP
-      port: 8080
-      targetPort: 8080
+      port: 8443
+      targetPort: 8443

# Ingress, both backends
               port:
-                number: 8080
+                number: 8443
```

Container port and probe in that same render are untouched:

```yaml
          readinessProbe:
            httpGet:
              path: /api/status
              port: 8080
          ports:
            - containerPort: 8080
```

With `--set infisical.service.port=8443` alone, `targetPort` correctly stays on the container's listener:

```diff
   ports:
     - protocol: TCP
-      port: 8080
+      port: 8443
       targetPort: 8080
```

## Proof: auto-bootstrap follows the Service port

`--set infisical.autoBootstrap.enabled=true`, default port vs `8443`:

```diff
-          until curl -f http://rel-infisical-standalone-infisical:8080/api/status; do
+          until curl -f http://rel-infisical-standalone-infisical:8443/api/status; do
-            - --domain=http://rel-infisical-standalone-infisical:8080
+            - --domain=http://rel-infisical-standalone-infisical:8443
```

`helm lint` passes (only the pre-existing `icon is recommended` info).
