### PR TITLE
fix: return inputs from PATCH `/dynamic-secrets`

### DIFF
--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -492,7 +492,7 @@ export const dynamicSecretServiceFactory = ({
     });
 
     return {
-      dynamicSecret: updatedDynamicCfg,
+      dynamicSecret: { ...updatedDynamicCfg, inputs: updatedInput },
       updatedFields,
       projectId: project.id,
       environment: environmentSlug,

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -496,7 +496,7 @@ export const dynamicSecretServiceFactory = ({
       subject(ProjectPermissionSub.DynamicSecrets, {
         environment: environmentSlug,
         secretPath: path,
-        metadata: updatedDynamicCfg.metadata
+        metadata: metadata ?? []
       })
     );
 

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -491,8 +491,17 @@ export const dynamicSecretServiceFactory = ({
       return cfg;
     });
 
+    const canReadRootCredential = permission.can(
+      ProjectPermissionDynamicSecretActions.ReadRootCredential,
+      subject(ProjectPermissionSub.DynamicSecrets, {
+        environment: environmentSlug,
+        secretPath: path,
+        metadata: updatedDynamicCfg.metadata
+      })
+    );
+
     return {
-      dynamicSecret: { ...updatedDynamicCfg, inputs: updatedInput },
+      dynamicSecret: { ...updatedDynamicCfg, inputs: canReadRootCredential ? updatedInput : null },
       updatedFields,
       projectId: project.id,
       environment: environmentSlug,

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -496,7 +496,7 @@ export const dynamicSecretServiceFactory = ({
       subject(ProjectPermissionSub.DynamicSecrets, {
         environment: environmentSlug,
         secretPath: path,
-        metadata: metadata ?? []
+        metadata: metadata ?? dynamicSecretCfg.metadata
       })
     );
 

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
@@ -95,7 +95,7 @@ export type TDynamicSecretServiceFactory = {
     arg: TCreateDynamicSecretDTO
   ) => Promise<TDynamicSecrets & { projectId: string; environment: string; secretPath: string }>;
   updateByName: (arg: TUpdateDynamicSecretDTO) => Promise<{
-    dynamicSecret: TDynamicSecrets;
+    dynamicSecret: TDynamicSecrets & { inputs?: unknown };
     updatedFields: string[];
     projectId: string;
     environment: string;

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
@@ -95,7 +95,7 @@ export type TDynamicSecretServiceFactory = {
     arg: TCreateDynamicSecretDTO
   ) => Promise<TDynamicSecrets & { projectId: string; environment: string; secretPath: string }>;
   updateByName: (arg: TUpdateDynamicSecretDTO) => Promise<{
-    dynamicSecret: TDynamicSecrets & { inputs?: unknown };
+    dynamicSecret: TDynamicSecrets;
     updatedFields: string[];
     projectId: string;
     environment: string;


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

We used to return the `inputs` on the response of the `PATH /dynamic-secrets` but it got removed. This reintroduces it as this is a required field for the terraform provider.

But it requires user to have the `ReadRootCredentials` permission, otherwise we keep returning the `inputs` as `null` to prevent leaking those values to unauthorized identities.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)