### PR TITLE
fix(secrets): constrain bulk delete dialog width

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/components/BulkDeleteDialog/BulkDeleteDialog.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SelectionPanel/components/BulkDeleteDialog/BulkDeleteDialog.tsx
@@ -105,7 +105,7 @@ const BulkDeleteDialogContent = ({
   };
 
   return (
-    <DialogContent className="max-w-7xl">
+    <DialogContent className="max-w-3xl [&>*]:min-w-0">
       <DialogHeader>
         <DialogTitle>{title}</DialogTitle>
         {subTitle && <DialogDescription>{subTitle}</DialogDescription>}
@@ -123,7 +123,7 @@ const BulkDeleteDialogContent = ({
               <TableHead className="sticky left-0 z-20 w-10 max-w-10 min-w-10 border-b-0 bg-container shadow-[inset_0_-1px_0_var(--color-border)]">
                 Type
               </TableHead>
-              <TableHead className="sticky left-10 z-20 max-w-[30vw] min-w-[30vw] border-b-0 bg-container shadow-[inset_-1px_0_0_var(--color-border),inset_0_-1px_0_var(--color-border)]">
+              <TableHead className="sticky left-10 z-20 w-32 max-w-32 min-w-32 border-b-0 bg-container shadow-[inset_-1px_0_0_var(--color-border),inset_0_-1px_0_var(--color-border)] sm:w-72 sm:max-w-72 sm:min-w-72">
                 Name
               </TableHead>
               {visibleEnvs.map((env) => (
@@ -148,7 +148,7 @@ const BulkDeleteDialogContent = ({
                   )}
                 </TableCell>
                 <TableCell
-                  className="sticky left-10 z-10 max-w-80 bg-container shadow-[inset_-1px_0_0_var(--color-border)] transition-colors duration-75 group-hover:bg-container-hover"
+                  className="sticky left-10 z-10 w-32 max-w-32 min-w-32 bg-container shadow-[inset_-1px_0_0_var(--color-border)] transition-colors duration-75 group-hover:bg-container-hover sm:w-72 sm:max-w-72 sm:min-w-72"
                   isTruncatable
                 >
                   {item.name}


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

The bulk secret deletion dialog became nearly viewport-wide after the shared v3 Dialog width contract changed to use the consumer's `max-w-*` override as its effective desktop width. This dialog still specified `max-w-7xl`, so even a single selected secret and environment produced an oversized confirmation surface.

This change:

- caps the bulk deletion dialog at `max-w-3xl`
- allows direct dialog children to shrink into their overflow containers
- replaces the viewport-relative `30vw` sticky Name column with a bounded responsive width
- preserves the existing deletion, permission, confirmation, and API behavior

No linked ticket.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

Before
<img width="3192" height="2192" alt="image" src="https://github.com/user-attachments/assets/2ea9133a-258c-4cc3-b564-9f040a8d92d1" />
After
<img width="3192" height="2192" alt="CleanShot 2026-08-07 at 17 47 06@2x" src="https://github.com/user-attachments/assets/23f98559-70d9-41c8-a372-60c3b1c47a7a" />

## Steps to verify the change

1. Start the local preview and open a Secrets Management project containing at least one secret.
2. Select a secret or folder from the Overview table and choose **Delete** from the selected action bar.
3. Confirm the dialog no longer expands to the previous `max-w-7xl` width.
4. Verify the sticky Name column truncates within its responsive bound and at least one environment column remains accessible.
5. With several visible environments, verify the table scrolls horizontally while the Type and Name columns remain sticky.
6. Verify the confirmation input, Cancel action, and Delete action remain usable.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)