### PR TITLE
fix(identity): guard instance admin identities on v2 and UA client-secret paths

### DIFF
--- a/backend/src/server/routes/v1/identity-universal-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-universal-auth-router.ts
@@ -581,6 +581,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
           actorAuthMethod: req.permission.authMethod,
           actorOrgId: req.permission.orgId,
           identityId: req.params.identityId,
+          isActorSuperAdmin: isSuperAdmin(req.auth),
           ...req.body
         });
 
@@ -752,7 +753,8 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
         actorAuthMethod: req.permission.authMethod,
         actorOrgId: req.permission.orgId,
         identityId: req.params.identityId,
-        clientSecretId: req.params.clientSecretId
+        clientSecretId: req.params.clientSecretId,
+        isActorSuperAdmin: isSuperAdmin(req.auth)
       });
 
       await server.services.auditLog.createAuditLog({

--- a/backend/src/server/routes/v1/identity-universal-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-universal-auth-router.ts
@@ -819,7 +819,8 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
         actorId: req.permission.id,
         actorAuthMethod: req.permission.authMethod,
         actorOrgId: req.permission.orgId,
-        identityId: req.params.identityId
+        identityId: req.params.identityId,
+        isActorSuperAdmin: isSuperAdmin(req.auth)
       });
 
       await server.services.auditLog.createAuditLog({

--- a/backend/src/server/routes/v1/org-identity-router.ts
+++ b/backend/src/server/routes/v1/org-identity-router.ts
@@ -6,6 +6,7 @@ import { ApiDocsTags, IDENTITIES } from "@app/lib/api-docs";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { isSuperAdmin } from "@app/services/super-admin/super-admin-fns";
 
 const metadataSchema = z.object({
   key: z.string().trim().min(1, "Metadata key cannot be empty"),
@@ -122,6 +123,7 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
           scope: AccessScope.Organization,
           orgId: req.permission.orgId
         },
+        isActorSuperAdmin: isSuperAdmin(req.auth),
         selector: {
           identityId: req.params.identityId
         },
@@ -182,6 +184,7 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
           scope: AccessScope.Organization,
           orgId: req.permission.orgId
         },
+        isActorSuperAdmin: isSuperAdmin(req.auth),
         selector: {
           identityId: req.params.identityId
         }

--- a/backend/src/server/routes/v1/project-identity-router.ts
+++ b/backend/src/server/routes/v1/project-identity-router.ts
@@ -7,6 +7,7 @@ import { ms } from "@app/lib/ms";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
+import { isSuperAdmin } from "@app/services/super-admin/super-admin-fns";
 
 const metadataSchema = z.object({
   key: z.string().trim().min(1, "Metadata key cannot be empty"),
@@ -168,6 +169,7 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
           projectId: req.params.projectId,
           orgId: req.permission.orgId
         },
+        isActorSuperAdmin: isSuperAdmin(req.auth),
         selector: {
           identityId: req.params.identityId
         },
@@ -231,6 +233,7 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
           scope: AccessScope.Project,
           projectId: req.params.projectId
         },
+        isActorSuperAdmin: isSuperAdmin(req.auth),
         selector: {
           identityId: req.params.identityId
         }

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -1251,7 +1251,8 @@ export const identityUaServiceFactory = ({
     actorId,
     actor,
     actorOrgId,
-    actorAuthMethod
+    actorAuthMethod,
+    isActorSuperAdmin
   }: TClearUaLockoutsDTO) => {
     const identityMembershipOrg = await membershipIdentityDAL.getIdentityById({
       scopeData: {
@@ -1296,6 +1297,9 @@ export const identityUaServiceFactory = ({
       });
       ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
     }
+
+    await validateIdentityUpdateForSuperAdminPrivileges(identityId, isActorSuperAdmin);
+
     const deleted = await keyStore.deleteItems({
       pattern: KeyStorePrefixes.IdentityLockoutStateByMethodPattern(identityId, IdentityAuthMethod.UNIVERSAL_AUTH)
     });

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -848,7 +848,8 @@ export const identityUaServiceFactory = ({
     ttl,
     actorAuthMethod,
     description,
-    numUsesLimit
+    numUsesLimit,
+    isActorSuperAdmin
   }: TCreateUaClientSecretDTO) => {
     const identityMembershipOrg = await membershipIdentityDAL.getIdentityById({
       scopeData: {
@@ -926,6 +927,9 @@ export const identityUaServiceFactory = ({
           details: { missingPermissions: permissionBoundary.missingPermissions }
         });
     }
+
+    await validateIdentityUpdateForSuperAdminPrivileges(identityId, isActorSuperAdmin);
+
     const appCfg = getConfig();
     const clientSecret = crypto.randomBytes(32).toString("hex");
     const clientSecretHash = await crypto.hashing().createHash(clientSecret, appCfg.SALT_ROUNDS);
@@ -1137,7 +1141,8 @@ export const identityUaServiceFactory = ({
     actor,
     actorOrgId,
     actorAuthMethod,
-    clientSecretId
+    clientSecretId,
+    isActorSuperAdmin
   }: TRevokeUaClientSecretDTO) => {
     const identityMembershipOrg = await membershipIdentityDAL.getIdentityById({
       scopeData: {
@@ -1223,6 +1228,9 @@ export const identityUaServiceFactory = ({
         });
       }
     }
+
+    await validateIdentityUpdateForSuperAdminPrivileges(identityId, isActorSuperAdmin);
+
     // Insert the revocation marker BEFORE flipping isClientSecretRevoked. If
     // the flip fails, tokens are already dead and a retry safely re-flips the
     // bit; flipping first would leave the secret flagged but tokens authentic.

--- a/backend/src/services/identity-ua/identity-ua-types.ts
+++ b/backend/src/services/identity-ua/identity-ua-types.ts
@@ -56,6 +56,7 @@ export type TCreateUaClientSecretDTO = {
   description: string;
   numUsesLimit: number;
   ttl: number;
+  isActorSuperAdmin?: boolean;
 } & Omit<TProjectPermission, "projectId">;
 
 export type TGetUaClientSecretsDTO = {
@@ -65,6 +66,7 @@ export type TGetUaClientSecretsDTO = {
 export type TRevokeUaClientSecretDTO = {
   identityId: string;
   clientSecretId: string;
+  isActorSuperAdmin?: boolean;
 } & Omit<TProjectPermission, "projectId">;
 
 export type TClearUaLockoutsDTO = {

--- a/backend/src/services/identity-ua/identity-ua-types.ts
+++ b/backend/src/services/identity-ua/identity-ua-types.ts
@@ -71,6 +71,7 @@ export type TRevokeUaClientSecretDTO = {
 
 export type TClearUaLockoutsDTO = {
   identityId: string;
+  isActorSuperAdmin?: boolean;
 } & Omit<TProjectPermission, "projectId">;
 
 export type TGetUniversalAuthClientSecretByIdDTO = {

--- a/backend/src/services/identity-v2/identity-service.test.ts
+++ b/backend/src/services/identity-v2/identity-service.test.ts
@@ -15,6 +15,14 @@ vi.mock("@app/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }));
 
+// `vi.mock` factories are hoisted above imports — the spy they reference must come from `vi.hoisted`.
+// Stubbing the config read rather than the guard itself keeps the real instance-admin check under test.
+const { getServerCfgMock } = vi.hoisted(() => ({ getServerCfgMock: vi.fn() }));
+
+vi.mock("@app/services/super-admin/super-admin-service", () => ({
+  getServerCfg: getServerCfgMock
+}));
+
 const ORG_ID = "org-1";
 const PROJECT_ID = "project-1";
 const IDENTITY_ID = "identity-1";
@@ -39,7 +47,8 @@ const createService = ({
   const identityDAL = {
     findOne: vi.fn().mockResolvedValue(existingIdentity),
     transaction: vi.fn(async (cb: (tx: Knex) => Promise<unknown>) => cb(TX)),
-    deleteById: vi.fn().mockResolvedValue({ id: IDENTITY_ID, name: "ident" })
+    deleteById: vi.fn().mockResolvedValue({ id: IDENTITY_ID, name: "ident" }),
+    updateById: vi.fn().mockResolvedValue({ id: IDENTITY_ID, name: "renamed" })
   };
 
   const service = identityV2ServiceFactory({
@@ -77,7 +86,10 @@ const createService = ({
 };
 
 describe("deleteIdentity alert cleanup", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServerCfgMock.mockResolvedValue({ adminIdentityIds: [] });
+  });
 
   test("reaps the identity's alerts in every org, in the same transaction as the row delete", async () => {
     const { service, identityDAL, deleteAlertsForDeletedResource } = createService();
@@ -127,5 +139,51 @@ describe("deleteIdentity alert cleanup", () => {
     await expect(service.deleteIdentity(buildDto())).rejects.toThrow(`Identity with id ${IDENTITY_ID} not found`);
 
     expect(deleteAlertsForDeletedResource).not.toHaveBeenCalled();
+  });
+});
+
+describe("instance admin identities are protected on the v2 surface", () => {
+  const INSTANCE_ADMIN_ERROR =
+    "You are attempting to modify an instance admin identity. This requires elevated instance admin privileges";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getServerCfgMock.mockResolvedValue({ adminIdentityIds: [IDENTITY_ID] });
+  });
+
+  test("delete is refused for a non instance admin actor, and nothing is reaped", async () => {
+    const { service, identityDAL, deleteAlertsForDeletedResource } = createService();
+
+    await expect(service.deleteIdentity(buildDto())).rejects.toThrow(INSTANCE_ADMIN_ERROR);
+
+    expect(identityDAL.deleteById).not.toHaveBeenCalled();
+    expect(deleteAlertsForDeletedResource).not.toHaveBeenCalled();
+  });
+
+  test("update is refused for a non instance admin actor", async () => {
+    const { service, identityDAL } = createService();
+
+    await expect(service.updateIdentity({ ...buildDto(), data: { name: "renamed" } } as never)).rejects.toThrow(
+      INSTANCE_ADMIN_ERROR
+    );
+
+    expect(identityDAL.updateById).not.toHaveBeenCalled();
+  });
+
+  test("an instance admin actor is allowed through", async () => {
+    const { service, identityDAL } = createService();
+
+    await service.deleteIdentity({ ...buildDto(), isActorSuperAdmin: true });
+
+    expect(identityDAL.deleteById).toHaveBeenCalledWith(IDENTITY_ID, TX);
+  });
+
+  test("the guard is inert when no instance admin identities are configured", async () => {
+    getServerCfgMock.mockResolvedValue({ adminIdentityIds: [] });
+    const { service, identityDAL } = createService();
+
+    await service.deleteIdentity(buildDto());
+
+    expect(identityDAL.deleteById).toHaveBeenCalledWith(IDENTITY_ID, TX);
   });
 });

--- a/backend/src/services/identity-v2/identity-service.test.ts
+++ b/backend/src/services/identity-v2/identity-service.test.ts
@@ -186,4 +186,23 @@ describe("instance admin identities are protected on the v2 surface", () => {
 
     expect(identityDAL.deleteById).toHaveBeenCalledWith(IDENTITY_ID, TX);
   });
+
+  test("an out-of-scope instance admin identity is not found, not refused as privileged", async () => {
+    const { service, identityDAL, deleteAlertsForDeletedResource } = createService({ existingIdentity: null });
+
+    await expect(service.deleteIdentity(buildDto())).rejects.toThrow(`Identity with id ${IDENTITY_ID} not found`);
+
+    expect(identityDAL.deleteById).not.toHaveBeenCalled();
+    expect(deleteAlertsForDeletedResource).not.toHaveBeenCalled();
+  });
+
+  test("an out-of-scope instance admin identity is not found on update either", async () => {
+    const { service, identityDAL } = createService({ existingIdentity: null });
+
+    await expect(service.updateIdentity({ ...buildDto(), data: { name: "renamed" } } as never)).rejects.toThrow(
+      `Identity with id ${IDENTITY_ID} not found`
+    );
+
+    expect(identityDAL.updateById).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -37,6 +37,7 @@ import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TRoleDALFactory } from "@app/services/role/role-dal";
+import { validateIdentityUpdateForSuperAdminPrivileges } from "@app/services/super-admin/super-admin-fns";
 
 import { ActorType } from "../auth/auth-type";
 import { getIdentityActiveLockoutAuthMethods } from "../identity/identity-fns";
@@ -322,6 +323,8 @@ export const identityV2ServiceFactory = ({
     const factory = scopeFactory[scopeData.scope];
 
     await factory.onUpdateIdentityGuard(dto);
+    await validateIdentityUpdateForSuperAdminPrivileges(dto.selector.identityId, dto.isActorSuperAdmin);
+
     const existingIdentity = await identityDAL.findOne({
       id: dto.selector.identityId,
       orgId: dto.permission.orgId,
@@ -375,6 +378,7 @@ export const identityV2ServiceFactory = ({
     const factory = scopeFactory[scopeData.scope];
 
     await factory.onDeleteIdentityGuard(dto);
+    await validateIdentityUpdateForSuperAdminPrivileges(dto.selector.identityId, dto.isActorSuperAdmin);
 
     const existingIdentity = await identityDAL.findOne({
       id: dto.selector.identityId,

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -323,7 +323,6 @@ export const identityV2ServiceFactory = ({
     const factory = scopeFactory[scopeData.scope];
 
     await factory.onUpdateIdentityGuard(dto);
-    await validateIdentityUpdateForSuperAdminPrivileges(dto.selector.identityId, dto.isActorSuperAdmin);
 
     const existingIdentity = await identityDAL.findOne({
       id: dto.selector.identityId,
@@ -332,6 +331,8 @@ export const identityV2ServiceFactory = ({
     });
     if (!existingIdentity)
       throw new NotFoundError({ message: `Identity with id ${dto.selector.identityId} not found` });
+
+    await validateIdentityUpdateForSuperAdminPrivileges(dto.selector.identityId, dto.isActorSuperAdmin);
 
     const identity = await identityDAL.transaction(async (tx) => {
       const updatedIdentity =
@@ -378,7 +379,6 @@ export const identityV2ServiceFactory = ({
     const factory = scopeFactory[scopeData.scope];
 
     await factory.onDeleteIdentityGuard(dto);
-    await validateIdentityUpdateForSuperAdminPrivileges(dto.selector.identityId, dto.isActorSuperAdmin);
 
     const existingIdentity = await identityDAL.findOne({
       id: dto.selector.identityId,
@@ -387,6 +387,8 @@ export const identityV2ServiceFactory = ({
     });
     if (!existingIdentity)
       throw new NotFoundError({ message: `Identity with id ${dto.selector.identityId} not found` });
+
+    await validateIdentityUpdateForSuperAdminPrivileges(dto.selector.identityId, dto.isActorSuperAdmin);
     if (existingIdentity.hasDeleteProtection) {
       throw new BadRequestError({ message: "Cannot delete identity while delete protection is enabled" });
     }

--- a/backend/src/services/identity-v2/identity-types.ts
+++ b/backend/src/services/identity-v2/identity-types.ts
@@ -48,6 +48,7 @@ export type TUpdateIdentityV2DTO = {
     hasDeleteProtection: boolean;
     metadata?: { key: string; value: string }[];
   }>;
+  isActorSuperAdmin?: boolean;
 };
 
 export type TDeleteIdentityV2DTO = {
@@ -56,6 +57,7 @@ export type TDeleteIdentityV2DTO = {
   selector: {
     identityId: string;
   };
+  isActorSuperAdmin?: boolean;
 };
 
 export type TGetIdentityByIdV2DTO = {


### PR DESCRIPTION
## Context

Instance admin machine identities are listed in server config (`adminIdentityIds`). Other identity auth surfaces already call `validateIdentityUpdateForSuperAdminPrivileges` so org/project admins cannot mutate those identities without elevated privileges. Two gaps remained:

1. **Identity v2 update/delete** — `identityV2.updateIdentity` and `deleteIdentity` had no instance-admin guard, and the org/project identity routers did not pass `isActorSuperAdmin`.
2. **Universal Auth client-secret operations** — attach/update/revoke UA already had the guard, but create client secret, revoke client secret, and clear lockouts did not.

This PR threads `isActorSuperAdmin: isSuperAdmin(req.auth)` from the affected routes into the service layer and invokes `validateIdentityUpdateForSuperAdminPrivileges` before mutating an identity in `serverCfg.adminIdentityIds`. Non–instance-admin actors receive `403` with: *"You are attempting to modify an instance admin identity. This requires elevated instance admin privileges"*. Instance admins (super-admin users or identities with `isInstanceAdmin`) can still modify them.

## Steps to verify the change

1. Configure an instance admin identity (`adminIdentityIds` in server config / super-admin settings).
2. As an org admin **without** instance admin privileges, attempt:
   - `PATCH` / `DELETE` on org or project identity v2 routes for that identity → expect `403`.
   - Universal Auth: create client secret, revoke client secret, clear lockouts for that identity → expect `403`.
3. As a super-admin user or instance-admin identity, repeat the same operations → expect success.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)