### PR TITLE
chore: only limit cloud discovery jobs

### DIFF
--- a/backend/src/ee/services/pki-discovery/pki-discovery-service.ts
+++ b/backend/src/ee/services/pki-discovery/pki-discovery-service.ts
@@ -9,6 +9,7 @@ import {
   ProjectPermissionPkiDiscoveryActions,
   ProjectPermissionSub
 } from "@app/ee/services/permission/project-permission";
+import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, DatabaseError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 
 import { TGatewayV2DALFactory } from "../gateway-v2/gateway-v2-dal";
@@ -28,7 +29,7 @@ import {
   TUpdatePkiDiscoveryDTO
 } from "./pki-discovery-types";
 
-const MAX_DISCOVERIES_PER_PROJECT = 10;
+const MAX_CLOUD_DISCOVERIES_PER_PROJECT = 10;
 const SCAN_RATE_LIMIT_HOURS = 24;
 
 type TPkiDiscoveryServiceFactoryDep = {
@@ -112,11 +113,14 @@ export const pkiDiscoveryServiceFactory = ({
       ProjectPermissionSub.PkiDiscovery
     );
 
-    const existingCount = await pkiDiscoveryConfigDAL.countByProjectId(projectId);
-    if (existingCount >= MAX_DISCOVERIES_PER_PROJECT) {
-      throw new BadRequestError({
-        message: `Maximum number of discovery configurations (${MAX_DISCOVERIES_PER_PROJECT}) reached for this project`
-      });
+    const appCfg = getConfig();
+    if (appCfg.isCloud) {
+      const existingCount = await pkiDiscoveryConfigDAL.countByProjectId(projectId);
+      if (existingCount >= MAX_CLOUD_DISCOVERIES_PER_PROJECT) {
+        throw new BadRequestError({
+          message: `Maximum number of discovery configurations (${MAX_CLOUD_DISCOVERIES_PER_PROJECT}) reached for this project`
+        });
+      }
     }
 
     validateTargetConfigForType(discoveryType, targetConfig);

--- a/backend/src/ee/services/pki-discovery/pki-discovery-service.ts
+++ b/backend/src/ee/services/pki-discovery/pki-discovery-service.ts
@@ -29,7 +29,7 @@ import {
   TUpdatePkiDiscoveryDTO
 } from "./pki-discovery-types";
 
-const MAX_CLOUD_DISCOVERIES_PER_PROJECT = 10;
+const MAX_CLOUD_DISCOVERIES = 10;
 const SCAN_RATE_LIMIT_HOURS = 24;
 
 type TPkiDiscoveryServiceFactoryDep = {
@@ -116,9 +116,9 @@ export const pkiDiscoveryServiceFactory = ({
     const appCfg = getConfig();
     if (appCfg.isCloud) {
       const existingCount = await pkiDiscoveryConfigDAL.countByProjectId(projectId);
-      if (existingCount >= MAX_CLOUD_DISCOVERIES_PER_PROJECT) {
+      if (existingCount >= MAX_CLOUD_DISCOVERIES) {
         throw new BadRequestError({
-          message: `Maximum number of discovery configurations (${MAX_CLOUD_DISCOVERIES_PER_PROJECT}) reached for this project`
+          message: `Maximum number of discovery configurations (${MAX_CLOUD_DISCOVERIES}) reached`
         });
       }
     }


### PR DESCRIPTION
## Context

Only apply the discovery job limit (10) on Cloud instances, self-hosted instances should not be limited by it

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)