### PR TITLE
fix(app-connection): paginate Cloudflare Pages projects

### DIFF
--- a/backend/CODE_QUALITY.md
+++ b/backend/CODE_QUALITY.md
@@ -136,9 +136,13 @@ while (page <= totalPages && page <= MAX_PAGES) {
   `src/services/app-connection/cloudflare/cloudflare-connection-fns.ts`.
 - **Do not truncate silently.** If you hit the cap, log it.
 
-In that same Cloudflare file, `listCloudflareZones` paginates correctly while
-`listCloudflarePagesProjects` and `listCloudflareWorkersScripts` return only the first
-page. That is exactly the bug, and it is easy to write by accident.
+In that same Cloudflare file, `listCloudflarePagesProjects` used to read a single response
+while `listCloudflareZones` walked every page, even though both endpoints report
+`result_info.total_pages`. Any account past the first page silently lost the rest of its
+projects. That is exactly the bug, and it is easy to write by accident. Both now share
+`$paginateCloudflare`. `listCloudflareWorkersScripts` stays a single request because
+`workers/scripts` accepts no page parameters and returns no `result_info` — check the
+endpoint before assuming either way.
 
 ---
 

--- a/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.test.ts
+++ b/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.test.ts
@@ -1,0 +1,92 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` factories are hoisted above imports — the spies they reference must come from `vi.hoisted`.
+const { safeRequestGetMock } = vi.hoisted(() => ({
+  safeRequestGetMock: vi.fn()
+}));
+
+vi.mock("@app/lib/validator", () => ({
+  safeRequest: { get: (...args: unknown[]) => (safeRequestGetMock as any)(...args) }
+}));
+vi.mock("@app/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+// Stub out the heavier transitive imports so the module loads in isolation.
+vi.mock("@app/services/integration-auth/integration-list", () => ({
+  IntegrationUrls: { CLOUDFLARE_API_URL: "https://api.cloudflare.com" }
+}));
+
+// eslint-disable-next-line import/first
+import { listCloudflarePagesProjects, listCloudflareWorkersScripts } from "./cloudflare-connection-fns";
+
+const connection = {
+  credentials: { apiToken: "test-token", accountId: "acct-1" }
+} as any;
+
+// Cloudflare reports how many pages exist on every paginated list endpoint; a caller that ignores
+// it keeps whatever landed in the first response.
+const pageOf = <T>(result: T[], totalPages: number) => ({
+  data: { result, result_info: { total_pages: totalPages } }
+});
+
+describe("listCloudflarePagesProjects", () => {
+  beforeEach(() => {
+    safeRequestGetMock.mockReset();
+  });
+
+  it("returns projects from every page, not just the first", async () => {
+    safeRequestGetMock
+      .mockResolvedValueOnce(pageOf([{ id: "p1", name: "alpha" }], 3))
+      .mockResolvedValueOnce(pageOf([{ id: "p2", name: "beta" }], 3))
+      .mockResolvedValueOnce(pageOf([{ id: "p3", name: "gamma" }], 3));
+
+    const projects = await listCloudflarePagesProjects(connection);
+
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(3);
+    expect(projects).toEqual([
+      { id: "p1", name: "alpha" },
+      { id: "p2", name: "beta" },
+      { id: "p3", name: "gamma" }
+    ]);
+  });
+
+  it("walks the pages in order, asking for the account's projects endpoint each time", async () => {
+    safeRequestGetMock
+      .mockResolvedValueOnce(pageOf([{ id: "p1", name: "alpha" }], 2))
+      .mockResolvedValueOnce(pageOf([{ id: "p2", name: "beta" }], 2));
+
+    await listCloudflarePagesProjects(connection);
+
+    const requestedPages = safeRequestGetMock.mock.calls.map(([, config]: any[]) => config.params.page);
+    expect(requestedPages).toEqual([1, 2]);
+
+    safeRequestGetMock.mock.calls.forEach(([url]: any[]) => {
+      expect(url).toContain("/accounts/acct-1/pages/projects");
+    });
+  });
+
+  it("stops after one request when the account only has a single page", async () => {
+    safeRequestGetMock.mockResolvedValueOnce(pageOf([{ id: "p1", name: "alpha" }], 1));
+
+    const projects = await listCloudflarePagesProjects(connection);
+
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(1);
+    expect(projects).toEqual([{ id: "p1", name: "alpha" }]);
+  });
+});
+
+describe("listCloudflareWorkersScripts", () => {
+  beforeEach(() => {
+    safeRequestGetMock.mockReset();
+  });
+
+  it("issues a single request, since workers/scripts is not a paginated endpoint", async () => {
+    safeRequestGetMock.mockResolvedValueOnce({ data: { result: [{ id: "worker-a" }, { id: "worker-b" }] } });
+
+    const scripts = await listCloudflareWorkersScripts(connection);
+
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(1);
+    expect(scripts).toEqual([{ id: "worker-a" }, { id: "worker-b" }]);
+  });
+});

--- a/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.test.ts
+++ b/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.test.ts
@@ -2,15 +2,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // `vi.mock` factories are hoisted above imports — the spies they reference must come from `vi.hoisted`.
-const { safeRequestGetMock } = vi.hoisted(() => ({
-  safeRequestGetMock: vi.fn()
+const { safeRequestGetMock, warnMock } = vi.hoisted(() => ({
+  safeRequestGetMock: vi.fn(),
+  warnMock: vi.fn()
 }));
 
 vi.mock("@app/lib/validator", () => ({
   safeRequest: { get: (...args: unknown[]) => (safeRequestGetMock as any)(...args) }
 }));
 vi.mock("@app/lib/logger", () => ({
-  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: (...args: unknown[]) => (warnMock as any)(...args) },
+  sanitizeUrlForLog: (url: string) => url
 }));
 // Stub out the heavier transitive imports so the module loads in isolation.
 vi.mock("@app/services/integration-auth/integration-list", () => ({
@@ -33,6 +35,7 @@ const pageOf = <T>(result: T[], totalPages: number) => ({
 describe("listCloudflarePagesProjects", () => {
   beforeEach(() => {
     safeRequestGetMock.mockReset();
+    warnMock.mockReset();
   });
 
   it("returns projects from every page, not just the first", async () => {
@@ -73,6 +76,27 @@ describe("listCloudflarePagesProjects", () => {
 
     expect(safeRequestGetMock).toHaveBeenCalledTimes(1);
     expect(projects).toEqual([{ id: "p1", name: "alpha" }]);
+  });
+
+  it("stops at the page cap and logs rather than truncating silently", async () => {
+    // More pages than the helper will walk: the list comes back short, so it has to say so.
+    safeRequestGetMock.mockResolvedValue(pageOf([{ id: "p", name: "alpha" }], 500));
+
+    const projects = await listCloudflarePagesProjects(connection);
+
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(100);
+    expect(projects).toHaveLength(100);
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining("page cap reached"));
+  });
+
+  it("does not warn when every page was read", async () => {
+    safeRequestGetMock
+      .mockResolvedValueOnce(pageOf([{ id: "p1", name: "alpha" }], 2))
+      .mockResolvedValueOnce(pageOf([{ id: "p2", name: "beta" }], 2));
+
+    await listCloudflarePagesProjects(connection);
+
+    expect(warnMock).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.ts
+++ b/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from "axios";
 
 import { BadRequestError } from "@app/lib/errors";
-import { logger } from "@app/lib/logger";
+import { logger, sanitizeUrlForLog } from "@app/lib/logger";
 import { safeRequest } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
@@ -64,6 +64,12 @@ const $paginateCloudflare = async <T>(
 
     totalPages = data.result_info?.total_pages ?? 1;
     page += 1;
+  }
+
+  if (page <= totalPages) {
+    logger.warn(
+      `$paginateCloudflare: page cap reached, returning a partial list [url=${sanitizeUrlForLog(url)}] [pagesRead=${CLOUDFLARE_MAX_PAGES}] [totalPages=${totalPages}]`
+    );
   }
 
   return results;

--- a/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.ts
+++ b/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.ts
@@ -84,17 +84,21 @@ export const listCloudflarePagesProjects = async (
     credentials: { apiToken, accountId }
   } = appConnection;
 
-  const { data } = await safeRequest.get<{ result: { name: string; id: string }[] }>(
+  const projects = await $paginateCloudflare<{ id: string; name: string }>(
     `${IntegrationUrls.CLOUDFLARE_API_URL}/client/v4/accounts/${accountId}/pages/projects`,
-    { headers: getCloudflareAuthHeaders(apiToken) }
+    { apiToken }
   );
 
-  return data.result.map((a) => ({
+  return projects.map((a) => ({
     name: a.name,
     id: a.id
   }));
 };
 
+/**
+ * `workers/scripts` takes no page parameters and reports no `result_info` — Cloudflare's own SDKs type it
+ * as a single page — so the account's full script list arrives in one response.
+ */
 export const listCloudflareWorkersScripts = async (
   appConnection: TCloudflareConnection
 ): Promise<TCloudflareWorkersScript[]> => {


### PR DESCRIPTION
## Context

`listCloudflarePagesProjects` reads a single response from `/accounts/{account_id}/pages/projects` and returns whatever landed in it:

```ts
const { data } = await safeRequest.get<{ result: { name: string; id: string }[] }>(
  `${IntegrationUrls.CLOUDFLARE_API_URL}/client/v4/accounts/${accountId}/pages/projects`,
  { headers: getCloudflareAuthHeaders(apiToken) }
);

return data.result.map(...);
```

That endpoint is paginated. Cloudflare's generated SDKs type it as `V4PagePaginationArray<Project>` (page/per_page style), and the REST reference documents `page` and `per_page` query parameters plus a `result_info` block carrying `total_pages` ([API reference](https://developers.cloudflare.com/api/resources/pages/subresources/projects/methods/list/), [Node SDK](https://developers.cloudflare.com/api/node/resources/pages/subresources/projects/methods/list/)). No page parameter is sent and `result_info` is ignored, so an account with more projects than one page silently loses the rest, and the missing ones cannot be selected when configuring a Cloudflare Pages sync.

The file already has the helper for exactly this. `$paginateCloudflare` walks `result_info.total_pages`, requests `per_page=50`, and caps the loop at `CLOUDFLARE_MAX_PAGES`. `listCloudflareZones` has used it since #7419; this routes the projects call through the same helper.

`backend/CODE_QUALITY.md` names this function as a live example of the missing-pagination bug, so its Cloudflare paragraph is updated in the same change.

### On `listCloudflareWorkersScripts`

That same paragraph also lists `listCloudflareWorkersScripts`, but that one is correct as written and is left alone. `/accounts/{account_id}/workers/scripts` takes no page parameters (only `tags`), returns no `result_info`, and Cloudflare types it as `SinglePage<ScriptListResponse>` rather than a paginated array ([API reference](https://developers.cloudflare.com/api/resources/workers/subresources/scripts/methods/list/), [Node SDK](https://developers.cloudflare.com/api/node/resources/workers/subresources/scripts/methods/list/)). The full script list arrives in one response. I noted the reason above the function and corrected the guide so it no longer points at it, since that is the kind of claim the next person will act on.

Happy to route it through the helper anyway if you would rather have it uniform. It would be harmless (`total_pages ?? 1` collapses to a single request), but it would also imply a pagination contract the endpoint does not offer.

## Screenshots

N/A, backend only.

## Steps to verify the change

Unit tests cover it:

```bash
cd backend && npx vitest run -c vitest.unit.config.mts src/services/app-connection/cloudflare/cloudflare-connection-fns.test.ts
```

They fail on `main` and pass with this change. Reverting only `cloudflare-connection-fns.ts` and keeping the test file:

```
× listCloudflarePagesProjects > returns projects from every page, not just the first
  → expected "spy" to be called 3 times, but got 1 times
× listCloudflarePagesProjects > walks the pages in order, asking for the account's projects endpoint each time
  → Cannot read properties of undefined (reading 'page')
✓ listCloudflarePagesProjects > stops after one request when the account only has a single page
✓ listCloudflareWorkersScripts > issues a single request, since workers/scripts is not a paginated endpoint

Tests  2 failed | 2 passed (4)
```

With the fix applied, all 4 pass. The two that pass either way are the controls: single-page behaviour and the Workers path are both meant to be unchanged.

Against a real account:

1. Point a Cloudflare app connection at an account with more Pages projects than one page (`per_page` is 50 here, and Cloudflare's own docs example uses 20).
2. Open the Cloudflare Pages sync destination picker.
3. Every project is listed, not just the first page.

`npm run lint` and `npm run type:check` are clean.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
