### PR TITLE
fix(frontend): improve command input accessibility

### DIFF
--- a/frontend/src/components/v3/generic/Command/Command.stories.tsx
+++ b/frontend/src/components/v3/generic/Command/Command.stories.tsx
@@ -26,7 +26,7 @@ import {
 } from "./Command";
 
 /**
- * Command renders a fuzzy-searchable command palette — an input paired with a scrollable
+ * Command renders a searchable command palette — an input paired with a scrollable
  * list of items the user can navigate with keyboard or pointer. Built on `cmdk`.
  * Compose items into `CommandGroup`s (with optional headings) and separate groups with
  * `CommandSeparator`. Wrap in `CommandDialog` for a global `⌘K`-style overlay, or inline
@@ -57,13 +57,13 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          "The baseline command palette — input + list + grouped items. Typing filters the list via the default fuzzy matcher (matches on value and any `keywords` passed to each item)."
+          "The baseline command palette — input + list + grouped items. Typing filters the list via the default case-insensitive substring matcher (matching the value and any `keywords` passed to each item)."
       }
     }
   },
   render: () => (
     <Command className="w-80 border border-border">
-      <CommandInput placeholder="Type a command or search..." />
+      <CommandInput aria-label="Search commands" placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
         <CommandGroup heading="Suggestions">
@@ -97,7 +97,7 @@ export const WithGroups: Story = {
   },
   render: () => (
     <Command className="w-80 border border-border">
-      <CommandInput placeholder="Type a command or search..." />
+      <CommandInput aria-label="Search commands" placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
         <CommandGroup heading="Suggestions">
@@ -142,7 +142,7 @@ export const WithShortcuts: Story = {
   },
   render: () => (
     <Command className="w-80 border border-border">
-      <CommandInput placeholder="Type a command or search..." />
+      <CommandInput aria-label="Search commands" placeholder="Type a command or search..." />
       <CommandList>
         <CommandEmpty>No results found.</CommandEmpty>
         <CommandGroup heading="Actions">
@@ -176,7 +176,7 @@ const AsDialogStory = () => {
         <CommandShortcut>⌘K</CommandShortcut>
       </Button>
       <CommandDialog className="max-w-lg" open={open} onOpenChange={setOpen}>
-        <CommandInput placeholder="Type a command or search..." />
+        <CommandInput aria-label="Search commands" placeholder="Type a command or search..." />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Suggestions">
@@ -241,7 +241,7 @@ const InPopoverStory = () => {
       </PopoverTrigger>
       <PopoverContent align="start" sideOffset={4} className="w-80 p-0">
         <Command>
-          <CommandInput placeholder="Search organizations..." />
+          <CommandInput aria-label="Search organizations" placeholder="Search organizations..." />
           <CommandList>
             <CommandEmpty>No organizations found.</CommandEmpty>
             <CommandGroup heading="Organizations">

--- a/frontend/src/components/v3/generic/DataGrid/data-grid-cell-variants.tsx
+++ b/frontend/src/components/v3/generic/DataGrid/data-grid-cell-variants.tsx
@@ -1184,6 +1184,7 @@ export function MultiSelectCell<TData>({
                   );
                 })}
                 <CommandInput
+                  aria-label="Search options"
                   ref={inputRef}
                   value={searchValue}
                   onValueChange={setSearchValue}

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -450,7 +450,10 @@ export const Navbar = () => {
                 </PopoverTrigger>
                 <PopoverContent align="start" sideOffset={20} className="w-96 p-0">
                   <Command>
-                    <CommandInput placeholder="Search organizations..." />
+                    <CommandInput
+                      aria-label="Search organizations"
+                      placeholder="Search organizations..."
+                    />
                     <CommandList>
                       <CommandEmpty>No organizations found.</CommandEmpty>
                       {/* Current Organization */}

