### PR TITLE
fix(ui): correct tooltip behavior in select menus

### DIFF
--- a/frontend/src/components/v3/generic/ReactSelect/FilterableSelect.stories.tsx
+++ b/frontend/src/components/v3/generic/ReactSelect/FilterableSelect.stories.tsx
@@ -1,11 +1,15 @@
 import { useState } from "react";
+import { components, OptionProps } from "react-select";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InfoIcon } from "lucide-react";
 
 import { Field, FieldDescription, FieldError, FieldLabel } from "../Field";
+import { Tooltip, TooltipContent, TooltipTrigger } from "../Tooltip";
 import { FilterableSelect } from "./FilterableSelect";
 
 type Option = { label: string; value: string };
 type RegionOption = Option & { region: string };
+type PolicyOption = Option & { description: string };
 
 const ENVIRONMENT_OPTIONS: Option[] = [
   { label: "Development", value: "dev" },
@@ -24,6 +28,36 @@ const REGION_OPTIONS: RegionOption[] = [
   { label: "ap-south-1 (Mumbai)", value: "ap-south-1", region: "Asia Pacific" },
   { label: "ap-southeast-1 (Singapore)", value: "ap-southeast-1", region: "Asia Pacific" }
 ];
+
+const POLICY_OPTIONS: PolicyOption[] = [
+  {
+    label: "Secret Viewing Policies",
+    value: "secret-viewer",
+    description: "Grants read access to secrets and related resources"
+  },
+  {
+    label: "Secret Editing Policies",
+    value: "secret-editor",
+    description: "Grants read and edit access to secrets and related resources"
+  }
+];
+
+const PolicyOptionRow = ({ children, ...props }: OptionProps<PolicyOption>) => (
+  <components.Option {...props}>
+    <div className="flex items-center justify-between gap-2">
+      <div className="min-w-0 flex-1">
+        <p className="truncate">{children}</p>
+        <p className="text-xs text-muted">{props.data.description}</p>
+      </div>
+      <Tooltip defaultOpen={props.data.value === "secret-viewer"}>
+        <TooltipTrigger type="button" aria-label={`View ${props.data.label}`}>
+          <InfoIcon className="size-4 text-muted" />
+        </TooltipTrigger>
+        <TooltipContent side="left">Secrets: Read</TooltipContent>
+      </Tooltip>
+    </div>
+  </components.Option>
+);
 
 /**
  * `FilterableSelect` is the v3 react-select-based dropdown for searchable
@@ -154,6 +188,26 @@ export const Grouped: Story = {
   },
   render: () => (
     <FilterableSelect options={REGION_OPTIONS} groupBy="region" placeholder="Choose a region..." />
+  )
+};
+
+export const WithTooltipOption: Story = {
+  name: "Example: Tooltip Inside Menu",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Option content can open a portaled tooltip above the select menu. This composition documents the overlay order used when an option needs secondary detail."
+      }
+    }
+  },
+  render: () => (
+    <FilterableSelect
+      menuIsOpen
+      options={POLICY_OPTIONS}
+      placeholder="Select additional privileges..."
+      components={{ Option: PolicyOptionRow }}
+    />
   )
 };
 

--- a/frontend/src/components/v3/generic/ReactSelect/styles.ts
+++ b/frontend/src/components/v3/generic/ReactSelect/styles.ts
@@ -54,7 +54,7 @@ export const selectStyles: StylesConfig<unknown, boolean, GroupBase<unknown>> = 
   }),
   menuPortal: (provided) => ({
     ...provided,
-    zIndex: 99999,
+    zIndex: 60,
     pointerEvents: "auto"
   })
 };

--- a/frontend/src/components/v3/generic/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/v3/generic/Tooltip/Tooltip.tsx
@@ -42,7 +42,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "pointer-events-none z-[70] w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-sm bg-border px-3 py-1.5 text-xs text-pretty text-foreground fade-in-0 select-none zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "!pointer-events-none z-[70] w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-sm bg-border px-3 py-1.5 text-xs text-pretty text-foreground fade-in-0 select-none zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className
         )}
         {...props}


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

The policy-detail tooltip in the Add Machine Identity sheet could render behind the open Additional Privileges select menu. The shared React Select portal used an effectively unbounded `z-index: 99999`, which placed it above the v3 tooltip overlay.

This change:

- moves the shared v3 React Select menu portal to overlay tier `60`, above sheets and dialogs but below tooltips
- enforces non-hit-testable tooltip content inside modal layers so Radix cannot override it with inline pointer-event behavior
- adds a Storybook composition with an open select menu and tooltip to document the expected overlay order

This affects shared v3 React Select menus and tooltips without changing selection behavior, data, permissions, or APIs.

[PLATFOR-641](https://linear.app/infisical/issue/PLATFOR-641/tooltip-opens-behind-dropdown)

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

No shareable visual artifact is attached yet. Outstanding capture:

- **State:** Add Machine Identity sheet with the Additional Privileges menu open and a policy info tooltip visible above the menu.
- **Prerequisites:** A Secret Management project and permission to open Project Access Control.
- **Navigation:** Project Access Control → Machine Identities → Add Machine Identity to Project.
- **Interaction:** Open Additional Privileges and hover a policy row's info icon.
- **Expected result:** The tooltip renders above the select menu and remains non-hit-testable.

## Steps to verify the change

1. Open a Secret Management project's Project Access Control page.
2. Select **Machine Identities** and open **Add Machine Identity to Project**.
3. Open the **Additional Privileges** select.
4. Hover each policy row's info icon from multiple directions.
5. Confirm the tooltip renders above the select menu and does not prevent interaction with the menu.
6. Run `make reviewable-ui`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)