### PR TITLE
fix(dynamic-secrets): require project permission on provider discovery

### DIFF
--- a/backend/src/ee/routes/v1/dynamic-secret-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-router.ts
@@ -625,7 +625,10 @@ echo ""
         instanceUrl: z.string().url().min(1).describe("The IBM API Connect instance URL"),
         apiKey: z.string().min(1).describe("The IBM API Connect API key"),
         clientId: z.string().min(1).describe("The IBM API Connect client ID"),
-        clientSecret: z.string().min(1).describe("The IBM API Connect client secret")
+        clientSecret: z.string().min(1).describe("The IBM API Connect client secret"),
+        projectSlug: slugSchema({ max: 64, field: "Project slug" }).describe(
+          "The slug of the project to configure the dynamic secret in"
+        )
       }),
       response: {
         200: z
@@ -643,7 +646,12 @@ echo ""
         instanceUrl: req.body.instanceUrl,
         apiKey: req.body.apiKey,
         clientId: req.body.clientId,
-        clientSecret: req.body.clientSecret
+        clientSecret: req.body.clientSecret,
+        projectSlug: req.body.projectSlug,
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId
       });
       return data;
     }
@@ -663,7 +671,10 @@ echo ""
         instanceUrl: z.string().url().min(1).describe("The IBM API Connect instance URL"),
         apiKey: z.string().min(1).describe("The IBM API Connect API key"),
         clientId: z.string().min(1).describe("The IBM API Connect client ID"),
-        clientSecret: z.string().min(1).describe("The IBM API Connect client secret")
+        clientSecret: z.string().min(1).describe("The IBM API Connect client secret"),
+        projectSlug: slugSchema({ max: 64, field: "Project slug" }).describe(
+          "The slug of the project to configure the dynamic secret in"
+        )
       }),
       response: {
         200: z
@@ -682,7 +693,12 @@ echo ""
         apiKey: req.body.apiKey,
         clientId: req.body.clientId,
         clientSecret: req.body.clientSecret,
-        orgId: req.params.orgId
+        orgId: req.params.orgId,
+        projectSlug: req.body.projectSlug,
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId
       });
       return data;
     }
@@ -703,7 +719,10 @@ echo ""
         instanceUrl: z.string().url().min(1).describe("The IBM API Connect instance URL"),
         apiKey: z.string().min(1).describe("The IBM API Connect API key"),
         clientId: z.string().min(1).describe("The IBM API Connect client ID"),
-        clientSecret: z.string().min(1).describe("The IBM API Connect client secret")
+        clientSecret: z.string().min(1).describe("The IBM API Connect client secret"),
+        projectSlug: slugSchema({ max: 64, field: "Project slug" }).describe(
+          "The slug of the project to configure the dynamic secret in"
+        )
       }),
       response: {
         200: z
@@ -724,7 +743,12 @@ echo ""
         clientId: req.body.clientId,
         clientSecret: req.body.clientSecret,
         orgId: req.params.orgId,
-        catalogId: req.params.catalogId
+        catalogId: req.params.catalogId,
+        projectSlug: req.body.projectSlug,
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId
       });
       return data;
     }
