### PR TITLE
fix(ui): keep a corrupted localStorage value from crashing the page

### DIFF
--- a/frontend/src/hooks/useLocalStorageState.ts
+++ b/frontend/src/hooks/useLocalStorageState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 
 type SetStateAction<T> = T | ((prevState: T) => T);
 
@@ -63,11 +63,19 @@ export const useLocalStorageState = <T>(
     getLocalStorageServerSnapshot
   );
 
+  // Read through a ref so setState can fall back to the same value the caller sees without
+  // taking initialValue as a dependency — callers commonly pass a fresh literal each render,
+  // which would give setState a new identity every time.
+  const initialValueRef = useRef(initialValue);
+  initialValueRef.current = initialValue;
+
   const setState = useCallback(
     (v: SetStateAction<T>): void => {
       try {
         const nextState =
-          typeof v === "function" ? (v as (prevState: T) => T)(JSON.parse(store || "null")) : v;
+          typeof v === "function"
+            ? (v as (prevState: T) => T)(parseStoredValue(store, initialValueRef.current))
+            : v;
 
         if (nextState === undefined || nextState === null) {
           removeLocalStorageItem(key);

--- a/frontend/src/hooks/useLocalStorageState.ts
+++ b/frontend/src/hooks/useLocalStorageState.ts
@@ -38,6 +38,19 @@ const getLocalStorageServerSnapshot = (): never => {
   throw Error("useLocalStorage is a client-only hook");
 };
 
+// localStorage is writable by anything on the origin, so the stored string may not be
+// valid JSON. Parsing happens during render, where a throw takes down the whole page
+// instead of degrading to the initial value.
+const parseStoredValue = <T>(raw: string | null, fallback: T): T => {
+  if (!raw) return fallback;
+
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+};
+
 export const useLocalStorageState = <T>(
   key: string,
   initialValue: T
@@ -74,5 +87,5 @@ export const useLocalStorageState = <T>(
     }
   }, [key, initialValue]);
 
-  return [store ? JSON.parse(store) : initialValue, setState];
+  return [parseStoredValue(store, initialValue), setState];
 };


### PR DESCRIPTION
## Context

Fixes #7597.

`infisical.lastLogin` is read on every login page. If that key holds anything that is not valid JSON, the login page dies with a `SyntaxError` and the user gets the error boundary instead of the sign-in form. It does not self-clear either: the bad value lives in the browser, so the page keeps breaking on every reload until the user knows to clear site data.

**High level:** reading a stored value should never be able to take down the page that reads it. A value that cannot be parsed should degrade to the hook's initial value.

**Low level:** `useLocalStorageState` returned

```ts
return [store ? JSON.parse(store) : initialValue, setState];
```

That `JSON.parse` runs *during render*, so a throw propagates into React's render phase and unmounts the tree. The write path already accounted for this — `setState` wraps its own `JSON.parse` in `try/catch` (and still does) — but the read path was unguarded.

This adds a `parseStoredValue` helper that falls back to `initialValue` when the stored string is missing or unparseable, and uses it for the returned value. The `!raw` check preserves the previous `store ? … : initialValue` behaviour, so an empty string still yields the initial value exactly as before.

Once the user signs in again, `saveLastLogin` overwrites the bad entry, so a corrupt value clears itself in normal use.

### Note on the approach

The parse is deliberately left outside `getSnapshot`. `useSyncExternalStore` requires `getSnapshot` to be referentially stable, and it currently returns the raw string. Parsing inside it would allocate a new object on every call and drive an infinite re-render loop, so the guard belongs where the parse already happens.

Scope is small: `useLocalStorageState` has a single consumer today (`useLastLogin`), which the login pages use.

## Screenshots

_Before — corrupt value in `infisical.lastLogin`, login page replaced by the error boundary:_

<img width="1536" height="730" alt="step2-crash-before-fix" src="https://github.com/user-attachments/assets/9fa4efc8-43ba-460a-9035-8a1a535f7538" />

_After — same corrupt value still in localStorage, login page renders normally:_

<img width="1536" height="730" alt="step3-fixed-with-corrupt-value" src="https://github.com/user-attachments/assets/a0b5d611-bd30-4cfc-855b-442093504dcf" />

_After — a valid value still works, "Last used" hint intact:_

<img width="1536" height="730" alt="step4-valid-value-still-works" src="https://github.com/user-attachments/assets/34012f33-d138-4b1c-abb0-2b186bddc7e5" />

## Steps to verify the change

1. Open `/login` and confirm it renders.
2. In devtools: `localStorage.setItem("infisical.lastLogin", "{bad-json")`
3. Reload `/login`.
   - **Before this change:** the error boundary appears, and the console shows `SyntaxError: Expected property name or '}' in JSON at position 1` thrown from `useLocalStorageState` via `useLastLogin`.
   - **After this change:** the login form renders normally, with the invalid value still sitting in localStorage.
4. Confirm good data is unaffected:
   `localStorage.setItem("infisical.lastLogin", JSON.stringify({ method: "email", timestamp: Date.now() }))`
   Reload — the page renders and the "Last used" hint still shows on the email method.

Verified against the dev frontend, as the change is entirely client-side. `npm run type:check` and `eslint --max-warnings 0` both pass.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)