### PR TITLE
fix(app-connection): paginate Northflank projects and secret groups

### DIFF
--- a/backend/src/services/app-connection/northflank/northflank-connection-fns.test.ts
+++ b/backend/src/services/app-connection/northflank/northflank-connection-fns.test.ts
@@ -1,0 +1,128 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `vi.mock` factories are hoisted above imports — the spies they reference must come from `vi.hoisted`.
+const { requestGetMock, warnMock } = vi.hoisted(() => ({
+  requestGetMock: vi.fn(),
+  warnMock: vi.fn()
+}));
+
+vi.mock("@app/lib/config/request", () => ({
+  request: { get: (...args: unknown[]) => (requestGetMock as any)(...args) }
+}));
+vi.mock("@app/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: (...args: unknown[]) => (warnMock as any)(...args) },
+  sanitizeUrlForLog: (url: string) => url
+}));
+
+// eslint-disable-next-line import/first
+import { listProjects, listSecretGroups } from "./northflank-connection-fns";
+
+const connection = {
+  credentials: { apiToken: "test-token" }
+} as any;
+
+// Northflank nests the array under `data.<key>` and reports more results via `pagination.hasNextPage`
+// plus an opaque `pagination.cursor`.
+const page = <T>(key: string, items: T[], next?: string) => ({
+  data: {
+    data: { [key]: items },
+    pagination: next
+      ? { hasNextPage: true, cursor: next, count: items.length }
+      : { hasNextPage: false, count: items.length }
+  }
+});
+
+describe("listProjects", () => {
+  beforeEach(() => {
+    requestGetMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it("follows the cursor so projects past the first page are still returned", async () => {
+    requestGetMock
+      .mockResolvedValueOnce(page("projects", [{ id: "p1", name: "alpha" }], "cursor-1"))
+      .mockResolvedValueOnce(page("projects", [{ id: "p2", name: "beta" }]));
+
+    const projects = await listProjects(connection);
+
+    expect(requestGetMock).toHaveBeenCalledTimes(2);
+    expect(projects).toEqual([
+      { id: "p1", name: "alpha" },
+      { id: "p2", name: "beta" }
+    ]);
+  });
+
+  it("sends the cursor returned by the previous page and asks for the maximum page size", async () => {
+    requestGetMock
+      .mockResolvedValueOnce(page("projects", [{ id: "p1", name: "alpha" }], "cursor-1"))
+      .mockResolvedValueOnce(page("projects", [{ id: "p2", name: "beta" }]));
+
+    await listProjects(connection);
+
+    const [firstParams, secondParams] = requestGetMock.mock.calls.map(([, config]: any[]) => config.params);
+    expect(firstParams).toEqual({ per_page: 100 });
+    expect(secondParams).toEqual({ per_page: 100, cursor: "cursor-1" });
+  });
+
+  it("stops after one request when there is no next page", async () => {
+    requestGetMock.mockResolvedValueOnce(page("projects", [{ id: "p1", name: "alpha" }]));
+
+    const projects = await listProjects(connection);
+
+    expect(requestGetMock).toHaveBeenCalledTimes(1);
+    expect(projects).toEqual([{ id: "p1", name: "alpha" }]);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it("stops at the page cap and logs rather than looping forever or truncating silently", async () => {
+    // A cursor that never clears would otherwise loop without end.
+    requestGetMock.mockResolvedValue(page("projects", [{ id: "p", name: "alpha" }], "cursor-next"));
+
+    const projects = await listProjects(connection);
+
+    expect(requestGetMock).toHaveBeenCalledTimes(100);
+    expect(projects).toHaveLength(100);
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining("page cap reached"));
+  });
+
+  it("treats hasNextPage without a cursor as the end of the list", async () => {
+    // Nothing to advance with, so continuing would refetch page one until the cap.
+    requestGetMock.mockResolvedValueOnce({
+      data: {
+        data: { projects: [{ id: "p1", name: "alpha" }] },
+        pagination: { hasNextPage: true, count: 1 }
+      }
+    });
+
+    const projects = await listProjects(connection);
+
+    expect(requestGetMock).toHaveBeenCalledTimes(1);
+    expect(projects).toEqual([{ id: "p1", name: "alpha" }]);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("listSecretGroups", () => {
+  beforeEach(() => {
+    requestGetMock.mockReset();
+    warnMock.mockReset();
+  });
+
+  it("follows the cursor so secret groups past the first page are still returned", async () => {
+    requestGetMock
+      .mockResolvedValueOnce(page("secrets", [{ id: "s1", name: "group-a" }], "cursor-1"))
+      .mockResolvedValueOnce(page("secrets", [{ id: "s2", name: "group-b" }]));
+
+    const groups = await listSecretGroups(connection, "project-1");
+
+    expect(requestGetMock).toHaveBeenCalledTimes(2);
+    expect(groups).toEqual([
+      { id: "s1", name: "group-a" },
+      { id: "s2", name: "group-b" }
+    ]);
+    requestGetMock.mock.calls.forEach(([url]: any[]) => {
+      expect(url).toContain("/v1/projects/project-1/secrets");
+    });
+  });
+});

--- a/backend/src/services/app-connection/northflank/northflank-connection-fns.ts
+++ b/backend/src/services/app-connection/northflank/northflank-connection-fns.ts
@@ -2,6 +2,7 @@ import { AxiosError } from "axios";
 
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
+import { logger, sanitizeUrlForLog } from "@app/lib/logger";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 
 import { NorthflankConnectionMethod } from "./northflank-connection-enums";
@@ -13,6 +14,57 @@ import {
 } from "./northflank-connection-types";
 
 const NORTHFLANK_API_URL = "https://api.northflank.com";
+
+// Northflank returns 50 entries per page by default and caps per_page at 100.
+const NORTHFLANK_PER_PAGE = 100;
+const NORTHFLANK_MAX_PAGES = 100;
+
+/**
+ * Walks a paginated Northflank list endpoint using the opaque `pagination.cursor` it returns,
+ * stopping on `hasNextPage`. `key` selects the array Northflank nests under `data`.
+ */
+const $paginateNorthflank = async <T>({
+  url,
+  apiToken,
+  key
+}: {
+  url: string;
+  apiToken: string;
+  key: string;
+}): Promise<T[]> => {
+  const results: T[] = [];
+
+  let cursor: string | undefined;
+  let hasNextPage = false;
+
+  for (let page = 0; page < NORTHFLANK_MAX_PAGES; page += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const { data } = await request.get<{
+      data: Record<string, T[]>;
+      pagination?: { hasNextPage?: boolean; cursor?: string };
+    }>(url, {
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        Accept: "application/json"
+      },
+      params: { per_page: NORTHFLANK_PER_PAGE, ...(cursor ? { cursor } : {}) }
+    });
+
+    results.push(...(data.data?.[key] ?? []));
+
+    cursor = data.pagination?.cursor;
+    hasNextPage = Boolean(data.pagination?.hasNextPage && cursor);
+    if (!hasNextPage) break;
+  }
+
+  if (hasNextPage) {
+    logger.warn(
+      `$paginateNorthflank: page cap reached, returning a partial list [url=${sanitizeUrlForLog(url)}] [pagesRead=${NORTHFLANK_MAX_PAGES}]`
+    );
+  }
+
+  return results;
+};
 
 export const getNorthflankConnectionListItem = () => {
   return {
@@ -51,18 +103,11 @@ export const listProjects = async (appConnection: TNorthflankConnection): Promis
   const { credentials } = appConnection;
 
   try {
-    const {
-      data: {
-        data: { projects }
-      }
-    } = await request.get<{ data: { projects: TNorthflankProject[] } }>(`${NORTHFLANK_API_URL}/v1/projects`, {
-      headers: {
-        Authorization: `Bearer ${credentials.apiToken}`,
-        Accept: "application/json"
-      }
+    return await $paginateNorthflank<TNorthflankProject>({
+      url: `${NORTHFLANK_API_URL}/v1/projects`,
+      apiToken: credentials.apiToken,
+      key: "projects"
     });
-
-    return projects;
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
       throw new BadRequestError({
@@ -84,21 +129,11 @@ export const listSecretGroups = async (
   const { credentials } = appConnection;
 
   try {
-    const {
-      data: {
-        data: { secrets }
-      }
-    } = await request.get<{ data: { secrets: TNorthflankSecretGroup[] } }>(
-      `${NORTHFLANK_API_URL}/v1/projects/${projectId}/secrets`,
-      {
-        headers: {
-          Authorization: `Bearer ${credentials.apiToken}`,
-          Accept: "application/json"
-        }
-      }
-    );
-
-    return secrets;
+    return await $paginateNorthflank<TNorthflankSecretGroup>({
+      url: `${NORTHFLANK_API_URL}/v1/projects/${projectId}/secrets`,
+      apiToken: credentials.apiToken,
+      key: "secrets"
+    });
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
       throw new BadRequestError({


### PR DESCRIPTION
## Context

`listProjects` and `listSecretGroups` each read a single response and return the array Northflank nests under `data`:

```ts
const {
  data: {
    data: { projects }
  }
} = await request.get<{ data: { projects: TNorthflankProject[] } }>(`${NORTHFLANK_API_URL}/v1/projects`, { ... });

return projects;
```

Both endpoints are paginated. Northflank returns **50 entries per page by default**, caps `per_page` at 100, and reports more results through a `pagination` object carrying `hasNextPage` and an opaque `cursor` ([pagination](https://northflank.com/docs/v1/api/introduction), [list projects](https://northflank.com/docs/v1/api/team/projects/list-projects)).

Neither the page size nor the cursor is used, so a team with more than 50 projects, or a project with more than 50 secret groups, silently loses the rest. Those entries then cannot be picked as a Northflank sync destination.

## Fix

Adds `$paginateNorthflank`, shared by both callers. It requests `per_page=100`, follows `pagination.cursor` while `hasNextPage` is set, caps the loop at `NORTHFLANK_MAX_PAGES`, and warns rather than truncating silently if that cap is reached, per the pagination section of `backend/CODE_QUALITY.md`.

One edge case is handled explicitly: `hasNextPage: true` with no `cursor` is treated as the end of the list. Continuing without a cursor would refetch the first page until the cap, duplicating entries 100 times over.

`request` is kept rather than `safeRequest` because the Northflank host is the fixed `NORTHFLANK_API_URL` constant, not user-supplied, so there is no host to validate or pin.

## Screenshots

N/A, backend only.

## Steps to verify the change

Unit tests cover it:

```bash
cd backend && npx vitest run -c vitest.unit.config.mts src/services/app-connection/northflank/northflank-connection-fns.test.ts
```

They fail on `main` and pass with this change. Reverting only `northflank-connection-fns.ts` and keeping the test file:

```
× listProjects > follows the cursor so projects past the first page are still returned
  → expected "spy" to be called 2 times, but got 1 times
× listProjects > sends the cursor returned by the previous page and asks for the maximum page size
  → expected undefined to deeply equal { per_page: 100 }
✓ listProjects > stops after one request when there is no next page
× listProjects > stops at the page cap and logs rather than looping forever or truncating silently
  → expected "spy" to be called 100 times, but got 1 times
✓ listProjects > treats hasNextPage without a cursor as the end of the list
× listSecretGroups > follows the cursor so secret groups past the first page are still returned
  → expected "spy" to be called 2 times, but got 1 times

Tests  4 failed | 2 passed (6)
```

With the fix applied all 6 pass. The two that pass either way are the controls: single-page behaviour is meant to be unchanged.

Against a real account:

1. Point a Northflank app connection at a team with more than 50 projects.
2. Open the Northflank sync destination picker.
3. Every project is listed. Same for a project holding more than 50 secret groups.

`npm run lint` and `npm run type:check` are clean.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
