### PR TITLE
docs(style): light mode previews

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -10,6 +10,9 @@
   "styling": {
     "codeblocks": "dark"
   },
+  "thumbnails": {
+    "appearance": "light"
+  },
   "favicon": "/favicon.ico",
   "contextual": {
     "options": [


### PR DESCRIPTION
## Context

Switches the preview for docs links to light mode.

## Screenshots

<img width="609" height="292" alt="Screenshot 2026-08-11 at 9 15 07 AM" src="https://github.com/user-attachments/assets/a834e2c9-a85a-4e44-b8b3-f6825d23d69f" />

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)