### PR TITLE
fix(build): pin shell scripts to LF so Windows clones build working images

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Shell scripts are executed inside Linux containers. Git for Windows checks out with
+# core.autocrlf=true by default, which rewrites them to CRLF, and the trailing \r becomes
+# part of the shebang — the kernel then looks for an interpreter named "sh\r" and the
+# container exits with a misleading "no such file or directory". Pin them to LF on every
+# platform so a Windows clone produces a working image.
+*.sh text eol=lf
+
+# Same reason: husky hooks are run by sh.
+.husky/* text eol=lf


### PR DESCRIPTION
## Context

On Windows, a fresh clone produces containers that fail to start:

```
infisical-dev-api  | exec /app/dev-entrypoint.sh: no such file or directory
```

The file is present and executable, so the message is misleading.

**High level:** the repo has no `.gitattributes`, so line endings depend on each contributor's local Git config rather than on what the files actually need.

**Low level:** Git for Windows installs with `core.autocrlf=true`, so every checkout rewrites text files to CRLF. For a shell script the trailing `\r` becomes part of the shebang, and Linux then looks for an interpreter literally named `sh\r`. `execve` fails with `ENOENT`, which Docker surfaces as "no such file or directory" — pointing at the script rather than at the interpreter.

This affects more than local dev: `backend/Dockerfile.dev`, `backend/Dockerfile.dev.fips`, `Dockerfile.standalone-infisical` and `Dockerfile.fips.standalone-infisical` all copy and execute `.sh` files, so the standalone images are affected too when built on Windows.

`.husky/*` is included for the same reason — the hooks are run by `sh`, and they are rewritten to CRLF by the same default.

### Scope

- Verified the repo has **no** `.bat`, `.cmd` or `.ps1` files, so nothing here needs to stay CRLF.
- 17 tracked `.sh` files plus `.husky/pre-commit` are affected.
- Deliberately narrow: this pins only the files that must be LF, rather than applying a repo-wide `* text=auto`, which would touch every file in the tree.

### Note for existing checkouts

`.gitattributes` only affects future checkouts. Anyone who already cloned on Windows will still have CRLF locally and can renormalize with:

```bash
git rm --cached -r .
git reset --hard
```

## Screenshots

Not applicable — terminal output included below.

## Steps to verify the change

On any machine (this simulates a fresh Windows clone):

```bash
git config core.autocrlf true
rm backend/dev-entrypoint.sh frontend/scripts/start.sh .husky/pre-commit
git checkout -- backend/dev-entrypoint.sh frontend/scripts/start.sh .husky/pre-commit
file backend/dev-entrypoint.sh frontend/scripts/start.sh .husky/pre-commit
```

**Before this change:**
```
backend/dev-entrypoint.sh: POSIX shell script, ASCII text executable, with CRLF line terminators
frontend/scripts/start.sh: POSIX shell script, ASCII text executable, with CRLF line terminators
.husky/pre-commit:         a sh script, Unicode text, UTF-8 text executable, with CRLF line terminators
```

**After this change:**
```
backend/dev-entrypoint.sh: POSIX shell script, ASCII text executable
frontend/scripts/start.sh: POSIX shell script, ASCII text executable
.husky/pre-commit:         a sh script, Unicode text, UTF-8 text executable
```

All 17 tracked `.sh` files check out with LF (0 remaining with CRLF), and `docker compose -f docker-compose.dev.yml up` then starts the backend container instead of exiting.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)