### PR TITLE
fix(docs): hotfix for landing page assets

### DIFF
--- a/docs/snippets/home.jsx
+++ b/docs/snippets/home.jsx
@@ -109,41 +109,46 @@ export const HomeSteps = ({ steps }) => {
   );
 };
 
-export const HomeStack = ({ items }) => (
-  <div className="ifx-stack">
-    {items.map((item) => (
-      <a key={item.href} className="ifx-stack__tile" href={item.href}>
-        {item.logo ? (
-          <img
-            className={`ifx-stack__logo${
-              item.adapt ? ` ifx-stack__logo--adapt-${item.adapt}` : ""
-            }`}
-            src={item.logo}
-            alt=""
-            aria-hidden="true"
-          />
-        ) : (
-          <svg
-            className="ifx-stack__logo ifx-stack__glyph"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-          >
-            <rect x="3" y="3" width="7" height="7" />
-            <rect x="14" y="3" width="7" height="7" />
-            <rect x="3" y="14" width="7" height="7" />
-            <rect x="14" y="14" width="7" height="7" />
-          </svg>
-        )}
-        <span className="ifx-stack__label">{item.label}</span>
-      </a>
-    ))}
-  </div>
-);
+export const HomeStack = ({ items }) => {
+  const path = typeof window === "undefined" ? "" : window.location.pathname;
+  const base = path === "/docs" || path.startsWith("/docs/") ? "/docs" : "";
+
+  return (
+    <div className="ifx-stack">
+      {items.map((item) => (
+        <a key={item.href} className="ifx-stack__tile" href={item.href}>
+          {item.logo ? (
+            <img
+              className={`ifx-stack__logo${
+                item.adapt ? ` ifx-stack__logo--adapt-${item.adapt}` : ""
+              }`}
+              src={`${base}${item.logo}`}
+              alt=""
+              aria-hidden="true"
+            />
+          ) : (
+            <svg
+              className="ifx-stack__logo ifx-stack__glyph"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="3" y="3" width="7" height="7" />
+              <rect x="14" y="3" width="7" height="7" />
+              <rect x="3" y="14" width="7" height="7" />
+              <rect x="14" y="14" width="7" height="7" />
+            </svg>
+          )}
+          <span className="ifx-stack__label">{item.label}</span>
+        </a>
+      ))}
+    </div>
+  );
+};
 
 export const Mark = ({ children }) => <span className="ifx-mark">{children}</span>;
 


### PR DESCRIPTION
## Context

Assets aren't loading on the docs landing page because Mintlfiy is serving them from `/` instead of `/docs`. This should fix that.

## Screenshots

<img width="1511" height="834" alt="Screenshot 2026-08-18 at 7 02 31 PM" src="https://github.com/user-attachments/assets/983c9960-7024-4c6c-80c3-1894874d985b" />

## Steps to verify the change

Check the docs landing page is loading its assets correctly

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)