### PR TITLE
fix: use paginated endpoint for listing groups

### DIFF
--- a/frontend/src/pages/project/AccessControlPage/components/GroupsTab/components/GroupsSection/GroupModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/GroupsTab/components/GroupsSection/GroupModal.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Link } from "@tanstack/react-router";
@@ -20,11 +20,12 @@ import {
   FilterableSelect
 } from "@app/components/v3";
 import { useOrganization, useProject } from "@app/context";
+import { useDebounce } from "@app/hooks";
 import {
   useAddGroupToWorkspace,
-  useGetOrganizationGroups,
   useGetProjectRoles,
-  useListWorkspaceGroups
+  useListWorkspaceGroups,
+  useSearchOrganizationGroups
 } from "@app/hooks/api";
 import { ProjectType } from "@app/hooks/api/projects/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
@@ -49,7 +50,14 @@ const Content = ({ onClose }: { onClose: () => void }) => {
 
   const orgId = currentOrg?.id || "";
 
-  const { data: groups } = useGetOrganizationGroups(orgId);
+  const [searchInput, setSearchInput] = useState("");
+  const [debouncedSearch] = useDebounce(searchInput);
+
+  const { data: orgGroupsData, isLoading: isLoadingGroups } = useSearchOrganizationGroups({
+    organizationId: orgId,
+    search: debouncedSearch,
+    limit: 20
+  });
   const { data: groupMemberships } = useListWorkspaceGroups(
     currentProject?.id || "",
     currentProject?.type
@@ -66,8 +74,8 @@ const Content = ({ onClose }: { onClose: () => void }) => {
       wsGroupIds.set(groupMembership.group.id, true);
     });
 
-    return (groups || []).filter(({ id }) => !wsGroupIds.has(id));
-  }, [groups, groupMemberships]);
+    return (orgGroupsData?.groups || []).filter(({ id }) => !wsGroupIds.has(id));
+  }, [orgGroupsData?.groups, groupMemberships]);
 
   const {
     control,
@@ -95,7 +103,10 @@ const Content = ({ onClose }: { onClose: () => void }) => {
     });
   };
 
