### PR TITLE
feat: switched lock in redis in create folder

### DIFF
--- a/backend/e2e-test/routes/v1/secret-folder.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-folder.spec.ts
@@ -185,4 +185,62 @@ describe("Secret Folder Router", async () => {
     expect(payload).toHaveProperty("error");
     await deleteFolder({ path: "/level1/level2", id: newFolder.id });
   });
+
+  const listFolderNames = async (path: string) => {
+    const res = await testServer.inject({
+      method: "GET",
+      url: `/api/v1/folders`,
+      headers: {
+        authorization: `Bearer ${jwtAuthToken}`
+      },
+      query: {
+        workspaceId: seedData1.project.id,
+        environment: seedData1.environment.slug,
+        path
+      }
+    });
+    expect(res.statusCode).toBe(200);
+    return (JSON.parse(res.payload).folders as { id: string; name: string }[]).map((folder) => folder.name);
+  };
+
+  // Concurrent creates of the same folder race on the create-folder lock. The lock keeps them from all inserting:
+  // exactly one request wins and the rest observe the committed row and are rejected, so no duplicate siblings.
+  test.each([
+    { name: "concurrent-shallow", path: "/" },
+    { name: "concurrent-deep", path: "/conc-level1/conc-level2" }
+  ])("Concurrent creation of $name in $path collapses to a single folder", async ({ name, path }) => {
+    const CONCURRENCY = 10;
+
+    const responses = await Promise.all(
+      Array.from({ length: CONCURRENCY }, () =>
+        testServer.inject({
+          method: "POST",
+          url: `/api/v1/folders`,
+          headers: {
+            authorization: `Bearer ${jwtAuthToken}`
+          },
+          body: {
+            workspaceId: seedData1.project.id,
+            environment: seedData1.environment.slug,
+            name,
+            path
+          }
+        })
+      )
+    );
+
+    const created = responses.filter((res) => res.statusCode === 200);
+    const rejected = responses.filter((res) => res.statusCode === 400);
+
+    expect(created).toHaveLength(1);
+    expect(rejected).toHaveLength(CONCURRENCY - 1);
+
+    // the folder exists exactly once at its path, and every rejection is the "already exists" conflict
+    const namesAtPath = await listFolderNames(path);
+    expect(namesAtPath.filter((folderName) => folderName === name)).toHaveLength(1);
+    rejected.forEach((res) => expect(JSON.parse(res.payload)).toHaveProperty("error"));
+
+    const createdFolder = created[0].json().folder as { id: string };
+    await deleteFolder({ path, id: createdFolder.id });
+  });
 });

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -50,6 +50,7 @@ export const KeyStorePrefixes = {
   WaitUntilReadyProjectEnvironmentOperation: (projectId: string) =>
     `wait-until-ready-project-environments-operation-${projectId}`,
   ProjectEnvironmentLock: (projectId: string) => `project-environment-lock-${projectId}` as const,
+  CreateFolderLock: (envId: string) => `create-folder-lock-${envId}` as const,
   SyncSecretIntegrationLock: (projectId: string, environmentSlug: string, secretPath: string) =>
     `sync-integration-mutex-${projectId}-${environmentSlug}-${secretPath}` as const,
   SyncSecretIntegrationLastRunTimestamp: (projectId: string, environmentSlug: string, secretPath: string) =>

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2313,7 +2313,8 @@ export const registerRoutes = async (
     secretImportDAL,
     secretV2BridgeService,
     reminderDAL,
-    reminderService
+    reminderService,
+    keyStore
   });
 
   const secretSharingService = secretSharingServiceFactory({

--- a/backend/src/services/secret-folder/secret-folder-service.ts
+++ b/backend/src/services/secret-folder/secret-folder-service.ts
@@ -178,7 +178,7 @@ export const secretFolderServiceFactory = ({
     const pathWithFolder = path.join(secretPath, name);
 
     const lock = await keyStore.acquireLock([KeyStorePrefixes.CreateFolderLock(env.id)], 5000, {
-      retryCount: -1,
+      retryCount: 25,
       retryDelay: 200,
       retryJitter: 50
     });

--- a/backend/src/services/secret-folder/secret-folder-service.ts
+++ b/backend/src/services/secret-folder/secret-folder-service.ts
@@ -14,7 +14,7 @@ import { TSecretApprovalPolicyServiceFactory } from "@app/ee/services/secret-app
 import { TSecretApprovalRequestDALFactory } from "@app/ee/services/secret-approval-request/secret-approval-request-dal";
 import { TSecretApprovalRequestSecretDALFactory } from "@app/ee/services/secret-approval-request/secret-approval-request-secret-dal";
 import { TSecretRotationV2DALFactory } from "@app/ee/services/secret-rotation-v2/secret-rotation-v2-dal";
-import { PgSqlLock } from "@app/keystore/keystore";
+import { KeyStorePrefixes, PgSqlLock, TKeyStoreFactory } from "@app/keystore/keystore";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { OrderByDirection, OrgServiceActor } from "@app/lib/types";
 import { ActorType } from "@app/services/auth/auth-type";
@@ -112,6 +112,7 @@ type TSecretFolderServiceFactoryDep = {
   secretV2BridgeService: Pick<TSecretV2BridgeServiceFactory, "dispatchSecretMoveSideEffects">;
   reminderDAL: Pick<TReminderDALFactory, "findSecretReminders" | "delete">;
   reminderService: Pick<TReminderServiceFactory, "batchCreateReminders">;
+  keyStore: Pick<TKeyStoreFactory, "acquireLock">;
 };
 
 export type TSecretFolderServiceFactory = ReturnType<typeof secretFolderServiceFactory>;
@@ -139,7 +140,8 @@ export const secretFolderServiceFactory = ({
   secretImportDAL,
   secretV2BridgeService,
   reminderDAL,
-  reminderService
+  reminderService,
+  keyStore
 }: TSecretFolderServiceFactoryDep) => {
   const createFolder = async ({
     projectId,
@@ -173,146 +175,151 @@ export const secretFolderServiceFactory = ({
       });
     }
 
-    const folder = await folderDAL.transaction(async (tx) => {
-      // the logic is simple we need to avoid creating same folder in same path multiple times
-      // that is this request must be idempotent
-      // so we do a tricky move. we try to find the to be created folder path if that is exactly match return that
-      // else we get some path before that then we will start creating remaining folder
-      await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.CreateFolder(env.id, env.projectId)]);
+    const pathWithFolder = path.join(secretPath, name);
 
-      const pathWithFolder = path.join(secretPath, name);
-      const parentFolder = await folderDAL.findClosestFolder(projectId, environment, pathWithFolder, tx);
+    const lock = await keyStore.acquireLock([KeyStorePrefixes.CreateFolderLock(env.id)], 5000, {
+      retryCount: -1,
+      retryDelay: 200,
+      retryJitter: 50
+    });
 
-      if (!parentFolder) {
-        throw new NotFoundError({
-          message: `Parent folder for path '${pathWithFolder}' not found`
-        });
-      }
+    try {
+      const folder = await folderDAL.transaction(async (tx) => {
+        const parentFolder = await folderDAL.findClosestFolder(projectId, environment, pathWithFolder, tx);
 
-      // exact folder case
-      if (parentFolder.path === pathWithFolder) {
-        throw new BadRequestError({
-          message: `Folder with name '${name}' already exists in path '${secretPath}'`
-        });
-      }
+        if (!parentFolder) {
+          throw new NotFoundError({
+            message: `Parent folder for path '${pathWithFolder}' not found`
+          });
+        }
 
-      let currentParentId = parentFolder.id;
+        // exact folder case
+        if (parentFolder.path === pathWithFolder) {
+          throw new BadRequestError({
+            message: `Folder with name '${name}' already exists in path '${secretPath}'`
+          });
+        }
 
-      // build the full path we need by processing each segment
-      if (parentFolder.path !== secretPath) {
-        const missingSegments = secretPath.substring(parentFolder.path.length).split("/").filter(Boolean);
+        let currentParentId = parentFolder.id;
 
-        const newFolders: TSecretFoldersInsert[] = [];
+        // build the full path we need by processing each segment
+        if (parentFolder.path !== secretPath) {
+          const missingSegments = secretPath.substring(parentFolder.path.length).split("/").filter(Boolean);
 
-        // process each segment sequentially
-        for await (const segment of missingSegments) {
-          const existingSegment = await folderDAL.findOne(
-            {
-              name: segment,
-              parentId: currentParentId,
-              envId: env.id,
-              isReserved: false
-            },
-            tx
-          );
+          const newFolders: TSecretFoldersInsert[] = [];
 
-          if (existingSegment) {
-            // use existing folder and update the path / parent
-            currentParentId = existingSegment.id;
-          } else {
-            const newFolder = {
-              name: segment,
-              parentId: currentParentId,
-              id: uuidv4(),
-              envId: env.id,
-              version: 1
-            };
+          // process each segment sequentially
+          for await (const segment of missingSegments) {
+            const existingSegment = await folderDAL.findOne(
+              {
+                name: segment,
+                parentId: currentParentId,
+                envId: env.id,
+                isReserved: false
+              },
+              tx
+            );
 
-            currentParentId = newFolder.id;
-            newFolders.push(newFolder);
+            if (existingSegment) {
+              // use existing folder and update the path / parent
+              currentParentId = existingSegment.id;
+            } else {
+              const newFolder = {
+                name: segment,
+                parentId: currentParentId,
+                id: uuidv4(),
+                envId: env.id,
+                version: 1
+              };
+
+              currentParentId = newFolder.id;
+              newFolders.push(newFolder);
+            }
+          }
+
+          if (newFolders.length) {
+            const docs = await folderDAL.insertMany(newFolders, tx);
+            const folderVersions = await folderVersionDAL.insertMany(
+              docs.map((doc) => ({
+                name: doc.name,
+                envId: doc.envId,
+                version: doc.version,
+                folderId: doc.id,
+                description: doc.description
+              })),
+              tx
+            );
+            await folderCommitService.createCommit(
+              {
+                actor: {
+                  type: actor,
+                  metadata: {
+                    id: actorId
+                  }
+                },
+                message: "Folder created",
+                folderId: currentParentId,
+                changes: folderVersions.map((fv) => ({
+                  type: CommitType.ADD,
+                  folderVersionId: fv.id
+                }))
+              },
+              tx
+            );
           }
         }
 
-        if (newFolders.length) {
-          const docs = await folderDAL.insertMany(newFolders, tx);
-          const folderVersions = await folderVersionDAL.insertMany(
-            docs.map((doc) => ({
-              name: doc.name,
-              envId: doc.envId,
-              version: doc.version,
-              folderId: doc.id,
-              description: doc.description
-            })),
-            tx
-          );
-          await folderCommitService.createCommit(
-            {
-              actor: {
-                type: actor,
-                metadata: {
-                  id: actorId
-                }
-              },
-              message: "Folder created",
-              folderId: currentParentId,
-              changes: folderVersions.map((fv) => ({
-                type: CommitType.ADD,
-                folderVersionId: fv.id
-              }))
-            },
-            tx
-          );
-        }
-      }
+        const doc = await folderDAL.create(
+          { name, envId: env.id, version: 1, parentId: currentParentId, description },
+          tx
+        );
 
-      const doc = await folderDAL.create(
-        { name, envId: env.id, version: 1, parentId: currentParentId, description },
-        tx
-      );
-
-      const folderVersion = await folderVersionDAL.create(
-        {
-          name: doc.name,
-          envId: doc.envId,
-          version: doc.version,
-          folderId: doc.id,
-          description: doc.description
-        },
-        tx
-      );
-
-      await folderCommitService.createCommit(
-        {
-          actor: {
-            type: actor,
-            metadata: {
-              id: actorId
-            }
+        const folderVersion = await folderVersionDAL.create(
+          {
+            name: doc.name,
+            envId: doc.envId,
+            version: doc.version,
+            folderId: doc.id,
+            description: doc.description
           },
-          message: "Folder created",
-          folderId: parentFolder.id,
-          changes: [
-            {
-              type: CommitType.ADD,
-              folderVersionId: folderVersion.id
-            }
-          ]
-        },
-        tx
-      );
+          tx
+        );
 
-      const [folderWithFullPath] = await folderDAL.findSecretPathByFolderIds(projectId, [doc.id], tx);
+        await folderCommitService.createCommit(
+          {
+            actor: {
+              type: actor,
+              metadata: {
+                id: actorId
+              }
+            },
+            message: "Folder created",
+            folderId: parentFolder.id,
+            changes: [
+              {
+                type: CommitType.ADD,
+                folderVersionId: folderVersion.id
+              }
+            ]
+          },
+          tx
+        );
 
-      if (!folderWithFullPath) {
-        throw new NotFoundError({
-          message: `Failed to retrieve path for folder with ID '${doc.id}'`
-        });
-      }
+        const [folderWithFullPath] = await folderDAL.findSecretPathByFolderIds(projectId, [doc.id], tx);
 
-      return { ...doc, path: folderWithFullPath.path };
-    });
+        if (!folderWithFullPath) {
+          throw new NotFoundError({
+            message: `Failed to retrieve path for folder with ID '${doc.id}'`
+          });
+        }
 
-    return folder;
+        return { ...doc, path: folderWithFullPath.path };
+      });
+
+      return folder;
+    } finally {
+      await lock.release();
+    }
   };
 
   const updateManyFolders = async ({


### PR DESCRIPTION
## Context

This PR converts the postgres lock to redis lock for create folder

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)