### PR TITLE
fix: only show sheet if user has permission

### DIFF
--- a/frontend/src/components/honey-tokens/HoneyTokenDetailsDrawer.tsx
+++ b/frontend/src/components/honey-tokens/HoneyTokenDetailsDrawer.tsx
@@ -311,19 +311,15 @@ const DrawerContent = ({
                 How should I respond?
               </AccordionTrigger>
               <AccordionContent>
-                <Alert variant="info" className="flex flex-col gap-4">
+                <Alert variant="info" className="flex flex-col gap-4 [&>*]:ml-0">
                   <div>
-                    <p className="text-xs font-medium text-white">1. False alarm confirmed?</p>
-                    <p className="text-xs text-accent">
+                    <p className="text-xs font-medium text-white">False alarm confirmed?</p>
+                    <p className="mb-4 text-xs text-accent">
                       You might want to <strong>reset the honey token</strong>. This will revert its
                       status to active and hide the past events, so that the honey token can be
                       triggered again.
                     </p>
-                  </div>
-                  <div>
-                    <p className="text-xs font-medium text-white">
-                      2. Malicious activity confirmed?
-                    </p>
+                    <p className="text-xs font-medium text-white">Malicious activity confirmed? </p>
                     <p className="text-xs text-accent">
                       1. Take immediate steps as per your company Incident Response Plan.
                       <br />

--- a/frontend/src/context/ProjectPermissionContext/index.tsx
+++ b/frontend/src/context/ProjectPermissionContext/index.tsx
@@ -21,6 +21,7 @@ export {
   ProjectPermissionPkiSubscriberActions,
   ProjectPermissionPkiSyncActions,
   ProjectPermissionPkiTemplateActions,
+  ProjectPermissionProjectFolderGrantActions,
   ProjectPermissionProxiedServiceActions,
   ProjectPermissionSub
 } from "./types";

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -82,6 +82,7 @@ import {
   useGetOrgTrialUrl,
   useLogoutUser
 } from "@app/hooks/api";
+import { appConnectionKeys } from "@app/hooks/api/appConnections/queries";
 import { authKeys, selectOrganization } from "@app/hooks/api/auth/queries";
 import { MfaMethod } from "@app/hooks/api/auth/types";
 import { getAuthToken } from "@app/hooks/api/reactQuery";
@@ -224,6 +225,7 @@ export const Navbar = () => {
     queryClient.removeQueries({ queryKey: adminQueryKeys.serverConfig() });
     queryClient.removeQueries({ queryKey: authKeys.getAuthToken });
     queryClient.removeQueries({ queryKey: subOrgQuery.queryKey });
+    queryClient.removeQueries({ queryKey: appConnectionKeys.all });
 
     await queryClient.refetchQueries({ queryKey: authKeys.getAuthToken });
     await queryClient.refetchQueries({ queryKey: adminQueryKeys.serverConfig() });

--- a/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
+++ b/frontend/src/pages/project/SettingsPage/components/CrossProjectSharingSection/CrossProjectSharingSection.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
+import { ProjectPermissionCan } from "@app/components/permissions";
 import {
   Accordion,
   AccordionContent,
@@ -50,6 +51,10 @@ import {
 } from "@app/components/v3";
 import { apiRequest } from "@app/config/request";
 import { useProject } from "@app/context";
+import {
+  ProjectPermissionProjectFolderGrantActions,
+  ProjectPermissionSub
+} from "@app/context/ProjectPermissionContext";
 import {
   TProjectFolderGrant,
   useListProjectFolderGrants
@@ -215,17 +220,25 @@ export const CrossProjectSharingSection = () => {
             Cross-Project Secret Sharing
             <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/secret-reference#cross-project-secret-sharing" />
           </CardTitle>
-          <Button
-            variant="project"
-            size="sm"
-            onClick={() => {
-              setEditData(null);
-              setIsShareSheetOpen(true);
-            }}
+          <ProjectPermissionCan
+            I={ProjectPermissionProjectFolderGrantActions.CreateGrant}
+            a={ProjectPermissionSub.ProjectFolderGrant}
           >
-            <Plus className="size-3.5" />
-            Share Secrets
-          </Button>
+            {(isAllowed) => (
+              <Button
+                variant="project"
+                size="sm"
+                isDisabled={!isAllowed}
+                onClick={() => {
+                  setEditData(null);
+                  setIsShareSheetOpen(true);
+                }}
+              >
+                <Plus className="size-3.5" />
+                Share Secrets
+              </Button>
+            )}
+          </ProjectPermissionCan>
           <ShareSecretsSheet
             isOpen={isShareSheetOpen}
             onOpenChange={handleSheetOpenChange}
@@ -287,17 +300,35 @@ export const CrossProjectSharingSection = () => {
                         </IconButton>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => handleEdit(projectGroup)}>
-                          <PencilIcon className="mr-2 size-4" />
-                          Edit
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          variant="danger"
-                          onClick={() => setDeleteTarget(projectGroup)}
+                        <ProjectPermissionCan
+                          I={ProjectPermissionProjectFolderGrantActions.CreateGrant}
+                          a={ProjectPermissionSub.ProjectFolderGrant}
                         >
-                          <TrashIcon className="mr-2 size-4" />
-                          Delete
-                        </DropdownMenuItem>
+                          {(isAllowed) => (
+                            <DropdownMenuItem
+                              isDisabled={!isAllowed}
+                              onClick={() => handleEdit(projectGroup)}
+                            >
+                              <PencilIcon className="mr-2 size-4" />
+                              Edit
+                            </DropdownMenuItem>
+                          )}
+                        </ProjectPermissionCan>
+                        <ProjectPermissionCan
+                          I={ProjectPermissionProjectFolderGrantActions.RevokeGrant}
+                          a={ProjectPermissionSub.ProjectFolderGrant}
+                        >
+                          {(isAllowed) => (
+                            <DropdownMenuItem
+                              variant="danger"
+                              isDisabled={!isAllowed}
+                              onClick={() => setDeleteTarget(projectGroup)}
+                            >
+                              <TrashIcon className="mr-2 size-4" />
+                              Delete
+                            </DropdownMenuItem>
+                          )}
+                        </ProjectPermissionCan>
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </div>


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Fixes:

1. Make "add" button for cross-project secret sharing only be enabled if user has permission
2. Cache invalidation for app connections when org is changed
3. margin in the honey token "how should I proceed?" section


## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="1506" height="462" alt="CleanShot 2026-08-09 at 21 58 11@2x" src="https://github.com/user-attachments/assets/934a4d48-98ef-436f-9ca1-2ffbda97bb99" />


## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)