--- a/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ApplicationSelect.tsx
+++ b/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ApplicationSelect.tsx
@@ -71,6 +71,7 @@ const ApplicationSelectInner = ({
         <PopoverContent align="start" sideOffset={20} className="w-96 p-0">
           <Command shouldFilter={false}>
             <CommandInput
+              aria-label="Search applications"
               placeholder="Search applications..."
               value={search}
               onValueChange={setSearch}

--- a/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ProjectSelect.tsx
+++ b/frontend/src/layouts/ProjectLayout/components/ProjectSelect/ProjectSelect.tsx
@@ -132,7 +132,7 @@ const ProjectSelectInner = () => {
         </PopoverTrigger>
         <PopoverContent align="start" sideOffset={20} className="w-96 p-0">
           <Command>
-            <CommandInput placeholder="Search projects..." />
+            <CommandInput aria-label="Search projects" placeholder="Search projects..." />
             <CommandList>
               <CommandEmpty>No projects found.</CommandEmpty>
               <CommandGroup heading="Projects">

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/AssignCertificateToApplicationModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/AssignCertificateToApplicationModal.tsx
@@ -100,6 +100,7 @@ export const AssignCertificateToApplicationModal = ({ isOpen, onClose, certifica
               <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
                 <Command shouldFilter={false}>
                   <CommandInput
+                    aria-label="Search applications"
                     placeholder="Search applications..."
                     value={search}
                     onValueChange={setSearch}

--- a/frontend/src/pages/organization/RoleByIDPage/components/RolePermissionsSection/OrgPolicySelectionModal.tsx
+++ b/frontend/src/pages/organization/RoleByIDPage/components/RolePermissionsSection/OrgPolicySelectionModal.tsx
@@ -48,7 +48,7 @@ const Content = ({ invalidSubjects }: { invalidSubjects?: string[] }) => {
         return 0;
       }}
     >
-      <CommandInput placeholder="Search policies..." />
+      <CommandInput aria-label="Search policies" placeholder="Search policies..." />
       <CommandList>
         <CommandEmpty>No policies found.</CommandEmpty>
         <CommandGroup>

--- a/frontend/src/pages/pam/PamAccountsPage/components/RotationTab.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/RotationTab.tsx
@@ -101,7 +101,7 @@ const RotationAccountPicker = ({
       </PopoverTrigger>
       <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0" align="start">
         <Command>
-          <CommandInput placeholder="Search accounts..." />
+          <CommandInput aria-label="Search accounts" placeholder="Search accounts..." />
           <CommandList>
             {isPending ? (
               <div className="p-2">

--- a/frontend/src/pages/pam/PamDataExplorerPage/components/SortPopover.tsx
+++ b/frontend/src/pages/pam/PamDataExplorerPage/components/SortPopover.tsx
@@ -73,7 +73,7 @@ export const SortPopover = ({
           </button>
         </div>
         <Command>
-          <CommandInput placeholder="Search columns..." />
+          <CommandInput aria-label="Search columns" placeholder="Search columns..." />
           <CommandList>
             <CommandEmpty>No matching columns</CommandEmpty>
             <CommandGroup>

--- a/frontend/src/pages/project/AccessControlPage/components/GroupsTab/components/GroupsSection/GroupRoles.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/GroupsTab/components/GroupsSection/GroupRoles.tsx
@@ -290,7 +290,7 @@ const GroupRolesForm = ({ projectRoles, roles, groupId, onClose }: FormProps) =>
   return (
     <form onSubmit={handleSubmit(handleRoleUpdate)} id="role-update-form">
       <Command>
-        <CommandInput placeholder="Search roles..." />
+        <CommandInput aria-label="Search roles" placeholder="Search roles..." />
         <CommandList>
           <CommandEmpty>No roles found</CommandEmpty>
           <CommandGroup>

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/PolicySelectionModal.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/PolicySelectionModal.tsx
@@ -104,7 +104,7 @@ const Content = ({
         return 0;
       }}
     >
-      <CommandInput placeholder="Search policies..." />
+      <CommandInput aria-label="Search policies" placeholder="Search policies..." />
       <CommandList>
         <CommandEmpty>No policies found.</CommandEmpty>
         <CommandGroup>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/EnvironmentSelect/EnvironmentSelect.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/EnvironmentSelect/EnvironmentSelect.tsx
@@ -140,6 +140,7 @@ export function EnvironmentSelect({ selectedEnvs, setSelectedEnvs, isDisabled }:
         <PopoverContent align="start" className="p-0">
           <Command>
             <CommandInput
+              aria-label="Filter environments"
               value={inputValue}
               onValueChange={setInputValue}
               placeholder="Filter environments"

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretAccessInsights.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretAccessInsights.tsx
@@ -325,7 +325,7 @@ function AddMemberPopover({
       </PopoverTrigger>
       <PopoverContent onWheel={(e) => e.stopPropagation()} align="end" className="w-lg p-0">
         <Command>
-          <CommandInput placeholder="Search users..." />
+          <CommandInput aria-label="Search users" placeholder="Search users..." />
           <CommandList>
             <CommandEmpty>No users available to add.</CommandEmpty>
             {availableOrgUsers.length > 0 && (

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
@@ -136,6 +136,7 @@ const FilterMenu = ({
       <PopoverContent align="end" className="w-[220px] p-0">
         <Command>
           <CommandInput
+            aria-label={searchPlaceholder}
             value={inputValue}
             onValueChange={setInputValue}
             placeholder={searchPlaceholder}

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/EnvironmentFilterSelect.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/EnvironmentFilterSelect.tsx
@@ -56,6 +56,7 @@ export const EnvironmentFilterSelect = ({
       <PopoverContent align="start" className="w-[240px] p-0">
         <Command>
           <CommandInput
+            aria-label="Filter environments"
             value={inputValue}
             onValueChange={setInputValue}
             placeholder="Filter environments"

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/SecretApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/SecretApprovalRequest.tsx
@@ -134,6 +134,7 @@ const FilterMenu = ({
       <PopoverContent align="end" className="w-[220px] p-0">
         <Command>
           <CommandInput
+            aria-label={searchPlaceholder}
             value={inputValue}
             onValueChange={setInputValue}
             placeholder={searchPlaceholder}


### PR DESCRIPTION
## Context

The shared Command component was used with placeholder-only search inputs, leaving production search controls without explicit accessible names. Its Storybook documentation also described the default matcher as fuzzy even though the implementation performs case-insensitive substring matching.

This PR adds explicit `aria-label` values to all production and Storybook `CommandInput` usages and corrects the filtering documentation. There are no intentional visual changes.

## Screenshots

Not applicable: this is an accessibility metadata and documentation-only change with no visual UI changes.

## Steps to verify the change

1. Inspect the changed `CommandInput` usages and confirm each has an explicit `aria-label`.
2. Open the Command Storybook stories and confirm the default filtering description says case-insensitive substring matching.
3. Run the frontend validation commands when frontend dependencies are available.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`.
- [ ] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)