### PR TITLE
fix: derive bucket timestamp from audit log when streaming

### DIFF
--- a/backend/src/ee/services/audit-log-stream/audit-log-stream-fns.ts
+++ b/backend/src/ee/services/audit-log-stream/audit-log-stream-fns.ts
@@ -17,6 +17,17 @@ import { getSumoLogicProviderListItem } from "./sumo-logic/sumo-logic-provider-f
 export const blockAuditLogStreamInternalIps = (url: string) =>
   blockLocalAndPrivateIpAddresses(url, false, getConfig().AUDIT_LOG_STREAM_ALLOW_INTERNAL_IP);
 
+// The instant a provider should report the event at. Delivery can lag the event by minutes
+// (retry backoff tops out around 240s) or by months during a backfill, so a provider that
+// stamps its own send time misdates the record. Falls back to now for payloads that carry no
+// createdAt
+export const resolveEventTimestamp = (event: { createdAt?: Date | string | null }): Date => {
+  if (!event.createdAt) return new Date();
+
+  const createdAt = new Date(event.createdAt);
+  return Number.isNaN(createdAt.getTime()) ? new Date() : createdAt;
+};
+
 export const listProviderOptions = () => {
   return [
     getDatadogProviderListItem(),

--- a/backend/src/ee/services/audit-log-stream/datadog/datadog-provider-factory.test.ts
+++ b/backend/src/ee/services/audit-log-stream/datadog/datadog-provider-factory.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { TAuditLogs } from "@app/db/schemas";
+
+import { DatadogProviderFactory } from "./datadog-provider-factory";
+import { TDatadogProviderCredentials } from "./datadog-provider-types";
+
+const { sentRequests } = vi.hoisted(() => ({
+  sentRequests: [] as { body: string; contentType: string }[]
+}));
+
+vi.mock("@app/lib/config/env", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/config/env")>()),
+  getConfig: () => ({
+    SITE_URL: "https://app.infisical.com",
+    NODE_ENV: "production",
+    AUDIT_LOG_STREAM_ALLOW_INTERNAL_IP: false
+  })
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}));
+
+// Only the hostname check is stubbed, because the real one needs DNS. resolveEventTimestamp
+// stays real so the timestamp assertions exercise actual behaviour.
+vi.mock("../audit-log-stream-fns", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../audit-log-stream-fns")>()),
+  blockAuditLogStreamInternalIps: vi.fn(async () => undefined)
+}));
+
+// Captures the body post-transformRequest, i.e. the exact bytes that go on the wire.
+vi.mock("@app/lib/config/request", async () => {
+  const { default: axios } = await vi.importActual<typeof import("axios")>("axios");
+
+  return {
+    request: axios.create({
+      adapter: async (config) => {
+        sentRequests.push({
+          body: config.data as string,
+          contentType: String(config.headers["Content-Type"])
+        });
+
+        return { data: {}, status: 200, statusText: "OK", headers: {}, config };
+      }
+    })
+  };
+});
+
+const CREDENTIALS: TDatadogProviderCredentials = {
+  url: "https://http-intake.logs.datadoghq.com/api/v2/logs",
+  token: "dd-api-key"
+} as TDatadogProviderCredentials;
+
+const buildLog = (idx: number) =>
+  ({
+    id: `log-${idx}`,
+    event: { type: "get-secrets" },
+    createdAt: new Date(Date.UTC(2026, 5, 11, 22, 7, 30, 732) + idx * 1_000).toISOString()
+  }) as unknown as TAuditLogs;
+
+describe("DatadogProviderFactory batchStreamLog", () => {
+  beforeEach(() => {
+    sentRequests.length = 0;
+  });
+
+  test("sends nothing for an empty batch", async () => {
+    await DatadogProviderFactory().batchStreamLog({ credentials: CREDENTIALS, auditLogs: [] });
+
+    expect(sentRequests).toHaveLength(0);
+  });
+
+  test("sends a JSON array of events, one entry per log", async () => {
+    const auditLogs = [buildLog(0), buildLog(1), buildLog(2)];
+
+    await DatadogProviderFactory().batchStreamLog({ credentials: CREDENTIALS, auditLogs });
+
+    expect(sentRequests).toHaveLength(1);
+    const { body, contentType } = sentRequests[0];
+    expect(contentType).toBe("application/json");
+    expect(body.startsWith("[")).toBe(true);
+
+    const events = JSON.parse(body) as Record<string, unknown>[];
+    expect(events).toHaveLength(3);
+    expect(events.map((entry) => entry.id)).toEqual(["log-0", "log-1", "log-2"]);
+    events.forEach((entry) =>
+      expect(entry).toMatchObject({
+        ddsource: "infisical",
+        service: "infisical",
+        ddtags: "env:production",
+        hostname: "app.infisical.com"
+      })
+    );
+  });
+
+  // Datadog's date remapper reads `timestamp` but not `createdAt`, so without this field the
+  // log is stamped when Datadog receives it rather than when the event happened.
+  test("carries a remappable timestamp taken from the event's createdAt", async () => {
+    const auditLogs = [buildLog(0), buildLog(1)];
+
+    await DatadogProviderFactory().batchStreamLog({ credentials: CREDENTIALS, auditLogs });
+
+    const events = JSON.parse(sentRequests[0].body) as Record<string, unknown>[];
+    expect(events.map((entry) => entry.timestamp)).toEqual(["2026-06-11T22:07:30.732Z", "2026-06-11T22:07:31.732Z"]);
+  });
+
+  test("falls back to the current time when the log carries no createdAt", async () => {
+    const before = Date.now();
+    const auditLog = { id: "log-x", event: { type: "get-secrets" } } as unknown as TAuditLogs;
+
+    await DatadogProviderFactory().batchStreamLog({ credentials: CREDENTIALS, auditLogs: [auditLog] });
+
+    const [entry] = JSON.parse(sentRequests[0].body) as Record<string, unknown>[];
+    const stamped = Date.parse(entry.timestamp as string);
+    expect(stamped).toBeGreaterThanOrEqual(before);
+    expect(stamped).toBeLessThanOrEqual(Date.now());
+  });
+});