-  return filteredGroupMembershipOrgs.length ? (
+  const hasNoAvailableGroups =
+    !isLoadingGroups && !searchInput && filteredGroupMembershipOrgs.length === 0;
+
+  return !hasNoAvailableGroups ? (
     <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
       <Controller
         control={control}
@@ -110,7 +121,10 @@ const Content = ({ onClose }: { onClose: () => void }) => {
               placeholder="Select group..."
               autoFocus
               isError={Boolean(error)}
+              isLoading={isLoadingGroups || searchInput !== debouncedSearch}
               options={filteredGroupMembershipOrgs}
+              onInputChange={setSearchInput}
+              filterOption={() => true}
               getOptionValue={(option) => option.id}
               getOptionLabel={(option) => option.name}
             />

--- a/frontend/src/pages/project/AccessControlPage/components/GroupsTab/components/GroupsSection/GroupModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/GroupsTab/components/GroupsSection/GroupModal.tsx
@@ -53,7 +53,11 @@ const Content = ({ onClose }: { onClose: () => void }) => {
   const [searchInput, setSearchInput] = useState("");
   const [debouncedSearch] = useDebounce(searchInput);
 
-  const { data: orgGroupsData, isLoading: isLoadingGroups } = useSearchOrganizationGroups({
+  const {
+    data: orgGroupsData,
+    isLoading: isLoadingGroups,
+    isFetching: isFetchingGroups
+  } = useSearchOrganizationGroups({
     organizationId: orgId,
     search: debouncedSearch,
     limit: 20
@@ -103,8 +107,10 @@ const Content = ({ onClose }: { onClose: () => void }) => {
     });
   };
 
+  const totalOrgGroups = orgGroupsData?.totalCount ?? 0;
+  const assignedCount = groupMemberships?.length ?? 0;
   const hasNoAvailableGroups =
-    !isLoadingGroups && !searchInput && filteredGroupMembershipOrgs.length === 0;
+    !isLoadingGroups && !searchInput && totalOrgGroups > 0 && assignedCount >= totalOrgGroups;
 
   return !hasNoAvailableGroups ? (
     <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
@@ -121,9 +127,13 @@ const Content = ({ onClose }: { onClose: () => void }) => {
               placeholder="Select group..."
               autoFocus
               isError={Boolean(error)}
-              isLoading={isLoadingGroups || searchInput !== debouncedSearch}
-              options={filteredGroupMembershipOrgs}
-              onInputChange={setSearchInput}
+              isLoading={isFetchingGroups || searchInput !== debouncedSearch}
+              options={isFetchingGroups ? [] : filteredGroupMembershipOrgs}
+              onInputChange={(newValue, actionMeta) => {
+                if (actionMeta.action === "input-change") {
+                  setSearchInput(newValue);
+                }
+              }}
               filterOption={() => true}
               getOptionValue={(option) => option.id}
               getOptionLabel={(option) => option.name}

--- a/frontend/src/pages/project/AccessControlPage/components/GroupsTab/components/GroupsSection/GroupModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/GroupsTab/components/GroupsSection/GroupModal.tsx
@@ -15,6 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
   Field,
+  FieldDescription,
   FieldError,
   FieldLabel,
   FilterableSelect
@@ -36,6 +37,8 @@ const schema = z.object({
 });
 
 export type FormData = z.infer<typeof schema>;
+
+const GROUP_PAGE_SIZE = 20;
 
 type Props = {
   popUp: UsePopUpState<["group"]>;
@@ -60,7 +63,7 @@ const Content = ({ onClose }: { onClose: () => void }) => {
   } = useSearchOrganizationGroups({
     organizationId: orgId,
     search: debouncedSearch,
-    limit: 20
+    limit: GROUP_PAGE_SIZE
   });
   const { data: groupMemberships } = useListWorkspaceGroups(
     currentProject?.id || "",
@@ -109,8 +112,17 @@ const Content = ({ onClose }: { onClose: () => void }) => {
 
   const totalOrgGroups = orgGroupsData?.totalCount ?? 0;
   const assignedCount = groupMemberships?.length ?? 0;
+  // totalCount is scoped to the active search, so only trust it against the project's group count
+  // once both the input and the debounced query it drives are clear.
+  const hasSearchTerm = Boolean(searchInput || debouncedSearch);
   const hasNoAvailableGroups =
-    !isLoadingGroups && !searchInput && totalOrgGroups > 0 && assignedCount >= totalOrgGroups;
+    !isLoadingGroups && !hasSearchTerm && assignedCount >= totalOrgGroups;
+  const isGroupListTruncated = totalOrgGroups > GROUP_PAGE_SIZE;
+
+  const noOptionsMessage = () => {
+    if (hasSearchTerm) return "No groups match your search";
+    return `The first ${GROUP_PAGE_SIZE} groups are already added. Search by name to find others.`;
+  };
 
   return !hasNoAvailableGroups ? (
     <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
@@ -137,7 +149,11 @@ const Content = ({ onClose }: { onClose: () => void }) => {
               filterOption={() => true}
               getOptionValue={(option) => option.id}
               getOptionLabel={(option) => option.name}
+              noOptionsMessage={noOptionsMessage}
             />
+            <FieldDescription>
+              {isGroupListTruncated ? "Search by name to find groups that are not listed." : null}
+            </FieldDescription>
             <FieldError>{error?.message}</FieldError>
           </Field>
         )}
@@ -175,18 +191,21 @@ const Content = ({ onClose }: { onClose: () => void }) => {
   ) : (
     <div className="flex flex-col gap-4">
       <p className="text-sm">
-        Every group in your organization is already added. To add another group, create one at the
-        organization level first.
+        {totalOrgGroups === 0
+          ? "Your organization has no groups yet. Create one at the organization level to add it to this project."
+          : "Every group in your organization is already added. To add another group, create one at the organization level first."}
       </p>
-      <Button asChild variant="outline" className="self-end">
-        <Link
-          to={"/organizations/$orgId/access-management" as const}
-          params={{ orgId }}
-          search={{ selectedTab: "groups" }}
-        >
-          Go to organization groups <ArrowRightIcon />
-        </Link>
-      </Button>
+      <DialogFooter>
+        <Button asChild variant="outline">
+          <Link
+            to={"/organizations/$orgId/access-management" as const}
+            params={{ orgId }}
+            search={{ selectedTab: "groups" }}
+          >
+            Go to organization groups <ArrowRightIcon />
+          </Link>
+        </Button>
+      </DialogFooter>
     </div>
   );
 };


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

When adding a new group to a project, it was using the non-paginated query causing only the top 100 results to show up. Now it supports searching and paginating the results.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="3436" height="1812" alt="CleanShot 2026-08-17 at 15 43 22@2x" src="https://github.com/user-attachments/assets/16a09e47-f2c5-4d9e-bfb2-76e8207b7bf3" />


<img width="3436" height="1812" alt="CleanShot 2026-08-17 at 15 41 37@2x" src="https://github.com/user-attachments/assets/065bdcb9-db3a-4b08-9c8c-8d81714705b1" />


## Steps to verify the change

1. Create more than 100 groups
2. Go to a project and try to search for a group
3. All groups should be searchable, not only the ones that show on the first page of the filterableSelect

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)