### PR TITLE
fix: legacy boundary ignore read on secret folders

### DIFF
--- a/backend/src/lib/casl/boundary.test.ts
+++ b/backend/src/lib/casl/boundary.test.ts
@@ -999,6 +999,34 @@ describe("Validate Permission Boundary: inverted (deny) rule overlap", () => {
     expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeTruthy();
   });
 
+  test("Folder read in the child does not raise its privilege above a parent without it", () => {
+    const parentPermission = createMongoAbility([{ action: ["create", "edit", "delete"], subject: "secret-folders" }]);
+    const childPermission = createMongoAbility([
+      { action: ["read", "create", "edit", "delete"], subject: "secret-folders" }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeTruthy();
+  });
+
+  test("Folder read in the child is ignored even when the child holds no other folder action", () => {
+    const parentPermission = createMongoAbility([{ action: "read", subject: "secrets" }]);
+    const childPermission = createMongoAbility([
+      {
+        action: "read",
+        subject: "secret-folders",
+        conditions: { environment: { [PermissionConditionOperators.$EQ]: "prod" } }
+      }
+    ]);
+    expect(validatePermissionBoundary(parentPermission, childPermission).isValid).toBeTruthy();
+  });
+
+  test("Folder write in the child is still bounded by the parent", () => {
+    const parentPermission = createMongoAbility([{ action: ["read", "create"], subject: "secret-folders" }]);
+    const childPermission = createMongoAbility([{ action: ["read", "delete"], subject: "secret-folders" }]);
+    const result = validatePermissionBoundary(parentPermission, childPermission);
+    expect(result.isValid).toBeFalsy();
+    expect(result.missingPermissions).toEqual([{ action: "delete", subject: "secret-folders" }]);
+  });
+
   test("Unconditional inverted rule denies all subsets", () => {
     const parentPermission = createMongoAbility([
       { action: "read", subject: "secrets" },

--- a/backend/src/lib/casl/boundary.ts
+++ b/backend/src/lib/casl/boundary.ts
@@ -19,6 +19,9 @@ type TPermissionConditionShape = {
 };
 
 const getPermissionSetID = (action: string, subject: string) => `${action}:${subject}`;
+
+const IGNORED_PERMISSIONS = new Set([getPermissionSetID("read", "secret-folders")]);
+
 const invertTheOperation = (shouldInvert: boolean, operation: boolean) => (shouldInvert ? !operation : operation);
 const formatConditionOperator = (condition: TPermissionConditionShape | string) => {
   return (
@@ -281,9 +284,11 @@ export const validatePermissionBoundary = (parentSetPermissions: MongoAbility, s
       });
     }
 
-    // if action is already processed ignore
+    // if action is already processed or is explicitly ignored, ignore
     subsetPermissionActions = subsetPermissionActions.filter(
-      (el) => !checkedPermissionRules.has(getPermissionSetID(el, subsetPermissionSubject))
+      (el) =>
+        !checkedPermissionRules.has(getPermissionSetID(el, subsetPermissionSubject)) &&
+        !IGNORED_PERMISSIONS.has(getPermissionSetID(el, subsetPermissionSubject))
     );
 
     if (!subsetPermissionActions.length) return;

--- a/backend/src/lib/casl/boundary.ts
+++ b/backend/src/lib/casl/boundary.ts
@@ -2,6 +2,8 @@ import { MongoAbility } from "@casl/ability";
 import { MongoQuery } from "@ucast/mongo2js";
 import picomatch from "picomatch";
 
+import { ProjectPermissionActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+
 import { haveDisjointLiteralPrefixes, isGlobSubsetOfGlob } from "./glob-subset";
 import { PermissionConditionOperators } from "./index";
 
@@ -20,7 +22,9 @@ type TPermissionConditionShape = {
 
 const getPermissionSetID = (action: string, subject: string) => `${action}:${subject}`;
 
-const IGNORED_PERMISSIONS = new Set([getPermissionSetID("read", "secret-folders")]);
+const IGNORED_PERMISSIONS = new Set([
+  getPermissionSetID(ProjectPermissionActions.Read, ProjectPermissionSub.SecretFolders)
+]);
 
 const invertTheOperation = (shouldInvert: boolean, operation: boolean) => (shouldInvert ? !operation : operation);
 const formatConditionOperator = (condition: TPermissionConditionShape | string) => {


### PR DESCRIPTION
## Context

This fixes the permission boundary issue reported by users, which was recently introduced when we removed the read permission on secret folders on the default roles. Read permission on secret folders is implied as always true, and everyone has access to read on secret folders no matter what. We simply ignore that rule when falling back to the legacy permission boundary validation. 

Note that the issue only affects organizations that are still using the old permission boundary logic

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)