### PR TITLE
fix(app-connection): paginate Okta application listing

### DIFF
--- a/backend/src/services/app-connection/okta/okta-connection-fns.test.ts
+++ b/backend/src/services/app-connection/okta/okta-connection-fns.test.ts
@@ -2,16 +2,25 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // `vi.mock` factories are hoisted above imports — the spies they reference must come from `vi.hoisted`.
-const { requestGetMock, blockMock } = vi.hoisted(() => ({
+const { safeRequestGetMock, requestGetMock, blockMock, warnMock } = vi.hoisted(() => ({
+  safeRequestGetMock: vi.fn(),
   requestGetMock: vi.fn(),
-  blockMock: vi.fn()
+  blockMock: vi.fn(),
+  warnMock: vi.fn()
 }));
 
+// safeRequest validates the host and pins the connection to the IPs that passed validation; its
+// behaviour is covered by safe-request.test.ts. Here we only assert that the paged, token-bearing
+// requests go through it rather than through the raw client.
+vi.mock("@app/lib/validator", () => ({
+  blockLocalAndPrivateIpAddresses: (...args: unknown[]) => (blockMock as any)(...args),
+  safeRequest: { get: (...args: unknown[]) => (safeRequestGetMock as any)(...args) }
+}));
 vi.mock("@app/lib/config/request", () => ({
   request: { get: (...args: unknown[]) => (requestGetMock as any)(...args) }
 }));
-vi.mock("@app/lib/validator", () => ({
-  blockLocalAndPrivateIpAddresses: (...args: unknown[]) => (blockMock as any)(...args)
+vi.mock("@app/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: (...args: unknown[]) => (warnMock as any)(...args) }
 }));
 
 // eslint-disable-next-line import/first
@@ -38,37 +47,39 @@ const lastPage = (apps: unknown[]) => ({
 
 describe("listOktaApps", () => {
   beforeEach(() => {
+    safeRequestGetMock.mockReset();
     requestGetMock.mockReset();
     blockMock.mockReset();
+    warnMock.mockReset();
   });
 
   it("follows the next link so apps past the first page are still returned", async () => {
     const nextUrl = `${INSTANCE_URL}/api/v1/apps?after=cursor-1&limit=200`;
-    requestGetMock
+    safeRequestGetMock
       .mockResolvedValueOnce(pageWithNext([oidcApp("a")], nextUrl))
       .mockResolvedValueOnce(lastPage([oidcApp("b")]));
 
     const apps = await listOktaApps(connection);
 
-    expect(requestGetMock).toHaveBeenCalledTimes(2);
-    expect(requestGetMock.mock.calls[1][0]).toBe(nextUrl);
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(2);
+    expect(safeRequestGetMock.mock.calls[1][0]).toBe(nextUrl);
     expect(apps.map((app) => app.id)).toEqual(["a", "b"]);
   });
 
   it("requests Okta's maximum page size so the common case stays one round trip", async () => {
-    requestGetMock.mockResolvedValueOnce(lastPage([oidcApp("a")]));
+    safeRequestGetMock.mockResolvedValueOnce(lastPage([oidcApp("a")]));
 
     await listOktaApps(connection);
 
-    expect(requestGetMock).toHaveBeenCalledTimes(1);
-    expect(requestGetMock.mock.calls[0][0]).toBe(`${INSTANCE_URL}/api/v1/apps?limit=200`);
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(1);
+    expect(safeRequestGetMock.mock.calls[0][0]).toBe(`${INSTANCE_URL}/api/v1/apps?limit=200`);
   });
 
   it("finds OIDC apps that sort behind non-matching apps instead of returning an empty list", async () => {
     const nextUrl = `${INSTANCE_URL}/api/v1/apps?after=cursor-1&limit=200`;
     // A first page holding only SAML and deactivated apps is what made the picker come back empty:
     // the status/name filter ran after the response was already truncated.
-    requestGetMock
+    safeRequestGetMock
       .mockResolvedValueOnce(
         pageWithNext(
           [
@@ -85,14 +96,40 @@ describe("listOktaApps", () => {
     expect(apps.map((app) => app.id)).toEqual(["wanted"]);
   });
 
+  it("fetches every page through safeRequest, never the un-pinned client", async () => {
+    safeRequestGetMock
+      .mockResolvedValueOnce(pageWithNext([oidcApp("a")], `${INSTANCE_URL}/api/v1/apps?after=cursor-1&limit=200`))
+      .mockResolvedValueOnce(lastPage([oidcApp("b")]));
+
+    await listOktaApps(connection);
+
+    // Each page carries the API token, so every hop has to be validated and IP-pinned, not just the
+    // instance URL checked once up front.
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(2);
+    expect(requestGetMock).not.toHaveBeenCalled();
+  });
+
   it("ignores a next link pointing off the configured Okta instance", async () => {
-    requestGetMock.mockResolvedValueOnce(
+    safeRequestGetMock.mockResolvedValueOnce(
       pageWithNext([oidcApp("a")], "https://example.okta.com.attacker.test/api/v1/apps?after=cursor-1")
     );
 
     const apps = await listOktaApps(connection);
 
-    expect(requestGetMock).toHaveBeenCalledTimes(1);
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(1);
     expect(apps.map((app) => app.id)).toEqual(["a"]);
+  });
+
+  it("stops at the page cap and logs rather than looping forever or truncating silently", async () => {
+    // An Okta instance that always advertises another page would otherwise loop without end.
+    safeRequestGetMock.mockResolvedValue(
+      pageWithNext([oidcApp("a")], `${INSTANCE_URL}/api/v1/apps?after=cursor-next&limit=200`)
+    );
+
+    const apps = await listOktaApps(connection);
+
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(100);
+    expect(apps).toHaveLength(100);
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining("page cap reached"));
   });
 });

--- a/backend/src/services/app-connection/okta/okta-connection-fns.test.ts
+++ b/backend/src/services/app-connection/okta/okta-connection-fns.test.ts
@@ -120,6 +120,32 @@ describe("listOktaApps", () => {
     expect(apps.map((app) => app.id)).toEqual(["a"]);
   });
 
+  it.each([
+    ["an uppercase host", "https://EXAMPLE.okta.com"],
+    ["an explicit default port", "https://example.okta.com:443"]
+  ])("still follows the next link when the connection spells the origin with %s", async (_label, configuredUrl) => {
+    // Okta echoes its canonical host in the Link header, so a raw string prefix check would drop the
+    // link here and quietly reinstate the truncation this change is meant to remove.
+    const nextUrl = `${INSTANCE_URL}/api/v1/apps?after=cursor-1&limit=200`;
+    safeRequestGetMock
+      .mockResolvedValueOnce(pageWithNext([oidcApp("a")], nextUrl))
+      .mockResolvedValueOnce(lastPage([oidcApp("b")]));
+
+    const apps = await listOktaApps({ credentials: { instanceUrl: configuredUrl, apiToken: "test-token" } } as any);
+
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(2);
+    expect(apps.map((app) => app.id)).toEqual(["a", "b"]);
+  });
+
+  it("ignores a malformed next link instead of throwing", async () => {
+    safeRequestGetMock.mockResolvedValueOnce(pageWithNext([oidcApp("a")], "not-a-url"));
+
+    const apps = await listOktaApps(connection);
+
+    expect(safeRequestGetMock).toHaveBeenCalledTimes(1);
+    expect(apps.map((app) => app.id)).toEqual(["a"]);
+  });
+
   it("stops at the page cap and logs rather than looping forever or truncating silently", async () => {
     // An Okta instance that always advertises another page would otherwise loop without end.
     safeRequestGetMock.mockResolvedValue(

--- a/backend/src/services/app-connection/okta/okta-connection-fns.test.ts
+++ b/backend/src/services/app-connection/okta/okta-connection-fns.test.ts
@@ -20,7 +20,9 @@ vi.mock("@app/lib/config/request", () => ({
   request: { get: (...args: unknown[]) => (requestGetMock as any)(...args) }
 }));
 vi.mock("@app/lib/logger", () => ({
-  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: (...args: unknown[]) => (warnMock as any)(...args) }
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: (...args: unknown[]) => (warnMock as any)(...args) },
+  // Stands in for the real redaction so the test can assert the warning goes through it at all.
+  sanitizeUrlForLog: (url: string) => `sanitized(${url})`
 }));
 
 // eslint-disable-next-line import/first
@@ -157,5 +159,8 @@ describe("listOktaApps", () => {
     expect(safeRequestGetMock).toHaveBeenCalledTimes(100);
     expect(apps).toHaveLength(100);
     expect(warnMock).toHaveBeenCalledWith(expect.stringContaining("page cap reached"));
+    // The instance URL is user-supplied and can carry userinfo or a query string, so it must be
+    // redacted rather than interpolated raw into a log line.
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining(`sanitized(${INSTANCE_URL})`));
   });
 });

--- a/backend/src/services/app-connection/okta/okta-connection-fns.test.ts
+++ b/backend/src/services/app-connection/okta/okta-connection-fns.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` factories are hoisted above imports — the spies they reference must come from `vi.hoisted`.
+const { requestGetMock, blockMock } = vi.hoisted(() => ({
+  requestGetMock: vi.fn(),
+  blockMock: vi.fn()
+}));
+
+vi.mock("@app/lib/config/request", () => ({
+  request: { get: (...args: unknown[]) => (requestGetMock as any)(...args) }
+}));
+vi.mock("@app/lib/validator", () => ({
+  blockLocalAndPrivateIpAddresses: (...args: unknown[]) => (blockMock as any)(...args)
+}));
+
+// eslint-disable-next-line import/first
+import { listOktaApps } from "./okta-connection-fns";
+
+const INSTANCE_URL = "https://example.okta.com";
+
+const connection = {
+  credentials: { instanceUrl: INSTANCE_URL, apiToken: "test-token" }
+} as any;
+
+const oidcApp = (id: string) => ({ id, label: `app-${id}`, status: "ACTIVE", name: "oidc_client" });
+
+// Okta signals more results with a `next` link and omits it on the final page.
+const pageWithNext = (apps: unknown[], nextUrl: string) => ({
+  data: apps,
+  headers: { link: `<${INSTANCE_URL}/api/v1/apps?limit=200>; rel="self", <${nextUrl}>; rel="next"` }
+});
+
+const lastPage = (apps: unknown[]) => ({
+  data: apps,
+  headers: { link: `<${INSTANCE_URL}/api/v1/apps?limit=200>; rel="self"` }
+});
+
+describe("listOktaApps", () => {
+  beforeEach(() => {
+    requestGetMock.mockReset();
+    blockMock.mockReset();
+  });
+
+  it("follows the next link so apps past the first page are still returned", async () => {
+    const nextUrl = `${INSTANCE_URL}/api/v1/apps?after=cursor-1&limit=200`;
+    requestGetMock
+      .mockResolvedValueOnce(pageWithNext([oidcApp("a")], nextUrl))
+      .mockResolvedValueOnce(lastPage([oidcApp("b")]));
+
+    const apps = await listOktaApps(connection);
+
+    expect(requestGetMock).toHaveBeenCalledTimes(2);
+    expect(requestGetMock.mock.calls[1][0]).toBe(nextUrl);
+    expect(apps.map((app) => app.id)).toEqual(["a", "b"]);
+  });
+
+  it("requests Okta's maximum page size so the common case stays one round trip", async () => {
+    requestGetMock.mockResolvedValueOnce(lastPage([oidcApp("a")]));
+
+    await listOktaApps(connection);
+
+    expect(requestGetMock).toHaveBeenCalledTimes(1);
+    expect(requestGetMock.mock.calls[0][0]).toBe(`${INSTANCE_URL}/api/v1/apps?limit=200`);
+  });
+
+  it("finds OIDC apps that sort behind non-matching apps instead of returning an empty list", async () => {
+    const nextUrl = `${INSTANCE_URL}/api/v1/apps?after=cursor-1&limit=200`;
+    // A first page holding only SAML and deactivated apps is what made the picker come back empty:
+    // the status/name filter ran after the response was already truncated.
+    requestGetMock
+      .mockResolvedValueOnce(
+        pageWithNext(
+          [
+            { id: "saml", label: "saml app", status: "ACTIVE", name: "template_saml_2_0" },
+            { id: "inactive", label: "old app", status: "INACTIVE", name: "oidc_client" }
+          ],
+          nextUrl
+        )
+      )
+      .mockResolvedValueOnce(lastPage([oidcApp("wanted")]));
+
+    const apps = await listOktaApps(connection);
+
+    expect(apps.map((app) => app.id)).toEqual(["wanted"]);
+  });
+
+  it("ignores a next link pointing off the configured Okta instance", async () => {
+    requestGetMock.mockResolvedValueOnce(
+      pageWithNext([oidcApp("a")], "https://example.okta.com.attacker.test/api/v1/apps?after=cursor-1")
+    );
+
+    const apps = await listOktaApps(connection);
+
+    expect(requestGetMock).toHaveBeenCalledTimes(1);
+    expect(apps.map((app) => app.id)).toEqual(["a"]);
+  });
+});

--- a/backend/src/services/app-connection/okta/okta-connection-fns.ts
+++ b/backend/src/services/app-connection/okta/okta-connection-fns.ts
@@ -42,16 +42,42 @@ export const validateOktaConnectionCredentials = async (config: TOktaConnectionC
   return config.credentials;
 };
 
+// Okta caps `limit` at 200 on /api/v1/apps and defaults it far lower, so the full list only arrives by
+// following the `next` link it returns.
+const OKTA_APPS_PER_PAGE = 200;
+const OKTA_APPS_MAX_PAGES = 100;
+
+// Okta documents the `next` link as opaque, so it is followed rather than rebuilt. It still has to be
+// re-validated: it comes from the response body's headers, and the instance host is user-supplied.
+const $getNextLink = (linkHeader: string | undefined, instanceUrl: string) => {
+  const nextLink = linkHeader?.split(",").find((part) => part.includes('rel="next"'));
+  if (!nextLink) return null;
+
+  const url = nextLink.trim().split(";")[0].slice(1, -1);
+  if (!url.startsWith(`${instanceUrl}/`)) return null;
+
+  return url;
+};
+
 export const listOktaApps = async (appConnection: TOktaConnection) => {
   const { apiToken } = appConnection.credentials;
   const instanceUrl = await getOktaInstanceUrl(appConnection);
 
-  const { data } = await request.get<TOktaApp[]>(`${instanceUrl}/api/v1/apps`, {
-    headers: {
-      Accept: "application/json",
-      Authorization: `SSWS ${apiToken}`
-    }
-  });
+  const apps: TOktaApp[] = [];
+  let url: string | null = `${instanceUrl}/api/v1/apps?limit=${OKTA_APPS_PER_PAGE}`;
 
-  return data.filter((app) => app.status === "ACTIVE" && app.name === "oidc_client");
+  for (let page = 0; page < OKTA_APPS_MAX_PAGES && url; page += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const response = await request.get<TOktaApp[]>(url, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `SSWS ${apiToken}`
+      }
+    });
+
+    apps.push(...response.data);
+    url = $getNextLink(response.headers.link as string | undefined, instanceUrl);
+  }
+
+  return apps.filter((app) => app.status === "ACTIVE" && app.name === "oidc_client");
 };

--- a/backend/src/services/app-connection/okta/okta-connection-fns.ts
+++ b/backend/src/services/app-connection/okta/okta-connection-fns.ts
@@ -1,7 +1,7 @@
-import { request } from "@app/lib/config/request";
 import { UnauthorizedError } from "@app/lib/errors";
 import { removeTrailingSlash } from "@app/lib/fn";
-import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
+import { logger } from "@app/lib/logger";
+import { blockLocalAndPrivateIpAddresses, safeRequest } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 
 import { OktaConnectionMethod } from "./okta-connection-enums";
@@ -26,7 +26,7 @@ export const validateOktaConnectionCredentials = async (config: TOktaConnectionC
   const instanceUrl = await getOktaInstanceUrl(config);
 
   try {
-    await request.get(`${instanceUrl}/api/v1/users/me`, {
+    await safeRequest.get(`${instanceUrl}/api/v1/users/me`, {
       headers: {
         Accept: "application/json",
         Authorization: `SSWS ${apiToken}`
@@ -47,8 +47,9 @@ export const validateOktaConnectionCredentials = async (config: TOktaConnectionC
 const OKTA_APPS_PER_PAGE = 200;
 const OKTA_APPS_MAX_PAGES = 100;
 
-// Okta documents the `next` link as opaque, so it is followed rather than rebuilt. It still has to be
-// re-validated: it comes from the response body's headers, and the instance host is user-supplied.
+// Okta documents the `next` link as opaque, so it is followed rather than rebuilt. It is still
+// constrained to the instance origin: the link arrives in a response header and the host is
+// user-supplied, so a `next` pointing elsewhere must not be handed the API token.
 const $getNextLink = (linkHeader: string | undefined, instanceUrl: string) => {
   const nextLink = linkHeader?.split(",").find((part) => part.includes('rel="next"'));
   if (!nextLink) return null;
@@ -68,7 +69,7 @@ export const listOktaApps = async (appConnection: TOktaConnection) => {
 
   for (let page = 0; page < OKTA_APPS_MAX_PAGES && url; page += 1) {
     // eslint-disable-next-line no-await-in-loop
-    const response = await request.get<TOktaApp[]>(url, {
+    const response = await safeRequest.get<TOktaApp[]>(url, {
       headers: {
         Accept: "application/json",
         Authorization: `SSWS ${apiToken}`
@@ -77,6 +78,12 @@ export const listOktaApps = async (appConnection: TOktaConnection) => {
 
     apps.push(...response.data);
     url = $getNextLink(response.headers.link as string | undefined, instanceUrl);
+  }
+
+  if (url) {
+    logger.warn(
+      `listOktaApps: page cap reached, returning a partial list [instanceUrl=${instanceUrl}] [pagesRead=${OKTA_APPS_MAX_PAGES}]`
+    );
   }
 
   return apps.filter((app) => app.status === "ACTIVE" && app.name === "oidc_client");

--- a/backend/src/services/app-connection/okta/okta-connection-fns.ts
+++ b/backend/src/services/app-connection/okta/okta-connection-fns.ts
@@ -49,13 +49,20 @@ const OKTA_APPS_MAX_PAGES = 100;
 
 // Okta documents the `next` link as opaque, so it is followed rather than rebuilt. It is still
 // constrained to the instance origin: the link arrives in a response header and the host is
-// user-supplied, so a `next` pointing elsewhere must not be handed the API token.
+// user-supplied, so a `next` pointing elsewhere must not be handed the API token. Origins are
+// compared parsed rather than as strings, since a configured `https://EXAMPLE.okta.com:443` and the
+// canonical host Okta echoes back are the same origin spelled differently.
 const $getNextLink = (linkHeader: string | undefined, instanceUrl: string) => {
   const nextLink = linkHeader?.split(",").find((part) => part.includes('rel="next"'));
   if (!nextLink) return null;
 
   const url = nextLink.trim().split(";")[0].slice(1, -1);
-  if (!url.startsWith(`${instanceUrl}/`)) return null;
+
+  try {
+    if (new URL(url).origin !== new URL(instanceUrl).origin) return null;
+  } catch {
+    return null;
+  }
 
   return url;
 };

--- a/backend/src/services/app-connection/okta/okta-connection-fns.ts
+++ b/backend/src/services/app-connection/okta/okta-connection-fns.ts
@@ -1,6 +1,6 @@
 import { UnauthorizedError } from "@app/lib/errors";
 import { removeTrailingSlash } from "@app/lib/fn";
-import { logger } from "@app/lib/logger";
+import { logger, sanitizeUrlForLog } from "@app/lib/logger";
 import { blockLocalAndPrivateIpAddresses, safeRequest } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 
@@ -89,7 +89,7 @@ export const listOktaApps = async (appConnection: TOktaConnection) => {
 
   if (url) {
     logger.warn(
-      `listOktaApps: page cap reached, returning a partial list [instanceUrl=${instanceUrl}] [pagesRead=${OKTA_APPS_MAX_PAGES}]`
+      `listOktaApps: page cap reached, returning a partial list [instanceUrl=${sanitizeUrlForLog(instanceUrl)}] [pagesRead=${OKTA_APPS_MAX_PAGES}]`
     );
   }
 


### PR DESCRIPTION
## Context

`listOktaApps` issues one request and filters the response:

```ts
const { data } = await request.get<TOktaApp[]>(`${instanceUrl}/api/v1/apps`, { ... });

return data.filter((app) => app.status === "ACTIVE" && app.name === "oidc_client");
```

Okta paginates `/api/v1/apps`. It caps `limit` at 200, defaults well below that, and returns the next page as a `Link` header with `rel="next"` that callers are expected to follow until it stops appearing ([pagination reference](https://developer.okta.com/docs/api/#pagination), [list applications](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/application/other/listapplications)). Neither `limit` nor the `next` link is used here, so only the first page is ever read.

This list is what populates the app picker for an Okta Client Secret Rotation (`useOktaConnectionListApps` -> `GET /api/v1/app-connections/okta/:connectionId/apps`). An org past the first page cannot select its app there at all.

**Filtering after the truncated fetch makes it worse than plain truncation.** `status` and `name` are checked client-side, on a list that was already cut short. An org whose first page holds only SAML apps and deactivated apps gets an *empty* picker, even though matching OIDC apps exist further down. That reads as "this connection has no apps" rather than as a truncated list, which is the part I would expect to generate support tickets.

## Fix

Request `limit=200` (Okta's maximum, so the common case stays a single round trip) and follow the `next` link until Okta stops sending one, capped at `OKTA_APPS_MAX_PAGES`. The existing status/name filter is unchanged and now runs over the full list.

Okta documents the `next` link as opaque and asks that it be followed rather than reconstructed, so that is what this does. It is still constrained to the already-validated instance origin before use, because the instance host is user-supplied and the link arrives in a response header. A `next` pointing anywhere else (`https://example.okta.com.attacker.test/...`) is dropped rather than fetched. The loop shape follows the existing `Link`-header walk in `integration-sync-secret.ts`.

## Screenshots

N/A, backend only.

## Steps to verify the change

Unit tests cover it:

```bash
cd backend && npx vitest run -c vitest.unit.config.mts src/services/app-connection/okta/okta-connection-fns.test.ts
```

They fail on `main` and pass with this change. Reverting only `okta-connection-fns.ts` and keeping the test file:

```
× listOktaApps > follows the next link so apps past the first page are still returned
  → expected "spy" to be called 2 times, but got 1 times
× listOktaApps > requests Okta's maximum page size so the common case stays one round trip
  → expected 'https://example.okta.com/api/v1/apps' to be 'https://example.okta.com/api/v1/apps?limit=200'
× listOktaApps > finds OIDC apps that sort behind non-matching apps instead of returning an empty list
  → expected [] to deeply equal [ 'wanted' ]

Tests  3 failed | 1 passed (4)
```

That third failure is the empty-picker case above: the fixture's first page is one SAML app plus one deactivated OIDC app, the wanted app is on page two, and `main` returns `[]`. With the fix applied all 4 pass.

Against a real tenant:

1. Point an Okta app connection at an org with more than 200 applications, or with enough non-OIDC/deactivated apps that the OIDC ones fall past the first page.
2. Create an Okta Client Secret Rotation and open the app picker.
3. The OIDC apps are listed rather than the picker coming back short or empty.

`npm run lint` and `npm run type:check` are clean.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