@@ -740,7 +764,10 @@ echo ""
       body: z.object({
         tenantId: z.string().min(1).describe("The tenant ID of the Azure Entra ID"),
         applicationId: z.string().min(1).describe("The application ID of the Azure Entra ID App Registration"),
-        clientSecret: z.string().min(1).describe("The client secret of the Azure Entra ID App Registration")
+        clientSecret: z.string().min(1).describe("The client secret of the Azure Entra ID App Registration"),
+        projectSlug: slugSchema({ max: 64, field: "Project slug" }).describe(
+          "The slug of the project to configure the dynamic secret in"
+        )
       }),
       response: {
         200: z
@@ -757,7 +784,12 @@ echo ""
       const data = await server.services.dynamicSecret.fetchAzureEntraIdUsers({
         tenantId: req.body.tenantId,
         applicationId: req.body.applicationId,
-        clientSecret: req.body.clientSecret
+        clientSecret: req.body.clientSecret,
+        projectSlug: req.body.projectSlug,
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId
       });
       return data;
     }

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.test.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.test.ts
@@ -1,0 +1,189 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import {
+  ProjectPermissionDynamicSecretActions,
+  ProjectPermissionSub
+} from "@app/ee/services/permission/project-permission";
+import { ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+import { ActorType, AuthMethod } from "@app/services/auth/auth-type";
+
+const { ibmProviderFns, entraProviderFns } = vi.hoisted(() => ({
+  ibmProviderFns: {
+    fetchOrganizations: vi.fn().mockResolvedValue([]),
+    fetchOrganizationCatalogs: vi.fn().mockResolvedValue([]),
+    fetchOrganizationApps: vi.fn().mockResolvedValue([])
+  },
+  entraProviderFns: {
+    fetchAzureEntraIdUsers: vi.fn().mockResolvedValue([])
+  }
+}));
+
+// the provider barrel reaches @app/lib/gateway, whose QUIC native binding is not loadable in unit tests
+vi.mock("@app/lib/gateway", async () => {
+  const gatewayTypes = await import("@app/lib/gateway/types");
+  return {
+    ...gatewayTypes,
+    pingGatewayAndVerify: vi.fn(),
+    withGatewayProxy: vi.fn()
+  };
+});
+
+vi.mock("./providers/ibm-api-connect", () => ({
+  IbmApiConnectProvider: () => ibmProviderFns
+}));
+
+vi.mock("./providers/azure-entra-id", () => ({
+  AzureEntraIDProvider: () => entraProviderFns
+}));
+
+// eslint-disable-next-line import/first
+import { dynamicSecretServiceFactory } from "./dynamic-secret-service";
+
+const PROJECT_SLUG = "my-project";
+const PROJECT_ID = "3d1b1b0a-0000-4000-8000-000000000001";
+
+const actorArgs = {
+  actor: ActorType.USER,
+  actorId: "user-1",
+  actorAuthMethod: AuthMethod.EMAIL,
+  actorOrgId: "org-1"
+};
+
+const ibmCredentials = {
+  instanceUrl: "https://api-connect.example.com",
+  apiKey: "api-key",
+  clientId: "client-id",
+  clientSecret: "client-secret"
+};
+
+const makeService = (permission: MongoAbility, project: { id: string } | null = { id: PROJECT_ID }) => {
+  const findProjectBySlug = vi.fn().mockResolvedValue(project);
+  const getProjectPermission = vi.fn().mockResolvedValue({ permission });
+
+  const service = dynamicSecretServiceFactory({
+    projectDAL: { findProjectBySlug } as never,
+    permissionService: { getProjectPermission } as never,
+    dynamicSecretDAL: {} as never,
+    dynamicSecretLeaseDAL: {} as never,
+    dynamicSecretProviders: {} as never,
+    dynamicSecretQueueService: {} as never,
+    licenseService: {} as never,
+    folderDAL: {} as never,
+    kmsService: {} as never,
+    gatewayDAL: {} as never,
+    gatewayV2DAL: {} as never,
+    gatewayPoolService: {} as never,
+    resourceMetadataDAL: {} as never
+  });
+
+  return { service, findProjectBySlug, getProjectPermission };
+};
+
+const discoveryCalls = (service: ReturnType<typeof makeService>["service"]) => [
+  {
+    name: "fetchIbmApiConnectOrgs",
+    call: () => service.fetchIbmApiConnectOrgs({ ...ibmCredentials, projectSlug: PROJECT_SLUG, ...actorArgs })
+  },
+  {
+    name: "fetchIbmApiConnectOrgCatalogs",
+    call: () =>
+      service.fetchIbmApiConnectOrgCatalogs({
+        ...ibmCredentials,
+        orgId: "org-id",
+        projectSlug: PROJECT_SLUG,
+        ...actorArgs
+      })
+  },
+  {
+    name: "fetchIbmApiConnectOrgApps",
+    call: () =>
+      service.fetchIbmApiConnectOrgApps({
+        ...ibmCredentials,
+        orgId: "org-id",
+        catalogId: "catalog-id",
+        projectSlug: PROJECT_SLUG,
+        ...actorArgs
+      })
+  },
+  {
+    name: "fetchAzureEntraIdUsers",
+    call: () =>
+      service.fetchAzureEntraIdUsers({
+        tenantId: "tenant-id",
+        applicationId: "application-id",
+        clientSecret: "client-secret",
+        projectSlug: PROJECT_SLUG,
+        ...actorArgs
+      })
+  }
+];
+
+describe("dynamic secret provider discovery authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test.each(discoveryCalls(makeService(createMongoAbility([])).service).map((c) => c.name))(
+    "%s rejects an actor with no dynamic secret permission",
+    async (name) => {
+      const { service } = makeService(createMongoAbility([{ action: "read", subject: ProjectPermissionSub.Secrets }]));
+      const { call } = discoveryCalls(service).find((c) => c.name === name)!;
+
+      await expect(call()).rejects.toBeInstanceOf(ForbiddenRequestError);
+    }
+  );
+
+  test("no provider request is made when the actor is unauthorized", async () => {
+    const { service } = makeService(createMongoAbility([]));
+
+    await Promise.all(discoveryCalls(service).map(({ call }) => expect(call()).rejects.toThrow()));
+
+    expect(ibmProviderFns.fetchOrganizations).not.toHaveBeenCalled();
+    expect(ibmProviderFns.fetchOrganizationCatalogs).not.toHaveBeenCalled();
+    expect(ibmProviderFns.fetchOrganizationApps).not.toHaveBeenCalled();
+    expect(entraProviderFns.fetchAzureEntraIdUsers).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ProjectPermissionDynamicSecretActions.CreateRootCredential,
+    ProjectPermissionDynamicSecretActions.EditRootCredential
+  ])("an actor holding %s in the project reaches the provider", async (action) => {
+    const { service, getProjectPermission } = makeService(
+      createMongoAbility([{ action, subject: ProjectPermissionSub.DynamicSecrets }])
+    );
+
+    await Promise.all(discoveryCalls(service).map(({ call }) => call()));
+
+    expect(ibmProviderFns.fetchOrganizations).toHaveBeenCalledTimes(1);
+    expect(ibmProviderFns.fetchOrganizationCatalogs).toHaveBeenCalledTimes(1);
+    expect(ibmProviderFns.fetchOrganizationApps).toHaveBeenCalledTimes(1);
+    expect(entraProviderFns.fetchAzureEntraIdUsers).toHaveBeenCalledTimes(1);
+    expect(getProjectPermission).toHaveBeenCalledWith(expect.objectContaining({ projectId: PROJECT_ID }));
+  });
+
+  // a role scoped to one environment or path still grants discovery, which has no environment to check against
+  test("an actor whose create permission is scoped to one environment reaches the provider", async () => {
+    const { service } = makeService(
+      createMongoAbility([
+        {
+          action: ProjectPermissionDynamicSecretActions.CreateRootCredential,
+          subject: ProjectPermissionSub.DynamicSecrets,
+          conditions: { environment: "dev", secretPath: "/" }
+        }
+      ])
+    );
+
+    await expect(
+      service.fetchIbmApiConnectOrgs({ ...ibmCredentials, projectSlug: PROJECT_SLUG, ...actorArgs })
+    ).resolves.toEqual([]);
+  });
+
+  test("a project outside the actor's org is reported as not found", async () => {
+    const { service } = makeService(createMongoAbility([]), null);
+
+    await expect(
+      service.fetchIbmApiConnectOrgs({ ...ibmCredentials, projectSlug: PROJECT_SLUG, ...actorArgs })
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-service.ts
@@ -8,7 +8,7 @@ import {
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
 import { crypto } from "@app/lib/crypto";
-import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { extractObjectFieldPaths } from "@app/lib/fn";
 import { OrderByDirection } from "@app/lib/types";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -24,7 +24,11 @@ import { TGatewayPoolServiceFactory } from "../gateway-pool/gateway-pool-service
 import { TGatewayV2DALFactory } from "../gateway-v2/gateway-v2-dal";
 import { OrgPermissionGatewayActions, OrgPermissionSubjects } from "../permission/org-permission";
 import { TDynamicSecretDALFactory } from "./dynamic-secret-dal";
-import { DynamicSecretStatus, TDynamicSecretServiceFactory } from "./dynamic-secret-types";
+import {
+  DynamicSecretStatus,
+  TDynamicSecretProviderDiscoveryDTO,
+  TDynamicSecretServiceFactory
+} from "./dynamic-secret-types";
 import { AzureEntraIDProvider } from "./providers/azure-entra-id";
 import { GcpIamServiceAccountSuffixError } from "./providers/gcp-iam";
 import { IbmApiConnectProvider } from "./providers/ibm-api-connect";
@@ -946,11 +950,50 @@ export const dynamicSecretServiceFactory = ({
     return { caPublicKey: decryptedStoredInput.caPublicKey };
   };
 
+  // discovery endpoints have no dynamic secret to scope against yet, so they gate on the caller being able to
+  // configure dynamic secrets somewhere in the project rather than at a specific environment and secret path
+  const assertProviderDiscoveryPermission = async ({
+    projectSlug,
+    actor,
+    actorId,
+    actorAuthMethod,
+    actorOrgId
+  }: TDynamicSecretProviderDiscoveryDTO) => {
+    const project = await projectDAL.findProjectBySlug(projectSlug, actorOrgId);
+    if (!project) throw new NotFoundError({ message: `Project with slug '${projectSlug}' not found` });
+
+    const { permission } = await permissionService.getProjectPermission({
+      actor,
+      actorId,
+      projectId: project.id,
+      actorAuthMethod,
+      actorOrgId,
+      actionProjectType: ActionProjectType.SecretManager
+    });
+
+    const canConfigureDynamicSecrets =
+      permission.can(ProjectPermissionDynamicSecretActions.CreateRootCredential, ProjectPermissionSub.DynamicSecrets) ||
+      permission.can(ProjectPermissionDynamicSecretActions.EditRootCredential, ProjectPermissionSub.DynamicSecrets);
+
+    if (!canConfigureDynamicSecrets) {
+      throw new ForbiddenRequestError({
+        message: `You do not have permission to create or edit dynamic secrets in project '${projectSlug}'`
+      });
+    }
+  };
+
   const fetchAzureEntraIdUsers: TDynamicSecretServiceFactory["fetchAzureEntraIdUsers"] = async ({
     tenantId,
     applicationId,
-    clientSecret
+    clientSecret,
+    projectSlug,
+    actor,
+    actorId,
+    actorAuthMethod,
+    actorOrgId
   }) => {
+    await assertProviderDiscoveryPermission({ projectSlug, actor, actorId, actorAuthMethod, actorOrgId });
+
     const azureEntraIdUsers = await AzureEntraIDProvider().fetchAzureEntraIdUsers(
       tenantId,
       applicationId,
@@ -963,8 +1006,15 @@ export const dynamicSecretServiceFactory = ({
     instanceUrl,
     apiKey,
     clientId,
-    clientSecret
+    clientSecret,
+    projectSlug,
+    actor,
+    actorId,
+    actorAuthMethod,
+    actorOrgId
   }) => {
+    await assertProviderDiscoveryPermission({ projectSlug, actor, actorId, actorAuthMethod, actorOrgId });
+
     return IbmApiConnectProvider().fetchOrganizations({ instanceUrl, apiKey, clientId, clientSecret });
   };
 
@@ -973,8 +1023,15 @@ export const dynamicSecretServiceFactory = ({
     apiKey,
     clientId,
     clientSecret,
-    orgId
+    orgId,
+    projectSlug,
+    actor,
+    actorId,
+    actorAuthMethod,
+    actorOrgId
   }) => {
+    await assertProviderDiscoveryPermission({ projectSlug, actor, actorId, actorAuthMethod, actorOrgId });
+
     return IbmApiConnectProvider().fetchOrganizationCatalogs({ instanceUrl, apiKey, clientId, clientSecret }, orgId);
   };
 
@@ -984,8 +1041,15 @@ export const dynamicSecretServiceFactory = ({
     clientId,
     clientSecret,
     orgId,
-    catalogId
+    catalogId,
+    projectSlug,
+    actor,
+    actorId,
+    actorAuthMethod,
+    actorOrgId
   }) => {
+    await assertProviderDiscoveryPermission({ projectSlug, actor, actorId, actorAuthMethod, actorOrgId });
+
     return IbmApiConnectProvider().fetchOrganizationApps(
       { instanceUrl, apiKey, clientId, clientSecret },
       orgId,

--- a/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
+++ b/backend/src/ee/services/dynamic-secret/dynamic-secret-types.ts
@@ -59,6 +59,10 @@ export type TGetSshCaPublicKeyDTO = {
   dynamicSecretId: string;
 } & Omit<TProjectPermission, "projectId">;
 
+export type TDynamicSecretProviderDiscoveryDTO = {
+  projectSlug: string;
+} & Omit<TProjectPermission, "projectId">;
+
 export type ListDynamicSecretsFilters = {
   offset?: number;
   limit?: number;
@@ -118,19 +122,27 @@ export type TDynamicSecretServiceFactory = {
   ) => Promise<Array<TDynamicSecretWithMetadata & { environment: string }>>;
   getDynamicSecretCount: (arg: TGetDynamicSecretsCountDTO) => Promise<number>;
   getCountMultiEnv: (arg: TListDynamicSecretsMultiEnvDTO) => Promise<number>;
-  fetchAzureEntraIdUsers: (arg: { tenantId: string; applicationId: string; clientSecret: string }) => Promise<
+  fetchAzureEntraIdUsers: (
+    arg: {
+      tenantId: string;
+      applicationId: string;
+      clientSecret: string;
+    } & TDynamicSecretProviderDiscoveryDTO
+  ) => Promise<
     {
       name: string;
       id: string;
       email: string;
     }[]
   >;
-  fetchIbmApiConnectOrgs: (arg: TIbmApiConnectBaseCredentials) => Promise<TApiConnectResource[]>;
+  fetchIbmApiConnectOrgs: (
+    arg: TIbmApiConnectBaseCredentials & TDynamicSecretProviderDiscoveryDTO
+  ) => Promise<TApiConnectResource[]>;
   fetchIbmApiConnectOrgCatalogs: (
-    arg: TIbmApiConnectBaseCredentials & { orgId: string }
+    arg: TIbmApiConnectBaseCredentials & { orgId: string } & TDynamicSecretProviderDiscoveryDTO
   ) => Promise<TApiConnectResource[]>;
   fetchIbmApiConnectOrgApps: (
-    arg: TIbmApiConnectBaseCredentials & { orgId: string; catalogId: string }
+    arg: TIbmApiConnectBaseCredentials & { orgId: string; catalogId: string } & TDynamicSecretProviderDiscoveryDTO
   ) => Promise<TApiConnectApp[]>;
   listDynamicSecretsByFolderIds: (
     arg: TListDynamicSecretsByFolderMappingsDTO,

--- a/frontend/src/hooks/api/dynamicSecret/queries.ts
+++ b/frontend/src/hooks/api/dynamicSecret/queries.ts
@@ -77,11 +77,13 @@ export const useGetDynamicSecretProviderData = ({
   tenantId,
   applicationId,
   clientSecret,
+  projectSlug,
   enabled
 }: {
   tenantId: string;
   applicationId: string;
   clientSecret: string;
+  projectSlug: string;
   enabled: boolean;
 }) => {
   return useQuery({
@@ -92,7 +94,8 @@ export const useGetDynamicSecretProviderData = ({
         {
           tenantId,
           applicationId,
-          clientSecret
+          clientSecret,
+          projectSlug
         }
       );
       return data;
@@ -106,12 +109,14 @@ export const useGetIbmApiConnectOrgs = ({
   apiKey,
   clientId,
   clientSecret,
+  projectSlug,
   enabled
 }: {
   instanceUrl: string;
   apiKey: string;
   clientId: string;
   clientSecret: string;
+  projectSlug: string;
   enabled: boolean;
 }) => {
   return useQuery({
@@ -119,7 +124,7 @@ export const useGetIbmApiConnectOrgs = ({
     queryFn: async () => {
       const { data } = await apiRequest.post<{ name: string; title: string; id: string }[]>(
         "/api/v1/dynamic-secrets/ibm-api-connect/orgs",
-        { instanceUrl, apiKey, clientId, clientSecret }
+        { instanceUrl, apiKey, clientId, clientSecret, projectSlug }
       );
       return data;
     },
@@ -133,6 +138,7 @@ export const useGetIbmApiConnectOrgCatalogs = ({
   clientId,
   clientSecret,
   orgId,
+  projectSlug,
   enabled
 }: {
   instanceUrl: string;
@@ -140,6 +146,7 @@ export const useGetIbmApiConnectOrgCatalogs = ({
   clientId: string;
   clientSecret: string;
   orgId: string;
+  projectSlug: string;
   enabled: boolean;
 }) => {
   return useQuery({
@@ -147,7 +154,7 @@ export const useGetIbmApiConnectOrgCatalogs = ({
     queryFn: async () => {
       const { data } = await apiRequest.post<{ name: string; title: string; id: string }[]>(
         `/api/v1/dynamic-secrets/ibm-api-connect/orgs/${orgId}/catalogs`,
-        { instanceUrl, apiKey, clientId, clientSecret }
+        { instanceUrl, apiKey, clientId, clientSecret, projectSlug }
       );
       return data;
     },
@@ -162,6 +169,7 @@ export const useGetIbmApiConnectOrgApps = ({
   clientSecret,
   orgId,
   catalogId,
+  projectSlug,
   enabled
 }: {
   instanceUrl: string;
@@ -170,6 +178,7 @@ export const useGetIbmApiConnectOrgApps = ({
   clientSecret: string;
   orgId: string;
   catalogId: string;
+  projectSlug: string;
   enabled: boolean;
 }) => {
   return useQuery({
@@ -189,7 +198,8 @@ export const useGetIbmApiConnectOrgApps = ({
         instanceUrl,
         apiKey,
         clientId,
-        clientSecret
+        clientSecret,
+        projectSlug
       });
       return data;
     },

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AzureEntraIdInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/AzureEntraIdInputForm.tsx
@@ -95,6 +95,7 @@ export const AzureEntraIdInputForm = ({
     tenantId,
     applicationId,
     clientSecret,
+    projectSlug,
     enabled: !!configurationComplete
   });
   const loading = configurationComplete && isFetching;

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/IbmApiConnectInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/IbmApiConnectInputForm.tsx
@@ -119,6 +119,7 @@ export const IbmApiConnectInputForm = ({
     apiKey: apiKey || "",
     clientId: clientId || "",
     clientSecret: clientSecret || "",
+    projectSlug,
     enabled: credentialsComplete
   });
 
@@ -134,6 +135,7 @@ export const IbmApiConnectInputForm = ({
     clientId: clientId || "",
     clientSecret: clientSecret || "",
     orgId: selectedOrg?.id || "",
+    projectSlug,
     enabled: orgSelected
   });
 
@@ -150,6 +152,7 @@ export const IbmApiConnectInputForm = ({
     clientSecret: clientSecret || "",
     orgId: selectedOrg?.id || "",
     catalogId: selectedCatalog?.id || "",
+    projectSlug,
     enabled: catalogSelected
   });
 

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretIbmApiConnectForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/DynamicSecretListView/EditDynamicSecretForm/EditDynamicSecretIbmApiConnectForm.tsx
@@ -121,6 +121,7 @@ export const EditDynamicSecretIbmApiConnectForm = ({
     apiKey: apiKey || "",
     clientId: clientId || "",
     clientSecret: clientSecret || "",
+    projectSlug,
     enabled: credentialsComplete
   });
 
@@ -136,6 +137,7 @@ export const EditDynamicSecretIbmApiConnectForm = ({
     clientId: clientId || "",
     clientSecret: clientSecret || "",
     orgId: selectedOrg?.id || "",
+    projectSlug,
     enabled: orgSelected
   });
 
@@ -152,6 +154,7 @@ export const EditDynamicSecretIbmApiConnectForm = ({
     clientSecret: clientSecret || "",
     orgId: selectedOrg?.id || "",
     catalogId: selectedCatalog?.id || "",
+    projectSlug,
     enabled: catalogSelected
   });
 


### PR DESCRIPTION
## Context

The dynamic-secret provider discovery endpoints performed authentication but no authorization (Pylon #4119, finding 11, reported by Drew Morana, medium severity):

- `POST /api/v1/dynamic-secrets/ibm-api-connect/orgs`
- `POST /api/v1/dynamic-secrets/ibm-api-connect/orgs/:orgId/catalogs`
- `POST /api/v1/dynamic-secrets/ibm-api-connect/orgs/:orgId/catalogs/:catalogId/apps`
- `POST /api/v1/dynamic-secrets/entra-id/users`

`fetchIbmApiConnectOrgs`, `fetchIbmApiConnectOrgCatalogs`, `fetchIbmApiConnectOrgApps` and `fetchAzureEntraIdUsers` took no `projectId` and never called `permissionService`. The routes were `verifyAuth([AuthMode.JWT])`, which is authentication only, and there was no second gate behind the route. Every other exported function in `dynamic-secret-service.ts` calls `getProjectPermission`.

So any logged-in user in any organization on the instance — no project membership, no role, no permission — could send an attacker-chosen `instanceUrl`, have the server run a two-step token flow against that host, and receive the third-party response body. The SSRF reach is already bounded (private and loopback blocked, `maxRedirects: 0`); the defect fixed here is the missing authorization on a server-side credential-relay primitive. The SSRF-hardening angle overlaps SEC-76 / VERIA-101 and is not in scope for this PR.

**Fix.** All four functions now take a `projectSlug`, resolve the project within the caller's org, call `getProjectPermission`, and require `create-root-credential` or `edit-root-credential` on `dynamic-secrets` in that project.

Two decisions worth review:

- **Project-wide check, not environment/secret-path scoped.** `getDetails` and friends assert against `subject(DynamicSecrets, { environment, secretPath, metadata })`, but discovery has no dynamic secret and no chosen environment yet — in the create form the environment is picked in the same dialog, often after the provider credentials. So the check is against the bare subject, which in CASL ignores conditions: a role scoped to one environment or path still passes (covered by a test). Both `create` and `edit` are accepted because the edit forms call the same endpoints, and a role with only edit would otherwise lose the resource pickers.
- **`projectSlug` is a new required body field on four existing endpoints.** That is a breaking change to their contract, which `backend/CODE_QUALITY.md` says to avoid, rather than a new optional field. Making it optional would leave the hole open, so it is deliberate. These are UI-support endpoints (the frontend is updated in this PR) and are not in the docs; `POST /entra-id/users` is the only one reachable by a machine identity, so a caller other than our UI is possible there.

## Steps to verify the change

1. As an org member with **no** membership in project `P`, call any of the four endpoints with `projectSlug` = `P`'s slug → 403 `"You do not have permission to create or edit dynamic secrets in project 'P'"`.
2. With a `projectSlug` from another organization → 404, so the endpoints cannot confirm another tenant's project slugs.
3. As a member of `P` holding the dynamic-secret create (or edit) permission → unchanged behavior, provider results returned.
4. In the UI, create and edit an IBM API Connect dynamic secret and an Entra ID dynamic secret; the org/catalog/app and user pickers populate as before.
5. `cd backend && npx vitest run --config vitest.unit.config.mts src/ee/services/dynamic-secret/` → 26 passing, including 9 new cases in `dynamic-secret-service.test.ts` (unauthorized actor rejected on all four functions, provider never reached, env-scoped role still allowed, cross-org project reported as not found). Reverting the assertion in any function fails the suite.
6. `make reviewable-api` and `make reviewable-ui` pass.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [x] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed) — the four endpoints are not documented
- [ ] Updated CLAUDE.md files (if needed) — no new pattern introduced
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)