### PR TITLE
feat(ui): dismiss selected actions with escape

### DIFF
--- a/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.stories.tsx
+++ b/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "../Button";
@@ -50,5 +51,28 @@ export const Hidden: Story = {
   name: "Example: No Selection",
   args: {
     selectedCount: 0
+  }
+};
+
+export const EscapeClearsSelection: Story = {
+  name: "Interaction: Escape clears selection",
+  render: (args) => {
+    const [selectedCount, setSelectedCount] = useState(args.selectedCount);
+
+    return (
+      <>
+        <div className="fixed top-6 left-6 space-y-2 text-sm text-foreground">
+          <p>Press Escape while this story is focused to clear the selection.</p>
+          <Button size="sm" variant="outline_bg" onClick={() => setSelectedCount(3)}>
+            Restore selection
+          </Button>
+        </div>
+        <SelectedActionBar
+          {...args}
+          selectedCount={selectedCount}
+          onClearSelection={() => setSelectedCount(0)}
+        />
+      </>
+    );
   }
 };

--- a/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.stories.tsx
+++ b/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.stories.tsx
@@ -63,7 +63,7 @@ export const EscapeClearsSelection: Story = {
       <>
         <div className="fixed top-6 left-6 space-y-2 text-sm text-foreground">
           <p>Press Escape while this story is focused to clear the selection.</p>
-          <Button size="sm" variant="outline_bg" onClick={() => setSelectedCount(3)}>
+          <Button size="sm" variant="outline" onClick={() => setSelectedCount(3)}>
             Restore selection
           </Button>
         </div>

--- a/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
+++ b/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
@@ -24,7 +24,33 @@ function SelectedActionBar({
   ...props
 }: SelectedActionBarProps) {
   const isVisible = selectedCount > 0;
+  const clearSelectionRef = React.useRef(onClearSelection);
   const lastVisibleContent = React.useRef({ children, selectedCount, selectionLabel });
+
+  clearSelectionRef.current = onClearSelection;
+
+  React.useEffect(() => {
+    if (!isVisible) return undefined;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.defaultPrevented) return;
+
+      const target = event.target instanceof Element ? event.target : null;
+      const isEditableTarget =
+        target?.closest("input, textarea, select, [contenteditable='true']") ?? false;
+      const isOverlayTarget =
+        target?.closest(
+          '[role="dialog"], [role="menu"], [role="listbox"], [data-slot$="-content"]'
+        ) ?? false;
+
+      if (isEditableTarget || isOverlayTarget) return;
+
+      clearSelectionRef.current();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isVisible]);
 
   if (isVisible) {
     lastVisibleContent.current = { children, selectedCount, selectionLabel };

--- a/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
+++ b/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
@@ -5,6 +5,16 @@ import { cn } from "@app/components/v3/utils";
 
 import { Button } from "../Button";
 
+const OVERLAY_SELECTOR = [
+  '[role="dialog"]',
+  '[role="menu"]',
+  '[role="listbox"]',
+  '[data-slot="dialog-content"]',
+  '[data-slot="popover-content"]',
+  '[data-slot="dropdown-menu-content"]',
+  '[data-slot="select-content"]'
+].join(", ");
+
 type SelectedActionBarProps = Omit<React.ComponentProps<"div">, "children"> & {
   selectedCount: number;
   onClearSelection: () => void;
@@ -38,10 +48,7 @@ function SelectedActionBar({
       const target = event.target instanceof Element ? event.target : null;
       const isEditableTarget =
         target?.closest("input, textarea, select, [contenteditable='true']") ?? false;
-      const isOverlayTarget =
-        target?.closest(
-          '[role="dialog"], [role="menu"], [role="listbox"], [data-slot$="-content"]'
-        ) ?? false;
+      const isOverlayTarget = target?.closest(OVERLAY_SELECTOR) ?? false;
 
       if (isEditableTarget || isOverlayTarget) return;
 


### PR DESCRIPTION
## Context

SelectedActionBar currently requires clicking “Unselect All” to clear an active multi-selection. This adds Escape-key dismissal in the shared v3 component, invoking the same consumer-provided clear-selection callback while the bar is visible. Escape remains available to higher-priority dialogs, menus, popovers, selects, and editable controls.

Related ticket: ENG-5511

## Screenshots

No screenshot captured. The change is keyboard behavior; the focused Storybook story `Generic/SelectedActionBar → Interaction: Escape clears selection` provides the UI evidence.

## Steps to verify the change

1. Open the `Generic/SelectedActionBar` Storybook stories.
2. Open `Interaction: Escape clears selection`.
3. Confirm the selection bar is visible.
4. Press Escape and confirm the bar dismisses.
5. Click `Restore selection`, open an overlay or focus an editable control, and press Escape; confirm the overlay/control retains Escape precedence and selection is not cleared unexpectedly.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.com/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)