### PR TITLE
feat(ui): rework organization shell navigation

### DIFF
--- a/frontend/src/components/v3/generic/Command/GlobalCommandMenu.tsx
+++ b/frontend/src/components/v3/generic/Command/GlobalCommandMenu.tsx
@@ -15,6 +15,7 @@ import {
 } from "./Command";
 
 const APPLE_PLATFORM_PATTERN = /Mac|iPhone|iPad|iPod/i;
+const GLOBAL_COMMAND_MENU_OPEN_EVENT = "infisical:open-command-menu";
 const SHORTCUT_EXCLUSION_SELECTOR =
   '[data-command-menu-shortcut="ignore"], [contenteditable]:not([contenteditable="false"]), .cm-editor, .monaco-editor, .xterm';
 
@@ -55,6 +56,12 @@ const usesAppleCommandKey = () => {
   if (typeof navigator === "undefined") return false;
   return APPLE_PLATFORM_PATTERN.test(`${navigator.platform} ${navigator.userAgent}`);
 };
+
+export const openGlobalCommandMenu = () => {
+  window.dispatchEvent(new Event(GLOBAL_COMMAND_MENU_OPEN_EVENT));
+};
+
+export const getGlobalCommandMenuShortcutLabel = () => (usesAppleCommandKey() ? "⌘K" : "Ctrl K");
 
 const isGlobalCommandShortcut = (event: KeyboardEvent) => {
   if (
@@ -195,7 +202,13 @@ export const GlobalCommandMenu = ({
     };
 
     window.addEventListener("keydown", handleKeyDown, true);
-    return () => window.removeEventListener("keydown", handleKeyDown, true);
+    const handleOpenRequest = () => setOpen(true);
+    window.addEventListener(GLOBAL_COMMAND_MENU_OPEN_EVENT, handleOpenRequest);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown, true);
+      window.removeEventListener(GLOBAL_COMMAND_MENU_OPEN_EVENT, handleOpenRequest);
+    };
   }, [isEnabled, setOpen]);
 
   const goBack = () => {

--- a/frontend/src/components/v3/platform/RootCommandMenu/RootCommandMenu.tsx
+++ b/frontend/src/components/v3/platform/RootCommandMenu/RootCommandMenu.tsx
@@ -381,6 +381,16 @@ const getOrganizationItems = ({
       navigate({ to: "/organizations/$orgId/integrations", params: { orgId: organizationId } })
   },
   {
+    id: `organization-${organizationId}-pam`,
+    label: "PAM",
+    breadcrumb: `${organizationName} / Organization`,
+    icon: UsersIcon,
+    keywords: ["privileged access", "accounts", "sessions"],
+    priority: 25,
+    onSelect: () =>
+      navigate({ to: "/organizations/$orgId/pam/access", params: { orgId: organizationId } })
+  },
+  {
     id: `organization-${organizationId}-access-control`,
     label: "Access Control",
     breadcrumb: `${organizationName} / Organization`,
@@ -428,6 +438,33 @@ const getOrganizationItems = ({
         to: "/organizations/$orgId/settings",
         params: { orgId: organizationId },
         search: { selectedTab: "tab-org-general" }
+      })
+  },
+  {
+    id: `organization-${organizationId}-secrets-product-settings`,
+    label: "Secrets Product Settings",
+    breadcrumb: `${organizationName} / Product Settings`,
+    icon: SettingsIcon,
+    keywords: ["secrets management", "organization settings", "product"],
+    priority: 25,
+    onSelect: () =>
+      navigate({
+        to: "/organizations/$orgId/projects/secret-management/product-settings",
+        params: { orgId: organizationId }
+      })
+  },
+  {
+    id: `organization-${organizationId}-pki-product-settings`,
+    label: "PKI Product Settings",
+    breadcrumb: `${organizationName} / Product Settings`,
+    icon: SettingsIcon,
+    keywords: ["certificate manager", "pki", "organization settings", "product"],
+    priority: 25,
+    onSelect: () =>
+      navigate({
+        to: "/organizations/$orgId/settings",
+        params: { orgId: organizationId },
+        search: { selectedTab: "product-settings" }
       })
   }
 ];

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -9,8 +9,6 @@ import {
   ChevronLeft,
   ChevronsUpDown,
   CircleHelp,
-  Clipboard,
-  ExternalLink,
   Github,
   Infinity,
   Info,
@@ -20,7 +18,6 @@ import {
   Settings,
   Slack,
   TriangleAlertIcon,
-  User,
   UserPlus,
   Users
 } from "lucide-react";
@@ -28,7 +25,6 @@ import { twMerge } from "tailwind-merge";
 
 import { AnnouncementNavButton } from "@app/components/announcements/AnnouncementNavButton";
 import { Mfa } from "@app/components/auth/Mfa";
-import { createNotification } from "@app/components/notifications";
 import { NewSubOrganizationModal } from "@app/components/organization/NewSubOrganizationModal";
 import { OrgPermissionCan } from "@app/components/permissions";
 import SecurityClient from "@app/components/utilities/SecurityClient";
@@ -61,7 +57,7 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
-import { SidebarTrigger } from "@app/components/v3/generic/Sidebar";
+import { SidebarTrigger, useSidebar } from "@app/components/v3/generic/Sidebar";
 import { envConfig } from "@app/config/env";
 import {
   OrgPermissionActions,
@@ -85,7 +81,6 @@ import {
 import { appConnectionKeys } from "@app/hooks/api/appConnections";
 import { authKeys, selectOrganization } from "@app/hooks/api/auth/queries";
 import { MfaMethod } from "@app/hooks/api/auth/types";
-import { getAuthToken } from "@app/hooks/api/reactQuery";
 import { getSubscriptionPlanLabel } from "@app/hooks/api/subscriptions";
 import { SubscriptionPlanTypes } from "@app/hooks/api/subscriptions/types";
 import { Organization } from "@app/hooks/api/types";
@@ -98,7 +93,7 @@ import { TypeSelect } from "@app/layouts/ProjectLayout/components/TypeSelect";
 import { navigateUserToOrg } from "@app/pages/auth/LoginPage/Login.utils";
 
 import { ServerAdminsPanel } from "../ServerAdminsPanel/ServerAdminsPanel";
-import { NotificationDropdown } from "./NotificationDropdown";
+import { ProductLauncher } from "./ProductLauncher";
 import { VersionBadge } from "./VersionBadge";
 
 const getFormattedSupportEmailLink = (variables: {
@@ -140,8 +135,18 @@ export const INFISICAL_SUPPORT_OPTIONS = [
   [Users, "Instance Admins", () => "server-admins"]
 ] as const;
 
+const getOrganizationLocationLabel = (pathname: string) => {
+  if (pathname.includes("/integrations")) return "Integrations";
+  if (pathname.includes("/access-management")) return "Access Control";
+  if (pathname.includes("/audit-logs")) return "Audit Logs";
+  if (pathname.includes("/billing")) return "Usage & Billing";
+  if (pathname.includes("/settings")) return "Settings";
+  return "Projects";
+};
+
 export const Navbar = () => {
   const { user } = useUser();
+  const { state: sidebarState, isMobile: isSidebarMobile } = useSidebar();
   const { subscription } = useSubscription();
   const { currentOrg, isSubOrganization } = useOrganization();
   const { config: serverConfig } = useServerConfig();
@@ -283,19 +288,6 @@ export const Navbar = () => {
     }
   };
 
-  const handleCopyToken = async () => {
-    try {
-      await window.navigator.clipboard.writeText(getAuthToken());
-      createNotification({
-        type: "success",
-        text: "Copied current login session token to clipboard"
-      });
-    } catch (error) {
-      console.log(error);
-      createNotification({ type: "error", text: "Failed to copy user token to clipboard" });
-    }
-  };
-
   if (shouldShowMfa) {
     return (
       <Mfa
@@ -346,7 +338,7 @@ export const Navbar = () => {
   return (
     <div
       className={twMerge(
-        "z-10 flex min-h-12 items-center border-b border-border bg-gradient-to-br to-transparent",
+        "z-10 flex h-14 min-h-14 items-center border-b border-border bg-gradient-to-br to-transparent",
         isServerAdminPanel && "from-admin/5",
         !isServerAdminPanel && isPamScope && "from-product-pam/5",
         !isServerAdminPanel && isProjectScope && !isPamScope && "from-project/5",
@@ -383,8 +375,10 @@ export const Navbar = () => {
           <>
             <div
               className={twMerge(
-                "flex h-full min-w-0 items-center overflow-hidden border-border pr-2 pl-4 transition-all duration-300 ease-in-out",
-                isProjectScope ? "mr-2 w-[72px] border-r" : "mr-4 w-96 max-w-96"
+                "mr-4 flex h-full min-w-0 shrink-0 items-center overflow-hidden border-r border-border pr-2 pl-4 transition-all duration-200 ease-linear",
+                sidebarState === "collapsed" && !isSidebarMobile
+                  ? "w-(--sidebar-width-icon) px-2"
+                  : "w-(--sidebar-width)"
               )}
             >
               <Popover open={isOrgSelectOpen} onOpenChange={setIsOrgSelectOpen}>
@@ -593,6 +587,11 @@ export const Navbar = () => {
                 </PopoverContent>
               </Popover>
             </div>
+            {!isProjectScope && (
+              <span className="truncate text-sm font-medium text-foreground">
+                {getOrganizationLocationLabel(location.pathname)}
+              </span>
+            )}
             {isProjectScope && (
               <>
                 <TypeSelect />
@@ -604,6 +603,7 @@ export const Navbar = () => {
         )}
       </div>
 
+      {!isServerAdminPanel && <ProductLauncher />}
       <VersionBadge />
       {subscription &&
       subscription.slug === SubscriptionPlanTypes.Starter &&
@@ -724,86 +724,6 @@ export const Navbar = () => {
           </DropdownMenuContent>
         </DropdownMenu>
         <AnnouncementNavButton />
-        <NotificationDropdown />
-        <DropdownMenu modal={false}>
-          <DropdownMenuTrigger asChild>
-            <IconButton variant="outline" size="sm" aria-label="User menu">
-              <User />
-            </IconButton>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent side="bottom" align="end" sideOffset={8}>
-            <div className="cursor-default px-3 py-2">
-              <div className="text-sm font-medium capitalize">
-                {user?.firstName} {user?.lastName}
-              </div>
-              <div className="text-muted-foreground text-xs">{user.email}</div>
-            </div>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <Link to="/personal-settings">
-                <Settings className="size-4" />
-                Personal Settings
-              </Link>
-            </DropdownMenuItem>
-            <OrgPermissionCan I={OrgPermissionActions.Create} a={OrgPermissionSubjects.Member}>
-              {(isAllowed) =>
-                isAllowed ? (
-                  <DropdownMenuItem asChild>
-                    <Link
-                      to="/organizations/$orgId/access-management"
-                      params={{ orgId: currentOrg.id }}
-                      search={{
-                        selectedTab: "members",
-                        action: "invite-members"
-                      }}
-                    >
-                      <UserPlus />
-                      Invite Users
-                    </Link>
-                  </DropdownMenuItem>
-                ) : null
-              }
-            </OrgPermissionCan>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <a
-                href="https://infisical.com/docs/documentation/getting-started/introduction"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Book />
-                Documentation
-                <ExternalLink className="ml-auto size-3.5 opacity-50" />
-              </a>
-            </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <a href="https://infisical.com/slack" target="_blank" rel="noopener noreferrer">
-                <Slack />
-                Join Slack Community
-                <ExternalLink className="ml-auto size-3.5 opacity-50" />
-              </a>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={handleCopyToken}>
-              <Clipboard />
-              Copy Token
-              <Tooltip>
-                <TooltipTrigger>
-                  <Info className="size-3.5 opacity-50" />
-                </TooltipTrigger>
-                <TooltipContent className="max-w-xs">
-                  This token is linked to your current login session and can only access resources
-                  within the organization you&apos;re currently logged into.
-                </TooltipContent>
-              </Tooltip>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={logOutUser}>
-              <LogOut />
-              Log Out
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </ButtonGroup>
 
       <Modal

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/NotificationDropdown.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/NotificationDropdown.tsx
@@ -21,7 +21,13 @@ import { isCriticalNotification } from "@app/hooks/api/notifications/types";
 
 import { Notification } from "./Notification";
 
-export const NotificationDropdown = () => {
+export const NotificationDropdown = ({
+  side = "bottom",
+  align = "end"
+}: {
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+}) => {
   const router = useRouter();
 
   const { data: notifications, isLoading } = useGetMyNotifications();
@@ -55,9 +61,10 @@ export const NotificationDropdown = () => {
         </IconButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent
-        align="end"
-        side="bottom"
-        className="z-999 mt-3 flex h-[550px] w-[400px] overflow-hidden rounded-lg"
+        align={align}
+        side={side}
+        sideOffset={8}
+        className="z-999 flex h-[550px] w-[400px] max-w-[calc(100vw-1rem)] overflow-hidden rounded-lg"
       >
         <div className="flex w-full flex-col">
           <div className="flex items-center justify-between border-b border-mineshaft-500 px-3 py-2">

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/ProductLauncher.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/ProductLauncher.tsx
@@ -1,0 +1,224 @@
+import { useState } from "react";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
+import {
+  FileKey,
+  KeyRound,
+  LockKeyhole,
+  MoreHorizontal,
+  Radar,
+  Server,
+  Share2,
+  SlidersHorizontal,
+  Users
+} from "lucide-react";
+
+import { CertManagerNotConfiguredModal } from "@app/components/projects/CertManagerNotConfiguredModal";
+import {
+  Button,
+  ButtonGroup,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from "@app/components/v3";
+import { useOrganization } from "@app/context";
+import { useCertManagerInstanceState } from "@app/hooks/api/certManagerInstance";
+
+export const ProductLauncher = () => {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const { currentOrg } = useOrganization();
+  const { data: certManagerInstance, isPending: isCertManagerPending } =
+    useCertManagerInstanceState();
+  const [isCertManagerSetupOpen, setIsCertManagerSetupOpen] = useState(false);
+
+  const openCertificateManager = () => {
+    if (isCertManagerPending) return;
+
+    if (!certManagerInstance?.activeProjectId) {
+      setIsCertManagerSetupOpen(true);
+      return;
+    }
+
+    navigate({
+      to: "/organizations/$orgId/projects/cert-manager/$projectId/overview",
+      params: { orgId: currentOrg.id, projectId: certManagerInstance.activeProjectId }
+    });
+  };
+
+  const productItems = (
+    <>
+      <DropdownMenuItem asChild>
+        <Link
+          to="/organizations/$orgId/projects/$type"
+          params={{ orgId: currentOrg.id, type: "secret-management" }}
+        >
+          <KeyRound className="text-product-sm" />
+          Secrets
+        </Link>
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={openCertificateManager} disabled={isCertManagerPending}>
+        <FileKey className="text-product-pki" />
+        PKI
+      </DropdownMenuItem>
+      <DropdownMenuItem asChild>
+        <Link
+          to="/organizations/$orgId/projects/$type"
+          params={{ orgId: currentOrg.id, type: "kms" }}
+        >
+          <LockKeyhole className="text-product-kms" />
+          KMS
+        </Link>
+      </DropdownMenuItem>
+      <DropdownMenuItem asChild>
+        <Link
+          to="/organizations/$orgId/projects/$type"
+          params={{ orgId: currentOrg.id, type: "secret-scanning" }}
+        >
+          <Radar className="text-product-ss" />
+          Scanners
+        </Link>
+      </DropdownMenuItem>
+      <DropdownMenuItem asChild>
+        <Link to="/organizations/$orgId/pam/access" params={{ orgId: currentOrg.id }}>
+          <Users className="text-product-pam" />
+          PAM
+        </Link>
+      </DropdownMenuItem>
+    </>
+  );
+
+  return (
+    <>
+      <div className="mr-2 flex items-center">
+        <ButtonGroup className="hidden 2xl:flex">
+          <Button
+            variant="outline"
+            size="sm"
+            className={pathname.includes("/secret-management") ? "bg-foreground/5" : undefined}
+            asChild
+          >
+            <Link
+              to="/organizations/$orgId/projects/$type"
+              params={{ orgId: currentOrg.id, type: "secret-management" }}
+            >
+              <KeyRound className="text-product-sm" />
+              Secrets
+            </Link>
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={pathname.includes("/cert-manager") ? "bg-foreground/5" : undefined}
+            onClick={openCertificateManager}
+            isDisabled={isCertManagerPending}
+          >
+            <FileKey className="text-product-pki" />
+            PKI
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className={pathname.includes("/projects/kms") ? "bg-foreground/5" : undefined}
+            asChild
+          >
+            <Link
+              to="/organizations/$orgId/projects/$type"
+              params={{ orgId: currentOrg.id, type: "kms" }}
+            >
+              <LockKeyhole className="text-product-kms" />
+              KMS
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className={pathname.includes("/secret-scanning") ? "bg-foreground/5" : undefined}
+            asChild
+          >
+            <Link
+              to="/organizations/$orgId/projects/$type"
+              params={{ orgId: currentOrg.id, type: "secret-scanning" }}
+            >
+              <Radar className="text-product-ss" />
+              Scanners
+            </Link>
+          </Button>
+        </ButtonGroup>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="2xl:hidden">
+              Products
+              <MoreHorizontal />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">{productItems}</DropdownMenuContent>
+        </DropdownMenu>
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="hidden 2xl:inline-flex">
+              More
+              <MoreHorizontal />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="min-w-60">
+            <DropdownMenuItem asChild>
+              <Link to="/organizations/$orgId/pam/access" params={{ orgId: currentOrg.id }}>
+                <Users className="text-product-pam" />
+                PAM
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link
+                to="/organizations/$orgId/projects/secret-management/secret-sharing"
+                params={{ orgId: currentOrg.id }}
+              >
+                <Share2 />
+                Secret Sharing
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link
+                to="/organizations/$orgId/projects/kms/kmip-servers"
+                params={{ orgId: currentOrg.id }}
+              >
+                <Server />
+                KMIP Servers
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <Link
+                to="/organizations/$orgId/projects/secret-management/product-settings"
+                params={{ orgId: currentOrg.id }}
+              >
+                <SlidersHorizontal />
+                Secrets Product Settings
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <Link
+                to="/organizations/$orgId/settings"
+                params={{ orgId: currentOrg.id }}
+                search={{ selectedTab: "product-settings" }}
+              >
+                <SlidersHorizontal />
+                PKI Product Settings
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <CertManagerNotConfiguredModal
+        isOpen={isCertManagerSetupOpen}
+        onOpenChange={setIsCertManagerSetupOpen}
+      />
+    </>
+  );
+};

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/CertManagerNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/CertManagerNav.tsx
@@ -13,7 +13,8 @@ import {
   Search,
   Settings,
   Shield,
-  ShieldCheck
+  ShieldCheck,
+  SlidersHorizontal
 } from "lucide-react";
 
 import { ResourceIcon, SidebarCollapsibleGroup } from "@app/components/v3";
@@ -194,7 +195,14 @@ export const CertManagerNav = ({
       activeMatch: /\/access-management|\/groups\/|\/identities\/|\/members\/|\/roles\//
     },
     { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" },
-    { label: "Settings", icon: Settings, pathSuffix: "settings" }
+    { label: "Settings", icon: Settings, pathSuffix: "settings" },
+    {
+      label: "Product Settings",
+      icon: SlidersHorizontal,
+      pathSuffix: "settings",
+      targetScope: "organization",
+      search: { selectedTab: "product-settings" }
+    }
   ];
 
   const generalItemsForRole = isCertManagerAdmin

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgNav.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import { Blocks, CreditCard, FileText, Settings, Shield } from "lucide-react";
+import { Blocks, CreditCard, FileText, Settings, Shield, Users } from "lucide-react";
 
-import { OrgIcon, SidebarCollapsibleGroup, SubOrgIcon } from "@app/components/v3";
+import { OrgIcon, SubOrgIcon } from "@app/components/v3";
 import { useOrganization } from "@app/context";
 
 import { OrgNavList } from "./OrgNavLink";
 import { OrgSettingsSubmenuView } from "./OrgSubmenuView";
-import type { OrgNavGroup } from "./types";
+import type { OrgNavItem } from "./types";
 
 // --- Org nav ---
 
@@ -39,44 +39,39 @@ export const OrgNav = () => {
     });
   };
 
-  const groups: OrgNavGroup[] = [
+  const items: OrgNavItem[] = [
     {
-      label: "General",
-      collapsible: false,
-      items: [
-        {
-          label: "Home",
-          icon: isRootOrganization ? OrgIcon : SubOrgIcon,
-          pathSuffix: "projects"
-        },
-        {
-          label: "Integrations",
-          icon: Blocks,
-          pathSuffix: "integrations",
-          // Keep highlighted on the app-connections OAuth/manifest callback pages
-          activeMatch: /organizations\/[^/]+\/app-connections/
-        }
-      ]
+      label: "Projects",
+      icon: isRootOrganization ? OrgIcon : SubOrgIcon,
+      pathSuffix: "projects"
     },
     {
-      label: "Administration",
-      items: [
-        {
-          label: "Access Control",
-          icon: Shield,
-          pathSuffix: "access-management",
-          activeMatch: /organizations\/[^/]+\/(members|identities|groups|roles)/
-        },
-        {
-          label: "Usage & Billing",
-          icon: CreditCard,
-          pathSuffix: "billing",
-          hidden: !isRootOrganization
-        },
-        { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" },
-        { label: "Settings", icon: Settings, pathSuffix: "settings", opensSubmenu: true }
-      ]
-    }
+      label: "Integrations",
+      icon: Blocks,
+      pathSuffix: "integrations",
+      // Keep highlighted on the app-connections OAuth/manifest callback pages
+      activeMatch: /organizations\/[^/]+\/app-connections/
+    },
+    {
+      label: "PAM",
+      icon: Users,
+      pathSuffix: "pam/access",
+      activeMatch: /organizations\/[^/]+\/pam\//
+    },
+    {
+      label: "Access Control",
+      icon: Shield,
+      pathSuffix: "access-management",
+      activeMatch: /organizations\/[^/]+\/(members|identities|groups|roles)/
+    },
+    {
+      label: "Usage & Billing",
+      icon: CreditCard,
+      pathSuffix: "billing",
+      hidden: !isRootOrganization
+    },
+    { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" },
+    { label: "Settings", icon: Settings, pathSuffix: "settings", opensSubmenu: true }
   ];
 
   return (
@@ -99,16 +94,9 @@ export const OrgNav = () => {
           exit={{ x: -30, opacity: 0 }}
           transition={{ duration: 0.11, ease: "easeOut" }}
         >
-          {groups.map((group) => (
-            <SidebarCollapsibleGroup
-              key={group.label}
-              label={group.label}
-              collapsible={group.collapsible}
-              defaultOpen={group.defaultOpen}
-            >
-              <OrgNavList items={group.items} onOpenSubmenu={handleOpenSettings} />
-            </SidebarCollapsibleGroup>
-          ))}
+          <div className="py-2">
+            <OrgNavList items={items} onOpenSubmenu={handleOpenSettings} />
+          </div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgSidebar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/OrgSidebar.tsx
@@ -1,6 +1,19 @@
 import { useLocation, useParams } from "@tanstack/react-router";
+import { Search } from "lucide-react";
 
-import { Sidebar, SidebarContent, SidebarFooter, SidebarTrigger } from "@app/components/v3";
+import {
+  getGlobalCommandMenuShortcutLabel,
+  openGlobalCommandMenu,
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarTrigger
+} from "@app/components/v3";
+import { Kbd } from "@app/components/v3/generic/DataGrid/ui/kbd";
 import { useOrganization } from "@app/context";
 import {
   hasIntermediateProjectsView,
@@ -8,9 +21,11 @@ import {
   urlSlugToProjectType
 } from "@app/helpers/project";
 
+import { NotificationDropdown } from "../NavBar/NotificationDropdown";
 import { OrgNav } from "./OrgNav";
 import { ProjectNav } from "./ProjectNav";
 import { ProjectTypeNav } from "./ProjectTypeNav";
+import { SidebarUserMenu } from "./SidebarUserMenu";
 
 // --- Main sidebar ---
 
@@ -45,8 +60,32 @@ export const OrgSidebar = () => {
 
   return (
     <Sidebar scope={scope} collapsible="none" side="left">
+      <SidebarHeader className="border-b border-border p-2">
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              size="lg"
+              tooltip="Find"
+              onClick={openGlobalCommandMenu}
+              className="border border-border bg-background/40"
+            >
+              <Search />
+              <span>Find</span>
+              <Kbd className="ml-auto group-data-[collapsible=icon]:hidden">
+                {getGlobalCommandMenuShortcutLabel()}
+              </Kbd>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarHeader>
       <SidebarContent>{body}</SidebarContent>
       <SidebarFooter className="border-t border-border p-2">
+        <div className="flex min-w-0 items-center gap-1">
+          <SidebarUserMenu />
+          <div className="group-data-[collapsible=icon]:hidden">
+            <NotificationDropdown side="right" align="end" />
+          </div>
+        </div>
         <SidebarTrigger variant="ghost" className="w-full" />
       </SidebarFooter>
     </Sidebar>

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNavLink.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/ProjectNavLink.tsx
@@ -30,11 +30,15 @@ export const ProjectNavLink = ({
   const sidebarScope = useSidebarScope();
 
   const typePath = PROJECT_TYPE_PATH[currentProject.type];
-  const isPam = currentProject.type === ProjectType.PAM;
-  const basePath = isPam
-    ? `/organizations/${currentOrg.id}/pam`
-    : `/organizations/${currentOrg.id}/projects/${typePath}/${currentProject.id}`;
+  const isOrganizationTarget = item.targetScope === "organization";
+  const isPam = currentProject.type === ProjectType.PAM && !isOrganizationTarget;
+  let basePath = `/organizations/${currentOrg.id}/projects/${typePath}/${currentProject.id}`;
+  if (isOrganizationTarget) basePath = `/organizations/${currentOrg.id}`;
+  else if (isPam) basePath = `/organizations/${currentOrg.id}/pam`;
   const fullPath = `${basePath}/${item.pathSuffix}`;
+  let destination = `/organizations/$orgId/projects/${typePath}/$projectId/${item.pathSuffix}`;
+  if (isOrganizationTarget) destination = `/organizations/$orgId/${item.pathSuffix}`;
+  else if (isPam) destination = `/organizations/$orgId/pam/${item.pathSuffix}`;
 
   const activeMatchResult = (() => {
     if (!item.activeMatch) return false;
@@ -88,11 +92,7 @@ export const ProjectNavLink = ({
       >
         <Link
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          to={
-            isPam
-              ? (`/organizations/$orgId/pam/${item.pathSuffix}` as any)
-              : (`/organizations/$orgId/projects/${typePath}/$projectId/${item.pathSuffix}` as any)
-          }
+          to={destination as any}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           params={{ orgId: currentOrg.id, projectId: currentProject.id } as any}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/SecretManagerNav.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/SecretManagerNav.tsx
@@ -1,4 +1,12 @@
-import { ActivityIcon, Blocks, BookCheck, FileText, Settings, Shield } from "lucide-react";
+import {
+  ActivityIcon,
+  Blocks,
+  BookCheck,
+  FileText,
+  Settings,
+  Shield,
+  SlidersHorizontal
+} from "lucide-react";
 
 import { ProjectIcon, SidebarCollapsibleGroup } from "@app/components/v3";
 
@@ -49,7 +57,14 @@ export const SecretManagerNav = ({
       activeMatch: /\/groups\/|\/identities\/|\/members\/|\/roles\//
     },
     { label: "Audit Logs", icon: FileText, pathSuffix: "audit-logs" },
-    { label: "Settings", icon: Settings, pathSuffix: "settings", submenu: SM_SETTINGS_SUBMENU }
+    { label: "Settings", icon: Settings, pathSuffix: "settings", submenu: SM_SETTINGS_SUBMENU },
+    {
+      label: "Product Settings",
+      icon: SlidersHorizontal,
+      pathSuffix: "projects/secret-management/product-settings",
+      targetScope: "organization",
+      exactPath: true
+    }
   ];
 
   return (

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/SidebarUserMenu.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/SidebarUserMenu.tsx
@@ -1,0 +1,138 @@
+import { Link, useNavigate } from "@tanstack/react-router";
+import {
+  Book,
+  Clipboard,
+  ExternalLink,
+  Info,
+  LogOut,
+  Settings,
+  Slack,
+  UserPlus
+} from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import { OrgPermissionCan } from "@app/components/permissions";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
+import {
+  OrgPermissionActions,
+  OrgPermissionSubjects,
+  useOrganization,
+  useUser
+} from "@app/context";
+import { useLogoutUser } from "@app/hooks/api";
+import { getAuthToken } from "@app/hooks/api/reactQuery";
+
+export const SidebarUserMenu = () => {
+  const navigate = useNavigate();
+  const { user } = useUser();
+  const { currentOrg } = useOrganization();
+  const logout = useLogoutUser();
+  const displayName = [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email;
+
+  const handleCopyToken = async () => {
+    try {
+      await window.navigator.clipboard.writeText(getAuthToken());
+      createNotification({ type: "success", text: "Copied current login session token" });
+    } catch {
+      createNotification({ type: "error", text: "Failed to copy user token" });
+    }
+  };
+
+  const handleLogout = async () => {
+    await logout.mutateAsync();
+    navigate({ to: "/login" });
+  };
+
+  return (
+    <SidebarMenu className="min-w-0 flex-1">
+      <SidebarMenuItem>
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <SidebarMenuButton size="lg" tooltip={displayName} className="border border-border">
+              <span className="flex size-6 shrink-0 items-center justify-center rounded-sm bg-foreground text-xs font-semibold text-background">
+                {(user.firstName?.[0] ?? user.email?.[0] ?? "U").toUpperCase()}
+              </span>
+              <span className="min-w-0">
+                <span className="block truncate font-medium text-foreground">{displayName}</span>
+                <span className="block truncate text-xs text-muted">{user.email}</span>
+              </span>
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent side="right" align="end" sideOffset={8} className="min-w-64">
+            <DropdownMenuItem asChild>
+              <Link to="/personal-settings">
+                <Settings />
+                Personal Settings
+              </Link>
+            </DropdownMenuItem>
+            <OrgPermissionCan I={OrgPermissionActions.Create} a={OrgPermissionSubjects.Member}>
+              {(isAllowed) =>
+                isAllowed ? (
+                  <DropdownMenuItem asChild>
+                    <Link
+                      to="/organizations/$orgId/access-management"
+                      params={{ orgId: currentOrg.id }}
+                      search={{ selectedTab: "members", action: "invite-members" }}
+                    >
+                      <UserPlus />
+                      Invite Users
+                    </Link>
+                  </DropdownMenuItem>
+                ) : null
+              }
+            </OrgPermissionCan>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem asChild>
+              <a
+                href="https://infisical.com/docs/documentation/getting-started/introduction"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Book />
+                Documentation
+                <ExternalLink className="ml-auto size-3.5 opacity-50" />
+              </a>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild>
+              <a href="https://infisical.com/slack" target="_blank" rel="noopener noreferrer">
+                <Slack />
+                Join Slack Community
+                <ExternalLink className="ml-auto size-3.5 opacity-50" />
+              </a>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={handleCopyToken}>
+              <Clipboard />
+              Copy Token
+              <Tooltip>
+                <TooltipTrigger>
+                  <Info className="size-3.5 opacity-50" />
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  This token is linked to your current login session and organization.
+                </TooltipContent>
+              </Tooltip>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={handleLogout}>
+              <LogOut />
+              Log Out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  );
+};

--- a/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/types.ts
+++ b/frontend/src/layouts/OrganizationLayout/components/OrgSidebar/types.ts
@@ -30,6 +30,8 @@ export type NavItem = {
   label: string;
   icon: React.ComponentType<{ className?: string }>;
   pathSuffix: string;
+  /** Organization targets remain available from a project sidebar without inheriting projectId. */
+  targetScope?: "project" | "organization";
   activeMatch?: RegExp | ((pathname: string, search: Record<string, unknown>) => boolean);
   badgeCount?: number;
   badgeVariant?: "warning" | "danger" | "pam";


### PR DESCRIPTION
## Context

The project-first dashboard makes projects the organization landing surface, but organization-wide product pages and product settings still required backing out of a project or knowing their routes. The existing shell also concentrated organization selection, product selection, account controls, and notifications in the top bar.

This stacked change:
- adds a persistent responsive product launcher for Secrets, PKI, KMS, and Scanners, with PAM and lower-frequency product utilities in More;
- resolves PKI through the organization’s active Certificate Manager project and retains setup handling;
- makes organization-scoped Product Settings destinations reachable directly from Secrets and Certificate Manager project sidebars;
- adds PAM to the organization sidebar and flattens organization navigation around the new project-first hierarchy;
- adds a sidebar Find / Command-K trigger backed by the global command menu;
- moves account and notification utilities to the sidebar footer;
- aligns top-bar organization/location chrome with the sidebar’s expanded and collapsed widths;
- adds Product Settings and PAM commands to global search.

This is PR 4 in the stack and targets `andrew/projects-dashboard`.

## Screenshots

Screenshots are outstanding. Recommended captures:
- the organization projects dashboard at desktop width;
- a Secrets project showing direct Product Settings access;
- the responsive Products dropdown at a narrower width.

## Steps to verify the change

1. Open `/organizations/<org-id>/projects`.
2. Use the top product launcher to open Secrets, PKI, KMS, and Scanners; verify PAM and product utilities in More.
3. Open a Secrets project and select Product Settings from Administration.
4. Open the active Certificate Manager project and select Product Settings.
5. Select Find in the sidebar and confirm the global command menu opens.
6. Open the account and notification controls from the sidebar footer.
7. Collapse the sidebar and verify the top-bar organization region remains aligned.
8. Resize below the direct-launcher breakpoint and verify the Products dropdown remains available.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)