### PR TITLE
fix: issue bootstrap instance admin token with an exp claim

### DIFF
--- a/backend-go/tests/infra/nodejs.go
+++ b/backend-go/tests/infra/nodejs.go
@@ -134,8 +134,9 @@ func startNodeJS(ctx context.Context, networkName string, files []testcontainers
 	}, nil
 }
 
-// bootstrap creates the initial admin user, org, and machine identity,
-// then logs in to obtain a user JWT. Uses log.Fatalf since it runs in TestMain.
+// bootstrap creates the initial admin user, org, and machine identity, logs in
+// to obtain a user JWT, then mints the identity access token used by the infra
+// helpers. Uses log.Fatalf since it runs in TestMain.
 func (n *NodeJSService) bootstrap() {
 	var bootstrapResp BootstrapResponse
 	resp, err := n.client.R().
@@ -154,7 +155,6 @@ func (n *NodeJSService) bootstrap() {
 	}
 
 	n.orgID = bootstrapResp.Organization.ID
-	n.identityToken = bootstrapResp.Identity.Credentials.Token
 	n.userEmail = bootstrapResp.User.Email
 	n.userID = bootstrapResp.User.ID
 
@@ -189,6 +189,24 @@ func (n *NodeJSService) bootstrap() {
 		log.Fatalf("infra.bootstrap: select-org returned %d: %s", resp.StatusCode(), resp.String())
 	}
 	n.userToken = selectOrgResp.Token
+
+	// The bootstrap response token is signed without an exp claim, which the
+	// backend rejects as over max age once past the legacy no-exp token cutoff
+	// (2026-08-02 on default config). Mint a standard Token Auth access token
+	// for the instance admin identity and use that for all infra calls.
+	var tokenResp CreateTokenAuthTokenResponse
+	resp, err = n.client.R().
+		SetHeader("Authorization", "Bearer "+n.userToken).
+		SetBody(CreateTokenAuthTokenRequest{Name: "test-infra"}).
+		SetResult(&tokenResp).
+		Post("/api/v1/auth/token-auth/identities/" + bootstrapResp.Identity.ID + "/tokens")
+	if err != nil {
+		log.Fatalf("infra.bootstrap: create token-auth token request failed: %v", err)
+	}
+	if resp.IsError() {
+		log.Fatalf("infra.bootstrap: create token-auth token returned %d: %s", resp.StatusCode(), resp.String())
+	}
+	n.identityToken = tokenResp.AccessToken
 }
 
 // MustCreateProject creates a new project via the Node.js API.

