### PR TITLE
fix(app-connections): add timeout to outbound HTTP requests in connectors

### DIFF
--- a/backend/src/services/app-connection/teamcity/teamcity-connection-fns.ts
+++ b/backend/src/services/app-connection/teamcity/teamcity-connection-fns.ts
@@ -39,7 +39,8 @@ export const validateTeamCityConnectionCredentials = async (config: TTeamCityCon
       headers: {
         Authorization: `Bearer ${accessToken}`,
         Accept: "application/json"
-      }
+      },
+      timeout: 30_000
     });
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
@@ -65,7 +66,8 @@ export const listTeamCityProjects = async (appConnection: TTeamCityConnection) =
       headers: {
         Authorization: `Bearer ${accessToken}`,
         Accept: "application/json"
-      }
+      },
+      timeout: 30_000
     }
   );
 

--- a/backend/src/services/app-connection/zabbix/zabbix-connection-fns.ts
+++ b/backend/src/services/app-connection/zabbix/zabbix-connection-fns.ts
@@ -44,7 +44,8 @@ export const validateZabbixConnectionCredentials = async (config: TZabbixConnect
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiToken}`
-      }
+      },
+      timeout: 30_000
     });
 
     if (response.data.error) {
@@ -86,7 +87,8 @@ export const listZabbixHosts = async (appConnection: TZabbixConnection): Promise
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiToken}`
-      }
+      },
+      timeout: 30_000
     });
 
     return response.data.result


### PR DESCRIPTION
The TeamCity and Zabbix app-connection helpers make outbound requests to user-configured instance URLs with no timeout set. A slow or unresponsive self-hosted instance can hang the connection validation and host-listing calls indefinitely. Added a 30-second timeout to each request so failures surface quickly rather than blocking the caller.