### PR TITLE
docs(agent-proxy): document machine identity auth methods for start and connect

### DIFF
--- a/docs/cli/commands/agent-proxy.mdx
+++ b/docs/cli/commands/agent-proxy.mdx
@@ -317,7 +317,7 @@ $ infisical secrets agent-proxy start --port 17322 --unmatched-host=block
   <Accordion title="--auth-method">
     How to authenticate the agent proxy's machine identity: `universal-auth`, `kubernetes`, `azure`, `gcp-id-token`, `gcp-iam`, `aws-iam`, `oidc-auth`, `jwt-auth`, or `ldap-auth`. Alternative to the `INFISICAL_AUTH_METHOD` environment variable.
 
-    Omit it and passing `--client-id` with `--client-secret` is taken to mean `universal-auth`, so a Universal Auth setup needs no extra flag. `--token` takes precedence over both.
+    Omit it and passing `--client-id` with `--client-secret` is taken to mean `universal-auth`, so a Universal Auth setup needs no extra flag. A token takes precedence over both, including one that came from `INFISICAL_TOKEN` rather than `--token`.
 
     The proxy re-authenticates before its token expires, using the same credential each time, so it keeps running for as long as that credential stays valid. That holds indefinitely for client credentials, LDAP, and the cloud methods, which re-read the host's identity every time. It does not hold for `jwt-auth` and `oidc-auth`: the JWT you passed is reused at every refresh, so a short-lived one (a CI OIDC token, say) will already have expired by then. Use those two only with a JWT that outlives the proxy.
 

