### PR TITLE
feat(secrets): surface comments in secret overview

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretCommentDisplay.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretCommentDisplay.tsx
@@ -1,0 +1,308 @@
+import { useEffect, useRef, useState } from "react";
+import { MessageSquareIcon, MessageSquarePlusIcon } from "lucide-react";
+
+import {
+  IconButton,
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+  PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@app/components/v3";
+
+import { SecretCommentForm } from "./SecretCommentForm";
+
+const commentIndicatorClassName =
+  "inline-flex size-7 shrink-0 items-center justify-center text-muted outline-none focus-visible:ring-1 focus-visible:ring-ring [&>svg]:size-4 [&>svg]:stroke-[1.75]";
+
+type Props = {
+  comment?: string;
+  secretKey: string;
+  environment: string;
+  secretPath: string;
+  isBatchMode?: boolean;
+  onCommentChange?: (comment: string) => void;
+  isReadOnly?: boolean;
+  isUnavailable?: boolean;
+};
+
+type SecretCommentSummaryBadgeProps = {
+  environments: {
+    slug: string;
+    name: string;
+    comment?: string;
+    isReadOnly: boolean;
+  }[];
+  secretKey: string;
+  secretPath: string;
+};
+
+export const SecretCommentSummaryBadge = ({
+  environments,
+  secretKey,
+  secretPath
+}: SecretCommentSummaryBadgeProps) => {
+  const commentedEnvironments = environments.filter(({ comment }) => comment?.trim());
+  const [selectedEnvironmentSlug, setSelectedEnvironmentSlug] = useState(
+    commentedEnvironments[0]?.slug ?? environments[0]?.slug ?? ""
+  );
+  const [isOpen, setIsOpen] = useState(false);
+  const openTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const isEnvironmentSelectOpenRef = useRef(false);
+
+  const selectedEnvironment =
+    environments.find(({ slug }) => slug === selectedEnvironmentSlug) ??
+    commentedEnvironments[0] ??
+    environments[0];
+
+  const cancelOpen = () => {
+    if (openTimerRef.current) clearTimeout(openTimerRef.current);
+  };
+
+  const cancelClose = () => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+  };
+
+  const handleHoverStart = () => {
+    cancelClose();
+    cancelOpen();
+    openTimerRef.current = setTimeout(() => {
+      setIsOpen(true);
+    }, 250);
+  };
+
+  const handleHoverEnd = () => {
+    cancelOpen();
+    cancelClose();
+    closeTimerRef.current = setTimeout(() => {
+      if (isEnvironmentSelectOpenRef.current) return;
+      if (contentRef.current?.matches(":hover")) return;
+      if (contentRef.current?.contains(document.activeElement)) return;
+      setIsOpen(false);
+    }, 150);
+  };
+
+  const openForFocus = () => {
+    cancelOpen();
+    cancelClose();
+    setIsOpen(true);
+  };
+
+  useEffect(
+    () => () => {
+      if (openTimerRef.current) clearTimeout(openTimerRef.current);
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    },
+    []
+  );
+
+  if (!commentedEnvironments.length || !selectedEnvironment) return null;
+
+  const environmentLabel = commentedEnvironments.length === 1 ? "environment" : "environments";
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverAnchor asChild>
+        <button
+          type="button"
+          aria-label={`${commentedEnvironments.length} ${environmentLabel} with comments. View or edit comments`}
+          className={commentIndicatorClassName}
+          onPointerEnter={handleHoverStart}
+          onPointerLeave={handleHoverEnd}
+          onFocus={openForFocus}
+        >
+          <MessageSquareIcon />
+        </button>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        className="w-80"
+        onPointerEnter={cancelClose}
+        onPointerLeave={handleHoverEnd}
+        onOpenAutoFocus={(event) => event.preventDefault()}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div
+          ref={contentRef}
+          onFocusCapture={cancelClose}
+          onBlurCapture={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+              handleHoverEnd();
+            }
+          }}
+        >
+          <SecretCommentForm
+            key={selectedEnvironment.slug}
+            comment={selectedEnvironment.comment}
+            secretKey={secretKey}
+            secretPath={secretPath}
+            environment={selectedEnvironment.slug}
+            onClose={() => setIsOpen(false)}
+            isReadOnly={selectedEnvironment.isReadOnly}
+            autoFocus={false}
+            headerContent={
+              <Select
+                value={selectedEnvironment.slug}
+                onValueChange={setSelectedEnvironmentSlug}
+                onOpenChange={(open) => {
+                  isEnvironmentSelectOpenRef.current = open;
+                  if (open) cancelClose();
+                  else handleHoverEnd();
+                }}
+              >
+                <SelectTrigger size="sm" className="max-w-40" aria-label="Comment environment">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent position="popper" align="end">
+                  {environments.map(({ slug, name }) => (
+                    <SelectItem key={slug} value={slug}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            }
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export const SecretCommentControl = ({
+  comment,
+  secretKey,
+  environment,
+  secretPath,
+  isBatchMode,
+  onCommentChange,
+  isReadOnly = false,
+  isUnavailable = false
+}: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [shouldAutoFocus, setShouldAutoFocus] = useState(false);
+  const openTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const hasComment = Boolean(comment?.trim());
+
+  const cancelOpen = () => {
+    if (openTimerRef.current) clearTimeout(openTimerRef.current);
+  };
+
+  const cancelClose = () => {
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+  };
+
+  const handleHoverStart = () => {
+    cancelClose();
+    cancelOpen();
+    openTimerRef.current = setTimeout(() => {
+      setShouldAutoFocus(false);
+      setIsOpen(true);
+    }, 250);
+  };
+
+  const handleHoverEnd = () => {
+    cancelOpen();
+    cancelClose();
+    closeTimerRef.current = setTimeout(() => {
+      if (contentRef.current?.contains(document.activeElement)) return;
+      setIsOpen(false);
+    }, 150);
+  };
+
+  const openForFocus = () => {
+    cancelOpen();
+    cancelClose();
+    setShouldAutoFocus(false);
+    setIsOpen(true);
+  };
+
+  useEffect(
+    () => () => {
+      if (openTimerRef.current) clearTimeout(openTimerRef.current);
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    },
+    []
+  );
+
+  if (isUnavailable || (!hasComment && isReadOnly)) return null;
+
+  return (
+    <Popover
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (open && !hasComment) setShouldAutoFocus(true);
+      }}
+    >
+      {hasComment ? (
+        <PopoverAnchor asChild>
+          <button
+            type="button"
+            aria-label={isReadOnly ? "View comment" : "View or edit comment"}
+            className={commentIndicatorClassName}
+            onPointerEnter={handleHoverStart}
+            onPointerLeave={handleHoverEnd}
+            onFocus={openForFocus}
+          >
+            <MessageSquareIcon />
+          </button>
+        </PopoverAnchor>
+      ) : (
+        <PopoverTrigger asChild>
+          <IconButton
+            variant="ghost"
+            size="xs"
+            aria-label="Add comment"
+            className="pointer-events-none size-7 border-0 text-muted opacity-0 group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <MessageSquarePlusIcon />
+          </IconButton>
+        </PopoverTrigger>
+      )}
+      <PopoverContent
+        align="start"
+        className="w-80"
+        onPointerEnter={hasComment ? cancelClose : undefined}
+        onPointerLeave={hasComment ? handleHoverEnd : undefined}
+        onOpenAutoFocus={(event) => {
+          if (!shouldAutoFocus) event.preventDefault();
+        }}
+        onCloseAutoFocus={(event) => event.preventDefault()}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div
+          ref={contentRef}
+          onFocusCapture={cancelClose}
+          onBlurCapture={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+              handleHoverEnd();
+            }
+          }}
+        >
+          <SecretCommentForm
+            comment={comment}
+            secretKey={secretKey}
+            secretPath={secretPath}
+            environment={environment}
+            onClose={() => setIsOpen(false)}
+            isBatchMode={isBatchMode}
+            onCommentChange={onCommentChange}
+            isReadOnly={isReadOnly}
+            autoFocus={shouldAutoFocus}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretCommentForm.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretCommentForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { subject } from "@casl/ability";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -25,7 +25,33 @@ type Props = {
   onClose?: () => void;
   isBatchMode?: boolean;
   onCommentChange?: (comment: string) => void;
+  isReadOnly?: boolean;
+  autoFocus?: boolean;
+  headerContent?: ReactNode;
 };
+
+type SecretCommentViewProps = {
+  comment?: string;
+  footer?: ReactNode;
+  headerContent?: ReactNode;
+};
+
+const SecretCommentHeader = ({ headerContent }: { headerContent?: ReactNode }) => (
+  <div className="flex items-center justify-between gap-3">
+    <p className="text-sm font-medium">Comment</p>
+    {headerContent}
+  </div>
+);
+
+export const SecretCommentView = ({ comment, footer, headerContent }: SecretCommentViewProps) => (
+  <div className="space-y-3">
+    <SecretCommentHeader headerContent={headerContent} />
+    <p className="max-h-48 min-h-24 thin-scrollbar overflow-y-auto rounded-md border border-border px-3 py-2 text-sm break-words whitespace-pre-wrap opacity-100">
+      {comment?.trim() ? comment : <span className="text-muted-foreground">No comment</span>}
+    </p>
+    {footer}
+  </div>
+);
 
 export const SecretCommentForm = ({
   comment,
@@ -34,21 +60,26 @@ export const SecretCommentForm = ({
   secretPath,
   onClose,
   isBatchMode,
-  onCommentChange
+  onCommentChange,
+  isReadOnly = false,
+  autoFocus = true,
+  headerContent
 }: Props) => {
   const { projectId } = useProject();
   const { permission } = useProjectPermission();
   const { mutateAsync: updateSecretV3, isPending } = useUpdateSecretV3();
 
-  const canEdit = permission.can(
-    ProjectPermissionSecretActions.Edit,
-    subject(ProjectPermissionSub.Secrets, {
-      environment,
-      secretPath,
-      secretName: secretKey,
-      secretTags: ["*"]
-    })
-  );
+  const canEdit =
+    !isReadOnly &&
+    permission.can(
+      ProjectPermissionSecretActions.Edit,
+      subject(ProjectPermissionSub.Secrets, {
+        environment,
+        secretPath,
+        secretName: secretKey,
+        secretTags: ["*"]
+      })
+    );
 
   const {
     handleSubmit,
@@ -114,31 +145,31 @@ export const SecretCommentForm = ({
 
   if (!canEdit) {
     return (
-      <div className="space-y-3">
-        <p className="text-sm font-medium">Comment</p>
-        <p className="max-h-48 min-h-24 thin-scrollbar overflow-y-auto rounded-md border border-border px-3 py-2 text-sm break-words whitespace-pre-wrap opacity-100">
-          {comment}
-        </p>
-        <div className="flex justify-end">
-          <Button variant="ghost" size="xs" type="button" onClick={onClose}>
-            Close
-          </Button>
-        </div>
-      </div>
+      <SecretCommentView
+        comment={comment}
+        headerContent={headerContent}
+        footer={
+          <div className="flex justify-end">
+            <Button variant="ghost" size="xs" type="button" onClick={onClose}>
+              Close
+            </Button>
+          </div>
+        }
+      />
     );
   }
 
   if (isBatchMode) {
     return (
       <div className="space-y-3">
-        <p className="text-sm font-medium">Comment</p>
+        <SecretCommentHeader headerContent={headerContent} />
         <Controller
           name="comment"
           control={control}
           render={({ field }) => (
             <TextArea
               {...field}
-              autoFocus
+              autoFocus={autoFocus}
               placeholder="Add a comment..."
               className="max-h-48 min-h-24 resize-none"
             />
@@ -155,14 +186,14 @@ export const SecretCommentForm = ({
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
-      <p className="text-sm font-medium">Comment</p>
+      <SecretCommentHeader headerContent={headerContent} />
       <Controller
         name="comment"
         control={control}
         render={({ field }) => (
           <TextArea
             {...field}
-            autoFocus
+            autoFocus={autoFocus}
             placeholder="Add a comment..."
             className="max-h-48 min-h-24 resize-none"
           />

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretEditTableRow.tsx
@@ -15,7 +15,6 @@ import {
   ForwardIcon,
   GitBranchIcon,
   HistoryIcon,
-  MessageSquareIcon,
   PencilLineIcon,
   SaveIcon,
   TagsIcon,
@@ -99,7 +98,7 @@ import { useBatchStoreApi } from "@app/pages/secret-manager/SecretDashboardPage/
 
 import { DuplicateSecretModal } from "./DuplicateSecretModal";
 import { SecretAccessInsights } from "./SecretAccessInsights";
-import { SecretCommentForm } from "./SecretCommentForm";
+import { SecretCommentControl } from "./SecretCommentDisplay";
 import { SecretMetadataForm } from "./SecretMetadataForm";
 import { SecretReminderForm } from "./SecretReminderForm";
 import { SecretTagForm } from "./SecretTagForm";
@@ -170,6 +169,7 @@ type Props = {
   hasPendingValueChange?: boolean;
   pendingKeyName?: string;
   revokedProjectFolderGrant?: boolean;
+  commentPreview?: string;
 };
 
 export const SecretEditTableRow = ({
@@ -207,7 +207,8 @@ export const SecretEditTableRow = ({
   hasPendingChange,
   hasPendingValueChange,
   pendingKeyName,
-  revokedProjectFolderGrant
+  revokedProjectFolderGrant,
+  commentPreview
 }: Props) => {
   const { handlePopUpOpen, handlePopUpToggle, handlePopUpClose, popUp } = usePopUp([
     "editSecret",
@@ -329,13 +330,12 @@ export const SecretEditTableRow = ({
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState("");
   const [editConfirmation, setEditConfirmation] = useState("");
-  const [isCommentOpen, setIsCommentOpen] = useState(false);
   const [isTagOpen, setIsTagOpen] = useState(false);
   const [isMetadataOpen, setIsMetadataOpen] = useState(false);
   const [isReminderOpen, setIsReminderOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [pendingAnnotation, setPendingAnnotation] = useState<
-    "comment" | "tags" | "reminder" | "metadata" | null
+    "tags" | "reminder" | "metadata" | null
   >(null);
   const [isVersionHistoryOpen, setIsVersionHistoryOpen] = useState(false);
   const [isAccessInsightsOpen, setIsAccessInsightsOpen] = useState(false);
@@ -424,6 +424,9 @@ export const SecretEditTableRow = ({
   const watchedValue = watch("value");
   const watchedKey = watch("key");
   const watchedComment = watch("comment");
+  const displayedComment = isBatchMode
+    ? ((watchedComment as string) ?? commentPreview)
+    : commentPreview;
   const watchedTags = watch("tags") as { id: string; slug: string }[] | undefined;
   const watchedMetadata = watch("metadata") as
     | { key: string; value: string; isEncrypted: boolean }[]
@@ -896,8 +899,7 @@ export const SecretEditTableRow = ({
     isErrorFetchingSharedValue ||
     (isCreatable ? !canCreate : !canEditSecretValue);
 
-  const shouldStayExpanded =
-    isCommentOpen || isTagOpen || isMetadataOpen || isReminderOpen || isDropdownOpen;
+  const shouldStayExpanded = isTagOpen || isMetadataOpen || isReminderOpen || isDropdownOpen;
 
   const [isHoveringActionZone, setIsHoveringActionZone] = useState(false);
   const showMenuWhileFocused = isHoveringActionZone || shouldStayExpanded;
@@ -1065,16 +1067,6 @@ export const SecretEditTableRow = ({
         {!isDirtyState && !isFieldActive && (
           <div className="flex w-fit items-start justify-end self-start pl-2 transition-opacity group-hover:pointer-events-none group-hover:opacity-0">
             <div className="flex items-center gap-1">
-              {comment && !isImportedSecret && (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="flex size-5 items-center justify-center text-muted">
-                      <MessageSquareIcon className="size-3.5" />
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>Has comment</TooltipContent>
-                </Tooltip>
-              )}
               {canReadTags && tags?.length && !isImportedSecret ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -1226,26 +1218,6 @@ export const SecretEditTableRow = ({
             isSingleEnvView ? "top-[3px] right-0.5" : "-top-px -right-1.5"
           )}
         >
-          <Popover open={isCommentOpen} onOpenChange={setIsCommentOpen}>
-            <PopoverAnchor asChild>
-              <span className="pointer-events-none absolute inset-0" />
-            </PopoverAnchor>
-            <PopoverContent
-              onCloseAutoFocus={(e) => e.preventDefault()}
-              className="w-80"
-              align="end"
-            >
-              <SecretCommentForm
-                comment={isBatchMode ? ((watchedComment as string) ?? comment) : comment}
-                secretKey={secretName}
-                secretPath={secretPath}
-                environment={environment}
-                onClose={() => setIsCommentOpen(false)}
-                isBatchMode={isBatchMode}
-                onCommentChange={handleCommentChange}
-              />
-            </PopoverContent>
-          </Popover>
           <Popover modal open={isTagOpen} onOpenChange={setIsTagOpen}>
             <PopoverAnchor asChild>
               <span className="pointer-events-none absolute inset-0" />
@@ -1333,23 +1305,8 @@ export const SecretEditTableRow = ({
           {!isImportedSecret &&
             !isCreatable &&
             !isPendingDelete &&
-            !!(comment || (canReadTags && tags?.length) || reminder || secretMetadata?.length) && (
+            !!((canReadTags && tags?.length) || reminder || secretMetadata?.length) && (
               <>
-                {comment && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <IconButton
-                        variant="ghost"
-                        size="xs"
-                        className="size-7 border-0 text-muted hover:text-foreground"
-                        onClick={() => setIsCommentOpen(true)}
-                      >
-                        <MessageSquareIcon className="size-3.5" />
-                      </IconButton>
-                    </TooltipTrigger>
-                    <TooltipContent>View Comment</TooltipContent>
-                  </Tooltip>
-                )}
                 {canReadTags && tags?.length ? (
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -1477,8 +1434,7 @@ export const SecretEditTableRow = ({
               className="min-w-[200px] [&_[data-variant=default]]:text-mineshaft-100 [&_[data-variant=default]:focus]:text-foreground [&_svg:not([class*='size-'])]:!size-3"
               onCloseAutoFocus={(e) => {
                 e.preventDefault();
-                if (pendingAnnotation === "comment") setIsCommentOpen(true);
-                else if (pendingAnnotation === "tags") setIsTagOpen(true);
+                if (pendingAnnotation === "tags") setIsTagOpen(true);
                 else if (pendingAnnotation === "reminder") setIsReminderOpen(true);
                 else if (pendingAnnotation === "metadata") setIsMetadataOpen(true);
                 setPendingAnnotation(null);
@@ -1489,10 +1445,7 @@ export const SecretEditTableRow = ({
                   disabled={isPendingDelete || isCreatable || isImportedSecret}
                   className={twMerge(
                     "px-2.5 py-1.5 text-xs",
-                    (comment ||
-                      (canReadTags && tags?.length) ||
-                      reminder ||
-                      secretMetadata?.length) &&
+                    ((canReadTags && tags?.length) || reminder || secretMetadata?.length) &&
                       !isImportedSecret &&
                       "[&>svg:first-child]:text-project"
                   )}
@@ -1501,13 +1454,6 @@ export const SecretEditTableRow = ({
                   Annotate
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="min-w-[185px]">
-                  <DropdownMenuItem
-                    className="px-2.5 py-1.5 text-xs"
-                    onClick={() => setPendingAnnotation("comment")}
-                  >
-                    <MessageSquareIcon className={twMerge(comment && "text-project")} />
-                    {comment ? "View Comment" : "Add Comment"}
-                  </DropdownMenuItem>
                   <Tooltip open={!canReadTags ? undefined : false} disableHoverableContent>
                     <TooltipTrigger className="block w-full">
                       <DropdownMenuItem
@@ -2004,7 +1950,19 @@ export const SecretEditTableRow = ({
         <TableCell
           className={twMerge("border-r pt-1 align-top", isOverride && "border-b-border/50")}
         >
-          {nameInput}
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="min-w-0 grow">{nameInput}</div>
+            <SecretCommentControl
+              comment={displayedComment}
+              secretKey={secretName}
+              environment={environment}
+              secretPath={secretPath}
+              isBatchMode={isBatchMode}
+              onCommentChange={handleCommentChange}
+              isReadOnly={isImportedSecret || !canEditSecretValue}
+              isUnavailable={isPendingDelete || (isCreatable && !isImportedSecret)}
+            />
+          </div>
         </TableCell>
         <TableCell
           className={twMerge("relative w-full p-0 px-2", isOverride && "border-b-border/50")}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretTableRow.tsx
@@ -48,6 +48,7 @@ import { HIDDEN_SECRET_VALUE } from "@app/pages/secret-manager/SecretDashboardPa
 
 import { pendingActionBorderClass, pendingActionRowClass } from "../pendingActionStyles";
 import { EnvironmentStatus, ResourceEnvironmentStatusCell } from "../ResourceEnvironmentStatusCell";
+import { SecretCommentControl, SecretCommentSummaryBadge } from "./SecretCommentDisplay";
 import { SecretEditTableRow } from "./SecretEditTableRow";
 import { SecretOverrideRow } from "./SecretOverrideRow";
 import SecretRenameForm from "./SecretRenameForm";
@@ -130,6 +131,7 @@ export const SecretTableRow = ({
 
   const isSingleEnvView = environments.length === 1;
   const { projectId } = useProject();
+  const { permission } = useProjectPermission();
   const { mutateAsync: updateSecretV3ForRename } = useUpdateSecretV3();
 
   // Pre-compute single-env data
@@ -151,6 +153,40 @@ export const SecretTableRow = ({
     ? creatingOverrideEnvs.has(singleEnvSlug)
     : false;
   const singleEnvShowOverride = singleEnvHasOverride || singleEnvIsCreatingOverride;
+  const singleEnvComment = singleEnvIsImported
+    ? singleEnvImportedSecret?.secret?.comment
+    : singleEnvSecret?.comment;
+  const multiEnvCommentEnvironments = isSingleEnvView
+    ? []
+    : environments.flatMap(({ name, slug }) => {
+        const secret = getSecretByKey(slug, secretKey);
+        const isImportedSecret = isImportedSecretPresentInEnv(slug, secretKey);
+        const importedSecret = isImportedSecret
+          ? getImportedSecretByKey(slug, secretKey)
+          : undefined;
+        const comment = isImportedSecret ? importedSecret?.secret?.comment : secret?.comment;
+
+        if (!secret && !importedSecret?.secret) return [];
+
+        return [
+          {
+            slug,
+            name,
+            comment,
+            isReadOnly:
+              isImportedSecret ||
+              !permission.can(
+                ProjectPermissionSecretActions.Edit,
+                subject(ProjectPermissionSub.Secrets, {
+                  environment: slug,
+                  secretPath,
+                  secretName: secretKey,
+                  secretTags: ["*"]
+                })
+              )
+          }
+        ];
+      });
 
   const handleSecretRename = async (newName: string) => {
     if (!isSingleEnvView || !singleEnvSecret) return;
@@ -195,8 +231,6 @@ export const SecretTableRow = ({
     navigator.clipboard.writeText(secretKey);
     setIsSecNameCopied.on();
   };
-
-  const { permission } = useProjectPermission();
 
   const getDefaultValue = (
     secret: SecretV3RawSanitized | undefined,
@@ -330,6 +364,7 @@ export const SecretTableRow = ({
             importedBy={importedBy}
             isSecretPresent={Boolean(singleEnvSecret)}
             comment={singleEnvSecret?.comment}
+            commentPreview={singleEnvComment}
             tags={singleEnvSecret?.tags}
             secretMetadata={singleEnvSecret?.secretMetadata}
             skipMultilineEncoding={singleEnvSecret?.skipMultilineEncoding}
@@ -352,6 +387,11 @@ export const SecretTableRow = ({
               >
                 {secretKey}
               </span>
+              <SecretCommentSummaryBadge
+                environments={multiEnvCommentEnvironments}
+                secretKey={secretKey}
+                secretPath={secretPath}
+              />
               {!isFormExpanded &&
                 environments.some(
                   ({ slug }) => getSecretByKey(slug, secretKey)?.revokedProjectFolderGrant
@@ -528,6 +568,18 @@ export const SecretTableRow = ({
 
                     const isImportedSecret = isImportedSecretPresentInEnv(slug, secretKey);
                     const importedSecret = getImportedSecretByKey(slug, secretKey);
+                    const secretComment = isImportedSecret
+                      ? importedSecret?.secret?.comment
+                      : secret?.comment;
+                    const canEditComment = permission.can(
+                      ProjectPermissionSecretActions.Edit,
+                      subject(ProjectPermissionSub.Secrets, {
+                        environment: slug,
+                        secretPath,
+                        secretName: secretKey,
+                        secretTags: ["*"]
+                      })
+                    );
 
                     const hasOverride = Boolean(secret?.idOverride);
                     const isCreatingOverride = creatingOverrideEnvs.has(slug);
@@ -540,7 +592,7 @@ export const SecretTableRow = ({
                             isTruncatable
                             className={hasOverride ? "border-b-border/50" : undefined}
                           >
-                            <div className="flex h-8 items-center space-x-2">
+                            <div className="flex h-8 min-w-0 items-center space-x-2">
                               <Tooltip disableHoverableContent>
                                 <TooltipTrigger asChild>
                                   <span className="truncate">{name}</span>
@@ -549,6 +601,14 @@ export const SecretTableRow = ({
                                   {name}
                                 </TooltipContent>
                               </Tooltip>
+                              <SecretCommentControl
+                                comment={secretComment}
+                                secretKey={secretKey}
+                                environment={slug}
+                                secretPath={secretPath}
+                                isReadOnly={isImportedSecret || !canEditComment}
+                                isUnavailable={isCreatable && !isImportedSecret}
+                              />
                               {isImportedSecret && (
                                 <Tooltip>
                                   <TooltipTrigger asChild>


### PR DESCRIPTION
## Context

Secret comments were only available through the secret value action area, which made them easy to miss when comparing environments. This change surfaces comments beside secret and environment names across the Project Overview secret table without exposing secret values or changing the API.

- Show a persistent comment indicator beside a secret name when a comment exists.
- Reveal an add-comment action on row hover for editable secrets without comments.
- Show an aggregate comment indicator in the collapsed multi-environment view when at least one environment has a comment.
- Add an environment selector to the aggregate comment popover.
- Show each environment's comment control beside its environment name in the expanded comparison view.
- Keep imported or permission-restricted comments read-only and preserve existing value masking behavior.

Linear: https://linear.app/infisical/issue/SECRETS-303/add-comment-display-to-comparison-view

## Screenshots

Not captured in this task. Before review, capture:

- Single-environment view with an existing comment indicator and the add-comment hover action.
- Collapsed multi-environment view with the aggregate comment indicator and environment selector open.
- Expanded multi-environment view with comment controls beside environment names.

## Steps to verify the change

1. Open a project's Secret Manager overview and select one environment.
2. Confirm a secret with a comment shows a persistent comment icon beside its name; hover or keyboard-focus the icon and verify the comment popover opens.
3. Hover a secret without a comment and confirm an add-comment button appears beside its name; add, edit, and remove a comment.
4. Select multiple environments and confirm a collapsed secret shows one comment icon when at least one environment has a comment.
5. Open the aggregate comment popover and switch environments with the header selector.
6. Expand the secret and confirm each comment control appears beside its environment name, not its value.
7. Confirm imported and permission-restricted comments are view-only and secret values remain masked unless explicitly revealed.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
