### PR TITLE
feature(helm): bump infisical-nkp to 0.2.0 with valkey and extraEnv support

### DIFF
--- a/helm-charts/infisical-nkp/Chart.yaml
+++ b/helm-charts/infisical-nkp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infisical-nkp
 description: Infisical, the open-source secrets management platform, packaged for the Nutanix NKP partner catalog.
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "v0.162.11"
 home: https://infisical.com
 sources:

--- a/helm-charts/infisical-nkp/templates/deployment.yaml
+++ b/helm-charts/infisical-nkp/templates/deployment.yaml
@@ -69,6 +69,9 @@ spec:
                 name: {{ include "infisical.fullname" . }}-secrets
           env:
             {{- include "infisical.dbEnv" . | nindent 12 }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /api/status

--- a/helm-charts/infisical-nkp/values.yaml
+++ b/helm-charts/infisical-nkp/values.yaml
@@ -25,17 +25,19 @@ secrets:
   # the chart wires REDIS_URL to the in-cluster Redis service automatically.
   redisUrl: ""
 
-# Lightweight in-cluster Redis (Infisical requires REDIS_URL). Set enabled=false
-# to point at an external Redis via secrets.redisUrl instead.
+# Lightweight in-cluster Valkey, the open-source Redis-compatible fork
+# (Infisical requires REDIS_URL). The values keys keep the redis.* naming since
+# the wire protocol and connection URL are Redis-compatible. Set enabled=false
+# to point at an external Redis/Valkey via secrets.redisUrl instead.
 redis:
   enabled: true
   image:
-    repository: redis
-    tag: "7.4-alpine"
+    repository: valkey/valkey
+    tag: "8.1-alpine"
     pullPolicy: IfNotPresent
   port: 6379
-  # Restrict Redis ingress to the Infisical pods (enforced where the CNI
-  # supports NetworkPolicy). The bundled Redis is also password-protected with
+  # Restrict Valkey ingress to the Infisical pods (enforced where the CNI
+  # supports NetworkPolicy). The bundled Valkey is also password-protected with
   # a generated password stored in the chart Secret (REDIS_PASSWORD).
   networkPolicy: true
 
@@ -60,6 +62,24 @@ postgres:
 # Run "npm run migration:latest" as an initContainer before the app starts.
 migration:
   enabled: true
+
+# Additional environment variables for the Infisical container, in Kubernetes
+# EnvVar format. Useful for optional configuration such as SMTP, for example:
+# extraEnv:
+#   - name: SMTP_HOST
+#     value: smtp.example.com
+#   - name: SMTP_PORT
+#     value: "587"
+#   - name: SMTP_FROM_ADDRESS
+#     value: infisical@example.com
+#   - name: SMTP_USERNAME
+#     value: mailer
+#   - name: SMTP_PASSWORD          # reference a Secret for sensitive values
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-smtp-secret
+#         key: password
+extraEnv: []
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## What

Chart updates requested by Nutanix reviewers on the NKP partner catalog submission (nutanix-cloud-native/nkp-partner-catalog#62):

- **Valkey instead of Redis**: the bundled cache/queue now uses `valkey/valkey:8.1-alpine`. Drop-in compatible (same protocol, same `--requirepass`/`--port` flags, REDIS_URL unchanged), matches what Nutanix uses across their other catalog apps, and Valkey is BSD-licensed whereas redis 7.4+ images carry the non-open-source RSAL/SSPL license. The generated password and NetworkPolicy hardening carry over unchanged; values keep the `redis.*` key naming.
- **`extraEnv` value**: append arbitrary EnvVars to the Infisical container, e.g. SMTP configuration (commented example in values.yaml, including secretKeyRef for the password).
- Chart version 0.1.0 → 0.2.0. App version stays v0.162.11 and remains overridable via `image.tag` without a chart release.

Verified with `helm lint` and `helm template` (default render diff is only the image swap and version labels; extraEnv renders correctly; valkey still receives `--port`/`--requirepass`).

## After merge

Run the "Release Infisical NKP Helm chart" workflow to publish `infisical-nkp:0.2.0` to Cloudsmith; the catalog PR is being updated to reference 0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/infisical/infisical/pull/7725" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->