### PR TITLE
fix(pki): scope EST enrollment routes by path params instead of the matched route

### DIFF
--- a/backend/src/ee/routes/est/certificate-est-router.ts
+++ b/backend/src/ee/routes/est/certificate-est-router.ts
@@ -102,7 +102,8 @@ export const registerCertificateEstRouter = async (server: FastifyZodProvider) =
     }
 
     const params = (req.params as { identifier?: string; applicationId?: string; profileId?: string }) ?? {};
-    const isAppScoped = matchedRoute.startsWith("/applications/");
+    // routeOptions.url carries the plugin prefix, so the route shape is not visible there
+    const isAppScoped = Boolean(params.applicationId && params.profileId);
 
     let estConfig;
     if (isAppScoped) {


### PR DESCRIPTION
## Context

The application-scoped EST endpoints always return `404 Certificate template or profile not found`, even with correct credentials:

- `POST /.well-known/est/applications/{applicationId}/profiles/{profileId}/simpleenroll`
- `POST /.well-known/est/applications/{applicationId}/profiles/{profileId}/simplereenroll`

The `preHandler` in `backend/src/ee/routes/est/certificate-est-router.ts` decides whether a request is application-scoped from the matched route:

```ts
const matchedRoute = req.routeOptions?.url ?? "";
...
const isAppScoped = matchedRoute.startsWith("/applications/");
```

The router is registered under a prefix (`server.register(registerCertificateEstRouter, { prefix: "/.well-known/est" })`, `backend/src/server/routes/index.ts`), and Fastify reports `routeOptions.url` with the prefix included, so `matchedRoute` is `/.well-known/est/applications/:applicationId/profiles/:profileId/simpleenroll`. `startsWith("/applications/")` is therefore always `false`, the hook takes the template/profile branch, and that branch throws `NotFoundError` because these routes have no `identifier` param.

`cacerts` on the same prefix is unaffected because it returns early on `matchedRoute.endsWith("/cacerts")`, which still matches with a prefix in front.

This derives the scope from the path params instead, which does not depend on where the router is mounted.

## Steps to verify the change

With a certificate profile attached to a PKI application, EST enabled, and a passphrase set on the application enrollment config:

1. `POST /.well-known/est/applications/{applicationId}/profiles/{profileId}/simpleenroll` with `Content-Type: application/pkcs10`, HTTP Basic credentials, and a CSR body. Before: `404 Certificate template or profile not found`. After: the passphrase is checked against the application enrollment config and a certificate is issued.
2. Same for `.../simplereenroll`.
3. A wrong passphrase on those routes returns `401 Invalid credentials` rather than `404`.
4. `POST /.well-known/est/{profileId}/simpleenroll` (template/profile-scoped) is unchanged and still resolves the EST config from the profile.
5. `GET /.well-known/est/applications/{applicationId}/profiles/{profileId}/cacerts` is unchanged.

What I verified locally: `npm run lint` and `npm run type:check` pass on the changed tree, and I reproduced the routing behaviour on its own — registering these four route shapes under the same prefix on Fastify 5.8.5 (the version in the lockfile) shows `routeOptions.url` carrying the prefix, the guard evaluating to `false` for the application-scoped routes, and the request 404ing in the hook before the handler runs; with the params-based check the same requests reach the handler. I did not run a full instance with a configured EST profile, so steps 1-5 above are from reading the code path rather than from an end-to-end run.

Happy to add a test if you want one — I left it out because there are currently no tests under `src/server/routes` or `src/ee/routes`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
