### PR TITLE
feat(pam): fix legacy ssh log rendering and move new logging to gateway

### DIFF
--- a/frontend/src/hooks/api/pam/types/index.ts
+++ b/frontend/src/hooks/api/pam/types/index.ts
@@ -259,6 +259,8 @@ export type TSessionEvent = {
   eventType: "input" | "output" | "resize" | "error";
   channelType?: SessionChannelType;
   data: string;
+  // set by gateways that render the terminal before recording. absent on older recordings, whose data is raw terminal bytes
+  rendered?: boolean;
   elapsedTime: number;
 };
 

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -62,15 +62,20 @@ const decodeBase64Utf8 = (b64: string): string => {
   }
 };
 
-// matches ANSI/VT escape sequences emitted by a terminal (colors, cursor moves, etc.)
-const ANSI_ESCAPE_REGEX =
-  // eslint-disable-next-line no-control-regex
-  /[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-ntqry=><~]))/g;
+// Only reached for recordings written before gateways rendered the terminal themselves, which the `rendered` flag distinguishes.
+const LEGACY_ANSI_ESCAPE_REGEX = new RegExp(
+  [
+    "\u001B[\\]PX^_][\\s\\S]*?(?:\u0007|\u001B\\\\|$)",
+    "[\u001B\u009B]\\[[0-?]*[ -/]*[@-~]",
+    "\u001B[()*+\\-./][ -~]",
+    "\u001B[@-Z\\\\-_]"
+  ].join("|"),
+  "g"
+);
 
-// turns raw terminal bytes into readable log text by stripping escape sequences
-const cleanTerminalOutput = (raw: string): string =>
+const cleanLegacyTerminalOutput = (raw: string): string =>
   raw
-    .replace(ANSI_ESCAPE_REGEX, "")
+    .replace(LEGACY_ANSI_ESCAPE_REGEX, "")
     // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u0008\u000B-\u001F\u007F]/g, "")
     .trim();
@@ -82,7 +87,8 @@ const getLogText = (log: TPamSessionLog): string => {
   if ("data" in log) {
     // resize events carry window dimensions, not terminal content. skip them
     if (log.eventType === "resize") return "";
-    return cleanTerminalOutput(decodeBase64Utf8(log.data));
+    const data = decodeBase64Utf8(log.data);
+    return log.rendered ? data.trim() : cleanLegacyTerminalOutput(data);
   }
   if ("method" in log) {
     return `${log.method} ${log.url}`;

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -65,8 +65,8 @@ const decodeBase64Utf8 = (b64: string): string => {
 // Only reached for recordings written before gateways rendered the terminal themselves, which the `rendered` flag distinguishes.
 const LEGACY_ANSI_ESCAPE_REGEX = new RegExp(
   [
-    "\u001B[\\]PX^_][\\s\\S]*?(?:\u0007|\u001B\\\\|$)",
-    "[\u001B\u009B]\\[[0-?]*[ -/]*[@-~]",
+    "\u001B[\\]PX^_][\\s\\S]*?(?:\u0007|\u001B\\\\)",
+    "(?:\u001B\\[|\u009B)[0-?]*[ -/]*[@-~]",
     "\u001B[()*+\\-./][ -~]",
     "\u001B[@-Z\\\\-_]"
   ].join("|"),


### PR DESCRIPTION
## Context

Fix legacy ssh log rendering and move new logging to gateway.

Adds a small fix for legacy frontend parsing, and migrates the entire parsing mechanism to the gateway for all new logs.

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)