### PR TITLE
docs(cli): fix infisical.json typo

### DIFF
--- a/docs/cli/commands/init.mdx
+++ b/docs/cli/commands/init.mdx
@@ -12,5 +12,5 @@ infisical init
 Link a local project to your Infisical project. Once connected, you can then access the secrets locally from the connected Infisical project.
 
 <Info>
-This command creates a `infisical.json` file containing your Project ID.
+This command creates a `.infisical.json` file containing your Project ID.
 </Info>

--- a/docs/documentation/getting-started/cli.mdx
+++ b/docs/documentation/getting-started/cli.mdx
@@ -99,7 +99,7 @@ $ infisical login
 
 ## Initialization
 
-Navigate to the root of your project directory and run the `init` command. This step connects your local project to the project on the Infisical platform and creates a `infisical.json` file containing a reference to that latter project.
+Navigate to the root of your project directory and run the `init` command. This step connects your local project to the project on the Infisical platform and creates a `.infisical.json` file containing a reference to that latter project.
 
 ```console
 $ infisical init

--- a/docs/documentation/guides/nextjs-vercel.mdx
+++ b/docs/documentation/guides/nextjs-vercel.mdx
@@ -161,7 +161,7 @@ $ infisical login
 
 ### Initialization
 
-Run the `init` command at the root of the Next.js app. This step connects your local project to the project on the Infisical platform and creates a `infisical.json` file containing a reference to that latter project.
+Run the `init` command at the root of the Next.js app. This step connects your local project to the project on the Infisical platform and creates a `.infisical.json` file containing a reference to that latter project.
 
 ```console
 $ infisical init


### PR DESCRIPTION
## Context

Corrects `infisical.json` to `.infisical.json` throughout the docs.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)