### PR TITLE
feat(ui): add v3 page header

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -126,7 +126,7 @@ font or substitute one role for another:
 | Role                    | Class                                                                     | Notes                                                              |
 | ----------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | Page title (h1)         | `text-2xl font-medium underline underline-offset-4 decoration-<scope>/90` | In `PageHeader`; scope icon (size 26) sits inline before the title |
-| Page description        | `text-mineshaft-300`                                                      | Sits under the title, `mt-1.5`                                     |
+| Page description        | `text-label`                                                              | Sits under the title, `mt-1.5`                                     |
 | Card title              | `text-lg font-semibold leading-none`                                      | `flex gap-1.5` so badges can sit inline                            |
 | Card description        | `text-sm text-accent`                                                     |                                                                    |
 | Body                    | `text-sm`                                                                 | Default for table cells, form values, dialog content               |
@@ -148,7 +148,6 @@ labels, and dropdown menu items. See §8 for voice rules on copy itself.
 
 New UI must use v3 components from [`frontend/src/components/v3/`](frontend/src/components/v3).
 The v2 library is legacy; only fall back when no v3 equivalent exists.
-`PageHeader` is the notable exception — still v2, still canonical for page titles.
 
 For exact tokens, class lists, and every variant, read the component source
 and its `*.stories.tsx` — this doc cites them rather than duplicating them.
@@ -246,6 +245,7 @@ variants, sizes, and class lists, open the source or its `*.stories.tsx`
 | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | [`Separator`](frontend/src/components/v3/generic/Separator/Separator.tsx)                                         | Horizontal/vertical divider.                                                          |
 | [`ScopeIcons`](frontend/src/components/v3/platform/ScopeIcons.tsx)                                                | `OrgIcon` / `SubOrgIcon` / `ProjectIcon` / `InstanceIcon` — use when intent is scope. |