--- a/backend-go/tests/infra/nodejs_types.go
+++ b/backend-go/tests/infra/nodejs_types.go
@@ -18,6 +18,7 @@ type BootstrapResponse struct {
 		ID string `json:"id"`
 	} `json:"organization"`
 	Identity struct {
+		ID          string `json:"id"`
 		Credentials struct {
 			Token string `json:"token"`
 		} `json:"credentials"`
@@ -26,6 +27,16 @@ type BootstrapResponse struct {
 		ID    string `json:"id"`
 		Email string `json:"email"`
 	} `json:"user"`
+}
+
+// CreateTokenAuthTokenRequest is the request body for POST /api/v1/auth/token-auth/identities/{id}/tokens.
+type CreateTokenAuthTokenRequest struct {
+	Name string `json:"name,omitempty"`
+}
+
+// CreateTokenAuthTokenResponse is the response from POST /api/v1/auth/token-auth/identities/{id}/tokens.
+type CreateTokenAuthTokenResponse struct {
+	AccessToken string `json:"accessToken"`
 }
 
 // LoginRequest is the request body for POST /api/v3/auth/login.

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1465,7 +1465,7 @@ export const registerRoutes = async (
     userAliasDAL,
     emailDomainDAL,
     identityTokenAuthDAL,
-    identityAccessTokenDAL,
+    identityAccessTokenService,
     authService: loginService,
     serverCfgDAL: superAdminDAL,
     kmsRootConfigDAL,

--- a/backend/src/services/super-admin/super-admin-service.ts
+++ b/backend/src/services/super-admin/super-admin-service.ts
@@ -23,6 +23,7 @@ import {
 } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
+import { TIp } from "@app/lib/ip";
 import { logger } from "@app/lib/logger";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
@@ -38,9 +39,8 @@ import { SmtpTemplates, TSmtpService } from "@app/services/smtp/smtp-service";
 import { TAlertChannelRecipientDALFactory } from "../alert/alert-channel-recipient-dal";
 import { AlertPrincipalType } from "../alert/alert-types";
 import { TAuthLoginFactory } from "../auth/auth-login-service";
-import { ActorType, AuthMethod, AuthTokenType } from "../auth/auth-type";
-import { TIdentityAccessTokenDALFactory } from "../identity-access-token/identity-access-token-dal";
-import { TIdentityAccessTokenJwtPayload } from "../identity-access-token/identity-access-token-types";
+import { ActorType, AuthMethod } from "../auth/auth-type";
+import { TIdentityAccessTokenServiceFactory } from "../identity-access-token/identity-access-token-service";
 import { TIdentityTokenAuthDALFactory } from "../identity-token-auth/identity-token-auth-dal";
 import { KMS_ROOT_CONFIG_UUID } from "../kms/kms-fns";
 import { TKmsRootConfigDALFactory } from "../kms/kms-root-config-dal";
@@ -78,7 +78,7 @@ import {
 type TSuperAdminServiceFactoryDep = {
   identityDAL: TIdentityDALFactory;
   identityTokenAuthDAL: TIdentityTokenAuthDALFactory;
-  identityAccessTokenDAL: TIdentityAccessTokenDALFactory;
+  identityAccessTokenService: Pick<TIdentityAccessTokenServiceFactory, "issueIdentityAccessToken">;
   orgDAL: TOrgDALFactory;
   serverCfgDAL: TSuperAdminDALFactory;
   userDAL: TUserDALFactory;
@@ -152,7 +152,7 @@ export const superAdminServiceFactory = ({
   kmsRootConfigDAL,
   kmsService,
   licenseService,
-  identityAccessTokenDAL,
+  identityAccessTokenService,
   identityTokenAuthDAL,
   microsoftTeamsService,
   invalidateCacheQueue,
@@ -664,31 +664,26 @@ export const superAdminServiceFactory = ({
         tx
       );
 
-      const newToken = await identityAccessTokenDAL.create(
-        {
-          identityId: newIdentity.id,
-          isAccessTokenRevoked: false,
-          accessTokenTTL: tokenAuth.accessTokenTTL,
-          accessTokenMaxTTL: tokenAuth.accessTokenMaxTTL,
-          accessTokenNumUses: 0,
-          accessTokenNumUsesLimit: tokenAuth.accessTokenNumUsesLimit,
-          name: "Instance Admin Token",
-          authMethod: IdentityAuthMethod.TOKEN_AUTH,
-          subOrganizationId: organization.id
-        },
-        tx
-      );
+      // Issue through the standard path so the JWT carries an exp claim; a
+      // hand-rolled no-exp token is rejected as over max age since the legacy
+      // token cutoff (LEGACY_IDENTITY_ACCESS_TOKEN_EXPIRATION_ENFORCED_AT).
+      const { accessToken } = await identityAccessTokenService.issueIdentityAccessToken({
+        identityId: newIdentity.id,
+        identityName: newIdentity.name,
+        authMethod: IdentityAuthMethod.TOKEN_AUTH,
+        orgId: organization.id,
+        rootOrgId: organization.id,
+        parentOrgId: organization.id,
+        subOrganizationId: organization.id,
+        accessTokenTTL: Number(tokenAuth.accessTokenTTL),
+        accessTokenMaxTTL: Number(tokenAuth.accessTokenMaxTTL),
+        accessTokenNumUsesLimit: Number(tokenAuth.accessTokenNumUsesLimit),
+        accessTokenPeriod: 0,
+        accessTokenTrustedIps: tokenAuth.accessTokenTrustedIps as TIp[],
+        persistToPg: { tx, name: "Instance Admin Token" }
+      });
 
-      const generatedAccessToken = crypto.jwt().sign(
-        {
-          identityId: newIdentity.id,
-          identityAccessTokenId: newToken.id,
-          authTokenType: AuthTokenType.IDENTITY_ACCESS_TOKEN
-        } as TIdentityAccessTokenJwtPayload,
-        appCfg.AUTH_SECRET
-      );
-
-      return { identity: newIdentity, auth: tokenAuth, credentials: { token: generatedAccessToken } };
+      return { identity: newIdentity, auth: tokenAuth, credentials: { token: accessToken } };
     });
 
     const shouldDisableSignUp = !appCfg.isCloud;


### PR DESCRIPTION
## Context

This PR fixes the bootstrap flow to use a token with an exp claim which was causing the GO CI to fail

## Screenshots

N/A

## Steps to verify the change

- [ ] Boot the backend against a fresh (uninitialized) database and confirm `POST /api/v1/admin/bootstrap` returns 200 with `identity.credentials.token`.
- [ ] Decode the returned JWT and confirm it now carries an `exp` claim set 90 days after `iat`, plus the full claim set (`jti`, `orgId`, `rootOrgId`, `parentOrgId`, `authMethod`).
- [ ] Call `POST /api/v1/projects` with the bootstrap token and confirm it returns 200 instead of 401 "Identity access token exceeded max age".
- [ ] Run `go test -tags integration ./tests/...` in `backend-go/` and confirm the auth, kms, permission, and secrets packages pass against `infisical/infisical:latest`.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)