--- a/backend/src/ee/services/audit-log-stream/datadog/datadog-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/datadog/datadog-provider-factory.ts
@@ -5,7 +5,7 @@ import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 
 import { AUDIT_LOG_STREAM_BATCH_TIMEOUT, AUDIT_LOG_STREAM_TIMEOUT } from "../../audit-log/audit-log-queue";
-import { blockAuditLogStreamInternalIps } from "../audit-log-stream-fns";
+import { blockAuditLogStreamInternalIps, resolveEventTimestamp } from "../audit-log-stream-fns";
 import {
   TLogStreamFactoryBatchStreamLog,
   TLogStreamFactoryGetProviderBatchLimit,
@@ -13,13 +13,14 @@ import {
 } from "../audit-log-stream-types";
 import { TDatadogProviderCredentials } from "./datadog-provider-types";
 
-function createPayload(event: Record<string, unknown>) {
+function createPayload(event: Record<string, unknown> & { createdAt?: Date | string }) {
   const appCfg = getConfig();
 
   const ddtags = [`env:${appCfg.NODE_ENV || "unknown"}`].join(",");
 
   return {
     ...event,
+    timestamp: resolveEventTimestamp(event).toISOString(),
     hostname: new URL(appCfg.SITE_URL || "http://infisical").hostname,
     ddsource: "infisical",
     service: "infisical",

--- a/backend/src/ee/services/audit-log-stream/splunk/splunk-provider-factory.test.ts
+++ b/backend/src/ee/services/audit-log-stream/splunk/splunk-provider-factory.test.ts
@@ -18,8 +18,10 @@ vi.mock("@app/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }));
 
-// The real helper resolves the hostname to check it isn't internal, which needs DNS.
-vi.mock("../audit-log-stream-fns", () => ({
+// Only the hostname check is stubbed, because the real one needs DNS. resolveEventTimestamp
+// stays real so the timestamp assertions exercise actual behaviour.
+vi.mock("../audit-log-stream-fns", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../audit-log-stream-fns")>()),
   blockAuditLogStreamInternalIps: vi.fn(async () => undefined)
 }));
 
@@ -79,7 +81,14 @@ const readConcatenatedJson = (raw: string): Record<string, unknown>[] => {
 
 const CREDENTIALS: TSplunkProviderCredentials = { hostname: "hec.example.com", token: "hec-token" };
 
-const buildLog = (idx: number) => ({ id: `log-${idx}`, event: { type: "get-secrets" } }) as unknown as TAuditLogs;
+// createdAt is a string, not a Date: the payload reaches a provider after a jsonb round trip
+// through the outbox, so that is the shape production actually delivers.
+const buildLog = (idx: number) =>
+  ({
+    id: `log-${idx}`,
+    event: { type: "get-secrets" },
+    createdAt: new Date(Date.UTC(2026, 5, 11, 22, 7, 30, 732) + idx * 1_000).toISOString()
+  }) as unknown as TAuditLogs;
 
 describe("SplunkProviderFactory batchStreamLog", () => {
   beforeEach(() => {
@@ -115,5 +124,27 @@ describe("SplunkProviderFactory batchStreamLog", () => {
       expect(entry).toMatchObject({ source: "infisical", sourcetype: "_json", host: "app.infisical.com" });
       expect(typeof entry.time).toBe("number");
     });
+  });
+
+  test("stamps HEC time from the event's createdAt, not the time of delivery", async () => {
+    const auditLogs = [buildLog(0), buildLog(1)];
+
+    await SplunkProviderFactory().batchStreamLog({ credentials: CREDENTIALS, auditLogs });
+
+    const events = readConcatenatedJson(sentRequests[0].body);
+    // Epoch seconds carrying the millisecond fraction, which HEC accepts to 3 decimals.
+    // 1781215650.732 is 2026-06-11T22:07:30.732Z, the createdAt of buildLog(0).
+    expect(events.map((entry) => entry.time)).toEqual([1781215650.732, 1781215651.732]);
+  });
+
+  test("falls back to the current time when the log carries no createdAt", async () => {
+    const before = Date.now() / 1000;
+    const auditLog = { id: "log-x", event: { type: "get-secrets" } } as unknown as TAuditLogs;
+
+    await SplunkProviderFactory().batchStreamLog({ credentials: CREDENTIALS, auditLogs: [auditLog] });
+
+    const [entry] = readConcatenatedJson(sentRequests[0].body);
+    expect(entry.time as number).toBeGreaterThanOrEqual(before);
+    expect(entry.time as number).toBeLessThanOrEqual(Date.now() / 1000);
   });
 });

--- a/backend/src/ee/services/audit-log-stream/splunk/splunk-provider-factory.ts
+++ b/backend/src/ee/services/audit-log-stream/splunk/splunk-provider-factory.ts
@@ -5,7 +5,7 @@ import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 
 import { AUDIT_LOG_STREAM_BATCH_TIMEOUT, AUDIT_LOG_STREAM_TIMEOUT } from "../../audit-log/audit-log-queue";
-import { blockAuditLogStreamInternalIps } from "../audit-log-stream-fns";
+import { blockAuditLogStreamInternalIps, resolveEventTimestamp } from "../audit-log-stream-fns";
 import {
   TLogStreamFactoryBatchStreamLog,
   TLogStreamFactoryGetProviderBatchLimit,
@@ -13,11 +13,11 @@ import {
 } from "../audit-log-stream-types";
 import { TSplunkProviderCredentials } from "./splunk-provider-types";
 
-function createPayload(event: Record<string, unknown>) {
+function createPayload(event: Record<string, unknown> & { createdAt?: Date | string }) {
   const appCfg = getConfig();
 
   return {
-    time: Math.floor(Date.now() / 1000),
+    time: resolveEventTimestamp(event).getTime() / 1000,
     ...(appCfg.SITE_URL && { host: new URL(appCfg.SITE_URL).host }),
     source: "infisical",
     sourcetype: "_json",


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)