### PR TITLE
fix: allow suborgs to create gh app connection

### DIFF
--- a/backend/src/services/github-app/github-app-service.ts
+++ b/backend/src/services/github-app/github-app-service.ts
@@ -317,7 +317,7 @@ export const gitHubAppServiceFactory = ({
       projectId: app.projectId,
       orgAction: OrgPermissionAppConnectionActions.Delete,
       projectAction: ProjectPermissionAppConnectionActions.Delete,
-      orgScope: OrganizationActionScope.ParentOrganization
+      orgScope: OrganizationActionScope.Any
     });
 
     // Resolve credentials up front — once the row is deleted the private key is gone and we can no
@@ -410,7 +410,7 @@ export const gitHubAppServiceFactory = ({
       projectId,
       orgAction: OrgPermissionAppConnectionActions.Create,
       projectAction: ProjectPermissionAppConnectionActions.Create,
-      orgScope: OrganizationActionScope.ParentOrganization
+      orgScope: OrganizationActionScope.Any
     });
 
     assertPlatformGitHubHostAllowed(githubHost);
@@ -541,7 +541,7 @@ export const gitHubAppServiceFactory = ({
         projectId,
         orgAction: OrgPermissionAppConnectionActions.Create,
         projectAction: ProjectPermissionAppConnectionActions.Create,
-        orgScope: OrganizationActionScope.ParentOrganization
+        orgScope: OrganizationActionScope.Any
       });
 
       const existingByName = await gitHubAppDAL.findOne({ orgId, projectId, name });

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -221,15 +221,12 @@ export const Navbar = () => {
     }
 
     SecurityClient.setToken(token);
-    queryClient.removeQueries({ queryKey: adminQueryKeys.serverConfig() });
-    queryClient.removeQueries({ queryKey: authKeys.getAuthToken });
-    queryClient.removeQueries({ queryKey: subOrgQuery.queryKey });
+    queryClient.clear();
 
     await queryClient.refetchQueries({ queryKey: authKeys.getAuthToken });
     await queryClient.refetchQueries({ queryKey: adminQueryKeys.serverConfig() });
 
     await navigateUserToOrg({ navigate, organizationId, navigateTo });
