### PR TITLE
improvement: migrate add member to sub-org to v3 and refactor to share role selection

### DIFF
--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo } from "react";
-import { Controller, useForm } from "react-hook-form";
-import { components, OptionProps, SingleValueProps } from "react-select";
+import { useEffect } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { CheckIcon, Info } from "lucide-react";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
@@ -27,151 +26,26 @@ import {
 } from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { emailListSchema, parseEmailList } from "@app/helpers/email";
-import { getProjectLucideIcon, getProjectTitle } from "@app/helpers/project";
 import { findOrgMembershipRole } from "@app/helpers/roles";
 import {
   useAddUsersToOrg,
   useAddUserToWsNonE2EE,
   useFetchServerStatus,
   useGetOrgRoles,
-  useGetProjectRoles,
   useGetUserProjects
 } from "@app/hooks/api";
-import { ProjectType, ProjectVersion } from "@app/hooks/api/projects/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 import { OrgInviteLink } from "./OrgInviteLink";
+import {
+  ProjectAssignmentFields,
+  projectAssignmentSchema,
+  resolveTargetProjects
+} from "./ProjectAssignmentFields";
+import { DEFAULT_PROJECT_ROLE } from "./ProjectRoleSelect";
 
-const DEFAULT_PROJECT_ROLE = { slug: "member", name: "Member" };
-
-const BUILT_IN_PROJECT_ROLES = [
-  { slug: "admin", name: "Admin", description: "Full administrative access over a project" },
-  { slug: "member", name: "Member", description: "Limited read/write role in a project" },
-  { slug: "viewer", name: "Viewer", description: "Only read role in a project" },
-  { slug: "no-access", name: "No Access", description: "No access to any resources in the project" }
-];
-
-const CERT_MANAGER_ROLES = [
-  {
-    slug: "admin",
-    name: "Admin",
-    description: "Full administrative access over Certificate Manager"
-  },
-  {
-    slug: "member",
-    name: "Member",
-    description: "Access scoped to the Applications and Code Signers they've been added to"
-  }
-];
-
-const PAM_ROLES = [
-  {
-    slug: "admin",
-    name: "Admin",
-    description: "Full administrative access over Privileged Access Manager"
-  },
-  {
-    slug: "member",
-    name: "Member",
-    description: "Access scoped to the folders and accounts they've been added to"
-  }
-];
-
-type ProductDefinition = {
-  type: ProjectType;
-  name: string;
-  isSingleton: boolean;
-  roles?: { slug: string; name: string; description: string }[];
-};
-
-// Names come from the shared getProjectTitle util so the select matches the Projects pages.
-const PRODUCT_DEFINITIONS: ProductDefinition[] = [
-  {
-    type: ProjectType.SecretManager,
-    name: getProjectTitle(ProjectType.SecretManager),
-    isSingleton: false
-  },
-  {
-    type: ProjectType.CertificateManager,
-    name: getProjectTitle(ProjectType.CertificateManager),
-    isSingleton: true,
-    roles: CERT_MANAGER_ROLES
-  },
-  { type: ProjectType.KMS, name: getProjectTitle(ProjectType.KMS), isSingleton: false },
-  {
-    type: ProjectType.SecretScanning,
-    name: getProjectTitle(ProjectType.SecretScanning),
-    isSingleton: false
-  },
-  {
-    type: ProjectType.PAM,
-    name: getProjectTitle(ProjectType.PAM),
-    isSingleton: true,
-    roles: PAM_ROLES
-  }
-];
-
-// Render each product with its shared project icon (getProjectLucideIcon) so the select matches the
-// Projects pages and the org sidebar.
-const ProductOption = ({ isSelected, children, ...props }: OptionProps<ProductDefinition>) => {
-  const Icon = getProjectLucideIcon(props.data.type);
-  return (
-    <components.Option isSelected={isSelected} {...props}>
-      <div className="flex flex-row items-center gap-2">
-        <Icon className="size-4 shrink-0 text-muted" />
-        <p className="mr-auto truncate">{children}</p>
-        {isSelected && <CheckIcon className="ml-2 size-4 shrink-0" />}
-      </div>
-    </components.Option>
-  );
-};
-
-const ProductSingleValue = ({ children, ...props }: SingleValueProps<ProductDefinition>) => {
-  const Icon = getProjectLucideIcon(props.data.type);
-  return (
-    <components.SingleValue {...props}>
-      <div className="flex flex-row items-center gap-2">
-        <Icon className="size-4 shrink-0 text-muted" />
-        <span className="truncate">{children}</span>
-      </div>
-    </components.SingleValue>
-  );
-};
-
-const addMemberFormSchema = z.object({
+const addMemberFormSchema = projectAssignmentSchema.extend({
   emails: emailListSchema,
-  product: z
-    .object({
-      type: z.nativeEnum(ProjectType),
-      name: z.string(),
-      isSingleton: z.boolean(),
-      roles: z
-        .object({
-          slug: z.string(),
-          name: z.string(),
-          description: z.string()
-        })
-        .array()
-        .optional()
-    })
-    .optional(),
-  projects: z
-    .array(
-      z.object({
-        name: z.string(),
-        id: z.string(),
-        slug: z.string(),
-        version: z.nativeEnum(ProjectVersion),
-        type: z.nativeEnum(ProjectType).optional()
-      })
-    )
-    .default([]),
-  projectRole: z
-    .object({
-      slug: z.string().min(1),
-      name: z.string().min(1)
-    })
-    .default(DEFAULT_PROJECT_ROLE),
   organizationRole: z.object({
     name: z.string(),
     slug: z.string(),
@@ -203,51 +77,19 @@ export const AddOrgMemberModal = ({
   const { data: serverDetails } = useFetchServerStatus();
   const { mutateAsync: addUsersMutateAsync } = useAddUsersToOrg();
   const { mutateAsync: addUserToProject } = useAddUserToWsNonE2EE();
-  const { data: rawProjects, isPending: isProjectsLoading } = useGetUserProjects({
+  const { data: rawProjects } = useGetUserProjects({
     includeRoles: true
   });
 
-  const availableProducts = useMemo(
-    () => PRODUCT_DEFINITIONS.filter((def) => rawProjects?.some((p) => p.type === def.type)),
-    [rawProjects]
-  );
-
+  const methods = useForm<TAddMemberForm>({
+    resolver: zodResolver(addMemberFormSchema)
+  });
   const {
     control,
     handleSubmit,
-    watch,
     reset,
-    setValue,
     formState: { isSubmitting }
-  } = useForm<TAddMemberForm>({
-    resolver: zodResolver(addMemberFormSchema)
-  });
-
-  const selectedProduct = watch("product");
-  const isSingletonProduct = Boolean(selectedProduct?.isSingleton);
-
-  const productProjects = useMemo(() => {
-    if (!rawProjects || !selectedProduct || selectedProduct.isSingleton) return [];
-    return rawProjects.filter((p) => p.type === selectedProduct.type);
-  }, [rawProjects, selectedProduct]);
-
-  const selectedProjects = watch("projects", []);
-  const singleSelectedProjectId =
-    selectedProjects.length === 1 ? selectedProjects[0].id : undefined;
-  const { data: fetchedProjectRoles, isPending: isProjectRolesLoading } = useGetProjectRoles(
-    singleSelectedProjectId ?? ""
-  );
-
-  // eslint-disable-next-line no-nested-ternary
-  const projectRoles = selectedProduct?.roles
-    ? selectedProduct.roles
-    : fetchedProjectRoles?.length
-      ? fetchedProjectRoles
-      : BUILT_IN_PROJECT_ROLES;
-
-  useEffect(() => {
-    setValue("projectRole", DEFAULT_PROJECT_ROLE);
-  }, [singleSelectedProjectId, selectedProduct?.type, setValue]);
+  } = methods;
 
   // set initial form role based off org default role
   useEffect(() => {
@@ -271,26 +113,8 @@ export const AddOrgMemberModal = ({
   }: TAddMemberForm) => {
     if (!currentOrg?.id) return;
 
-    let targetProjects: typeof projectsToInvite = [];
-    if (product?.isSingleton) {
-      const singletonProject = rawProjects?.find((p) => p.type === product.type);
-      if (singletonProject) targetProjects = [singletonProject];
-    } else if (product) {
-      targetProjects = projectsToInvite;
-    }
-
-    if (!isSingletonProduct) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const project of targetProjects) {
-        if (project.version !== ProjectVersion.V3) {
-          createNotification({
-            type: "error",
-            text: `Cannot add users to project "${project.name}" because it's incompatible. Please upgrade the project.`
-          });
-          return;
-        }
-      }
-    }
+    const targetProjects = resolveTargetProjects(product, projectsToInvite, rawProjects);
+    if (!targetProjects) return;
 
     const usernames = parseEmailList(emails);
     const { data } = await addUsersMutateAsync({
@@ -358,183 +182,55 @@ export const AddOrgMemberModal = ({
           </DialogDescription>
         </DialogHeader>
         {!completeInviteLinks && (
-          <form onSubmit={handleSubmit(onAddMembers)} className="flex flex-col gap-4">
-            <Controller
-              control={control}
-              name="emails"
-              render={({ field, fieldState: { error } }) => (
-                <Field>
-                  <FieldLabel htmlFor="add-org-member-emails">Emails</FieldLabel>
-                  <TextArea
-                    id="add-org-member-emails"
-                    className="h-24"
-                    isError={Boolean(error)}
-                    placeholder="email@example.com, email2@example.com..."
-                    {...field}
-                  />
-                  <FieldError>{error?.message}</FieldError>
-                </Field>
-              )}
-            />
-
-            <Controller
-              control={control}
-              name="organizationRole"
-              render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <Field>
-                  <FieldLabel
-                    htmlFor="add-org-member-org-role"
-                    className="flex items-center gap-1.5"
-                  >
-                    Assign organization role
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span>
-                          <Info className="size-3 text-muted" />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-md">
-                        Select which organization role you want to assign to the user.
-                      </TooltipContent>
-                    </Tooltip>
-                  </FieldLabel>
-                  <FilterableSelect
-                    inputId="add-org-member-org-role"
-                    placeholder="Select role..."
-                    options={organizationRoles}
-                    getOptionValue={(option) => option.slug}
-                    getOptionLabel={(option) => option.name}
-                    value={value}
-                    onChange={onChange}
-                    isError={Boolean(error)}
-                    components={{ Option: RoleOption }}
-                  />
-                  <FieldError>{error?.message}</FieldError>
-                </Field>
-              )}
-            />
-
-            <Controller
-              control={control}
-              name="product"
-              render={({ field: { value, onChange }, fieldState: { error } }) => (
-                <Field>
-                  <FieldLabel
-                    htmlFor="add-org-member-product"
-                    className="flex items-center gap-1.5"
-                  >
-                    Assign users to a product
-                    <span className="text-xs font-normal text-muted">(optional)</span>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span>
-                          <Info className="size-3 text-muted" />
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent className="max-w-md">
-                        Select which product to grant the users access to.
-                      </TooltipContent>
-                    </Tooltip>
-                  </FieldLabel>
-                  <FilterableSelect
-                    inputId="add-org-member-product"
-                    isClearable
-                    value={value ?? null}
-                    isLoading={isProjectsLoading}
-                    onChange={(option) => {
-                      onChange(option);
-                      setValue("projects", []);
-                      setValue("projectRole", DEFAULT_PROJECT_ROLE);
-                    }}
-                    getOptionLabel={(product) => product.name}
-                    getOptionValue={(product) => product.type}
-                    options={availableProducts}
-                    placeholder="Select a product..."
-                    isError={Boolean(error?.message)}
-                    components={{ Option: ProductOption, SingleValue: ProductSingleValue }}
-                  />
-                  <FieldError>{error?.message}</FieldError>
-                </Field>
-              )}
-            />
-
-            {selectedProduct && !isSingletonProduct && (
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onAddMembers)} className="flex flex-col gap-4">
               <Controller
                 control={control}
-                name="projects"
-                render={({ field: { value, onChange }, fieldState: { error } }) => (
+                name="emails"
+                render={({ field, fieldState: { error } }) => (
                   <Field>
-                    <FieldLabel
-                      htmlFor="add-org-member-projects"
-                      className="flex items-center gap-1.5"
-                    >
-                      Assign users to projects
-                      <span className="text-xs font-normal text-muted">(optional)</span>
-                    </FieldLabel>
-                    <FilterableSelect
-                      inputId="add-org-member-projects"
-                      isMulti
-                      value={value}
-                      onChange={onChange}
-                      isLoading={isProjectsLoading}
-                      getOptionLabel={(project) => project.name}
-                      getOptionValue={(project) => project.id}
-                      options={productProjects}
-                      placeholder="Select projects..."
-                      isError={Boolean(error?.message)}
+                    <FieldLabel htmlFor="add-org-member-emails">Emails</FieldLabel>
+                    <TextArea
+                      id="add-org-member-emails"
+                      className="h-24"
+                      isError={Boolean(error)}
+                      placeholder="email@example.com, email2@example.com..."
+                      {...field}
                     />
                     <FieldError>{error?.message}</FieldError>
                   </Field>
                 )}
               />
-            )}
 
-            {selectedProduct && (
               <Controller
                 control={control}
-                name="projectRole"
+                name="organizationRole"
                 render={({ field: { value, onChange }, fieldState: { error } }) => (
                   <Field>
                     <FieldLabel
-                      htmlFor="add-org-member-project-role"
+                      htmlFor="add-org-member-org-role"
                       className="flex items-center gap-1.5"
                     >
-                      {isSingletonProduct ? "Product role" : "Project role"}
+                      Assign organization role
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <span>
                             <Info className="size-3 text-muted" />
                           </span>
                         </TooltipTrigger>
-                        <TooltipContent className="max-w-md whitespace-pre-line">
-                          {isSingletonProduct ? (
-                            "Select which role to assign to the users for this product."
-                          ) : (
-                            <>
-                              Select which role to assign to the users in the selected projects.
-                              <br />
-                              <br />
-                              When multiple projects are selected, only built-in roles are available
-                              for selection.
-                              <br />
-                              <br />
-                              You can assign users to additional projects after they&apos;ve been
-                              invited.
-                            </>
-                          )}
+                        <TooltipContent className="max-w-md">
+                          Select which organization role you want to assign to the user.
                         </TooltipContent>
                       </Tooltip>
                     </FieldLabel>
                     <FilterableSelect
-                      inputId="add-org-member-project-role"
-                      isDisabled={!isSingletonProduct && selectedProjects.length === 0}
-                      isLoading={Boolean(singleSelectedProjectId) && isProjectRolesLoading}
-                      value={value}
-                      onChange={onChange}
-                      options={projectRoles ?? []}
+                      inputId="add-org-member-org-role"
+                      placeholder="Select role..."
+                      options={organizationRoles}
                       getOptionValue={(option) => option.slug}
                       getOptionLabel={(option) => option.name}
-                      placeholder="Select role..."
+                      value={value}
+                      onChange={onChange}
                       isError={Boolean(error)}
                       components={{ Option: RoleOption }}
                     />
@@ -542,26 +238,28 @@ export const AddOrgMemberModal = ({
                   </Field>
                 )}
               />
-            )}
 
-            <DialogFooter>
-              <Button
-                variant="ghost"
-                type="button"
-                onClick={() => handlePopUpToggle("addMember", false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="org"
-                type="submit"
-                isPending={isSubmitting}
-                isDisabled={isSubmitting}
-              >
-                Add Member
-              </Button>
-            </DialogFooter>
-          </form>
+              <ProjectAssignmentFields />
+
+              <DialogFooter>
+                <Button
+                  variant="ghost"
+                  type="button"
+                  onClick={() => handlePopUpToggle("addMember", false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="org"
+                  type="submit"
+                  isPending={isSubmitting}
+                  isDisabled={isSubmitting}
+                >
+                  Add Member
+                </Button>
+              </DialogFooter>
+            </form>
+          </FormProvider>
         )}
         {completeInviteLinks && (
           <>

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddSubOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddSubOrgMemberModal.tsx
@@ -1,11 +1,26 @@
 import { useEffect } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, FormProvider, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Info } from "lucide-react";
 import { z } from "zod";
 
-import { createNotification } from "@app/components/notifications";
 import { RoleOption } from "@app/components/roles";
-import { Button, FilterableSelect, FormControl, Select, SelectItem } from "@app/components/v2";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  FilterableSelect,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { findOrgMembershipRole } from "@app/helpers/roles";
 import {
@@ -15,12 +30,16 @@ import {
   useGetUserProjects
 } from "@app/hooks/api";
 import { useGetAvailableOrgUsers } from "@app/hooks/api/organization/queries";
-import { ProjectType, ProjectVersion } from "@app/hooks/api/projects/types";
-import { ProjectMembershipRole } from "@app/hooks/api/roles/types";
+import { UsePopUpState } from "@app/hooks/usePopUp";
 
-const DEFAULT_ORG_AND_PROJECT_MEMBER_ROLE_SLUG = "member";
+import {
+  ProjectAssignmentFields,
+  projectAssignmentSchema,
+  resolveTargetProjects
+} from "./ProjectAssignmentFields";
+import { DEFAULT_PROJECT_ROLE } from "./ProjectRoleSelect";
 
-const addMemberFormSchema = z.object({
+const addMemberFormSchema = projectAssignmentSchema.extend({
   users: z
     .array(
       z.object({
@@ -28,19 +47,7 @@ const addMemberFormSchema = z.object({
         email: z.string().trim()
       })
     )
-    .min(1),
-  projects: z
-    .array(
-      z.object({
-        name: z.string(),
-        id: z.string(),
-        slug: z.string(),
-        type: z.string().optional(),
-        version: z.nativeEnum(ProjectVersion)
-      })
-    )
-    .default([]),
-  projectRoleSlug: z.string().min(1).default(DEFAULT_ORG_AND_PROJECT_MEMBER_ROLE_SLUG),
+    .min(1, "Select at least one user"),
   organizationRole: z.object({
     name: z.string(),
     slug: z.string(),
@@ -51,10 +58,14 @@ const addMemberFormSchema = z.object({
 type TAddMemberForm = z.infer<typeof addMemberFormSchema>;
 
 type Props = {
-  onClose: () => void;
+  popUp: UsePopUpState<["addMemberToSubOrg"]>;
+  handlePopUpToggle: (
+    popUpName: keyof UsePopUpState<["addMemberToSubOrg"]>,
+    state?: boolean
+  ) => void;
 };
 
-export const AddSubOrgMemberModal = ({ onClose }: Props) => {
+export const AddSubOrgMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
   const { currentOrg } = useOrganization();
 
   const { data: organizationRoles } = useGetOrgRoles(currentOrg?.id ?? "");
@@ -63,49 +74,60 @@ export const AddSubOrgMemberModal = ({ onClose }: Props) => {
   const { mutateAsync: addUsersMutateAsync } = useAddUsersToOrg();
   const { mutateAsync: addUserToProject } = useAddUserToWsNonE2EE();
 
-  const { data: projects, isPending: isProjectsLoading } = useGetUserProjects({
+  const { data: rawProjects } = useGetUserProjects({
     includeRoles: true
   });
 
+  const methods = useForm<TAddMemberForm>({
+    resolver: zodResolver(addMemberFormSchema),
+    defaultValues: {
+      users: [],
+      projects: [],
+      projectRole: DEFAULT_PROJECT_ROLE
+    }
+  });
   const {
     control,
     handleSubmit,
-    watch,
     reset,
     formState: { isSubmitting }
-  } = useForm<TAddMemberForm>({
-    resolver: zodResolver(addMemberFormSchema)
-  });
+  } = methods;
+
+  const resetForm = () => {
+    reset({
+      users: [],
+      product: undefined,
+      projects: [],
+      projectRole: DEFAULT_PROJECT_ROLE,
+      organizationRole: organizationRoles
+        ? findOrgMembershipRole(organizationRoles, currentOrg.defaultMembershipRole)
+        : undefined
+    });
+  };
 
   // set initial form role based off org default role
   useEffect(() => {
     if (organizationRoles) {
-      reset({
-        organizationRole: findOrgMembershipRole(organizationRoles, currentOrg.defaultMembershipRole)
-      });
+      resetForm();
     }
   }, [organizationRoles]);
+
+  const handleClose = () => {
+    handlePopUpToggle("addMemberToSubOrg", false);
+    resetForm();
+  };
 
   const onAddMembers = async ({
     users,
     organizationRole,
-    projects: selectedProjects,
-    projectRoleSlug
+    product,
+    projects: projectsToAssign,
+    projectRole
   }: TAddMemberForm) => {
     if (!currentOrg?.id) return;
 
-    if (selectedProjects?.length) {
-      // eslint-disable-next-line no-restricted-syntax
-      for (const project of selectedProjects) {
-        if (project.version !== ProjectVersion.V3) {
-          createNotification({
-            type: "error",
-            text: `Cannot add users to project "${project.name}" because it's incompatible. Please upgrade the project.`
-          });
-          return;
-        }
-      }
-    }
+    const targetProjects = resolveTargetProjects(product, projectsToAssign, rawProjects);
+    if (!targetProjects) return;
 
     const usernames = users.map((el) => el.username);
     await addUsersMutateAsync({
@@ -115,158 +137,113 @@ export const AddSubOrgMemberModal = ({ onClose }: Props) => {
     });
 
     await Promise.allSettled(
-      selectedProjects.map((el) =>
+      targetProjects.map((el) =>
         addUserToProject({
           orgId: currentOrg.id,
           projectId: el.id,
           projectType: el.type,
-          roleSlugs: [projectRoleSlug],
+          roleSlugs: [projectRole.slug],
           usernames
         })
       )
     );
-    onClose();
-  };
-
-  const getGroupHeaderLabel = (type: ProjectType) => {
-    switch (type) {
-      case ProjectType.SecretManager:
-        return "Secrets";
-      case ProjectType.CertificateManager:
-        return "Certificate Manager";
-      case ProjectType.KMS:
-        return "KMS";
-      default:
-        return "Other";
-    }
+    handleClose();
   };
 
   return (
-    <form onSubmit={handleSubmit(onAddMembers)}>
-      <Controller
-        control={control}
-        name="users"
-        render={({ field, fieldState: { error } }) => (
-          <FormControl label="Emails" isError={Boolean(error)} errorText={error?.message}>
-            <FilterableSelect
-              className="w-full"
-              placeholder="Add one or more users..."
-              isMulti
-              name="members"
-              isLoading={isMembersPending}
-              options={members}
-              value={field.value}
-              onChange={field.onChange}
-              getOptionValue={(option) => option.username}
-              getOptionLabel={(option) => option.username}
-              /* eslint-disable-next-line react/no-unstable-nested-components */
-              noOptionsMessage={() => (
-                <p>All root organization users are already assigned to this project</p>
+    <Dialog
+      open={popUp.addMemberToSubOrg.isOpen}
+      onOpenChange={(isOpen) =>
+        isOpen ? handlePopUpToggle("addMemberToSubOrg", true) : handleClose()
+      }
+    >
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Add member from your organization</DialogTitle>
+          <DialogDescription>
+            Add existing users from your root organization to this sub-organization.
+          </DialogDescription>
+        </DialogHeader>
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onAddMembers)} className="flex flex-col gap-4">
+            <Controller
+              control={control}
+              name="users"
+              render={({ field, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="add-sub-org-member-users">Emails</FieldLabel>
+                  <FilterableSelect
+                    inputId="add-sub-org-member-users"
+                    placeholder="Add one or more users..."
+                    isMulti
+                    isLoading={isMembersPending}
+                    options={members}
+                    value={field.value}
+                    onChange={field.onChange}
+                    getOptionValue={(option) => option.username}
+                    getOptionLabel={(option) => option.username}
+                    isError={Boolean(error)}
+                    noOptionsMessage={() =>
+                      "All root organization users are already in this sub-organization"
+                    }
+                  />
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
               )}
             />
-          </FormControl>
-        )}
-      />
-      <Controller
-        control={control}
-        name="organizationRole"
-        render={({ field: { value, onChange }, fieldState: { error } }) => (
-          <FormControl
-            tooltipText="Select which organization role you want to assign to the user."
-            label="Assign organization role"
-            isError={Boolean(error)}
-            errorText={error?.message}
-          >
-            <FilterableSelect
-              placeholder="Select role..."
-              options={organizationRoles}
-              getOptionValue={(option) => option.slug}
-              getOptionLabel={(option) => option.name}
-              value={value}
-              onChange={onChange}
-              components={{ Option: RoleOption }}
+
+            <Controller
+              control={control}
+              name="organizationRole"
+              render={({ field: { value, onChange }, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="add-sub-org-member-org-role">
+                    Assign organization role
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span>
+                          <Info className="size-3 text-muted" />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-md">
+                        Select which organization role you want to assign to the user.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FieldLabel>
+                  <FilterableSelect
+                    inputId="add-sub-org-member-org-role"
+                    placeholder="Select role..."
+                    options={organizationRoles}
+                    getOptionValue={(option) => option.slug}
+                    getOptionLabel={(option) => option.name}
+                    value={value}
+                    onChange={onChange}
+                    isError={Boolean(error)}
+                    components={{ Option: RoleOption }}
+                  />
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
+              )}
             />
-          </FormControl>
-        )}
-      />
 
-      <div className="flex items-start justify-between gap-2">
-        <div className="w-full">
-          <Controller
-            control={control}
-            name="projects"
-            render={({ field: { value, onChange }, fieldState: { error } }) => (
-              <FormControl
-                label="Assign users to projects"
-                isOptional
-                isError={Boolean(error?.message)}
-                errorText={error?.message}
-              >
-                <FilterableSelect
-                  isMulti
-                  value={value}
-                  onChange={onChange}
-                  isLoading={isProjectsLoading}
-                  getOptionLabel={(project) => project.name}
-                  getOptionValue={(project) => project.id}
-                  options={projects}
-                  groupBy="type"
-                  getGroupHeaderLabel={getGroupHeaderLabel}
-                  placeholder="Select projects..."
-                />
-              </FormControl>
-            )}
-          />
-        </div>
-        <div className="mt-[0.15rem] flex min-w-fit justify-end">
-          <Controller
-            control={control}
-            name="projectRoleSlug"
-            render={({ field, fieldState: { error } }) => (
-              <FormControl
-                tooltipText="Select which role to assign to the users in the selected projects."
-                label="Role"
-                isError={Boolean(error)}
-                errorText={error?.message}
-              >
-                <div>
-                  <Select
-                    isDisabled={watch("projects", []).length === 0}
-                    defaultValue={DEFAULT_ORG_AND_PROJECT_MEMBER_ROLE_SLUG}
-                    {...field}
-                    onValueChange={(val) => field.onChange(val)}
-                  >
-                    {Object.entries(ProjectMembershipRole).map(
-                      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                      ([_, slug]) =>
-                        slug !== "custom" && (
-                          <SelectItem key={slug} value={slug}>
-                            <span className="capitalize">{slug.replace("-", " ")}</span>
-                          </SelectItem>
-                        )
-                    )}
-                  </Select>
-                </div>
-              </FormControl>
-            )}
-          />
-        </div>
-      </div>
+            <ProjectAssignmentFields />
 
-      <div className="mt-8 flex items-center">
-        <Button
-          className="mr-4"
-          size="sm"
-          type="submit"
-          isLoading={isSubmitting}
-          isDisabled={isSubmitting}
-        >
-          Add Member
-        </Button>
-        <Button colorSchema="secondary" variant="plain" onClick={onClose}>
-          Cancel
-        </Button>
-      </div>
-    </form>
+            <DialogFooter>
+              <Button variant="ghost" type="button" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button
+                variant="sub-org"
+                type="submit"
+                isPending={isSubmitting}
+                isDisabled={isSubmitting}
+              >
+                Add Member
+              </Button>
+            </DialogFooter>
+          </form>
+        </FormProvider>
+      </DialogContent>
+    </Dialog>
   );
 };

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
@@ -5,13 +5,7 @@ import { BanIcon, TrashIcon, UserPlusIcon } from "lucide-react";
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
-import {
-  DeleteActionModal,
-  EmailServiceSetupModal,
-  Modal,
-  ModalContent,
-  Tooltip
-} from "@app/components/v2";
+import { DeleteActionModal, EmailServiceSetupModal, Tooltip } from "@app/components/v2";
 import {
   Badge,
   Button,
@@ -227,14 +221,7 @@ export const OrgMembersSection = () => {
         completeInviteLinks={completeInviteLinks}
         setCompleteInviteLinks={setCompleteInviteLinks}
       />
-      <Modal
-        isOpen={popUp.addMemberToSubOrg.isOpen}
-        onOpenChange={(isOpen) => handlePopUpToggle("addMemberToSubOrg", isOpen)}
-      >
-        <ModalContent title="Add member from your organization" bodyClassName="overflow-visible">
-          <AddSubOrgMemberModal onClose={() => handlePopUpClose("addMemberToSubOrg")} />
-        </ModalContent>
-      </Modal>
+      <AddSubOrgMemberModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />
       <DeleteActionModal
         isOpen={popUp.removeMember.isOpen}
         title={`Are you sure you want to remove member with username ${

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectAssignmentFields.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectAssignmentFields.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useMemo } from "react";
+import { Controller, useFormContext, useWatch } from "react-hook-form";
+import { components, OptionProps, SingleValueProps } from "react-select";
+import { CheckIcon, Info } from "lucide-react";
+import { z } from "zod";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Field,
+  FieldError,
+  FieldLabel,
+  FilterableSelect,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
+import { getProjectLucideIcon, getProjectTitle } from "@app/helpers/project";
+import { useGetUserProjects } from "@app/hooks/api";
+import { ProjectType, ProjectVersion } from "@app/hooks/api/projects/types";
+
+import {
+  CERT_MANAGER_ROLES,
+  DEFAULT_PROJECT_ROLE,
+  getSingleSelectedProjectId,
+  PAM_ROLES,
+  ProjectRoleSelect
+} from "./ProjectRoleSelect";
+
+type ProductDefinition = {
+  type: ProjectType;
+  name: string;
+  isSingleton: boolean;
+  roles?: { slug: string; name: string; description: string }[];
+};
+
+// Names come from the shared getProjectTitle util so the select matches the Projects pages.
+const PRODUCT_DEFINITIONS: ProductDefinition[] = [
+  {
+    type: ProjectType.SecretManager,
+    name: getProjectTitle(ProjectType.SecretManager),
+    isSingleton: false
+  },
+  {
+    type: ProjectType.CertificateManager,
+    name: getProjectTitle(ProjectType.CertificateManager),
+    isSingleton: true,
+    roles: CERT_MANAGER_ROLES
+  },
+  { type: ProjectType.KMS, name: getProjectTitle(ProjectType.KMS), isSingleton: false },
+  {
+    type: ProjectType.SecretScanning,
+    name: getProjectTitle(ProjectType.SecretScanning),
+    isSingleton: false
+  },
+  {
+    type: ProjectType.PAM,
+    name: getProjectTitle(ProjectType.PAM),
+    isSingleton: true,
+    roles: PAM_ROLES
+  }
+];
+
+// Render each product with its shared project icon (getProjectLucideIcon) so the select matches the
+// Projects pages and the org sidebar.
+const ProductOption = ({ isSelected, children, ...props }: OptionProps<ProductDefinition>) => {
+  const Icon = getProjectLucideIcon(props.data.type);
+  return (
+    <components.Option isSelected={isSelected} {...props}>
+      <div className="flex flex-row items-center gap-2">
+        <Icon className="size-4 shrink-0 text-muted" />
+        <p className="mr-auto truncate">{children}</p>
+        {isSelected && <CheckIcon className="ml-2 size-4 shrink-0" />}
+      </div>
+    </components.Option>
+  );
+};
+
+const ProductSingleValue = ({ children, ...props }: SingleValueProps<ProductDefinition>) => {
+  const Icon = getProjectLucideIcon(props.data.type);
+  return (
+    <components.SingleValue {...props}>
+      <div className="flex flex-row items-center gap-2">
+        <Icon className="size-4 shrink-0 text-muted" />
+        <span className="truncate">{children}</span>
+      </div>
+    </components.SingleValue>
+  );
+};
+
+export const projectAssignmentSchema = z.object({
+  product: z
+    .object({
+      type: z.nativeEnum(ProjectType),
+      name: z.string(),
+      isSingleton: z.boolean(),
+      roles: z
+        .object({
+          slug: z.string(),
+          name: z.string(),
+          description: z.string()
+        })
+        .array()
+        .optional()
+    })
+    .optional(),
+  projects: z
+    .array(
+      z.object({
+        name: z.string(),
+        id: z.string(),
+        slug: z.string(),
+        version: z.nativeEnum(ProjectVersion),
+        type: z.nativeEnum(ProjectType).optional()
+      })
+    )
+    .default([]),
+  projectRole: z
+    .object({
+      slug: z.string().min(1),
+      name: z.string().min(1)
+    })
+    .default(DEFAULT_PROJECT_ROLE)
+});
+
+export type TProjectAssignmentFields = z.infer<typeof projectAssignmentSchema>;
+
+type TTargetProject = {
+  id: string;
+  name: string;
+  version: ProjectVersion;
+  type?: ProjectType | string;
+};
+
+// Resolves which projects the submitted users should be added to: the product's single
+// project for singleton products, the selected projects otherwise. Returns null (after
+// notifying) when a selected project is on an incompatible version.
+export const resolveTargetProjects = (
+  product: TProjectAssignmentFields["product"],
+  selectedProjects: TTargetProject[],
+  allProjects: TTargetProject[] | undefined
+): TTargetProject[] | null => {
+  if (product?.isSingleton) {
+    const singletonProject = allProjects?.find((p) => p.type === product.type);
+    return singletonProject ? [singletonProject] : [];
+  }
+
+  if (!product) return [];
+
+  const incompatibleProject = selectedProjects.find((p) => p.version !== ProjectVersion.V3);
+  if (incompatibleProject) {
+    createNotification({
+      type: "error",
+      text: `Cannot add users to project "${incompatibleProject.name}" because it's incompatible. Please upgrade the project.`
+    });
+    return null;
+  }
+
+  return selectedProjects;
+};
+
+export const ProjectAssignmentFields = () => {
+  const { control, setValue } = useFormContext<TProjectAssignmentFields>();
+
+  const { data: rawProjects, isPending: isProjectsLoading } = useGetUserProjects({
+    includeRoles: true
+  });
+
+  const availableProducts = useMemo(
+    () => PRODUCT_DEFINITIONS.filter((def) => rawProjects?.some((p) => p.type === def.type)),
+    [rawProjects]
+  );
+
+  const selectedProduct = useWatch({ control, name: "product" });
+  const isSingletonProduct = Boolean(selectedProduct?.isSingleton);
+
+  const productProjects = useMemo(() => {
+    if (!rawProjects || !selectedProduct || selectedProduct.isSingleton) return [];
+    return rawProjects.filter((p) => p.type === selectedProduct.type);
+  }, [rawProjects, selectedProduct]);
+
+  const selectedProjects = useWatch({ control, name: "projects" }) ?? [];
+  const singleSelectedProjectId = getSingleSelectedProjectId(selectedProjects);
+
+  useEffect(() => {
+    setValue("projectRole", DEFAULT_PROJECT_ROLE);
+  }, [singleSelectedProjectId, selectedProduct?.type, setValue]);
+
+  return (
+    <>
+      <Controller
+        control={control}
+        name="product"
+        render={({ field: { value, onChange }, fieldState: { error } }) => (
+          <Field>
+            <FieldLabel htmlFor="assign-users-product" className="flex items-center gap-1.5">
+              Assign users to a product
+              <span className="text-xs font-normal text-muted">(optional)</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Info className="size-3 text-muted" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-md">
+                  Select which product to grant the users access to.
+                </TooltipContent>
+              </Tooltip>
+            </FieldLabel>
+            <FilterableSelect
+              inputId="assign-users-product"
+              isClearable
+              value={value ?? null}
+              isLoading={isProjectsLoading}
+              onChange={(option) => {
+                onChange(option);
+                setValue("projects", []);
+                setValue("projectRole", DEFAULT_PROJECT_ROLE);
+              }}
+              getOptionLabel={(product) => product.name}
+              getOptionValue={(product) => product.type}
+              options={availableProducts}
+              placeholder="Select a product..."
+              isError={Boolean(error?.message)}
+              components={{ Option: ProductOption, SingleValue: ProductSingleValue }}
+            />
+            <FieldError>{error?.message}</FieldError>
+          </Field>
+        )}
+      />
+
+      {selectedProduct && !isSingletonProduct && (
+        <Controller
+          control={control}
+          name="projects"
+          render={({ field: { value, onChange }, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel htmlFor="assign-users-projects" className="flex items-center gap-1.5">
+                Assign users to projects
+                <span className="text-xs font-normal text-muted">(optional)</span>
+              </FieldLabel>
+              <FilterableSelect
+                inputId="assign-users-projects"
+                isMulti
+                value={value}
+                onChange={onChange}
+                isLoading={isProjectsLoading}
+                getOptionLabel={(project) => project.name}
+                getOptionValue={(project) => project.id}
+                options={productProjects}
+                placeholder="Select projects..."
+                isError={Boolean(error?.message)}
+              />
+              <FieldError>{error?.message}</FieldError>
+            </Field>
+          )}
+        />
+      )}
+
+      {selectedProduct && (
+        <Controller
+          control={control}
+          name="projectRole"
+          render={({ field: { value, onChange }, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel htmlFor="assign-users-project-role" className="flex items-center gap-1.5">
+                {isSingletonProduct ? "Product role" : "Project role"}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Info className="size-3 text-muted" />
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-md whitespace-pre-line">
+                    {isSingletonProduct ? (
+                      "Select which role to assign to the users for this product."
+                    ) : (
+                      <>
+                        Select which role to assign to the users in the selected projects.
+                        <br />
+                        <br />
+                        When multiple projects are selected, only built-in roles are available for
+                        selection.
+                        <br />
+                        <br />
+                        You can assign users to additional projects after they&apos;ve been invited.
+                      </>
+                    )}
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <ProjectRoleSelect
+                inputId="assign-users-project-role"
+                value={value}
+                onChange={onChange}
+                isError={Boolean(error)}
+                selectedProjects={selectedProjects}
+                fixedRoles={selectedProduct?.roles}
+              />
+              <FieldError>{error?.message}</FieldError>
+            </Field>
+          )}
+        />
+      )}
+    </>
+  );
+};

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectAssignmentFields.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectAssignmentFields.tsx
@@ -295,6 +295,7 @@ export const ProjectAssignmentFields = () => {
                 isError={Boolean(error)}
                 selectedProjects={selectedProjects}
                 fixedRoles={selectedProduct?.roles}
+                productType={selectedProduct?.type}
               />
               <FieldError>{error?.message}</FieldError>
             </Field>

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectRoleSelect.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectRoleSelect.tsx
@@ -1,6 +1,7 @@
 import { RoleOption } from "@app/components/roles";
 import { FilterableSelect } from "@app/components/v3";
 import { useGetProjectRoles } from "@app/hooks/api";
+import { ProjectType } from "@app/hooks/api/projects/types";
 
 export type TProjectRoleOption = {
   slug: string;
@@ -10,12 +11,23 @@ export type TProjectRoleOption = {
 
 export const DEFAULT_PROJECT_ROLE: TProjectRoleOption = { slug: "member", name: "Member" };
 
-export const BUILT_IN_PROJECT_ROLES = [
+// Mirrors the backend's getPredefinedRoles: type-tagged roles are only valid for
+// projects of that type.
+const PREDEFINED_PROJECT_ROLES: (TProjectRoleOption & { type?: ProjectType })[] = [
   { slug: "admin", name: "Admin", description: "Full administrative access over a project" },
   { slug: "member", name: "Member", description: "Limited read/write role in a project" },
+  {
+    slug: "cryptographic-operator",
+    name: "Cryptographic Operator",
+    description: "Perform cryptographic operations, such as encryption and signing, in a project",
+    type: ProjectType.KMS
+  },
   { slug: "viewer", name: "Viewer", description: "Only read role in a project" },
   { slug: "no-access", name: "No Access", description: "No access to any resources in the project" }
 ];
+
+const getBuiltInProjectRoles = (productType?: ProjectType) =>
+  PREDEFINED_PROJECT_ROLES.filter((role) => !role.type || role.type === productType);
 
 export const CERT_MANAGER_ROLES = [
   {
@@ -53,19 +65,21 @@ type Props = {
   isError?: boolean;
   selectedProjects: { id: string }[];
   fixedRoles?: TProjectRoleOption[];
+  productType?: ProjectType;
 };
 
 // Shared by AddOrgMemberModal and AddSubOrgMemberModal: with fixed roles (singleton
 // products) use those; with exactly one project selected offer that project's real
-// roles (custom + type-filtered predefined); otherwise only the built-in roles valid
-// for every project type.
+// roles (custom + type-filtered predefined); otherwise the built-in roles valid for
+// the selected product type.
 export const ProjectRoleSelect = ({
   inputId,
   value,
   onChange,
   isError,
   selectedProjects,
-  fixedRoles
+  fixedRoles,
+  productType
 }: Props) => {
   const singleSelectedProjectId = getSingleSelectedProjectId(selectedProjects);
   const { data: fetchedProjectRoles, isPending: isProjectRolesLoading } = useGetProjectRoles(
@@ -80,7 +94,7 @@ export const ProjectRoleSelect = ({
           name: role.name,
           description: role.description ?? undefined
         }))
-      : BUILT_IN_PROJECT_ROLES);
+      : getBuiltInProjectRoles(productType));
 
   return (
     <FilterableSelect

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectRoleSelect.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectRoleSelect.tsx
@@ -1,0 +1,100 @@
+import { RoleOption } from "@app/components/roles";
+import { FilterableSelect } from "@app/components/v3";
+import { useGetProjectRoles } from "@app/hooks/api";
+
+export type TProjectRoleOption = {
+  slug: string;
+  name: string;
+  description?: string;
+};
+
+export const DEFAULT_PROJECT_ROLE: TProjectRoleOption = { slug: "member", name: "Member" };
+
+export const BUILT_IN_PROJECT_ROLES = [
+  { slug: "admin", name: "Admin", description: "Full administrative access over a project" },
+  { slug: "member", name: "Member", description: "Limited read/write role in a project" },
+  { slug: "viewer", name: "Viewer", description: "Only read role in a project" },
+  { slug: "no-access", name: "No Access", description: "No access to any resources in the project" }
+];
+
+export const CERT_MANAGER_ROLES = [
+  {
+    slug: "admin",
+    name: "Admin",
+    description: "Full administrative access over Certificate Manager"
+  },
+  {
+    slug: "member",
+    name: "Member",
+    description: "Access scoped to the Applications and Code Signers they've been added to"
+  }
+];
+
+export const PAM_ROLES = [
+  {
+    slug: "admin",
+    name: "Admin",
+    description: "Full administrative access over Privileged Access Manager"
+  },
+  {
+    slug: "member",
+    name: "Member",
+    description: "Access scoped to the folders and accounts they've been added to"
+  }
+];
+
+export const getSingleSelectedProjectId = (selectedProjects: { id: string }[]) =>
+  selectedProjects.length === 1 ? selectedProjects[0].id : undefined;
+
+type Props = {
+  inputId?: string;
+  value?: TProjectRoleOption | null;
+  onChange: (value: unknown) => void;
+  isError?: boolean;
+  selectedProjects: { id: string }[];
+  fixedRoles?: TProjectRoleOption[];
+};
+
+// Shared by AddOrgMemberModal and AddSubOrgMemberModal: with fixed roles (singleton
+// products) use those; with exactly one project selected offer that project's real
+// roles (custom + type-filtered predefined); otherwise only the built-in roles valid
+// for every project type.
+export const ProjectRoleSelect = ({
+  inputId,
+  value,
+  onChange,
+  isError,
+  selectedProjects,
+  fixedRoles
+}: Props) => {
+  const singleSelectedProjectId = getSingleSelectedProjectId(selectedProjects);
+  const { data: fetchedProjectRoles, isPending: isProjectRolesLoading } = useGetProjectRoles(
+    singleSelectedProjectId ?? ""
+  );
+
+  const projectRoles: TProjectRoleOption[] =
+    fixedRoles ??
+    (fetchedProjectRoles?.length
+      ? fetchedProjectRoles.map((role) => ({
+          slug: role.slug,
+          name: role.name,
+          description: role.description ?? undefined
+        }))
+      : BUILT_IN_PROJECT_ROLES);
+
+  return (
+    <FilterableSelect
+      inputId={inputId}
+      isDisabled={!fixedRoles && selectedProjects.length === 0}
+      isLoading={Boolean(singleSelectedProjectId) && isProjectRolesLoading}
+      value={value}
+      onChange={onChange}
+      options={projectRoles}
+      getOptionValue={(option) => option.slug}
+      getOptionLabel={(option) => option.name}
+      placeholder="Select role..."
+      isError={isError}
+      components={{ Option: RoleOption }}
+    />
+  );
+};


### PR DESCRIPTION
## Context

This PR migrates the add member to sub-org dialog to v3 and refactors to share the role selection with org-level add member dialog

## Screenshots

<img width="3456" height="1914" alt="CleanShot 2026-08-07 at 12 53 15@2x" src="https://github.com/user-attachments/assets/b2961e29-b2c7-4266-af4e-c7a1412cf96b" />

## Steps to verify the change

- [ ] invite members to sub org, various form permutations
- [ ] invite members to org to ensure refactoring didn't introduce any regressions

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)