+| [`PageHeader`](frontend/src/components/v3/platform/PageHeader/PageHeader.tsx)                                     | Canonical full-width page heading with scope semantics, description, and page actions. |
 | [`DocumentationLinkBadge`](frontend/src/components/v3/platform/DocumentationLinkBadge/DocumentationLinkBadge.tsx) | Inline "Documentation" link badge in `CardTitle`.                                     |
 
 **Icons** — [`lucide-react`](https://lucide.dev). Sizing is bound by the
@@ -254,7 +254,7 @@ host component; don't override unless necessary.
 ## 5. Layout Principles
 
 - **Page container** — `max-w-8xl` (88rem) centered, `bg-bunker-800`.
-- **Page header** — `PageHeader` with scope icon + underlined `h1` + description. See [`PageHeader.tsx`](frontend/src/components/v2/PageHeader/PageHeader.tsx). Always set `scope` to the correct hierarchy level.
+- **Page header** — v3 `PageHeader` with scope icon + underlined `h1` + description. Import it from `@app/components/v3` and always set `scope` to the correct hierarchy level. See [`PageHeader.tsx`](frontend/src/components/v3/platform/PageHeader/PageHeader.tsx).
 - **Section** — one `Card` per logical section. Title + optional `DocumentationLinkBadge` in `CardHeader`; primary action in `CardAction` (top-right).
 - **Tables inside Cards** — filters and search sit in the `CardHeader` above the table; pagination sits in the `CardFooter` or bottom of `CardContent`. **Empty state** — when the table has no rows (and isn't loading), hide the `Table` entirely and render `Empty` in its place; never leave a column header floating above a blank body. Add `className="border"` to `Empty` whenever it's nested in a `Card`, `Sheet`, or `Dialog` so the dashed frame is visible against the parent surface (the component ships dashed-but-borderless on purpose for page-level use).
 - **Forms inside Sheets/Dialog** — create / edit flows open in a Sheet or Dialog, never inline, never as a full-page route. **Pick by form size:** small forms (1–2 fields, e.g. "Add domain", "Rename") go in a centered `Dialog`; large or multi-step forms (multiple fields, scrollable detail, file uploads, wizard steps) go in a right-side `Sheet`. When in doubt, default to Dialog — Sheet is for cases where Dialog feels cramped.
@@ -406,7 +406,7 @@ Pasteable prompt fragments for AI coding agents producing new UI.
 **Refer to:**
 
 - [`Badge.stories.tsx`](frontend/src/components/v3/generic/Badge/Badge.stories.tsx) — canonical semantic reference for variant choice.
-- [`OverviewPage`](frontend/src/pages/secret-manager/OverviewPage) — full-page reference (PageHeader, Card-with-table, Create Secret Sheet, filters, DropdownMenu + ButtonGroup).
+- [`OverviewPage`](frontend/src/pages/secret-manager/OverviewPage) — full-page composition reference (Card-with-table, Create Secret Sheet, filters, DropdownMenu + ButtonGroup). Use the v3 `PageHeader` documented above rather than mirroring its legacy header import.
 - [`AccessControlPage`](frontend/src/pages/project/AccessControlPage) — full-page reference (permission-gated actions, `DocumentationLinkBadge`, role badges with `ClockAlertIcon` for expired access).
 - §8 above for any user-visible copy.
 
@@ -421,7 +421,7 @@ Pasteable prompt fragments for AI coding agents producing new UI.
 4. **Adding a variant** — extend the `cva()` block in the component and add
    a story. Keep the tint pattern (`bg-<c>/15 border-<c>/10` for Badge,
    `bg-<c>/10 border-<c>/25` for Button).
-5. **Never use v2 for new code** — unless no v3 equivalent exists.
-   `PageHeader` is the notable v2 exception still used by all pages.
+5. **Never use v2 for new code** — unless no v3 equivalent exists. Use the v3
+   `PageHeader` for new page headings; existing v2 consumers migrate separately.
 6. **Before merging** — `make reviewable-ui` (lint + type-check).
 7. **When in doubt** — mirror `OverviewPage`.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -36,7 +36,7 @@ Middleware pages in `src/pages/middlewares/`: `authenticate.tsx` (auth guard + r
 
 - **`src/pages/`** — Route-level components organized by product feature (secret-manager, cert-manager, kms, pam, secret-scanning, organization, project, admin, auth). Each has `route.tsx` + page component + local `components/`.
 - **`src/views/`** — Reusable page-level UI composed into multiple pages. Pages import views with configuration props.
-- **`src/components/v3/`** — Latest shared UI component library (preferred). Contains `generic/` (Accordion, Alert, Button, Dialog, Select, Table, etc.) and `platform/` (domain-specific components). **Always use v3 components for new code.** Only use v2 components when a v3 equivalent does not exist.
+- **`src/components/v3/`** — Latest shared UI component library (preferred). Contains `generic/` (Accordion, Alert, Button, Dialog, Select, Table, etc.) and `platform/` (domain-specific components such as `PageHeader` and scope icons). **Always use v3 components for new code.** Only use v2 components when a v3 equivalent does not exist.
 - **`src/components/v2/`** — Legacy shared UI components built on Radix UI primitives + Tailwind. Uses `cva` (class-variance-authority) for variants and `tailwind-merge` for class conflict resolution. Being superseded by v3 — do not use for new features if a v3 alternative exists.
 
 ### API Layer (React Query + Axios)

--- a/frontend/src/components/v3/platform/PageHeader/PageHeader.stories.tsx
+++ b/frontend/src/components/v3/platform/PageHeader/PageHeader.stories.tsx
@@ -1,0 +1,149 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FingerprintIcon, PlusIcon } from "lucide-react";
+
+import { ProjectType } from "@app/hooks/api/projects/types";
+
+import { Button } from "../../generic/Button";
+import { PageHeader, type TPageHeaderScope } from "./PageHeader";
+
+const meta = {
+  title: "Platform/Page Header",
+  component: PageHeader,
+  parameters: {
+    layout: "padded"
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-6xl">
+        <Story />
+      </div>
+    )
+  ],
+  tags: ["autodocs"],
+  args: {
+    scope: ProjectType.SecretManager,
+    title: "Project Overview"
+  }
+} satisfies Meta<typeof PageHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const SCOPES: { label: string; scope: NonNullable<TPageHeaderScope> }[] = [
+  { label: "Organization", scope: "org" },
+  { label: "Namespace", scope: "namespace" },
+  { label: "Instance", scope: "instance" },
+  { label: "Secret Manager Project", scope: ProjectType.SecretManager },
+  { label: "Certificate Manager Project", scope: ProjectType.CertificateManager },
+  { label: "KMS Project", scope: ProjectType.KMS },
+  { label: "Secret Scanning Project", scope: ProjectType.SecretScanning },
+  { label: "PAM Project", scope: ProjectType.PAM }
+];
+
+export const Default: Story = {
+  name: "Example: Default",
+  parameters: {
+    docs: {
+      description: {
+        story: "Use a project-scoped header as the standard heading for project pages."
+      }
+    }
+  }
+};
+
+export const SupportedScopes: Story = {
+  name: "Example: Supported Scopes",
+  render: () => (
+    <div className="flex flex-col gap-10">
+      {SCOPES.map(({ label, scope }) => (
+        <PageHeader key={scope} scope={scope} title={label} className="mb-0" />
+      ))}
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Each supported scope resolves to its canonical icon, icon color, and title decoration."
+      }
+    }
+  }
+};
+
+export const NoScope: Story = {
+  name: "Example: No Scope",
+  args: {
+    scope: null,
+    title: "Account Settings"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Use a null scope for pages that do not belong to an Infisical resource scope."
+      }
+    }
+  }
+};
+
+export const CustomIcon: Story = {
+  name: "Example: Custom Icon",
+  args: {
+    scope: null,
+    icon: FingerprintIcon,
+    title: "Identity Details"
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Provide a custom Lucide icon when the page represents a specific resource."
+      }
+    }
+  }
+};
+
+export const WithDescriptionAndActions: Story = {
+  name: "Example: Description and Actions",
+  args: {
+    title: "Project Access Control",
+    description:
+      "Manage fine-grained access for users, groups, roles, and machine identities within your project resources.",
+    children: (
+      <Button variant="project">
+        <PlusIcon />
+        Add Member
+      </Button>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Descriptions provide page context while children render page-level actions on the right."
+      }
+    }
+  }
+};
+
+export const LongTitle: Story = {
+  name: "Example: Long Title",
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-xl">
+        <Story />
+      </div>
+    )
+  ],
+  args: {
+    title:
+      "A Project Title That Is Intentionally Long Enough to Demonstrate Truncation Beside Page Actions",
+    description: "The title remains on one line while the action stays visible.",
+    children: <Button variant="project">Create Secret</Button>
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Long titles truncate before they displace the page action."
+      }
+    }
+  }
+};

