### PR TITLE
fix(ui): use TableCell for skeleton rows in Secret Sharing tables

### DIFF
--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsTable.tsx
@@ -9,6 +9,7 @@ import {
   Skeleton,
   Table,
   TableBody,
+  TableCell,
   TableHead,
   TableHeader,
   TableRow
@@ -56,9 +57,9 @@ export const RequestedSecretsTable = ({ handlePopUpOpen }: Props) => {
                 <TableRow key={`skeleton-${i}`}>
                   {Array.from({ length: 6 }).map((__, j) => (
                     // eslint-disable-next-line react/no-array-index-key
-                    <td key={`skeleton-cell-${j}`} className="px-3 py-3">
+                    <TableCell key={`skeleton-cell-${j}`}>
                       <Skeleton className="h-4 w-full" />
-                    </td>
+                    </TableCell>
                   ))}
                 </TableRow>
               ))}

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
@@ -9,6 +9,7 @@ import {
   Skeleton,
   Table,
   TableBody,
+  TableCell,
   TableHead,
   TableHeader,
   TableRow
@@ -62,9 +63,9 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
                 <TableRow key={`skeleton-${i}`}>
                   {Array.from({ length: 7 }).map((__, j) => (
                     // eslint-disable-next-line react/no-array-index-key
-                    <td key={`skeleton-cell-${j}`} className="px-3 py-3">
+                    <TableCell key={`skeleton-cell-${j}`}>
                       <Skeleton className="h-4 w-full" />
-                    </td>
+                    </TableCell>
                   ))}
                 </TableRow>
               ))}


### PR DESCRIPTION
## Context

Fixes #7456

The skeleton loading rows in the Secret Sharing tables (Share Secrets and Request Secret) used raw `<td>` elements with ad-hoc `px-3 py-3` padding. This caused the skeleton rows to render with inconsistent height and missing the `border-b` divider that the real data rows have, creating a visual jump when the table transitions from loading to loaded state.

This change replaces the raw `<td>` elements with the v3 `TableCell` component, which provides consistent `h-[40px]` height and `border-b border-border` styling — matching the real data rows exactly.

## Screenshots

N/A — visual consistency fix; no screenshots available.

## Steps to verify the change

1. Navigate to Organization → Secret Sharing → Share Secret tab
2. Observe the skeleton loading rows render with consistent 40px height and bottom border, matching the loaded data rows
3. Navigate to Organization → Secret Sharing → Request Secret tab
4. Repeat the same verification

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)