### PR TITLE
docs(search): decrease api priority

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1263,6 +1263,7 @@
           },
           {
             "group": "Organization",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Organization Users",
@@ -1371,6 +1372,7 @@
           },
           {
             "group": "Project",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Projects",
@@ -1533,6 +1535,7 @@
           },
           {
             "group": "Shared",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "App Connections",
@@ -2409,6 +2412,7 @@
           },
           {
             "group": "Identity Auth",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Token Auth",
@@ -2549,6 +2553,7 @@
           },
           {
             "group": "Secrets Management",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Environments",
@@ -3658,6 +3663,7 @@
           },
           {
             "group": "Certificate Management",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Applications",
@@ -4110,6 +4116,7 @@
           },
           {
             "group": "Secret Scanning",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Data Sources",
@@ -4181,6 +4188,7 @@
           },
           {
             "group": "Secret Sharing",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Shared Secrets",
@@ -4196,6 +4204,7 @@
           },
           {
             "group": "Infisical KMS",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Keys",
@@ -4238,6 +4247,7 @@
           },
           {
             "group": "KMIP Servers",
+            "boost": 0.5,
             "pages": [
               "api-reference/endpoints/kmip-servers/list",
               "api-reference/endpoints/kmip-servers/get",
@@ -4251,6 +4261,7 @@
           },
           {
             "group": "Gateways",
+            "boost": 0.5,
             "pages": [
               "api-reference/endpoints/gateways/get",
               "api-reference/endpoints/gateways/create",
@@ -4260,6 +4271,7 @@
           },
           {
             "group": "External Migrations",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Doppler",
@@ -4273,6 +4285,7 @@
           },
           {
             "group": "Other",
+            "boost": 0.5,
             "pages": [
               {
                 "group": "Admin",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1263,7 +1263,7 @@
           },
           {
             "group": "Organization",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Organization Users",
@@ -1372,7 +1372,7 @@
           },
           {
             "group": "Project",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Projects",
@@ -1535,7 +1535,7 @@
           },
           {
             "group": "Shared",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "App Connections",
@@ -2412,7 +2412,7 @@
           },
           {
             "group": "Identity Auth",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Token Auth",
@@ -2553,7 +2553,7 @@
           },
           {
             "group": "Secrets Management",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Environments",
@@ -3663,7 +3663,7 @@
           },
           {
             "group": "Certificate Management",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Applications",
@@ -4116,7 +4116,7 @@
           },
           {
             "group": "Secret Scanning",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Data Sources",
@@ -4188,7 +4188,7 @@
           },
           {
             "group": "Secret Sharing",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Shared Secrets",
@@ -4204,7 +4204,7 @@
           },
           {
             "group": "Infisical KMS",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Keys",
@@ -4247,7 +4247,7 @@
           },
           {
             "group": "KMIP Servers",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               "api-reference/endpoints/kmip-servers/list",
               "api-reference/endpoints/kmip-servers/get",
@@ -4261,7 +4261,7 @@
           },
           {
             "group": "Gateways",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               "api-reference/endpoints/gateways/get",
               "api-reference/endpoints/gateways/create",
@@ -4271,7 +4271,7 @@
           },
           {
             "group": "External Migrations",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Doppler",
@@ -4285,7 +4285,7 @@
           },
           {
             "group": "Other",
-            "boost": 0.5,
+            "boost": 0.25,
             "pages": [
               {
                 "group": "Admin",


### PR DESCRIPTION
## Context

Decreases the search priority for API endpoint docs.

## Steps to verify the change

1. Enter a docs search query with a title/content that overlaps with API endpoint pages (like Secret Syncs).
2. Check that results are correctly prioritized.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)