### PR TITLE
fix: secret scanning report when message is too long

### DIFF
--- a/frontend/src/pages/secret-scanning/SecretScanningFindingsPage/components/SecretScanningFindingRow.tsx
+++ b/frontend/src/pages/secret-scanning/SecretScanningFindingsPage/components/SecretScanningFindingRow.tsx
@@ -163,8 +163,8 @@ export const SecretScanningFindingRow = ({
       <Tr>
         <Td colSpan={7} className="border-none! p-0">
           <div
-            className={`w-full overflow-hidden bg-mineshaft-900/75 transition-all duration-500 ${
-              isExpanded ? "max-h-200 opacity-100" : "max-h-0"
+            className={`w-full bg-mineshaft-900/75 transition-all duration-500 ${
+              isExpanded ? "max-h-200 overflow-y-auto opacity-100" : "max-h-0 overflow-hidden"
             }`}
           >
             <div className="grid gap-4 p-4 2xl:grid-cols-6">
@@ -187,7 +187,7 @@ export const SecretScanningFindingRow = ({
                 {details.commit}
               </GenericFieldLabel>
               <GenericFieldLabel className="col-span-full" label="Commit Message">
-                {details.message}
+                <div className="max-h-48 overflow-y-auto">{details.message}</div>
               </GenericFieldLabel>
               <GenericFieldLabel label="Start Line">{details.startLine}</GenericFieldLabel>
               <GenericFieldLabel label="End Line">{details.endLine}</GenericFieldLabel>


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

<img width="2794" height="1490" alt="CleanShot 2026-08-14 at 12 34 41@2x" src="https://github.com/user-attachments/assets/7754a4d1-208c-4dc3-82fc-92ad35d3b71c" />


<img width="2794" height="1490" alt="CleanShot 2026-08-14 at 12 34 48@2x" src="https://github.com/user-attachments/assets/4c454f79-f402-41af-95e4-b09a6c9f75fc" />


## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)