### PR TITLE
fix(admin): sign bootstrap token with exp claim

### DIFF
--- a/backend/src/services/super-admin/super-admin-service.ts
+++ b/backend/src/services/super-admin/super-admin-service.ts
@@ -38,9 +38,9 @@ import { SmtpTemplates, TSmtpService } from "@app/services/smtp/smtp-service";
 import { TAlertChannelRecipientDALFactory } from "../alert/alert-channel-recipient-dal";
 import { AlertPrincipalType } from "../alert/alert-types";
 import { TAuthLoginFactory } from "../auth/auth-login-service";
-import { ActorType, AuthMethod, AuthTokenType } from "../auth/auth-type";
+import { ActorType, AuthMethod } from "../auth/auth-type";
 import { TIdentityAccessTokenDALFactory } from "../identity-access-token/identity-access-token-dal";
-import { TIdentityAccessTokenJwtPayload } from "../identity-access-token/identity-access-token-types";
+import { signIdentityAccessToken } from "../identity-access-token/identity-access-token-fns";
 import { TIdentityTokenAuthDALFactory } from "../identity-token-auth/identity-token-auth-dal";
 import { KMS_ROOT_CONFIG_UUID } from "../kms/kms-fns";
 import { TKmsRootConfigDALFactory } from "../kms/kms-root-config-dal";
@@ -669,14 +669,24 @@ export const superAdminServiceFactory = ({
         tx
       );
 
-      const generatedAccessToken = crypto.jwt().sign(
-        {
-          identityId: newIdentity.id,
-          identityAccessTokenId: newToken.id,
-          authTokenType: AuthTokenType.IDENTITY_ACCESS_TOKEN
-        } as TIdentityAccessTokenJwtPayload,
-        appCfg.AUTH_SECRET
-      );
+      const { accessToken: generatedAccessToken } = signIdentityAccessToken({
+        identityAccessTokenId: newToken.id,
+        identityId: newIdentity.id,
+        identityName: newIdentity.name,
+        authMethod: IdentityAuthMethod.TOKEN_AUTH,
+        orgId: organization.id,
+        rootOrgId: organization.id,
+        parentOrgId: organization.id,
+        clientSecretId: "",
+        numUsesLimit: tokenAuth.accessTokenNumUsesLimit,
+        ipRestrictionEnabled: false,
+        ttlSeconds: appCfg.MAX_MACHINE_IDENTITY_TOKEN_AGE,
+        accessTokenTTL: tokenAuth.accessTokenTTL,
+        accessTokenMaxTTL: tokenAuth.accessTokenMaxTTL,
+        accessTokenPeriod: 0,
+        creationEpoch: Math.floor(Date.now() / 1000),
+        identityAuth: {}
+      });
 
       return { identity: newIdentity, auth: tokenAuth, credentials: { token: generatedAccessToken } };
     });


### PR DESCRIPTION
## Context

Fixes #7599.

The `bootstrapInstance` method signed the initial admin identity token with raw `crypto.jwt().sign()` without an `exp` claim. The identity access token service enforces a legacy-token max-age cutoff (`LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT`), which rejects any token missing an `exp` after May 4 2026. This means freshly bootstrapped instances on v0.160.0+ get a token that is immediately rejected.

The fix uses the existing `signIdentityAccessToken` helper, which always produces a JWT with a proper `exp` claim via the `expiresIn` option. The TTL is set to the configured `MAX_MACHINE_IDENTITY_TOKEN_AGE`.

## Steps to verify the change

1. Deploy a fresh instance with an empty database.
2. Run `infisical bootstrap`.
3. Use the returned token to call any authenticated endpoint.
4. The request succeeds instead of returning "Identity access token exceeded max age".

Backend type-check and lint pass:

```sh
cd backend && npm run type:check && npm run lint:fix -- src/services/super-admin/super-admin-service.ts --max-warnings 0
```

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`.
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)