--- a/docs/cli/commands/agent-proxy.mdx
+++ b/docs/cli/commands/agent-proxy.mdx
@@ -40,7 +40,7 @@ These subcommands run the [Infisical Agent Proxy](/documentation/platform/agent-
 
 - `run` is for an agent on your own computer. It does the proxy's work and the agent's launch in one process, authenticating as your logged-in user, and sandboxes the agent. It always starts its own proxy, so `--proxy` is rejected rather than ignored. See [Local Agent Proxy](/documentation/platform/agent-proxy/local-agent-proxy).
 - `start` runs the proxy as a long-running service on a host of its own, serving agents across your network.
-- `connect` launches an agent behind a proxy **already running elsewhere**, setting up proxy routing, CA trust, and placeholder credentials. It needs a proxy address, which is why it goes with `start`. Both authenticate with a [machine identity](/documentation/platform/identities/machine-identities) via [Universal Auth](/documentation/platform/identities/universal-auth), and the proxy's is always separate from your agents'; see [Standalone Agent Proxy](/documentation/platform/agent-proxy/standalone-agent-proxy).
+- `connect` launches an agent behind a proxy **already running elsewhere**, setting up proxy routing, CA trust, and placeholder credentials. It needs a proxy address, which is why it goes with `start`. Both authenticate as a [machine identity](/documentation/platform/identities/machine-identities), by any of the CLI's auth methods, and the proxy's identity is always separate from your agents'; see [Standalone Agent Proxy](/documentation/platform/agent-proxy/standalone-agent-proxy).
 
 Each arrangement stands on its own: `run` is complete by itself, and a deployed proxy pairs only with `connect`. All three read the same [proxied services](/documentation/platform/agent-proxy/proxied-services) and secrets from Infisical.
 
@@ -246,8 +246,18 @@ $ infisical secrets agent-proxy start --port 17322 --unmatched-host=block
 
 ### Environment variables
 
+  <Accordion title="INFISICAL_AUTH_METHOD">
+    How to authenticate the agent proxy's machine identity. Alternative to passing `--auth-method`; see that flag for the methods and the credentials each one takes.
+
+    ```bash
+      # Example
+      export INFISICAL_AUTH_METHOD=aws-iam
+      export INFISICAL_MACHINE_IDENTITY_ID=<agent-proxy-machine-identity-id>
+    ```
+  </Accordion>
+
   <Accordion title="INFISICAL_UNIVERSAL_AUTH_CLIENT_ID / INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET">
-    The Universal Auth credentials of the agent proxy's machine identity. Alternative to passing `--client-id` and `--client-secret`.
+    The Universal Auth credentials of the agent proxy's machine identity. Alternative to passing `--client-id` and `--client-secret`. Setting both is taken to mean `universal-auth`, so `INFISICAL_AUTH_METHOD` can be left unset.
 
     ```bash
       # Example
@@ -304,12 +314,62 @@ $ infisical secrets agent-proxy start --port 17322 --unmatched-host=block
     Default value: `60`
   </Accordion>
 
+  <Accordion title="--auth-method">
+    How to authenticate the agent proxy's machine identity: `universal-auth`, `kubernetes`, `azure`, `gcp-id-token`, `gcp-iam`, `aws-iam`, `oidc-auth`, `jwt-auth`, or `ldap-auth`. Alternative to the `INFISICAL_AUTH_METHOD` environment variable.
+
+    Omit it and passing `--client-id` with `--client-secret` is taken to mean `universal-auth`, so a Universal Auth setup needs no extra flag. `--token` takes precedence over both.
+
+    The proxy re-authenticates before its token expires, using the same credential each time, so it keeps running for as long as that credential stays valid. That holds indefinitely for client credentials, LDAP, and the cloud methods, which re-read the host's identity every time. It does not hold for `jwt-auth` and `oidc-auth`: the JWT you passed is reused at every refresh, so a short-lived one (a CI OIDC token, say) will already have expired by then. Use those two only with a JWT that outlives the proxy.
+
+    ```bash
+    # Example: on a Kubernetes pod, with no credential to provision
+    infisical secrets agent-proxy start \
+      --auth-method=kubernetes \
+      --machine-identity-id=<machine-identity-id> \
+      --service-account-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
+    ```
+  </Accordion>
+
   <Accordion title="--client-id / --client-secret">
     Universal Auth credentials for the agent proxy's machine identity. Alternative to the `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` / `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` environment variables.
 
     ```bash
     # Example
     infisical secrets agent-proxy start --client-id=<client-id> --client-secret=<client-secret>
+    ```
+  </Accordion>
+
+  <Accordion title="--machine-identity-id">
+    The machine identity to authenticate as. Required by every method except `universal-auth`, which identifies itself by its client id. Alternative to the `INFISICAL_MACHINE_IDENTITY_ID` environment variable.
+  </Accordion>
+
+  <Accordion title="Credentials for the other auth methods">
+    Each method takes the credential it needs, and each flag has an environment variable alternative:
+
+    | Flag | Used by | Environment variable |
+    | --- | --- | --- |
+    | `--service-account-token-path` | `kubernetes` | `INFISICAL_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH` |
+    | `--service-account-key-file-path` | `gcp-iam` | `INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH` |
+    | `--jwt` | `oidc-auth`, `jwt-auth` | `INFISICAL_JWT` |
+    | `--ldap-username` / `--ldap-password` | `ldap-auth` | `INFISICAL_LDAP_USERNAME` / `INFISICAL_LDAP_PASSWORD` |
+
+    `aws-iam`, `azure` and `gcp-id-token` take no credential of their own: they authenticate with the identity the host already has, so `--machine-identity-id` is all they need.
+
+    On Kubernetes the token path has to be given explicitly; on a pod it is `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+  </Accordion>
+
+  <Accordion title="--organization-slug">
+    Scope the identity to this sub-organization. Defaults to the organization the identity was created in.
+  </Accordion>
+
+  <Accordion title="--token">
+    Run on a machine identity access token you have already fetched, instead of authenticating. Also read from `INFISICAL_TOKEN`.
+
+    The proxy cannot renew a token it did not fetch, so it stops working once that token expires, and says so in a warning at startup. Prefer `--auth-method` for anything long-lived.
+
+    ```bash
+    # Example
+    infisical secrets agent-proxy start --token=<access-token>
     ```
   </Accordion>
 
@@ -354,7 +414,11 @@ $ infisical secrets agent-proxy start --port 17322 --unmatched-host=block
   - Real values for regular secrets the agent has **Read Value** on in the scoped folder, including secrets imported into it (similar to `infisical run`). This is opt-in; an agent identity scoped to just the proxy permission has no read access, and brokered credentials never appear in the agent's environment. If the agent can read a secret that a proxied service brokers to it, `connect` refuses to start, since the agent would receive the real value directly and bypass the proxy; fix the permissions or pass `--allow-readable-brokered-secrets` to override.
   - `INFISICAL_TOKEN` set to the agent's access token, so the agent can run Infisical CLI commands itself.
 
-  The client ID and client secret used to authenticate are stripped from the child environment. The wrapper forwards signals to the agent process and exits with its exit code.
+  The credentials used to authenticate are stripped from the child environment, whichever auth method they belong to, along with `INFISICAL_AUTH_METHOD` itself. The wrapper forwards signals to the agent process and exits with its exit code.
+
+  <Note>
+    The agent's token is written into its environment once, at launch. `connect` does not renew it, so an agent outliving its token's TTL starts getting `403` from the proxy and has to be relaunched. Give the agent identity's auth method a TTL that covers how long you expect the agent to run.
+  </Note>
 
   <Note>
     Every input below resolves from the same sources, in order: **the flag → an environment variable → `.infisical.json` → the built-in default.** An explicitly-passed flag always wins. This is why, where the environment variables are already set on the host, the command collapses to `infisical secrets agent-proxy connect -- claude`.
@@ -372,8 +436,19 @@ $ infisical secrets agent-proxy connect -- claude
 
 ### Environment variables
 
+  <Accordion title="INFISICAL_AUTH_METHOD">
+    How to authenticate the agent's machine identity. Alternative to passing `--auth-method`; see that flag for the methods and the credentials each one takes. Stripped from the agent's own environment along with the credentials.
+
+    ```bash
+      # Example
+      export INFISICAL_AUTH_METHOD=jwt-auth
+      export INFISICAL_MACHINE_IDENTITY_ID=<agent-machine-identity-id>
+      export INFISICAL_JWT=<jwt>
+    ```
+  </Accordion>
+
   <Accordion title="INFISICAL_UNIVERSAL_AUTH_CLIENT_ID / INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET">
-    The Universal Auth credentials of the agent's machine identity. Alternative to passing `--client-id` and `--client-secret`.
+    The Universal Auth credentials of the agent's machine identity. Alternative to passing `--client-id` and `--client-secret`. Setting both is taken to mean `universal-auth`, so `INFISICAL_AUTH_METHOD` can be left unset.
 
     ```bash
       # Example
@@ -476,6 +551,21 @@ $ infisical secrets agent-proxy connect -- claude
     ```
   </Accordion>
 
+  <Accordion title="--auth-method">
+    How to authenticate the agent's machine identity: `universal-auth`, `kubernetes`, `azure`, `gcp-id-token`, `gcp-iam`, `aws-iam`, `oidc-auth`, `jwt-auth`, or `ldap-auth`. Alternative to the `INFISICAL_AUTH_METHOD` environment variable.
+
+    Omit it and passing `--client-id` with `--client-secret` is taken to mean `universal-auth`, so a Universal Auth setup needs no extra flag. In CI, `jwt-auth` and `oidc-auth` let a runner authenticate with the token its platform already issues, so there is no stored credential on the runner at all.
+
+    ```bash
+    # Example: a CI runner authenticating with its OIDC token
+    infisical secrets agent-proxy connect --proxy=<proxy-host>:17322 --env=prod \
+      --auth-method=oidc-auth \
+      --machine-identity-id=<machine-identity-id> \
+      --jwt=<ci-oidc-token> \
+      -- claude
+    ```
+  </Accordion>
+
   <Accordion title="--client-id / --client-secret">
     Universal Auth credentials for the agent's machine identity. Alternative to the `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` / `INFISICAL_UNIVERSAL_AUTH_CLIENT_SECRET` environment variables.
 
@@ -483,6 +573,31 @@ $ infisical secrets agent-proxy connect -- claude
     # Example
     infisical secrets agent-proxy connect --proxy=<proxy-host>:17322 --env=prod --client-id=<client-id> --client-secret=<client-secret> -- claude
     ```
+  </Accordion>
+
+  <Accordion title="--machine-identity-id">
+    The machine identity to authenticate as. Required by every method except `universal-auth`, which identifies itself by its client id. Alternative to the `INFISICAL_MACHINE_IDENTITY_ID` environment variable.
+  </Accordion>
+
+  <Accordion title="Credentials for the other auth methods">
+    Each method takes the credential it needs, and each flag has an environment variable alternative:
+
+    | Flag | Used by | Environment variable |
+    | --- | --- | --- |
+    | `--service-account-token-path` | `kubernetes` | `INFISICAL_KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH` |
+    | `--service-account-key-file-path` | `gcp-iam` | `INFISICAL_GCP_IAM_SERVICE_ACCOUNT_KEY_FILE_PATH` |
+    | `--jwt` | `oidc-auth`, `jwt-auth` | `INFISICAL_JWT` |
+    | `--ldap-username` / `--ldap-password` | `ldap-auth` | `INFISICAL_LDAP_USERNAME` / `INFISICAL_LDAP_PASSWORD` |
+
+    `aws-iam`, `azure` and `gcp-id-token` take no credential of their own: they authenticate with the identity the host already has, so `--machine-identity-id` is all they need.
+
+    On Kubernetes the token path has to be given explicitly; on a pod it is `/var/run/secrets/kubernetes.io/serviceaccount/token`.
+
+    All of these are stripped from the agent's environment. Prefer the environment variables to the flags: a flag value sits in the wrapper's own argv, which on Linux the agent can read from `/proc`.
+  </Accordion>
+
+  <Accordion title="--organization-slug">
+    Scope the identity to this sub-organization. Defaults to the organization the identity was created in.
   </Accordion>
 
   <Accordion title="--token">

--- a/docs/documentation/platform/agent-proxy/quickstart/standalone-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/quickstart/standalone-proxy.mdx
@@ -34,7 +34,7 @@ By the end of this page an agent on one host makes authenticated GitHub calls th
   The template grants exactly what a proxy needs: read access to secret values, leases for dynamic secrets, and usage reporting. That is the identity's entire access, which is why its **Role** stays **No Access**. For production, scope the same permissions to specific environments and paths: see [Permissions](/documentation/platform/agent-proxy/standalone-agent-proxy#permissions).
 </Note>
 
-Now open the identity and go to its [Universal Auth](/documentation/platform/identities/universal-auth) authentication method.
+Now open the identity and go to its [Universal Auth](/documentation/platform/identities/universal-auth) authentication method. This quickstart uses Universal Auth because it works on any host; either command accepts [any of the CLI's auth methods](/documentation/platform/agent-proxy/standalone-agent-proxy#agent-authentication), and on a cloud host one of those saves you provisioning a credential at all.
 
 ![The machine identity's Universal Auth authentication method highlighted](/images/platform/agent-proxy/quickstart-universal-auth.png)
 

--- a/docs/documentation/platform/agent-proxy/quickstart/standalone-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/quickstart/standalone-proxy.mdx
@@ -34,7 +34,7 @@ By the end of this page an agent on one host makes authenticated GitHub calls th
   The template grants exactly what a proxy needs: read access to secret values, leases for dynamic secrets, and usage reporting. That is the identity's entire access, which is why its **Role** stays **No Access**. For production, scope the same permissions to specific environments and paths: see [Permissions](/documentation/platform/agent-proxy/standalone-agent-proxy#permissions).
 </Note>
 
-Now open the identity and go to its [Universal Auth](/documentation/platform/identities/universal-auth) authentication method. This quickstart uses Universal Auth because it works on any host; either command accepts [any of the CLI's auth methods](/documentation/platform/agent-proxy/standalone-agent-proxy#agent-authentication), and on a cloud host one of those saves you provisioning a credential at all.
+Now open the identity and go to its [Universal Auth](/documentation/platform/identities/universal-auth) authentication method. This quickstart uses Universal Auth because it works on any host; either command accepts [any of the CLI's auth methods](/documentation/platform/agent-proxy/standalone-agent-proxy#the-two-commands), and on a cloud host one of those saves you provisioning a credential at all.
 
 ![The machine identity's Universal Auth authentication method highlighted](/images/platform/agent-proxy/quickstart-universal-auth.png)
 

--- a/docs/documentation/platform/agent-proxy/standalone-agent-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/standalone-agent-proxy.mdx
@@ -49,7 +49,9 @@ infisical secrets agent-proxy start
 infisical secrets agent-proxy connect --proxy=<proxy-host>:17322 --projectId=<project-id> --env=dev --path=/coding-agent -- claude
 ```
 
-Each authenticates as its own [machine identity](/documentation/platform/identities/machine-identities) via [Universal Auth](/documentation/platform/identities/universal-auth), and the proxy's is always separate from the agents'. The proxy needs read access to the secrets its services reference; an agent needs only **Proxy** on the services it uses. [Permissions](#permissions) covers both in full.
+Each authenticates as its own [machine identity](/documentation/platform/identities/machine-identities), and the proxy's is always separate from the agents'. The proxy needs read access to the secrets its services reference; an agent needs only **Proxy** on the services it uses. [Permissions](#permissions) covers both in full.
+
+Either command can authenticate by any of the CLI's machine identity auth methods, chosen with `--auth-method` or `INFISICAL_AUTH_METHOD`: `universal-auth`, `kubernetes`, `azure`, `gcp-id-token`, `gcp-iam`, `aws-iam`, `oidc-auth`, `jwt-auth`, or `ldap-auth`. Pick the one that suits where each host runs. On a cloud host, `kubernetes`, `aws-iam`, `azure` and `gcp-id-token` authenticate with the identity the host already has, so there is no credential to provision or rotate; elsewhere [Universal Auth](/documentation/platform/identities/universal-auth) is the straightforward choice, and passing `--client-id` with `--client-secret` selects it without naming a method.
 
 ## What `connect` puts in the agent's environment
 
@@ -66,7 +68,9 @@ Every option resolves from the same sources, in order: **the flag → an environ
 
 | Option | Flag | Environment variable | `.infisical.json` |
 | --- | --- | --- | --- |
-| Auth | `--client-id` / `--client-secret` | `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` / `_SECRET` | — |
+| Auth method | `--auth-method` | `INFISICAL_AUTH_METHOD` | — |
+| Auth (universal-auth) | `--client-id` / `--client-secret` | `INFISICAL_UNIVERSAL_AUTH_CLIENT_ID` / `_SECRET` | — |
+| Auth (other methods) | `--machine-identity-id`, plus that method's credential | `INFISICAL_MACHINE_IDENTITY_ID`, and so on | — |
 | Instance | `--domain` | `INFISICAL_DOMAIN` | `domain` |
 | Project | `--projectId` | `INFISICAL_PROJECT_ID` | `workspaceId` |
 | Environment slug | `--env` | `INFISICAL_ENVIRONMENT` | `defaultEnvironment` |
@@ -81,7 +85,11 @@ See the [CLI reference](/cli/commands/agent-proxy) for every flag on both subcom
 
 ## Deployment
 
-Starting the proxy in a shell is fine while you are trying it out, but it dies with the terminal. Pick one of these instead. Whichever you choose, provide the identity's credentials, publish port `17322` to your agent machines only, and set `INFISICAL_DOMAIN` for EU Cloud or self-hosted.
+Starting the proxy in a shell is fine while you are trying it out, but it dies with the terminal. Pick one of these instead. Whichever you choose, publish port `17322` to your agent machines only, and set `INFISICAL_DOMAIN` for EU Cloud or self-hosted.
+
+How the proxy authenticates follows from where you run it. The first three tabs use Universal Auth, which works anywhere and means provisioning a client id and secret on the host. The Kubernetes and EC2 tabs use the identity the host already has, so there is no credential on the host to provision or rotate.
+
+With those two, what separates the proxy's identity from your agents' is no longer possession of a secret, because there isn't one, and the machine identity id is not confidential. It is the auth method's own configuration. Scope the proxy identity's **Allowed Principal ARNs** (AWS) or **Allowed Namespaces** and **Allowed Service Account Names** (Kubernetes) to the proxy host alone. Leave them unset or wildcarded and any host in the same account or cluster, including every agent host, can authenticate as the proxy and read every secret it can read.
 
 <Tabs>
   <Tab title="CLI (systemd, VM)">
@@ -117,7 +125,48 @@ Starting the proxy in a shell is fine while you are trying it out, but it dies w
 
     On Render, this is a private service pointed at the image with the start command above.
   </Tab>
+  <Tab title="Kubernetes">
+    On a cluster, authenticate with [Kubernetes Auth](/documentation/platform/identities/kubernetes-auth) and the pod's own service account, so no credential is stored in the cluster. The token path has to be given explicitly:
+
+    ```yaml
+    containers:
+      - name: agent-proxy
+        image: infisical/cli:latest
+        args:
+          - secrets
+          - agent-proxy
+          - start
+          - --auth-method=kubernetes
+          - --service-account-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
+        env:
+          - name: INFISICAL_MACHINE_IDENTITY_ID
+            value: <agent-proxy-machine-identity-id>
+          # - name: INFISICAL_DOMAIN
+          #   value: https://eu.infisical.com
+        ports:
+          - containerPort: 17322
+    ```
+
+    Expose it with a `ClusterIP` service so only pods in the cluster can reach it, and restrict which of them can with a network policy.
+  </Tab>
+  <Tab title="EC2">
+    On an instance with an IAM role, authenticate with [AWS Auth](/documentation/platform/identities/aws-auth). The instance metadata service supplies the credential, so there is nothing to provision on the host:
+
+    ```bash
+    export INFISICAL_AUTH_METHOD=aws-iam
+    export INFISICAL_MACHINE_IDENTITY_ID=<agent-proxy-machine-identity-id>
+    # export INFISICAL_DOMAIN=https://eu.infisical.com   # EU Cloud or self-hosted
+
+    infisical secrets agent-proxy start
+    ```
+
+    The same shape works on Azure with `--auth-method=azure` and on GCP with `--auth-method=gcp-id-token`.
+  </Tab>
 </Tabs>
+
+<Note>
+  The proxy re-authenticates before its token expires, using the same credential each time, so it keeps running for as long as that credential stays valid. Two cases do not last: `--token`, where you supply a token the proxy did not fetch and cannot renew (it warns at startup), and `jwt-auth` / `oidc-auth` given a short-lived JWT, which is reused at every refresh and will have expired by the first one.
+</Note>
 
 <Note>
   Keep the Agent Proxy on a private network reachable only by your agent machines (see [Network placement](#network-placement)). To run more than one instance, see [High availability](#high-availability).
@@ -131,7 +180,7 @@ Check that the proxy sits where the diagram above shows it:
 - **Reachable only by your agent machines.** Restrict inbound access to the Agent Proxy's port to the hosts that run agents, using your usual controls (security groups, firewall rules, network policies).
 - **On its own host.** Same network as the agents for low per-request latency, but a separate machine, which keeps the real credentials fully isolated from the agents.
 - **Alongside any plain-HTTP upstreams.** Internal services the Agent Proxy reaches over plain HTTP belong inside the same trusted network.
-- **Credentials where they are used.** Provision the Agent Proxy identity's client credentials only on its host, and each agent identity's only on its agent machine.
+- **Credentials where they are used.** Provision the Agent Proxy identity's client credentials only on its host, and each agent identity's only on its agent machine. Where an identity authenticates with the host's own cloud or cluster identity instead of a credential, there is nothing to place: scope its auth method to the right hosts instead, as under [Deployment](#deployment).
 
 Outbound, the Agent Proxy only needs to reach your Infisical instance and the APIs your proxied services define.
 

--- a/docs/documentation/platform/agent-proxy/standalone-agent-proxy.mdx
+++ b/docs/documentation/platform/agent-proxy/standalone-agent-proxy.mdx
@@ -89,7 +89,16 @@ Starting the proxy in a shell is fine while you are trying it out, but it dies w
 
 How the proxy authenticates follows from where you run it. The first three tabs use Universal Auth, which works anywhere and means provisioning a client id and secret on the host. The Kubernetes and EC2 tabs use the identity the host already has, so there is no credential on the host to provision or rotate.
 
-With those two, what separates the proxy's identity from your agents' is no longer possession of a secret, because there isn't one, and the machine identity id is not confidential. It is the auth method's own configuration. Scope the proxy identity's **Allowed Principal ARNs** (AWS) or **Allowed Namespaces** and **Allowed Service Account Names** (Kubernetes) to the proxy host alone. Leave them unset or wildcarded and any host in the same account or cluster, including every agent host, can authenticate as the proxy and read every secret it can read.
+With those two, what separates the proxy's identity from your agents' is no longer possession of a secret, because there isn't one, and the machine identity id is not confidential. It is the auth method's own configuration. Scope the proxy identity to the proxy host alone, using whichever fields its method provides:
+
+| Method | Fields to scope |
+| --- | --- |
+| `aws-iam` | **Allowed Principal ARNs**, **Allowed Account IDs** |
+| `kubernetes` | **Allowed Namespaces**, **Allowed Service Account Names** |
+| `azure` | **Allowed Service Principal IDs** |
+| `gcp-id-token` | **Allowed Service Account Emails**, **Allowed Projects** |
+
+Infisical enforces each of these only when it is set. Leave them unset or wildcarded and any workload in the same account, cluster, tenant or project, including every agent host, can authenticate as the proxy and read every secret it can read.
 
 <Tabs>
   <Tab title="CLI (systemd, VM)">


### PR DESCRIPTION
## Context

Docs for Infisical/cli#357, which lets `agent-proxy start` and `agent-proxy connect` authenticate with any machine identity auth method, not just Universal Auth.

The pages said Universal Auth was the only option in several places, so all of those are updated. The quickstart still uses Universal Auth, since it works on any host and is the simplest way to start, with a pointer to the other methods.

<details>
<summary>What changed, page by page</summary>

**`docs/cli/commands/agent-proxy.mdx`**
- `--auth-method`, `--machine-identity-id`, `--organization-slug` and the per-method credential flags, on both `start` and `connect`
- `--token` on `start`, and a note that it takes precedence over `--auth-method`
- The `connect` section now says the credentials are scrubbed from the agent's environment whichever method they belong to, and that the agent's token is frozen at launch

**`docs/documentation/platform/agent-proxy/standalone-agent-proxy.mdx`**
- Agent authentication section no longer says Universal Auth only
- Configuration table covers the new inputs
- Kubernetes and EC2 deployment tabs added, alongside the existing systemd, Docker and PaaS ones

**`docs/documentation/platform/agent-proxy/quickstart/standalone-proxy.mdx`**
- One line pointing at the other methods

</details>

Two things the pages did not say before, and now do:

- With `kubernetes`, `aws-iam`, `azure` and `gcp-id-token` there is no secret keeping the proxy identity separate from the agent identities, and the machine identity id is not a secret either. What keeps them separate is the auth method's own configuration. So the deployment section now says to scope **Allowed Principal ARNs** or **Allowed Namespaces** to the proxy host only. If you leave them empty, any host in the same account or cluster, including agent hosts, can authenticate as the proxy and read every secret it can read.
- The proxy re-authenticates using the same credential every time. That works forever for client credentials, LDAP and the cloud methods, but not for `jwt-auth` or `oidc-auth` with a short-lived JWT.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
