### PR TITLE
feat(gateway-pools): load balancing

### DIFF
--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -79,6 +79,9 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     },
     claimLeastLoaded: async (keys, baseOccupancies) => {
       if (keys.length === 0) return 0;
+      if (keys.length !== baseOccupancies.length) {
+        throw new Error("claimLeastLoaded: baseOccupancies must have one entry per key");
+      }
       let bestIdx = 0;
       let bestTotal: number | null = null;
       keys.forEach((key, i) => {

--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -138,14 +138,6 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     hashGet: async (key, field) => {
       return hashStore[key]?.[field] ?? null;
     },
-    hashGetAll: async (key) => {
-      return { ...(hashStore[key] ?? {}) };
-    },
-    hashDelete: async (key, field) => {
-      if (!hashStore[key]?.[field]) return 0;
-      delete hashStore[key][field];
-      return 1;
-    },
     pgIncrementBy: async () => {
       return 1;
     },

--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -19,7 +19,7 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     },
     setExpiry: async () => 0,
     ttl: async () => -1,
-    setItemWithExpiry: async (key, value) => {
+    setItemWithExpiry: async (key, _expiryInSeconds, value) => {
       store[key] = value;
       return "OK";
     },
@@ -77,8 +77,15 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     incrementByAndRefreshExpiryIfUnderLimit: async () => {
       return 1;
     },
-    decrementByOrDelete: async () => {
-      return 0;
+    decrementByOrDelete: async (key) => {
+      const current = typeof store[key] === "string" ? parseInt(store[key] as string, 10) : 0;
+      const next = current - 1;
+      if (next <= 0) {
+        delete store[key];
+        return 0;
+      }
+      store[key] = String(next);
+      return next;
     },
     incrementByWithExpiry: async (key, value) => {
       const current = typeof store[key] === "string" ? parseInt(store[key] as string, 10) : 0;
@@ -111,8 +118,22 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     hashGet: async (key, field) => {
       return hashStore[key]?.[field] ?? null;
     },
+    hashGetAll: async (key) => {
+      return { ...(hashStore[key] ?? {}) };
+    },
+    hashDelete: async (key, field) => {
+      if (!hashStore[key]?.[field]) return 0;
+      delete hashStore[key][field];
+      return 1;
+    },
     pgIncrementBy: async () => {
       return 1;
+    },
+    getItemsPrimary: async (keys) => {
+      return keys.map((key) => {
+        const value = store[key];
+        return typeof value === "string" ? value : null;
+      });
     },
     getItems: async (keys) => {
       const values = keys.map((key) => {

--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -77,6 +77,23 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     incrementByAndRefreshExpiryIfUnderLimit: async () => {
       return 1;
     },
+    claimLeastLoaded: async (keys, baseOccupancies) => {
+      if (keys.length === 0) return 0;
+      let bestIdx = 0;
+      let bestTotal: number | null = null;
+      keys.forEach((key, i) => {
+        const reserved = typeof store[key] === "string" ? parseInt(store[key] as string, 10) : 0;
+        const total = baseOccupancies[i] + reserved;
+        if (bestTotal === null || total < bestTotal) {
+          bestTotal = total;
+          bestIdx = i + 1;
+        }
+      });
+      const chosen = keys[bestIdx - 1];
+      const current = typeof store[chosen] === "string" ? parseInt(store[chosen] as string, 10) : 0;
+      store[chosen] = String(current + 1);
+      return bestIdx;
+    },
     decrementByOrDelete: async (key) => {
       const current = typeof store[key] === "string" ? parseInt(store[key] as string, 10) : 0;
       const next = current - 1;

--- a/backend/src/ee/routes/v2/gateway-router.ts
+++ b/backend/src/ee/routes/v2/gateway-router.ts
@@ -3,7 +3,7 @@ import z from "zod";
 import { GatewaysV2Schema } from "@app/db/schemas";
 import { GATEWAYS } from "@app/lib/api-docs";
 import { zodBuffer } from "@app/lib/zod";
-import { gatewayLoadReportLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { gatewayMetricsReportLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { slugSchema } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
@@ -68,25 +68,25 @@ export const registerGatewayV2Router = async (server: FastifyZodProvider) => {
   // gateway cannot look alive just by reporting load.
   server.route({
     method: "POST",
-    url: "/load",
+    url: "/metrics",
     config: {
-      rateLimit: gatewayLoadReportLimit
+      rateLimit: gatewayMetricsReportLimit
     },
     schema: {
-      operationId: "gatewayLoadReport",
+      operationId: "gatewayMetricsReport",
       body: z.object({
-        activeChannels: z.number().int().min(0).max(1_000_000).describe(GATEWAYS.LOAD_REPORT.activeChannels)
+        activeChannels: z.number().int().min(0).max(1_000_000).describe(GATEWAYS.METRICS_REPORT.activeChannels)
       }),
       response: {
         200: z.object({
-          gatewayId: z.string().uuid().describe(GATEWAYS.LOAD_REPORT.gatewayId),
-          activeChannels: z.number().int().describe(GATEWAYS.LOAD_REPORT.activeChannels)
+          gatewayId: z.string().uuid().describe(GATEWAYS.METRICS_REPORT.gatewayId),
+          activeChannels: z.number().int().describe(GATEWAYS.METRICS_REPORT.activeChannels)
         })
       }
     },
     onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.GATEWAY_ACCESS_TOKEN]),
     handler: async (req) => {
-      return server.services.gatewayV2.reportLoad({
+      return server.services.gatewayV2.reportMetrics({
         orgPermission: req.permission,
         activeChannels: req.body.activeChannels
       });

--- a/backend/src/ee/routes/v2/gateway-router.ts
+++ b/backend/src/ee/routes/v2/gateway-router.ts
@@ -1,8 +1,9 @@
 import z from "zod";
 
 import { GatewaysV2Schema } from "@app/db/schemas";
+import { GATEWAYS } from "@app/lib/api-docs";
 import { zodBuffer } from "@app/lib/zod";
-import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { gatewayLoadReportLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { slugSchema } from "@app/server/lib/schemas";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
@@ -61,34 +62,34 @@ export const registerGatewayV2Router = async (server: FastifyZodProvider) => {
     }
   });
 
-  // Deliberately separate from /heartbeat: that one probes back through the relay and writes to the
-  // database, which is far too costly to run at the cadence pool selection needs. This only touches
-  // the load tracker's Redis keys.
+  // Separate from /heartbeat because of what its handler costs, not how it is called: a heartbeat
+  // makes the platform dial back through the relay to probe liveness and then writes to Postgres,
+  // which is far too expensive at the cadence pool selection needs. This one only writes a Redis key,
+  // and deliberately does not touch heartbeat, so a gateway cannot look alive by reporting load.
   server.route({
     method: "POST",
     url: "/load",
     config: {
-      rateLimit: writeLimit
+      rateLimit: gatewayLoadReportLimit
     },
     schema: {
       operationId: "gatewayLoadReport",
       body: z.object({
-        activeChannels: z.number().int().min(0).max(1_000_000)
+        activeChannels: z.number().int().min(0).max(1_000_000).describe(GATEWAYS.LOAD_REPORT.activeChannels)
       }),
       response: {
         200: z.object({
-          message: z.string()
+          gatewayId: z.string().uuid().describe(GATEWAYS.LOAD_REPORT.gatewayId),
+          activeChannels: z.number().int().describe(GATEWAYS.LOAD_REPORT.activeChannels)
         })
       }
     },
     onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.GATEWAY_ACCESS_TOKEN]),
     handler: async (req) => {
-      await server.services.gatewayV2.reportLoad({
+      return server.services.gatewayV2.reportLoad({
         orgPermission: req.permission,
         activeChannels: req.body.activeChannels
       });
-
-      return { message: "Successfully reported gateway load" };
     }
   });
 

--- a/backend/src/ee/routes/v2/gateway-router.ts
+++ b/backend/src/ee/routes/v2/gateway-router.ts
@@ -62,10 +62,10 @@ export const registerGatewayV2Router = async (server: FastifyZodProvider) => {
     }
   });
 
-  // Separate from /heartbeat because of what its handler costs, not how it is called: a heartbeat
-  // makes the platform dial back through the relay to probe liveness and then writes to Postgres,
-  // which is far too expensive at the cadence pool selection needs. This one only writes a Redis key,
-  // and deliberately does not touch heartbeat, so a gateway cannot look alive by reporting load.
+  // Heartbeat is expensive: the platform dials back through the relay to check the gateway is
+  // really there, then writes to Postgres. Every gateway reports load every 10 seconds, which is
+  // far too often for that. This one just writes a Redis key. It does not touch heartbeat, so a
+  // gateway cannot look alive just by reporting load.
   server.route({
     method: "POST",
     url: "/load",

--- a/backend/src/ee/routes/v2/gateway-router.ts
+++ b/backend/src/ee/routes/v2/gateway-router.ts
@@ -61,6 +61,37 @@ export const registerGatewayV2Router = async (server: FastifyZodProvider) => {
     }
   });
 
+  // Deliberately separate from /heartbeat: that one probes back through the relay and writes to the
+  // database, which is far too costly to run at the cadence pool selection needs. This only touches
+  // the load tracker's Redis keys.
+  server.route({
+    method: "POST",
+    url: "/load",
+    config: {
+      rateLimit: writeLimit
+    },
+    schema: {
+      operationId: "gatewayLoadReport",
+      body: z.object({
+        activeChannels: z.number().int().min(0).max(1_000_000)
+      }),
+      response: {
+        200: z.object({
+          message: z.string()
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.GATEWAY_ACCESS_TOKEN]),
+    handler: async (req) => {
+      await server.services.gatewayV2.reportLoad({
+        orgPermission: req.permission,
+        activeChannels: req.body.activeChannels
+      });
+
+      return { message: "Successfully reported gateway load" };
+    }
+  });
+
   server.route({
     method: "POST",
     url: "/heartbeat",

--- a/backend/src/ee/services/app-connections/chef/chef-connection-fns.ts
+++ b/backend/src/ee/services/app-connections/chef/chef-connection-fns.ts
@@ -187,9 +187,7 @@ export const requestWithChefGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }

--- a/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/azure-sql-database.ts
@@ -213,9 +213,7 @@ export const AzureSqlDatabaseProvider = ({
           await gatewayCallback("localhost", port);
         },
         {
-          relayHost: gatewayV2ConnectionDetails.relayHost,
-          gateway: gatewayV2ConnectionDetails.gateway,
-          relay: gatewayV2ConnectionDetails.relay,
+          ...gatewayV2ConnectionDetails,
           protocol: GatewayProxyProtocol.Tcp
         }
       );

--- a/backend/src/ee/services/dynamic-secret/providers/clickhouse.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/clickhouse.ts
@@ -187,9 +187,7 @@ export const ClickhouseProvider = ({
           await gatewayCallback("localhost", port);
         },
         {
-          relayHost: gatewayV2ConnectionDetails.relayHost,
-          gateway: gatewayV2ConnectionDetails.gateway,
-          relay: gatewayV2ConnectionDetails.relay,
+          ...gatewayV2ConnectionDetails,
           protocol: GatewayProxyProtocol.Tcp
         }
       );

--- a/backend/src/ee/services/dynamic-secret/providers/kubernetes.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/kubernetes.ts
@@ -76,9 +76,7 @@ export const KubernetesProvider = ({
           );
         },
         {
-          relayHost: gatewayV2ConnectionDetails.relayHost,
-          gateway: gatewayV2ConnectionDetails.gateway,
-          relay: gatewayV2ConnectionDetails.relay,
+          ...gatewayV2ConnectionDetails,
           protocol: inputs.reviewTokenThroughGateway ? GatewayProxyProtocol.Http : GatewayProxyProtocol.Tcp,
           httpsAgent: inputs.httpsAgent
         }

--- a/backend/src/ee/services/dynamic-secret/providers/milvus.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/milvus.ts
@@ -142,9 +142,7 @@ export const MilvusProvider = ({
 
     if (gatewayV2ConnectionDetails) {
       return withGatewayV2Proxy(async (port) => gatewayCallback("localhost", port), {
-        relayHost: gatewayV2ConnectionDetails.relayHost,
-        gateway: gatewayV2ConnectionDetails.gateway,
-        relay: gatewayV2ConnectionDetails.relay,
+        ...gatewayV2ConnectionDetails,
         protocol: GatewayProxyProtocol.Tcp,
         httpsAgent: inputs.httpsAgent
       });

--- a/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/sql-database.ts
@@ -229,9 +229,7 @@ export const SqlDatabaseProvider = ({
           await gatewayCallback("localhost", port);
         },
         {
-          relayHost: gatewayV2ConnectionDetails.relayHost,
-          gateway: gatewayV2ConnectionDetails.gateway,
-          relay: gatewayV2ConnectionDetails.relay,
+          ...gatewayV2ConnectionDetails,
           protocol: GatewayProxyProtocol.Tcp
         }
       );

--- a/backend/src/ee/services/dynamic-secret/providers/vertica.ts
+++ b/backend/src/ee/services/dynamic-secret/providers/vertica.ts
@@ -216,9 +216,7 @@ export const VerticaProvider = ({
           await gatewayCallback("localhost", port);
         },
         {
-          relayHost: gatewayV2ConnectionDetails.relayHost,
-          gateway: gatewayV2ConnectionDetails.gateway,
-          relay: gatewayV2ConnectionDetails.relay,
+          ...gatewayV2ConnectionDetails,
           protocol: GatewayProxyProtocol.Tcp
         }
       );

--- a/backend/src/ee/services/gateway-pool/gateway-pool-failover.test.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-failover.test.ts
@@ -6,13 +6,14 @@ const markSuspect = vi.fn();
 const getSuspect = vi.fn().mockResolvedValue(new Set<string>());
 const getScores = vi.fn();
 const reserve = vi.fn();
+const claimLeastLoaded = vi.fn();
 
 vi.mock("@app/lib/logger", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }));
 
 vi.mock("@app/lib/gateway-v2/gateway-load-tracker", () => ({
-  getGatewayLoadTracker: () => ({ markSuspect, getSuspect, getScores, reserve })
+  getGatewayLoadTracker: () => ({ markSuspect, getSuspect, getScores, reserve, claimLeastLoaded })
 }));
 
 // eslint-disable-next-line import/first
@@ -40,8 +41,10 @@ describe("selectGatewayFromPool under load-tracker failure", () => {
     // clearAllMocks keeps implementations, so a rejection set by one test would leak into the next.
     markSuspect.mockResolvedValue(undefined);
     reserve.mockResolvedValue(undefined);
+    // Without this the load-aware branch throws and every test silently measures the random fallback.
+    claimLeastLoaded.mockImplementation(async (c: { id: string }[]) => c[0]?.id);
     getSuspect.mockResolvedValue(new Set<string>());
-    getScores.mockResolvedValue(new Map(MEMBERS.map((m) => [m.id, { score: 0, reported: true }])));
+    getScores.mockResolvedValue(new Map(MEMBERS.map((m) => [m.id, { score: 0, base: 0, reported: true }])));
   });
 
   test("still selects, and spreads, when Redis reads fail", async () => {
@@ -87,6 +90,34 @@ describe("selectGatewayFromPool under load-tracker failure", () => {
     await expect(svc.selectGatewayFromPool({ poolId: POOL_ID })).resolves.toBeDefined();
   });
 
+  test("actually uses the load-aware claim, not the random fallback", async () => {
+    const svc = buildService();
+    claimLeastLoaded.mockResolvedValue("gw-c");
+
+    for (let i = 0; i < 50; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      expect((await svc.selectGatewayFromPool({ poolId: POOL_ID })).id).toBe("gw-c");
+    }
+    expect(claimLeastLoaded).toHaveBeenCalled();
+    // The atomic claim already reserved, so no separate write should follow it.
+    expect(reserve).not.toHaveBeenCalled();
+  });
+
+  test("keeps the suspect filter when the load path fails", async () => {
+    const svc = buildService();
+    getSuspect.mockResolvedValue(new Set(["gw-a"]));
+    // Anything after the suspect read blowing up must not re-admit the member that just failed.
+    claimLeastLoaded.mockRejectedValue(new Error("EVAL failed"));
+
+    const picked = new Set<string>();
+    for (let i = 0; i < 200; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      picked.add((await svc.selectGatewayFromPool({ poolId: POOL_ID })).id);
+    }
+    expect(picked.has("gw-a")).toBe(false);
+    expect(picked).toEqual(new Set(["gw-b", "gw-c"]));
+  });
+
   test("404s an unknown pool rather than blaming gateway health", async () => {
     const svc = gatewayPoolServiceFactory({
       gatewayPoolDAL: { findById: vi.fn().mockResolvedValue(undefined) },
@@ -101,7 +132,7 @@ describe("selectGatewayFromPool under load-tracker failure", () => {
     } as unknown as TDeps);
 
     await expect(svc.selectGatewayFromPool({ poolId: POOL_ID })).rejects.toThrow(
-      `Gateway pool with ID ${POOL_ID} not found`
+      `Gateway pool with ID '${POOL_ID}' not found`
     );
   });
 
@@ -154,7 +185,7 @@ describe("runWithPoolFailover", () => {
     markSuspect.mockResolvedValue(undefined);
     reserve.mockResolvedValue(undefined);
     getSuspect.mockResolvedValue(new Set<string>());
-    getScores.mockResolvedValue(new Map(MEMBERS.map((m) => [m.id, { score: 0, reported: true }])));
+    getScores.mockResolvedValue(new Map(MEMBERS.map((m) => [m.id, { score: 0, base: 0, reported: true }])));
   });
 
   test("returns the result and the member it ran on", async () => {

--- a/backend/src/ee/services/gateway-pool/gateway-pool-failover.test.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-failover.test.ts
@@ -1,0 +1,237 @@
+import { BadRequestError, GatewayTransportError } from "@app/lib/errors";
+
+type TDeps = Parameters<typeof import("./gateway-pool-service").gatewayPoolServiceFactory>[0];
+
+const markSuspect = vi.fn();
+const getSuspect = vi.fn().mockResolvedValue(new Set<string>());
+const getScores = vi.fn();
+const reserve = vi.fn();
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}));
+
+vi.mock("@app/lib/gateway-v2/gateway-load-tracker", () => ({
+  getGatewayLoadTracker: () => ({ markSuspect, getSuspect, getScores, reserve })
+}));
+
+// eslint-disable-next-line import/first
+import { gatewayPoolServiceFactory } from "./gateway-pool-service";
+
+const POOL_ID = "11111111-1111-1111-1111-111111111111";
+const MEMBERS: { id: string; capabilities?: unknown }[] = [{ id: "gw-a" }, { id: "gw-b" }, { id: "gw-c" }];
+
+const buildService = (members = MEMBERS) =>
+  gatewayPoolServiceFactory({
+    gatewayPoolDAL: { findById: vi.fn().mockResolvedValue({ id: POOL_ID, orgId: "org" }) },
+    gatewayPoolMembershipDAL: { findHealthyGatewaysByPoolId: vi.fn().mockResolvedValue(members) },
+    gatewayV2DAL: { findById: vi.fn() },
+    permissionService: {},
+    licenseService: { getPlan: vi.fn() },
+    identityKubernetesAuthDAL: {},
+    pkiDiscoveryConfigDAL: {},
+    appConnectionDAL: {},
+    dynamicSecretDAL: {}
+  } as unknown as TDeps);
+
+describe("selectGatewayFromPool under load-tracker failure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // clearAllMocks keeps implementations, so a rejection set by one test would leak into the next.
+    markSuspect.mockResolvedValue(undefined);
+    reserve.mockResolvedValue(undefined);
+    getSuspect.mockResolvedValue(new Set<string>());
+    getScores.mockResolvedValue(new Map(MEMBERS.map((m) => [m.id, { score: 0, reported: true }])));
+  });
+
+  test("still selects, and spreads, when Redis reads fail", async () => {
+    const svc = buildService();
+    getScores.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const picked = new Set<string>();
+    for (let i = 0; i < 300; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      picked.add((await svc.selectGatewayFromPool({ poolId: POOL_ID })).id);
+    }
+
+    // A Redis outage must degrade to random selection, never fail the request.
+    expect(picked).toEqual(new Set(["gw-a", "gw-b", "gw-c"]));
+  });
+
+  test("still selects when the suspect lookup fails", async () => {
+    const svc = buildService();
+    getSuspect.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(svc.selectGatewayFromPool({ poolId: POOL_ID })).resolves.toBeDefined();
+  });
+
+  test("a failed reservation write does not fail the selection", async () => {
+    const svc = buildService();
+    reserve.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(svc.selectGatewayFromPool({ poolId: POOL_ID })).resolves.toBeDefined();
+  });
+
+  test("skips a suspect member but still routes when every member is suspect", async () => {
+    const svc = buildService();
+    getSuspect.mockResolvedValue(new Set(["gw-a"]));
+    const picked = new Set<string>();
+    for (let i = 0; i < 200; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      picked.add((await svc.selectGatewayFromPool({ poolId: POOL_ID })).id);
+    }
+    expect(picked.has("gw-a")).toBe(false);
+
+    getSuspect.mockResolvedValue(new Set(["gw-a", "gw-b", "gw-c"]));
+    // Refusing to route at all would be a guaranteed outage; the marks may simply have aged badly.
+    await expect(svc.selectGatewayFromPool({ poolId: POOL_ID })).resolves.toBeDefined();
+  });
+
+  test("404s an unknown pool rather than blaming gateway health", async () => {
+    const svc = gatewayPoolServiceFactory({
+      gatewayPoolDAL: { findById: vi.fn().mockResolvedValue(undefined) },
+      gatewayPoolMembershipDAL: { findHealthyGatewaysByPoolId: vi.fn() },
+      gatewayV2DAL: { findById: vi.fn() },
+      permissionService: {},
+      licenseService: { getPlan: vi.fn() },
+      identityKubernetesAuthDAL: {},
+      pkiDiscoveryConfigDAL: {},
+      appConnectionDAL: {},
+      dynamicSecretDAL: {}
+    } as unknown as TDeps);
+
+    await expect(svc.selectGatewayFromPool({ poolId: POOL_ID })).rejects.toThrow(
+      `Gateway pool with ID ${POOL_ID} not found`
+    );
+  });
+
+  test("applies a capability filter before anything else, so HSM cannot land on a bare gateway", async () => {
+    const svc = gatewayPoolServiceFactory({
+      gatewayPoolDAL: { findById: vi.fn().mockResolvedValue({ id: POOL_ID, orgId: "org" }) },
+      gatewayPoolMembershipDAL: {
+        findHealthyGatewaysByPoolId: vi.fn().mockResolvedValue([
+          { id: "gw-a", capabilities: {} },
+          { id: "gw-hsm", capabilities: { pkcs11: true } },
+          { id: "gw-c", capabilities: null }
+        ])
+      },
+      gatewayV2DAL: { findById: vi.fn() },
+      permissionService: {},
+      licenseService: { getPlan: vi.fn() },
+      identityKubernetesAuthDAL: {},
+      pkiDiscoveryConfigDAL: {},
+      appConnectionDAL: {},
+      dynamicSecretDAL: {}
+    } as unknown as TDeps);
+
+    for (let i = 0; i < 200; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      const picked = await svc.selectGatewayFromPool({
+        poolId: POOL_ID,
+        filter: (g) => (g.capabilities as { pkcs11?: boolean } | null)?.pkcs11 === true
+      });
+      expect(picked.id).toBe("gw-hsm");
+    }
+  });
+
+  test("reports the caller's message when a filter excludes every member", async () => {
+    const svc = buildService([{ id: "gw-a", capabilities: {} }]);
+
+    await expect(
+      svc.selectGatewayFromPool({
+        poolId: POOL_ID,
+        filter: () => false,
+        unavailableMessage: "No HSM-capable gateway available in the pool."
+      })
+    ).rejects.toThrow("No HSM-capable gateway available in the pool.");
+  });
+});
+
+describe("runWithPoolFailover", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // clearAllMocks keeps implementations, so a rejection set by one test would leak into the next.
+    markSuspect.mockResolvedValue(undefined);
+    reserve.mockResolvedValue(undefined);
+    getSuspect.mockResolvedValue(new Set<string>());
+    getScores.mockResolvedValue(new Map(MEMBERS.map((m) => [m.id, { score: 0, reported: true }])));
+  });
+
+  test("returns the result and the member it ran on", async () => {
+    const svc = buildService();
+    const out = await svc.runWithPoolFailover({ poolId: POOL_ID }, async () => "done");
+
+    expect(out.result).toBe("done");
+    expect(MEMBERS.map((m) => m.id)).toContain(out.gatewayId);
+  });
+
+  test("retries on another member when no tunnel was established", async () => {
+    const svc = buildService();
+    const seen: string[] = [];
+
+    const out = await svc.runWithPoolFailover({ poolId: POOL_ID }, async (gatewayId) => {
+      seen.push(gatewayId);
+      if (seen.length === 1) throw new GatewayTransportError({ message: "relay unreachable", gatewayId });
+      return "recovered";
+    });
+
+    expect(out.result).toBe("recovered");
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).not.toBe(seen[1]);
+  });
+
+  test("never retries a failure raised after the target was reached", async () => {
+    const svc = buildService();
+    const seen: string[] = [];
+
+    // The defining safety property: a rotation that half-applied must not run twice.
+    await expect(
+      svc.runWithPoolFailover({ poolId: POOL_ID }, async (gatewayId) => {
+        seen.push(gatewayId);
+        throw new BadRequestError({ message: "password authentication failed" });
+      })
+    ).rejects.toThrow("password authentication failed");
+
+    expect(seen).toHaveLength(1);
+  });
+
+  test("stops at the attempt cap instead of walking the whole pool", async () => {
+    const svc = buildService();
+    const seen: string[] = [];
+
+    await expect(
+      svc.runWithPoolFailover({ poolId: POOL_ID }, async (gatewayId) => {
+        seen.push(gatewayId);
+        throw new GatewayTransportError({ message: "relay unreachable", gatewayId });
+      })
+    ).rejects.toThrow("relay unreachable");
+
+    // Two attempts, not three: retrying every member multiplies load onto whatever is still up.
+    expect(seen).toHaveLength(2);
+  });
+
+  test("surfaces the transport failure, not a selection error, once members run out", async () => {
+    const svc = buildService([{ id: "only-one" }]);
+
+    await expect(
+      svc.runWithPoolFailover({ poolId: POOL_ID }, async (gatewayId) => {
+        throw new GatewayTransportError({ message: "relay unreachable", gatewayId });
+      })
+    ).rejects.toThrow("relay unreachable");
+  });
+
+  test("runs directly with no selection when a specific gateway is configured", async () => {
+    const svc = buildService();
+    const out = await svc.runWithPoolFailover({ gatewayId: "pinned" }, async (gatewayId) => gatewayId);
+
+    expect(out).toEqual({ result: "pinned", gatewayId: "pinned" });
+    expect(reserve).not.toHaveBeenCalled();
+  });
+
+  test("rejects when neither a gateway nor a pool is configured", async () => {
+    const svc = buildService();
+    await expect(svc.runWithPoolFailover({}, async () => "x")).rejects.toThrow(
+      "No gateway or gateway pool is configured."
+    );
+  });
+});

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
@@ -1,6 +1,6 @@
 import { TGatewayScore } from "@app/lib/gateway-v2/gateway-load-tracker";
 
-import { isPoolComparable, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
+import { everyMemberReportsLoad, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
 
 // Every member reports unless a test says otherwise; a mixed pool is covered separately.
 const reported = (entries: Record<string, number>): Map<string, TGatewayScore> =>
@@ -8,27 +8,31 @@ const reported = (entries: Record<string, number>): Map<string, TGatewayScore> =
 
 const gateways = [{ id: "a" }, { id: "b" }, { id: "c" }];
 
-describe("isPoolComparable", () => {
-  test("comparable when every member reports", () => {
-    expect(isPoolComparable(gateways, reported({ a: 1, b: 2, c: 3 }))).toBe(true);
+describe("everyMemberReportsLoad", () => {
+  test("true when every member reports", () => {
+    expect(everyMemberReportsLoad(gateways, reported({ a: 1, b: 2, c: 3 }))).toBe(true);
   });
 
-  test("comparable when no member reports, since the scale is consistent", () => {
+  test("false when no member reports, because a platform-side count is not the same measurement", () => {
     const legacy = new Map(["a", "b", "c"].map((id) => [id, { score: 1, base: 1, reported: false }]));
-    expect(isPoolComparable(gateways, legacy)).toBe(true);
+    expect(everyMemberReportsLoad(gateways, legacy)).toBe(false);
   });
 
-  test("not comparable when the pool is mid-rollout", () => {
+  test("false when the pool is mid-rollout", () => {
     const mixed = new Map([
       ["a", { score: 40, base: 40, reported: true }],
       ["b", { score: 0, base: 0, reported: false }],
       ["c", { score: 41, base: 41, reported: true }]
     ]);
-    expect(isPoolComparable(gateways, mixed)).toBe(false);
+    expect(everyMemberReportsLoad(gateways, mixed)).toBe(false);
   });
 
-  test("not comparable when a member has no data at all", () => {
-    expect(isPoolComparable(gateways, reported({ a: 5, b: 5 }))).toBe(false);
+  test("false when a member has no data at all", () => {
+    expect(everyMemberReportsLoad(gateways, reported({ a: 5, b: 5 }))).toBe(false);
+  });
+
+  test("false for an empty pool, so the caller never claims against nothing", () => {
+    expect(everyMemberReportsLoad([], reported({}))).toBe(false);
   });
 });
 

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
@@ -1,6 +1,6 @@
 import { TGatewayScore } from "@app/lib/gateway-v2/gateway-load-tracker";
 
-import { everyMemberReportsLoad, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
+import { canLoadBalance, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
 
 // Every member reports unless a test says otherwise; a mixed pool is covered separately.
 const reported = (entries: Record<string, number>): Map<string, TGatewayScore> =>
@@ -8,14 +8,14 @@ const reported = (entries: Record<string, number>): Map<string, TGatewayScore> =
 
 const gateways = [{ id: "a" }, { id: "b" }, { id: "c" }];
 
-describe("everyMemberReportsLoad", () => {
+describe("canLoadBalance", () => {
   test("true when every member reports", () => {
-    expect(everyMemberReportsLoad(gateways, reported({ a: 1, b: 2, c: 3 }))).toBe(true);
+    expect(canLoadBalance(gateways, reported({ a: 1, b: 2, c: 3 }))).toBe(true);
   });
 
   test("false when no member reports, because a platform-side count is not the same measurement", () => {
     const legacy = new Map(["a", "b", "c"].map((id) => [id, { score: 1, base: 1, reported: false }]));
-    expect(everyMemberReportsLoad(gateways, legacy)).toBe(false);
+    expect(canLoadBalance(gateways, legacy)).toBe(false);
   });
 
   test("false when the pool is mid-rollout", () => {
@@ -24,15 +24,15 @@ describe("everyMemberReportsLoad", () => {
       ["b", { score: 0, base: 0, reported: false }],
       ["c", { score: 41, base: 41, reported: true }]
     ]);
-    expect(everyMemberReportsLoad(gateways, mixed)).toBe(false);
+    expect(canLoadBalance(gateways, mixed)).toBe(false);
   });
 
   test("false when a member has no data at all", () => {
-    expect(everyMemberReportsLoad(gateways, reported({ a: 5, b: 5 }))).toBe(false);
+    expect(canLoadBalance(gateways, reported({ a: 5, b: 5 }))).toBe(false);
   });
 
   test("false for an empty pool, so the caller never claims against nothing", () => {
-    expect(everyMemberReportsLoad([], reported({}))).toBe(false);
+    expect(canLoadBalance([], reported({}))).toBe(false);
   });
 });
 

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
@@ -1,0 +1,129 @@
+import { chooseLeastLoadedGateway, pickRandomGateway } from "./gateway-pool-selection-fns";
+
+const gateways = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+describe("chooseLeastLoadedGateway", () => {
+  test("returns undefined when there are no candidates", () => {
+    expect(chooseLeastLoadedGateway([], new Map())).toBeUndefined();
+  });
+
+  test("returns the only candidate without consulting scores", () => {
+    const random = vi.fn();
+    expect(chooseLeastLoadedGateway([{ id: "a" }], new Map(), random)).toEqual({ id: "a" });
+    expect(random).not.toHaveBeenCalled();
+  });
+
+  test("takes the clear minimum alone when the runner-up is not close", () => {
+    const scores = new Map([
+      ["a", 10],
+      ["b", 1],
+      ["c", 4]
+    ]);
+
+    for (let i = 0; i < 500; i += 1) {
+      expect(chooseLeastLoadedGateway(gateways, scores)).toEqual({ id: "b" });
+    }
+  });
+
+  test("spreads across both members when their scores are within the tie band", () => {
+    const scores = new Map([
+      ["a", 10],
+      ["b", 1],
+      ["c", 2]
+    ]);
+
+    const picked = new Set<string>();
+    for (let i = 0; i < 500; i += 1) {
+      picked.add(chooseLeastLoadedGateway(gateways, scores)!.id);
+    }
+
+    expect(picked).toEqual(new Set(["b", "c"]));
+  });
+
+  test("does not hand a two-member pool a coin flip when one is clearly busier", () => {
+    // Two gateways is the common HA pool size. Always shortlisting both would make the load score
+    // a no-op there and leave the pool behaving exactly like the old random selection.
+    const pair = [{ id: "a" }, { id: "b" }];
+    const scores = new Map([
+      ["a", 8],
+      ["b", 0]
+    ]);
+
+    for (let i = 0; i < 500; i += 1) {
+      expect(chooseLeastLoadedGateway(pair, scores)).toEqual({ id: "b" });
+    }
+  });
+
+  test("never sends half the traffic to a near-saturated member", () => {
+    const scores = new Map([
+      ["a", 0],
+      ["b", 99],
+      ["c", 100]
+    ]);
+
+    for (let i = 0; i < 500; i += 1) {
+      expect(chooseLeastLoadedGateway(gateways, scores)).toEqual({ id: "a" });
+    }
+  });
+
+  test("treats a missing score as zero load", () => {
+    const scores = new Map([
+      ["a", 5],
+      ["b", 5]
+    ]);
+
+    expect(chooseLeastLoadedGateway(gateways, scores, () => 0)).toEqual({ id: "c" });
+  });
+
+  test("reaches every member when the pool is idle and all scores tie", () => {
+    // A deterministic tie-break would shortlist the same two members forever, so a third gateway
+    // would sit unused for as long as the pool stays idle. That is the common case, not an edge case.
+    const seen = new Set<string>();
+    for (let i = 0; i < 3000; i += 1) {
+      seen.add(chooseLeastLoadedGateway(gateways, new Map())!.id);
+    }
+    expect(seen).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  test("spreads an idle pool roughly evenly", () => {
+    const tally: Record<string, number> = { a: 0, b: 0, c: 0 };
+    for (let i = 0; i < 30_000; i += 1) {
+      tally[chooseLeastLoadedGateway(gateways, new Map())!.id] += 1;
+    }
+    // Uniform would be 10,000 each. Loose bound: this asserts nobody is starved, not an exact ratio.
+    for (const id of ["a", "b", "c"]) {
+      expect(tally[id]).toBeGreaterThan(7_000);
+    }
+  });
+
+  test("still prefers the least loaded once scores differ", () => {
+    const scores = new Map([
+      ["a", 50],
+      ["b", 0],
+      ["c", 1]
+    ]);
+
+    // Whatever the shuffle does, the heavily loaded member must never be shortlisted.
+    for (let i = 0; i < 500; i += 1) {
+      expect(chooseLeastLoadedGateway(gateways, scores)!.id).not.toBe("a");
+    }
+  });
+
+  test("does not mutate the caller's candidate array", () => {
+    const input = [{ id: "c" }, { id: "a" }, { id: "b" }];
+    chooseLeastLoadedGateway(input, new Map(), () => 0);
+    expect(input.map((g) => g.id)).toEqual(["c", "a", "b"]);
+  });
+});
+
+describe("pickRandomGateway", () => {
+  test("returns undefined when there are no candidates", () => {
+    expect(pickRandomGateway([], () => 0)).toBeUndefined();
+  });
+
+  test("can reach every candidate", () => {
+    expect(pickRandomGateway(gateways, () => 0)).toEqual({ id: "a" });
+    expect(pickRandomGateway(gateways, () => 0.5)).toEqual({ id: "b" });
+    expect(pickRandomGateway(gateways, () => 0.99)).toEqual({ id: "c" });
+  });
+});

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
@@ -1,154 +1,51 @@
 import { TGatewayScore } from "@app/lib/gateway-v2/gateway-load-tracker";
 
-import { chooseLeastLoadedGateway, pickRandomGateway } from "./gateway-pool-selection-fns";
+import { isPoolComparable, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
 
 // Every member reports unless a test says otherwise; a mixed pool is covered separately.
 const reported = (entries: Record<string, number>): Map<string, TGatewayScore> =>
-  new Map(Object.entries(entries).map(([id, score]) => [id, { score, reported: true }]));
+  new Map(Object.entries(entries).map(([id, score]) => [id, { score, base: score, reported: true }]));
 
 const gateways = [{ id: "a" }, { id: "b" }, { id: "c" }];
 
-describe("chooseLeastLoadedGateway", () => {
-  test("returns undefined when there are no candidates", () => {
-    expect(chooseLeastLoadedGateway([], new Map())).toBeUndefined();
+describe("isPoolComparable", () => {
+  test("comparable when every member reports", () => {
+    expect(isPoolComparable(gateways, reported({ a: 1, b: 2, c: 3 }))).toBe(true);
   });
 
-  test("returns the only candidate without consulting scores", () => {
-    const random = vi.fn();
-    expect(chooseLeastLoadedGateway([{ id: "a" }], new Map(), random)).toEqual({ id: "a" });
-    expect(random).not.toHaveBeenCalled();
+  test("comparable when no member reports, since the scale is consistent", () => {
+    const legacy = new Map(["a", "b", "c"].map((id) => [id, { score: 1, base: 1, reported: false }]));
+    expect(isPoolComparable(gateways, legacy)).toBe(true);
   });
 
-  test("takes the clear minimum alone when the runner-up is not close", () => {
-    const scores = reported({ a: 10, b: 1, c: 4 });
-
-    for (let i = 0; i < 500; i += 1) {
-      expect(chooseLeastLoadedGateway(gateways, scores)).toEqual({ id: "b" });
-    }
-  });
-
-  test("spreads across members that tie exactly", () => {
-    const scores = reported({ a: 10, b: 1, c: 1 });
-
-    const picked = new Set<string>();
-    for (let i = 0; i < 500; i += 1) {
-      picked.add(chooseLeastLoadedGateway(gateways, scores)!.id);
-    }
-
-    expect(picked).toEqual(new Set(["b", "c"]));
-  });
-
-  test("a single reservation is decisive, so a concurrent selection moves on", () => {
-    // A reservation is worth exactly +1. If a tie band of 1 were tolerated it would cancel the
-    // reservation out and re-shortlist the member the previous selection just claimed.
-    const pair = [{ id: "a" }, { id: "b" }];
-    const afterReservingA = reported({ a: 1, b: 0 });
-
-    for (let i = 0; i < 500; i += 1) {
-      expect(chooseLeastLoadedGateway(pair, afterReservingA)).toEqual({ id: "b" });
-    }
-  });
-
-  test("does not hand a two-member pool a coin flip when one is busier", () => {
-    // Two gateways is the common HA pool size. Always shortlisting both would make the load score
-    // a no-op there and leave the pool behaving exactly like the old random selection.
-    const pair = [{ id: "a" }, { id: "b" }];
-    const scores = reported({ a: 8, b: 0 });
-
-    for (let i = 0; i < 500; i += 1) {
-      expect(chooseLeastLoadedGateway(pair, scores)).toEqual({ id: "b" });
-    }
-  });
-
-  test("never sends half the traffic to a near-saturated member", () => {
-    const scores = reported({ a: 0, b: 99, c: 100 });
-
-    for (let i = 0; i < 500; i += 1) {
-      expect(chooseLeastLoadedGateway(gateways, scores)).toEqual({ id: "a" });
-    }
-  });
-
-  test("does not compare a member it has no data for", () => {
-    // c is absent entirely, so the set is not on one scale. Guessing it is idle would pull traffic
-    // toward the one member we know least about.
-    const scores = reported({ a: 5, b: 5 });
-    const picked = new Set<string>();
-    for (let i = 0; i < 500; i += 1) {
-      picked.add(chooseLeastLoadedGateway(gateways, scores)!.id);
-    }
-    expect(picked).toEqual(new Set(["a", "b", "c"]));
-  });
-
-  test("gives a mixed-version pool no load awareness rather than a biased guess", () => {
-    // b is too old to report, so its score covers only platform-opened channels and is strictly
-    // lower than a reporting peer's true occupancy. Comparing them would favour b all rollout long.
+  test("not comparable when the pool is mid-rollout", () => {
     const mixed = new Map([
-      ["a", { score: 40, reported: true }],
-      ["b", { score: 0, reported: false }],
-      ["c", { score: 41, reported: true }]
+      ["a", { score: 40, base: 40, reported: true }],
+      ["b", { score: 0, base: 0, reported: false }],
+      ["c", { score: 41, base: 41, reported: true }]
     ]);
+    expect(isPoolComparable(gateways, mixed)).toBe(false);
+  });
 
-    const tally: Record<string, number> = { a: 0, b: 0, c: 0 };
+  test("not comparable when a member has no data at all", () => {
+    expect(isPoolComparable(gateways, reported({ a: 5, b: 5 }))).toBe(false);
+  });
+});
+
+describe("shuffleForTieBreak", () => {
+  test("reaches every position, which is what randomises ties in the claim", () => {
+    const firsts = new Set<string>();
     for (let i = 0; i < 3000; i += 1) {
-      tally[chooseLeastLoadedGateway(gateways, mixed)!.id] += 1;
+      firsts.add(shuffleForTieBreak(gateways, Math.random)[0].id);
     }
-
-    // Uniform, not "b wins every time".
-    for (const id of ["a", "b", "c"]) expect(tally[id]).toBeGreaterThan(700);
+    expect(firsts).toEqual(new Set(["a", "b", "c"]));
   });
 
-  test("uses load awareness when every member reports", () => {
-    const scores = reported({ a: 40, b: 0, c: 41 });
-    for (let i = 0; i < 500; i += 1) {
-      expect(chooseLeastLoadedGateway(gateways, scores)).toEqual({ id: "b" });
-    }
-  });
-
-  test("uses load awareness when no member reports, since the scale is consistent", () => {
-    const legacy = new Map([
-      ["a", { score: 9, reported: false }],
-      ["b", { score: 1, reported: false }],
-      ["c", { score: 8, reported: false }]
-    ]);
-    for (let i = 0; i < 500; i += 1) {
-      expect(chooseLeastLoadedGateway(gateways, legacy)).toEqual({ id: "b" });
-    }
-  });
-
-  test("reaches every member when the pool is idle and all scores tie", () => {
-    // A deterministic tie-break would shortlist the same two members forever, so a third gateway
-    // would sit unused for as long as the pool stays idle. That is the common case, not an edge case.
-    const seen = new Set<string>();
-    for (let i = 0; i < 3000; i += 1) {
-      seen.add(chooseLeastLoadedGateway(gateways, new Map())!.id);
-    }
-    expect(seen).toEqual(new Set(["a", "b", "c"]));
-  });
-
-  test("spreads an idle pool roughly evenly", () => {
-    const tally: Record<string, number> = { a: 0, b: 0, c: 0 };
-    for (let i = 0; i < 30_000; i += 1) {
-      tally[chooseLeastLoadedGateway(gateways, new Map())!.id] += 1;
-    }
-    // Uniform would be 10,000 each. Loose bound: this asserts nobody is starved, not an exact ratio.
-    for (const id of ["a", "b", "c"]) {
-      expect(tally[id]).toBeGreaterThan(7_000);
-    }
-  });
-
-  test("still prefers the least loaded once scores differ", () => {
-    const scores = reported({ a: 50, b: 0, c: 1 });
-
-    // Whatever the shuffle does, the heavily loaded member must never be shortlisted.
-    for (let i = 0; i < 500; i += 1) {
-      expect(chooseLeastLoadedGateway(gateways, scores)!.id).not.toBe("a");
-    }
-  });
-
-  test("does not mutate the caller's candidate array", () => {
+  test("does not mutate the caller's array and keeps every member", () => {
     const input = [{ id: "c" }, { id: "a" }, { id: "b" }];
-    chooseLeastLoadedGateway(input, new Map(), () => 0);
+    const out = shuffleForTieBreak(input, Math.random);
     expect(input.map((g) => g.id)).toEqual(["c", "a", "b"]);
+    expect(out.map((g) => g.id).sort()).toEqual(["a", "b", "c"]);
   });
 });
 

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.test.ts
@@ -1,4 +1,10 @@
+import { TGatewayScore } from "@app/lib/gateway-v2/gateway-load-tracker";
+
 import { chooseLeastLoadedGateway, pickRandomGateway } from "./gateway-pool-selection-fns";
+
+// Every member reports unless a test says otherwise; a mixed pool is covered separately.
+const reported = (entries: Record<string, number>): Map<string, TGatewayScore> =>
+  new Map(Object.entries(entries).map(([id, score]) => [id, { score, reported: true }]));
 
 const gateways = [{ id: "a" }, { id: "b" }, { id: "c" }];
 
@@ -14,23 +20,15 @@ describe("chooseLeastLoadedGateway", () => {
   });
 
   test("takes the clear minimum alone when the runner-up is not close", () => {
-    const scores = new Map([
-      ["a", 10],
-      ["b", 1],
-      ["c", 4]
-    ]);
+    const scores = reported({ a: 10, b: 1, c: 4 });
 
     for (let i = 0; i < 500; i += 1) {
       expect(chooseLeastLoadedGateway(gateways, scores)).toEqual({ id: "b" });
     }
   });
 
-  test("spreads across both members when their scores are within the tie band", () => {
-    const scores = new Map([
-      ["a", 10],
-      ["b", 1],
-      ["c", 2]
-    ]);
+  test("spreads across members that tie exactly", () => {
+    const scores = reported({ a: 10, b: 1, c: 1 });
 
     const picked = new Set<string>();
     for (let i = 0; i < 500; i += 1) {
@@ -40,14 +38,22 @@ describe("chooseLeastLoadedGateway", () => {
     expect(picked).toEqual(new Set(["b", "c"]));
   });
 
-  test("does not hand a two-member pool a coin flip when one is clearly busier", () => {
+  test("a single reservation is decisive, so a concurrent selection moves on", () => {
+    // A reservation is worth exactly +1. If a tie band of 1 were tolerated it would cancel the
+    // reservation out and re-shortlist the member the previous selection just claimed.
+    const pair = [{ id: "a" }, { id: "b" }];
+    const afterReservingA = reported({ a: 1, b: 0 });
+
+    for (let i = 0; i < 500; i += 1) {
+      expect(chooseLeastLoadedGateway(pair, afterReservingA)).toEqual({ id: "b" });
+    }
+  });
+
+  test("does not hand a two-member pool a coin flip when one is busier", () => {
     // Two gateways is the common HA pool size. Always shortlisting both would make the load score
     // a no-op there and leave the pool behaving exactly like the old random selection.
     const pair = [{ id: "a" }, { id: "b" }];
-    const scores = new Map([
-      ["a", 8],
-      ["b", 0]
-    ]);
+    const scores = reported({ a: 8, b: 0 });
 
     for (let i = 0; i < 500; i += 1) {
       expect(chooseLeastLoadedGateway(pair, scores)).toEqual({ id: "b" });
@@ -55,24 +61,58 @@ describe("chooseLeastLoadedGateway", () => {
   });
 
   test("never sends half the traffic to a near-saturated member", () => {
-    const scores = new Map([
-      ["a", 0],
-      ["b", 99],
-      ["c", 100]
-    ]);
+    const scores = reported({ a: 0, b: 99, c: 100 });
 
     for (let i = 0; i < 500; i += 1) {
       expect(chooseLeastLoadedGateway(gateways, scores)).toEqual({ id: "a" });
     }
   });
 
-  test("treats a missing score as zero load", () => {
-    const scores = new Map([
-      ["a", 5],
-      ["b", 5]
+  test("does not compare a member it has no data for", () => {
+    // c is absent entirely, so the set is not on one scale. Guessing it is idle would pull traffic
+    // toward the one member we know least about.
+    const scores = reported({ a: 5, b: 5 });
+    const picked = new Set<string>();
+    for (let i = 0; i < 500; i += 1) {
+      picked.add(chooseLeastLoadedGateway(gateways, scores)!.id);
+    }
+    expect(picked).toEqual(new Set(["a", "b", "c"]));
+  });
+
+  test("gives a mixed-version pool no load awareness rather than a biased guess", () => {
+    // b is too old to report, so its score covers only platform-opened channels and is strictly
+    // lower than a reporting peer's true occupancy. Comparing them would favour b all rollout long.
+    const mixed = new Map([
+      ["a", { score: 40, reported: true }],
+      ["b", { score: 0, reported: false }],
+      ["c", { score: 41, reported: true }]
     ]);
 
-    expect(chooseLeastLoadedGateway(gateways, scores, () => 0)).toEqual({ id: "c" });
+    const tally: Record<string, number> = { a: 0, b: 0, c: 0 };
+    for (let i = 0; i < 3000; i += 1) {
+      tally[chooseLeastLoadedGateway(gateways, mixed)!.id] += 1;
+    }
+
+    // Uniform, not "b wins every time".
+    for (const id of ["a", "b", "c"]) expect(tally[id]).toBeGreaterThan(700);
+  });
+
+  test("uses load awareness when every member reports", () => {
+    const scores = reported({ a: 40, b: 0, c: 41 });
+    for (let i = 0; i < 500; i += 1) {
+      expect(chooseLeastLoadedGateway(gateways, scores)).toEqual({ id: "b" });
+    }
+  });
+
+  test("uses load awareness when no member reports, since the scale is consistent", () => {
+    const legacy = new Map([
+      ["a", { score: 9, reported: false }],
+      ["b", { score: 1, reported: false }],
+      ["c", { score: 8, reported: false }]
+    ]);
+    for (let i = 0; i < 500; i += 1) {
+      expect(chooseLeastLoadedGateway(gateways, legacy)).toEqual({ id: "b" });
+    }
   });
 
   test("reaches every member when the pool is idle and all scores tie", () => {
@@ -97,11 +137,7 @@ describe("chooseLeastLoadedGateway", () => {
   });
 
   test("still prefers the least loaded once scores differ", () => {
-    const scores = new Map([
-      ["a", 50],
-      ["b", 0],
-      ["c", 1]
-    ]);
+    const scores = reported({ a: 50, b: 0, c: 1 });
 
     // Whatever the shuffle does, the heavily loaded member must never be shortlisted.
     for (let i = 0; i < 500; i += 1) {

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
@@ -11,24 +11,18 @@ export const pickRandomGateway = <T extends TSelectableGateway>(
 };
 
 /**
- * Load numbers are only worth comparing when every member is measured the same way.
+ * Load-aware selection only runs when every member reports its own connection count.
  *
- * A gateway new enough to report sends its real connection count, including PAM sessions the
- * platform never sees. A gateway too old to report is counted only on the connections the platform
- * itself opened, which is always the lower number.
- *
- * So a pool mid-upgrade is the bad case: the old member always looks emptier and would soak up
- * traffic for the whole rollout. That pool gets no load awareness at all and falls back to random.
- * A pool where nobody reports is fine, because every member is measured the same lower way, so
- * comparing them is still fair.
+ * A gateway new enough to report sends its real count, including PAM sessions the platform never
+ * sees. A gateway too old to report can only be scored on the connections the platform itself
+ * opened, which is always lower and misses whatever it is really carrying. There is no way to line
+ * those two numbers up, and no reason to trust the second one on its own, so any pool that is not
+ * fully upgraded picks at random instead.
  */
-export const isPoolComparable = <T extends TSelectableGateway>(
+export const everyMemberReportsLoad = <T extends TSelectableGateway>(
   candidates: T[],
   scores: Map<string, TGatewayScore>
-): boolean => {
-  const reportedCount = candidates.filter((c) => scores.get(c.id)?.reported).length;
-  return reportedCount === 0 || reportedCount === candidates.length;
-};
+): boolean => candidates.length > 0 && candidates.every((candidate) => scores.get(candidate.id)?.reported);
 
 /** Ties are resolved by position, so shuffling first is what randomises between equally loaded members. */
 export const shuffleForTieBreak = <T>(candidates: T[], random: () => number): T[] => {

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
@@ -11,10 +11,16 @@ export const pickRandomGateway = <T extends TSelectableGateway>(
 };
 
 /**
- * False when some members report their own load and others are too old to, because the two numbers
- * are on different scales: a non-reporting member is counted only on channels this platform opened,
- * which is strictly lower than a reporting peer's true occupancy. Comparing them would pull traffic
- * onto un-upgraded gateways for a whole rollout, so such a pool gets no load awareness at all.
+ * Load numbers are only worth comparing when every member is measured the same way.
+ *
+ * A gateway new enough to report sends its real connection count, including PAM sessions the
+ * platform never sees. A gateway too old to report is counted only on the connections the platform
+ * itself opened, which is always the lower number.
+ *
+ * So a pool mid-upgrade is the bad case: the old member always looks emptier and would soak up
+ * traffic for the whole rollout. That pool gets no load awareness at all and falls back to random.
+ * A pool where nobody reports is fine, because every member is measured the same lower way, so
+ * comparing them is still fair.
  */
 export const isPoolComparable = <T extends TSelectableGateway>(
   candidates: T[],

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
@@ -11,13 +11,9 @@ export const pickRandomGateway = <T extends TSelectableGateway>(
 };
 
 /**
- * Load-aware selection only runs when every member reports its own connection count.
- *
  * A gateway new enough to report sends its real count, including PAM sessions the platform never
- * sees. A gateway too old to report can only be scored on the connections the platform itself
- * opened, which is always lower and misses whatever it is really carrying. There is no way to line
- * those two numbers up, and no reason to trust the second one on its own, so any pool that is not
- * fully upgraded picks at random instead.
+ * sees. One too old to report can only be scored on what the platform opened itself, which is always
+ * lower. Rather than trust that, a pool that is not fully upgraded picks at random.
  */
 export const everyMemberReportsLoad = <T extends TSelectableGateway>(
   candidates: T[],

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
@@ -1,0 +1,50 @@
+export type TSelectableGateway = { id: string };
+
+// Two members this close are treated as equally loaded, since cross-pod counts are published
+// asynchronously and routinely disagree by one.
+const SCORE_TIE_BAND = 1;
+
+/**
+ * Picks the least-loaded member, breaking between the two lowest at random.
+ *
+ * The random tie-break matters because every backend pod reads the same shared counters. Taking the
+ * strict minimum would make all of them choose the same idle gateway in the same instant and stampede
+ * it, which is the imbalance this is meant to remove.
+ */
+export const chooseLeastLoadedGateway = <T extends TSelectableGateway>(
+  candidates: T[],
+  scores: Map<string, number>,
+  random: () => number = Math.random
+): T | undefined => {
+  if (candidates.length === 0) return undefined;
+  if (candidates.length === 1) return candidates[0];
+
+  // Shuffle before ranking. An idle pool scores every member zero, and a deterministic tie-break
+  // would then always shortlist the same two, leaving every member past the second with no traffic
+  // at all. Sort is stable, so shuffling first randomises ties while keeping the least-loaded order.
+  const shuffled = [...candidates];
+  for (let i = shuffled.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+
+  const ranked = shuffled.sort((a, b) => (scores.get(a.id) ?? 0) - (scores.get(b.id) ?? 0));
+
+  // Only shortlist the runner-up when it is genuinely comparable. Always taking the two lowest would
+  // hand a two-member pool a coin flip regardless of load, and would still send half the traffic to a
+  // near-saturated member in a pool scored {0, 99, 100}. The band absorbs the off-by-one that stale
+  // cross-pod counts produce, which is the case the random draw exists for.
+  const best = scores.get(ranked[0].id) ?? 0;
+  const runnerUp = scores.get(ranked[1].id) ?? 0;
+  const shortlist = runnerUp - best <= SCORE_TIE_BAND ? ranked.slice(0, 2) : [ranked[0]];
+
+  return shortlist[Math.floor(random() * shortlist.length)];
+};
+
+export const pickRandomGateway = <T extends TSelectableGateway>(
+  candidates: T[],
+  random: () => number = Math.random
+): T | undefined => {
+  if (candidates.length === 0) return undefined;
+  return candidates[Math.floor(random() * candidates.length)];
+};

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
@@ -1,8 +1,19 @@
+import { TGatewayScore } from "@app/lib/gateway-v2/gateway-load-tracker";
+
 export type TSelectableGateway = { id: string };
 
-// Two members this close are treated as equally loaded, since cross-pod counts are published
-// asynchronously and routinely disagree by one.
-const SCORE_TIE_BAND = 1;
+// Only exact ties are randomised. A reservation is worth exactly +1, so any wider band would cancel
+// it out and re-shortlist the member a concurrent selection just claimed, which is the stampede the
+// reservation exists to prevent.
+const SCORE_TIE_BAND = 0;
+
+export const pickRandomGateway = <T extends TSelectableGateway>(
+  candidates: T[],
+  random: () => number = Math.random
+): T | undefined => {
+  if (candidates.length === 0) return undefined;
+  return candidates[Math.floor(random() * candidates.length)];
+};
 
 /**
  * Picks the least-loaded member, breaking between the two lowest at random.
@@ -13,11 +24,20 @@ const SCORE_TIE_BAND = 1;
  */
 export const chooseLeastLoadedGateway = <T extends TSelectableGateway>(
   candidates: T[],
-  scores: Map<string, number>,
+  scores: Map<string, TGatewayScore>,
   random: () => number = Math.random
 ): T | undefined => {
   if (candidates.length === 0) return undefined;
   if (candidates.length === 1) return candidates[0];
+
+  // A member too old to report its own count is scored only on the channels this platform opened,
+  // which is a strictly lower number than a reporting peer's true occupancy. Comparing the two would
+  // make the un-upgraded member look idle and pull traffic toward it for the whole rollout, so a
+  // mixed pool gets no load awareness at all rather than a biased guess.
+  const reportedCount = candidates.filter((c) => scores.get(c.id)?.reported).length;
+  if (reportedCount > 0 && reportedCount < candidates.length) {
+    return pickRandomGateway(candidates, random);
+  }
 
   // Shuffle before ranking. An idle pool scores every member zero, and a deterministic tie-break
   // would then always shortlist the same two, leaving every member past the second with no traffic
@@ -28,23 +48,15 @@ export const chooseLeastLoadedGateway = <T extends TSelectableGateway>(
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
 
-  const ranked = shuffled.sort((a, b) => (scores.get(a.id) ?? 0) - (scores.get(b.id) ?? 0));
+  const scoreOf = (id: string) => scores.get(id)?.score ?? 0;
+  const ranked = shuffled.sort((a, b) => scoreOf(a.id) - scoreOf(b.id));
 
-  // Only shortlist the runner-up when it is genuinely comparable. Always taking the two lowest would
-  // hand a two-member pool a coin flip regardless of load, and would still send half the traffic to a
-  // near-saturated member in a pool scored {0, 99, 100}. The band absorbs the off-by-one that stale
-  // cross-pod counts produce, which is the case the random draw exists for.
-  const best = scores.get(ranked[0].id) ?? 0;
-  const runnerUp = scores.get(ranked[1].id) ?? 0;
+  // Only shortlist the runner-up when it ties. Always taking the two lowest would hand a two-member
+  // pool a coin flip regardless of load, and would still send half the traffic to a near-saturated
+  // member in a pool scored {0, 99, 100}.
+  const best = scoreOf(ranked[0].id);
+  const runnerUp = scoreOf(ranked[1].id);
   const shortlist = runnerUp - best <= SCORE_TIE_BAND ? ranked.slice(0, 2) : [ranked[0]];
 
   return shortlist[Math.floor(random() * shortlist.length)];
-};
-
-export const pickRandomGateway = <T extends TSelectableGateway>(
-  candidates: T[],
-  random: () => number = Math.random
-): T | undefined => {
-  if (candidates.length === 0) return undefined;
-  return candidates[Math.floor(random() * candidates.length)];
 };

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
@@ -2,11 +2,6 @@ import { TGatewayScore } from "@app/lib/gateway-v2/gateway-load-tracker";
 
 export type TSelectableGateway = { id: string };
 
-// Only exact ties are randomised. A reservation is worth exactly +1, so any wider band would cancel
-// it out and re-shortlist the member a concurrent selection just claimed, which is the stampede the
-// reservation exists to prevent.
-const SCORE_TIE_BAND = 0;
-
 export const pickRandomGateway = <T extends TSelectableGateway>(
   candidates: T[],
   random: () => number = Math.random
@@ -16,47 +11,25 @@ export const pickRandomGateway = <T extends TSelectableGateway>(
 };
 
 /**
- * Picks the least-loaded member, breaking between the two lowest at random.
- *
- * The random tie-break matters because every backend pod reads the same shared counters. Taking the
- * strict minimum would make all of them choose the same idle gateway in the same instant and stampede
- * it, which is the imbalance this is meant to remove.
+ * False when some members report their own load and others are too old to, because the two numbers
+ * are on different scales: a non-reporting member is counted only on channels this platform opened,
+ * which is strictly lower than a reporting peer's true occupancy. Comparing them would pull traffic
+ * onto un-upgraded gateways for a whole rollout, so such a pool gets no load awareness at all.
  */
-export const chooseLeastLoadedGateway = <T extends TSelectableGateway>(
+export const isPoolComparable = <T extends TSelectableGateway>(
   candidates: T[],
-  scores: Map<string, TGatewayScore>,
-  random: () => number = Math.random
-): T | undefined => {
-  if (candidates.length === 0) return undefined;
-  if (candidates.length === 1) return candidates[0];
-
-  // A member too old to report its own count is scored only on the channels this platform opened,
-  // which is a strictly lower number than a reporting peer's true occupancy. Comparing the two would
-  // make the un-upgraded member look idle and pull traffic toward it for the whole rollout, so a
-  // mixed pool gets no load awareness at all rather than a biased guess.
+  scores: Map<string, TGatewayScore>
+): boolean => {
   const reportedCount = candidates.filter((c) => scores.get(c.id)?.reported).length;
-  if (reportedCount > 0 && reportedCount < candidates.length) {
-    return pickRandomGateway(candidates, random);
-  }
+  return reportedCount === 0 || reportedCount === candidates.length;
+};
 
-  // Shuffle before ranking. An idle pool scores every member zero, and a deterministic tie-break
-  // would then always shortlist the same two, leaving every member past the second with no traffic
-  // at all. Sort is stable, so shuffling first randomises ties while keeping the least-loaded order.
+/** Ties are resolved by position, so shuffling first is what randomises between equally loaded members. */
+export const shuffleForTieBreak = <T>(candidates: T[], random: () => number): T[] => {
   const shuffled = [...candidates];
   for (let i = shuffled.length - 1; i > 0; i -= 1) {
     const j = Math.floor(random() * (i + 1));
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
-
-  const scoreOf = (id: string) => scores.get(id)?.score ?? 0;
-  const ranked = shuffled.sort((a, b) => scoreOf(a.id) - scoreOf(b.id));
-
-  // Only shortlist the runner-up when it ties. Always taking the two lowest would hand a two-member
-  // pool a coin flip regardless of load, and would still send half the traffic to a near-saturated
-  // member in a pool scored {0, 99, 100}.
-  const best = scoreOf(ranked[0].id);
-  const runnerUp = scoreOf(ranked[1].id);
-  const shortlist = runnerUp - best <= SCORE_TIE_BAND ? ranked.slice(0, 2) : [ranked[0]];
-
-  return shortlist[Math.floor(random() * shortlist.length)];
+  return shuffled;
 };

--- a/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-selection-fns.ts
@@ -15,7 +15,7 @@ export const pickRandomGateway = <T extends TSelectableGateway>(
  * sees. One too old to report can only be scored on what the platform opened itself, which is always
  * lower. Rather than trust that, a pool that is not fully upgraded picks at random.
  */
-export const everyMemberReportsLoad = <T extends TSelectableGateway>(
+export const canLoadBalance = <T extends TSelectableGateway>(
   candidates: T[],
   scores: Map<string, TGatewayScore>
 ): boolean => candidates.length > 0 && candidates.every((candidate) => scores.get(candidate.id)?.reported);

--- a/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
@@ -259,6 +259,11 @@ export const gatewayPoolServiceFactory = ({
   };
 
   const selectGatewayFromPool = async ({ poolId, exclude, filter, unavailableMessage }: TSelectGatewayFromPoolDTO) => {
+    const targetPool = await gatewayPoolDAL.findById(poolId);
+    if (!targetPool) {
+      throw new NotFoundError({ message: `Gateway pool with ID ${poolId} not found` });
+    }
+
     const healthyGateways = await gatewayPoolMembershipDAL.findHealthyGatewaysByPoolId(poolId);
 
     const eligible = healthyGateways
@@ -294,7 +299,12 @@ export const gatewayPoolServiceFactory = ({
     if (!selected)
       throw new BadRequestError({ message: unavailableMessage ?? "Gateway pool has no healthy gateways." });
 
-    await loadTracker?.reserve(selected.id);
+    // Bookkeeping must never be able to fail a selection, whatever the tracker does internally.
+    try {
+      await loadTracker?.reserve(selected.id);
+    } catch (err) {
+      logger.warn({ err, poolId }, `Failed to reserve gateway capacity [poolId=${poolId}]`);
+    }
 
     logger.info(
       { poolId, selectedGatewayId: selected.id },
@@ -344,7 +354,7 @@ export const gatewayPoolServiceFactory = ({
       }
       tried.add(selected.id);
 
-      const gatewayAttempt = { transportFailed: false };
+      const gatewayAttempt = { transportFailed: false, tunnelEstablished: false };
       try {
         return {
           result: await runGatewayAttempt(gatewayAttempt, () => operation(selected.id)),
@@ -353,7 +363,9 @@ export const gatewayPoolServiceFactory = ({
       } catch (err) {
         // Providers rewrap gateway errors in their own BadRequestError, so the async-local flag is
         // the only reliable signal that nothing reached the target.
-        if (!gatewayAttempt.transportFailed && !(err instanceof GatewayTransportError)) throw err;
+        const retryable =
+          (gatewayAttempt.transportFailed || err instanceof GatewayTransportError) && !gatewayAttempt.tunnelEstablished;
+        if (!retryable) throw err;
         lastError = err;
         logger.warn(
           { err, poolId, gatewayId: selected.id, attempt },

--- a/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
@@ -2,7 +2,9 @@ import { ForbiddenError } from "@casl/ability";
 
 import { OrganizationActionScope } from "@app/db/schemas";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
-import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, DatabaseError, GatewayTransportError, NotFoundError } from "@app/lib/errors";
+import { runGatewayAttempt } from "@app/lib/gateway-v2/gateway-attempt-context";
+import { getGatewayLoadTracker } from "@app/lib/gateway-v2/gateway-load-tracker";
 import { logger } from "@app/lib/logger";
 import { OrgServiceActor } from "@app/lib/types";
 import { TAppConnectionDALFactory } from "@app/services/app-connection/app-connection-dal";
@@ -10,22 +12,23 @@ import { TIdentityKubernetesAuthDALFactory } from "@app/services/identity-kubern
 
 import { TDynamicSecretDALFactory } from "../dynamic-secret/dynamic-secret-dal";
 import { TGatewayV2DALFactory } from "../gateway-v2/gateway-v2-dal";
-import { TGatewayV2ServiceFactory } from "../gateway-v2/gateway-v2-service";
-import { TGatewayV2ConnectionDetails } from "../gateway-v2/gateway-v2-types";
 import { TLicenseServiceFactory } from "../license/license-service";
 import { OrgPermissionGatewayPoolActions, OrgPermissionSubjects } from "../permission/org-permission";
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
 import { TPkiDiscoveryConfigDALFactory } from "../pki-discovery/pki-discovery-config-dal";
 import { TGatewayPoolDALFactory } from "./gateway-pool-dal";
 import { TGatewayPoolMembershipDALFactory } from "./gateway-pool-membership-dal";
+import { chooseLeastLoadedGateway, pickRandomGateway } from "./gateway-pool-selection-fns";
 import {
+  DEFAULT_POOL_FAILOVER_ATTEMPTS,
   TAddGatewayToPoolDTO,
   TCreateGatewayPoolDTO,
   TDeleteGatewayPoolDTO,
   TGetGatewayPoolByIdDTO,
-  TGetPlatformConnectionDetailsByPoolIdDTO,
   TListGatewayPoolsDTO,
   TRemoveGatewayFromPoolDTO,
+  TRunWithPoolFailoverDTO,
+  TSelectGatewayFromPoolDTO,
   TUpdateGatewayPoolDTO
 } from "./gateway-pool-types";
 
@@ -33,7 +36,6 @@ type TGatewayPoolServiceFactoryDep = {
   gatewayPoolDAL: TGatewayPoolDALFactory;
   gatewayPoolMembershipDAL: TGatewayPoolMembershipDALFactory;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "findById">;
-  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
   permissionService: TPermissionServiceFactory;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   identityKubernetesAuthDAL: Pick<TIdentityKubernetesAuthDALFactory, "findByGatewayPoolId" | "countByGatewayPoolId">;
@@ -48,7 +50,6 @@ export const gatewayPoolServiceFactory = ({
   gatewayPoolDAL,
   gatewayPoolMembershipDAL,
   gatewayV2DAL,
-  gatewayV2Service,
   permissionService,
   licenseService,
   identityKubernetesAuthDAL,
@@ -257,14 +258,44 @@ export const gatewayPoolServiceFactory = ({
     return { membership: deleted, poolName: pool.name, gatewayName: gateway.name };
   };
 
-  const pickRandomHealthyGateway = async (poolId: string) => {
+  const selectGatewayFromPool = async ({ poolId, exclude, filter, unavailableMessage }: TSelectGatewayFromPoolDTO) => {
     const healthyGateways = await gatewayPoolMembershipDAL.findHealthyGatewaysByPoolId(poolId);
-    if (healthyGateways.length === 0) {
+
+    const eligible = healthyGateways
+      .filter((gateway) => !exclude?.has(gateway.id))
+      .filter((gateway) => (filter ? filter(gateway) : true));
+
+    if (eligible.length === 0) {
       throw new BadRequestError({
-        message: "Gateway pool has no healthy gateways."
+        message: unavailableMessage ?? "Gateway pool has no healthy gateways."
       });
     }
-    const selected = healthyGateways[Math.floor(Math.random() * healthyGateways.length)];
+
+    const loadTracker = getGatewayLoadTracker();
+    let selected: (typeof eligible)[number] | undefined;
+
+    if (loadTracker) {
+      try {
+        const ids = eligible.map((gateway) => gateway.id);
+        const suspect = await loadTracker.getSuspect(ids);
+        // A pool where every member recently failed is still worth attempting: refusing to route is a
+        // guaranteed outage, whereas the suspect marks may simply have aged badly.
+        const candidates = eligible.filter((gateway) => !suspect.has(gateway.id));
+        const pool = candidates.length > 0 ? candidates : eligible;
+
+        const scores = await loadTracker.getScores(pool.map((gateway) => gateway.id));
+        selected = chooseLeastLoadedGateway(pool, scores);
+      } catch (err) {
+        logger.warn({ err, poolId }, `Gateway load lookup failed, falling back to random selection [poolId=${poolId}]`);
+      }
+    }
+
+    if (!selected) selected = pickRandomGateway(eligible);
+    if (!selected)
+      throw new BadRequestError({ message: unavailableMessage ?? "Gateway pool has no healthy gateways." });
+
+    await loadTracker?.reserve(selected.id);
+
     logger.info(
       { poolId, selectedGatewayId: selected.id },
       `Pool gateway selection: picked gateway [gatewayId=${selected.id}] from pool [poolId=${poolId}]`
@@ -272,27 +303,73 @@ export const gatewayPoolServiceFactory = ({
     return selected;
   };
 
-  const listHealthyGateways = async (poolId: string) => {
-    return gatewayPoolMembershipDAL.findHealthyGatewaysByPoolId(poolId);
-  };
+  const pickHealthyGateway = async (poolId: string) => selectGatewayFromPool({ poolId });
 
-  const getPlatformConnectionDetailsByPoolId = async ({
-    poolId,
-    targetHost,
-    targetPort
-  }: TGetPlatformConnectionDetailsByPoolIdDTO): Promise<TGatewayV2ConnectionDetails | undefined> => {
-    const pool = await gatewayPoolDAL.findById(poolId);
-    if (!pool) {
-      throw new NotFoundError({ message: `Gateway pool with ID ${poolId} not found` });
+  /**
+   * Runs an operation against a pool, retrying on another member when the tunnel could not be
+   * established. Only GatewayTransportError retries, because it is the one failure that guarantees
+   * nothing reached the target.
+   */
+  const runWithPoolFailover = async <T>(
+    {
+      poolId,
+      gatewayId,
+      filter,
+      maxAttempts = DEFAULT_POOL_FAILOVER_ATTEMPTS,
+      unavailableMessage
+    }: TRunWithPoolFailoverDTO,
+    operation: (gatewayId: string) => Promise<T>
+  ): Promise<{ result: T; gatewayId: string }> => {
+    if (gatewayId || !poolId) {
+      if (!gatewayId) {
+        throw new BadRequestError({ message: unavailableMessage ?? "No gateway or gateway pool is configured." });
+      }
+      return { result: await operation(gatewayId), gatewayId };
     }
 
-    const selectedGateway = await pickRandomHealthyGateway(poolId);
+    const tried = new Set<string>();
+    let lastError: unknown;
 
-    return gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
-      gatewayId: selectedGateway.id,
-      targetHost,
-      targetPort
-    });
+    // Sequential by design: each attempt has to know which member just failed.
+    /* eslint-disable no-await-in-loop */
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      let selected: Awaited<ReturnType<typeof selectGatewayFromPool>>;
+      try {
+        selected = await selectGatewayFromPool({ poolId, exclude: tried, filter, unavailableMessage });
+      } catch (err) {
+        // Running out of untried members is only interesting on the first attempt. After that the
+        // transport failure that got us here is the useful error, not "pool has no healthy gateways".
+        if (!lastError) throw err;
+        break;
+      }
+      tried.add(selected.id);
+
+      const gatewayAttempt = { transportFailed: false };
+      try {
+        return {
+          result: await runGatewayAttempt(gatewayAttempt, () => operation(selected.id)),
+          gatewayId: selected.id
+        };
+      } catch (err) {
+        // Providers rewrap gateway errors in their own BadRequestError, so the async-local flag is
+        // the only reliable signal that nothing reached the target.
+        if (!gatewayAttempt.transportFailed && !(err instanceof GatewayTransportError)) throw err;
+        lastError = err;
+        logger.warn(
+          { err, poolId, gatewayId: selected.id, attempt },
+          `Gateway unreachable, retrying on another pool member [poolId=${poolId}] [gatewayId=${selected.id}]`
+        );
+      }
+    }
+    /* eslint-enable no-await-in-loop */
+
+    throw lastError instanceof Error
+      ? lastError
+      : new BadRequestError({ message: "Failed to reach any gateway in the pool." });
+  };
+
+  const listHealthyGateways = async (poolId: string) => {
+    return gatewayPoolMembershipDAL.findHealthyGatewaysByPoolId(poolId);
   };
 
   // Enforce license + RBAC + pool-belongs-to-org before a consumer attaches a pool. Does NOT require a healthy member.
@@ -336,7 +413,7 @@ export const gatewayPoolServiceFactory = ({
   }): Promise<string | null> => {
     if (gatewayId) return gatewayId;
     if (gatewayPoolId) {
-      const picked = await pickRandomHealthyGateway(gatewayPoolId);
+      const picked = await pickHealthyGateway(gatewayPoolId);
       return picked.id;
     }
     return null;
@@ -386,9 +463,11 @@ export const gatewayPoolServiceFactory = ({
     deleteGatewayPool,
     addGatewayToPool,
     removeGatewayFromPool,
-    pickRandomHealthyGateway,
+    pickHealthyGateway,
+    selectGatewayFromPool,
+    runWithPoolFailover,
     listHealthyGateways,
-    getPlatformConnectionDetailsByPoolId,
+
     getConnectedResources,
     getConnectedResourcesCount,
     resolveAttachableGatewayFromPool,

--- a/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
@@ -19,7 +19,7 @@ import { TPermissionServiceFactory } from "../permission/permission-service-type
 import { TPkiDiscoveryConfigDALFactory } from "../pki-discovery/pki-discovery-config-dal";
 import { TGatewayPoolDALFactory } from "./gateway-pool-dal";
 import { TGatewayPoolMembershipDALFactory } from "./gateway-pool-membership-dal";
-import { chooseLeastLoadedGateway, pickRandomGateway } from "./gateway-pool-selection-fns";
+import { isPoolComparable, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
 import {
   DEFAULT_POOL_FAILOVER_ATTEMPTS,
   TAddGatewayToPoolDTO,
@@ -262,7 +262,7 @@ export const gatewayPoolServiceFactory = ({
   const selectGatewayFromPool = async ({ poolId, exclude, filter, unavailableMessage }: TSelectGatewayFromPoolDTO) => {
     const targetPool = await gatewayPoolDAL.findById(poolId);
     if (!targetPool) {
-      throw new NotFoundError({ message: `Gateway pool with ID ${poolId} not found` });
+      throw new NotFoundError({ message: `Gateway pool with ID '${poolId}' not found` });
     }
 
     const healthyGateways = await gatewayPoolMembershipDAL.findHealthyGatewaysByPoolId(poolId);
@@ -279,6 +279,10 @@ export const gatewayPoolServiceFactory = ({
 
     const loadTracker = getGatewayLoadTracker();
     let selected: (typeof eligible)[number] | undefined;
+    let claimedAtomically = false;
+    // Outlives the try: if anything in the load path fails we still want the suspect filter, or the
+    // fallback would happily hand back the member whose transport just failed.
+    let pool = eligible;
 
     if (loadTracker) {
       try {
@@ -287,24 +291,42 @@ export const gatewayPoolServiceFactory = ({
         // A pool where every member recently failed is still worth attempting: refusing to route is a
         // guaranteed outage, whereas the suspect marks may simply have aged badly.
         const candidates = eligible.filter((gateway) => !suspect.has(gateway.id));
-        const pool = candidates.length > 0 ? candidates : eligible;
+        pool = candidates.length > 0 ? candidates : eligible;
 
         const scores = await loadTracker.getScores(pool.map((gateway) => gateway.id));
-        selected = chooseLeastLoadedGateway(pool, scores);
+
+        if (isPoolComparable(pool, scores)) {
+          // Choose and claim atomically. Reading the minimum and then writing the reservation as two
+          // calls lets every concurrent selection observe the same minimum and pile onto it.
+          const claimed = await loadTracker.claimLeastLoaded(
+            shuffleForTieBreak(pool, Math.random).map((gateway) => ({
+              id: gateway.id,
+              base: scores.get(gateway.id)?.base ?? 0
+            }))
+          );
+          selected = pool.find((gateway) => gateway.id === claimed);
+          if (selected) claimedAtomically = true;
+        } else {
+          // Mixed-version pool: the scales are not comparable, so there is nothing to claim against.
+          selected = pickRandomGateway(pool);
+        }
       } catch (err) {
         logger.warn({ err, poolId }, `Gateway load lookup failed, falling back to random selection [poolId=${poolId}]`);
       }
     }
 
-    if (!selected) selected = pickRandomGateway(eligible);
+    if (!selected) selected = pickRandomGateway(pool);
     if (!selected)
       throw new BadRequestError({ message: unavailableMessage ?? "Gateway pool has no healthy gateways." });
 
     // Bookkeeping must never be able to fail a selection, whatever the tracker does internally.
-    try {
-      await loadTracker?.reserve(selected.id);
-    } catch (err) {
-      logger.warn({ err, poolId }, `Failed to reserve gateway capacity [poolId=${poolId}]`);
+    // The atomic path has already claimed its member.
+    if (!claimedAtomically) {
+      try {
+        await loadTracker?.reserve(selected.id);
+      } catch (err) {
+        logger.warn({ err, poolId }, `Failed to reserve gateway capacity [poolId=${poolId}]`);
+      }
     }
 
     logger.info(

--- a/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
@@ -21,7 +21,7 @@ import { TPermissionServiceFactory } from "../permission/permission-service-type
 import { TPkiDiscoveryConfigDALFactory } from "../pki-discovery/pki-discovery-config-dal";
 import { TGatewayPoolDALFactory } from "./gateway-pool-dal";
 import { TGatewayPoolMembershipDALFactory } from "./gateway-pool-membership-dal";
-import { isPoolComparable, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
+import { everyMemberReportsLoad, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
 import {
   DEFAULT_POOL_FAILOVER_ATTEMPTS,
   TAddGatewayToPoolDTO,
@@ -300,7 +300,7 @@ export const gatewayPoolServiceFactory = ({
 
         const scores = await loadTracker.getScores(pool.map((gateway) => gateway.id));
 
-        if (isPoolComparable(pool, scores)) {
+        if (everyMemberReportsLoad(pool, scores)) {
           // Choose and claim atomically. Reading the minimum and then writing the reservation as two
           // calls lets every concurrent selection observe the same minimum and pile onto it.
           const claimed = await loadTracker.claimLeastLoaded(
@@ -312,7 +312,8 @@ export const gatewayPoolServiceFactory = ({
           selected = pool.find((gateway) => gateway.id === claimed);
           if (selected) claimedAtomically = true;
         } else {
-          // Mixed-version pool: the scales are not comparable, so there is nothing to claim against.
+          // At least one member is too old to report its load, so there is no sound comparison to
+          // make and nothing to claim against.
           selected = pickRandomGateway(pool);
         }
       } catch (err) {

--- a/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
@@ -285,24 +285,21 @@ export const gatewayPoolServiceFactory = ({
     const loadTracker = getGatewayLoadTracker();
     let selected: (typeof eligible)[number] | undefined;
     let claimedAtomically = false;
-    // Outlives the try: if anything in the load path fails we still want the suspect filter, or the
-    // fallback would happily hand back the member whose transport just failed.
+    // Outlives the try so the fallback keeps the suspect filter.
     let pool = eligible;
 
     if (loadTracker) {
       try {
         const ids = eligible.map((gateway) => gateway.id);
         const suspect = await loadTracker.getSuspect(ids);
-        // A pool where every member recently failed is still worth attempting: refusing to route is a
-        // guaranteed outage, whereas the suspect marks may simply have aged badly.
+        // All-suspect is still worth attempting: refusing to route is a guaranteed outage.
         const candidates = eligible.filter((gateway) => !suspect.has(gateway.id));
         pool = candidates.length > 0 ? candidates : eligible;
 
         const scores = await loadTracker.getScores(pool.map((gateway) => gateway.id));
 
         if (everyMemberReportsLoad(pool, scores)) {
-          // Choose and claim atomically. Reading the minimum and then writing the reservation as two
-          // calls lets every concurrent selection observe the same minimum and pile onto it.
+          // Two calls would let every concurrent selection read the same minimum and pile onto it.
           const claimed = await loadTracker.claimLeastLoaded(
             shuffleForTieBreak(pool, Math.random).map((gateway) => ({
               id: gateway.id,
@@ -312,8 +309,7 @@ export const gatewayPoolServiceFactory = ({
           selected = pool.find((gateway) => gateway.id === claimed);
           if (selected) claimedAtomically = true;
         } else {
-          // At least one member is too old to report its load, so there is no sound comparison to
-          // make and nothing to claim against.
+          // A member too old to report leaves nothing sound to compare or claim against.
           selected = pickRandomGateway(pool);
         }
       } catch (err) {
@@ -325,8 +321,7 @@ export const gatewayPoolServiceFactory = ({
     if (!selected)
       throw new BadRequestError({ message: unavailableMessage ?? "Gateway pool has no healthy gateways." });
 
-    // Bookkeeping must never be able to fail a selection, whatever the tracker does internally.
-    // The atomic path has already claimed its member.
+    // Bookkeeping must never fail a selection. The atomic path already claimed its member.
     if (!claimedAtomically) {
       try {
         await loadTracker?.reserve(selected.id);
@@ -344,11 +339,7 @@ export const gatewayPoolServiceFactory = ({
 
   const pickHealthyGateway = async (poolId: string) => selectGatewayFromPool({ poolId });
 
-  /**
-   * Runs an operation against a pool, retrying on another member when the tunnel could not be
-   * established. Only GatewayTransportError retries, because it is the one failure that guarantees
-   * nothing reached the target.
-   */
+  /** Retries on another member only for a failed tunnel, the one case that cannot have reached the target. */
   const runWithPoolFailover = async <T>(
     {
       poolId,
@@ -376,8 +367,7 @@ export const gatewayPoolServiceFactory = ({
       try {
         selected = await selectGatewayFromPool({ poolId, exclude: tried, filter, unavailableMessage });
       } catch (err) {
-        // Running out of untried members is only interesting on the first attempt. After that the
-        // transport failure that got us here is the useful error, not "pool has no healthy gateways".
+        // After the first attempt the transport failure is the useful error, not "no healthy gateways".
         if (!lastError) throw err;
         break;
       }

--- a/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
@@ -13,6 +13,8 @@ import { TIdentityKubernetesAuthDALFactory } from "@app/services/identity-kubern
 
 import { TDynamicSecretDALFactory } from "../dynamic-secret/dynamic-secret-dal";
 import { TGatewayV2DALFactory } from "../gateway-v2/gateway-v2-dal";
+import { TGatewayV2ServiceFactory } from "../gateway-v2/gateway-v2-service";
+import { TGatewayV2ConnectionDetails } from "../gateway-v2/gateway-v2-types";
 import { TLicenseServiceFactory } from "../license/license-service";
 import { OrgPermissionGatewayPoolActions, OrgPermissionSubjects } from "../permission/org-permission";
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
@@ -26,6 +28,7 @@ import {
   TCreateGatewayPoolDTO,
   TDeleteGatewayPoolDTO,
   TGetGatewayPoolByIdDTO,
+  TGetPlatformConnectionDetailsByPoolIdDTO,
   TListGatewayPoolsDTO,
   TRemoveGatewayFromPoolDTO,
   TRunWithPoolFailoverDTO,
@@ -37,6 +40,7 @@ type TGatewayPoolServiceFactoryDep = {
   gatewayPoolDAL: TGatewayPoolDALFactory;
   gatewayPoolMembershipDAL: TGatewayPoolMembershipDALFactory;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "findById">;
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
   permissionService: TPermissionServiceFactory;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   identityKubernetesAuthDAL: Pick<TIdentityKubernetesAuthDALFactory, "findByGatewayPoolId" | "countByGatewayPoolId">;
@@ -51,6 +55,7 @@ export const gatewayPoolServiceFactory = ({
   gatewayPoolDAL,
   gatewayPoolMembershipDAL,
   gatewayV2DAL,
+  gatewayV2Service,
   permissionService,
   licenseService,
   identityKubernetesAuthDAL,
@@ -406,6 +411,20 @@ export const gatewayPoolServiceFactory = ({
       : new BadRequestError({ message: "Failed to reach any gateway in the pool." });
   };
 
+  const getPlatformConnectionDetailsByPoolId = async ({
+    poolId,
+    targetHost,
+    targetPort
+  }: TGetPlatformConnectionDetailsByPoolIdDTO): Promise<TGatewayV2ConnectionDetails | undefined> => {
+    const selectedGateway = await selectGatewayFromPool({ poolId });
+
+    return gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
+      gatewayId: selectedGateway.id,
+      targetHost,
+      targetPort
+    });
+  };
+
   const listHealthyGateways = async (poolId: string) => {
     return gatewayPoolMembershipDAL.findHealthyGatewaysByPoolId(poolId);
   };
@@ -505,6 +524,7 @@ export const gatewayPoolServiceFactory = ({
     selectGatewayFromPool,
     runWithPoolFailover,
     listHealthyGateways,
+    getPlatformConnectionDetailsByPoolId,
 
     getConnectedResources,
     getConnectedResourcesCount,

--- a/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
@@ -5,6 +5,7 @@ import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, GatewayTransportError, NotFoundError } from "@app/lib/errors";
 import { runGatewayAttempt } from "@app/lib/gateway-v2/gateway-attempt-context";
 import { getGatewayLoadTracker } from "@app/lib/gateway-v2/gateway-load-tracker";
+import { isAttemptRetryable } from "@app/lib/gateway-v2/gateway-retry";
 import { logger } from "@app/lib/logger";
 import { OrgServiceActor } from "@app/lib/types";
 import { TAppConnectionDALFactory } from "@app/services/app-connection/app-connection-dal";
@@ -363,8 +364,11 @@ export const gatewayPoolServiceFactory = ({
       } catch (err) {
         // Providers rewrap gateway errors in their own BadRequestError, so the async-local flag is
         // the only reliable signal that nothing reached the target.
-        const retryable =
-          (gatewayAttempt.transportFailed || err instanceof GatewayTransportError) && !gatewayAttempt.tunnelEstablished;
+        const retryable = isAttemptRetryable({
+          transportFailed: gatewayAttempt.transportFailed,
+          tunnelEstablished: gatewayAttempt.tunnelEstablished,
+          isTransportError: err instanceof GatewayTransportError
+        });
         if (!retryable) throw err;
         lastError = err;
         logger.warn(

--- a/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-service.ts
@@ -21,7 +21,7 @@ import { TPermissionServiceFactory } from "../permission/permission-service-type
 import { TPkiDiscoveryConfigDALFactory } from "../pki-discovery/pki-discovery-config-dal";
 import { TGatewayPoolDALFactory } from "./gateway-pool-dal";
 import { TGatewayPoolMembershipDALFactory } from "./gateway-pool-membership-dal";
-import { everyMemberReportsLoad, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
+import { canLoadBalance, pickRandomGateway, shuffleForTieBreak } from "./gateway-pool-selection-fns";
 import {
   DEFAULT_POOL_FAILOVER_ATTEMPTS,
   TAddGatewayToPoolDTO,
@@ -298,7 +298,7 @@ export const gatewayPoolServiceFactory = ({
 
         const scores = await loadTracker.getScores(pool.map((gateway) => gateway.id));
 
-        if (everyMemberReportsLoad(pool, scores)) {
+        if (canLoadBalance(pool, scores)) {
           // Two calls would let every concurrent selection read the same minimum and pile onto it.
           const claimed = await loadTracker.claimLeastLoaded(
             shuffleForTieBreak(pool, Math.random).map((gateway) => ({

--- a/backend/src/ee/services/gateway-pool/gateway-pool-types.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-types.ts
@@ -1,4 +1,9 @@
+import { TGatewaysV2 } from "@app/db/schemas";
 import { OrgServiceActor } from "@app/lib/types";
+
+// One retry past the first attempt. Higher multiplies load onto whichever members are still up,
+// which is the flood this is meant to avoid.
+export const DEFAULT_POOL_FAILOVER_ATTEMPTS = 2;
 
 export type TCreateGatewayPoolDTO = {
   name: string;
@@ -29,8 +34,19 @@ export type TRemoveGatewayFromPoolDTO = {
   gatewayId: string;
 } & OrgServiceActor;
 
-export type TGetPlatformConnectionDetailsByPoolIdDTO = {
+export type TGatewayPoolMemberFilter = (gateway: TGatewaysV2) => boolean;
+
+export type TSelectGatewayFromPoolDTO = {
   poolId: string;
-  targetHost: string;
-  targetPort: number;
+  exclude?: Set<string>;
+  filter?: TGatewayPoolMemberFilter;
+  unavailableMessage?: string;
+};
+
+export type TRunWithPoolFailoverDTO = {
+  poolId?: string | null;
+  gatewayId?: string | null;
+  filter?: TGatewayPoolMemberFilter;
+  maxAttempts?: number;
+  unavailableMessage?: string;
 };

--- a/backend/src/ee/services/gateway-pool/gateway-pool-types.ts
+++ b/backend/src/ee/services/gateway-pool/gateway-pool-types.ts
@@ -36,6 +36,12 @@ export type TRemoveGatewayFromPoolDTO = {
 
 export type TGatewayPoolMemberFilter = (gateway: TGatewaysV2) => boolean;
 
+export type TGetPlatformConnectionDetailsByPoolIdDTO = {
+  poolId: string;
+  targetHost: string;
+  targetPort: number;
+};
+
 export type TSelectGatewayFromPoolDTO = {
   poolId: string;
   exclude?: Set<string>;

--- a/backend/src/ee/services/gateway-v2/gateway-v2-fns.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-fns.ts
@@ -31,9 +31,7 @@ export const testConnectionWithGateway = async (
       (proxyPort) => callTestConnection({ port: proxyPort, body: request, timeoutMs, signal }),
       {
         protocol: GatewayProxyProtocol.ConnectionTest,
-        relayHost: platform.relayHost,
-        gateway: platform.gateway,
-        relay: platform.relay
+        ...platform
       }
     );
   } catch {

--- a/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
@@ -987,7 +987,7 @@ export const gatewayV2ServiceFactory = ({
     await $checkGatewayHealth(gateway.id);
   };
 
-  const reportLoad = async ({
+  const reportMetrics = async ({
     orgPermission,
     activeChannels
   }: {
@@ -1351,7 +1351,7 @@ export const gatewayV2ServiceFactory = ({
   return {
     listGateways,
     registerGateway,
-    reportLoad,
+    reportMetrics,
     getPlatformConnectionDetailsByGatewayId,
     getPAMConnectionDetails,
     deleteGatewayById,

--- a/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
@@ -10,6 +10,7 @@ import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
 import { groupBy } from "@app/lib/fn";
 import { GatewayProxyProtocol } from "@app/lib/gateway/types";
+import { getGatewayLoadTracker } from "@app/lib/gateway-v2/gateway-load-tracker";
 import { withGatewayV2Proxy } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
 import { OrgServiceActor } from "@app/lib/types";
@@ -986,6 +987,27 @@ export const gatewayV2ServiceFactory = ({
     await $checkGatewayHealth(gateway.id);
   };
 
+  const reportLoad = async ({
+    orgPermission,
+    activeChannels
+  }: {
+    orgPermission: OrgServiceActor;
+    activeChannels: number;
+  }) => {
+    const gateway =
+      orgPermission.type === ActorType.GATEWAY
+        ? await gatewayV2DAL.findById(orgPermission.id)
+        : await gatewayV2DAL.findOne({ orgId: orgPermission.orgId, identityId: orgPermission.id });
+
+    if (!gateway || gateway.orgId !== orgPermission.orgId) {
+      throw new NotFoundError({ message: `Gateway ${orgPermission.id} not found.` });
+    }
+
+    // Deliberately no heartbeat side effect: liveness stays with /heartbeat so a gateway cannot look
+    // healthy purely by reporting load, and so this stays a single Redis write.
+    await getGatewayLoadTracker()?.recordReportedLoad(gateway.id, activeChannels);
+  };
+
   const deleteGatewayById = async ({ orgPermission, id }: { orgPermission: OrgServiceActor; id: string }) => {
     const gateway = await gatewayV2DAL.findOne({ id, orgId: orgPermission.orgId });
     if (!gateway) {
@@ -1321,6 +1343,7 @@ export const gatewayV2ServiceFactory = ({
   return {
     listGateways,
     registerGateway,
+    reportLoad,
     getPlatformConnectionDetailsByGatewayId,
     getPAMConnectionDetails,
     deleteGatewayById,

--- a/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
@@ -464,6 +464,7 @@ export const gatewayV2ServiceFactory = ({
     });
 
     return {
+      gatewayId,
       relayHost: relayCredentials.relayHost,
       gateway: {
         clientCertificate: clientCert.toString("pem"),
@@ -627,6 +628,7 @@ export const gatewayV2ServiceFactory = ({
     });
 
     return {
+      gatewayId,
       relayHost: relayCredentials.relayHost,
       gateway: {
         clientCertificate: clientCert.toString("pem"),
@@ -891,9 +893,7 @@ export const gatewayV2ServiceFactory = ({
         },
         {
           protocol: GatewayProxyProtocol.Health,
-          relayHost: gatewayV2ConnectionDetails.relayHost,
-          gateway: gatewayV2ConnectionDetails.gateway,
-          relay: gatewayV2ConnectionDetails.relay
+          ...gatewayV2ConnectionDetails
         }
       );
     } catch (err) {

--- a/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
@@ -994,18 +994,25 @@ export const gatewayV2ServiceFactory = ({
     orgPermission: OrgServiceActor;
     activeChannels: number;
   }) => {
-    const gateway =
-      orgPermission.type === ActorType.GATEWAY
-        ? await gatewayV2DAL.findById(orgPermission.id)
-        : await gatewayV2DAL.findOne({ orgId: orgPermission.orgId, identityId: orgPermission.id });
+    let gateway;
+    if (orgPermission.type === ActorType.GATEWAY) {
+      gateway = await gatewayV2DAL.findById(orgPermission.id);
+    } else {
+      // Same check heartbeat makes: an identity whose gateway permission was revoked must not keep
+      // submitting occupancy values and steering pool routing.
+      await $validateIdentityAccessToGateway(orgPermission.orgId, orgPermission.id, orgPermission.authMethod);
+      gateway = await gatewayV2DAL.findOne({ orgId: orgPermission.orgId, identityId: orgPermission.id });
+    }
 
     if (!gateway || gateway.orgId !== orgPermission.orgId) {
-      throw new NotFoundError({ message: `Gateway ${orgPermission.id} not found.` });
+      throw new NotFoundError({ message: `Gateway with ID '${orgPermission.id}' not found` });
     }
 
     // Deliberately no heartbeat side effect: liveness stays with /heartbeat so a gateway cannot look
     // healthy purely by reporting load, and so this stays a single Redis write.
     await getGatewayLoadTracker()?.recordReportedLoad(gateway.id, activeChannels);
+
+    return { gatewayId: gateway.id, activeChannels };
   };
 
   const deleteGatewayById = async ({ orgPermission, id }: { orgPermission: OrgServiceActor; id: string }) => {

--- a/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-service.ts
@@ -1008,8 +1008,9 @@ export const gatewayV2ServiceFactory = ({
       throw new NotFoundError({ message: `Gateway with ID '${orgPermission.id}' not found` });
     }
 
-    // Deliberately no heartbeat side effect: liveness stays with /heartbeat so a gateway cannot look
-    // healthy purely by reporting load, and so this stays a single Redis write.
+    // Do not mark the gateway alive here. A load report only proves the gateway can reach us;
+    // heartbeat proves we can reach it back through the relay. Updating liveness from this would
+    // keep a gateway whose relay path is broken looking healthy.
     await getGatewayLoadTracker()?.recordReportedLoad(gateway.id, activeChannels);
 
     return { gatewayId: gateway.id, activeChannels };

--- a/backend/src/ee/services/gateway-v2/gateway-v2-types.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-types.ts
@@ -1,4 +1,5 @@
 export type TGatewayV2ConnectionDetails = {
+  gatewayId: string;
   relayHost: string;
   gateway: {
     clientCertificate: string;

--- a/backend/src/ee/services/pam-discovery/pam-discovery-fns.ts
+++ b/backend/src/ee/services/pam-discovery/pam-discovery-fns.ts
@@ -44,9 +44,7 @@ export const sshExecWithGateway = async (
     },
     {
       protocol: GatewayProxyProtocol.Discovery,
-      relayHost: platform.relayHost,
-      gateway: platform.gateway,
-      relay: platform.relay
+      ...platform
     }
   );
 };
@@ -69,9 +67,7 @@ export const executeWithGateway = async <T>(
 
   return withGatewayV2Proxy((proxyPort) => operation(proxyPort), {
     protocol: GatewayProxyProtocol.Tcp,
-    relayHost: platform.relayHost,
-    gateway: platform.gateway,
-    relay: platform.relay
+    ...platform
   });
 };
 
@@ -228,9 +224,7 @@ export const winrmRpcWithGateway = async <T>({
       }),
     {
       protocol: GatewayProxyProtocol.WinRm,
-      relayHost: platform.relayHost,
-      gateway: platform.gateway,
-      relay: platform.relay
+      ...platform
     }
   );
 
@@ -272,9 +266,7 @@ export const sweepReachableTargets = async (
       }),
     {
       protocol: GatewayProxyProtocol.Discovery,
-      relayHost: platform.relayHost,
-      gateway: platform.gateway,
-      relay: platform.relay,
+      ...platform,
       longLived: true
     }
   );

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -60,10 +60,10 @@ type TPamWebAccessServiceFactoryDep = {
   tokenService: Pick<TAuthTokenServiceFactory, "createTokenForUser">;
   pamSessionDAL: Pick<
     TPamSessionDALFactory,
-    "create" | "endSessionById" | "activateSession" | "countActiveWebSessions" | "endExpiredWebSessions"
+    "create" | "endSessionById" | "activateSession" | "countActiveWebSessions" | "endExpiredWebSessions" | "updateById"
   >;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPAMConnectionDetails">;
-  gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
+  gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId" | "runWithPoolFailover">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   userDAL: Pick<TUserDALFactory, "findById">;
   mfaSessionService: Pick<
@@ -507,22 +507,62 @@ export const pamWebAccessServiceFactory = ({
         selectedHost: targetHost
       });
 
-      const certs = await gatewayV2Service.getPAMConnectionDetails({
-        gatewayId: effectiveGatewayId,
-        sessionId: session.id,
-        accountType: handlerEntry.gatewayAccountType,
-        host: targetHost,
-        port: gatewayTarget.port,
-        duration: sessionDurationMs,
-        actorMetadata: {
-          id: userId,
-          type: ActorType.USER,
-          name: user?.email ?? ""
-        }
-      });
+      const createdSession = session;
+      const isRdp = account.accountType === PamAccountType.Windows || account.accountType === PamAccountType.WindowsAd;
 
-      if (!certs) {
-        throw new BadRequestError({ message: "Failed to obtain gateway connection details" });
+      // Certs are minted per gateway, so each attempt has to re-mint. `eager` opens the tunnel
+      // during setup, so an unreachable gateway fails here where another member can still be tried.
+      const attempt = await gatewayPoolService.runWithPoolFailover(
+        {
+          gatewayId: account.gatewayId ?? account.templateGatewayId,
+          poolId: account.gatewayPoolId ?? account.templateGatewayPoolId
+        },
+        async (gatewayId) => {
+          const attemptCerts = await gatewayV2Service.getPAMConnectionDetails({
+            gatewayId,
+            sessionId: createdSession.id,
+            accountType: handlerEntry.gatewayAccountType,
+            host: targetHost,
+            port: gatewayTarget.port,
+            duration: sessionDurationMs,
+            actorMetadata: {
+              id: userId,
+              type: ActorType.USER,
+              name: user?.email ?? ""
+            }
+          });
+
+          if (!attemptCerts) {
+            throw new BadRequestError({ message: "Failed to obtain gateway connection details" });
+          }
+
+          return {
+            certs: attemptCerts,
+            server: await setupRelayServer({
+              protocol: isRdp ? GatewayProxyProtocol.PamRdpBrowser : GatewayProxyProtocol.Pam,
+              ...attemptCerts,
+              longLived: true,
+              eager: true
+            })
+          };
+        }
+      );
+
+      const { certs } = attempt.result;
+      relayServer = attempt.result.server;
+
+      // The tunnel is open from here rather than from whenever the session handler first dials, so
+      // a socket that closed during setup has to be caught: its "close" fired before the listener
+      // further down was attached, and nothing else would release the channel until session expiry.
+      if (socket.readyState !== socket.OPEN) {
+        await cleanup();
+        return;
+      }
+
+      // The row was written against the first pick. Cancellation and credential fetch look the
+      // session up by gateway, so it has to name the one that actually answered.
+      if (attempt.gatewayId !== effectiveGatewayId) {
+        await pamSessionDAL.updateById(createdSession.id, { gatewayId: attempt.gatewayId });
       }
 
       relayCerts = {
@@ -530,14 +570,6 @@ export const pamWebAccessServiceFactory = ({
         relay: certs.relay,
         gateway: certs.gateway
       };
-
-      const isRdp = account.accountType === PamAccountType.Windows || account.accountType === PamAccountType.WindowsAd;
-
-      relayServer = await setupRelayServer({
-        protocol: isRdp ? GatewayProxyProtocol.PamRdpBrowser : GatewayProxyProtocol.Pam,
-        ...certs,
-        longLived: true
-      });
 
       const isNearSessionExpiry = () => Date.now() >= expiresAt.getTime() - 30_000;
 

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -535,9 +535,7 @@ export const pamWebAccessServiceFactory = ({
 
       relayServer = await setupRelayServer({
         protocol: isRdp ? GatewayProxyProtocol.PamRdpBrowser : GatewayProxyProtocol.Pam,
-        relayHost: certs.relayHost,
-        relay: certs.relay,
-        gateway: certs.gateway,
+        ...certs,
         longLived: true
       });
 

--- a/backend/src/ee/services/pki-discovery/pki-discovery-scan-fns.ts
+++ b/backend/src/ee/services/pki-discovery/pki-discovery-scan-fns.ts
@@ -205,9 +205,7 @@ export const executeScan = async (discoveryId: string, deps: TExecuteScanDeps): 
                 return scanEndpoint("localhost", proxyPort, DEFAULT_SCAN_TIMEOUT, sniHostname);
               },
               {
-                relayHost: targetGatewayDetails.relayHost,
-                gateway: targetGatewayDetails.gateway,
-                relay: targetGatewayDetails.relay,
+                ...targetGatewayDetails,
                 protocol: GatewayProxyProtocol.Tcp
               }
             );

--- a/backend/src/ee/services/resource-auth-method/kubernetes-gateway-executor.ts
+++ b/backend/src/ee/services/resource-auth-method/kubernetes-gateway-executor.ts
@@ -80,9 +80,7 @@ export const buildGatewayKubernetesExecutor = ({
       },
       {
         protocol: isGatewayReviewer ? GatewayProxyProtocol.Http : GatewayProxyProtocol.Tcp,
-        relayHost: connectionDetails.relayHost,
-        gateway: connectionDetails.gateway,
-        relay: connectionDetails.relay,
+        ...connectionDetails,
         httpsAgent
       }
     );

--- a/backend/src/keystore/keystore.test.ts
+++ b/backend/src/keystore/keystore.test.ts
@@ -1,0 +1,24 @@
+import { inMemoryKeyStore } from "./memory";
+
+describe("claimLeastLoaded", () => {
+  test("rejects a mismatched base-occupancy list rather than reading the ttl as a count", async () => {
+    const keyStore = inMemoryKeyStore();
+    await expect(keyStore.claimLeastLoaded(["a", "b"], [0], 60)).rejects.toThrow(
+      "baseOccupancies must have one entry per key"
+    );
+  });
+
+  test("claims the lowest total and counts existing reservations", async () => {
+    const keyStore = inMemoryKeyStore();
+    expect(await keyStore.claimLeastLoaded(["a", "b"], [5, 1], 60)).toBe(2);
+    expect(await keyStore.claimLeastLoaded(["a", "b"], [5, 1], 60)).toBe(2);
+    expect(await keyStore.claimLeastLoaded(["a", "b"], [5, 1], 60)).toBe(2);
+    expect(await keyStore.claimLeastLoaded(["a", "b"], [5, 1], 60)).toBe(2);
+    // b has now taken 4, so 1 + 4 ties a's 5 and the strict comparison leaves a first
+    expect(await keyStore.claimLeastLoaded(["a", "b"], [5, 1], 60)).toBe(1);
+  });
+
+  test("returns 0 for no candidates", async () => {
+    expect(await inMemoryKeyStore().claimLeastLoaded([], [], 60)).toBe(0);
+  });
+});

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -284,6 +284,7 @@ export type TKeyStoreFactory = {
   incrementBy: (key: string, value: number) => Promise<number>;
   incrementByAndRefreshExpiryIfUnderLimit: (key: string, limit: number, expiryInSeconds: number) => Promise<number>;
   decrementByOrDelete: (key: string) => Promise<number>;
+  claimLeastLoaded: (keys: string[], baseOccupancies: number[], expiryInSeconds: number) => Promise<number>;
   incrementByWithExpiry: (key: string, value: number, expiryInSeconds: number) => Promise<number>;
   incrementSeededWithExpiry: (key: string, seed: number, expiryInSeconds: number) => Promise<number>;
   getKeysByPattern: (pattern: string, limit?: number) => Promise<string[]>;
@@ -469,6 +470,45 @@ export const keyStoreFactory = (
 
   const decrementByOrDelete = async (key: string): Promise<number> => {
     const result = await primaryRedis.eval(DECREMENT_OR_DELETE_SCRIPT, 1, key);
+    return Number(result);
+  };
+
+  // Choosing and claiming has to be one round trip. Done as separate read and write calls, every
+  // concurrent selection reads the same minimum before any of them claims it and they all pile onto
+  // the same gateway, which is the stampede the reservation exists to prevent.
+  const CLAIM_LEAST_LOADED_SCRIPT = `
+    local ttl = tonumber(ARGV[#ARGV])
+    local bestIdx = 0
+    local bestTotal = nil
+    for i = 1, #KEYS do
+      local reserved = tonumber(redis.call("GET", KEYS[i]) or "0")
+      local total = tonumber(ARGV[i]) + reserved
+      -- strict less-than, so ties fall to the caller's order (pre-shuffled for a random tie-break)
+      if bestTotal == nil or total < bestTotal then
+        bestTotal = total
+        bestIdx = i
+      end
+    end
+    if bestIdx == 0 then return 0 end
+    redis.call("INCR", KEYS[bestIdx])
+    redis.call("EXPIRE", KEYS[bestIdx], ttl)
+    return bestIdx
+  `;
+
+  /** Returns the 1-based index of the claimed key, or 0 when no keys were given. */
+  const claimLeastLoaded = async (
+    keys: string[],
+    baseOccupancies: number[],
+    expiryInSeconds: number
+  ): Promise<number> => {
+    if (keys.length === 0) return 0;
+    const result = await primaryRedis.eval(
+      CLAIM_LEAST_LOADED_SCRIPT,
+      keys.length,
+      ...keys,
+      ...baseOccupancies.map((n) => String(n)),
+      String(expiryInSeconds)
+    );
     return Number(result);
   };
 
@@ -659,6 +699,7 @@ export const keyStoreFactory = (
     incrementBy,
     incrementByAndRefreshExpiryIfUnderLimit,
     decrementByOrDelete,
+    claimLeastLoaded,
     incrementByWithExpiry,
     incrementSeededWithExpiry,
     acquireLock(resources: string[], duration: number, settings?: Partial<Settings>) {

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -83,6 +83,7 @@ export const KeyStorePrefixes = {
   ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`,
   GatewayIdentityCredential: (identityId: string) => `gateway-credentials:${identityId}`,
   GatewayLoad: (gatewayId: string) => `gateway-load:${gatewayId}` as const,
+  GatewayReportedLoad: (gatewayId: string) => `gateway-reported-load:${gatewayId}` as const,
   GatewayLoadReservation: (gatewayId: string) => `gateway-reservation:${gatewayId}` as const,
   GatewaySuspect: (gatewayId: string) => `gateway-suspect:${gatewayId}` as const,
   ActiveSSEConnectionsSet: (projectId: string, identityId: string) =>

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -82,6 +82,9 @@ export const KeyStorePrefixes = {
   ProxiedServiceUsageDebounce: (serviceId: string) => `proxied-service-usage-debounce:${serviceId}` as const,
   ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`,
   GatewayIdentityCredential: (identityId: string) => `gateway-credentials:${identityId}`,
+  GatewayLoad: (gatewayId: string) => `gateway-load:${gatewayId}` as const,
+  GatewayLoadReservation: (gatewayId: string) => `gateway-reservation:${gatewayId}` as const,
+  GatewaySuspect: (gatewayId: string) => `gateway-suspect:${gatewayId}` as const,
   ActiveSSEConnectionsSet: (projectId: string, identityId: string) =>
     `sse-connections:${projectId}:${identityId}` as const,
   ActiveSSEConnections: (projectId: string, identityId: string, connectionId: string) =>
@@ -259,6 +262,7 @@ export type TKeyStoreFactory = {
   getItem: (key: string, prefix?: string) => Promise<string | null>;
   getItemPrimary: (key: string, prefix?: string) => Promise<string | null>;
   getItems: (keys: string[], prefix?: string) => Promise<(string | null)[]>;
+  getItemsPrimary: (keys: string[], prefix?: string) => Promise<(string | null)[]>;
   setExpiry: (key: string, expiryInSeconds: number) => Promise<number>;
   ttl: (key: string) => Promise<number>;
   setItemWithExpiry: (
@@ -306,6 +310,8 @@ export type TKeyStoreFactory = {
   // hash operations
   hashSet: (key: string, field: string, value: string) => Promise<number>;
   hashGet: (key: string, field: string) => Promise<string | null>;
+  hashGetAll: (key: string) => Promise<Record<string, string>>;
+  hashDelete: (key: string, field: string) => Promise<number>;
   // pg
   pgIncrementBy: (key: string, dto: { incr?: number; expiry?: string; tx?: Knex }) => Promise<number>;
   pgGetIntItem: (key: string, prefix?: string) => Promise<number | undefined>;
@@ -359,6 +365,9 @@ export const keyStoreFactory = (
     pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas).get(prefix ? `${prefix}:${key}` : key);
 
   const getItemPrimary = async (key: string, prefix?: string) => primaryRedis.get(prefix ? `${prefix}:${key}` : key);
+
+  const getItemsPrimary = async (keys: string[], prefix?: string) =>
+    primaryRedis.mget(keys.map((key) => (prefix ? `${prefix}:${key}` : key)));
 
   const getItems = async (keys: string[], prefix?: string) =>
     pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas).mget(
@@ -532,6 +541,10 @@ export const keyStoreFactory = (
 
   const hashGet = async (key: string, field: string) => primaryRedis.hget(key, field);
 
+  const hashGetAll = async (key: string) => primaryRedis.hgetall(key);
+
+  const hashDelete = async (key: string, field: string) => primaryRedis.hdel(key, field);
+
   // List operations
   const listPush = async (key: string, value: string) => primaryRedis.rpush(key, value);
 
@@ -654,10 +667,13 @@ export const keyStoreFactory = (
     getKeysByPattern,
     deleteItemsByKeyIn,
     getItems,
+    getItemsPrimary,
     pgGetIntItem,
     pgIncrementBy,
     hashSet,
     hashGet,
+    hashGetAll,
+    hashDelete,
     listPush,
     listRange,
     listRemove,

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -85,8 +85,7 @@ export const KeyStorePrefixes = {
   // The braces are a Redis Cluster hash tag: only the tagged part picks the slot, so these land on
   // one node. Selection reads them for several gateways at once (one Lua script and two MGETs), and
   // cluster refuses a multi-key command whose keys span slots. They are small counters, so
-  // concentrating them costs nothing. GatewayLoad is read one key at a time and needs no tag.
-  GatewayLoad: (gatewayId: string) => `gateway-load:${gatewayId}` as const,
+  // concentrating them costs nothing.
   GatewayReportedLoad: (gatewayId: string) => `gateway-reported-load:{gw-pool}:${gatewayId}` as const,
   GatewayLoadReservation: (gatewayId: string) => `gateway-reservation:{gw-pool}:${gatewayId}` as const,
   GatewaySuspect: (gatewayId: string) => `gateway-suspect:{gw-pool}:${gatewayId}` as const,
@@ -316,8 +315,6 @@ export type TKeyStoreFactory = {
   // hash operations
   hashSet: (key: string, field: string, value: string) => Promise<number>;
   hashGet: (key: string, field: string) => Promise<string | null>;
-  hashGetAll: (key: string) => Promise<Record<string, string>>;
-  hashDelete: (key: string, field: string) => Promise<number>;
   // pg
   pgIncrementBy: (key: string, dto: { incr?: number; expiry?: string; tx?: Knex }) => Promise<number>;
   pgGetIntItem: (key: string, prefix?: string) => Promise<number | undefined>;
@@ -592,10 +589,6 @@ export const keyStoreFactory = (
 
   const hashGet = async (key: string, field: string) => primaryRedis.hget(key, field);
 
-  const hashGetAll = async (key: string) => primaryRedis.hgetall(key);
-
-  const hashDelete = async (key: string, field: string) => primaryRedis.hdel(key, field);
-
   // List operations
   const listPush = async (key: string, value: string) => primaryRedis.rpush(key, value);
 
@@ -724,8 +717,6 @@ export const keyStoreFactory = (
     pgIncrementBy,
     hashSet,
     hashGet,
-    hashGetAll,
-    hashDelete,
     listPush,
     listRange,
     listRemove,

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -82,10 +82,14 @@ export const KeyStorePrefixes = {
   ProxiedServiceUsageDebounce: (serviceId: string) => `proxied-service-usage-debounce:${serviceId}` as const,
   ServiceTokenStatusUpdate: (serviceTokenId: string) => `service-token-status:${serviceTokenId}`,
   GatewayIdentityCredential: (identityId: string) => `gateway-credentials:${identityId}`,
+  // The braces are a Redis Cluster hash tag: only the tagged part picks the slot, so these land on
+  // one node. Selection reads them for several gateways at once (one Lua script and two MGETs), and
+  // cluster refuses a multi-key command whose keys span slots. They are small counters, so
+  // concentrating them costs nothing. GatewayLoad is read one key at a time and needs no tag.
   GatewayLoad: (gatewayId: string) => `gateway-load:${gatewayId}` as const,
-  GatewayReportedLoad: (gatewayId: string) => `gateway-reported-load:${gatewayId}` as const,
-  GatewayLoadReservation: (gatewayId: string) => `gateway-reservation:${gatewayId}` as const,
-  GatewaySuspect: (gatewayId: string) => `gateway-suspect:${gatewayId}` as const,
+  GatewayReportedLoad: (gatewayId: string) => `gateway-reported-load:{gw-pool}:${gatewayId}` as const,
+  GatewayLoadReservation: (gatewayId: string) => `gateway-reservation:{gw-pool}:${gatewayId}` as const,
+  GatewaySuspect: (gatewayId: string) => `gateway-suspect:{gw-pool}:${gatewayId}` as const,
   ActiveSSEConnectionsSet: (projectId: string, identityId: string) =>
     `sse-connections:${projectId}:${identityId}` as const,
   ActiveSSEConnections: (projectId: string, identityId: string, connectionId: string) =>
@@ -490,8 +494,11 @@ export const keyStoreFactory = (
       end
     end
     if bestIdx == 0 then return 0 end
-    redis.call("INCR", KEYS[bestIdx])
-    redis.call("EXPIRE", KEYS[bestIdx], ttl)
+    -- Set the expiry only on the first increment. Refreshing it on every claim means a busy key
+    -- never elapses, so a crashed pod's leaked reservations would stay counted indefinitely.
+    if redis.call("INCR", KEYS[bestIdx]) == 1 then
+      redis.call("EXPIRE", KEYS[bestIdx], ttl)
+    end
     return bestIdx
   `;
 
@@ -502,6 +509,9 @@ export const keyStoreFactory = (
     expiryInSeconds: number
   ): Promise<number> => {
     if (keys.length === 0) return 0;
+    if (keys.length !== baseOccupancies.length) {
+      throw new Error("claimLeastLoaded: baseOccupancies must have one entry per key");
+    }
     const result = await primaryRedis.eval(
       CLAIM_LEAST_LOADED_SCRIPT,
       keys.length,

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -103,6 +103,23 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     incrementByAndRefreshExpiryIfUnderLimit: async () => {
       return 1;
     },
+    claimLeastLoaded: async (keys, baseOccupancies) => {
+      if (keys.length === 0) return 0;
+      let bestIdx = 0;
+      let bestTotal: number | null = null;
+      keys.forEach((key, i) => {
+        const reserved = typeof store[key] === "string" ? parseInt(store[key] as string, 10) : 0;
+        const total = baseOccupancies[i] + reserved;
+        if (bestTotal === null || total < bestTotal) {
+          bestTotal = total;
+          bestIdx = i + 1;
+        }
+      });
+      const chosen = keys[bestIdx - 1];
+      const current = typeof store[chosen] === "string" ? parseInt(store[chosen] as string, 10) : 0;
+      store[chosen] = String(current + 1);
+      return bestIdx;
+    },
     decrementByOrDelete: async (key) => {
       const current = typeof store[key] === "string" ? parseInt(store[key] as string, 10) : 0;
       const next = current - 1;

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -105,6 +105,9 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     },
     claimLeastLoaded: async (keys, baseOccupancies) => {
       if (keys.length === 0) return 0;
+      if (keys.length !== baseOccupancies.length) {
+        throw new Error("claimLeastLoaded: baseOccupancies must have one entry per key");
+      }
       let bestIdx = 0;
       let bestTotal: number | null = null;
       keys.forEach((key, i) => {

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -83,14 +83,6 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     hashGet: async (key, field) => {
       return hashStore[key]?.[field] ?? null;
     },
-    hashGetAll: async (key) => {
-      return { ...(hashStore[key] ?? {}) };
-    },
-    hashDelete: async (key, field) => {
-      if (!hashStore[key]?.[field]) return 0;
-      delete hashStore[key][field];
-      return 1;
-    },
     pgIncrementBy: async () => {
       return 1;
     },

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -20,7 +20,7 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     },
     setExpiry: async () => 0,
     ttl: async () => -1,
-    setItemWithExpiry: async (key, value) => {
+    setItemWithExpiry: async (key, _expiryInSeconds, value) => {
       store[key] = value;
       return "OK";
     },
@@ -83,6 +83,14 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     hashGet: async (key, field) => {
       return hashStore[key]?.[field] ?? null;
     },
+    hashGetAll: async (key) => {
+      return { ...(hashStore[key] ?? {}) };
+    },
+    hashDelete: async (key, field) => {
+      if (!hashStore[key]?.[field]) return 0;
+      delete hashStore[key][field];
+      return 1;
+    },
     pgIncrementBy: async () => {
       return 1;
     },
@@ -95,8 +103,15 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     incrementByAndRefreshExpiryIfUnderLimit: async () => {
       return 1;
     },
-    decrementByOrDelete: async () => {
-      return 0;
+    decrementByOrDelete: async (key) => {
+      const current = typeof store[key] === "string" ? parseInt(store[key] as string, 10) : 0;
+      const next = current - 1;
+      if (next <= 0) {
+        delete store[key];
+        return 0;
+      }
+      store[key] = String(next);
+      return next;
     },
     incrementByWithExpiry: async (key, value) => {
       const current = typeof store[key] === "string" ? parseInt(store[key] as string, 10) : 0;
@@ -131,6 +146,12 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
         delete store[key];
       }
       return keys.length;
+    },
+    getItemsPrimary: async (keys) => {
+      return keys.map((key) => {
+        const value = store[key];
+        return typeof value === "string" ? value : null;
+      });
     },
     getItems: async (keys) => {
       const values = keys.map((key) => {

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -3857,6 +3857,11 @@ export const SECRET_SHARING = {
 } as const;
 
 export const GATEWAYS = {
+  LOAD_REPORT: {
+    activeChannels:
+      "Number of channels the gateway is currently serving. Used to route new work to the least busy member of a gateway pool.",
+    gatewayId: "ID of the gateway the report was recorded against."
+  },
   CREATE: {
     name: "Name of the gateway.",
     authMethod:

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -3857,7 +3857,7 @@ export const SECRET_SHARING = {
 } as const;
 
 export const GATEWAYS = {
-  LOAD_REPORT: {
+  METRICS_REPORT: {
     activeChannels:
       "Number of channels the gateway is currently serving. Used to route new work to the least busy member of a gateway pool.",
     gatewayId: "ID of the gateway the report was recorded against."

--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -127,7 +127,9 @@ export class GatewayTransportError extends BadRequestError {
   gatewayId?: string;
 
   constructor({ message, gatewayId }: { message?: string; gatewayId?: string }) {
-    super({ message: message ?? "Failed to reach the gateway", name: "GatewayTransportError" });
+    // Deliberately keeps the BadRequest name so the serialised `error` field is unchanged for
+    // callers. Retry decisions use instanceof, never the name.
+    super({ message: message ?? "Failed to reach the gateway" });
     this.gatewayId = gatewayId;
   }
 }

--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -118,6 +118,20 @@ export class BadRequestError extends Error {
   }
 }
 
+/**
+ * The tunnel to the gateway could never be established, so nothing reached the target and the
+ * operation is safe to retry against a different pool member. Any failure raised once the tunnel is
+ * up must NOT use this class: the target may have already applied a partial change.
+ */
+export class GatewayTransportError extends BadRequestError {
+  gatewayId?: string;
+
+  constructor({ message, gatewayId }: { message?: string; gatewayId?: string }) {
+    super({ message: message ?? "Failed to reach the gateway", name: "GatewayTransportError" });
+    this.gatewayId = gatewayId;
+  }
+}
+
 export class RateLimitError extends Error {
   constructor({ message }: { message?: string }) {
     super(message || "Rate limit exceeded");

--- a/backend/src/lib/gateway-v2/gateway-attempt-context.ts
+++ b/backend/src/lib/gateway-v2/gateway-attempt-context.ts
@@ -1,0 +1,25 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type TGatewayAttempt = {
+  transportFailed: boolean;
+};
+
+const storage = new AsyncLocalStorage<TGatewayAttempt>();
+
+/**
+ * Records that the tunnel to a gateway could never be established, so the target saw nothing and
+ * the work can safely move to another pool member.
+ *
+ * This is a side channel rather than an error type because nearly every app-connection provider
+ * catches whatever the gateway layer throws and rewraps it in its own BadRequestError ("Unable to
+ * validate connection: ..."), which destroys any marker carried on the exception. The flag lives in
+ * async-local storage so it stays scoped to one attempt and concurrent requests to the same gateway
+ * cannot see each other's failures, which would otherwise let a target-side error trigger a retry.
+ */
+export const runGatewayAttempt = async <T>(attempt: TGatewayAttempt, fn: () => Promise<T>): Promise<T> =>
+  storage.run(attempt, fn);
+
+export const markAttemptTransportFailure = () => {
+  const attempt = storage.getStore();
+  if (attempt) attempt.transportFailed = true;
+};

--- a/backend/src/lib/gateway-v2/gateway-attempt-context.ts
+++ b/backend/src/lib/gateway-v2/gateway-attempt-context.ts
@@ -8,14 +8,8 @@ export type TGatewayAttempt = {
 const storage = new AsyncLocalStorage<TGatewayAttempt>();
 
 /**
- * Records that the tunnel to a gateway could never be established, so the target saw nothing and
- * the work can safely move to another pool member.
- *
- * This is a side channel rather than an error type because nearly every app-connection provider
- * catches whatever the gateway layer throws and rewraps it in its own BadRequestError ("Unable to
- * validate connection: ..."), which destroys any marker carried on the exception. The flag lives in
- * async-local storage so it stays scoped to one attempt and concurrent requests to the same gateway
- * cannot see each other's failures, which would otherwise let a target-side error trigger a retry.
+ * A side channel rather than an error type, because providers rewrap whatever the gateway layer
+ * throws and destroy any marker on the exception. Async-local so one attempt cannot see another's.
  */
 export const runGatewayAttempt = async <T>(attempt: TGatewayAttempt, fn: () => Promise<T>): Promise<T> =>
   storage.run(attempt, fn);
@@ -25,10 +19,7 @@ export const markAttemptTransportFailure = () => {
   if (attempt) attempt.transportFailed = true;
 };
 
-/**
- * Once any tunnel in this attempt comes up, the target may have been reached, so the attempt is no
- * longer safe to replay even if an earlier tunnel in the same attempt failed and was swallowed.
- */
+/** Once any tunnel comes up the target may have been reached, so the attempt is not replayable. */
 export const markAttemptTunnelEstablished = () => {
   const attempt = storage.getStore();
   if (attempt) attempt.tunnelEstablished = true;

--- a/backend/src/lib/gateway-v2/gateway-attempt-context.ts
+++ b/backend/src/lib/gateway-v2/gateway-attempt-context.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 
 export type TGatewayAttempt = {
   transportFailed: boolean;
+  tunnelEstablished: boolean;
 };
 
 const storage = new AsyncLocalStorage<TGatewayAttempt>();
@@ -22,4 +23,13 @@ export const runGatewayAttempt = async <T>(attempt: TGatewayAttempt, fn: () => P
 export const markAttemptTransportFailure = () => {
   const attempt = storage.getStore();
   if (attempt) attempt.transportFailed = true;
+};
+
+/**
+ * Once any tunnel in this attempt comes up, the target may have been reached, so the attempt is no
+ * longer safe to replay even if an earlier tunnel in the same attempt failed and was swallowed.
+ */
+export const markAttemptTunnelEstablished = () => {
+  const attempt = storage.getStore();
+  if (attempt) attempt.tunnelEstablished = true;
 };

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
@@ -171,13 +171,30 @@ describe("gatewayLoadTracker", () => {
     tracker.shutdown();
   });
 
+  test("adds channels opened since the gateway's last report", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    await tracker.recordReportedLoad(GW_A, 4);
+    // Reports land every 10s. Without counting what opened since, every selection inside that window
+    // reads the same stale 4 and piles onto this member.
+    await vi.advanceTimersByTimeAsync(1_000);
+    tracker.channelOpened(GW_A);
+    tracker.channelOpened(GW_A);
+
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(6);
+
+    tracker.shutdown();
+  });
+
   test("does not sum its own view into the gateway's count", async () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
 
-    // The reported 3 already includes the 3 this pod opened; summing would say 6.
+    // The reported 3 already includes the 3 this pod opened before the report; summing would say 6.
     tracker.channelOpened(GW_A);
     tracker.channelOpened(GW_A);
     tracker.channelOpened(GW_A);
+    await vi.advanceTimersByTimeAsync(1_000);
     await tracker.recordReportedLoad(GW_A, 3);
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(3);
@@ -205,8 +222,8 @@ describe("gatewayLoadTracker", () => {
     await tracker.recordReportedLoad(GW_B, 7);
 
     const scores = await tracker.getScores([GW_A, GW_B]);
-    expect(scores.get(GW_A)).toEqual({ score: 2, reported: false });
-    expect(scores.get(GW_B)).toEqual({ score: 7, reported: true });
+    expect(scores.get(GW_A)).toEqual({ base: 2, score: 2, reported: false });
+    expect(scores.get(GW_B)).toEqual({ base: 7, score: 7, reported: true });
 
     tracker.shutdown();
   });
@@ -222,6 +239,69 @@ describe("gatewayLoadTracker", () => {
     await vi.advanceTimersByTimeAsync(40_000);
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
 
+    tracker.shutdown();
+  });
+
+  test("claims the least loaded member and reserves it in the same call", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    const claimed = await tracker.claimLeastLoaded([
+      { id: GW_A, base: 9 },
+      { id: GW_B, base: 1 }
+    ]);
+
+    expect(claimed).toBe(GW_B);
+    // Claiming and reserving must be one operation, otherwise concurrent selections all read the
+    // same minimum before any of them writes and every one of them routes to it. The base passed in
+    // is the caller's view; the score here is this gateway's real occupancy plus that reservation.
+    expect((await tracker.getScores([GW_B])).get(GW_B)?.score).toBe(1);
+
+    tracker.shutdown();
+  });
+
+  test("concurrent claims stop piling on once the minimum catches up", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    // A unique minimum is the stampede case: read-then-write would send all four to the idle member
+    // because none of them would see the others' claims. Each claim here raises its reservation, so
+    // the traffic moves across once it reaches the busier member's level.
+    const claims = await Promise.all(
+      Array.from({ length: 4 }, () =>
+        tracker.claimLeastLoaded([
+          { id: GW_B, base: 2 },
+          { id: GW_A, base: 0 }
+        ])
+      )
+    );
+
+    expect(claims.filter((c) => c === GW_A)).toHaveLength(3);
+    expect(claims.filter((c) => c === GW_B)).toHaveLength(1);
+
+    tracker.shutdown();
+  });
+
+  test("resolves a tie by the order it is given, so callers control the tie-break", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    expect(
+      await tracker.claimLeastLoaded([
+        { id: GW_A, base: 0 },
+        { id: GW_B, base: 0 }
+      ])
+    ).toBe(GW_A);
+    expect(
+      await tracker.claimLeastLoaded([
+        { id: GW_B, base: 0 },
+        { id: GW_A, base: 0 }
+      ])
+    ).toBe(GW_B);
+
+    tracker.shutdown();
+  });
+
+  test("claims nothing when given no candidates", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+    expect(await tracker.claimLeastLoaded([])).toBeUndefined();
     tracker.shutdown();
   });
 

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
@@ -1,0 +1,161 @@
+import { KeyStorePrefixes } from "@app/keystore/keystore";
+import { inMemoryKeyStore } from "@app/keystore/memory";
+
+import { initGatewayLoadTracker } from "./gateway-load-tracker";
+
+vi.mock("@app/lib/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  }
+}));
+
+const GW_A = "11111111-1111-1111-1111-111111111111";
+const GW_B = "22222222-2222-2222-2222-222222222222";
+
+// The debounce means a publish lands on a later tick of the event loop.
+const flushPublishes = async () => {
+  await vi.advanceTimersByTimeAsync(500);
+};
+
+describe("gatewayLoadTracker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("scores an idle gateway at zero", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+    const scores = await tracker.getScores([GW_A, GW_B]);
+    expect(scores.get(GW_A)).toBe(0);
+    expect(scores.get(GW_B)).toBe(0);
+    tracker.shutdown();
+  });
+
+  test("counts open channels and releases them on close", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    tracker.channelOpened(GW_A);
+    tracker.channelOpened(GW_A);
+    tracker.channelOpened(GW_B);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)).toBe(2);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)).toBe(1);
+
+    tracker.channelClosed(GW_A);
+    tracker.channelClosed(GW_A);
+    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(0);
+
+    tracker.shutdown();
+  });
+
+  test("a reservation counts toward the score before the channel opens", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    await tracker.reserve(GW_A);
+    // Without this the second concurrent selection would read zero and stampede the same gateway.
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)).toBe(1);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)).toBe(0);
+
+    tracker.shutdown();
+  });
+
+  test("releases reservations so repeated selections do not accumulate into round-robin", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    for (let i = 0; i < 10; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await tracker.reserve(GW_A);
+    }
+    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(10);
+
+    // Left to expire on their own these would keep counting and turn the score into
+    // "selections in the last N seconds", which is request-count round-robin.
+    await vi.advanceTimersByTimeAsync(6_000);
+    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(0);
+
+    tracker.shutdown();
+  });
+
+  test("sums another pod's published count alongside local channels", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "other-pod", `5:${Date.now()}`);
+    tracker.channelOpened(GW_A);
+
+    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(6);
+    tracker.shutdown();
+  });
+
+  test("ignores a dead pod's stale count instead of counting it forever", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "dead-pod", `9:${Date.now() - 120_000}`);
+
+    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(0);
+    tracker.shutdown();
+  });
+
+  test("ignores a malformed published entry rather than scoring NaN", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "bad-pod", "not-a-count");
+
+    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(0);
+    tracker.shutdown();
+  });
+
+  test("drops its own field once it holds nothing, so the hash does not grow per restart", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    tracker.channelOpened(GW_A);
+    await flushPublishes();
+    expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(1);
+
+    tracker.channelClosed(GW_A);
+    await flushPublishes();
+    expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(0);
+
+    tracker.shutdown();
+  });
+
+  test("does not double count its own published field against its live count", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    tracker.channelOpened(GW_A);
+    await flushPublishes();
+
+    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(1);
+    tracker.shutdown();
+  });
+
+  test("marks and reports suspect gateways", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    await tracker.markSuspect(GW_A);
+    const suspect = await tracker.getSuspect([GW_A, GW_B]);
+
+    expect(suspect.has(GW_A)).toBe(true);
+    expect(suspect.has(GW_B)).toBe(false);
+    tracker.shutdown();
+  });
+
+  test("returns empty results for an empty gateway list without touching the store", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    expect((await tracker.getScores([])).size).toBe(0);
+    expect((await tracker.getSuspect([])).size).toBe(0);
+    tracker.shutdown();
+  });
+});

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
@@ -34,7 +34,7 @@ describe("gatewayLoadTracker", () => {
     const scores = await tracker.getScores([GW_A, GW_B]);
     expect(scores.get(GW_A)?.score).toBe(0);
     expect(scores.get(GW_B)?.score).toBe(0);
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("counts open channels and releases them on close", async () => {
@@ -50,7 +50,7 @@ describe("gatewayLoadTracker", () => {
     tracker.channelClosed(GW_A);
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("a reservation counts toward the score before the channel opens", async () => {
@@ -62,7 +62,7 @@ describe("gatewayLoadTracker", () => {
     expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)?.score).toBe(1);
     expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)?.score).toBe(0);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("hands the reservation off to the channel instead of double counting", async () => {
@@ -80,7 +80,7 @@ describe("gatewayLoadTracker", () => {
     tracker.channelClosed(GW_A);
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("releases a reservation whose channel never opens", async () => {
@@ -98,7 +98,7 @@ describe("gatewayLoadTracker", () => {
     await vi.advanceTimersByTimeAsync(240_000);
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("sums another pod's published count alongside local channels", async () => {
@@ -109,7 +109,7 @@ describe("gatewayLoadTracker", () => {
     tracker.channelOpened(GW_A);
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(6);
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("ignores a dead pod's stale count instead of counting it forever", async () => {
@@ -119,7 +119,7 @@ describe("gatewayLoadTracker", () => {
     await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "dead-pod", `9:${Date.now() - 120_000}`);
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("ignores a malformed published entry rather than scoring NaN", async () => {
@@ -129,7 +129,7 @@ describe("gatewayLoadTracker", () => {
     await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "bad-pod", "not-a-count");
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("drops its own field once it holds nothing, so the hash does not grow per restart", async () => {
@@ -144,7 +144,7 @@ describe("gatewayLoadTracker", () => {
     await flushPublishes();
     expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(0);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("does not double count its own published field against its live count", async () => {
@@ -155,7 +155,7 @@ describe("gatewayLoadTracker", () => {
     await flushPublishes();
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("prefers the gateway's own count over the platform's partial view", async () => {
@@ -168,7 +168,7 @@ describe("gatewayLoadTracker", () => {
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(50);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("adds channels opened since the gateway's last report", async () => {
@@ -184,7 +184,7 @@ describe("gatewayLoadTracker", () => {
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(6);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("does not sum its own view into the gateway's count", async () => {
@@ -199,7 +199,7 @@ describe("gatewayLoadTracker", () => {
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(3);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("still adds reservations on top of a reported count", async () => {
@@ -211,7 +211,7 @@ describe("gatewayLoadTracker", () => {
 
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(5);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("falls back to the platform's view for a gateway too old to report, and flags the scale", async () => {
@@ -225,7 +225,7 @@ describe("gatewayLoadTracker", () => {
     expect(scores.get(GW_A)).toEqual({ base: 2, score: 2, reported: false });
     expect(scores.get(GW_B)).toEqual({ base: 7, score: 7, reported: true });
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("falls back when a gateway stops reporting", async () => {
@@ -239,7 +239,7 @@ describe("gatewayLoadTracker", () => {
     await vi.advanceTimersByTimeAsync(40_000);
     expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("claims the least loaded member and reserves it in the same call", async () => {
@@ -256,7 +256,7 @@ describe("gatewayLoadTracker", () => {
     // is the caller's view; the score here is this gateway's real occupancy plus that reservation.
     expect((await tracker.getScores([GW_B])).get(GW_B)?.score).toBe(1);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("concurrent claims stop piling on once the minimum catches up", async () => {
@@ -277,7 +277,7 @@ describe("gatewayLoadTracker", () => {
     expect(claims.filter((c) => c === GW_A)).toHaveLength(3);
     expect(claims.filter((c) => c === GW_B)).toHaveLength(1);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("resolves a tie by the order it is given, so callers control the tie-break", async () => {
@@ -296,13 +296,27 @@ describe("gatewayLoadTracker", () => {
       ])
     ).toBe(GW_B);
 
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("claims nothing when given no candidates", async () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
     expect(await tracker.claimLeastLoaded([])).toBeUndefined();
-    tracker.shutdown();
+    void tracker.shutdown();
+  });
+
+  test("clears its published counts on shutdown", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    tracker.channelOpened(GW_A);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(1);
+
+    // A rolling deploy would otherwise leave this pod's dead channels counting for the whole
+    // freshness window.
+    await tracker.shutdown();
+    expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(0);
   });
 
   test("marks and reports suspect gateways", async () => {
@@ -313,7 +327,7 @@ describe("gatewayLoadTracker", () => {
 
     expect(suspect.has(GW_A)).toBe(true);
     expect(suspect.has(GW_B)).toBe(false);
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 
   test("returns empty results for an empty gateway list without touching the store", async () => {
@@ -321,6 +335,6 @@ describe("gatewayLoadTracker", () => {
 
     expect((await tracker.getScores([])).size).toBe(0);
     expect((await tracker.getSuspect([])).size).toBe(0);
-    tracker.shutdown();
+    void tracker.shutdown();
   });
 });

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
@@ -32,8 +32,8 @@ describe("gatewayLoadTracker", () => {
   test("scores an idle gateway at zero", async () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
     const scores = await tracker.getScores([GW_A, GW_B]);
-    expect(scores.get(GW_A)).toBe(0);
-    expect(scores.get(GW_B)).toBe(0);
+    expect(scores.get(GW_A)?.score).toBe(0);
+    expect(scores.get(GW_B)?.score).toBe(0);
     tracker.shutdown();
   });
 
@@ -43,12 +43,12 @@ describe("gatewayLoadTracker", () => {
     tracker.channelOpened(GW_A);
     tracker.channelOpened(GW_A);
     tracker.channelOpened(GW_B);
-    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)).toBe(2);
-    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)).toBe(1);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)?.score).toBe(2);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)?.score).toBe(1);
 
     tracker.channelClosed(GW_A);
     tracker.channelClosed(GW_A);
-    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(0);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
 
     tracker.shutdown();
   });
@@ -59,13 +59,31 @@ describe("gatewayLoadTracker", () => {
 
     await tracker.reserve(GW_A);
     // Without this the second concurrent selection would read zero and stampede the same gateway.
-    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)).toBe(1);
-    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)).toBe(0);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)?.score).toBe(1);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)?.score).toBe(0);
 
     tracker.shutdown();
   });
 
-  test("releases reservations so repeated selections do not accumulate into round-robin", async () => {
+  test("hands the reservation off to the channel instead of double counting", async () => {
+    const keyStore = inMemoryKeyStore();
+    const tracker = initGatewayLoadTracker(keyStore);
+
+    await tracker.reserve(GW_A);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
+
+    // The channel now carries the load the reservation stood in for, so the score must stay at 1
+    // rather than counting both.
+    tracker.channelOpened(GW_A);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
+
+    tracker.channelClosed(GW_A);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
+
+    tracker.shutdown();
+  });
+
+  test("releases a reservation whose channel never opens", async () => {
     const keyStore = inMemoryKeyStore();
     const tracker = initGatewayLoadTracker(keyStore);
 
@@ -73,12 +91,12 @@ describe("gatewayLoadTracker", () => {
       // eslint-disable-next-line no-await-in-loop
       await tracker.reserve(GW_A);
     }
-    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(10);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(10);
 
-    // Left to expire on their own these would keep counting and turn the score into
-    // "selections in the last N seconds", which is request-count round-robin.
-    await vi.advanceTimersByTimeAsync(6_000);
-    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(0);
+    // Left to accumulate these would turn the score into "selections in the last N seconds", which
+    // is request-count round-robin rather than occupancy.
+    await vi.advanceTimersByTimeAsync(240_000);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
 
     tracker.shutdown();
   });
@@ -90,7 +108,7 @@ describe("gatewayLoadTracker", () => {
     await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "other-pod", `5:${Date.now()}`);
     tracker.channelOpened(GW_A);
 
-    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(6);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(6);
     tracker.shutdown();
   });
 
@@ -100,7 +118,7 @@ describe("gatewayLoadTracker", () => {
 
     await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "dead-pod", `9:${Date.now() - 120_000}`);
 
-    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(0);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
     tracker.shutdown();
   });
 
@@ -110,7 +128,7 @@ describe("gatewayLoadTracker", () => {
 
     await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "bad-pod", "not-a-count");
 
-    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(0);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
     tracker.shutdown();
   });
 
@@ -136,7 +154,74 @@ describe("gatewayLoadTracker", () => {
     tracker.channelOpened(GW_A);
     await flushPublishes();
 
-    expect((await tracker.getScores([GW_A])).get(GW_A)).toBe(1);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
+    tracker.shutdown();
+  });
+
+  test("prefers the gateway's own count over the platform's partial view", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    // The platform only ever sees channels it opened itself. A PAM CLI session dials the relay
+    // directly, so without the gateway's own count this member would score 0 and look idle.
+    tracker.channelOpened(GW_A);
+    await tracker.recordReportedLoad(GW_A, 50);
+
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(50);
+
+    tracker.shutdown();
+  });
+
+  test("does not sum its own view into the gateway's count", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    // The reported 3 already includes the 3 this pod opened; summing would say 6.
+    tracker.channelOpened(GW_A);
+    tracker.channelOpened(GW_A);
+    tracker.channelOpened(GW_A);
+    await tracker.recordReportedLoad(GW_A, 3);
+
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(3);
+
+    tracker.shutdown();
+  });
+
+  test("still adds reservations on top of a reported count", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    // A reservation covers a channel the gateway has not seen yet, so it is additive.
+    await tracker.recordReportedLoad(GW_A, 4);
+    await tracker.reserve(GW_A);
+
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(5);
+
+    tracker.shutdown();
+  });
+
+  test("falls back to the platform's view for a gateway too old to report, and flags the scale", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    tracker.channelOpened(GW_A);
+    tracker.channelOpened(GW_A);
+    await tracker.recordReportedLoad(GW_B, 7);
+
+    const scores = await tracker.getScores([GW_A, GW_B]);
+    expect(scores.get(GW_A)).toEqual({ score: 2, reported: false });
+    expect(scores.get(GW_B)).toEqual({ score: 7, reported: true });
+
+    tracker.shutdown();
+  });
+
+  test("falls back when a gateway stops reporting", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    await tracker.recordReportedLoad(GW_A, 40);
+    tracker.channelOpened(GW_A);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(40);
+
+    // Past the freshness window the stale 40 must not pin the member out of rotation forever.
+    await vi.advanceTimersByTimeAsync(40_000);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
+
     tracker.shutdown();
   });
 

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.test.ts
@@ -1,4 +1,3 @@
-import { KeyStorePrefixes } from "@app/keystore/keystore";
 import { inMemoryKeyStore } from "@app/keystore/memory";
 
 import { initGatewayLoadTracker } from "./gateway-load-tracker";
@@ -15,11 +14,6 @@ vi.mock("@app/lib/logger", () => ({
 const GW_A = "11111111-1111-1111-1111-111111111111";
 const GW_B = "22222222-2222-2222-2222-222222222222";
 
-// The debounce means a publish lands on a later tick of the event loop.
-const flushPublishes = async () => {
-  await vi.advanceTimersByTimeAsync(500);
-};
-
 describe("gatewayLoadTracker", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -32,55 +26,72 @@ describe("gatewayLoadTracker", () => {
   test("scores an idle gateway at zero", async () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
     const scores = await tracker.getScores([GW_A, GW_B]);
-    expect(scores.get(GW_A)?.score).toBe(0);
-    expect(scores.get(GW_B)?.score).toBe(0);
+    expect(scores.get(GW_A)?.base).toBe(0);
+    expect(scores.get(GW_B)?.base).toBe(0);
     void tracker.shutdown();
   });
 
-  test("counts open channels and releases them on close", async () => {
+  test("counts open channels on top of a report and releases them on close", async () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    await tracker.recordReportedLoad(GW_A, 0);
+    await tracker.recordReportedLoad(GW_B, 0);
+    await vi.advanceTimersByTimeAsync(1_000);
 
     tracker.channelOpened(GW_A);
     tracker.channelOpened(GW_A);
     tracker.channelOpened(GW_B);
-    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)?.score).toBe(2);
-    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)?.score).toBe(1);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)?.base).toBe(2);
+    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)?.base).toBe(1);
 
     tracker.channelClosed(GW_A);
     tracker.channelClosed(GW_A);
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.base).toBe(0);
 
     void tracker.shutdown();
   });
 
-  test("a reservation counts toward the score before the channel opens", async () => {
-    const keyStore = inMemoryKeyStore();
-    const tracker = initGatewayLoadTracker(keyStore);
+  // Reservations are only ever read by the claim script, so that is where they have to be observed.
+  // getScores deliberately does not fold them in, or every decision would fetch them twice.
+  test("a reservation steers the next claim away before the channel opens", async () => {
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
 
     await tracker.reserve(GW_A);
     // Without this the second concurrent selection would read zero and stampede the same gateway.
-    expect((await tracker.getScores([GW_A, GW_B])).get(GW_A)?.score).toBe(1);
-    expect((await tracker.getScores([GW_A, GW_B])).get(GW_B)?.score).toBe(0);
+    expect(
+      await tracker.claimLeastLoaded([
+        { id: GW_A, base: 0 },
+        { id: GW_B, base: 0 }
+      ])
+    ).toBe(GW_B);
 
-    void tracker.shutdown();
+    tracker.shutdown();
   });
 
   test("hands the reservation off to the channel instead of double counting", async () => {
-    const keyStore = inMemoryKeyStore();
-    const tracker = initGatewayLoadTracker(keyStore);
+    const tracker = initGatewayLoadTracker(inMemoryKeyStore());
+
+    await tracker.recordReportedLoad(GW_A, 0);
+    await vi.advanceTimersByTimeAsync(1_000);
 
     await tracker.reserve(GW_A);
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
-
-    // The channel now carries the load the reservation stood in for, so the score must stay at 1
-    // rather than counting both.
+    // The channel now carries the load the reservation stood in for. Counting both would show A at
+    // two for one connection.
     tracker.channelOpened(GW_A);
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.base).toBe(1);
+    // Equal bases with the reservation released is a tie, which the script gives to the first entry.
+    // Had the reservation survived the handoff, A would total two and B would win.
+    expect(
+      await tracker.claimLeastLoaded([
+        { id: GW_A, base: 1 },
+        { id: GW_B, base: 1 }
+      ])
+    ).toBe(GW_A);
 
     tracker.channelClosed(GW_A);
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.base).toBe(0);
 
-    void tracker.shutdown();
+    tracker.shutdown();
   });
 
   test("releases a reservation whose channel never opens", async () => {
@@ -91,71 +102,24 @@ describe("gatewayLoadTracker", () => {
       // eslint-disable-next-line no-await-in-loop
       await tracker.reserve(GW_A);
     }
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(10);
+    expect(
+      await tracker.claimLeastLoaded([
+        { id: GW_A, base: 0 },
+        { id: GW_B, base: 5 }
+      ])
+    ).toBe(GW_B);
 
     // Left to accumulate these would turn the score into "selections in the last N seconds", which
     // is request-count round-robin rather than occupancy.
     await vi.advanceTimersByTimeAsync(240_000);
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
+    expect(
+      await tracker.claimLeastLoaded([
+        { id: GW_A, base: 0 },
+        { id: GW_B, base: 5 }
+      ])
+    ).toBe(GW_A);
 
-    void tracker.shutdown();
-  });
-
-  test("sums another pod's published count alongside local channels", async () => {
-    const keyStore = inMemoryKeyStore();
-    const tracker = initGatewayLoadTracker(keyStore);
-
-    await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "other-pod", `5:${Date.now()}`);
-    tracker.channelOpened(GW_A);
-
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(6);
-    void tracker.shutdown();
-  });
-
-  test("ignores a dead pod's stale count instead of counting it forever", async () => {
-    const keyStore = inMemoryKeyStore();
-    const tracker = initGatewayLoadTracker(keyStore);
-
-    await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "dead-pod", `9:${Date.now() - 120_000}`);
-
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
-    void tracker.shutdown();
-  });
-
-  test("ignores a malformed published entry rather than scoring NaN", async () => {
-    const keyStore = inMemoryKeyStore();
-    const tracker = initGatewayLoadTracker(keyStore);
-
-    await keyStore.hashSet(KeyStorePrefixes.GatewayLoad(GW_A), "bad-pod", "not-a-count");
-
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(0);
-    void tracker.shutdown();
-  });
-
-  test("drops its own field once it holds nothing, so the hash does not grow per restart", async () => {
-    const keyStore = inMemoryKeyStore();
-    const tracker = initGatewayLoadTracker(keyStore);
-
-    tracker.channelOpened(GW_A);
-    await flushPublishes();
-    expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(1);
-
-    tracker.channelClosed(GW_A);
-    await flushPublishes();
-    expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(0);
-
-    void tracker.shutdown();
-  });
-
-  test("does not double count its own published field against its live count", async () => {
-    const keyStore = inMemoryKeyStore();
-    const tracker = initGatewayLoadTracker(keyStore);
-
-    tracker.channelOpened(GW_A);
-    await flushPublishes();
-
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
-    void tracker.shutdown();
+    tracker.shutdown();
   });
 
   test("prefers the gateway's own count over the platform's partial view", async () => {
@@ -166,7 +130,7 @@ describe("gatewayLoadTracker", () => {
     tracker.channelOpened(GW_A);
     await tracker.recordReportedLoad(GW_A, 50);
 
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(50);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.base).toBe(50);
 
     void tracker.shutdown();
   });
@@ -182,7 +146,7 @@ describe("gatewayLoadTracker", () => {
     tracker.channelOpened(GW_A);
     tracker.channelOpened(GW_A);
 
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(6);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.base).toBe(6);
 
     void tracker.shutdown();
   });
@@ -197,7 +161,7 @@ describe("gatewayLoadTracker", () => {
     await vi.advanceTimersByTimeAsync(1_000);
     await tracker.recordReportedLoad(GW_A, 3);
 
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(3);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.base).toBe(3);
 
     void tracker.shutdown();
   });
@@ -205,39 +169,49 @@ describe("gatewayLoadTracker", () => {
   test("still adds reservations on top of a reported count", async () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
 
-    // A reservation covers a channel the gateway has not seen yet, so it is additive.
+    // A reservation covers a channel the gateway has not seen yet, so it is additive to the report.
     await tracker.recordReportedLoad(GW_A, 4);
     await tracker.reserve(GW_A);
 
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(5);
+    const base = (await tracker.getScores([GW_A])).get(GW_A)?.base;
+    expect(base).toBe(4);
+    expect(
+      await tracker.claimLeastLoaded([
+        { id: GW_A, base: 4 },
+        { id: GW_B, base: 4 }
+      ])
+    ).toBe(GW_B);
 
-    void tracker.shutdown();
+    tracker.shutdown();
   });
 
-  test("falls back to the platform's view for a gateway too old to report, and flags the scale", async () => {
+  test("flags a gateway too old to report instead of inventing a count for it", async () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
 
+    // Selection refuses to compare a pool containing this member, so scoring it from the channels
+    // we happened to open would only be a number that looks like an occupancy without being one.
     tracker.channelOpened(GW_A);
     tracker.channelOpened(GW_A);
     await tracker.recordReportedLoad(GW_B, 7);
 
     const scores = await tracker.getScores([GW_A, GW_B]);
-    expect(scores.get(GW_A)).toEqual({ base: 2, score: 2, reported: false });
-    expect(scores.get(GW_B)).toEqual({ base: 7, score: 7, reported: true });
+    expect(scores.get(GW_A)).toEqual({ base: 0, reported: false });
+    expect(scores.get(GW_B)).toEqual({ base: 7, reported: true });
 
     void tracker.shutdown();
   });
 
-  test("falls back when a gateway stops reporting", async () => {
+  test("stops trusting a gateway that goes quiet", async () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
 
     await tracker.recordReportedLoad(GW_A, 40);
     tracker.channelOpened(GW_A);
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(40);
+    expect((await tracker.getScores([GW_A])).get(GW_A)?.base).toBe(40);
 
-    // Past the freshness window the stale 40 must not pin the member out of rotation forever.
+    // Past the freshness window the stale 40 must not pin the member out of rotation forever. It
+    // drops to unreported, which takes the whole pool off load-aware selection.
     await vi.advanceTimersByTimeAsync(40_000);
-    expect((await tracker.getScores([GW_A])).get(GW_A)?.score).toBe(1);
+    expect((await tracker.getScores([GW_A])).get(GW_A)).toEqual({ base: 0, reported: false });
 
     void tracker.shutdown();
   });
@@ -252,9 +226,14 @@ describe("gatewayLoadTracker", () => {
 
     expect(claimed).toBe(GW_B);
     // Claiming and reserving must be one operation, otherwise concurrent selections all read the
-    // same minimum before any of them writes and every one of them routes to it. The base passed in
-    // is the caller's view; the score here is this gateway's real occupancy plus that reservation.
-    expect((await tracker.getScores([GW_B])).get(GW_B)?.score).toBe(1);
+    // same minimum before any of them writes and every one of them routes to it. Repeating the call
+    // with the same bases has to move, which only happens if the first claim also wrote.
+    expect(
+      await tracker.claimLeastLoaded([
+        { id: GW_A, base: 1 },
+        { id: GW_B, base: 1 }
+      ])
+    ).toBe(GW_A);
 
     void tracker.shutdown();
   });
@@ -303,20 +282,6 @@ describe("gatewayLoadTracker", () => {
     const tracker = initGatewayLoadTracker(inMemoryKeyStore());
     expect(await tracker.claimLeastLoaded([])).toBeUndefined();
     void tracker.shutdown();
-  });
-
-  test("clears its published counts on shutdown", async () => {
-    const keyStore = inMemoryKeyStore();
-    const tracker = initGatewayLoadTracker(keyStore);
-
-    tracker.channelOpened(GW_A);
-    await vi.advanceTimersByTimeAsync(500);
-    expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(1);
-
-    // A rolling deploy would otherwise leave this pod's dead channels counting for the whole
-    // freshness window.
-    await tracker.shutdown();
-    expect(Object.keys(await keyStore.hashGetAll(KeyStorePrefixes.GatewayLoad(GW_A)))).toHaveLength(0);
   });
 
   test("marks and reports suspect gateways", async () => {

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.ts
@@ -2,24 +2,17 @@ import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 
 import { logger } from "../logger";
 
-// A reservation bridges the gap between choosing a gateway and its channel actually opening, so two
-// concurrent selections cannot both read a stale zero and stampede the same member. It only has to
-// span a relay dial plus two TLS handshakes, and it is released explicitly: left to expire on its
-// own the counter would behave like "selections in the last N seconds", which is request-count
-// round-robin rather than the occupancy signal this is supposed to be.
+// A reservation marks a gateway as chosen until its channel opens, so concurrent selections do not
+// all read the same stale count and stampede one member.
 const RESERVATION_TTL_SECONDS = 240;
-// Backstop only, for a selection whose channel never opens. The relay dial allows 100s and the
-// gateway handshake 120s, so releasing sooner would reopen the window the reservation covers.
+// Must outlast a relay dial (100s) plus a gateway handshake (120s), or the window reopens.
 const RESERVATION_HOLD_MS = 230_000;
 const SUSPECT_TTL_SECONDS = 60;
 
 export type TGatewayScore = {
-  /**
-   * Occupancy without reservations. The claim script reads the reservation keys itself, so adding
-   * them here as well would mean fetching them twice for the same decision.
-   */
+  /** Occupancy without reservations; the claim script reads those keys itself. */
   base: number;
-  /** False when this member is too old to report its own count, which disables load-aware selection. */
+  /** False when this member is too old to report, which disables load-aware selection. */
   reported: boolean;
 };
 
@@ -45,8 +38,7 @@ const reservationKey = KeyStorePrefixes.GatewayLoadReservation;
 const suspectKey = KeyStorePrefixes.GatewaySuspect;
 
 export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoadTracker => {
-  // Open timestamps rather than a bare count, so a channel opened since a gateway's last report can
-  // be added on top of that report instead of being invisible until the next one lands.
+  // Timestamps rather than a count, so channels opened since a gateway's last report can be added on top.
   const openChannels = new Map<string, number[]>();
   const reservationTimers = new Set<NodeJS.Timeout>();
   const pendingReservations = new Map<string, NodeJS.Timeout[]>();
@@ -59,8 +51,6 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     }
   };
 
-  // The key TTL is only a backstop for a pod that dies holding reservations; the channel handoff or
-  // this timer is what normally releases them.
   function trackReservationRelease(gatewayId: string) {
     const timer = setTimeout(() => {
       reservationTimers.delete(timer);
@@ -88,8 +78,7 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     const open = openChannels.get(gatewayId);
     if (open) open.push(Date.now());
     else openChannels.set(gatewayId, [Date.now()]);
-    // The channel now carries the load the reservation was standing in for. Holding both would
-    // double count the member for the rest of the backstop window.
+    // The channel now carries the load the reservation stood in for; holding both double counts.
     const pending = pendingReservations.get(gatewayId);
     const timer = pending?.shift();
     if (timer) {
@@ -101,16 +90,14 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
 
   const channelClosed = (gatewayId: string) => {
     const open = openChannels.get(gatewayId);
-    // Drops the oldest: only the count and the open times matter, not which socket this was.
     open?.shift();
     if (!open?.length) openChannels.delete(gatewayId);
   };
 
   const reserve = async (gatewayId: string) => {
     try {
-      // Routed through the same claim path as a pool selection so the expiry is set only on the
-      // first increment. incrementByWithExpiry refreshes it on every call, which on a busy gateway
-      // means the key never elapses and a crashed pod's reservations stay counted forever.
+      // Same claim path as a selection, so the expiry is set only on the first increment. Refreshing
+      // it every call means a busy key never elapses and a dead pod's reservations persist.
       await keyStore.claimLeastLoaded([reservationKey(gatewayId)], [0], RESERVATION_TTL_SECONDS);
     } catch (err) {
       logger.debug({ err, gatewayId }, `Failed to reserve gateway capacity [gatewayId=${gatewayId}]`);
@@ -119,10 +106,7 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     trackReservationRelease(gatewayId);
   };
 
-  /**
-   * Picks and claims in one round trip. Ties fall to the caller's ordering, so the caller shuffles
-   * first to keep the random tie-break that stops every pod choosing the same idle member.
-   */
+  /** Ties fall to the caller's ordering, so callers shuffle first for a random tie-break. */
   const claimLeastLoaded = async (candidates: { id: string; base: number }[]) => {
     if (candidates.length === 0) return undefined;
     const idx = await keyStore.claimLeastLoaded(
@@ -169,14 +153,11 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     gatewayIds.forEach((gatewayId, idx) => {
       const report = parseStamped(reported[idx]);
 
-      // A gateway that cannot report is left at zero on purpose. Selection refuses to compare a pool
-      // containing one, so the number is never used, and inventing a platform-side count here would
-      // only look like a real occupancy to whoever reads it next.
+      // Left at zero on purpose: selection refuses to compare a pool containing one, so a
+      // platform-side count here would only look like a real occupancy without being one.
       let occupancy = 0;
       if (report) {
-        // The report is a snapshot up to its own timestamp. Anything this pod opened since then is
-        // not in it yet, and without this every selection inside one report interval reads the same
-        // stale number and piles onto the same member.
+        // Without this every selection inside one report interval reads the same stale count.
         const openedSinceReport = (openChannels.get(gatewayId) ?? []).filter((openedAt) => openedAt > report.at).length;
         occupancy = report.count + openedSinceReport;
       }
@@ -197,8 +178,7 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     return suspect;
   };
 
-  // Nothing here writes to Redis. Reservations this pod still holds are left to their TTL, which is
-  // the backstop that exists precisely for a pod that goes away without releasing them.
+  // Reservations still held are left to their TTL, which exists for exactly this case.
   const shutdown = () => {
     tracker = undefined;
     for (const timer of reservationTimers) clearTimeout(timer);

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.ts
@@ -9,8 +9,10 @@ import { logger } from "../logger";
 // span a relay dial plus two TLS handshakes, and it is released explicitly: left to expire on its
 // own the counter would behave like "selections in the last N seconds", which is request-count
 // round-robin rather than the occupancy signal this is supposed to be.
-const RESERVATION_TTL_SECONDS = 20;
-const RESERVATION_HOLD_MS = 5_000;
+const RESERVATION_TTL_SECONDS = 240;
+// Backstop only, for a selection whose channel never opens. The relay dial allows 100s and the
+// gateway handshake 120s, so releasing sooner would reopen the window the reservation covers.
+const RESERVATION_HOLD_MS = 230_000;
 const SUSPECT_TTL_SECONDS = 60;
 const LOAD_HASH_TTL_SECONDS = 600;
 
@@ -22,19 +24,34 @@ const PUBLISH_REFRESH_MS = 20_000;
 
 const podId = crypto.randomUUID();
 
+export type TGatewayScore = {
+  score: number;
+  /** False when this member is too old to report its own count, so its score is on a different scale. */
+  reported: boolean;
+};
+
 type TGatewayLoadTracker = {
+  recordReportedLoad: (gatewayId: string, activeChannels: number) => Promise<void>;
   reserve: (gatewayId: string) => Promise<void>;
   channelOpened: (gatewayId: string) => void;
   channelClosed: (gatewayId: string) => void;
   markSuspect: (gatewayId: string) => Promise<void>;
-  getScores: (gatewayIds: string[]) => Promise<Map<string, number>>;
+  getScores: (gatewayIds: string[]) => Promise<Map<string, TGatewayScore>>;
   getSuspect: (gatewayIds: string[]) => Promise<Set<string>>;
   shutdown: () => void;
 };
 
 let tracker: TGatewayLoadTracker | undefined;
 
+// A gateway's own count is authoritative: it is taken at the one place every channel must pass
+// through, so it sees work the platform never proxied (a PAM CLI session dials the relay itself) and
+// any future caller too. The per-pod counters below only cover platform-initiated channels and exist
+// as a fallback for gateways too old to report.
+const REPORTED_LOAD_TTL_SECONDS = 60;
+const REPORTED_LOAD_MAX_AGE_MS = 35_000;
+
 const loadKey = KeyStorePrefixes.GatewayLoad;
+const reportedKey = KeyStorePrefixes.GatewayReportedLoad;
 const reservationKey = KeyStorePrefixes.GatewayLoadReservation;
 const suspectKey = KeyStorePrefixes.GatewaySuspect;
 
@@ -42,9 +59,12 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
   const openChannels = new Map<string, number>();
   const pendingPublish = new Set<string>();
   const reservationTimers = new Set<NodeJS.Timeout>();
+  const pendingReservations = new Map<string, NodeJS.Timeout[]>();
   let debounceTimer: NodeJS.Timeout | undefined;
 
-  const publish = async (gatewayId: string) => {
+  const publishChain = new Map<string, Promise<void>>();
+
+  const publishNow = async (gatewayId: string) => {
     const count = openChannels.get(gatewayId) ?? 0;
     try {
       // Holding nothing means dropping the field rather than writing a zero, so the hash only ever
@@ -58,6 +78,15 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     } catch (err) {
       logger.debug({ err, gatewayId }, `Failed to publish gateway load [gatewayId=${gatewayId}]`);
     }
+  };
+
+  // Overlapping flushes must not interleave, or a hashSet for count 1 can land after the hashDelete
+  // for count 0 and leave this pod's field claiming load it does not hold.
+  const publish = (gatewayId: string) => {
+    const prev = publishChain.get(gatewayId) ?? Promise.resolve();
+    const next = prev.then(() => publishNow(gatewayId));
+    publishChain.set(gatewayId, next);
+    return next;
   };
 
   const flushPending = () => {
@@ -84,8 +113,33 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
   }, PUBLISH_REFRESH_MS);
   refreshTimer.unref();
 
+  const recordReportedLoad = async (gatewayId: string, activeChannels: number) => {
+    await keyStore.setItemWithExpiry(
+      reportedKey(gatewayId),
+      REPORTED_LOAD_TTL_SECONDS,
+      `${activeChannels}:${Date.now()}`
+    );
+  };
+
+  const releaseReservation = async (gatewayId: string) => {
+    try {
+      await keyStore.decrementByOrDelete(reservationKey(gatewayId));
+    } catch (err) {
+      logger.debug({ err, gatewayId }, `Failed to release gateway reservation [gatewayId=${gatewayId}]`);
+    }
+  };
+
   const channelOpened = (gatewayId: string) => {
     openChannels.set(gatewayId, (openChannels.get(gatewayId) ?? 0) + 1);
+    // The channel now carries the load the reservation was standing in for. Holding both would
+    // double count the member for the rest of the backstop window.
+    const pending = pendingReservations.get(gatewayId);
+    const timer = pending?.shift();
+    if (timer) {
+      clearTimeout(timer);
+      reservationTimers.delete(timer);
+      void releaseReservation(gatewayId);
+    }
     schedulePublish(gatewayId);
   };
 
@@ -99,14 +153,6 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     schedulePublish(gatewayId);
   };
 
-  const releaseReservation = async (gatewayId: string) => {
-    try {
-      await keyStore.decrementByOrDelete(reservationKey(gatewayId));
-    } catch (err) {
-      logger.debug({ err, gatewayId }, `Failed to release gateway reservation [gatewayId=${gatewayId}]`);
-    }
-  };
-
   const reserve = async (gatewayId: string) => {
     try {
       await keyStore.incrementByWithExpiry(reservationKey(gatewayId), 1, RESERVATION_TTL_SECONDS);
@@ -117,10 +163,16 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     // The key TTL is only a backstop for a pod that dies holding reservations.
     const timer = setTimeout(() => {
       reservationTimers.delete(timer);
+      const queue = pendingReservations.get(gatewayId);
+      const idx = queue?.indexOf(timer) ?? -1;
+      if (queue && idx >= 0) queue.splice(idx, 1);
       void releaseReservation(gatewayId);
     }, RESERVATION_HOLD_MS);
     timer.unref();
     reservationTimers.add(timer);
+    const queue = pendingReservations.get(gatewayId);
+    if (queue) queue.push(timer);
+    else pendingReservations.set(gatewayId, [timer]);
   };
 
   const markSuspect = async (gatewayId: string) => {
@@ -137,33 +189,50 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
   };
 
   const getScores = async (gatewayIds: string[]) => {
-    const scores = new Map<string, number>();
+    const scores = new Map<string, TGatewayScore>();
     if (gatewayIds.length === 0) return scores;
 
-    const [published, reservations] = await Promise.all([
+    const [published, reservations, reported] = await Promise.all([
       Promise.all(gatewayIds.map((id) => keyStore.hashGetAll(loadKey(id)))),
-      keyStore.getItemsPrimary(gatewayIds.map((id) => reservationKey(id)))
+      keyStore.getItemsPrimary(gatewayIds.map((id) => reservationKey(id))),
+      keyStore.getItemsPrimary(gatewayIds.map((id) => reportedKey(id)))
     ]);
 
-    const cutoff = Date.now() - PUBLISHED_COUNT_MAX_AGE_MS;
+    const now = Date.now();
+    const publishedCutoff = now - PUBLISHED_COUNT_MAX_AGE_MS;
+    const reportedCutoff = now - REPORTED_LOAD_MAX_AGE_MS;
+
+    const parseStamped = (raw: string | null, cutoff: number) => {
+      if (!raw) return undefined;
+      const [countStr, tsStr] = raw.split(":");
+      const count = Number(countStr);
+      const at = Number(tsStr);
+      if (!Number.isFinite(count) || !Number.isFinite(at) || at < cutoff) return undefined;
+      return count;
+    };
 
     gatewayIds.forEach((gatewayId, idx) => {
-      const fields = Object.entries(published[idx] ?? {})
-        // This pod's in-memory count is always fresher than what it last published.
-        .filter(([fieldPodId]) => fieldPodId !== podId);
+      // Never sum the two views: the gateway's own count already includes the channels this pod
+      // opened, so adding the per-pod counters would double count platform traffic.
+      const reportedOccupancy = parseStamped(reported[idx], reportedCutoff);
+      let occupancy = reportedOccupancy;
 
-      let total = 0;
-      for (const [, raw] of fields) {
-        const [countStr, tsStr] = raw.split(":");
-        const count = Number(countStr);
-        const publishedAt = Number(tsStr);
-        if (Number.isFinite(count) && Number.isFinite(publishedAt) && publishedAt >= cutoff) {
-          total += count;
+      if (occupancy === undefined) {
+        const fields = Object.entries(published[idx] ?? {})
+          // This pod's in-memory count is always fresher than what it last published.
+          .filter(([fieldPodId]) => fieldPodId !== podId);
+
+        occupancy = 0;
+        for (const [, raw] of fields) {
+          occupancy += parseStamped(raw, publishedCutoff) ?? 0;
         }
+        occupancy += openChannels.get(gatewayId) ?? 0;
       }
-      total += openChannels.get(gatewayId) ?? 0;
-      total += Number(reservations[idx] ?? 0) || 0;
-      scores.set(gatewayId, total);
+
+      scores.set(gatewayId, {
+        score: occupancy + (Number(reservations[idx] ?? 0) || 0),
+        reported: reportedOccupancy !== undefined
+      });
     });
 
     return scores;
@@ -183,10 +252,12 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     clearInterval(refreshTimer);
     if (debounceTimer) clearTimeout(debounceTimer);
     for (const timer of reservationTimers) clearTimeout(timer);
+    pendingReservations.clear();
     reservationTimers.clear();
   };
 
   tracker = {
+    recordReportedLoad,
     reserve,
     channelOpened,
     channelClosed,

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.ts
@@ -26,6 +26,8 @@ const podId = crypto.randomUUID();
 
 export type TGatewayScore = {
   score: number;
+  /** Occupancy excluding reservations, which the atomic claim reads for itself. */
+  base: number;
   /** False when this member is too old to report its own count, so its score is on a different scale. */
   reported: boolean;
 };
@@ -33,6 +35,7 @@ export type TGatewayScore = {
 type TGatewayLoadTracker = {
   recordReportedLoad: (gatewayId: string, activeChannels: number) => Promise<void>;
   reserve: (gatewayId: string) => Promise<void>;
+  claimLeastLoaded: (candidates: { id: string; base: number }[]) => Promise<string | undefined>;
   channelOpened: (gatewayId: string) => void;
   channelClosed: (gatewayId: string) => void;
   markSuspect: (gatewayId: string) => Promise<void>;
@@ -56,7 +59,9 @@ const reservationKey = KeyStorePrefixes.GatewayLoadReservation;
 const suspectKey = KeyStorePrefixes.GatewaySuspect;
 
 export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoadTracker => {
-  const openChannels = new Map<string, number>();
+  // Open timestamps rather than a bare count, so a channel opened since a gateway's last report can
+  // be added on top of that report instead of being invisible until the next one lands.
+  const openChannels = new Map<string, number[]>();
   const pendingPublish = new Set<string>();
   const reservationTimers = new Set<NodeJS.Timeout>();
   const pendingReservations = new Map<string, NodeJS.Timeout[]>();
@@ -64,8 +69,35 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
 
   const publishChain = new Map<string, Promise<void>>();
 
+  const channelCount = (gatewayId: string) => openChannels.get(gatewayId)?.length ?? 0;
+
+  const releaseReservation = async (gatewayId: string) => {
+    try {
+      await keyStore.decrementByOrDelete(reservationKey(gatewayId));
+    } catch (err) {
+      logger.debug({ err, gatewayId }, `Failed to release gateway reservation [gatewayId=${gatewayId}]`);
+    }
+  };
+
+  // The key TTL is only a backstop for a pod that dies holding reservations; the channel handoff or
+  // this timer is what normally releases them.
+  function trackReservationRelease(gatewayId: string) {
+    const timer = setTimeout(() => {
+      reservationTimers.delete(timer);
+      const queue = pendingReservations.get(gatewayId);
+      const idx = queue?.indexOf(timer) ?? -1;
+      if (queue && idx >= 0) queue.splice(idx, 1);
+      void releaseReservation(gatewayId);
+    }, RESERVATION_HOLD_MS);
+    timer.unref();
+    reservationTimers.add(timer);
+    const queue = pendingReservations.get(gatewayId);
+    if (queue) queue.push(timer);
+    else pendingReservations.set(gatewayId, [timer]);
+  }
+
   const publishNow = async (gatewayId: string) => {
-    const count = openChannels.get(gatewayId) ?? 0;
+    const count = channelCount(gatewayId);
     try {
       // Holding nothing means dropping the field rather than writing a zero, so the hash only ever
       // carries pods with live channels instead of accumulating one entry per restart.
@@ -121,16 +153,10 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     );
   };
 
-  const releaseReservation = async (gatewayId: string) => {
-    try {
-      await keyStore.decrementByOrDelete(reservationKey(gatewayId));
-    } catch (err) {
-      logger.debug({ err, gatewayId }, `Failed to release gateway reservation [gatewayId=${gatewayId}]`);
-    }
-  };
-
   const channelOpened = (gatewayId: string) => {
-    openChannels.set(gatewayId, (openChannels.get(gatewayId) ?? 0) + 1);
+    const open = openChannels.get(gatewayId);
+    if (open) open.push(Date.now());
+    else openChannels.set(gatewayId, [Date.now()]);
     // The channel now carries the load the reservation was standing in for. Holding both would
     // double count the member for the rest of the backstop window.
     const pending = pendingReservations.get(gatewayId);
@@ -144,12 +170,10 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
   };
 
   const channelClosed = (gatewayId: string) => {
-    const next = (openChannels.get(gatewayId) ?? 0) - 1;
-    if (next > 0) {
-      openChannels.set(gatewayId, next);
-    } else {
-      openChannels.delete(gatewayId);
-    }
+    const open = openChannels.get(gatewayId);
+    // Drops the oldest: only the count and the open times matter, not which socket this was.
+    open?.shift();
+    if (!open?.length) openChannels.delete(gatewayId);
     schedulePublish(gatewayId);
   };
 
@@ -160,19 +184,24 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
       logger.debug({ err, gatewayId }, `Failed to reserve gateway capacity [gatewayId=${gatewayId}]`);
       return;
     }
-    // The key TTL is only a backstop for a pod that dies holding reservations.
-    const timer = setTimeout(() => {
-      reservationTimers.delete(timer);
-      const queue = pendingReservations.get(gatewayId);
-      const idx = queue?.indexOf(timer) ?? -1;
-      if (queue && idx >= 0) queue.splice(idx, 1);
-      void releaseReservation(gatewayId);
-    }, RESERVATION_HOLD_MS);
-    timer.unref();
-    reservationTimers.add(timer);
-    const queue = pendingReservations.get(gatewayId);
-    if (queue) queue.push(timer);
-    else pendingReservations.set(gatewayId, [timer]);
+    trackReservationRelease(gatewayId);
+  };
+
+  /**
+   * Picks and claims in one round trip. Ties fall to the caller's ordering, so the caller shuffles
+   * first to keep the random tie-break that stops every pod choosing the same idle member.
+   */
+  const claimLeastLoaded = async (candidates: { id: string; base: number }[]) => {
+    if (candidates.length === 0) return undefined;
+    const idx = await keyStore.claimLeastLoaded(
+      candidates.map((c) => reservationKey(c.id)),
+      candidates.map((c) => c.base),
+      RESERVATION_TTL_SECONDS
+    );
+    if (idx < 1 || idx > candidates.length) return undefined;
+    const claimed = candidates[idx - 1].id;
+    trackReservationRelease(claimed);
+    return claimed;
   };
 
   const markSuspect = async (gatewayId: string) => {
@@ -214,10 +243,20 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     gatewayIds.forEach((gatewayId, idx) => {
       // Never sum the two views: the gateway's own count already includes the channels this pod
       // opened, so adding the per-pod counters would double count platform traffic.
-      const reportedOccupancy = parseStamped(reported[idx], reportedCutoff);
+      const rawReported = reported[idx];
+      const reportedOccupancy = parseStamped(rawReported, reportedCutoff);
       let occupancy = reportedOccupancy;
 
-      if (occupancy === undefined) {
+      if (occupancy !== undefined) {
+        // The report is a snapshot up to its own timestamp. Anything this pod opened since then is
+        // not in it yet, and without this every selection inside one report interval reads the same
+        // stale number and piles onto the same member.
+        const reportedAt = Number((rawReported ?? "").split(":")[1]);
+        const openedSinceReport = Number.isFinite(reportedAt)
+          ? (openChannels.get(gatewayId) ?? []).filter((openedAt) => openedAt > reportedAt).length
+          : 0;
+        occupancy += openedSinceReport;
+      } else {
         const fields = Object.entries(published[idx] ?? {})
           // This pod's in-memory count is always fresher than what it last published.
           .filter(([fieldPodId]) => fieldPodId !== podId);
@@ -226,10 +265,11 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
         for (const [, raw] of fields) {
           occupancy += parseStamped(raw, publishedCutoff) ?? 0;
         }
-        occupancy += openChannels.get(gatewayId) ?? 0;
+        occupancy += channelCount(gatewayId);
       }
 
       scores.set(gatewayId, {
+        base: occupancy,
         score: occupancy + (Number(reservations[idx] ?? 0) || 0),
         reported: reportedOccupancy !== undefined
       });
@@ -259,6 +299,7 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
   tracker = {
     recordReportedLoad,
     reserve,
+    claimLeastLoaded,
     channelOpened,
     channelClosed,
     markSuspect,

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.ts
@@ -1,0 +1,202 @@
+import crypto from "node:crypto";
+
+import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
+
+import { logger } from "../logger";
+
+// A reservation bridges the gap between choosing a gateway and its channel actually opening, so two
+// concurrent selections cannot both read a stale zero and stampede the same member. It only has to
+// span a relay dial plus two TLS handshakes, and it is released explicitly: left to expire on its
+// own the counter would behave like "selections in the last N seconds", which is request-count
+// round-robin rather than the occupancy signal this is supposed to be.
+const RESERVATION_TTL_SECONDS = 20;
+const RESERVATION_HOLD_MS = 5_000;
+const SUSPECT_TTL_SECONDS = 60;
+const LOAD_HASH_TTL_SECONDS = 600;
+
+// Another pod's published count is ignored past this age, so a pod that dies stops skewing selection
+// instead of leaving its channels counted forever.
+const PUBLISHED_COUNT_MAX_AGE_MS = 90_000;
+const PUBLISH_DEBOUNCE_MS = 250;
+const PUBLISH_REFRESH_MS = 20_000;
+
+const podId = crypto.randomUUID();
+
+type TGatewayLoadTracker = {
+  reserve: (gatewayId: string) => Promise<void>;
+  channelOpened: (gatewayId: string) => void;
+  channelClosed: (gatewayId: string) => void;
+  markSuspect: (gatewayId: string) => Promise<void>;
+  getScores: (gatewayIds: string[]) => Promise<Map<string, number>>;
+  getSuspect: (gatewayIds: string[]) => Promise<Set<string>>;
+  shutdown: () => void;
+};
+
+let tracker: TGatewayLoadTracker | undefined;
+
+const loadKey = KeyStorePrefixes.GatewayLoad;
+const reservationKey = KeyStorePrefixes.GatewayLoadReservation;
+const suspectKey = KeyStorePrefixes.GatewaySuspect;
+
+export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoadTracker => {
+  const openChannels = new Map<string, number>();
+  const pendingPublish = new Set<string>();
+  const reservationTimers = new Set<NodeJS.Timeout>();
+  let debounceTimer: NodeJS.Timeout | undefined;
+
+  const publish = async (gatewayId: string) => {
+    const count = openChannels.get(gatewayId) ?? 0;
+    try {
+      // Holding nothing means dropping the field rather than writing a zero, so the hash only ever
+      // carries pods with live channels instead of accumulating one entry per restart.
+      if (count === 0) {
+        await keyStore.hashDelete(loadKey(gatewayId), podId);
+        return;
+      }
+      await keyStore.hashSet(loadKey(gatewayId), podId, `${count}:${Date.now()}`);
+      await keyStore.setExpiry(loadKey(gatewayId), LOAD_HASH_TTL_SECONDS);
+    } catch (err) {
+      logger.debug({ err, gatewayId }, `Failed to publish gateway load [gatewayId=${gatewayId}]`);
+    }
+  };
+
+  const flushPending = () => {
+    const ids = [...pendingPublish];
+    pendingPublish.clear();
+    debounceTimer = undefined;
+    void Promise.all(ids.map((id) => publish(id)));
+  };
+
+  const schedulePublish = (gatewayId: string) => {
+    pendingPublish.add(gatewayId);
+    if (!debounceTimer) {
+      debounceTimer = setTimeout(flushPending, PUBLISH_DEBOUNCE_MS);
+      debounceTimer.unref();
+    }
+  };
+
+  // Long-lived channels change the count once and then sit for hours, so the timestamp has to be
+  // refreshed independently or other pods would age the entry out while it is still accurate.
+  const refreshTimer = setInterval(() => {
+    for (const gatewayId of openChannels.keys()) {
+      schedulePublish(gatewayId);
+    }
+  }, PUBLISH_REFRESH_MS);
+  refreshTimer.unref();
+
+  const channelOpened = (gatewayId: string) => {
+    openChannels.set(gatewayId, (openChannels.get(gatewayId) ?? 0) + 1);
+    schedulePublish(gatewayId);
+  };
+
+  const channelClosed = (gatewayId: string) => {
+    const next = (openChannels.get(gatewayId) ?? 0) - 1;
+    if (next > 0) {
+      openChannels.set(gatewayId, next);
+    } else {
+      openChannels.delete(gatewayId);
+    }
+    schedulePublish(gatewayId);
+  };
+
+  const releaseReservation = async (gatewayId: string) => {
+    try {
+      await keyStore.decrementByOrDelete(reservationKey(gatewayId));
+    } catch (err) {
+      logger.debug({ err, gatewayId }, `Failed to release gateway reservation [gatewayId=${gatewayId}]`);
+    }
+  };
+
+  const reserve = async (gatewayId: string) => {
+    try {
+      await keyStore.incrementByWithExpiry(reservationKey(gatewayId), 1, RESERVATION_TTL_SECONDS);
+    } catch (err) {
+      logger.debug({ err, gatewayId }, `Failed to reserve gateway capacity [gatewayId=${gatewayId}]`);
+      return;
+    }
+    // The key TTL is only a backstop for a pod that dies holding reservations.
+    const timer = setTimeout(() => {
+      reservationTimers.delete(timer);
+      void releaseReservation(gatewayId);
+    }, RESERVATION_HOLD_MS);
+    timer.unref();
+    reservationTimers.add(timer);
+  };
+
+  const markSuspect = async (gatewayId: string) => {
+    try {
+      await keyStore.setItemWithExpiry(suspectKey(gatewayId), SUSPECT_TTL_SECONDS, "1");
+    } catch (err) {
+      logger.debug({ err, gatewayId }, `Failed to mark gateway suspect [gatewayId=${gatewayId}]`);
+      return;
+    }
+    logger.warn(
+      { gatewayId },
+      `Gateway marked suspect after transport failure [gatewayId=${gatewayId}] [ttlSeconds=${SUSPECT_TTL_SECONDS}]`
+    );
+  };
+
+  const getScores = async (gatewayIds: string[]) => {
+    const scores = new Map<string, number>();
+    if (gatewayIds.length === 0) return scores;
+
+    const [published, reservations] = await Promise.all([
+      Promise.all(gatewayIds.map((id) => keyStore.hashGetAll(loadKey(id)))),
+      keyStore.getItemsPrimary(gatewayIds.map((id) => reservationKey(id)))
+    ]);
+
+    const cutoff = Date.now() - PUBLISHED_COUNT_MAX_AGE_MS;
+
+    gatewayIds.forEach((gatewayId, idx) => {
+      const fields = Object.entries(published[idx] ?? {})
+        // This pod's in-memory count is always fresher than what it last published.
+        .filter(([fieldPodId]) => fieldPodId !== podId);
+
+      let total = 0;
+      for (const [, raw] of fields) {
+        const [countStr, tsStr] = raw.split(":");
+        const count = Number(countStr);
+        const publishedAt = Number(tsStr);
+        if (Number.isFinite(count) && Number.isFinite(publishedAt) && publishedAt >= cutoff) {
+          total += count;
+        }
+      }
+      total += openChannels.get(gatewayId) ?? 0;
+      total += Number(reservations[idx] ?? 0) || 0;
+      scores.set(gatewayId, total);
+    });
+
+    return scores;
+  };
+
+  const getSuspect = async (gatewayIds: string[]) => {
+    const suspect = new Set<string>();
+    if (gatewayIds.length === 0) return suspect;
+    const values = await keyStore.getItemsPrimary(gatewayIds.map((id) => suspectKey(id)));
+    gatewayIds.forEach((gatewayId, idx) => {
+      if (values[idx]) suspect.add(gatewayId);
+    });
+    return suspect;
+  };
+
+  const shutdown = () => {
+    clearInterval(refreshTimer);
+    if (debounceTimer) clearTimeout(debounceTimer);
+    for (const timer of reservationTimers) clearTimeout(timer);
+    reservationTimers.clear();
+  };
+
+  tracker = {
+    reserve,
+    channelOpened,
+    channelClosed,
+    markSuspect,
+    getScores,
+    getSuspect,
+    shutdown
+  };
+
+  return tracker;
+};
+
+export const getGatewayLoadTracker = () => tracker;

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.ts
@@ -46,10 +46,6 @@ type TGatewayLoadTracker = {
 
 let tracker: TGatewayLoadTracker | undefined;
 
-// A gateway's own count is authoritative: it is taken at the one place every channel must pass
-// through, so it sees work the platform never proxied (a PAM CLI session dials the relay itself) and
-// any future caller too. The per-pod counters below only cover platform-initiated channels and exist
-// as a fallback for gateways too old to report.
 const REPORTED_LOAD_TTL_SECONDS = 60;
 const REPORTED_LOAD_MAX_AGE_MS = 35_000;
 

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.ts
@@ -1,5 +1,3 @@
-import crypto from "node:crypto";
-
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 
 import { logger } from "../logger";
@@ -14,21 +12,14 @@ const RESERVATION_TTL_SECONDS = 240;
 // gateway handshake 120s, so releasing sooner would reopen the window the reservation covers.
 const RESERVATION_HOLD_MS = 230_000;
 const SUSPECT_TTL_SECONDS = 60;
-const LOAD_HASH_TTL_SECONDS = 600;
-
-// Another pod's published count is ignored past this age, so a pod that dies stops skewing selection
-// instead of leaving its channels counted forever.
-const PUBLISHED_COUNT_MAX_AGE_MS = 90_000;
-const PUBLISH_DEBOUNCE_MS = 250;
-const PUBLISH_REFRESH_MS = 20_000;
-
-const podId = crypto.randomUUID();
 
 export type TGatewayScore = {
-  score: number;
-  /** Occupancy excluding reservations, which the atomic claim reads for itself. */
+  /**
+   * Occupancy without reservations. The claim script reads the reservation keys itself, so adding
+   * them here as well would mean fetching them twice for the same decision.
+   */
   base: number;
-  /** False when this member is too old to report its own count, so its score is on a different scale. */
+  /** False when this member is too old to report its own count, which disables load-aware selection. */
   reported: boolean;
 };
 
@@ -41,7 +32,7 @@ type TGatewayLoadTracker = {
   markSuspect: (gatewayId: string) => Promise<void>;
   getScores: (gatewayIds: string[]) => Promise<Map<string, TGatewayScore>>;
   getSuspect: (gatewayIds: string[]) => Promise<Set<string>>;
-  shutdown: () => Promise<void>;
+  shutdown: () => void;
 };
 
 let tracker: TGatewayLoadTracker | undefined;
@@ -49,7 +40,6 @@ let tracker: TGatewayLoadTracker | undefined;
 const REPORTED_LOAD_TTL_SECONDS = 60;
 const REPORTED_LOAD_MAX_AGE_MS = 35_000;
 
-const loadKey = KeyStorePrefixes.GatewayLoad;
 const reportedKey = KeyStorePrefixes.GatewayReportedLoad;
 const reservationKey = KeyStorePrefixes.GatewayLoadReservation;
 const suspectKey = KeyStorePrefixes.GatewaySuspect;
@@ -58,14 +48,8 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
   // Open timestamps rather than a bare count, so a channel opened since a gateway's last report can
   // be added on top of that report instead of being invisible until the next one lands.
   const openChannels = new Map<string, number[]>();
-  const pendingPublish = new Set<string>();
   const reservationTimers = new Set<NodeJS.Timeout>();
   const pendingReservations = new Map<string, NodeJS.Timeout[]>();
-  let debounceTimer: NodeJS.Timeout | undefined;
-
-  const publishChain = new Map<string, Promise<void>>();
-
-  const channelCount = (gatewayId: string) => openChannels.get(gatewayId)?.length ?? 0;
 
   const releaseReservation = async (gatewayId: string) => {
     try {
@@ -92,55 +76,6 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     else pendingReservations.set(gatewayId, [timer]);
   }
 
-  const publishNow = async (gatewayId: string) => {
-    const count = channelCount(gatewayId);
-    try {
-      // Holding nothing means dropping the field rather than writing a zero, so the hash only ever
-      // carries pods with live channels instead of accumulating one entry per restart.
-      if (count === 0) {
-        await keyStore.hashDelete(loadKey(gatewayId), podId);
-        return;
-      }
-      await keyStore.hashSet(loadKey(gatewayId), podId, `${count}:${Date.now()}`);
-      await keyStore.setExpiry(loadKey(gatewayId), LOAD_HASH_TTL_SECONDS);
-    } catch (err) {
-      logger.debug({ err, gatewayId }, `Failed to publish gateway load [gatewayId=${gatewayId}]`);
-    }
-  };
-
-  // Overlapping flushes must not interleave, or a hashSet for count 1 can land after the hashDelete
-  // for count 0 and leave this pod's field claiming load it does not hold.
-  const publish = (gatewayId: string) => {
-    const prev = publishChain.get(gatewayId) ?? Promise.resolve();
-    const next = prev.then(() => publishNow(gatewayId));
-    publishChain.set(gatewayId, next);
-    return next;
-  };
-
-  const flushPending = () => {
-    const ids = [...pendingPublish];
-    pendingPublish.clear();
-    debounceTimer = undefined;
-    void Promise.all(ids.map((id) => publish(id)));
-  };
-
-  const schedulePublish = (gatewayId: string) => {
-    pendingPublish.add(gatewayId);
-    if (!debounceTimer) {
-      debounceTimer = setTimeout(flushPending, PUBLISH_DEBOUNCE_MS);
-      debounceTimer.unref();
-    }
-  };
-
-  // Long-lived channels change the count once and then sit for hours, so the timestamp has to be
-  // refreshed independently or other pods would age the entry out while it is still accurate.
-  const refreshTimer = setInterval(() => {
-    for (const gatewayId of openChannels.keys()) {
-      schedulePublish(gatewayId);
-    }
-  }, PUBLISH_REFRESH_MS);
-  refreshTimer.unref();
-
   const recordReportedLoad = async (gatewayId: string, activeChannels: number) => {
     await keyStore.setItemWithExpiry(
       reportedKey(gatewayId),
@@ -162,7 +97,6 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
       reservationTimers.delete(timer);
       void releaseReservation(gatewayId);
     }
-    schedulePublish(gatewayId);
   };
 
   const channelClosed = (gatewayId: string) => {
@@ -170,7 +104,6 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     // Drops the oldest: only the count and the open times matter, not which socket this was.
     open?.shift();
     if (!open?.length) openChannels.delete(gatewayId);
-    schedulePublish(gatewayId);
   };
 
   const reserve = async (gatewayId: string) => {
@@ -220,58 +153,35 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     const scores = new Map<string, TGatewayScore>();
     if (gatewayIds.length === 0) return scores;
 
-    const [published, reservations, reported] = await Promise.all([
-      Promise.all(gatewayIds.map((id) => keyStore.hashGetAll(loadKey(id)))),
-      keyStore.getItemsPrimary(gatewayIds.map((id) => reservationKey(id))),
-      keyStore.getItemsPrimary(gatewayIds.map((id) => reportedKey(id)))
-    ]);
+    const reported = await keyStore.getItemsPrimary(gatewayIds.map((id) => reportedKey(id)));
 
-    const now = Date.now();
-    const publishedCutoff = now - PUBLISHED_COUNT_MAX_AGE_MS;
-    const reportedCutoff = now - REPORTED_LOAD_MAX_AGE_MS;
+    const reportedCutoff = Date.now() - REPORTED_LOAD_MAX_AGE_MS;
 
-    const parseStamped = (raw: string | null, cutoff: number) => {
+    const parseStamped = (raw: string | null) => {
       if (!raw) return undefined;
       const [countStr, tsStr] = raw.split(":");
       const count = Number(countStr);
       const at = Number(tsStr);
-      if (!Number.isFinite(count) || !Number.isFinite(at) || at < cutoff) return undefined;
-      return count;
+      if (!Number.isFinite(count) || !Number.isFinite(at) || at < reportedCutoff) return undefined;
+      return { count, at };
     };
 
     gatewayIds.forEach((gatewayId, idx) => {
-      // Never sum the two views: the gateway's own count already includes the channels this pod
-      // opened, so adding the per-pod counters would double count platform traffic.
-      const rawReported = reported[idx];
-      const reportedOccupancy = parseStamped(rawReported, reportedCutoff);
-      let occupancy = reportedOccupancy;
+      const report = parseStamped(reported[idx]);
 
-      if (occupancy !== undefined) {
+      // A gateway that cannot report is left at zero on purpose. Selection refuses to compare a pool
+      // containing one, so the number is never used, and inventing a platform-side count here would
+      // only look like a real occupancy to whoever reads it next.
+      let occupancy = 0;
+      if (report) {
         // The report is a snapshot up to its own timestamp. Anything this pod opened since then is
         // not in it yet, and without this every selection inside one report interval reads the same
         // stale number and piles onto the same member.
-        const reportedAt = Number((rawReported ?? "").split(":")[1]);
-        const openedSinceReport = Number.isFinite(reportedAt)
-          ? (openChannels.get(gatewayId) ?? []).filter((openedAt) => openedAt > reportedAt).length
-          : 0;
-        occupancy += openedSinceReport;
-      } else {
-        const fields = Object.entries(published[idx] ?? {})
-          // This pod's in-memory count is always fresher than what it last published.
-          .filter(([fieldPodId]) => fieldPodId !== podId);
-
-        occupancy = 0;
-        for (const [, raw] of fields) {
-          occupancy += parseStamped(raw, publishedCutoff) ?? 0;
-        }
-        occupancy += channelCount(gatewayId);
+        const openedSinceReport = (openChannels.get(gatewayId) ?? []).filter((openedAt) => openedAt > report.at).length;
+        occupancy = report.count + openedSinceReport;
       }
 
-      scores.set(gatewayId, {
-        base: occupancy,
-        score: occupancy + (Number(reservations[idx] ?? 0) || 0),
-        reported: reportedOccupancy !== undefined
-      });
+      scores.set(gatewayId, { base: occupancy, reported: report !== undefined });
     });
 
     return scores;
@@ -287,28 +197,14 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     return suspect;
   };
 
-  const shutdown = async () => {
+  // Nothing here writes to Redis. Reservations this pod still holds are left to their TTL, which is
+  // the backstop that exists precisely for a pod that goes away without releasing them.
+  const shutdown = () => {
     tracker = undefined;
-    clearInterval(refreshTimer);
-    if (debounceTimer) clearTimeout(debounceTimer);
     for (const timer of reservationTimers) clearTimeout(timer);
     pendingReservations.clear();
     reservationTimers.clear();
-    publishChain.clear();
-
-    // Without this the published fields linger for the freshness window, so a rolling deploy leaves
-    // this pod's already-dead channels counting against those gateways.
-    const held = [...openChannels.keys()];
     openChannels.clear();
-    await Promise.all(
-      held.map(async (gatewayId) => {
-        try {
-          await keyStore.hashDelete(loadKey(gatewayId), podId);
-        } catch (err) {
-          logger.debug({ err, gatewayId }, `Failed to clear published load on shutdown [gatewayId=${gatewayId}]`);
-        }
-      })
-    );
   };
 
   tracker = {

--- a/backend/src/lib/gateway-v2/gateway-load-tracker.ts
+++ b/backend/src/lib/gateway-v2/gateway-load-tracker.ts
@@ -41,7 +41,7 @@ type TGatewayLoadTracker = {
   markSuspect: (gatewayId: string) => Promise<void>;
   getScores: (gatewayIds: string[]) => Promise<Map<string, TGatewayScore>>;
   getSuspect: (gatewayIds: string[]) => Promise<Set<string>>;
-  shutdown: () => void;
+  shutdown: () => Promise<void>;
 };
 
 let tracker: TGatewayLoadTracker | undefined;
@@ -175,7 +175,10 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
 
   const reserve = async (gatewayId: string) => {
     try {
-      await keyStore.incrementByWithExpiry(reservationKey(gatewayId), 1, RESERVATION_TTL_SECONDS);
+      // Routed through the same claim path as a pool selection so the expiry is set only on the
+      // first increment. incrementByWithExpiry refreshes it on every call, which on a busy gateway
+      // means the key never elapses and a crashed pod's reservations stay counted forever.
+      await keyStore.claimLeastLoaded([reservationKey(gatewayId)], [0], RESERVATION_TTL_SECONDS);
     } catch (err) {
       logger.debug({ err, gatewayId }, `Failed to reserve gateway capacity [gatewayId=${gatewayId}]`);
       return;
@@ -284,12 +287,28 @@ export const initGatewayLoadTracker = (keyStore: TKeyStoreFactory): TGatewayLoad
     return suspect;
   };
 
-  const shutdown = () => {
+  const shutdown = async () => {
+    tracker = undefined;
     clearInterval(refreshTimer);
     if (debounceTimer) clearTimeout(debounceTimer);
     for (const timer of reservationTimers) clearTimeout(timer);
     pendingReservations.clear();
     reservationTimers.clear();
+    publishChain.clear();
+
+    // Without this the published fields linger for the freshness window, so a rolling deploy leaves
+    // this pod's already-dead channels counting against those gateways.
+    const held = [...openChannels.keys()];
+    openChannels.clear();
+    await Promise.all(
+      held.map(async (gatewayId) => {
+        try {
+          await keyStore.hashDelete(loadKey(gatewayId), podId);
+        } catch (err) {
+          logger.debug({ err, gatewayId }, `Failed to clear published load on shutdown [gatewayId=${gatewayId}]`);
+        }
+      })
+    );
   };
 
   tracker = {

--- a/backend/src/lib/gateway-v2/gateway-retry.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-retry.test.ts
@@ -1,0 +1,62 @@
+import { isAttemptRetryable, isGatewayTransportFailure } from "./gateway-retry";
+
+const RELAY_ERR = "TLS connection error: ECONNREFUSED";
+
+describe("isGatewayTransportFailure", () => {
+  test("retryable when a channel failed to come up and none ever did", () => {
+    expect(isGatewayTransportFailure({ relayError: RELAY_ERR, establishedChannel: false })).toBe(true);
+  });
+
+  test("not retryable once a channel came up, even with a relay error recorded", () => {
+    // The bug this guards: relayError accumulates across every channel a proxy serves and is never
+    // cleared, so one transient setup blip would otherwise mark a later target-side failure (a
+    // half-applied rotation) as safe to replay on another member.
+    expect(isGatewayTransportFailure({ relayError: RELAY_ERR, establishedChannel: true })).toBe(false);
+  });
+
+  test("not retryable with no relay error at all", () => {
+    expect(isGatewayTransportFailure({ relayError: "", establishedChannel: false })).toBe(false);
+    expect(isGatewayTransportFailure({ relayError: "", establishedChannel: true })).toBe(false);
+  });
+
+  test("several accumulated relay errors are still only retryable if nothing established", () => {
+    const many = [RELAY_ERR, RELAY_ERR].join(",");
+    expect(isGatewayTransportFailure({ relayError: many, establishedChannel: false })).toBe(true);
+    expect(isGatewayTransportFailure({ relayError: many, establishedChannel: true })).toBe(false);
+  });
+});
+
+describe("isAttemptRetryable", () => {
+  const attempt = (o: Partial<Parameters<typeof isAttemptRetryable>[0]>) =>
+    isAttemptRetryable({ transportFailed: false, tunnelEstablished: false, isTransportError: false, ...o });
+
+  test("retryable when the async-local flag says no tunnel came up", () => {
+    expect(attempt({ transportFailed: true })).toBe(true);
+  });
+
+  test("retryable when the error type says so, for callers that do not rewrap", () => {
+    expect(attempt({ isTransportError: true })).toBe(true);
+  });
+
+  test("not retryable once any tunnel in the attempt came up", () => {
+    // The sticky-flag bug: an early tunnel fails and is swallowed by provider code, a later one
+    // reaches the target and fails there. Replaying would apply the change twice.
+    expect(attempt({ transportFailed: true, tunnelEstablished: true })).toBe(false);
+    expect(attempt({ isTransportError: true, tunnelEstablished: true })).toBe(false);
+    expect(attempt({ transportFailed: true, isTransportError: true, tunnelEstablished: true })).toBe(false);
+  });
+
+  test("not retryable for a plain target-side failure", () => {
+    // e.g. "password authentication failed" wrapped in a provider's own BadRequestError
+    expect(attempt({})).toBe(false);
+    expect(attempt({ tunnelEstablished: true })).toBe(false);
+  });
+
+  test("tunnelEstablished overrides every retryable signal", () => {
+    for (const transportFailed of [true, false]) {
+      for (const isTransportError of [true, false]) {
+        expect(attempt({ transportFailed, isTransportError, tunnelEstablished: true })).toBe(false);
+      }
+    }
+  });
+});

--- a/backend/src/lib/gateway-v2/gateway-retry.ts
+++ b/backend/src/lib/gateway-v2/gateway-retry.ts
@@ -1,17 +1,9 @@
 /**
- * When a failed gateway operation may be replayed on another pool member.
- *
- * The rule both helpers enforce is the same: retry only when nothing can have reached the target.
- * A half-applied change (a password rotation, a write) replayed on a second member would apply
- * twice, so anything that might have got through is not retryable no matter what it looks like.
+ * Retry only when nothing can have reached the target. A half-applied change replayed on a second
+ * member would apply twice.
  */
 
-/**
- * Per proxy. `relayError` is non-empty once any channel this proxy served failed to come up, and it
- * is never cleared, so on its own it stays true for the rest of the proxy's life. Requiring that no
- * channel ever established is what stops a single transient setup failure from marking every later
- * target-side error as safe to replay.
- */
+/** `relayError` is never cleared, so requiring that no channel established is what bounds it. */
 export const isGatewayTransportFailure = ({
   relayError,
   establishedChannel
@@ -20,11 +12,7 @@ export const isGatewayTransportFailure = ({
   establishedChannel: boolean;
 }): boolean => Boolean(relayError) && !establishedChannel;
 
-/**
- * Per attempt, across however many tunnels the caller's operation opened. An early tunnel can fail
- * and be swallowed by provider code while a later one reaches the target, so a transport failure
- * alone is not enough: no tunnel in the attempt may have come up.
- */
+/** An early tunnel can fail while a later one reaches the target, so a transport failure alone is not enough. */
 export const isAttemptRetryable = ({
   transportFailed,
   tunnelEstablished,

--- a/backend/src/lib/gateway-v2/gateway-retry.ts
+++ b/backend/src/lib/gateway-v2/gateway-retry.ts
@@ -1,0 +1,36 @@
+/**
+ * When a failed gateway operation may be replayed on another pool member.
+ *
+ * The rule both helpers enforce is the same: retry only when nothing can have reached the target.
+ * A half-applied change (a password rotation, a write) replayed on a second member would apply
+ * twice, so anything that might have got through is not retryable no matter what it looks like.
+ */
+
+/**
+ * Per proxy. `relayError` is non-empty once any channel this proxy served failed to come up, and it
+ * is never cleared, so on its own it stays true for the rest of the proxy's life. Requiring that no
+ * channel ever established is what stops a single transient setup failure from marking every later
+ * target-side error as safe to replay.
+ */
+export const isGatewayTransportFailure = ({
+  relayError,
+  establishedChannel
+}: {
+  relayError: string;
+  establishedChannel: boolean;
+}): boolean => Boolean(relayError) && !establishedChannel;
+
+/**
+ * Per attempt, across however many tunnels the caller's operation opened. An early tunnel can fail
+ * and be swallowed by provider code while a later one reaches the target, so a transport failure
+ * alone is not enough: no tunnel in the attempt may have come up.
+ */
+export const isAttemptRetryable = ({
+  transportFailed,
+  tunnelEstablished,
+  isTransportError
+}: {
+  transportFailed: boolean;
+  tunnelEstablished: boolean;
+  isTransportError: boolean;
+}): boolean => (transportFailed || isTransportError) && !tunnelEstablished;

--- a/backend/src/lib/gateway-v2/gateway-v2.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.test.ts
@@ -1,0 +1,303 @@
+import net from "node:net";
+import tls from "node:tls";
+
+import forge from "node-forge";
+
+import { GatewayProxyProtocol } from "@app/lib/gateway/types";
+
+import { setupRelayServer } from "./gateway-v2";
+
+const tracker = vi.hoisted(() => ({
+  channelOpened: vi.fn(),
+  channelClosed: vi.fn(),
+  markSuspect: vi.fn()
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}));
+
+vi.mock("@app/lib/config/env", () => ({
+  getConfig: () => ({ isDevelopmentMode: true })
+}));
+
+vi.mock("./gateway-load-tracker", () => ({
+  getGatewayLoadTracker: () => tracker
+}));
+
+// Real relays are addressed by hostname and always reach the gateway on 8443, so the production
+// implementation resolves the host and never sees a port. The fake relay needs an ephemeral one.
+vi.mock("@app/ee/services/dynamic-secret/dynamic-secret-fns", () => ({
+  verifyHostInputValidity: ({ host }: { host: string }) => Promise.resolve([host.split(":")[0]])
+}));
+
+const GATEWAY_ID = "11111111-1111-1111-1111-111111111111";
+
+const freePort = async () =>
+  new Promise<number>((resolve, reject) => {
+    const probe = net.createServer();
+    probe.on("error", reject);
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (!address || typeof address === "string") {
+        probe.close();
+        reject(new Error("no port"));
+        return;
+      }
+      const { port } = address;
+      probe.close(() => resolve(port));
+    });
+  });
+
+// One keypair reused by every certificate: the test only needs a chain that validates, and forge's
+// RSA generation is slow enough that three of them dominates the runtime of the whole file.
+const keys = forge.pki.rsa.generateKeyPair(2048);
+
+type TAltName = { type: number; value?: string; ip?: string };
+
+const issue = ({ subject, isCa, altNames }: { subject: string; isCa?: boolean; altNames?: TAltName[] }) => {
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = "01";
+  cert.validity.notBefore = new Date(Date.now() - 60_000);
+  cert.validity.notAfter = new Date(Date.now() + 3_600_000);
+  const attrs = [{ name: "commonName", value: subject }];
+  cert.setSubject(attrs);
+  cert.setIssuer([{ name: "commonName", value: "test-ca" }]);
+  const extensions: Record<string, unknown>[] = [{ name: "basicConstraints", cA: Boolean(isCa) }];
+  if (altNames) extensions.push({ name: "subjectAltName", altNames });
+  cert.setExtensions(extensions);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+  return forge.pki.certificateToPem(cert);
+};
+
+const keyPem = forge.pki.privateKeyToPem(keys.privateKey);
+const caPem = issue({ subject: "test-ca", isCa: true });
+
+type TFakeRelay = {
+  relayHost: string;
+  tunnelsOpened: () => number;
+  tunnelsClosed: () => number;
+  close: () => Promise<void>;
+};
+
+/**
+ * Stands in for the relay plus the gateway behind it: an outer TLS listener whose accepted socket
+ * carries a second, inner TLS server. That nesting is the part under test, because a tunnel is only
+ * "open" from the gateway's point of view once the inner handshake completes.
+ */
+const startFakeRelay = async (): Promise<TFakeRelay> => {
+  const port = await freePort();
+  const relayHost = `127.0.0.1:${port}`;
+  const serverCert = issue({
+    subject: "relay",
+    altNames: [
+      { type: 2, value: relayHost },
+      { type: 2, value: "127.0.0.1" },
+      { type: 7, ip: "127.0.0.1" }
+    ]
+  });
+
+  let opened = 0;
+  let closed = 0;
+  const live = new Set<tls.TLSSocket>();
+
+  const server = tls.createServer(
+    { key: keyPem, cert: serverCert, ca: caPem, requestCert: true, rejectUnauthorized: false },
+    (outer) => {
+      live.add(outer);
+      outer.on("close", () => live.delete(outer));
+      const inner = new tls.TLSSocket(outer, {
+        isServer: true,
+        key: keyPem,
+        cert: serverCert,
+        ca: caPem,
+        requestCert: true,
+        rejectUnauthorized: false,
+        ALPNProtocols: ["infisical-tcp-proxy"]
+      });
+      inner.on("secure", () => {
+        opened += 1;
+      });
+      // Echo, so a claimed tunnel can be shown to still carry traffic.
+      inner.on("data", (chunk: Buffer) => inner.write(chunk));
+      inner.on("error", () => {});
+      inner.on("close", () => {
+        closed += 1;
+      });
+      outer.on("error", () => {});
+    }
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+
+  return {
+    relayHost,
+    tunnelsOpened: () => opened,
+    tunnelsClosed: () => closed,
+    close: () =>
+      new Promise<void>((resolve) => {
+        for (const socket of live) socket.destroy();
+        live.clear();
+        server.close(() => resolve());
+      })
+  };
+};
+
+const clientCertPem = issue({ subject: "client" });
+
+const argsFor = (relayHost: string) => ({
+  gatewayId: GATEWAY_ID,
+  protocol: GatewayProxyProtocol.Tcp,
+  relayHost,
+  gateway: { clientCertificate: clientCertPem, clientPrivateKey: keyPem, serverCertificateChain: caPem },
+  relay: { clientCertificate: clientCertPem, clientPrivateKey: keyPem, serverCertificateChain: caPem }
+});
+
+const connectAndEcho = (port: number) =>
+  new Promise<string>((resolve, reject) => {
+    const socket: net.Socket = net.connect({ host: "127.0.0.1", port }, () => socket.write("ping"));
+    socket.on("data", (chunk) => {
+      resolve(chunk.toString());
+      socket.end();
+    });
+    socket.on("error", reject);
+    socket.setTimeout(5000, () => {
+      socket.destroy();
+      reject(new Error("echo timed out"));
+    });
+  });
+
+const waitFor = async (predicate: () => boolean) => {
+  for (let i = 0; i < 100; i += 1) {
+    if (predicate()) return;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
+  throw new Error("condition never became true");
+};
+
+// Teardown is driven by socket "close" events, so a test that ends the moment its assertion passes
+// can leak a release into the next test's counters.
+const drainChannels = (count: number) => waitFor(() => tracker.channelClosed.mock.calls.length === count);
+
+describe("setupRelayServer", () => {
+  beforeEach(() => {
+    tracker.channelOpened.mockClear();
+    tracker.channelClosed.mockClear();
+    tracker.markSuspect.mockClear();
+  });
+
+  describe("against an unreachable gateway", () => {
+    // Nothing is listening here, so any dial fails.
+    const args = {
+      gatewayId: GATEWAY_ID,
+      protocol: GatewayProxyProtocol.Tcp,
+      relayHost: "127.0.0.1:1",
+      gateway: { clientCertificate: "c", clientPrivateKey: "k", serverCertificateChain: "chain" },
+      relay: { clientCertificate: "c", clientPrivateKey: "k", serverCertificateChain: "chain" }
+    };
+
+    test("resolves when not eager, because the dial is deferred to the first client", async () => {
+      const server = await setupRelayServer(args);
+      expect(server.port).toBeGreaterThan(0);
+      expect(server.hasEstablishedChannel()).toBe(false);
+      await server.cleanup();
+    });
+
+    test("rejects when eager, which is what gives pool failover something to catch", async () => {
+      await expect(setupRelayServer({ ...args, eager: true })).rejects.toThrow();
+    });
+
+    test("reports the failure as a transport error, so it is safe to retry elsewhere", async () => {
+      await expect(setupRelayServer({ ...args, eager: true })).rejects.toMatchObject({
+        name: "BadRequest",
+        gatewayId: GATEWAY_ID
+      });
+    });
+
+    test("counts no channel for a tunnel that never opened", async () => {
+      await expect(setupRelayServer({ ...args, eager: true })).rejects.toThrow();
+      expect(tracker.channelOpened).not.toHaveBeenCalled();
+      expect(tracker.markSuspect).toHaveBeenCalledWith(GATEWAY_ID);
+    });
+  });
+
+  describe("against a reachable gateway", () => {
+    let relay: TFakeRelay;
+
+    beforeEach(async () => {
+      relay = await startFakeRelay();
+    });
+
+    afterEach(async () => {
+      await relay.close();
+    });
+
+    test("does not touch the gateway until a client connects when not eager", async () => {
+      const server = await setupRelayServer(argsFor(relay.relayHost));
+      expect(relay.tunnelsOpened()).toBe(0);
+      expect(server.hasEstablishedChannel()).toBe(false);
+      await server.cleanup();
+    });
+
+    test("opens the tunnel during setup when eager", async () => {
+      const server = await setupRelayServer({ ...argsFor(relay.relayHost), eager: true, longLived: true });
+      await waitFor(() => relay.tunnelsOpened() === 1);
+      expect(server.hasEstablishedChannel()).toBe(true);
+      expect(tracker.channelOpened).toHaveBeenCalledTimes(1);
+
+      await server.cleanup();
+      await drainChannels(1);
+    });
+
+    test("hands the tunnel it already opened to the first client instead of dialing again", async () => {
+      const server = await setupRelayServer({ ...argsFor(relay.relayHost), eager: true, longLived: true });
+      await waitFor(() => relay.tunnelsOpened() === 1);
+
+      // The reused tunnel has to still carry traffic; a probe-and-drop would fail here.
+      await expect(connectAndEcho(server.port)).resolves.toBe("ping");
+      expect(relay.tunnelsOpened()).toBe(1);
+      expect(tracker.channelOpened).toHaveBeenCalledTimes(1);
+
+      await server.cleanup();
+      await drainChannels(1);
+    });
+
+    test("dials a fresh tunnel for the second client", async () => {
+      const server = await setupRelayServer({ ...argsFor(relay.relayHost), eager: true, longLived: true });
+
+      await expect(connectAndEcho(server.port)).resolves.toBe("ping");
+      await expect(connectAndEcho(server.port)).resolves.toBe("ping");
+
+      await waitFor(() => relay.tunnelsOpened() === 2);
+      expect(tracker.channelOpened).toHaveBeenCalledTimes(2);
+
+      await server.cleanup();
+      await drainChannels(2);
+    });
+
+    test("releases the tunnel and its channel count when no client ever claims it", async () => {
+      const server = await setupRelayServer({ ...argsFor(relay.relayHost), eager: true, longLived: true });
+      await waitFor(() => relay.tunnelsOpened() === 1);
+
+      await server.cleanup();
+
+      await waitFor(() => relay.tunnelsClosed() === 1);
+      await drainChannels(1);
+    });
+
+    test("releases the channel count once when a claimed tunnel closes", async () => {
+      const server = await setupRelayServer({ ...argsFor(relay.relayHost), eager: true, longLived: true });
+      await expect(connectAndEcho(server.port)).resolves.toBe("ping");
+      await server.cleanup();
+
+      await drainChannels(1);
+    });
+  });
+});

--- a/backend/src/lib/gateway-v2/gateway-v2.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.test.ts
@@ -13,12 +13,8 @@ const tracker = vi.hoisted(() => ({
   markSuspect: vi.fn()
 }));
 
-// The fake relay listens on an ephemeral loopback port, so the harness has to carry that port in
-// relayHost, which the implementation forwards as the TLS servername. A real relayHost is a
-// hostname with no port (a gateway is always reached on 8443), so this shape only exists here, and
-// Node rejects a servername containing a colon outright rather than matching it against a SAN.
-// Dropping it leaves verification to run against the connected host, which the cert covers, and
-// keeps the rest of the real TLS stack in the test.
+// A real relayHost carries no port, but the fake relay needs an ephemeral one, and Node rejects a
+// servername containing a colon. Dropping it verifies against the connected host instead.
 vi.mock("node:tls", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:tls")>();
   const connect = (options: tls.ConnectionOptions, callback?: () => void) =>

--- a/backend/src/lib/gateway-v2/gateway-v2.test.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.test.ts
@@ -13,6 +13,20 @@ const tracker = vi.hoisted(() => ({
   markSuspect: vi.fn()
 }));
 
+// The fake relay listens on an ephemeral loopback port, so the harness has to carry that port in
+// relayHost, which the implementation forwards as the TLS servername. A real relayHost is a
+// hostname with no port (a gateway is always reached on 8443), so this shape only exists here, and
+// Node rejects a servername containing a colon outright rather than matching it against a SAN.
+// Dropping it leaves verification to run against the connected host, which the cert covers, and
+// keeps the rest of the real TLS stack in the test.
+vi.mock("node:tls", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:tls")>();
+  const connect = (options: tls.ConnectionOptions, callback?: () => void) =>
+    actual.connect({ ...options, servername: undefined }, callback);
+  const patched = { ...actual, connect };
+  return { ...patched, default: patched };
+});
+
 vi.mock("@app/lib/logger", () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }));
@@ -92,7 +106,6 @@ const startFakeRelay = async (): Promise<TFakeRelay> => {
   const serverCert = issue({
     subject: "relay",
     altNames: [
-      { type: 2, value: relayHost },
       { type: 2, value: "127.0.0.1" },
       { type: 7, ip: "127.0.0.1" }
     ]

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -154,6 +154,8 @@ export const setupRelayServer = async ({
   httpsAgent,
   longLived
 }: {
+  // Consumed by the load tracker; accepted here so callers thread it through from the start.
+  gatewayId: string;
   protocol: GatewayProxyProtocol;
   relayHost: string;
   gateway: { clientCertificate: string; clientPrivateKey: string; serverCertificateChain: string };
@@ -279,9 +281,10 @@ export const withGatewayV2Proxy = async <T>(
     longLived?: boolean;
   } & TGatewayV2ConnectionDetails
 ): Promise<T> => {
-  const { protocol, relayHost, gateway, relay, httpsAgent, longLived } = options;
+  const { gatewayId, protocol, relayHost, gateway, relay, httpsAgent, longLived } = options;
 
   const { port, cleanup, getRelayError } = await setupRelayServer({
+    gatewayId,
     protocol,
     relayHost,
     gateway,

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -14,6 +14,7 @@ import { GatewayProxyProtocol } from "../gateway/types";
 import { logger } from "../logger";
 import { markAttemptTransportFailure, markAttemptTunnelEstablished } from "./gateway-attempt-context";
 import { getGatewayLoadTracker } from "./gateway-load-tracker";
+import { isGatewayTransportFailure } from "./gateway-retry";
 
 interface IGatewayRelayServer {
   server: net.Server;
@@ -349,10 +350,7 @@ export const withGatewayV2Proxy = async <T>(
       errorMessage = (err.response?.data as { message: string }).message;
     }
 
-    // Retryable only when no tunnel ever came up, so the target cannot have seen anything. The relay
-    // error list is shared by every channel this proxy served and is never cleared, so a single
-    // transient setup failure would otherwise keep marking later target-side errors as retryable.
-    if (relayErrorMessage && !hasEstablishedChannel()) {
+    if (isGatewayTransportFailure({ relayError: relayErrorMessage, establishedChannel: hasEstablishedChannel() })) {
       markAttemptTransportFailure();
       await getGatewayLoadTracker()?.markSuspect(gatewayId);
       throw new GatewayTransportError({ message: errorMessage, gatewayId });

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -168,11 +168,9 @@ export const setupRelayServer = async ({
   httpsAgent?: https.Agent;
   longLived?: boolean;
   /**
-   * Opens the tunnel during setup and hands it to the first client instead of dialing lazily.
-   * Callers that give the port to a long-lived session need this: otherwise setup succeeds against
-   * a dead gateway and the failure only surfaces once a user is attached, far too late to pick
-   * another pool member. The connection is kept and reused rather than probed and dropped, so the
-   * gateway sees one channel that becomes the session, not a session that opens and immediately dies.
+   * Opens the tunnel during setup and hands it to the first client, so an unreachable gateway fails
+   * here rather than once a user is already attached. Reused rather than probed and dropped, so the
+   * gateway sees one channel that becomes the session.
    */
   eager?: boolean;
 }): Promise<IGatewayRelayServer> => {
@@ -204,9 +202,8 @@ export const setupRelayServer = async ({
       throw err;
     }
 
-    // Marked as soon as both handshakes complete: the gateway dials the target the moment it
-    // accepts the channel, so the target may already have been reached even if we abandon this
-    // connection now. Treating the attempt as replayable after that point is what this prevents.
+    // The gateway dials the target the moment it accepts the channel, so from here the attempt is
+    // no longer safe to replay even if we abandon this connection.
     establishedChannel = true;
     markAttemptTunnelEstablished();
 
@@ -243,9 +240,8 @@ export const setupRelayServer = async ({
       }
     }
 
-    // Counted per channel rather than per caller operation: one operation can open many channels
-    // (a pooled SQL client, an HTTP client without keepalive, a discovery sweep), and it is the
-    // channel that costs the gateway a goroutine.
+    // Per channel, not per operation: one operation can open many, and the channel is what costs
+    // the gateway a goroutine.
     loadTracker?.channelOpened(gatewayId);
     let released = false;
 
@@ -285,8 +281,7 @@ export const setupRelayServer = async ({
           pendingUpstream = null;
           const { relayConn, gatewayConn, releaseChannel } = claimed ?? (await openUpstream());
 
-          // The caller may have given up while the handshakes were in flight. Its "close" event has
-          // already fired by now, so attaching the teardown listeners below would never run and the
+          // Its "close" already fired, so the teardown listeners below would never run and the
           // channel would stay counted for the life of the pod.
           if (clientConn.destroyed) {
             releaseChannel();
@@ -359,8 +354,8 @@ export const setupRelayServer = async ({
           const upstream = await openUpstream();
           pendingUpstream = upstream;
 
-          // If the gateway or relay drops the tunnel before anyone claims it, fall back to dialing
-          // on demand rather than handing the session a socket that is already dead.
+          // Dropped before anyone claims it, so the next client dials fresh rather than inheriting
+          // a dead socket.
           const dropIfUnclaimed = () => {
             if (pendingUpstream === upstream) discardPendingUpstream();
           };

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -9,15 +9,18 @@ import { TGatewayV2ConnectionDetails } from "@app/ee/services/gateway-v2/gateway
 import { splitPemChain } from "@app/services/certificate/certificate-fns";
 
 import { getConfig } from "../config/env";
-import { BadRequestError } from "../errors";
+import { BadRequestError, GatewayTransportError } from "../errors";
 import { GatewayProxyProtocol } from "../gateway/types";
 import { logger } from "../logger";
+import { markAttemptTransportFailure } from "./gateway-attempt-context";
+import { getGatewayLoadTracker } from "./gateway-load-tracker";
 
 interface IGatewayRelayServer {
   server: net.Server;
   port: number;
   cleanup: () => Promise<void>;
   getRelayError: () => string;
+  hasEstablishedChannel: () => boolean;
 }
 
 const DEFAULT_RELAY_CONNECTION_TIMEOUT_MS = 100000;
@@ -147,6 +150,7 @@ export const createGatewayConnection = async (
 };
 
 export const setupRelayServer = async ({
+  gatewayId,
   protocol,
   relayHost,
   gateway,
@@ -154,7 +158,6 @@ export const setupRelayServer = async ({
   httpsAgent,
   longLived
 }: {
-  // Consumed by the load tracker; accepted here so callers thread it through from the start.
   gatewayId: string;
   protocol: GatewayProxyProtocol;
   relayHost: string;
@@ -164,6 +167,8 @@ export const setupRelayServer = async ({
   longLived?: boolean;
 }): Promise<IGatewayRelayServer> => {
   const relayErrorMsg: string[] = [];
+  let establishedChannel = false;
+  const loadTracker = getGatewayLoadTracker();
 
   return new Promise((resolve, reject) => {
     const server = net.createServer();
@@ -184,6 +189,17 @@ export const setupRelayServer = async ({
 
           // Stage 2: Establish mTLS connection to gateway through the relay
           const gatewayConn = await createGatewayConnection(relayConn, gateway, protocol);
+
+          // The caller may have given up while the two handshakes were in flight. Its "close" event
+          // has already fired by now, so attaching the teardown listeners below would never run and
+          // the channel would stay counted for the life of the pod.
+          if (clientConn.destroyed) {
+            relayConn.destroy();
+            gatewayConn.destroy();
+            return;
+          }
+
+          establishedChannel = true;
 
           if (longLived) {
             // Disable the 30s idle-activity timeout that was set during connection establishment.
@@ -218,7 +234,19 @@ export const setupRelayServer = async ({
             }
           }
 
+          // Counted here rather than around the caller's operation: one operation can open many
+          // channels (a pooled SQL client, an HTTP client without keepalive, a discovery sweep), and
+          // it is the channel that costs the gateway a goroutine.
+          loadTracker?.channelOpened(gatewayId);
+          let released = false;
+          const releaseChannel = () => {
+            if (released) return;
+            released = true;
+            loadTracker?.channelClosed(gatewayId);
+          };
+
           const destroyAll = () => {
+            releaseChannel();
             clientConn.destroy();
             relayConn.destroy();
             gatewayConn.destroy();
@@ -266,7 +294,8 @@ export const setupRelayServer = async ({
             logger.debug("Error closing server:", err instanceof Error ? err.message : String(err));
           }
         },
-        getRelayError: () => relayErrorMsg.join(",")
+        getRelayError: () => relayErrorMsg.join(","),
+        hasEstablishedChannel: () => establishedChannel
       });
     });
   });
@@ -283,7 +312,7 @@ export const withGatewayV2Proxy = async <T>(
 ): Promise<T> => {
   const { gatewayId, protocol, relayHost, gateway, relay, httpsAgent, longLived } = options;
 
-  const { port, cleanup, getRelayError } = await setupRelayServer({
+  const { port, cleanup, getRelayError, hasEstablishedChannel } = await setupRelayServer({
     gatewayId,
     protocol,
     relayHost,
@@ -305,6 +334,15 @@ export const withGatewayV2Proxy = async <T>(
     let errorMessage = relayErrorMessage || (err instanceof Error ? err.message : String(err));
     if (isAxiosError(err) && (err.response?.data as { message?: string })?.message) {
       errorMessage = (err.response?.data as { message: string }).message;
+    }
+
+    // Retryable only when no tunnel ever came up, so the target cannot have seen anything. The relay
+    // error list is shared by every channel this proxy served and is never cleared, so a single
+    // transient setup failure would otherwise keep marking later target-side errors as retryable.
+    if (relayErrorMessage && !hasEstablishedChannel()) {
+      markAttemptTransportFailure();
+      await getGatewayLoadTracker()?.markSuspect(gatewayId);
+      throw new GatewayTransportError({ message: errorMessage, gatewayId });
     }
 
     throw new BadRequestError({ message: errorMessage });

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -157,7 +157,8 @@ export const setupRelayServer = async ({
   gateway,
   relay,
   httpsAgent,
-  longLived
+  longLived,
+  eager
 }: {
   gatewayId: string;
   protocol: GatewayProxyProtocol;
@@ -166,10 +167,110 @@ export const setupRelayServer = async ({
   relay: { clientCertificate: string; clientPrivateKey: string; serverCertificateChain: string };
   httpsAgent?: https.Agent;
   longLived?: boolean;
+  /**
+   * Opens the tunnel during setup and hands it to the first client instead of dialing lazily.
+   * Callers that give the port to a long-lived session need this: otherwise setup succeeds against
+   * a dead gateway and the failure only surfaces once a user is attached, far too late to pick
+   * another pool member. The connection is kept and reused rather than probed and dropped, so the
+   * gateway sees one channel that becomes the session, not a session that opens and immediately dies.
+   */
+  eager?: boolean;
 }): Promise<IGatewayRelayServer> => {
   const relayErrorMsg: string[] = [];
   let establishedChannel = false;
   const loadTracker = getGatewayLoadTracker();
+
+  type TUpstream = {
+    relayConn: net.Socket;
+    gatewayConn: net.Socket;
+    releaseChannel: () => void;
+  };
+
+  const openUpstream = async (): Promise<TUpstream> => {
+    // Stage 1: Connect to relay with TLS
+    const relayConn = await createRelayConnection({
+      relayHost,
+      clientCertificate: relay.clientCertificate,
+      clientPrivateKey: relay.clientPrivateKey,
+      serverCertificateChain: relay.serverCertificateChain
+    });
+
+    let gatewayConn: net.Socket;
+    try {
+      // Stage 2: Establish mTLS connection to gateway through the relay
+      gatewayConn = await createGatewayConnection(relayConn, gateway, protocol);
+    } catch (err) {
+      relayConn.destroy();
+      throw err;
+    }
+
+    // Marked as soon as both handshakes complete: the gateway dials the target the moment it
+    // accepts the channel, so the target may already have been reached even if we abandon this
+    // connection now. Treating the attempt as replayable after that point is what this prevents.
+    establishedChannel = true;
+    markAttemptTunnelEstablished();
+
+    if (longLived) {
+      // Disable the 30s idle-activity timeout that was set during connection establishment.
+      // Without this, the socket is destroyed after 30s of no data, killing idle sessions.
+      relayConn.setTimeout(0);
+      gatewayConn.setTimeout(0);
+
+      // Enable TCP keep-alive probes every 30s to detect dead connections
+      // without terminating idle-but-alive ones.
+      relayConn.setKeepAlive(true, 30000);
+      gatewayConn.setKeepAlive(true, 30000);
+    }
+
+    // Send protocol-specific configuration for HTTP requests
+    if (protocol === GatewayProxyProtocol.Http) {
+      if (httpsAgent) {
+        const agentOptions = httpsAgent.options;
+        if (agentOptions && agentOptions.ca) {
+          const caCert = Array.isArray(agentOptions.ca) ? agentOptions.ca.join("\n") : agentOptions.ca;
+          const caB64 = Buffer.from(caCert as string).toString("base64");
+          const rejectUnauthorized = agentOptions.rejectUnauthorized !== false;
+
+          const configCommand = `CONFIG ca=${caB64} verify=${rejectUnauthorized}\n`;
+          gatewayConn.write(Buffer.from(configCommand));
+        } else {
+          // Send empty config to signal end of configuration
+          gatewayConn.write(Buffer.from("CONFIG\n"));
+        }
+      } else {
+        // Send empty config to signal end of configuration
+        gatewayConn.write(Buffer.from("CONFIG\n"));
+      }
+    }
+
+    // Counted per channel rather than per caller operation: one operation can open many channels
+    // (a pooled SQL client, an HTTP client without keepalive, a discovery sweep), and it is the
+    // channel that costs the gateway a goroutine.
+    loadTracker?.channelOpened(gatewayId);
+    let released = false;
+
+    return {
+      relayConn,
+      gatewayConn,
+      releaseChannel: () => {
+        if (released) return;
+        released = true;
+        loadTracker?.channelClosed(gatewayId);
+      }
+    };
+  };
+
+  // Holds the tunnel opened during eager setup until a client claims it.
+  let pendingUpstream: TUpstream | null = null;
+
+  const discardPendingUpstream = () => {
+    if (!pendingUpstream) return;
+    const { relayConn, gatewayConn, releaseChannel } = pendingUpstream;
+    pendingUpstream = null;
+    releaseChannel();
+    relayConn.destroy();
+    gatewayConn.destroy();
+  };
 
   return new Promise((resolve, reject) => {
     const server = net.createServer();
@@ -180,72 +281,19 @@ export const setupRelayServer = async ({
           clientConn.setKeepAlive(true, 30000);
           clientConn.setNoDelay(true);
 
-          // Stage 1: Connect to relay with TLS
-          const relayConn = await createRelayConnection({
-            relayHost,
-            clientCertificate: relay.clientCertificate,
-            clientPrivateKey: relay.clientPrivateKey,
-            serverCertificateChain: relay.serverCertificateChain
-          });
+          const claimed = pendingUpstream;
+          pendingUpstream = null;
+          const { relayConn, gatewayConn, releaseChannel } = claimed ?? (await openUpstream());
 
-          // Stage 2: Establish mTLS connection to gateway through the relay
-          const gatewayConn = await createGatewayConnection(relayConn, gateway, protocol);
-
-          // The caller may have given up while the two handshakes were in flight. Its "close" event
-          // has already fired by now, so attaching the teardown listeners below would never run and
-          // the channel would stay counted for the life of the pod.
+          // The caller may have given up while the handshakes were in flight. Its "close" event has
+          // already fired by now, so attaching the teardown listeners below would never run and the
+          // channel would stay counted for the life of the pod.
           if (clientConn.destroyed) {
+            releaseChannel();
             relayConn.destroy();
             gatewayConn.destroy();
             return;
           }
-
-          establishedChannel = true;
-          markAttemptTunnelEstablished();
-
-          if (longLived) {
-            // Disable the 30s idle-activity timeout that was set during connection establishment.
-            // Without this, the socket is destroyed after 30s of no data, killing idle sessions.
-            relayConn.setTimeout(0);
-            gatewayConn.setTimeout(0);
-
-            // Enable TCP keep-alive probes every 30s to detect dead connections
-            // without terminating idle-but-alive ones.
-            relayConn.setKeepAlive(true, 30000);
-            gatewayConn.setKeepAlive(true, 30000);
-          }
-
-          // Send protocol-specific configuration for HTTP requests
-          if (protocol === GatewayProxyProtocol.Http) {
-            if (httpsAgent) {
-              const agentOptions = httpsAgent.options;
-              if (agentOptions && agentOptions.ca) {
-                const caCert = Array.isArray(agentOptions.ca) ? agentOptions.ca.join("\n") : agentOptions.ca;
-                const caB64 = Buffer.from(caCert as string).toString("base64");
-                const rejectUnauthorized = agentOptions.rejectUnauthorized !== false;
-
-                const configCommand = `CONFIG ca=${caB64} verify=${rejectUnauthorized}\n`;
-                gatewayConn.write(Buffer.from(configCommand));
-              } else {
-                // Send empty config to signal end of configuration
-                gatewayConn.write(Buffer.from("CONFIG\n"));
-              }
-            } else {
-              // Send empty config to signal end of configuration
-              gatewayConn.write(Buffer.from("CONFIG\n"));
-            }
-          }
-
-          // Counted here rather than around the caller's operation: one operation can open many
-          // channels (a pooled SQL client, an HTTP client without keepalive, a discovery sweep), and
-          // it is the channel that costs the gateway a goroutine.
-          loadTracker?.channelOpened(gatewayId);
-          let released = false;
-          const releaseChannel = () => {
-            if (released) return;
-            released = true;
-            loadTracker?.channelClosed(gatewayId);
-          };
 
           const destroyAll = () => {
             releaseChannel();
@@ -286,10 +334,11 @@ export const setupRelayServer = async ({
         return;
       }
 
-      resolve({
+      const relayServer: IGatewayRelayServer = {
         server,
         port: address.port,
         cleanup: async () => {
+          discardPendingUpstream();
           try {
             server.close();
           } catch (err) {
@@ -298,7 +347,41 @@ export const setupRelayServer = async ({
         },
         getRelayError: () => relayErrorMsg.join(","),
         hasEstablishedChannel: () => establishedChannel
-      });
+      };
+
+      if (!eager) {
+        resolve(relayServer);
+        return;
+      }
+
+      void (async () => {
+        try {
+          const upstream = await openUpstream();
+          pendingUpstream = upstream;
+
+          // If the gateway or relay drops the tunnel before anyone claims it, fall back to dialing
+          // on demand rather than handing the session a socket that is already dead.
+          const dropIfUnclaimed = () => {
+            if (pendingUpstream === upstream) discardPendingUpstream();
+          };
+          upstream.relayConn.once("close", dropIfUnclaimed);
+          upstream.gatewayConn.once("close", dropIfUnclaimed);
+          upstream.relayConn.once("error", dropIfUnclaimed);
+          upstream.gatewayConn.once("error", dropIfUnclaimed);
+
+          resolve(relayServer);
+        } catch (err) {
+          await relayServer.cleanup();
+          markAttemptTransportFailure();
+          await getGatewayLoadTracker()?.markSuspect(gatewayId);
+          reject(
+            new GatewayTransportError({
+              message: err instanceof Error ? err.message : String(err),
+              gatewayId
+            })
+          );
+        }
+      })();
     });
   });
 };

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -12,7 +12,7 @@ import { getConfig } from "../config/env";
 import { BadRequestError, GatewayTransportError } from "../errors";
 import { GatewayProxyProtocol } from "../gateway/types";
 import { logger } from "../logger";
-import { markAttemptTransportFailure } from "./gateway-attempt-context";
+import { markAttemptTransportFailure, markAttemptTunnelEstablished } from "./gateway-attempt-context";
 import { getGatewayLoadTracker } from "./gateway-load-tracker";
 
 interface IGatewayRelayServer {
@@ -200,6 +200,7 @@ export const setupRelayServer = async ({
           }
 
           establishedChannel = true;
+          markAttemptTunnelEstablished();
 
           if (longLived) {
             // Disable the 30s idle-activity timeout that was set during connection establishment.
@@ -312,15 +313,27 @@ export const withGatewayV2Proxy = async <T>(
 ): Promise<T> => {
   const { gatewayId, protocol, relayHost, gateway, relay, httpsAgent, longLived } = options;
 
-  const { port, cleanup, getRelayError, hasEstablishedChannel } = await setupRelayServer({
-    gatewayId,
-    protocol,
-    relayHost,
-    gateway,
-    relay,
-    httpsAgent,
-    longLived
-  });
+  let relayServer;
+  try {
+    relayServer = await setupRelayServer({
+      gatewayId,
+      protocol,
+      relayHost,
+      gateway,
+      relay,
+      httpsAgent,
+      longLived
+    });
+  } catch (err) {
+    // The local listener never came up, so no tunnel was attempted and nothing reached the target.
+    markAttemptTransportFailure();
+    throw new GatewayTransportError({
+      message: err instanceof Error ? err.message : String(err),
+      gatewayId
+    });
+  }
+
+  const { port, cleanup, getRelayError, hasEstablishedChannel } = relayServer;
 
   try {
     // Execute the callback with the allocated port

--- a/backend/src/server/config/rateLimiter.ts
+++ b/backend/src/server/config/rateLimiter.ts
@@ -38,13 +38,15 @@ export const writeLimit: RateLimitOptions = {
   keyGenerator: (req) => req.realIp
 };
 
-// Gateways report load every 10s (6/min each). Keyed by the reporting gateway rather than by IP,
-// because the write limiter's IP key is shared: ~100 gateways behind one NAT address would exhaust
-// a 200/min quota on load reports alone, start getting 429s, and their entries would go stale.
+// Gateways report load every 10s (6/min each), so 10 leaves room for tick drift and a restart
+// landing in the same window without leaving headroom for a flood. Keyed by the reporting gateway
+// rather than by IP, because the write limiter's IP key is shared: ~100 gateways behind one NAT
+// address would exhaust a 200/min quota on load reports alone, start getting 429s, and their
+// entries would go stale.
 export const gatewayLoadReportLimit: RateLimitOptions = {
   timeWindow: 60 * 1000,
   hook: "preValidation",
-  max: 30,
+  max: 10,
   keyGenerator: (req) => {
     const actorId = (req as { permission?: { id?: string } }).permission?.id;
     return actorId ? `gateway-load:${actorId}` : req.realIp;

--- a/backend/src/server/config/rateLimiter.ts
+++ b/backend/src/server/config/rateLimiter.ts
@@ -43,13 +43,13 @@ export const writeLimit: RateLimitOptions = {
 // rather than by IP, because the write limiter's IP key is shared: ~100 gateways behind one NAT
 // address would exhaust a 200/min quota on load reports alone, start getting 429s, and their
 // entries would go stale.
-export const gatewayLoadReportLimit: RateLimitOptions = {
+export const gatewayMetricsReportLimit: RateLimitOptions = {
   timeWindow: 60 * 1000,
   hook: "preValidation",
   max: 10,
   keyGenerator: (req) => {
     const actorId = (req as { permission?: { id?: string } }).permission?.id;
-    return actorId ? `gateway-load:${actorId}` : req.realIp;
+    return actorId ? `gateway-metrics:${actorId}` : req.realIp;
   }
 };
 

--- a/backend/src/server/config/rateLimiter.ts
+++ b/backend/src/server/config/rateLimiter.ts
@@ -38,6 +38,19 @@ export const writeLimit: RateLimitOptions = {
   keyGenerator: (req) => req.realIp
 };
 
+// Gateways report load every 10s (6/min each). Keyed by the reporting gateway rather than by IP,
+// because the write limiter's IP key is shared: ~100 gateways behind one NAT address would exhaust
+// a 200/min quota on load reports alone, start getting 429s, and their entries would go stale.
+export const gatewayLoadReportLimit: RateLimitOptions = {
+  timeWindow: 60 * 1000,
+  hook: "preValidation",
+  max: 30,
+  keyGenerator: (req) => {
+    const actorId = (req as { permission?: { id?: string } }).permission?.id;
+    return actorId ? `gateway-load:${actorId}` : req.realIp;
+  }
+};
+
 // special endpoints
 export const secretsLimit: RateLimitOptions = {
   // secrets, folders, secret imports

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -4264,8 +4264,6 @@ export const registerRoutes = async (
   }
 
   server.addHook("onClose", async () => {
-    // Drops this pod's published counts, so a rolling deploy does not leave its already-dead
-    // channels counting against those gateways for the freshness window.
     gatewayLoadTracker.shutdown();
     cronJobs.forEach((job) => job.stop());
     await cronJob.stop();

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -199,6 +199,7 @@ import { getConfig, TEnvConfig } from "@app/lib/config/env";
 import { cronJobFactory } from "@app/lib/cron/cron-job";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError } from "@app/lib/errors";
+import { initGatewayLoadTracker } from "@app/lib/gateway-v2/gateway-load-tracker";
 import { logger } from "@app/lib/logger";
 import { Redlock } from "@app/lib/red-lock";
 import { TQueueServiceFactory } from "@app/queue";
@@ -576,6 +577,10 @@ export const registerRoutes = async (
   const redlock = new Redlock([redis], { retryCount: 0 });
   const cronJob = cronJobFactory({ redis, redlock });
   cronJob.start();
+
+  // Reached from the gateway proxy layer in src/lib, which has no DI, so it is installed as a module
+  // singleton rather than threaded through every call site.
+  initGatewayLoadTracker(keyStore);
 
   await server.register(registerSecretScanningV2Webhooks, {
     prefix: "/secret-scanning/webhooks"
@@ -1839,7 +1844,6 @@ export const registerRoutes = async (
     gatewayPoolDAL,
     gatewayPoolMembershipDAL,
     gatewayV2DAL,
-    gatewayV2Service,
     permissionService,
     licenseService,
     identityKubernetesAuthDAL,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -580,7 +580,7 @@ export const registerRoutes = async (
 
   // Reached from the gateway proxy layer in src/lib, which has no DI, so it is installed as a module
   // singleton rather than threaded through every call site.
-  initGatewayLoadTracker(keyStore);
+  const gatewayLoadTracker = initGatewayLoadTracker(keyStore);
 
   await server.register(registerSecretScanningV2Webhooks, {
     prefix: "/secret-scanning/webhooks"
@@ -4263,6 +4263,9 @@ export const registerRoutes = async (
   }
 
   server.addHook("onClose", async () => {
+    // Drops this pod's published counts, so a rolling deploy does not leave its already-dead
+    // channels counting against those gateways for the freshness window.
+    await gatewayLoadTracker.shutdown();
     cronJobs.forEach((job) => job.stop());
     await cronJob.stop();
     await telemetryService.flushAll();

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -4266,7 +4266,7 @@ export const registerRoutes = async (
   server.addHook("onClose", async () => {
     // Drops this pod's published counts, so a rolling deploy does not leave its already-dead
     // channels counting against those gateways for the freshness window.
-    await gatewayLoadTracker.shutdown();
+    gatewayLoadTracker.shutdown();
     cronJobs.forEach((job) => job.stop());
     await cronJob.stop();
     await telemetryService.flushAll();

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1844,6 +1844,7 @@ export const registerRoutes = async (
     gatewayPoolDAL,
     gatewayPoolMembershipDAL,
     gatewayV2DAL,
+    gatewayV2Service,
     permissionService,
     licenseService,
     identityKubernetesAuthDAL,

--- a/backend/src/services/app-connection/adcs/adcs-connection-fns.ts
+++ b/backend/src/services/app-connection/adcs/adcs-connection-fns.ts
@@ -80,9 +80,7 @@ export const executeAdcsGatewayOperation = async <T>(
       }),
     {
       protocol: GatewayProxyProtocol.Adcs,
-      relayHost: connectionDetails.relayHost,
-      gateway: connectionDetails.gateway,
-      relay: connectionDetails.relay
+      ...connectionDetails
     }
   );
 

--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -209,7 +209,7 @@ export type TAppConnectionServiceFactoryDep = {
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
   gatewayPoolService: Pick<
     TGatewayPoolServiceFactory,
-    "pickRandomHealthyGateway" | "resolveAttachableGatewayFromPool" | "resolveEffectiveGatewayId"
+    "pickHealthyGateway" | "resolveAttachableGatewayFromPool" | "resolveEffectiveGatewayId" | "runWithPoolFailover"
   >;
   gatewayDAL: Pick<TGatewayDALFactory, "find">;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "find">;
@@ -581,12 +581,6 @@ export const appConnectionServiceFactory = ({
       });
     }
 
-    let validationGatewayId: string | null | undefined = gatewayId;
-    if (gatewayPoolId) {
-      const picked = await gatewayPoolService.pickRandomHealthyGateway(gatewayPoolId);
-      validationGatewayId = picked.id;
-    }
-
     await enterpriseAppCheck(
       licenseService,
       app,
@@ -601,21 +595,33 @@ export const appConnectionServiceFactory = ({
       }
     }
 
-    const validatedCredentials = await validateAppConnectionCredentials(
-      {
-        app,
-        credentials,
-        method,
-        orgId: actor.orgId,
-        projectId,
-        version: 2,
-        gatewayId: validationGatewayId,
-        projectType: project?.type
-      } as TAppConnectionConfig,
-      gatewayService,
-      gatewayV2Service,
-      { identityUaDAL, gitHubAppDAL, kmsService, keyStore, actorId: actor.id }
-    );
+    const runValidation = (validationGatewayId: string | null | undefined) =>
+      validateAppConnectionCredentials(
+        {
+          app,
+          credentials,
+          method,
+          orgId: actor.orgId,
+          projectId,
+          version: 2,
+          gatewayId: validationGatewayId,
+          projectType: project?.type
+        } as TAppConnectionConfig,
+        gatewayService,
+        gatewayV2Service,
+        { identityUaDAL, gitHubAppDAL, kmsService, keyStore, actorId: actor.id }
+      );
+
+    // Validation only dials the target and reads back, so retrying it on another member is safe.
+    let validationGatewayId: string | null | undefined = gatewayId;
+    let validatedCredentials;
+    if (gatewayPoolId) {
+      const outcome = await gatewayPoolService.runWithPoolFailover({ poolId: gatewayPoolId }, runValidation);
+      validatedCredentials = outcome.result;
+      validationGatewayId = outcome.gatewayId;
+    } else {
+      validatedCredentials = await runValidation(gatewayId);
+    }
 
     try {
       const createConnection = async (connectionCredentials: TAppConnection["credentials"]) => {
@@ -681,6 +687,8 @@ export const appConnectionServiceFactory = ({
       let connection: TAppConnectionRaw;
 
       if (params.isPlatformManagedCredentials) {
+        // Reuses the member validation actually succeeded on, and deliberately does not fail over:
+        // this rotates the credential on the target, so a retry could apply the change twice.
         connection = await TRANSITION_CONNECTION_CREDENTIALS_TO_PLATFORM[app](
           {
             app,
@@ -833,17 +841,11 @@ export const appConnectionServiceFactory = ({
     }
 
     let updatedCredentials: undefined | TAppConnection["credentials"];
-    let validationGatewayId: string | null | undefined;
 
     const { app, method } = appConnection as DiscriminativePick<TAppConnectionConfig, "app" | "method">;
+    let validationGatewayIdForUpdate: string | null | undefined = effectiveGatewayIdForUpdate;
 
     if (credentials) {
-      validationGatewayId = effectiveGatewayIdForUpdate;
-      if (effectiveGatewayPoolIdForUpdate) {
-        const picked = await gatewayPoolService.pickRandomHealthyGateway(effectiveGatewayPoolIdForUpdate);
-        validationGatewayId = picked.id;
-      }
-
       // Only checked when the caller explicitly selects an app — merged-in existing credentials
       // (gitHubAppId undefined) keep already-configured connections editable.
       if (app === AppConnection.GitHub && method === GitHubConnectionMethod.App && appConnection.projectId) {
@@ -886,21 +888,34 @@ export const appConnectionServiceFactory = ({
 
       const updateProject = appConnection.projectId ? await projectDAL.findProjectById(appConnection.projectId) : null;
 
-      updatedCredentials = await validateAppConnectionCredentials(
-        {
-          app,
-          orgId: actor.orgId,
-          projectId: appConnection.projectId,
-          version: appConnection.version,
-          credentials: credentialsToValidate,
-          method,
-          gatewayId: validationGatewayId,
-          projectType: updateProject?.type
-        } as TAppConnectionConfig,
-        gatewayService,
-        gatewayV2Service,
-        { identityUaDAL, gitHubAppDAL, kmsService, keyStore, actorId: actor.id }
-      );
+      const runUpdateValidation = (validationGatewayId: string | null | undefined) =>
+        validateAppConnectionCredentials(
+          {
+            app,
+            orgId: actor.orgId,
+            projectId: appConnection.projectId,
+            version: appConnection.version,
+            credentials: credentialsToValidate,
+            method,
+            gatewayId: validationGatewayId,
+            projectType: updateProject?.type
+          } as TAppConnectionConfig,
+          gatewayService,
+          gatewayV2Service,
+          { identityUaDAL, gitHubAppDAL, kmsService, keyStore, actorId: actor.id }
+        );
+
+      // Validation only dials the target and reads back, so retrying it on another member is safe.
+      if (effectiveGatewayPoolIdForUpdate) {
+        const outcome = await gatewayPoolService.runWithPoolFailover(
+          { poolId: effectiveGatewayPoolIdForUpdate },
+          runUpdateValidation
+        );
+        updatedCredentials = outcome.result;
+        validationGatewayIdForUpdate = outcome.gatewayId;
+      } else {
+        updatedCredentials = await runUpdateValidation(effectiveGatewayIdForUpdate);
+      }
 
       if (!updatedCredentials)
         throw new BadRequestError({ message: "Unable to validate connection - check credentials" });
@@ -961,13 +976,15 @@ export const appConnectionServiceFactory = ({
 
         let connection: TAppConnectionRaw;
         if (params.isPlatformManagedCredentials) {
+          // Reuses the member validation actually succeeded on, and deliberately does not fail over:
+          // this rotates the credential on the target, so a retry could apply the change twice.
           connection = await TRANSITION_CONNECTION_CREDENTIALS_TO_PLATFORM[app](
             {
               app,
               orgId: actor.orgId,
               credentials: updatedCredentials,
               method,
-              gatewayId: validationGatewayId
+              gatewayId: validationGatewayIdForUpdate
             } as TAppConnectionConfig,
             (platformCredentials) => updateConnection(platformCredentials, tx),
             gatewayService,

--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -209,7 +209,7 @@ export type TAppConnectionServiceFactoryDep = {
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
   gatewayPoolService: Pick<
     TGatewayPoolServiceFactory,
-    "pickHealthyGateway" | "resolveAttachableGatewayFromPool" | "resolveEffectiveGatewayId" | "runWithPoolFailover"
+    "resolveAttachableGatewayFromPool" | "resolveEffectiveGatewayId" | "runWithPoolFailover"
   >;
   gatewayDAL: Pick<TGatewayDALFactory, "find">;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "find">;
@@ -614,7 +614,7 @@ export const appConnectionServiceFactory = ({
 
     // Validation only dials the target and reads back, so retrying it on another member is safe.
     let validationGatewayId: string | null | undefined = gatewayId;
-    let validatedCredentials;
+    let validatedCredentials: Awaited<ReturnType<typeof runValidation>>;
     if (gatewayPoolId) {
       const outcome = await gatewayPoolService.runWithPoolFailover({ poolId: gatewayPoolId }, runValidation);
       validatedCredentials = outcome.result;

--- a/backend/src/services/app-connection/app-connection-service.ts
+++ b/backend/src/services/app-connection/app-connection-service.ts
@@ -687,8 +687,6 @@ export const appConnectionServiceFactory = ({
       let connection: TAppConnectionRaw;
 
       if (params.isPlatformManagedCredentials) {
-        // Reuses the member validation actually succeeded on, and deliberately does not fail over:
-        // this rotates the credential on the target, so a retry could apply the change twice.
         connection = await TRANSITION_CONNECTION_CREDENTIALS_TO_PLATFORM[app](
           {
             app,
@@ -976,8 +974,6 @@ export const appConnectionServiceFactory = ({
 
         let connection: TAppConnectionRaw;
         if (params.isPlatformManagedCredentials) {
-          // Reuses the member validation actually succeeded on, and deliberately does not fail over:
-          // this rotates the credential on the target, so a retry could apply the change twice.
           connection = await TRANSITION_CONNECTION_CREDENTIALS_TO_PLATFORM[app](
             {
               app,

--- a/backend/src/services/app-connection/azure-key-vault/azure-key-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/azure-key-vault/azure-key-vault-connection-fns.ts
@@ -121,9 +121,7 @@ export const requestWithAzureKeyVaultGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: gatewayConnectionDetailsV2.relayHost,
-        gateway: gatewayConnectionDetailsV2.gateway,
-        relay: gatewayConnectionDetailsV2.relay
+        ...gatewayConnectionDetailsV2
       }
     );
   }

--- a/backend/src/services/app-connection/f5-big-ip/f5-big-ip-connection-fns.ts
+++ b/backend/src/services/app-connection/f5-big-ip/f5-big-ip-connection-fns.ts
@@ -71,9 +71,7 @@ const requestWithF5BigIpGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }
@@ -218,9 +216,7 @@ export const executeF5BigIpOperationWithGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }

--- a/backend/src/services/app-connection/github/github-connection-fns.ts
+++ b/backend/src/services/app-connection/github/github-connection-fns.ts
@@ -250,9 +250,7 @@ export const requestWithGitHubGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: connectionDetails.relayHost,
-        gateway: connectionDetails.gateway,
-        relay: connectionDetails.relay
+        ...connectionDetails
       }
     );
   }

--- a/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
+++ b/backend/src/services/app-connection/hc-vault/hc-vault-connection-fns.ts
@@ -238,9 +238,7 @@ export const requestWithHCVaultGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: gatewayConnectionDetailsV2.relayHost,
-        gateway: gatewayConnectionDetailsV2.gateway,
-        relay: gatewayConnectionDetailsV2.relay
+        ...gatewayConnectionDetailsV2
       }
     );
   }

--- a/backend/src/services/app-connection/kemp-loadmaster/kemp-loadmaster-connection-fns.ts
+++ b/backend/src/services/app-connection/kemp-loadmaster/kemp-loadmaster-connection-fns.ts
@@ -116,9 +116,7 @@ export const executeKempLoadMasterOperationWithGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }

--- a/backend/src/services/app-connection/ldap/ldap-connection-fns.ts
+++ b/backend/src/services/app-connection/ldap/ldap-connection-fns.ts
@@ -282,9 +282,7 @@ export const executeWithPotentialGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }

--- a/backend/src/services/app-connection/netscaler/netscaler-connection-fns.ts
+++ b/backend/src/services/app-connection/netscaler/netscaler-connection-fns.ts
@@ -77,9 +77,7 @@ const requestWithNetScalerGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }
@@ -201,9 +199,7 @@ export const executeNetScalerOperationWithGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }

--- a/backend/src/services/app-connection/nutanix-prism-central/nutanix-prism-central-connection-fns.ts
+++ b/backend/src/services/app-connection/nutanix-prism-central/nutanix-prism-central-connection-fns.ts
@@ -111,9 +111,7 @@ export const executeNutanixOperationWithGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }

--- a/backend/src/services/app-connection/shared/sql/sql-connection-fns.ts
+++ b/backend/src/services/app-connection/shared/sql/sql-connection-fns.ts
@@ -211,9 +211,7 @@ export const executeWithPotentialGateway = async <T>(
         },
         {
           protocol: GatewayProxyProtocol.Tcp,
-          relayHost: platformConnectionDetails.relayHost,
-          gateway: platformConnectionDetails.gateway,
-          relay: platformConnectionDetails.relay
+          ...platformConnectionDetails
         }
       );
     }

--- a/backend/src/services/app-connection/smb/smb-connection-fns.ts
+++ b/backend/src/services/app-connection/smb/smb-connection-fns.ts
@@ -56,9 +56,7 @@ export const executeSmbWithPotentialGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }

--- a/backend/src/services/app-connection/ssh/ssh-connection-fns.ts
+++ b/backend/src/services/app-connection/ssh/ssh-connection-fns.ts
@@ -203,9 +203,7 @@ export const executeWithPotentialGateway = async <T>(
       },
       {
         protocol: GatewayProxyProtocol.Tcp,
-        relayHost: platformConnectionDetails.relayHost,
-        gateway: platformConnectionDetails.gateway,
-        relay: platformConnectionDetails.relay
+        ...platformConnectionDetails
       }
     );
   }
@@ -313,9 +311,7 @@ export const executeSshCommandViaGateway = async (
       }),
     {
       protocol: GatewayProxyProtocol.Discovery,
-      relayHost: connectionDetails.relayHost,
-      gateway: connectionDetails.gateway,
-      relay: connectionDetails.relay
+      ...connectionDetails
     }
   );
 

--- a/backend/src/services/app-connection/venafi-tpp/venafi-tpp-connection-fns.ts
+++ b/backend/src/services/app-connection/venafi-tpp/venafi-tpp-connection-fns.ts
@@ -106,9 +106,7 @@ export const requestWithVenafiTppGateway = async <T>(
     },
     {
       protocol: GatewayProxyProtocol.Tcp,
-      relayHost: gatewayConnectionDetails.relayHost,
-      gateway: gatewayConnectionDetails.gateway,
-      relay: gatewayConnectionDetails.relay
+      ...gatewayConnectionDetails
     }
   );
 };

--- a/backend/src/services/app-connection/winrm/winrm-connection-fns.ts
+++ b/backend/src/services/app-connection/winrm/winrm-connection-fns.ts
@@ -100,9 +100,7 @@ export const executeWinRMGatewayOperation = async <T>(
       }),
     {
       protocol: GatewayProxyProtocol.WinRm,
-      relayHost: connectionDetails.relayHost,
-      gateway: connectionDetails.gateway,
-      relay: connectionDetails.relay
+      ...connectionDetails
     }
   );
 

--- a/backend/src/services/external-migration/external-migration-fns/vault.ts
+++ b/backend/src/services/external-migration/external-migration-fns/vault.ts
@@ -49,9 +49,7 @@ const vaultFactory = (
         async (port) => gatewayCallback(`${targetProtocol}://localhost`, port, httpsAgent, targetHostname),
         {
           protocol: GatewayProxyProtocol.Tcp,
-          relayHost: gatewayV2Details.relayHost,
-          gateway: gatewayV2Details.gateway,
-          relay: gatewayV2Details.relay
+          ...gatewayV2Details
         }
       );
     }

--- a/backend/src/services/external-migration/external-migration-service.ts
+++ b/backend/src/services/external-migration/external-migration-service.ts
@@ -78,7 +78,7 @@ type TExternalMigrationServiceFactoryDep = {
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "find">;
   gatewayPoolService: Pick<
     TGatewayPoolServiceFactory,
-    "resolveEffectiveGatewayId" | "resolveAttachableGatewayFromPool" | "pickRandomHealthyGateway"
+    "resolveEffectiveGatewayId" | "resolveAttachableGatewayFromPool" | "pickHealthyGateway"
   >;
 };
 
@@ -250,7 +250,7 @@ export const externalMigrationServiceFactory = ({
         orgId: actorOrgId,
         actor: { type: actor, id: actorId, orgId: actorOrgId, authMethod: actorAuthMethod }
       });
-      const picked = await gatewayPoolService.pickRandomHealthyGateway(gatewayPoolId);
+      const picked = await gatewayPoolService.pickHealthyGateway(gatewayPoolId);
       effectiveGatewayId = picked.id;
     }
 

--- a/backend/src/services/hsm-connector/hsm-connector-routing.ts
+++ b/backend/src/services/hsm-connector/hsm-connector-routing.ts
@@ -96,12 +96,7 @@ export const hsmConnectorRoutingFactory = ({ gatewayV2Service, gatewayPoolServic
                 params: args.params
               }
             }),
-          {
-            protocol: GatewayProxyProtocol.Pkcs11,
-            relayHost: conn.relayHost,
-            gateway: conn.gateway,
-            relay: conn.relay
-          }
+          { ...conn, protocol: GatewayProxyProtocol.Pkcs11 }
         );
         if (response.ok) return response.result;
         lastError = { code: response.errorCode, message: response.errorMessage };
@@ -161,12 +156,7 @@ export const hsmConnectorRoutingFactory = ({ gatewayV2Service, gatewayPoolServic
               params: {}
             }
           }),
-        {
-          protocol: GatewayProxyProtocol.Pkcs11,
-          relayHost: conn.relayHost,
-          gateway: conn.gateway,
-          relay: conn.relay
-        }
+        { ...conn, protocol: GatewayProxyProtocol.Pkcs11 }
       );
       if (response.ok) {
         return { gatewayId, ok: true, slotInfo: response.result.slotInfo };

--- a/backend/src/services/hsm-connector/hsm-connector-routing.ts
+++ b/backend/src/services/hsm-connector/hsm-connector-routing.ts
@@ -15,6 +15,8 @@ import {
 const PKCS11_POOL_RETRY_LIMIT = 2;
 const TEST_FANOUT_MAX = 10;
 const PKCS11_TARGET_HOST = "pkcs11";
+const NO_CAPABLE_MEMBER_MESSAGE =
+  "No HSM-capable gateway available in the pool. Ensure at least one gateway in the pool has HSM support enabled.";
 
 type TGatewayRouting = {
   gatewayId: string | null | undefined;
@@ -23,7 +25,7 @@ type TGatewayRouting = {
 
 type THsmConnectorRoutingDeps = {
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
-  gatewayPoolService: Pick<TGatewayPoolServiceFactory, "listHealthyGateways">;
+  gatewayPoolService: Pick<TGatewayPoolServiceFactory, "listHealthyGateways" | "selectGatewayFromPool">;
 };
 
 const isPkcs11Capable = (capabilities: unknown): boolean => {
@@ -45,15 +47,16 @@ export const hsmConnectorRoutingFactory = ({ gatewayV2Service, gatewayPoolServic
     if (!connector.gatewayPoolId) {
       throw new BadRequestError({ message: "Connector has neither gatewayId nor gatewayPoolId set." });
     }
-    const healthy = await gatewayPoolService.listHealthyGateways(connector.gatewayPoolId);
-    const capable = healthy.filter((g) => isPkcs11Capable(g.capabilities) && !triedGatewayIds.has(g.id));
-    if (capable.length === 0) {
-      throw new BadRequestError({
-        message:
-          "No HSM-capable gateway available in the pool. Ensure at least one gateway in the pool has HSM support enabled."
-      });
-    }
-    return capable[Math.floor(Math.random() * capable.length)].id;
+
+    // Key material is not portable between HSMs, so a member without the module attached is not an
+    // acceptable substitute no matter how idle it is.
+    const selected = await gatewayPoolService.selectGatewayFromPool({
+      poolId: connector.gatewayPoolId,
+      exclude: triedGatewayIds,
+      filter: (gateway) => isPkcs11Capable(gateway.capabilities),
+      unavailableMessage: NO_CAPABLE_MEMBER_MESSAGE
+    });
+    return selected.id;
   };
 
   const dispatchPkcs11 = async <T>(args: {
@@ -70,7 +73,15 @@ export const hsmConnectorRoutingFactory = ({ gatewayV2Service, gatewayPoolServic
     // retryable, etc.). Parallelising would fire redundant PKCS#11 calls.
     /* eslint-disable no-await-in-loop */
     for (let attempt = 0; attempt <= PKCS11_POOL_RETRY_LIMIT; attempt += 1) {
-      const gatewayId = await pickGateway(args.connector, triedGatewayIds);
+      let gatewayId;
+      try {
+        gatewayId = await pickGateway(args.connector, triedGatewayIds);
+      } catch (err) {
+        // Once every capable member has been tried, the accumulated PKCS#11 failure is the useful
+        // error. Reporting "no HSM-capable gateway" instead points operators at the wrong problem.
+        if (!lastError) throw err;
+        break;
+      }
       triedGatewayIds.add(gatewayId);
 
       const conn = await gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
@@ -186,10 +197,7 @@ export const hsmConnectorRoutingFactory = ({ gatewayV2Service, gatewayPoolServic
         if (isPkcs11Capable(g.capabilities)) targets.push(g.id);
       }
       if (targets.length === 0) {
-        throw new BadRequestError({
-          message:
-            "No HSM-capable gateway available in the pool. Ensure at least one gateway in the pool has HSM support enabled."
-        });
+        throw new BadRequestError({ message: NO_CAPABLE_MEMBER_MESSAGE });
       }
     }
 

--- a/backend/src/services/hsm-connector/hsm-connector-service.ts
+++ b/backend/src/services/hsm-connector/hsm-connector-service.ts
@@ -42,7 +42,7 @@ export type THsmConnectorServiceFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">;
-  gatewayPoolService: Pick<TGatewayPoolServiceFactory, "listHealthyGateways">;
+  gatewayPoolService: Pick<TGatewayPoolServiceFactory, "listHealthyGateways" | "selectGatewayFromPool">;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "findById">;
   gatewayPoolDAL: Pick<TGatewayPoolDALFactory, "findById">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -180,7 +180,7 @@ export const identityKubernetesAuthServiceFactory = ({
             targetPort: inputs.targetPort ?? 443
           });
           if (!details) {
-            throw new NotFoundError({ message: `Connection details for gateway with ID ${gatewayId} not found` });
+            throw new NotFoundError({ message: `Connection details for gateway with ID '${gatewayId}' not found` });
           }
           return $proxyThroughGatewayV2(details);
         }

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -18,6 +18,7 @@ import { TGatewayPoolDALFactory } from "@app/ee/services/gateway-pool/gateway-po
 import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
 import { TGatewayV2DALFactory } from "@app/ee/services/gateway-v2/gateway-v2-dal";
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
+import { TGatewayV2ConnectionDetails } from "@app/ee/services/gateway-v2/gateway-v2-types";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import {
   OrgPermissionGatewayActions,
@@ -99,10 +100,7 @@ type TIdentityKubernetesAuthServiceFactoryDep = {
   gatewayV2Service: TGatewayV2ServiceFactory;
   gatewayDAL: Pick<TGatewayDALFactory, "find">;
   gatewayV2DAL: Pick<TGatewayV2DALFactory, "find">;
-  gatewayPoolService: Pick<
-    TGatewayPoolServiceFactory,
-    "getPlatformConnectionDetailsByPoolId" | "pickRandomHealthyGateway"
-  >;
+  gatewayPoolService: Pick<TGatewayPoolServiceFactory, "pickHealthyGateway" | "runWithPoolFailover">;
   gatewayPoolDAL: Pick<TGatewayPoolDALFactory, "findById">;
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
   identityAccessTokenService: Pick<
@@ -145,45 +143,59 @@ export const identityKubernetesAuthServiceFactory = ({
     },
     gatewayCallback: (host: string, port: number, httpsAgent?: https.Agent) => Promise<T>
   ): Promise<T> => {
-    const gatewayV2ConnectionDetails = inputs.gatewayPoolId
-      ? await gatewayPoolService.getPlatformConnectionDetailsByPoolId({
-          poolId: inputs.gatewayPoolId,
-          targetHost: inputs.targetHost ?? GATEWAY_AUTH_DEFAULT_HOST,
-          targetPort: inputs.targetPort ?? 443
-        })
-      : await gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
-          gatewayId: inputs.gatewayId!,
-          targetHost: inputs.targetHost ?? GATEWAY_AUTH_DEFAULT_HOST,
-          targetPort: inputs.targetPort ?? 443
-        });
+    let gatewayHttpsAgent: https.Agent | undefined;
+    if (!inputs.reviewTokenThroughGateway) {
+      gatewayHttpsAgent = new https.Agent({
+        ca: inputs.caCert || undefined,
+        rejectUnauthorized: inputs.verifyTlsCertificate ?? false,
+        servername: inputs.targetHost
+      });
+    }
 
-    if (gatewayV2ConnectionDetails) {
-      let httpsAgent: https.Agent | undefined;
-      if (!inputs.reviewTokenThroughGateway) {
-        httpsAgent = new https.Agent({
-          ca: inputs.caCert || undefined,
-          rejectUnauthorized: inputs.verifyTlsCertificate ?? false,
-          servername: inputs.targetHost
-        });
-      }
-
-      const callbackResult = await withGatewayV2Proxy(
+    const $proxyThroughGatewayV2 = async (details: TGatewayV2ConnectionDetails) =>
+      withGatewayV2Proxy(
         async (port) => {
           const res = await gatewayCallback(
             inputs.reviewTokenThroughGateway ? "http://localhost" : "https://localhost",
             port,
-            httpsAgent
+            gatewayHttpsAgent
           );
           return res;
         },
         {
-          ...gatewayV2ConnectionDetails,
           protocol: inputs.reviewTokenThroughGateway ? GatewayProxyProtocol.Http : GatewayProxyProtocol.Tcp,
-          httpsAgent
+          ...details,
+          httpsAgent: gatewayHttpsAgent
         }
       );
 
-      return callbackResult;
+    // Pools are gateway-v2 only, so there is no v1 fallback to preserve on this branch.
+    if (inputs.gatewayPoolId) {
+      const { result } = await gatewayPoolService.runWithPoolFailover(
+        { poolId: inputs.gatewayPoolId },
+        async (gatewayId) => {
+          const details = await gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
+            gatewayId,
+            targetHost: inputs.targetHost ?? GATEWAY_AUTH_DEFAULT_HOST,
+            targetPort: inputs.targetPort ?? 443
+          });
+          if (!details) {
+            throw new NotFoundError({ message: `Connection details for gateway with ID ${gatewayId} not found` });
+          }
+          return $proxyThroughGatewayV2(details);
+        }
+      );
+      return result;
+    }
+
+    const gatewayV2ConnectionDetails = await gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
+      gatewayId: inputs.gatewayId!,
+      targetHost: inputs.targetHost ?? GATEWAY_AUTH_DEFAULT_HOST,
+      targetPort: inputs.targetPort ?? 443
+    });
+
+    if (gatewayV2ConnectionDetails) {
+      return $proxyThroughGatewayV2(gatewayV2ConnectionDetails);
     }
 
     const relayDetails = await gatewayService.fnGetGatewayClientTlsByGatewayId(inputs.gatewayId!);
@@ -950,7 +962,7 @@ export const identityKubernetesAuthServiceFactory = ({
       }
 
       // Validate connectivity through a random healthy pool member
-      const validationGateway = await gatewayPoolService.pickRandomHealthyGateway(gatewayPoolId);
+      const validationGateway = await gatewayPoolService.pickHealthyGateway(gatewayPoolId);
       if (tokenReviewMode === IdentityKubernetesAuthTokenReviewMode.Gateway) {
         const gatewayExecutor = $createGatewayValidationRequest(validationGateway.id);
         await validateKubernetesHostConnectivity({ gatewayExecutor });
@@ -1285,7 +1297,7 @@ export const identityKubernetesAuthServiceFactory = ({
 
     let validationGatewayId: string | null = effectiveGatewayId ?? null;
     if (!validationGatewayId && effectiveGatewayPoolId) {
-      const picked = await gatewayPoolService.pickRandomHealthyGateway(effectiveGatewayPoolId);
+      const picked = await gatewayPoolService.pickHealthyGateway(effectiveGatewayPoolId);
       validationGatewayId = picked.id;
     }
 

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -177,10 +177,8 @@ export const identityKubernetesAuthServiceFactory = ({
           return res;
         },
         {
+          ...gatewayV2ConnectionDetails,
           protocol: inputs.reviewTokenThroughGateway ? GatewayProxyProtocol.Http : GatewayProxyProtocol.Tcp,
-          relayHost: gatewayV2ConnectionDetails.relayHost,
-          gateway: gatewayV2ConnectionDetails.gateway,
-          relay: gatewayV2ConnectionDetails.relay,
           httpsAgent
         }
       );

--- a/docs/documentation/platform/gateways/gateway-pools.mdx
+++ b/docs/documentation/platform/gateways/gateway-pools.mdx
@@ -67,9 +67,8 @@ Because the count comes from the gateway itself, it includes work the platform d
 
 <Warning>
   Load balancing requires gateways running a CLI version that reports connection counts. A gateway
-  on an older version does not report, and a pool that mixes reporting and non-reporting gateways
-  falls back to choosing at random rather than comparing counts that are not measured the same way.
-  Upgrade every gateway in a pool to get load balancing for that pool.
+  on an older version does not report, and a pool containing any non-reporting member falls back to
+  choosing at random. Upgrade every gateway in a pool to get load balancing for that pool.
 </Warning>
 
 ## Failover

--- a/docs/documentation/platform/gateways/gateway-pools.mdx
+++ b/docs/documentation/platform/gateways/gateway-pools.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Gateway pools"
 sidebarTitle: "Gateway pools"
-description: "High availability and automatic failover for gateways"
+description: "Load balancing, high availability, and automatic failover for gateways"
 ---
 
-Gateway Pools provide high availability for your gateway infrastructure. A pool is a named collection of gateways that all have connectivity to the same private network. When the platform needs to reach a resource through a pool, it automatically routes through a healthy gateway, providing failover if any individual gateway goes down.
+Gateway Pools spread work across your gateway infrastructure and keep it available when a gateway fails. A pool is a named collection of gateways that all have connectivity to the same private network. When the platform needs to reach a resource through a pool, it sends the work to whichever gateway is least busy, and retries on another gateway if the chosen one cannot be reached.
 
 <Info>
   Gateway Pools is an enterprise feature. Self-hosted users can contact
@@ -16,8 +16,9 @@ Gateway Pools provide high availability for your gateway infrastructure. A pool 
 
 1. You create a Gateway Pool and add multiple gateways that share network access to the same resources.
 2. When configuring a consumer (e.g., Kubernetes Auth), you select the pool instead of an individual gateway.
-3. At request time, the platform picks a random healthy gateway from the pool and routes through it.
-4. If a gateway goes down, subsequent requests automatically route through the remaining healthy gateways.
+3. At request time, the platform sends the work to whichever healthy gateway in the pool is handling the fewest connections.
+4. If that gateway cannot be reached, the request is retried on another member and the failed gateway is skipped for the next minute.
+5. If a gateway goes down, subsequent requests route through the remaining healthy gateways.
 
 A gateway is considered healthy if it has sent a successful heartbeat within its TTL window.
 
@@ -58,7 +59,24 @@ When you select a pool, the platform validates connectivity through one of its h
 
 ## Gateway selection
 
-When a request is routed through a pool, the platform picks a gateway at random from the pool's healthy gateways. There is no round-robin or weighted selection.
+Each gateway reports how many connections it is currently handling. When a request is routed through a pool, the platform picks the healthy member handling the fewest, so a gateway holding several long-lived sessions stops attracting new work until the others catch up.
+
+Members handling the same amount are chosen between at random. On an idle pool every member is equal, so traffic spreads evenly.
+
+Because the count comes from the gateway itself, it includes work the platform does not proxy, such as a PAM session opened from the CLI.
+
+<Warning>
+  Load balancing requires gateways running a CLI version that reports connection counts. A gateway
+  on an older version does not report, and a pool that mixes reporting and non-reporting gateways
+  falls back to choosing at random rather than comparing counts that are not measured the same way.
+  Upgrade every gateway in a pool to get load balancing for that pool.
+</Warning>
+
+## Failover
+
+If the platform cannot establish a connection to the gateway it chose, it retries the request on another member of the pool, then marks the failed gateway as suspect and skips it for the next minute. This covers the window where a gateway has stopped responding but its last heartbeat is still recent enough to look healthy.
+
+Only failures that occur *before* the platform reaches your resource are retried. If the connection succeeds and the resource itself rejects the request, for example bad credentials, that error is returned to you as-is and is never retried on another gateway. This is deliberate: an operation that changes something on the target, such as rotating a password, must not run twice.
 
 ## Pool health
 
@@ -81,6 +99,9 @@ If all gateways in a pool are unhealthy when a request is made, the request fail
   </Accordion>
   <Accordion title="What happens if all gateways in a pool are unhealthy?">
     The request fails with a descriptive error. You should ensure at least one gateway in the pool is online and has a recent heartbeat.
+  </Accordion>
+  <Accordion title="Why is my pool not load balancing?">
+    The most common reason is that one or more gateways in the pool are running an older CLI version and do not report their connection count. A pool that mixes reporting and non-reporting gateways chooses at random instead. Upgrade every gateway in the pool.
   </Accordion>
   <Accordion title="Can a gateway belong to multiple pools?">
     Yes. A gateway can belong to as many pools as needed, as long as it has connectivity to the resources served by each pool.

--- a/docs/documentation/platform/gateways/gateway-pools.mdx
+++ b/docs/documentation/platform/gateways/gateway-pools.mdx
@@ -100,9 +100,6 @@ If all gateways in a pool are unhealthy when a request is made, the request fail
   <Accordion title="What happens if all gateways in a pool are unhealthy?">
     The request fails with a descriptive error. You should ensure at least one gateway in the pool is online and has a recent heartbeat.
   </Accordion>
-  <Accordion title="Why is my pool not load balancing?">
-    The most common reason is that one or more gateways in the pool are running an older CLI version and do not report their connection count. A pool that mixes reporting and non-reporting gateways chooses at random instead. Upgrade every gateway in the pool.
-  </Accordion>
   <Accordion title="Can a gateway belong to multiple pools?">
     Yes. A gateway can belong to as many pools as needed, as long as it has connectivity to the resources served by each pool.
   </Accordion>


### PR DESCRIPTION
## Context

Gateway pools picked a gateway at random, so one could end up carrying far more work than the others while its peers sat idle. Pools now send each new job to whichever gateway is least busy, and retry on another gateway when one can't be reached.

Needs the matching CLI change so gateways report how busy they are: Infisical/cli#370

## Steps to verify the change

1. Put two or more gateways in a pool and point an app connection or Kubernetes auth config at it.
2. Drive traffic through and confirm it spreads instead of landing on one gateway.
3. Kill a gateway mid-traffic: requests keep succeeding and the logs show a retry on another member.
4. Load one gateway up (e.g. a few PAM CLI sessions) and confirm new work goes to the quieter one.
5. Use a wrong password on the target and confirm it fails straight away, without being retried elsewhere.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