-    queryClient.removeQueries({ queryKey: projectKeys.allProjectQueries() });
 
     if (onSuccess) {
       await onSuccess();

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -76,7 +76,6 @@ import { isInfisicalCloud } from "@app/helpers/platform";
 import { useToggle } from "@app/hooks";
 import {
   adminQueryKeys,
-  projectKeys,
   subOrganizationsQuery,
   useGetOrganizations,
   useGetOrgTrialUrl,

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -82,6 +82,7 @@ import {
   useGetOrgTrialUrl,
   useLogoutUser
 } from "@app/hooks/api";
+import { appConnectionKeys } from "@app/hooks/api/appConnections";
 import { authKeys, selectOrganization } from "@app/hooks/api/auth/queries";
 import { MfaMethod } from "@app/hooks/api/auth/types";
 import { getAuthToken } from "@app/hooks/api/reactQuery";
@@ -99,7 +100,6 @@ import { navigateUserToOrg } from "@app/pages/auth/LoginPage/Login.utils";
 import { ServerAdminsPanel } from "../ServerAdminsPanel/ServerAdminsPanel";
 import { NotificationDropdown } from "./NotificationDropdown";
 import { VersionBadge } from "./VersionBadge";
-import { appConnectionKeys } from "@app/hooks/api/appConnections";
 
 const getFormattedSupportEmailLink = (variables: {
   org_id: string;

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -76,6 +76,7 @@ import { isInfisicalCloud } from "@app/helpers/platform";
 import { useToggle } from "@app/hooks";
 import {
   adminQueryKeys,
+  projectKeys,
   subOrganizationsQuery,
   useGetOrganizations,
   useGetOrgTrialUrl,
@@ -98,6 +99,7 @@ import { navigateUserToOrg } from "@app/pages/auth/LoginPage/Login.utils";
 import { ServerAdminsPanel } from "../ServerAdminsPanel/ServerAdminsPanel";
 import { NotificationDropdown } from "./NotificationDropdown";
 import { VersionBadge } from "./VersionBadge";
+import { appConnectionKeys } from "@app/hooks/api/appConnections";
 
 const getFormattedSupportEmailLink = (variables: {
   org_id: string;
@@ -220,12 +222,16 @@ export const Navbar = () => {
     }
 
     SecurityClient.setToken(token);
-    queryClient.clear();
+    queryClient.removeQueries({ queryKey: adminQueryKeys.serverConfig() });
+    queryClient.removeQueries({ queryKey: authKeys.getAuthToken });
+    queryClient.removeQueries({ queryKey: subOrgQuery.queryKey });
+    queryClient.removeQueries({ queryKey: appConnectionKeys.all });
 
     await queryClient.refetchQueries({ queryKey: authKeys.getAuthToken });
     await queryClient.refetchQueries({ queryKey: adminQueryKeys.serverConfig() });
 
     await navigateUserToOrg({ navigate, organizationId, navigateTo });
+    queryClient.removeQueries({ queryKey: projectKeys.allProjectQueries() });
 
     if (onSuccess) {
       await onSuccess();

--- a/frontend/src/pages/middlewares/inject-org-details.tsx
+++ b/frontend/src/pages/middlewares/inject-org-details.tsx
@@ -3,12 +3,8 @@ import { createFileRoute, isRedirect, redirect } from "@tanstack/react-router";
 import SecurityClient from "@app/components/utilities/SecurityClient";
 import { SessionStorageKeys } from "@app/const";
 import { authKeys, fetchAuthToken, selectOrganization } from "@app/hooks/api/auth/queries";
-import { certManagerInstanceKeys } from "@app/hooks/api/certManagerInstance";
-import { identitiesKeys } from "@app/hooks/api/identities/queries";
 import { fetchOrganizationById, organizationKeys } from "@app/hooks/api/organization/queries";
-import { projectKeys } from "@app/hooks/api/projects";
 import { fetchUserOrgPermissions, roleQueryKeys } from "@app/hooks/api/roles/queries";
-import { subOrganizationsQuery } from "@app/hooks/api/subOrganizations";
 import { fetchOrgSubscription, subscriptionQueryKeys } from "@app/hooks/api/subscriptions/queries";
 
 // Route context to fill in organization's data like details, subscription etc
@@ -42,13 +38,7 @@ export const Route = createFileRoute("/_authenticate/_inject-org-details")({
 
           if (!isMfaEnabled && token) {
             SecurityClient.setToken(token);
-
-            context.queryClient.removeQueries({ queryKey: authKeys.getAuthToken });
-            context.queryClient.removeQueries({ queryKey: projectKeys.getAllUserProjects() });
-            context.queryClient.removeQueries({ queryKey: subOrganizationsQuery.allKey() });
-            context.queryClient.removeQueries({ queryKey: certManagerInstanceKeys.all });
-            context.queryClient.removeQueries({ queryKey: identitiesKeys.searchIdentitiesRoot });
-            context.queryClient.removeQueries({ queryKey: identitiesKeys.countIdentitiesRoot });
+            context.queryClient.clear();
 
             await context.queryClient.fetchQuery({
               queryKey: authKeys.getAuthToken,

--- a/frontend/src/pages/middlewares/inject-org-details.tsx
+++ b/frontend/src/pages/middlewares/inject-org-details.tsx
@@ -3,9 +3,14 @@ import { createFileRoute, isRedirect, redirect } from "@tanstack/react-router";
 import SecurityClient from "@app/components/utilities/SecurityClient";
 import { SessionStorageKeys } from "@app/const";
 import { authKeys, fetchAuthToken, selectOrganization } from "@app/hooks/api/auth/queries";
+import { certManagerInstanceKeys } from "@app/hooks/api/certManagerInstance";
+import { identitiesKeys } from "@app/hooks/api/identities/queries";
 import { fetchOrganizationById, organizationKeys } from "@app/hooks/api/organization/queries";
+import { projectKeys } from "@app/hooks/api/projects";
 import { fetchUserOrgPermissions, roleQueryKeys } from "@app/hooks/api/roles/queries";
+import { subOrganizationsQuery } from "@app/hooks/api/subOrganizations";
 import { fetchOrgSubscription, subscriptionQueryKeys } from "@app/hooks/api/subscriptions/queries";
+import { appConnectionKeys } from "@app/hooks/api/appConnections";
 
 // Route context to fill in organization's data like details, subscription etc
 export const Route = createFileRoute("/_authenticate/_inject-org-details")({
@@ -38,7 +43,14 @@ export const Route = createFileRoute("/_authenticate/_inject-org-details")({
 
           if (!isMfaEnabled && token) {
             SecurityClient.setToken(token);
-            context.queryClient.clear();
+
+            context.queryClient.removeQueries({ queryKey: authKeys.getAuthToken });
+            context.queryClient.removeQueries({ queryKey: projectKeys.getAllUserProjects() });
+            context.queryClient.removeQueries({ queryKey: subOrganizationsQuery.allKey() });
+            context.queryClient.removeQueries({ queryKey: certManagerInstanceKeys.all });
+            context.queryClient.removeQueries({ queryKey: identitiesKeys.searchIdentitiesRoot });
+            context.queryClient.removeQueries({ queryKey: identitiesKeys.countIdentitiesRoot });
+            context.queryClient.removeQueries({ queryKey: appConnectionKeys.all });
 
             await context.queryClient.fetchQuery({
               queryKey: authKeys.getAuthToken,

--- a/frontend/src/pages/middlewares/inject-org-details.tsx
+++ b/frontend/src/pages/middlewares/inject-org-details.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, isRedirect, redirect } from "@tanstack/react-router";
 
 import SecurityClient from "@app/components/utilities/SecurityClient";
 import { SessionStorageKeys } from "@app/const";
+import { appConnectionKeys } from "@app/hooks/api/appConnections";
 import { authKeys, fetchAuthToken, selectOrganization } from "@app/hooks/api/auth/queries";
 import { certManagerInstanceKeys } from "@app/hooks/api/certManagerInstance";
 import { identitiesKeys } from "@app/hooks/api/identities/queries";
@@ -10,7 +11,6 @@ import { projectKeys } from "@app/hooks/api/projects";
 import { fetchUserOrgPermissions, roleQueryKeys } from "@app/hooks/api/roles/queries";
 import { subOrganizationsQuery } from "@app/hooks/api/subOrganizations";
 import { fetchOrgSubscription, subscriptionQueryKeys } from "@app/hooks/api/subscriptions/queries";
-import { appConnectionKeys } from "@app/hooks/api/appConnections";
 
 // Route context to fill in organization's data like details, subscription etc
 export const Route = createFileRoute("/_authenticate/_inject-org-details")({


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Allows github app connection to be created by sub organizations, and also fix the cache invalidation when switching between organizations. We should invalidate everything as we see several times stale data showing up after changing orgs.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)