### PR TITLE
fix(logging): change health check logs from info to debug level

### DIFF
--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -4136,13 +4136,13 @@ export const registerRoutes = async (
       const maxLagMs = histogram.max / 1e6;
       const p99LagMs = histogram.percentile(99) / 1e6;
 
-      logger.info(
+      logger.debug(
         `Event loop stats - Mean: ${meanLagMs.toFixed(2)}ms, Max: ${maxLagMs.toFixed(2)}ms, p99: ${p99LagMs.toFixed(
           2
         )}ms`
       );
 
-      logger.info(`Raw event loop stats: ${JSON.stringify(histogram, null, 2)}`);
+      logger.debug(`Raw event loop stats: ${JSON.stringify(histogram, null, 2)}`);
 
       return {
         date: new Date(),


### PR DESCRIPTION
## Context

Fixes #7392 — the `/api/status` health check endpoint was logging event-loop performance statistics at `info` level on every request. Since health checks are typically polled frequently (by load balancers, orchestrators, and uptime monitors), this produced excessive log output in production, drowning out more meaningful logs and increasing log storage/egress costs.

These event-loop stats (`Mean`, `Max`, `p99` lag, and the raw histogram) are only useful for performance debugging and are not actionable during normal operation. This PR moves both log statements from `logger.info` to `logger.debug`, so they only appear when debug logging is explicitly enabled.

**Behavior before:** Every health check request emitted two `info`-level logs (event loop stats summary + full raw histogram).
**Behavior after:** Both statements log at `debug` level — silent in normal production logging, visible only when debug logging is enabled.

## Screenshots

N/A (logging-only change, no UI/UX impact)

## Steps to verify the change

1. Confirm the two changed log statements in `backend/src/server/routes/index.ts` now use `logger.debug(...)`.
2. `npm run type:check` — no new type errors introduced by this change.
3. `npm run lint` — passes on the changed file.
4. `npm run test:unit` — 995 tests pass; the 56 failing test files are pre-existing and caused by two packages (`tsyringe`, `@peculiar/asn1-pkcs8`) not declared in `package.json`, unrelated to this change.
5. With logging at default level, the `/api/status` endpoint no longer emits event-loop stat logs; they appear only when debug logging is enabled.

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format: `fix(logging): change health check logs from info to debug level`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