--- a/frontend/src/components/v3/platform/PageHeader/PageHeader.tsx
+++ b/frontend/src/components/v3/platform/PageHeader/PageHeader.tsx
@@ -1,0 +1,112 @@
+import type { ComponentProps, ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+
+import { ProjectType } from "@app/hooks/api/projects/types";
+
+import { cn } from "../../utils";
+import { InstanceIcon, OrgIcon, ProjectIcon, SubOrgIcon } from "../ScopeIcons";
+
+export type TPageHeaderScope = "org" | "namespace" | "instance" | ProjectType | null;
+
+export type TPageHeaderProps = Omit<ComponentProps<"header">, "title"> & {
+  title: ReactNode;
+  description?: ReactNode;
+  scope: TPageHeaderScope;
+  icon?: LucideIcon;
+};
+
+type TPageHeaderScopeConfig = {
+  icon: LucideIcon;
+  iconClassName: string;
+  titleClassName: string;
+};
+
+const PAGE_HEADER_SCOPE_CONFIG: Record<NonNullable<TPageHeaderScope>, TPageHeaderScopeConfig> = {
+  org: {
+    icon: OrgIcon,
+    iconClassName: "text-org",
+    titleClassName: "decoration-org/90"
+  },
+  namespace: {
+    icon: SubOrgIcon,
+    iconClassName: "text-sub-org",
+    titleClassName: "decoration-sub-org/90"
+  },
+  instance: {
+    icon: InstanceIcon,
+    iconClassName: "text-neutral",
+    titleClassName: "decoration-neutral/90"
+  },
+  [ProjectType.SecretManager]: {
+    icon: ProjectIcon,
+    iconClassName: "text-project",
+    titleClassName: "decoration-project/90"
+  },
+  [ProjectType.CertificateManager]: {
+    icon: ProjectIcon,
+    iconClassName: "text-project",
+    titleClassName: "decoration-project/90"
+  },
+  [ProjectType.KMS]: {
+    icon: ProjectIcon,
+    iconClassName: "text-project",
+    titleClassName: "decoration-project/90"
+  },
+  [ProjectType.SecretScanning]: {
+    icon: ProjectIcon,
+    iconClassName: "text-project",
+    titleClassName: "decoration-project/90"
+  },
+  [ProjectType.PAM]: {
+    icon: ProjectIcon,
+    iconClassName: "text-product-pam",
+    titleClassName: "decoration-product-pam/90"
+  }
+};
+
+export const PageHeader = ({
+  title,
+  description,
+  children,
+  className,
+  scope,
+  icon,
+  ...props
+}: TPageHeaderProps) => {
+  const scopeConfig = scope ? PAGE_HEADER_SCOPE_CONFIG[scope] : null;
+  const ResolvedIcon = icon ?? scopeConfig?.icon;
+
+  return (
+    <header data-slot="page-header" className={cn("mb-10 w-full", className)} {...props}>
+      <div data-slot="page-header-row" className="flex w-full justify-between">
+        <div className="mr-4 flex min-w-0 flex-1 items-center">
+          <h1
+            data-slot="page-header-title"
+            className={cn(
+              "truncate text-2xl font-medium text-foreground underline underline-offset-4",
+              scopeConfig?.titleClassName ?? "no-underline"
+            )}
+          >
+            {ResolvedIcon && (
+              <ResolvedIcon
+                aria-hidden
+                focusable="false"
+                size={26}
+                className={cn("mr-3 mb-1 inline-block", scopeConfig?.iconClassName)}
+              />
+            )}
+            {title}
+          </h1>
+        </div>
+        <div data-slot="page-header-actions" className="flex items-center gap-2">
+          {children}
+        </div>
+      </div>
+      {description && (
+        <div data-slot="page-header-description" className="mt-1.5 text-label">
+          {description}
+        </div>
+      )}
+    </header>
+  );
+};

--- a/frontend/src/components/v3/platform/PageHeader/index.ts
+++ b/frontend/src/components/v3/platform/PageHeader/index.ts
@@ -1,0 +1,1 @@
+export * from "./PageHeader";

--- a/frontend/src/components/v3/platform/index.ts
+++ b/frontend/src/components/v3/platform/index.ts
@@ -4,6 +4,7 @@ export * from "./DocumentationLinkBadge";
 export * from "./GatewayPicker";
 export * from "./IdentityRoleBadges";
 export * from "./OverflowBadgeList";
+export * from "./PageHeader";
 export * from "./PageLoader";
 export * from "./PasswordGenerator";
 export * from "./PermissionActionSelect";


### PR DESCRIPTION
## Context

Before this change, the canonical page heading remained the v2 `PageHeader`, leaving new v3 surfaces without a supported page-level header.

This change:

- adds a shared v3 platform `PageHeader` with the existing full-width title, optional description, right-aligned action slot, truncation, spacing, custom `className`, and custom Lucide icon contract;
- maps organization, namespace, instance, and every `ProjectType` to the established v3 scope icon and semantic decoration;
- exports the component through the platform barrel and the root `@app/components/v3` barrel;
- adds Storybook examples for every supported scope, no scope, a custom icon, description and actions, and long-title truncation;
- updates `DESIGN.md` and `frontend/CLAUDE.md` so v3 `PageHeader` is canonical for new work.

The v2 component and all existing page consumers remain unchanged.

[ENG-5546](https://linear.app/infisical/issue/ENG-5546/create-the-v3-pageheader-component)  
Related coordination only: [ENG-5540](https://linear.app/infisical/issue/ENG-5540/migrate-project-access-control-shell-and-groups-surface-to-v3)

## Screenshots

Not captured in this task. Browser automation, Test UI, Docker, and Storybook execution were explicitly excluded, and this worktree has no installed frontend dependencies.

Outstanding Storybook capture requests once dependencies are available:

- `http://localhost:6006/?path=/story/platform-page-header--supported-scopes` — capture organization, namespace, instance, and all project-type scope treatments.
- `http://localhost:6006/?path=/story/platform-page-header--description-and-actions` — capture description and right-aligned action placement.
- `http://localhost:6006/?path=/story/platform-page-header--long-title` — capture long-title truncation with the action remaining visible.

Start Storybook with `cd frontend && npm run storybook`; no product data or authentication is required.

## Steps to verify the change

1. Run `git diff --check origin/main...HEAD`.
2. Confirm `PAGE_HEADER_SCOPE_CONFIG` contains organization, namespace, instance, and all five current `ProjectType` values.
3. Confirm `frontend/src/components/v3/platform/PageHeader/index.ts` exports `PageHeader`, the platform barrel exports that folder, and `frontend/src/components/v3/index.ts` exports the platform barrel.
4. Inspect the PageHeader stories and confirm they cover every scope, no scope, a custom icon, description and actions, and long-title truncation.
5. With frontend dependencies installed, run focused ESLint/type validation and open the three Storybook URLs above.

Local evidence in this task:

- Focused Node contract assertion passed for all five `ProjectType` values, the three named scopes, required slots, representative story states, semantic class usage, and the complete barrel chain.
- `git diff --check` passed.
- The v2 PageHeader preservation check passed.
- The private-file safeguard passed after the commit. Its pre-commit staged run flagged the ticket-required tracked `frontend/CLAUDE.md` edit; that one-line repository-guidance change was manually reviewed and contains no private guidance.
- Frontend ESLint and type-check were not run because this worktree has no installed frontend dependencies. No dependencies were installed for this focused task.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)