### PR TITLE
feat(secret-sharing): improve secrets sharing UI

### DIFF
--- a/frontend/src/components/auth/AuthPageFooter.tsx
+++ b/frontend/src/components/auth/AuthPageFooter.tsx
@@ -1,5 +1,5 @@
 export const AuthPageFooter = () => (
-  <footer className="mt-5 flex flex-col-reverse items-center justify-between gap-3 border-t border-border pt-5 text-center sm:flex-row sm:text-left">
+  <footer className="mt-4 flex flex-col-reverse items-center justify-between gap-3 border-t border-border py-4 text-center sm:flex-row sm:text-left">
     <p className="text-[11px] text-muted">
       &copy; {new Date().getFullYear()} Infisical Inc. All rights reserved.
     </p>

--- a/frontend/src/pages/organization/SecretSharingPage/SecretSharingPage.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/SecretSharingPage.tsx
@@ -1,7 +1,7 @@
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 
-import { PageHeader } from "@app/components/v2";
+import { PageHeader } from "@app/components/v3";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
 import { ShareSecretSection } from "./ShareSecretSection";

--- a/frontend/src/pages/organization/SecretSharingPage/ShareSecretSection.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/ShareSecretSection.tsx
@@ -1,7 +1,7 @@
 import { Helmet } from "react-helmet";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 
-import { Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useOrganization } from "@app/context";
 
@@ -61,17 +61,17 @@ export const ShareSecretSection = () => {
       </Helmet>
 
       <Tabs value={activeTab} onValueChange={updateSelectedTab}>
-        <TabList>
+        <TabsList variant="project">
           {tabs.map(({ key, label }) => (
-            <Tab variant="project" value={key} key={`tab-${key}`}>
+            <TabsTrigger value={key} key={`tab-${key}`}>
               {label}
-            </Tab>
+            </TabsTrigger>
           ))}
-        </TabList>
+        </TabsList>
         {tabs.map(({ key, component: Component }) => (
-          <TabPanel value={key} key={`tab-panel-${key}`}>
+          <TabsContent value={key} key={`tab-panel-${key}`}>
             <Component />
-          </TabPanel>
+          </TabsContent>
         ))}
       </Tabs>
     </div>

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/AddShareSecretModal.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/AddShareSecretModal.tsx
@@ -1,6 +1,18 @@
-import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@app/components/v3";
+import { useState } from "react";
+
+import {
+  Button,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle
+} from "@app/components/v3";
 import { useOrganization } from "@app/context";
+import { useTimedReset } from "@app/hooks";
 import { UsePopUpState } from "@app/hooks/usePopUp";
+import type { SharedSecretResultActions } from "@app/pages/public/ShareSecretPage/components";
 import { ShareSecretForm } from "@app/pages/public/ShareSecretPage/components";
 
 type Props = {
@@ -13,10 +25,16 @@ type Props = {
 
 export const AddShareSecretModal = ({ popUp, handlePopUpToggle }: Props) => {
   const { currentOrg } = useOrganization();
+  const [resultActions, setResultActions] = useState<SharedSecretResultActions | null>(null);
+  const [, isCopyingLink, setCopyingLink] = useTimedReset<string>({
+    initialState: "Copy shared link"
+  });
+
   return (
     <Sheet
       open={popUp?.createSharedSecret?.isOpen}
       onOpenChange={(isOpen) => {
+        if (!isOpen) setResultActions(null);
         handlePopUpToggle("createSharedSecret", isOpen);
       }}
     >
@@ -34,8 +52,34 @@ export const AddShareSecretModal = ({ popUp, handlePopUpToggle }: Props) => {
             }
             maxSharedSecretLifetime={currentOrg?.maxSharedSecretLifetime}
             maxSharedSecretViewLimit={currentOrg?.maxSharedSecretViewLimit}
+            onResultActionsChange={setResultActions}
           />
         </div>
+        {resultActions && (
+          <SheetFooter className="flex-col border-t sm:flex-row">
+            <Button
+              className="w-full sm:flex-1"
+              variant="project"
+              size="lg"
+              onClick={resultActions.createMore}
+            >
+              Create more
+            </Button>
+            {resultActions.hasLink && resultActions.copyLink && (
+              <Button
+                className="w-full sm:flex-1"
+                variant="outline"
+                size="lg"
+                onClick={() => {
+                  resultActions.copyLink?.();
+                  setCopyingLink("Copied");
+                }}
+              >
+                {isCopyingLink ? "Copied" : "Copy shared link"}
+              </Button>
+            )}
+          </SheetFooter>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/AddShareSecretModal.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/AddShareSecretModal.tsx
@@ -1,11 +1,4 @@
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle
-} from "@app/components/v3";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 import { ShareSecretForm } from "@app/pages/public/ShareSecretPage/components";
@@ -21,18 +14,18 @@ type Props = {
 export const AddShareSecretModal = ({ popUp, handlePopUpToggle }: Props) => {
   const { currentOrg } = useOrganization();
   return (
-    <Dialog
+    <Sheet
       open={popUp?.createSharedSecret?.isOpen}
       onOpenChange={(isOpen) => {
         handlePopUpToggle("createSharedSecret", isOpen);
       }}
     >
-      <DialogContent className="max-w-xl">
-        <DialogHeader>
-          <DialogTitle>Share a Secret</DialogTitle>
-          <DialogDescription>Securely share one off secrets with your team.</DialogDescription>
-        </DialogHeader>
-        <DialogBody>
+      <SheetContent className="flex h-full max-h-full flex-col gap-0 sm:max-w-2xl">
+        <SheetHeader className="border-b">
+          <SheetTitle>Share a Secret</SheetTitle>
+          <SheetDescription>Securely share one off secrets with your team.</SheetDescription>
+        </SheetHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
           <ShareSecretForm
             isPublic={false}
             value={(popUp.createSharedSecret.data as { value?: string })?.value}
@@ -42,8 +35,8 @@ export const AddShareSecretModal = ({ popUp, handlePopUpToggle }: Props) => {
             maxSharedSecretLifetime={currentOrg?.maxSharedSecretLifetime}
             maxSharedSecretViewLimit={currentOrg?.maxSharedSecretViewLimit}
           />
-        </DialogBody>
-      </DialogContent>
-    </Dialog>
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretTab.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretTab.tsx
@@ -35,22 +35,20 @@ export const ShareSecretTab = () => {
   ] as const);
 
   const deleteSecretShare = useDeleteSharedSecret();
+  const deleteSecret = popUp?.deleteSharedSecretConfirmation?.data as DeleteModalData | undefined;
 
   const onDeleteApproved = async () => {
-    deleteSecretShare.mutateAsync({
-      sharedSecretId: (popUp?.deleteSharedSecretConfirmation?.data as DeleteModalData)?.id
-    });
-    createNotification({
-      text: "Successfully deleted shared secret",
-      type: "success"
-    });
+    if (!deleteSecret?.id) return;
+
+    await deleteSecretShare.mutateAsync({ sharedSecretId: deleteSecret?.id });
+    createNotification({ text: "Shared secret deleted", type: "success" });
 
     handlePopUpClose("deleteSharedSecretConfirmation");
   };
 
   return (
-    <Card>
-      <CardHeader>
+    <Card className="gap-0">
+      <CardHeader className="border-b">
         <CardTitle>
           Shared Secrets
           <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/secret-sharing" />
@@ -68,7 +66,7 @@ export const ShareSecretTab = () => {
           </Button>
         </CardAction>
       </CardHeader>
-      <CardContent>
+      <CardContent className="pt-5">
         <ShareSecretsTable handlePopUpOpen={handlePopUpOpen} />
       </CardContent>
       <AddShareSecretModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />
@@ -81,14 +79,20 @@ export const ShareSecretTab = () => {
             <AlertDialogMedia>
               <Trash2 />
             </AlertDialogMedia>
-            <AlertDialogTitle>Delete shared secret?</AlertDialogTitle>
+            <AlertDialogTitle>
+              Delete {deleteSecret?.name ? `"${deleteSecret.name}"` : "shared secret"}?
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              This action cannot be undone. The shared secret link will no longer be accessible.
+              The shared secret link will no longer be accessible. This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction variant="danger" onClick={onDeleteApproved}>
+            <AlertDialogAction
+              variant="danger"
+              onClick={onDeleteApproved}
+              isPending={deleteSecretShare.isPending}
+            >
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretTab.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretTab.tsx
@@ -1,4 +1,4 @@
-import { ForwardIcon, Trash2 } from "lucide-react";
+import { MessageSquareShare, Trash2 } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
 import {
@@ -61,7 +61,7 @@ export const ShareSecretTab = () => {
               handlePopUpOpen("createSharedSecret");
             }}
           >
-            <ForwardIcon />
+            <MessageSquareShare />
             Share Secret
           </Button>
         </CardAction>

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
@@ -1,6 +1,8 @@
+import { useSearch } from "@tanstack/react-router";
 import { format } from "date-fns";
-import { ClockAlertIcon, ClockIcon, Ellipsis, Mail, MailOpen, Trash2 } from "lucide-react";
+import { ClockAlertIcon, ClockIcon, Copy, Ellipsis, Mail, MailOpen, Trash2 } from "lucide-react";
 
+import { createNotification } from "@app/components/notifications";
 import {
   Badge,
   DropdownMenu,
@@ -33,6 +35,16 @@ export const ShareSecretsRow = ({
     }
   ) => void;
 }) => {
+  const subOrganization = useSearch({
+    strict: false,
+    select: (el) => el?.subOrganization
+  });
+
+  const sharedSecretUrl = new URL(`${window.location.origin}/shared/secret/${row.id}`);
+  if (subOrganization) {
+    sharedSecretUrl.searchParams.set("subOrganization", subOrganization);
+  }
+
   const lastViewedAt = row.lastViewedAt
     ? format(new Date(row.lastViewedAt), "MMM d, yyyy h:mm a")
     : undefined;
@@ -47,7 +59,7 @@ export const ShareSecretsRow = ({
   }
 
   return (
-    <TableRow key={row.id}>
+    <TableRow>
       <TableCell>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -62,10 +74,16 @@ export const ShareSecretsRow = ({
           </TooltipContent>
         </Tooltip>
       </TableCell>
-      <TableCell>{row.name || <span className="text-muted">&mdash;</span>}</TableCell>
+      <TableCell className="max-w-56 break-words whitespace-normal">
+        {row.name || <span className="text-muted">&mdash;</span>}
+      </TableCell>
 
-      <TableCell>{format(new Date(row.createdAt), "MMM d, yyyy h:mm a")}</TableCell>
-      <TableCell>{format(new Date(row.expiresAt), "MMM d, yyyy h:mm a")}</TableCell>
+      <TableCell className="text-label">
+        {format(new Date(row.createdAt), "MMM d, yyyy h:mm a")}
+      </TableCell>
+      <TableCell className="text-label">
+        {format(new Date(row.expiresAt), "MMM d, yyyy h:mm a")}
+      </TableCell>
       <TableCell>
         {row.expiresAfterViews !== null ? (
           row.expiresAfterViews
@@ -74,33 +92,51 @@ export const ShareSecretsRow = ({
         )}
       </TableCell>
       <TableCell>
-        <Badge variant={isExpired ? "danger" : "success"}>
+        <Badge className="whitespace-nowrap" variant={isExpired ? "danger" : "success"}>
           {isExpired ? <ClockAlertIcon /> : <ClockIcon />}
           {isExpired ? "Expired" : "Active"}
         </Badge>
       </TableCell>
       <TableCell>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <IconButton variant="ghost" size="xs" aria-label="actions">
-              <Ellipsis className="size-4" />
-            </IconButton>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              variant="danger"
-              onClick={() =>
-                handlePopUpOpen("deleteSharedSecretConfirmation", {
-                  name: "delete",
-                  id: row.id
-                })
-              }
-            >
-              <Trash2 />
-              Delete
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <div className="flex items-center justify-end gap-1">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <IconButton
+                variant="ghost"
+                size="xs"
+                aria-label={`Actions for ${row.name || "shared secret"}`}
+              >
+                <Ellipsis className="size-4" />
+              </IconButton>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem
+                onClick={() => {
+                  navigator.clipboard.writeText(sharedSecretUrl.toString());
+                  createNotification({
+                    text: "Shared secret link copied to clipboard.",
+                    type: "success"
+                  });
+                }}
+              >
+                <Copy />
+                Copy Link
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                variant="danger"
+                onClick={() =>
+                  handlePopUpOpen("deleteSharedSecretConfirmation", {
+                    name: row.name || "shared secret",
+                    id: row.id
+                  })
+                }
+              >
+                <Trash2 />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </TableCell>
     </TableRow>
   );

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react";
 
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
   Empty,
   EmptyDescription,
   EmptyHeader,
@@ -34,7 +38,7 @@ type Props = {
 export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
-  const { isPending, data } = useGetSharedSecrets({
+  const { isPending, isError, data, refetch } = useGetSharedSecrets({
     offset: (page - 1) * perPage,
     limit: perPage
   });
@@ -42,7 +46,18 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
 
   return (
     <div>
-      {(isPending || hasSecrets) && (
+      {isError && (
+        <Alert variant="danger">
+          <AlertTitle>Could not load shared secrets</AlertTitle>
+          <AlertDescription>
+            <span>Refresh the list and try again.</span>
+            <Button size="sm" variant="outline" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </AlertDescription>
+        </Alert>
+      )}
+      {!isError && (isPending || hasSecrets) && (
         <Table>
           <TableHeader>
             <TableRow>
@@ -84,7 +99,7 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
           onChangePerPage={(newPerPage) => setPerPage(newPerPage)}
         />
       )}
-      {!isPending && !data?.secrets?.length && (
+      {!isPending && !isError && !data?.secrets?.length && (
         <Empty className="border">
           <EmptyHeader>
             <EmptyTitle>No secrets shared yet</EmptyTitle>

--- a/frontend/src/pages/public/ShareSecretPage/ShareSecretPage.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/ShareSecretPage.tsx
@@ -3,7 +3,7 @@ import { Helmet } from "react-helmet";
 import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
 import { AuthPageFooter } from "@app/components/auth/AuthPageFooter";
 import { AuthPageHeader } from "@app/components/auth/AuthPageHeader";
-import { Card, CardContent, CardHeader, CardTitle } from "@app/components/v3";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@app/components/v3";
 
 import { ShareSecretForm } from "./components";
 
@@ -20,9 +20,10 @@ export const ShareSecretPage = () => {
       </Helmet>
       <AuthPageHeader />
 
-      <Card className="z-50 m-auto w-full max-w-xl">
+      <Card className="z-50 m-auto w-full max-w-2xl">
         <CardHeader>
           <CardTitle>Share a Secret</CardTitle>
+          <CardDescription>Create an encrypted link that expires automatically.</CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-y-4">
           <ShareSecretForm isPublic />

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSearch } from "@tanstack/react-router";
-import { Check, ClipboardCheck, Copy, Info, Lock, MessageSquareShare } from "lucide-react";
+import { Check, Info, Lock } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
@@ -12,14 +12,18 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Badge,
   Button,
   Field,
   FieldDescription,
   FieldError,
   FieldLabel,
-  IconButton,
   Input,
+  InputGroup,
+  InputGroupInput,
   Select,
   SelectContent,
   SelectItem,
@@ -88,6 +92,21 @@ type Props = {
   allowSecretSharingOutsideOrganization?: boolean;
   maxSharedSecretLifetime?: number;
   maxSharedSecretViewLimit?: number | null;
+  onResultActionsChange?: (actions: SharedSecretResultActions | null) => void;
+};
+
+type SharedSecretDetails = {
+  name?: string;
+  expiresIn: string;
+  maxViews: string;
+  access: string;
+  password: string;
+};
+
+export type SharedSecretResultActions = {
+  hasLink: boolean;
+  createMore: () => void;
+  copyLink?: () => void;
 };
 
 export const ShareSecretForm = ({
@@ -95,12 +114,23 @@ export const ShareSecretForm = ({
   value,
   allowSecretSharingOutsideOrganization = true,
   maxSharedSecretLifetime,
-  maxSharedSecretViewLimit
+  maxSharedSecretViewLimit,
+  onResultActionsChange
 }: Props) => {
   const [secretLink, setSecretLink] = useState<string | null>(null);
+  const [sharedSecretDetails, setSharedSecretDetails] = useState<SharedSecretDetails | null>(null);
   const [, isCopyingSecret, setCopyTextSecret] = useTimedReset<string>({
     initialState: "Copy to clipboard"
   });
+  const clearResult = () => {
+    setSharedSecretDetails(null);
+    setSecretLink(null);
+    onResultActionsChange?.(null);
+  };
+  const copyResultLink = () => {
+    navigator.clipboard.writeText(secretLink || "");
+    setCopyTextSecret("Copied");
+  };
   const subOrganization = useSearch({
     strict: false,
     select: (el) => el?.subOrganization
@@ -163,8 +193,23 @@ export const ShareSecretForm = ({
       allowExternalEmails
     });
 
+    setSharedSecretDetails({
+      name,
+      expiresIn: expiresInOptions.find((option) => option.value === expiresIn)?.label ?? expiresIn,
+      maxViews: shouldLimitView
+        ? `${viewLimit} view${Number(viewLimit) === 1 ? "" : "s"}`
+        : "Unlimited",
+      access:
+        formAccessType === SecretSharingAccessType.Organization ||
+        !allowSecretSharingOutsideOrganization
+          ? "Organization only"
+          : "Anyone with the link",
+      password: password ? "Protected" : "Not protected"
+    });
+
     if (processedEmails && processedEmails.length > 0) {
       setSecretLink("");
+      onResultActionsChange?.({ hasLink: false, createMore: clearResult });
 
       const showAccountRequiredMessage = !allowExternalEmails && !isOrgAccess;
 
@@ -181,6 +226,7 @@ export const ShareSecretForm = ({
       }
 
       setSecretLink(link.toString());
+      onResultActionsChange?.({ hasLink: true, createMore: clearResult, copyLink: copyResultLink });
 
       navigator.clipboard.writeText(link.toString());
 
@@ -513,50 +559,73 @@ export const ShareSecretForm = ({
   if (secretLink === "")
     return (
       <div className="flex flex-col gap-4">
-        <div className="flex items-start gap-3 rounded-lg border border-success/20 bg-success/5 p-4 text-success">
-          <Check className="mt-0.5 size-4 shrink-0" />
-          <div className="flex flex-col gap-1">
-            <p className="font-medium">Secret link sent</p>
-            <p className="text-sm text-success/80">
-              The shared secret link has been emailed to the selected recipients.
-            </p>
-          </div>
-        </div>
-        <Button className="w-full" variant="project" size="lg" onClick={() => setSecretLink(null)}>
-          Share Another Secret
-          <MessageSquareShare />
-        </Button>
+        <Alert variant="success">
+          <Check />
+          <AlertTitle>Secret link sent</AlertTitle>
+          <AlertDescription>
+            The shared secret link has been emailed to the selected recipients.
+          </AlertDescription>
+        </Alert>
+        {!onResultActionsChange && (
+          <Button className="w-full" variant="project" size="lg" onClick={clearResult}>
+            Create more
+          </Button>
+        )}
       </div>
     );
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-start gap-3 rounded-lg border border-success/20 bg-success/5 p-4 text-success">
-        <Check className="mt-0.5 size-4 shrink-0" />
-        <div className="flex flex-col gap-1">
-          <p className="font-medium">Secret link created</p>
-          <p className="text-sm text-success/80">The link was copied to your clipboard.</p>
+      <Alert variant="success">
+        <Check />
+        <AlertTitle>Secret link created</AlertTitle>
+        <AlertDescription>The link was copied to your clipboard.</AlertDescription>
+      </Alert>
+      {sharedSecretDetails && (
+        <div className="rounded-md border border-border bg-container p-4 text-sm">
+          <p className="text-heading mb-3 font-medium">Shared secret details</p>
+          <dl className="grid gap-x-4 gap-y-2 sm:grid-cols-2">
+            <div>
+              <dt className="text-muted">Name</dt>
+              <dd className="break-words text-label">{sharedSecretDetails.name || "—"}</dd>
+            </div>
+            <div>
+              <dt className="text-muted">Expires in</dt>
+              <dd className="text-label">{sharedSecretDetails.expiresIn}</dd>
+            </div>
+            <div>
+              <dt className="text-muted">Maximum views</dt>
+              <dd className="text-label">{sharedSecretDetails.maxViews}</dd>
+            </div>
+            <div>
+              <dt className="text-muted">Access</dt>
+              <dd className="text-label">{sharedSecretDetails.access}</dd>
+            </div>
+            <div>
+              <dt className="text-muted">Password</dt>
+              <dd className="text-label">{sharedSecretDetails.password}</dd>
+            </div>
+          </dl>
         </div>
-      </div>
-      <div className="flex items-start gap-3 rounded-md border border-border bg-container p-3 text-label">
-        <p className="min-w-0 flex-1 font-mono text-sm break-all">{secretLink}</p>
-        <IconButton
-          aria-label="Copy shared secret link"
-          variant="ghost-muted"
-          size="sm"
-          className="shrink-0"
-          onClick={() => {
-            navigator.clipboard.writeText(secretLink || "");
-            setCopyTextSecret("Copied");
-          }}
-        >
-          {isCopyingSecret ? <ClipboardCheck className="size-4" /> : <Copy className="size-4" />}
-        </IconButton>
-      </div>
-      <Button className="w-full" variant="project" size="lg" onClick={() => setSecretLink(null)}>
-        Share Another Secret
-        <MessageSquareShare />
-      </Button>
+      )}
+      <InputGroup>
+        <InputGroupInput
+          aria-label="Shared secret link"
+          value={secretLink || ""}
+          readOnly
+          className="min-w-0 font-mono text-xs"
+        />
+      </InputGroup>
+      {!onResultActionsChange && (
+        <div className="flex flex-col gap-3 sm:flex-row">
+          <Button className="w-full sm:flex-1" variant="project" size="lg" onClick={clearResult}>
+            Create more
+          </Button>
+          <Button className="w-full sm:flex-1" variant="outline" size="lg" onClick={copyResultLink}>
+            {isCopyingSecret ? "Copied" : "Copy shared link"}
+          </Button>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSearch } from "@tanstack/react-router";
-import { Check, ClipboardCheck, Copy, ForwardIcon, Info, Lock } from "lucide-react";
+import { Check, ClipboardCheck, Copy, Info, Lock, MessageSquareShare } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
@@ -524,7 +524,7 @@ export const ShareSecretForm = ({
         </div>
         <Button className="w-full" variant="project" size="lg" onClick={() => setSecretLink(null)}>
           Share Another Secret
-          <ForwardIcon />
+          <MessageSquareShare />
         </Button>
       </div>
     );
@@ -555,7 +555,7 @@ export const ShareSecretForm = ({
       </div>
       <Button className="w-full" variant="project" size="lg" onClick={() => setSecretLink(null)}>
         Share Another Secret
-        <ForwardIcon />
+        <MessageSquareShare />
       </Button>
     </div>
   );

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -195,7 +195,7 @@ export const ShareSecretForm = ({
 
   if (secretLink === null)
     return (
-      <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
+      <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-5">
         {!isPublic && (
           <Controller
             control={control}
@@ -332,11 +332,11 @@ export const ShareSecretForm = ({
         )}
 
         {(!isPublic || maxSharedSecretViewLimit === null || isLimitingView) && (
-          <Accordion type="single" collapsible variant="ghost">
+          <Accordion type="single" collapsible variant="default" className="mt-1">
             <AccordionItem value="advance-settings">
               <AccordionTrigger>Advanced Settings</AccordionTrigger>
-              <AccordionContent className="flex flex-col gap-y-4">
-                <div className="flex w-full items-end gap-2 overflow-visible">
+              <AccordionContent className="flex flex-col gap-y-5">
+                <div className="grid w-full gap-4 overflow-visible sm:grid-cols-2">
                   {maxSharedSecretViewLimit === null && (
                     <Controller
                       control={control}
@@ -485,9 +485,9 @@ export const ShareSecretForm = ({
             </AccordionItem>
           </Accordion>
         )}
-        <div className="flex w-full justify-end">
+        <div className="flex w-full flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
           {isPublic && (
-            <Badge variant="ghost" className="mt-auto mr-auto">
+            <Badge variant="ghost" className="mr-auto">
               <img
                 src="/images/logotransparent_trimmed.png"
                 alt="Infisical"
@@ -500,6 +500,7 @@ export const ShareSecretForm = ({
             size="md"
             variant="project"
             type="submit"
+            className="w-full sm:w-auto"
             isPending={isSubmitting}
             isDisabled={isSubmitting}
           >
@@ -511,27 +512,39 @@ export const ShareSecretForm = ({
 
   if (secretLink === "")
     return (
-      <>
-        <div className="relative flex items-center justify-center rounded-lg border border-border bg-container p-4 pr-6 text-foreground/85">
-          <Check className="mr-2 size-4 text-success" />
-          <span>Shared secret link has been emailed to select users.</span>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-3 rounded-lg border border-success/20 bg-success/5 p-4 text-success">
+          <Check className="mt-0.5 size-4 shrink-0" />
+          <div className="flex flex-col gap-1">
+            <p className="font-medium">Secret link sent</p>
+            <p className="text-sm text-success/80">
+              The shared secret link has been emailed to the selected recipients.
+            </p>
+          </div>
         </div>
         <Button className="w-full" variant="project" size="lg" onClick={() => setSecretLink(null)}>
           Share Another Secret
           <ForwardIcon />
         </Button>
-      </>
+      </div>
     );
 
   return (
-    <>
-      <div className="relative flex items-center justify-between rounded-md border border-border bg-container p-2 pr-5 pl-3 text-base text-label">
-        <p className="mr-4 break-all">{secretLink}</p>
+    <div className="flex flex-col gap-4">
+      <div className="flex items-start gap-3 rounded-lg border border-success/20 bg-success/5 p-4 text-success">
+        <Check className="mt-0.5 size-4 shrink-0" />
+        <div className="flex flex-col gap-1">
+          <p className="font-medium">Secret link created</p>
+          <p className="text-sm text-success/80">The link was copied to your clipboard.</p>
+        </div>
+      </div>
+      <div className="flex items-start gap-3 rounded-md border border-border bg-container p-3 text-label">
+        <p className="min-w-0 flex-1 font-mono text-sm break-all">{secretLink}</p>
         <IconButton
-          aria-label="copy icon"
+          aria-label="Copy shared secret link"
           variant="ghost-muted"
           size="sm"
-          className="absolute top-1 right-1"
+          className="shrink-0"
           onClick={() => {
             navigator.clipboard.writeText(secretLink || "");
             setCopyTextSecret("Copied");
@@ -544,6 +557,6 @@ export const ShareSecretForm = ({
         Share Another Secret
         <ForwardIcon />
       </Button>
-    </>
+    </div>
   );
 };

--- a/frontend/src/pages/public/ShareSecretPage/components/index.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/index.tsx
@@ -1,1 +1,2 @@
+export type { SharedSecretResultActions } from "./ShareSecretForm";
 export { ShareSecretForm } from "./ShareSecretForm";

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/ViewSharedSecretByIDPage.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/ViewSharedSecretByIDPage.tsx
@@ -3,15 +3,17 @@ import { Helmet } from "react-helmet";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { AxiosError } from "axios";
 import { addSeconds, formatISO } from "date-fns";
+import { KeyRoundIcon } from "lucide-react";
 
 import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
 import { AuthPageFooter } from "@app/components/auth/AuthPageFooter";
 import { AuthPageHeader } from "@app/components/auth/AuthPageHeader";
 import { createNotification } from "@app/components/notifications";
 import {
+  Button,
   Card,
   CardContent,
-  CardDescription,
+  CardFooter,
   CardHeader,
   CardTitle,
   PageLoader
@@ -287,10 +289,31 @@ export const ViewSharedSecretByIDPage = () => {
       <div className="relative z-10 my-auto flex flex-col items-center py-10">
         <Card className="w-full max-w-xl">
           <CardHeader>
-            <CardTitle>View shared secret</CardTitle>
-            <CardDescription>Reveal the value only when you are ready to use it.</CardDescription>
+            <CardTitle className="font-alliance text-2xl font-normal">View shared secret</CardTitle>
           </CardHeader>
-          <CardContent>{secretContent}</CardContent>
+          <CardContent className="-mt-4 flex flex-col gap-2">
+            {secret && (
+              <SecretContainer
+                description="Reveal the value when you're ready to use it."
+                secret={secret}
+                brandingTheme={brandingTheme}
+              />
+            )}
+            {!secret && secretContent}
+          </CardContent>
+          {secret && (
+            <CardFooter className="px-0 pt-0">
+              <Button
+                className="w-full"
+                variant="project"
+                size="lg"
+                onClick={() => window.open("/share-secret", "_blank", "noopener")}
+              >
+                <KeyRoundIcon />
+                Share your own secret
+              </Button>
+            </CardFooter>
+          )}
         </Card>
       </div>
       <AuthPageFooter />

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/ViewSharedSecretByIDPage.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/ViewSharedSecretByIDPage.tsx
@@ -8,7 +8,14 @@ import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
 import { AuthPageFooter } from "@app/components/auth/AuthPageFooter";
 import { AuthPageHeader } from "@app/components/auth/AuthPageHeader";
 import { createNotification } from "@app/components/notifications";
-import { Card, CardContent, CardHeader, CardTitle, PageLoader } from "@app/components/v3";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  PageLoader
+} from "@app/components/v3";
 import { SessionStorageKeys } from "@app/const";
 import { ROUTE_PATHS } from "@app/const/routes";
 import {
@@ -281,6 +288,7 @@ export const ViewSharedSecretByIDPage = () => {
         <Card className="w-full max-w-xl">
           <CardHeader>
             <CardTitle>View shared secret</CardTitle>
+            <CardDescription>Reveal the value only when you are ready to use it.</CardDescription>
           </CardHeader>
           <CardContent>{secretContent}</CardContent>
         </Card>

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -55,7 +55,7 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
         </p>
         <div className="ml-1 flex shrink-0 items-start gap-2 self-start">
           <IconButton
-            aria-label="copy icon"
+            aria-label="Copy shared secret value"
             variant="ghost"
             size="sm"
             onClick={() => {
@@ -71,7 +71,7 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
             )}
           </IconButton>
           <IconButton
-            aria-label="toggle visibility"
+            aria-label={isVisible ? "Hide shared secret value" : "Reveal shared secret value"}
             variant="ghost"
             size="sm"
             onClick={() => setIsVisible.toggle()}

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -1,4 +1,4 @@
-import { ClipboardCheckIcon, Copy, Eye, EyeOff, ForwardIcon } from "lucide-react";
+import { ClipboardCheckIcon, Copy, Eye, EyeOff, MessageSquareShare } from "lucide-react";
 
 import { Button, IconButton } from "@app/components/v3";
 import { useTimedReset, useToggle } from "@app/hooks";
@@ -90,7 +90,7 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
           onClick={() => window.open("/share-secret", "_blank", "noopener")}
         >
           Share Your Own Secret
-          <ForwardIcon />
+          <MessageSquareShare />
         </Button>
       )}
     </div>

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -1,6 +1,6 @@
-import { ClipboardCheckIcon, Copy, Eye, EyeOff, MessageSquareShare } from "lucide-react";
+import { ClipboardCheckIcon, Copy, Eye, EyeOff } from "lucide-react";
 
-import { Button, IconButton } from "@app/components/v3";
+import { Button, InputGroup, InputGroupButton, InputGroupTextArea } from "@app/components/v3";
 import { useTimedReset, useToggle } from "@app/hooks";
 import { TAccessSharedSecretResponse } from "@app/hooks/api/secretSharing";
 
@@ -10,22 +10,14 @@ import { SecretShareInfo } from "./SecretShareInfo";
 type Props = {
   secret: TAccessSharedSecretResponse;
   brandingTheme?: BrandingTheme;
+  description?: string;
 };
 
-export const SecretContainer = ({ secret, brandingTheme }: Props) => {
+export const SecretContainer = ({ secret, brandingTheme, description }: Props) => {
   const [isVisible, setIsVisible] = useToggle(false);
   const [, isCopyingSecret, setCopyTextSecret] = useTimedReset<string>({
     initialState: "Copy to clipboard"
   });
-
-  const hiddenSecret = "*".repeat(secret.secretValue.length);
-
-  const panelStyle = brandingTheme
-    ? {
-        backgroundColor: brandingTheme.panelBg,
-        borderColor: brandingTheme.panelBorder
-      }
-    : undefined;
 
   const secretDisplayStyle = brandingTheme
     ? {
@@ -35,64 +27,75 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
       }
     : undefined;
 
-  const iconButtonStyle = brandingTheme
+  const inputGroupStyle = brandingTheme
     ? {
         backgroundColor: brandingTheme.buttonBg,
-        color: brandingTheme.textColor
+        borderColor: brandingTheme.panelBorder
       }
     : undefined;
 
   return (
-    <div style={panelStyle}>
-      <div
-        className={`flex items-start justify-between rounded-md border p-2 pl-3 text-base ${
-          brandingTheme ? "" : "border-border bg-container text-label"
-        }`}
-        style={secretDisplayStyle}
-      >
-        <p className="min-w-0 break-all whitespace-pre-wrap">
-          {isVisible ? secret.secretValue : hiddenSecret}
-        </p>
-        <div className="ml-1 flex shrink-0 items-start gap-2 self-start">
-          <IconButton
+    <>
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        {description && (
+          <p
+            className={brandingTheme ? "text-sm" : "text-sm text-accent"}
+            style={brandingTheme ? { color: brandingTheme.textMutedColor } : undefined}
+          >
+            {description}
+          </p>
+        )}
+        <div className="flex items-center justify-end gap-1 sm:ml-auto">
+          <InputGroupButton
             aria-label="Copy shared secret value"
-            variant="ghost"
-            size="sm"
             onClick={() => {
               navigator.clipboard.writeText(secret.secretValue);
               setCopyTextSecret("Copied");
             }}
-            style={iconButtonStyle}
+            style={inputGroupStyle}
           >
             {isCopyingSecret ? (
               <ClipboardCheckIcon className="size-4" />
             ) : (
               <Copy className="size-4" />
             )}
-          </IconButton>
-          <IconButton
-            aria-label={isVisible ? "Hide shared secret value" : "Reveal shared secret value"}
-            variant="ghost"
-            size="sm"
-            onClick={() => setIsVisible.toggle()}
-            style={iconButtonStyle}
-          >
-            {isVisible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-          </IconButton>
+          </InputGroupButton>
+          {isVisible && (
+            <InputGroupButton
+              aria-label="Hide shared secret value"
+              onClick={() => setIsVisible.toggle()}
+              style={inputGroupStyle}
+            >
+              <EyeOff className="size-4" />
+            </InputGroupButton>
+          )}
         </div>
       </div>
-      <SecretShareInfo secret={secret} brandingTheme={brandingTheme} />
-      {!brandingTheme && (
-        <Button
-          className="mt-4 w-full"
-          variant="project"
-          size="lg"
-          onClick={() => window.open("/share-secret", "_blank", "noopener")}
+      {isVisible ? (
+        <InputGroup
+          className="min-h-24 items-start"
+          style={brandingTheme ? secretDisplayStyle : undefined}
         >
-          Share Your Own Secret
-          <MessageSquareShare />
+          <InputGroupTextArea
+            aria-label="Shared secret value"
+            value={secret.secretValue}
+            readOnly
+            className={`min-h-24 text-base ${brandingTheme ? "" : "text-label"}`}
+            style={brandingTheme ? secretDisplayStyle : undefined}
+          />
+        </InputGroup>
+      ) : (
+        <Button
+          className="min-h-24 w-full"
+          variant="outline"
+          onClick={() => setIsVisible.toggle()}
+          style={brandingTheme ? secretDisplayStyle : undefined}
+        >
+          <Eye className="size-4" />
+          Reveal
         </Button>
       )}
-    </div>
+      <SecretShareInfo secret={secret} brandingTheme={brandingTheme} />
+    </>
   );
 };

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretShareInfo.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretShareInfo.tsx
@@ -51,7 +51,7 @@ export const SecretShareInfo = ({ secret, brandingTheme }: Props) => {
       {timeRemaining && (
         <div className="flex items-center gap-2">
           <Clock className="size-3.5 shrink-0" style={iconStyle} />
-          <span>Expires on {timeRemaining}</span>
+          <span>Access expires on {timeRemaining}</span>
         </div>
       )}
       {viewsRemaining !== null && (

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretShareInfo.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretShareInfo.tsx
@@ -31,32 +31,22 @@ export const SecretShareInfo = ({ secret, brandingTheme }: Props) => {
     return null;
   }
 
-  const infoStyle = brandingTheme
-    ? {
-        backgroundColor: brandingTheme.inputBg,
-        borderColor: brandingTheme.panelBorder,
-        color: brandingTheme.textMutedColor
-      }
-    : undefined;
-
   const iconStyle = brandingTheme ? { color: brandingTheme.textMutedColor } : undefined;
 
   return (
     <div
-      className={`mt-4 flex flex-col gap-2 rounded-md border p-3 text-sm ${
-        brandingTheme ? "" : "border-border bg-container text-label"
-      }`}
-      style={infoStyle}
+      className={`flex flex-wrap gap-x-4 gap-y-1 text-xs ${brandingTheme ? "" : "text-accent"}`}
+      style={brandingTheme ? { color: brandingTheme.textMutedColor } : undefined}
     >
       {timeRemaining && (
-        <div className="flex items-center gap-2">
-          <Clock className="size-3.5 shrink-0" style={iconStyle} />
+        <div className="flex items-center gap-1">
+          <Clock className="size-3 shrink-0" style={iconStyle} />
           <span>Access expires on {timeRemaining}</span>
         </div>
       )}
       {viewsRemaining !== null && (
         <div className="flex items-center gap-2">
-          <Eye className="size-3.5 shrink-0" style={iconStyle} />
+          <Eye className="size-3 shrink-0" style={iconStyle} />
           <span>
             {viewsRemaining === 0
               ? "This is the last time you can view this secret"


### PR DESCRIPTION
## Context

SECRETS-515 improves the Secrets Sharing experience across the organization sharing surfaces and public shared-secret states. The previous experience mixed legacy v2 controls with v3 components, used a dialog for the authenticated share flow, and did not expose a direct way to copy a shared-secret link from the table action menu.

This change:
- migrates the sharing page header and share/request tabs to v3 components;
- presents the authenticated Share Secret form in a v3 sheet;
- adds a Copy Link action to the existing triple-dot menu in the Shared Secrets table;
- preserves sub-organization routing in copied links;
- refines loading, error, deletion, success, copy/reveal, expiry, and public-view presentation states.

Related ticket: [SECRETS-515](https://linear.app/infisical/issue/SECRETS-515/improve-secrets-sharing-uxui)

## Screenshots

<img width="2886" height="1962" alt="CleanShot 2026-08-18 at 08 14 03@2x" src="https://github.com/user-attachments/assets/fbdc4844-fc61-4bec-becb-c3177511c080" />
<img width="2886" height="1962" alt="CleanShot 2026-08-18 at 08 14 19@2x" src="https://github.com/user-attachments/assets/09ab9ea7-1bf8-46fa-8cd4-492f250f4bee" />
<img width="2886" height="1962" alt="CleanShot 2026-08-18 at 08 14 30@2x" src="https://github.com/user-attachments/assets/cc81f086-5fd0-40d1-a430-ddf485da952b" />



## Steps to verify the change

1. Open an organization project and navigate to Secret Management > Secret Sharing.
2. Confirm the page header and Share Secret / Request Secret tabs use the current v3 treatment and URL tab navigation still works.
3. In the Shared Secrets table, open a row's triple-dot menu and select Copy Link. Confirm a success notification appears and the copied URL targets `/shared/secret/:id`, preserving the optional `subOrganization` query parameter when present.
4. Select Share Secret and confirm the form opens in a right-side sheet. Exercise expiry and Advanced Settings, including password protection and organization restriction, then submit a valid secret.
5. Confirm the success state still supports copying the generated link and closing the sheet.
6. Open a public shared-secret link and verify masked/reveal/copy behavior, expiry information, password errors, and long secret values remain intact.
7. Verify loading, empty, retry/error, delete confirmation, and narrow viewport states as applicable.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)