### PR TITLE
fix: make product nullish instead of optional

### DIFF
--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectAssignmentFields.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/ProjectAssignmentFields.tsx
@@ -102,7 +102,7 @@ export const projectAssignmentSchema = z.object({
         .array()
         .optional()
     })
-    .optional(),
+    .nullish(),
   projects: z
     .array(
       z.object({


### PR DESCRIPTION
## Context

This PR updates the product selection validation when inviting users to orgs to handle null 

## Screenshots

N/A

## Steps to verify the change

- [ ] Select a product, and then unselect it - no form error should show

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)