### PR TITLE
docs(style): refresh light and dark theme colors

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4,7 +4,7 @@
   "name": "Infisical",
   "colors": {
     "primary": "#26272b",
-    "light": "#EFFF33",
+    "light": "#c2d72a",
     "dark": "#A1B659"
   },
   "styling": {
@@ -4296,7 +4296,7 @@
   "background": {
     "color": {
       "light": "#ffffff",
-      "dark": "#0D1117"
+      "dark": "#0b0d10"
     }
   },
   "navbar": {

--- a/docs/snippets/AppConnectionsBrowser.jsx
+++ b/docs/snippets/AppConnectionsBrowser.jsx
@@ -693,7 +693,7 @@ export const AppConnectionsBrowser = () => {
           <input
             type="text"
             placeholder="Search app connections..."
-            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-[#1e1f22] dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -710,7 +710,7 @@ export const AppConnectionsBrowser = () => {
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
                   ? "bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700"
-                  : "bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+                  : "bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-[#1e1f22] dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
               }`}
             >
               {category}
@@ -736,7 +736,7 @@ export const AppConnectionsBrowser = () => {
             <a
               key={connection.slug}
               href={connection.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-[#1e1f22] dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">

--- a/docs/snippets/DynamicSecretsBrowser.jsx
+++ b/docs/snippets/DynamicSecretsBrowser.jsx
@@ -71,7 +71,7 @@ export const DynamicSecretsBrowser = () => {
           <input
             type="text"
             placeholder="Search dynamic secrets..."
-            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-[#1e1f22] dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -88,7 +88,7 @@ export const DynamicSecretsBrowser = () => {
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
                   ? 'bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
+                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-[#1e1f22] dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
               }`}
             >
               {category}
@@ -113,7 +113,7 @@ export const DynamicSecretsBrowser = () => {
             <a
               key={secret.slug}
               href={secret.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-[#1e1f22] dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">

--- a/docs/snippets/FrameworkIntegrationsBrowser.jsx
+++ b/docs/snippets/FrameworkIntegrationsBrowser.jsx
@@ -49,7 +49,7 @@ export const FrameworkIntegrationsBrowser = () => {
           <input
             type="text"
             placeholder="Search framework integrations..."
-            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-[#1e1f22] dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -71,7 +71,7 @@ export const FrameworkIntegrationsBrowser = () => {
             <a
               key={integration.slug}
               href={integration.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-[#1e1f22] dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="mb-0.5">

--- a/docs/snippets/MachineAuthenticationBrowser.jsx
+++ b/docs/snippets/MachineAuthenticationBrowser.jsx
@@ -62,7 +62,7 @@ export const MachineAuthenticationBrowser = () => {
           <input
             type="text"
             placeholder="Search machine authentication methods..."
-            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-[#1e1f22] dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -79,7 +79,7 @@ export const MachineAuthenticationBrowser = () => {
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
                   ? 'bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
+                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-[#1e1f22] dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
               }`}
             >
               {category}
@@ -104,7 +104,7 @@ export const MachineAuthenticationBrowser = () => {
             <a
               key={method.slug}
               href={method.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-[#1e1f22] dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">

--- a/docs/snippets/RotationsBrowser.jsx
+++ b/docs/snippets/RotationsBrowser.jsx
@@ -298,7 +298,7 @@ export const RotationsBrowser = () => {
           <input
             type="text"
             placeholder="Search secret rotations..."
-            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-[#1e1f22] dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -315,7 +315,7 @@ export const RotationsBrowser = () => {
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
                   ? "bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700"
-                  : "bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+                  : "bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-[#1e1f22] dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
               }`}
             >
               {category}
@@ -341,7 +341,7 @@ export const RotationsBrowser = () => {
             <a
               key={rotation.slug}
               href={rotation.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-[#1e1f22] dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">

--- a/docs/snippets/SecretSyncsBrowser.jsx
+++ b/docs/snippets/SecretSyncsBrowser.jsx
@@ -89,7 +89,7 @@ export const SecretSyncsBrowser = () => {
           <input
             type="text"
             placeholder="Search secret syncs..."
-            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-[#1e1f22] dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -106,7 +106,7 @@ export const SecretSyncsBrowser = () => {
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
                   ? 'bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
+                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-[#1e1f22] dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
               }`}
             >
               {category}
@@ -131,7 +131,7 @@ export const SecretSyncsBrowser = () => {
             <a
               key={sync.slug}
               href={sync.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-[#1e1f22] dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">

--- a/docs/snippets/UserAuthenticationBrowser.jsx
+++ b/docs/snippets/UserAuthenticationBrowser.jsx
@@ -60,7 +60,7 @@ export const UserAuthenticationBrowser = () => {
           <input
             type="text"
             placeholder="Search user authentication methods..."
-            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-black dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
+            className="block w-full pl-9 pr-3 py-2 text-sm text-gray-900 border border-gray-300 rounded-lg placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 bg-white shadow-sm dark:bg-[#1e1f22] dark:text-gray-100 dark:border-gray-700 dark:placeholder-gray-400"
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
           />
@@ -77,7 +77,7 @@ export const UserAuthenticationBrowser = () => {
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors shadow-sm ${
                 selectedCategory === category
                   ? 'bg-yellow-100 text-yellow-700 border border-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-300 dark:border-yellow-700'
-                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-black dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
+                  : 'bg-white text-gray-700 border border-gray-200 hover:bg-yellow-50 hover:border-yellow-200 dark:bg-[#1e1f22] dark:text-gray-200 dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700'
               }`}
             >
               {category}
@@ -102,7 +102,7 @@ export const UserAuthenticationBrowser = () => {
             <a
               key={method.slug}
               href={method.path}
-              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-black dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
+              className="group block px-4 py-3 border border-gray-200 rounded-xl hover:border-yellow-200 hover:bg-yellow-50/50 hover:shadow-sm transition-all duration-200 bg-white shadow-sm dark:bg-[#1e1f22] dark:border-gray-700 dark:hover:bg-yellow-950/20 dark:hover:border-yellow-700"
             >
               <div className="w-full">
                 <div className="flex items-center justify-between mb-0.5">

--- a/docs/style.css
+++ b/docs/style.css
@@ -129,32 +129,32 @@
 }
 
 .dark #navbar .max-w-8xl {
-  border-bottom-color: #333330;
-  background-color: #1C1C1A;
+  border-bottom-color: #26272b;
+  background-color: #111419;
 }
 
 .dark #sidebar {
-  border-right-color: #333330;
-  background-color: #1C1C1A;
+  border-right-color: #26272b;
+  background-color: #111419;
 }
 
 .dark #sidebar li > a.text-primary {
-  background-color: #34380B;
-  border-left-color: #DCEB30;
+  background-color: #26272b;
+  border-left-color: #c2d72a;
 }
 
 .dark #header {
-  background-color: #292B16;
-  border-left-color: #DCEB30;
+  background-color: #15181e;
+  border-left-color: #c2d72a;
 }
 
 .dark #page-context-menu button:hover {
-  background-color: #343434;
+  background-color: #26272b;
 }
 
 .dark #content-area .mt-8 .block {
-  border-color: #333330;
-  background-color: #242421;
+  border-color: #26272b;
+  background-color: #1e1f22;
 }
 
 .dark #topbar-cta-button .group .absolute {
@@ -162,7 +162,7 @@
 }
 
 .dark #topbar-cta-button .group .flex > * {
-  color: #1C1C1A;
+  color: #0e1014;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
## Context

Refreshes the docs theme colors to match the brand system ([infisical.com/design.md](https://infisical.com/design.md) / `infisical-brand.css`). Dark mode is addressed first in this PR; light-mode refinements will follow on the same branch.

Follow-up to #7508, which added dark mode to the docs. That first pass built the dark theme on a **warm, olive-tinted** palette and a **neon** accent, which clashed with the brand system documented at [infisical.com/design.md](https://infisical.com/design.md) / `infisical-brand.css`. The brand dark theme is a **cool near-black family** with **Volt** as the single accent.

Two concrete mismatches this fixes:

1. **Temperature clash.** The page background was already cool (`#0D1117`), but the navbar, sidebar, cards, and header were warm (`#1C1C1A`, `#242421`, `#292B16`), so cool page + warm panels read as "off." All dark surfaces are now re-based onto the brand cool ramp: page `#0b0d10` → chrome `#111419` → raised cards `#1e1f22`, borders `#26272b`.
2. **Accent.** The dark-mode accent was a hot neon (`#EFFF33` / `#DCEB30`); it now uses brand dark Volt `#c2d72a`.

Also, the interactive snippet cards used `dark:bg-black` (pure `#000`), rendering darker than every surface around them — they now sit on the raised surface `#1e1f22`.


### Token mapping

| Element | Before (warm/neon) | After (brand) |
| --- | --- | --- |
| Dark-mode accent (`colors.light`) | `#EFFF33` | `#c2d72a` |
| Page background | `#0D1117` | `#0b0d10` |
| Navbar / sidebar | `#1C1C1A` | `#111419` |
| Content cards | `#242421` | `#1e1f22` |
| Header | `#292B16` | `#15181e` |
| Borders | `#333330` | `#26272b` |
| Accent lines | `#DCEB30` | `#c2d72a` |
| Snippet cards | `dark:bg-black` | `dark:bg-[#1e1f22]` |

## Screenshots

<!-- To add before marking ready for review. -->

## Steps to verify the change

1. Run `mint dev` from `docs/` to preview the docs site.
2. Switch to dark mode and confirm surfaces read as a single cool near-black elevation ramp (no warm/olive cast, no pure-black snippet cards).
3. Confirm the accent is brand Volt, not neon yellow.
4. Confirm light mode is unchanged.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
