### PR TITLE
fix(secret-sync): honour disableSecretDeletion in the Azure DevOps sync

### DIFF
--- a/backend/src/services/secret-sync/azure-devops/azure-devops-sync-fns.ts
+++ b/backend/src/services/secret-sync/azure-devops/azure-devops-sync-fns.ts
@@ -73,10 +73,10 @@ export const azureDevOpsSyncFactory = ({ kmsService, appConnectionDAL }: TAzureD
 
     for (const group of response.data.value) {
       if (group.name === environmentName) {
-        return { groupId: group.id.toString(), groupName: group.name };
+        return { groupId: group.id.toString(), groupName: group.name, variables: group.variables ?? {} };
       }
     }
-    return { groupId: "", groupName: "" };
+    return { groupId: "", groupName: "", variables: {} };
   };
 
   const syncSecrets = async (secretSync: TAzureDevOpsSyncWithCredentials, secretMap: TSecretMap) => {
@@ -94,7 +94,11 @@ export const azureDevOpsSyncFactory = ({ kmsService, appConnectionDAL }: TAzureD
 
     const { accessToken, orgName, isOAuth } = await getConnectionAuth(secretSync);
 
-    const { groupId, groupName } = await $getEnvGroupId(
+    const {
+      groupId,
+      groupName,
+      variables: existingVariables
+    } = await $getEnvGroupId(
       accessToken,
       orgName,
       secretSync.destinationConfig.devopsProjectId,
@@ -103,6 +107,20 @@ export const azureDevOpsSyncFactory = ({ kmsService, appConnectionDAL }: TAzureD
     );
 
     const variables: Record<string, { value: string; isSecret: boolean }> = {};
+
+    // The update below sets the group's whole variable collection, so anything left out of the
+    // request body is dropped. Carry over the variables Infisical does not manage when deletion
+    // is disabled, otherwise this destination would remove them regardless of the option.
+    // Azure DevOps returns secret values as null, and treats a null value on update as "keep the
+    // existing one", so round-tripping a secret variable here does not clear it.
+    if (secretSync.syncOptions.disableSecretDeletion) {
+      for (const [key, variable] of Object.entries(existingVariables)) {
+        if (!(key in secretMap)) {
+          variables[key] = variable;
+        }
+      }
+    }
+
     for (const [key, secret] of Object.entries(secretMap)) {
       if (secret?.value !== undefined) {
         variables[key] = { value: secret.value, isSecret: true };


### PR DESCRIPTION
## Context

Fixes #7609

`disableSecretDeletion` is enforced individually by each secret sync rather than centrally. Of the 44 destinations with a `*-sync-fns.ts`, 43 read it somewhere in their sync path. `azure-devops` was the only one that never did:

```console
$ grep -rn "disableSecretDeletion" backend/src/services/secret-sync/azure-devops/
$
```

That matters here because the destination sets the variable group's whole variable collection rather than patching it. The body was built from the Infisical secret map alone, so any variable already in the group that Infisical does not manage was dropped on every sync, whether or not the user had enabled the option.

The fix is small because `$getEnvGroupId` was already fetching each group's `variables` and throwing them away. It now returns them, and `syncSecrets` seeds the request body with the unmanaged ones when deletion is disabled.

## The secret round-trip, since this is the part worth checking

Azure DevOps does not return secret variable values on a GET; they come back as `null`. So the obvious worry with carrying variables through is that writing `null` back would blank a real secret.

It does not: the API treats a `null` value on update as "keep the existing one". That is the behaviour the Terraform provider relies on, and it is what made [microsoft/terraform-provider-azuredevops#1433](https://github.com/microsoft/terraform-provider-azuredevops/issues/1433) behave the way it does. I have called this out in a comment next to the merge so the next reader does not have to rediscover it.

## Steps to verify the change

1. Create an Azure DevOps secret sync and enable **Disable Secret Deletion**.
2. Add a variable directly in the destination variable group that does not exist in the Infisical environment. Add both a plain and a secret one.
3. Trigger a sync.
4. Before: both are gone. After: both survive, and the secret keeps its value.
5. Turn the option off and sync again to confirm pruning still happens.

I could not run step 4 myself, since I do not have an Azure DevOps organisation to sync into. The change is verified by `type:check` and `eslint --max-warnings 0`, and by reading the API contract, but someone with a real org should confirm the round-trip before this merges.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (`npm run type:check`, `eslint --max-warnings 0`); not exercised against a live Azure DevOps organisation, see above
- [ ] Updated docs (not needed, this makes an existing documented option work as described)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the contributing guide

## Two things deliberately left out of scope

**Pruning ignores `keySchema` here.** With the option off, this destination still drops every unmanaged variable, where other destinations only prune keys matching their schema. That is arguably a second bug, but fixing it changes behaviour for existing users, so it seemed wrong to fold in silently.

**The flag is reimplemented 43 times in seven different shapes.** Enforcing it once around the prune step would make this class of gap structurally impossible. Happy to do that instead if preferred, though it touches every destination and felt like a separate conversation.
