### PR TITLE
fix(identity): optimize lockout lookup to prevent full keyscan that caused slow machine identity page load

### DIFF
--- a/backend/e2e-test/routes/v1/identity-lockout-listing.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-lockout-listing.spec.ts
@@ -1,6 +1,10 @@
 import { IdentityAuthMethod, OrgMembershipRole, ProjectMembershipRole } from "@app/db/schemas";
 import { seedData1 } from "@app/db/seed-data";
 
+type TIdentityMembershipsResponse = {
+  identityMemberships: { identity: { id: string; activeLockoutAuthMethods: string[] } }[];
+};
+
 describe("Project identity listing lockout indicators", async () => {
   test("reports an active universal auth lockout and hides the client id", async () => {
     let identityId: string | undefined;
@@ -62,10 +66,11 @@ describe("Project identity listing lockout indicators", async () => {
       });
       expect(listRes.statusCode).toBe(200);
 
-      const row = listRes.json().identityMemberships.find((m) => m.identity.id === identity.id);
+      const { identityMemberships } = JSON.parse(listRes.payload) as TIdentityMembershipsResponse;
+      const row = identityMemberships.find((m) => m.identity.id === identity.id);
       expect(row).toBeDefined();
-      expect(row.identity.activeLockoutAuthMethods).toContain(IdentityAuthMethod.UNIVERSAL_AUTH);
-      expect(row.identity).not.toHaveProperty("universalAuthClientId");
+      expect(row?.identity.activeLockoutAuthMethods).toContain(IdentityAuthMethod.UNIVERSAL_AUTH);
+      expect(row?.identity).not.toHaveProperty("universalAuthClientId");
     } catch (err) {
       failure = err instanceof Error ? err : new Error(String(err));
     } finally {
@@ -95,7 +100,8 @@ describe("Project identity listing lockout indicators", async () => {
       headers: { authorization: `Bearer ${jwtAuthToken}` }
     });
     expect(listRes.statusCode).toBe(200);
-    listRes.json().identityMemberships.forEach((m) => {
+    const { identityMemberships } = JSON.parse(listRes.payload) as TIdentityMembershipsResponse;
+    identityMemberships.forEach((m) => {
       expect(m.identity.activeLockoutAuthMethods).toEqual([]);
     });
   });

--- a/backend/e2e-test/routes/v1/identity-lockout-listing.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-lockout-listing.spec.ts
@@ -3,65 +3,89 @@ import { seedData1 } from "@app/db/seed-data";
 
 describe("Project identity listing lockout indicators", async () => {
   test("reports an active universal auth lockout and hides the client id", async () => {
-    const createRes = await testServer.inject({
-      method: "POST",
-      url: "/api/v1/identities",
-      body: { name: "lockout-listing-mi", role: OrgMembershipRole.Admin, organizationId: seedData1.organization.id },
-      headers: { authorization: `Bearer ${jwtAuthToken}` }
-    });
-    expect(createRes.statusCode).toBe(200);
-    const { identity } = createRes.json();
+    let identityId: string | undefined;
+    let failure: Error | undefined;
 
-    const attachRes = await testServer.inject({
-      method: "POST",
-      url: `/api/v1/auth/universal-auth/identities/${identity.id}`,
-      body: { lockoutEnabled: true, lockoutThreshold: 3, lockoutDurationSeconds: 300 },
-      headers: { authorization: `Bearer ${jwtAuthToken}` }
-    });
-    expect(attachRes.statusCode).toBe(200);
-    const { clientId } = attachRes.json().identityUniversalAuth;
-
-    await testServer.inject({
-      method: "POST",
-      url: `/api/v1/projects/${seedData1.project.id}/memberships/identities/${identity.id}`,
-      body: { roles: [{ role: ProjectMembershipRole.Member }] },
-      headers: { authorization: `Bearer ${jwtAuthToken}` }
-    });
-
-    const secretRes = await testServer.inject({
-      method: "POST",
-      url: `/api/v1/auth/universal-auth/identities/${identity.id}/client-secrets`,
-      body: { description: "test" },
-      headers: { authorization: `Bearer ${jwtAuthToken}` }
-    });
-    expect(secretRes.statusCode).toBe(200);
-
-    for (let i = 0; i < 3; i += 1) {
-      // eslint-disable-next-line no-await-in-loop
-      await testServer.inject({
+    try {
+      const createRes = await testServer.inject({
         method: "POST",
-        url: "/api/v1/auth/universal-auth/login",
-        body: { clientId, clientSecret: "definitely-the-wrong-secret" }
+        url: "/api/v1/identities",
+        body: {
+          name: "lockout-listing-mi",
+          role: OrgMembershipRole.Admin,
+          organizationId: seedData1.organization.id
+        },
+        headers: { authorization: `Bearer ${jwtAuthToken}` }
       });
+      expect(createRes.statusCode).toBe(200);
+      const { identity } = createRes.json();
+      identityId = identity.id;
+
+      const attachRes = await testServer.inject({
+        method: "POST",
+        url: `/api/v1/auth/universal-auth/identities/${identity.id}`,
+        body: { lockoutEnabled: true, lockoutThreshold: 3, lockoutDurationSeconds: 300 },
+        headers: { authorization: `Bearer ${jwtAuthToken}` }
+      });
+      expect(attachRes.statusCode).toBe(200);
+      const { clientId } = attachRes.json().identityUniversalAuth;
+
+      const membershipRes = await testServer.inject({
+        method: "POST",
+        url: `/api/v1/projects/${seedData1.project.id}/memberships/identities/${identity.id}`,
+        body: { roles: [{ role: ProjectMembershipRole.Member }] },
+        headers: { authorization: `Bearer ${jwtAuthToken}` }
+      });
+      expect(membershipRes.statusCode).toBe(200);
+
+      const secretRes = await testServer.inject({
+        method: "POST",
+        url: `/api/v1/auth/universal-auth/identities/${identity.id}/client-secrets`,
+        body: { description: "test" },
+        headers: { authorization: `Bearer ${jwtAuthToken}` }
+      });
+      expect(secretRes.statusCode).toBe(200);
+
+      for (let i = 0; i < 3; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await testServer.inject({
+          method: "POST",
+          url: "/api/v1/auth/universal-auth/login",
+          body: { clientId, clientSecret: "definitely-the-wrong-secret" }
+        });
+      }
+
+      const listRes = await testServer.inject({
+        method: "GET",
+        url: `/api/v1/projects/${seedData1.project.id}/memberships/identities?limit=100`,
+        headers: { authorization: `Bearer ${jwtAuthToken}` }
+      });
+      expect(listRes.statusCode).toBe(200);
+
+      const row = listRes.json().identityMemberships.find((m) => m.identity.id === identity.id);
+      expect(row).toBeDefined();
+      expect(row.identity.activeLockoutAuthMethods).toContain(IdentityAuthMethod.UNIVERSAL_AUTH);
+      expect(row.identity).not.toHaveProperty("universalAuthClientId");
+    } catch (err) {
+      failure = err instanceof Error ? err : new Error(String(err));
+    } finally {
+      if (identityId) {
+        const deleteRes = await testServer.inject({
+          method: "DELETE",
+          url: `/api/v1/identities/${identityId}`,
+          headers: { authorization: `Bearer ${jwtAuthToken}` }
+        });
+        // Only report a cleanup failure when nothing else already failed, so it never
+        // masks the assertion this test exists to catch.
+        if (!failure && deleteRes.statusCode !== 200) {
+          failure = new Error(`cleanup DELETE /api/v1/identities/${identityId} returned ${deleteRes.statusCode}`);
+        }
+      }
     }
 
-    const listRes = await testServer.inject({
-      method: "GET",
-      url: `/api/v1/projects/${seedData1.project.id}/memberships/identities?limit=100`,
-      headers: { authorization: `Bearer ${jwtAuthToken}` }
-    });
-    expect(listRes.statusCode).toBe(200);
-
-    const row = listRes.json().identityMemberships.find((m) => m.identity.id === identity.id);
-    expect(row).toBeDefined();
-    expect(row.identity.activeLockoutAuthMethods).toContain(IdentityAuthMethod.UNIVERSAL_AUTH);
-    expect(row.identity).not.toHaveProperty("universalAuthClientId");
-
-    await testServer.inject({
-      method: "DELETE",
-      url: `/api/v1/identities/${identity.id}`,
-      headers: { authorization: `Bearer ${jwtAuthToken}` }
-    });
+    if (failure) {
+      throw failure;
+    }
   });
 
   test("reports no lockout for an identity that has never failed a login", async () => {
@@ -72,7 +96,7 @@ describe("Project identity listing lockout indicators", async () => {
     });
     expect(listRes.statusCode).toBe(200);
     listRes.json().identityMemberships.forEach((m) => {
-      expect(Array.isArray(m.identity.activeLockoutAuthMethods)).toBe(true);
+      expect(m.identity.activeLockoutAuthMethods).toEqual([]);
     });
   });
 });

--- a/backend/e2e-test/routes/v1/identity-lockout-listing.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-lockout-listing.spec.ts
@@ -1,0 +1,78 @@
+import { IdentityAuthMethod, OrgMembershipRole, ProjectMembershipRole } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+
+describe("Project identity listing lockout indicators", async () => {
+  test("reports an active universal auth lockout and hides the client id", async () => {
+    const createRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/identities",
+      body: { name: "lockout-listing-mi", role: OrgMembershipRole.Admin, organizationId: seedData1.organization.id },
+      headers: { authorization: `Bearer ${jwtAuthToken}` }
+    });
+    expect(createRes.statusCode).toBe(200);
+    const { identity } = createRes.json();
+
+    const attachRes = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/auth/universal-auth/identities/${identity.id}`,
+      body: { lockoutEnabled: true, lockoutThreshold: 3, lockoutDurationSeconds: 300 },
+      headers: { authorization: `Bearer ${jwtAuthToken}` }
+    });
+    expect(attachRes.statusCode).toBe(200);
+    const { clientId } = attachRes.json().identityUniversalAuth;
+
+    await testServer.inject({
+      method: "POST",
+      url: `/api/v1/projects/${seedData1.project.id}/memberships/identities/${identity.id}`,
+      body: { roles: [{ role: ProjectMembershipRole.Member }] },
+      headers: { authorization: `Bearer ${jwtAuthToken}` }
+    });
+
+    const secretRes = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/auth/universal-auth/identities/${identity.id}/client-secrets`,
+      body: { description: "test" },
+      headers: { authorization: `Bearer ${jwtAuthToken}` }
+    });
+    expect(secretRes.statusCode).toBe(200);
+
+    for (let i = 0; i < 3; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await testServer.inject({
+        method: "POST",
+        url: "/api/v1/auth/universal-auth/login",
+        body: { clientId, clientSecret: "definitely-the-wrong-secret" }
+      });
+    }
+
+    const listRes = await testServer.inject({
+      method: "GET",
+      url: `/api/v1/projects/${seedData1.project.id}/memberships/identities?limit=100`,
+      headers: { authorization: `Bearer ${jwtAuthToken}` }
+    });
+    expect(listRes.statusCode).toBe(200);
+
+    const row = listRes.json().identityMemberships.find((m) => m.identity.id === identity.id);
+    expect(row).toBeDefined();
+    expect(row.identity.activeLockoutAuthMethods).toContain(IdentityAuthMethod.UNIVERSAL_AUTH);
+    expect(row.identity).not.toHaveProperty("universalAuthClientId");
+
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/identities/${identity.id}`,
+      headers: { authorization: `Bearer ${jwtAuthToken}` }
+    });
+  });
+
+  test("reports no lockout for an identity that has never failed a login", async () => {
+    const listRes = await testServer.inject({
+      method: "GET",
+      url: `/api/v1/projects/${seedData1.project.id}/memberships/identities?limit=100`,
+      headers: { authorization: `Bearer ${jwtAuthToken}` }
+    });
+    expect(listRes.statusCode).toBe(200);
+    listRes.json().identityMemberships.forEach((m) => {
+      expect(Array.isArray(m.identity.activeLockoutAuthMethods)).toBe(true);
+    });
+  });
+});

--- a/backend/e2e-test/routes/v1/identity-lockout-listing.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-lockout-listing.spec.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { IdentityAuthMethod, OrgMembershipRole, ProjectMembershipRole } from "@app/db/schemas";
 import { seedData1 } from "@app/db/seed-data";
 
@@ -5,46 +7,78 @@ type TIdentityMembershipsResponse = {
   identityMemberships: { identity: { id: string; activeLockoutAuthMethods: string[] } }[];
 };
 
+type TIdentityMembershipResponse = {
+  identity: { identity: { id: string; activeLockoutAuthMethods: string[] } };
+};
+
+// The seeded project is shared with every other spec in the suite, and the suite runs in path
+// order on one database. Both tests here therefore create their own identity and read it back by
+// name, so neither can be reddened by an identity another spec left behind, and neither can pass
+// by asserting over an empty page.
+const createProjectIdentityWithUniversalAuth = async (name: string) => {
+  const createRes = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/identities",
+    body: {
+      name,
+      role: OrgMembershipRole.Admin,
+      organizationId: seedData1.organization.id
+    },
+    headers: { authorization: `Bearer ${jwtAuthToken}` }
+  });
+  expect(createRes.statusCode).toBe(200);
+  const { identity } = createRes.json();
+
+  const attachRes = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/auth/universal-auth/identities/${identity.id}`,
+    body: { lockoutEnabled: true, lockoutThreshold: 3, lockoutDurationSeconds: 300 },
+    headers: { authorization: `Bearer ${jwtAuthToken}` }
+  });
+  expect(attachRes.statusCode).toBe(200);
+
+  const membershipRes = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/projects/${seedData1.project.id}/memberships/identities/${identity.id}`,
+    body: { roles: [{ role: ProjectMembershipRole.Member }] },
+    headers: { authorization: `Bearer ${jwtAuthToken}` }
+  });
+  expect(membershipRes.statusCode).toBe(200);
+
+  return { identityId: identity.id as string, clientId: attachRes.json().identityUniversalAuth.clientId as string };
+};
+
+const deleteIdentity = (identityId: string) =>
+  testServer.inject({
+    method: "DELETE",
+    url: `/api/v1/identities/${identityId}`,
+    headers: { authorization: `Bearer ${jwtAuthToken}` }
+  });
+
+const findListedIdentity = async (identityName: string, identityId: string) => {
+  const listRes = await testServer.inject({
+    method: "GET",
+    url: `/api/v1/projects/${seedData1.project.id}/memberships/identities?identityName=${identityName}`,
+    headers: { authorization: `Bearer ${jwtAuthToken}` }
+  });
+  expect(listRes.statusCode).toBe(200);
+  const { identityMemberships } = JSON.parse(listRes.payload) as TIdentityMembershipsResponse;
+  return identityMemberships.find((m) => m.identity.id === identityId);
+};
+
 describe("Project identity listing lockout indicators", async () => {
   test("reports an active universal auth lockout and hides the client id", async () => {
+    const identityName = `lockout-listing-locked-${randomUUID().slice(0, 8)}`;
     let identityId: string | undefined;
     let failure: Error | undefined;
 
     try {
-      const createRes = await testServer.inject({
-        method: "POST",
-        url: "/api/v1/identities",
-        body: {
-          name: "lockout-listing-mi",
-          role: OrgMembershipRole.Admin,
-          organizationId: seedData1.organization.id
-        },
-        headers: { authorization: `Bearer ${jwtAuthToken}` }
-      });
-      expect(createRes.statusCode).toBe(200);
-      const { identity } = createRes.json();
-      identityId = identity.id;
-
-      const attachRes = await testServer.inject({
-        method: "POST",
-        url: `/api/v1/auth/universal-auth/identities/${identity.id}`,
-        body: { lockoutEnabled: true, lockoutThreshold: 3, lockoutDurationSeconds: 300 },
-        headers: { authorization: `Bearer ${jwtAuthToken}` }
-      });
-      expect(attachRes.statusCode).toBe(200);
-      const { clientId } = attachRes.json().identityUniversalAuth;
-
-      const membershipRes = await testServer.inject({
-        method: "POST",
-        url: `/api/v1/projects/${seedData1.project.id}/memberships/identities/${identity.id}`,
-        body: { roles: [{ role: ProjectMembershipRole.Member }] },
-        headers: { authorization: `Bearer ${jwtAuthToken}` }
-      });
-      expect(membershipRes.statusCode).toBe(200);
+      const created = await createProjectIdentityWithUniversalAuth(identityName);
+      identityId = created.identityId;
 
       const secretRes = await testServer.inject({
         method: "POST",
-        url: `/api/v1/auth/universal-auth/identities/${identity.id}/client-secrets`,
+        url: `/api/v1/auth/universal-auth/identities/${identityId}/client-secrets`,
         body: { description: "test" },
         headers: { authorization: `Bearer ${jwtAuthToken}` }
       });
@@ -55,31 +89,31 @@ describe("Project identity listing lockout indicators", async () => {
         await testServer.inject({
           method: "POST",
           url: "/api/v1/auth/universal-auth/login",
-          body: { clientId, clientSecret: "definitely-the-wrong-secret" }
+          body: { clientId: created.clientId, clientSecret: "definitely-the-wrong-secret" }
         });
       }
 
-      const listRes = await testServer.inject({
-        method: "GET",
-        url: `/api/v1/projects/${seedData1.project.id}/memberships/identities?limit=100`,
-        headers: { authorization: `Bearer ${jwtAuthToken}` }
-      });
-      expect(listRes.statusCode).toBe(200);
-
-      const { identityMemberships } = JSON.parse(listRes.payload) as TIdentityMembershipsResponse;
-      const row = identityMemberships.find((m) => m.identity.id === identity.id);
+      const row = await findListedIdentity(identityName, identityId);
       expect(row).toBeDefined();
       expect(row?.identity.activeLockoutAuthMethods).toContain(IdentityAuthMethod.UNIVERSAL_AUTH);
       expect(row?.identity).not.toHaveProperty("universalAuthClientId");
+
+      // The org detail route resolves the same lockout by exact key off the same new column, so it
+      // has to agree with the list and must not serialise the client id either.
+      const detailRes = await testServer.inject({
+        method: "GET",
+        url: `/api/v1/identities/${identityId}`,
+        headers: { authorization: `Bearer ${jwtAuthToken}` }
+      });
+      expect(detailRes.statusCode).toBe(200);
+      const detail = (JSON.parse(detailRes.payload) as TIdentityMembershipResponse).identity.identity;
+      expect(detail.activeLockoutAuthMethods).toContain(IdentityAuthMethod.UNIVERSAL_AUTH);
+      expect(detail).not.toHaveProperty("universalAuthClientId");
     } catch (err) {
       failure = err instanceof Error ? err : new Error(String(err));
     } finally {
       if (identityId) {
-        const deleteRes = await testServer.inject({
-          method: "DELETE",
-          url: `/api/v1/identities/${identityId}`,
-          headers: { authorization: `Bearer ${jwtAuthToken}` }
-        });
+        const deleteRes = await deleteIdentity(identityId);
         // Only report a cleanup failure when nothing else already failed, so it never
         // masks the assertion this test exists to catch.
         if (!failure && deleteRes.statusCode !== 200) {
@@ -94,15 +128,30 @@ describe("Project identity listing lockout indicators", async () => {
   });
 
   test("reports no lockout for an identity that has never failed a login", async () => {
-    const listRes = await testServer.inject({
-      method: "GET",
-      url: `/api/v1/projects/${seedData1.project.id}/memberships/identities?limit=100`,
-      headers: { authorization: `Bearer ${jwtAuthToken}` }
-    });
-    expect(listRes.statusCode).toBe(200);
-    const { identityMemberships } = JSON.parse(listRes.payload) as TIdentityMembershipsResponse;
-    identityMemberships.forEach((m) => {
-      expect(m.identity.activeLockoutAuthMethods).toEqual([]);
-    });
+    const identityName = `lockout-listing-clean-${randomUUID().slice(0, 8)}`;
+    let identityId: string | undefined;
+    let failure: Error | undefined;
+
+    try {
+      const created = await createProjectIdentityWithUniversalAuth(identityName);
+      identityId = created.identityId;
+
+      const row = await findListedIdentity(identityName, identityId);
+      expect(row).toBeDefined();
+      expect(row?.identity.activeLockoutAuthMethods).toEqual([]);
+    } catch (err) {
+      failure = err instanceof Error ? err : new Error(String(err));
+    } finally {
+      if (identityId) {
+        const deleteRes = await deleteIdentity(identityId);
+        if (!failure && deleteRes.statusCode !== 200) {
+          failure = new Error(`cleanup DELETE /api/v1/identities/${identityId} returned ${deleteRes.statusCode}`);
+        }
+      }
+    }
+
+    if (failure) {
+      throw failure;
+    }
   });
 });

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -1,5 +1,4 @@
-import type { Cluster } from "ioredis";
-import { Redis } from "ioredis";
+import { Cluster, Redis } from "ioredis";
 import { Knex } from "knex";
 
 import { buildRedisFromConfig, TRedisConfigKeys } from "@app/lib/config/redis";
@@ -345,10 +344,18 @@ export const keyStoreFactory = (
 
   const getItemPrimary = async (key: string, prefix?: string) => primaryRedis.get(prefix ? `${prefix}:${key}` : key);
 
-  const getItems = async (keys: string[], prefix?: string) =>
-    pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas).mget(
-      keys.map((key) => (prefix ? `${prefix}:${key}` : key))
-    );
+  const getItems = async (keys: string[], prefix?: string) => {
+    const redis = pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas);
+    const prefixedKeys = keys.map((key) => (prefix ? `${prefix}:${key}` : key));
+
+    // Cluster rejects an MGET whose keys span hash slots, and callers key by tenant or resource id
+    // rather than hash tag, so most batches here do span slots. Reading each key separately lets
+    // Cluster route them independently: N commands, but still pipelined over the per-node
+    // connections rather than N round trips, and the caller gets one batch API on both topologies.
+    if (redis instanceof Cluster) return Promise.all(prefixedKeys.map((key) => redis.get(key)));
+
+    return redis.mget(prefixedKeys);
+  };
 
   const setItemWithExpiry = async (
     key: string,

--- a/backend/src/server/routes/v1/identity-org-membership-router.ts
+++ b/backend/src/server/routes/v1/identity-org-membership-router.ts
@@ -324,7 +324,8 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
                 projectId: true
               }).extend({
                 authMethods: z.array(z.string()),
-                activeLockoutAuthMethods: z.array(z.string())
+                activeLockoutAuthMethods: z.array(z.string()),
+                lockoutStateUnavailable: z.boolean().optional()
               })
             })
             .array(),

--- a/backend/src/server/routes/v1/identity-project-membership-router.ts
+++ b/backend/src/server/routes/v1/identity-project-membership-router.ts
@@ -337,7 +337,8 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
                 projectId: true
               }).extend({
                 authMethods: z.array(z.string()),
-                activeLockoutAuthMethods: z.array(z.string())
+                activeLockoutAuthMethods: z.array(z.string()),
+                lockoutStateUnavailable: z.boolean().optional()
               })
             })
             .array(),

--- a/backend/src/server/routes/v1/identity-router.ts
+++ b/backend/src/server/routes/v1/identity-router.ts
@@ -290,7 +290,8 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
             }).optional(),
             identity: IdentitiesSchema.pick({ name: true, id: true, hasDeleteProtection: true, orgId: true }).extend({
               authMethods: z.array(z.string()),
-              activeLockoutAuthMethods: z.array(z.string())
+              activeLockoutAuthMethods: z.array(z.string()),
+              lockoutStateUnavailable: z.boolean().optional()
             })
           })
         })
@@ -436,7 +437,8 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
             }).optional(),
             identity: IdentitiesSchema.pick({ name: true, id: true, hasDeleteProtection: true, orgId: true }).extend({
               authMethods: z.array(z.string()),
-              activeLockoutAuthMethods: z.array(z.string())
+              activeLockoutAuthMethods: z.array(z.string()),
+              lockoutStateUnavailable: z.boolean().optional()
             })
           }).array(),
           totalCount: z.number()

--- a/backend/src/server/routes/v1/project-identity-router.ts
+++ b/backend/src/server/routes/v1/project-identity-router.ts
@@ -23,6 +23,7 @@ const sanitizedIdentitySchema = IdentitiesSchema.pick({
   hasDeleteProtection: true
 }).extend({
   activeLockoutAuthMethods: z.string().array().optional(),
+  lockoutStateUnavailable: z.boolean().optional(),
   authMethods: z.string().array().optional(),
   metadata: z
     .object({

--- a/backend/src/server/routes/v2/identity-router.ts
+++ b/backend/src/server/routes/v2/identity-router.ts
@@ -54,7 +54,8 @@ const identityMembershipResponseSchema = z.object({
   roles: z.array(roleSchema),
   identity: IdentitiesSchema.pick({ name: true, id: true, hasDeleteProtection: true, orgId: true }).extend({
     authMethods: z.array(z.string()),
-    activeLockoutAuthMethods: z.array(z.string())
+    activeLockoutAuthMethods: z.array(z.string()),
+    lockoutStateUnavailable: z.boolean().optional()
   })
 });
 

--- a/backend/src/services/identity-v2/identity-dal.ts
+++ b/backend/src/services/identity-v2/identity-dal.ts
@@ -60,6 +60,7 @@ export const identityV2DALFactory = (db: TDbClient) => {
         db.ref("key").withSchema(TableName.IdentityMetadata).as("metadataKey"),
         db.ref("value").withSchema(TableName.IdentityMetadata).as("metadataValue"),
         db.ref("id").as("uaId").withSchema(TableName.IdentityUniversalAuth),
+        db.ref("clientId").as("uaClientId").withSchema(TableName.IdentityUniversalAuth),
         db.ref("id").as("gcpId").withSchema(TableName.IdentityGcpAuth),
         db.ref("id").as("alicloudId").withSchema(TableName.IdentityAliCloudAuth),
         db.ref("id").as("awsId").withSchema(TableName.IdentityAwsAuth),
@@ -82,6 +83,7 @@ export const identityV2DALFactory = (db: TDbClient) => {
       parentMapper: (el) => {
         const {
           uaId,
+          uaClientId,
           awsId,
           gcpId,
           kubernetesId,
@@ -97,6 +99,7 @@ export const identityV2DALFactory = (db: TDbClient) => {
         } = el;
         return {
           ...IdentitiesSchema.parse(el),
+          universalAuthClientId: uaClientId,
           authMethods: buildAuthMethods({
             uaId,
             awsId,

--- a/backend/src/services/identity-v2/identity-membership-dal.ts
+++ b/backend/src/services/identity-v2/identity-membership-dal.ts
@@ -263,6 +263,7 @@ export const identityMembershipV2DALFactory = (db: TDbClient) => {
           db.ref("type").as("projectType").withSchema(TableName.Project),
 
           db.ref("id").as("uaId").withSchema(TableName.IdentityUniversalAuth),
+          db.ref("clientId").as("uaClientId").withSchema(TableName.IdentityUniversalAuth),
           db.ref("id").as("gcpId").withSchema(TableName.IdentityGcpAuth),
           db.ref("id").as("alicloudId").withSchema(TableName.IdentityAliCloudAuth),
           db.ref("id").as("awsId").withSchema(TableName.IdentityAwsAuth),
@@ -322,6 +323,7 @@ export const identityMembershipV2DALFactory = (db: TDbClient) => {
           projectSlug,
           projectType,
           uaId,
+          uaClientId,
           alicloudId,
           awsId,
           gcpId,
@@ -362,6 +364,7 @@ export const identityMembershipV2DALFactory = (db: TDbClient) => {
             name: identityName,
             hasDeleteProtection,
             orgId: identityOrgId,
+            universalAuthClientId: uaClientId,
             authMethods: buildAuthMethods({
               uaId,
               alicloudId,

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -39,7 +39,7 @@ import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TRoleDALFactory } from "@app/services/role/role-dal";
 
 import { ActorType } from "../auth/auth-type";
-import { getIdentityActiveLockoutAuthMethods } from "../identity/identity-fns";
+import { getActiveLockoutAuthMethodsForIdentities, TIdentityLockoutLookup } from "../identity/identity-fns";
 import { TIdentityMetadataDALFactory } from "../identity/identity-metadata-dal";
 import { TIdentityAccessTokenServiceFactory } from "../identity-access-token/identity-access-token-service";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
@@ -72,7 +72,7 @@ type TScopedIdentityV2ServiceFactoryDep = {
     TIdentityAccessTokenServiceFactory,
     "insertIdentityWideRevocationMarker" | "bumpIdentityRevocationVersion"
   >;
-  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem" | "getItems">;
   projectDAL: Pick<TProjectDALFactory, "findActorAccessibleProjectIds" | "findOrgProjectIds" | "findById">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   roleDAL: Pick<TRoleDALFactory, "find">;
@@ -422,9 +422,18 @@ export const identityV2ServiceFactory = ({
     const identity = await identityDAL.getIdentityById(dto.scopeData, dto.selector.identityId);
     if (!identity) throw new NotFoundError({ message: `Identity with id ${dto.selector.identityId} not found` });
 
-    const activeLockoutAuthMethods = await getIdentityActiveLockoutAuthMethods(identity.id, keyStore);
+    const { lockoutsByIdentityId, unreadableIdentityIds } = await getActiveLockoutAuthMethodsForIdentities(
+      [identity],
+      keyStore
+    );
 
-    return { identity: { ...identity, activeLockoutAuthMethods } };
+    return {
+      identity: {
+        ...identity,
+        activeLockoutAuthMethods: lockoutsByIdentityId[identity.id] ?? [],
+        lockoutStateUnavailable: unreadableIdentityIds.has(identity.id)
+      }
+    };
   };
 
   const listIdentities = async (dto: TListIdentityV2DTO) => {
@@ -566,16 +575,20 @@ export const identityV2ServiceFactory = ({
       return { identityMemberships: [], totalCount: 0 };
     }
 
-    const enrichWithLockouts = async <T extends { identity: { id: string } }>(rows: T[]) =>
-      Promise.all(
-        rows.map(async (row) => ({
-          ...row,
-          identity: {
-            ...row.identity,
-            activeLockoutAuthMethods: await getIdentityActiveLockoutAuthMethods(row.identity.id, keyStore)
-          }
-        }))
+    const enrichWithLockouts = async <T extends { identity: TIdentityLockoutLookup }>(rows: T[]) => {
+      const { lockoutsByIdentityId, unreadableIdentityIds } = await getActiveLockoutAuthMethodsForIdentities(
+        rows.map((row) => row.identity),
+        keyStore
       );
+      return rows.map((row) => ({
+        ...row,
+        identity: {
+          ...row.identity,
+          activeLockoutAuthMethods: lockoutsByIdentityId[row.identity.id] ?? [],
+          lockoutStateUnavailable: unreadableIdentityIds.has(row.identity.id)
+        }
+      }));
+    };
 
     if (conditionalProjectIds.size === 0) {
       const { totalCount, docs } = await identityMembershipV2DAL.searchIdentitiesV2({

--- a/backend/src/services/identity/identity-fns.test.ts
+++ b/backend/src/services/identity/identity-fns.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, type Mocked, test, vi } from "vitest";
+
+import { IdentityAuthMethod } from "@app/db/schemas";
+import { TKeyStoreFactory } from "@app/keystore/keystore";
+
+import { getActiveLockoutAuthMethodsForIdentities } from "./identity-fns";
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+type KeyStoreSlice = Pick<TKeyStoreFactory, "getItem" | "getItems" | "getKeysByPattern">;
+
+const makeKeyStore = (patch: Partial<Mocked<KeyStoreSlice>> = {}): Mocked<KeyStoreSlice> =>
+  ({
+    getItem: vi.fn().mockResolvedValue(null),
+    getItems: vi.fn().mockResolvedValue([]),
+    getKeysByPattern: vi.fn().mockResolvedValue([]),
+    ...patch
+  }) as Mocked<KeyStoreSlice>;
+
+const lockedValue = JSON.stringify({ lockedOut: true, failedAttempts: 3 });
+const countingValue = JSON.stringify({ lockedOut: false, failedAttempts: 1 });
+
+describe("getActiveLockoutAuthMethodsForIdentities", () => {
+  test("returns nothing and touches Redis zero times for an empty page", async () => {
+    const keyStore = makeKeyStore();
+    const result = await getActiveLockoutAuthMethodsForIdentities([], keyStore as never);
+    expect(result).toEqual({});
+    expect(keyStore.getItems).not.toHaveBeenCalled();
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+  });
+
+  test("does no Redis work for identities whose auth methods cannot lock out", async () => {
+    const keyStore = makeKeyStore();
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.KUBERNETES_AUTH], universalAuthClientId: null }],
+      keyStore as never
+    );
+    expect(result).toEqual({});
+    expect(keyStore.getItems).not.toHaveBeenCalled();
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+  });
+
+  test("reads universal auth lockout by exact key and reports it", async () => {
+    const keyStore = makeKeyStore({ getItems: vi.fn().mockResolvedValue([lockedValue]) });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
+      keyStore as never
+    );
+    expect(keyStore.getItems).toHaveBeenCalledWith(["lockout:identity:i1:universal-auth:client-1"]);
+    expect(result).toEqual({ i1: [IdentityAuthMethod.UNIVERSAL_AUTH] });
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+  });
+
+  test("does not report a record that is only counting failures", async () => {
+    const keyStore = makeKeyStore({ getItems: vi.fn().mockResolvedValue([countingValue]) });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
+      keyStore as never
+    );
+    expect(result).toEqual({});
+  });
+
+  test("resolves a full page of universal auth identities in a single MGET", async () => {
+    const identities = Array.from({ length: 20 }, (_, i) => ({
+      id: `i${i}`,
+      authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH],
+      universalAuthClientId: `client-${i}`
+    }));
+    const keyStore = makeKeyStore({
+      getItems: vi.fn().mockResolvedValue(new Array(20).fill(null) as (string | null)[])
+    });
+    await getActiveLockoutAuthMethodsForIdentities(identities, keyStore as never);
+    expect(keyStore.getItems).toHaveBeenCalledTimes(1);
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+  });
+
+  test("falls back to a pattern scan for LDAP, whose slug is not derivable", async () => {
+    const keyStore = makeKeyStore({
+      getKeysByPattern: vi.fn().mockResolvedValue(["lockout:identity:i1:ldap-auth:alice"]),
+      getItem: vi.fn().mockResolvedValue(lockedValue)
+    });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.LDAP_AUTH], universalAuthClientId: null }],
+      keyStore as never
+    );
+    expect(keyStore.getKeysByPattern).toHaveBeenCalledWith("lockout:identity:i1:*");
+    expect(result).toEqual({ i1: [IdentityAuthMethod.LDAP_AUTH] });
+  });
+
+  test("falls back to a scan when a universal auth identity has no client id", async () => {
+    const keyStore = makeKeyStore({
+      getKeysByPattern: vi.fn().mockResolvedValue(["lockout:identity:i1:universal-auth:client-1"]),
+      getItem: vi.fn().mockResolvedValue(lockedValue)
+    });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: null }],
+      keyStore as never
+    );
+    expect(keyStore.getItems).not.toHaveBeenCalled();
+    expect(result).toEqual({ i1: [IdentityAuthMethod.UNIVERSAL_AUTH] });
+  });
+
+  test("reports both methods when an identity is locked out on each", async () => {
+    const keyStore = makeKeyStore({
+      getItems: vi.fn().mockResolvedValue([lockedValue]),
+      getKeysByPattern: vi.fn().mockResolvedValue(["lockout:identity:i1:ldap-auth:alice"]),
+      getItem: vi.fn().mockResolvedValue(lockedValue)
+    });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [
+        {
+          id: "i1",
+          authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH, IdentityAuthMethod.LDAP_AUTH],
+          universalAuthClientId: "client-1"
+        }
+      ],
+      keyStore as never
+    );
+    expect(result.i1).toEqual(
+      expect.arrayContaining([IdentityAuthMethod.UNIVERSAL_AUTH, IdentityAuthMethod.LDAP_AUTH])
+    );
+    expect(result.i1).toHaveLength(2);
+  });
+
+  test("treats a malformed stored value as not locked out", async () => {
+    const keyStore = makeKeyStore({ getItems: vi.fn().mockResolvedValue(["not json"]) });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
+      keyStore as never
+    );
+    expect(result).toEqual({});
+  });
+
+  test("fails open when Redis errors rather than failing the page", async () => {
+    const keyStore = makeKeyStore({
+      getItems: vi.fn().mockRejectedValue(new Error("redis unavailable"))
+    });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
+      keyStore as never
+    );
+    expect(result).toEqual({});
+  });
+});

--- a/backend/src/services/identity/identity-fns.test.ts
+++ b/backend/src/services/identity/identity-fns.test.ts
@@ -26,7 +26,8 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
   test("returns nothing and touches Redis zero times for an empty page", async () => {
     const keyStore = makeKeyStore();
     const result = await getActiveLockoutAuthMethodsForIdentities([], keyStore as never);
-    expect(result).toEqual({});
+    expect(result.lockoutsByIdentityId).toEqual({});
+    expect(result.unreadableIdentityIds.size).toBe(0);
     expect(keyStore.getItems).not.toHaveBeenCalled();
     expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
   });
@@ -37,7 +38,7 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       [{ id: "i1", authMethods: [IdentityAuthMethod.KUBERNETES_AUTH], universalAuthClientId: null }],
       keyStore as never
     );
-    expect(result).toEqual({});
+    expect(result.lockoutsByIdentityId).toEqual({});
     expect(keyStore.getItems).not.toHaveBeenCalled();
     expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
   });
@@ -49,7 +50,7 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       keyStore as never
     );
     expect(keyStore.getItems).toHaveBeenCalledWith(["lockout:identity:i1:universal-auth:client-1"]);
-    expect(result).toEqual({ i1: [IdentityAuthMethod.UNIVERSAL_AUTH] });
+    expect(result.lockoutsByIdentityId).toEqual({ i1: [IdentityAuthMethod.UNIVERSAL_AUTH] });
     expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
   });
 
@@ -59,10 +60,10 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
       keyStore as never
     );
-    expect(result).toEqual({});
+    expect(result.lockoutsByIdentityId).toEqual({});
   });
 
-  test("resolves a full page of universal auth identities in a single MGET", async () => {
+  test("resolves a full page of universal auth identities in a single batched read", async () => {
     const identities = Array.from({ length: 20 }, (_, i) => ({
       id: `i${i}`,
       authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH],
@@ -86,7 +87,7 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       keyStore as never
     );
     expect(keyStore.getKeysByPattern).toHaveBeenCalledWith("lockout:identity:i1:*");
-    expect(result).toEqual({ i1: [IdentityAuthMethod.LDAP_AUTH] });
+    expect(result.lockoutsByIdentityId).toEqual({ i1: [IdentityAuthMethod.LDAP_AUTH] });
   });
 
   test("falls back to a scan when a universal auth identity has no client id", async () => {
@@ -99,7 +100,7 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       keyStore as never
     );
     expect(keyStore.getItems).not.toHaveBeenCalled();
-    expect(result).toEqual({ i1: [IdentityAuthMethod.UNIVERSAL_AUTH] });
+    expect(result.lockoutsByIdentityId).toEqual({ i1: [IdentityAuthMethod.UNIVERSAL_AUTH] });
   });
 
   test("reports both methods when an identity is locked out on each", async () => {
@@ -118,10 +119,10 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       ],
       keyStore as never
     );
-    expect(result.i1).toEqual(
+    expect(result.lockoutsByIdentityId.i1).toEqual(
       expect.arrayContaining([IdentityAuthMethod.UNIVERSAL_AUTH, IdentityAuthMethod.LDAP_AUTH])
     );
-    expect(result.i1).toHaveLength(2);
+    expect(result.lockoutsByIdentityId.i1).toHaveLength(2);
   });
 
   test("treats a malformed stored value as not locked out", async () => {
@@ -130,31 +131,47 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
       keyStore as never
     );
-    expect(result).toEqual({});
+    expect(result.lockoutsByIdentityId).toEqual({});
   });
 
-  test("fails open when Redis errors rather than failing the page", async () => {
+  test("reports the batch as unreadable rather than clean when the exact-key read errors", async () => {
     const keyStore = makeKeyStore({
       getItems: vi.fn().mockRejectedValue(new Error("redis unavailable"))
     });
     const result = await getActiveLockoutAuthMethodsForIdentities(
-      [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
+      [
+        { id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" },
+        { id: "i2", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-2" }
+      ],
       keyStore as never
     );
-    expect(result).toEqual({});
+    expect(result.lockoutsByIdentityId).toEqual({});
+    // One batched read covers the page, so a failure leaves every identity in it unknown.
+    expect([...result.unreadableIdentityIds]).toEqual(["i1", "i2"]);
   });
 
-  test("retries as single-key reads when a clustered batch read is rejected cross-slot", async () => {
+  test("reports only the scanned identity as unreadable when its pattern lookup errors", async () => {
     const keyStore = makeKeyStore({
-      getItems: vi.fn().mockRejectedValue(new Error("CROSSSLOT Keys in request don't hash to the same slot")),
-      getItem: vi.fn().mockResolvedValue(lockedValue)
+      getItems: vi.fn().mockResolvedValue([null]),
+      getKeysByPattern: vi.fn().mockRejectedValue(new Error("redis unavailable"))
     });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [
+        { id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" },
+        { id: "i2", authMethods: [IdentityAuthMethod.LDAP_AUTH], universalAuthClientId: null }
+      ],
+      keyStore as never
+    );
+    expect([...result.unreadableIdentityIds]).toEqual(["i2"]);
+  });
+
+  test("reports nothing unreadable when every lookup succeeds", async () => {
+    const keyStore = makeKeyStore({ getItems: vi.fn().mockResolvedValue([lockedValue]) });
     const result = await getActiveLockoutAuthMethodsForIdentities(
       [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
       keyStore as never
     );
-    expect(keyStore.getItem).toHaveBeenCalledWith("lockout:identity:i1:universal-auth:client-1");
-    expect(result).toEqual({ i1: [IdentityAuthMethod.UNIVERSAL_AUTH] });
+    expect(result.unreadableIdentityIds.size).toBe(0);
   });
 
   test("does not resurrect a universal auth lockout whose client id has since changed", async () => {
@@ -173,7 +190,7 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       ],
       keyStore as never
     );
-    expect(result).toEqual({});
+    expect(result.lockoutsByIdentityId).toEqual({});
   });
 
   test("does not report a lockout for an auth method the identity no longer holds", async () => {
@@ -185,6 +202,6 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
       [{ id: "i1", authMethods: [IdentityAuthMethod.LDAP_AUTH], universalAuthClientId: null }],
       keyStore as never
     );
-    expect(result).toEqual({});
+    expect(result.lockoutsByIdentityId).toEqual({});
   });
 });

--- a/backend/src/services/identity/identity-fns.test.ts
+++ b/backend/src/services/identity/identity-fns.test.ts
@@ -143,4 +143,48 @@ describe("getActiveLockoutAuthMethodsForIdentities", () => {
     );
     expect(result).toEqual({});
   });
+
+  test("retries as single-key reads when a clustered batch read is rejected cross-slot", async () => {
+    const keyStore = makeKeyStore({
+      getItems: vi.fn().mockRejectedValue(new Error("CROSSSLOT Keys in request don't hash to the same slot")),
+      getItem: vi.fn().mockResolvedValue(lockedValue)
+    });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH], universalAuthClientId: "client-1" }],
+      keyStore as never
+    );
+    expect(keyStore.getItem).toHaveBeenCalledWith("lockout:identity:i1:universal-auth:client-1");
+    expect(result).toEqual({ i1: [IdentityAuthMethod.UNIVERSAL_AUTH] });
+  });
+
+  test("does not resurrect a universal auth lockout whose client id has since changed", async () => {
+    const keyStore = makeKeyStore({
+      getItems: vi.fn().mockResolvedValue([null]),
+      getKeysByPattern: vi.fn().mockResolvedValue(["lockout:identity:i1:universal-auth:old-client"]),
+      getItem: vi.fn().mockResolvedValue(lockedValue)
+    });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [
+        {
+          id: "i1",
+          authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH, IdentityAuthMethod.LDAP_AUTH],
+          universalAuthClientId: "current-client"
+        }
+      ],
+      keyStore as never
+    );
+    expect(result).toEqual({});
+  });
+
+  test("does not report a lockout for an auth method the identity no longer holds", async () => {
+    const keyStore = makeKeyStore({
+      getKeysByPattern: vi.fn().mockResolvedValue(["lockout:identity:i1:universal-auth:stale-client"]),
+      getItem: vi.fn().mockResolvedValue(lockedValue)
+    });
+    const result = await getActiveLockoutAuthMethodsForIdentities(
+      [{ id: "i1", authMethods: [IdentityAuthMethod.LDAP_AUTH], universalAuthClientId: null }],
+      keyStore as never
+    );
+    expect(result).toEqual({});
+  });
 });

--- a/backend/src/services/identity/identity-fns.ts
+++ b/backend/src/services/identity/identity-fns.ts
@@ -64,6 +64,23 @@ const isLockedOut = (raw: string | null) => {
 const isExactlyResolvable = (el: TIdentityLockoutLookup, method: IdentityAuthMethod) =>
   method === IdentityAuthMethod.UNIVERSAL_AUTH && Boolean(el.universalAuthClientId);
 
+// A multi-key read is a single round trip on a single-node Redis, but Redis Cluster rejects one
+// whose keys span hash slots — and these keys are spread by identity id, so any page holding more
+// than one universal auth identity trips it. Retrying as concurrent single-key reads keeps
+// clustered deployments accurate, since Cluster routes each read independently: it costs N
+// commands but still one round trip of latency, against the N full keyspace scans this path
+// replaced. Hash-tagging the keys would avoid the retry entirely, but it would change the key
+// format the login path writes and orphan every lockout already held in Redis, so a properly
+// cluster-aware batched read is left to the Go rewrite.
+const readLockoutStates = async (keyStore: TLockoutKeyStore, keys: string[]) => {
+  try {
+    return await keyStore.getItems(keys);
+  } catch (err) {
+    if (!(err instanceof Error) || !err.message.includes("CROSSSLOT")) throw err;
+    return Promise.all(keys.map((key) => keyStore.getItem(key)));
+  }
+};
+
 export const getActiveLockoutAuthMethodsForIdentities = async (
   identities: TIdentityLockoutLookup[],
   keyStore: TLockoutKeyStore
@@ -92,7 +109,10 @@ export const getActiveLockoutAuthMethodsForIdentities = async (
 
   if (exactLookups.length) {
     try {
-      const values = await keyStore.getItems(exactLookups.map((el) => el.key));
+      const values = await readLockoutStates(
+        keyStore,
+        exactLookups.map((el) => el.key)
+      );
       values.forEach((raw, idx) => {
         if (isLockedOut(raw)) add(exactLookups[idx].identityId, IdentityAuthMethod.UNIVERSAL_AUTH);
       });
@@ -114,8 +134,18 @@ export const getActiveLockoutAuthMethodsForIdentities = async (
   await Promise.all(
     scanLookups.map(async (el) => {
       try {
+        // The scan matches every lockout key under this identity, including ones no longer
+        // reachable: a method since revoked, or a universal auth key from an earlier attach whose
+        // client id has changed. Reporting those resurrects badges for credentials that cannot be
+        // used, so keep only methods the identity still holds, and let the exact-key read above be
+        // the sole authority for the ones it resolves.
         const methods = await getIdentityActiveLockoutAuthMethods(el.id, keyStore);
-        methods.forEach((method) => add(el.id, method as IdentityAuthMethod));
+        methods.forEach((method) => {
+          const authMethod = method as IdentityAuthMethod;
+          if (el.authMethods.includes(authMethod) && !isExactlyResolvable(el, authMethod)) {
+            add(el.id, authMethod);
+          }
+        });
       } catch (err) {
         logger.error(err, `Failed to read lockout state, omitting lockout indicators [identityId=${el.id}]`);
       }

--- a/backend/src/services/identity/identity-fns.ts
+++ b/backend/src/services/identity/identity-fns.ts
@@ -1,5 +1,6 @@
 import { IdentityAuthMethod } from "@app/db/schemas";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
+import { logger } from "@app/lib/logger";
 
 export const getIdentityActiveLockoutAuthMethods = async (
   identityId: string,
@@ -22,6 +23,81 @@ export const getIdentityActiveLockoutAuthMethods = async (
   }
 
   return Array.from(activeLockoutAuthMethods);
+};
+
+export type TIdentityLockoutLookup = {
+  id: string;
+  authMethods: IdentityAuthMethod[];
+  universalAuthClientId?: string | null;
+};
+
+type TLockoutKeyStore = Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem" | "getItems">;
+
+const isLockedOut = (raw: string | null) => {
+  if (!raw) return false;
+  try {
+    return (JSON.parse(raw) as { lockedOut?: boolean }).lockedOut === true;
+  } catch {
+    return false;
+  }
+};
+
+export const getActiveLockoutAuthMethodsForIdentities = async (
+  identities: TIdentityLockoutLookup[],
+  keyStore: TLockoutKeyStore
+): Promise<Record<string, IdentityAuthMethod[]>> => {
+  const result: Record<string, IdentityAuthMethod[]> = {};
+  if (!identities.length) return result;
+
+  const add = (identityId: string, method: IdentityAuthMethod) => {
+    if (!result[identityId]) result[identityId] = [];
+    if (!result[identityId].includes(method)) result[identityId].push(method);
+  };
+
+  // Universal auth keys its lockout by client id, which the caller already has, so the
+  // whole page resolves in one MGET instead of a keyspace scan per row.
+  const exactLookups = identities
+    .filter((el) => el.authMethods.includes(IdentityAuthMethod.UNIVERSAL_AUTH) && el.universalAuthClientId)
+    .map((el) => ({
+      identityId: el.id,
+      key: KeyStorePrefixes.IdentityLockoutState(
+        el.id,
+        IdentityAuthMethod.UNIVERSAL_AUTH,
+        el.universalAuthClientId as string
+      )
+    }));
+
+  if (exactLookups.length) {
+    try {
+      const values = await keyStore.getItems(exactLookups.map((el) => el.key));
+      values.forEach((raw, idx) => {
+        if (isLockedOut(raw)) add(exactLookups[idx].identityId, IdentityAuthMethod.UNIVERSAL_AUTH);
+      });
+    } catch (err) {
+      logger.error(err, "Failed to read universal auth lockout state, omitting lockout indicators");
+    }
+  }
+
+  // LDAP keys its lockout by the submitted username, which lives in the customer's
+  // directory and is never persisted here, so those rows still need a pattern lookup.
+  const scanLookups = identities.filter(
+    (el) =>
+      el.authMethods.includes(IdentityAuthMethod.LDAP_AUTH) ||
+      (el.authMethods.includes(IdentityAuthMethod.UNIVERSAL_AUTH) && !el.universalAuthClientId)
+  );
+
+  await Promise.all(
+    scanLookups.map(async (el) => {
+      try {
+        const methods = await getIdentityActiveLockoutAuthMethods(el.id, keyStore);
+        methods.forEach((method) => add(el.id, method as IdentityAuthMethod));
+      } catch (err) {
+        logger.error(err, `Failed to read lockout state for identity ${el.id}, omitting lockout indicators`);
+      }
+    })
+  );
+
+  return result;
 };
 
 export const buildAuthMethods = ({

--- a/backend/src/services/identity/identity-fns.ts
+++ b/backend/src/services/identity/identity-fns.ts
@@ -33,6 +33,11 @@ export type TIdentityLockoutLookup = {
 
 type TLockoutKeyStore = Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem" | "getItems">;
 
+// Whatever writes a lockout key for one of these methods must stay resolvable by this reader.
+// Adding a method here without teaching `isExactlyResolvable` about it still returns correct
+// results, just via the scan fallback below rather than the batched exact-key path.
+export const LOCKOUT_CAPABLE_AUTH_METHODS = [IdentityAuthMethod.UNIVERSAL_AUTH, IdentityAuthMethod.LDAP_AUTH];
+
 const isLockedOut = (raw: string | null) => {
   if (!raw) return false;
   try {
@@ -41,6 +46,12 @@ const isLockedOut = (raw: string | null) => {
     return false;
   }
 };
+
+// Universal auth keys its lockout by client id, which the caller already has, so it is the only
+// lockout-capable method resolvable by exact key. Every other lockout-capable method falls
+// through to the pattern scan below.
+const isExactlyResolvable = (el: TIdentityLockoutLookup, method: IdentityAuthMethod) =>
+  method === IdentityAuthMethod.UNIVERSAL_AUTH && Boolean(el.universalAuthClientId);
 
 export const getActiveLockoutAuthMethodsForIdentities = async (
   identities: TIdentityLockoutLookup[],
@@ -54,10 +65,9 @@ export const getActiveLockoutAuthMethodsForIdentities = async (
     if (!result[identityId].includes(method)) result[identityId].push(method);
   };
 
-  // Universal auth keys its lockout by client id, which the caller already has, so the
-  // whole page resolves in one MGET instead of a keyspace scan per row.
+  // The whole page resolves in one MGET instead of a keyspace scan per row.
   const exactLookups = identities
-    .filter((el) => el.authMethods.includes(IdentityAuthMethod.UNIVERSAL_AUTH) && el.universalAuthClientId)
+    .filter((el) => el.authMethods.some((method) => isExactlyResolvable(el, method)))
     .map((el) => ({
       identityId: el.id,
       key: KeyStorePrefixes.IdentityLockoutState(
@@ -74,16 +84,18 @@ export const getActiveLockoutAuthMethodsForIdentities = async (
         if (isLockedOut(raw)) add(exactLookups[idx].identityId, IdentityAuthMethod.UNIVERSAL_AUTH);
       });
     } catch (err) {
-      logger.error(err, "Failed to read universal auth lockout state, omitting lockout indicators");
+      logger.error(
+        err,
+        `Failed to read universal auth lockout state, omitting lockout indicators [identityCount=${exactLookups.length}]`
+      );
     }
   }
 
-  // LDAP keys its lockout by the submitted username, which lives in the customer's
-  // directory and is never persisted here, so those rows still need a pattern lookup.
-  const scanLookups = identities.filter(
-    (el) =>
-      el.authMethods.includes(IdentityAuthMethod.LDAP_AUTH) ||
-      (el.authMethods.includes(IdentityAuthMethod.UNIVERSAL_AUTH) && !el.universalAuthClientId)
+  // LDAP keys its lockout by the submitted username, which lives in the customer's directory and
+  // is never persisted here, so it (and any other lockout-capable method not exactly resolvable
+  // above) still needs a pattern lookup.
+  const scanLookups = identities.filter((el) =>
+    el.authMethods.some((method) => LOCKOUT_CAPABLE_AUTH_METHODS.includes(method) && !isExactlyResolvable(el, method))
   );
 
   await Promise.all(
@@ -92,7 +104,7 @@ export const getActiveLockoutAuthMethodsForIdentities = async (
         const methods = await getIdentityActiveLockoutAuthMethods(el.id, keyStore);
         methods.forEach((method) => add(el.id, method as IdentityAuthMethod));
       } catch (err) {
-        logger.error(err, `Failed to read lockout state for identity ${el.id}, omitting lockout indicators`);
+        logger.error(err, `Failed to read lockout state, omitting lockout indicators [identityId=${el.id}]`);
       }
     })
   );

--- a/backend/src/services/identity/identity-fns.ts
+++ b/backend/src/services/identity/identity-fns.ts
@@ -25,6 +25,10 @@ export const getIdentityActiveLockoutAuthMethods = async (
   return Array.from(activeLockoutAuthMethods);
 };
 
+// The ingredients of a lockout key rather than the key itself, so callers that hold identity
+// rows never have to know the key format. `id` and `universalAuthClientId` are the first and
+// last segments of `lockout:identity:<id>:<authMethod>:<slug>`; `authMethods` is not part of
+// the format and instead selects which lookup strategy the identity gets below.
 export type TIdentityLockoutLookup = {
   id: string;
   authMethods: IdentityAuthMethod[];
@@ -50,6 +54,13 @@ const isLockedOut = (raw: string | null) => {
 // Universal auth keys its lockout by client id, which the caller already has, so it is the only
 // lockout-capable method resolvable by exact key. Every other lockout-capable method falls
 // through to the pattern scan below.
+//
+// That fallback is the expensive path, and it is worth removing rather than living with: every
+// scan walks the entire Redis keyspace, so a page of LDAP identities still costs one full sweep
+// per row and gets slower as the instance accumulates keys, hammering Redis and dragging out
+// page load. Making every method exactly resolvable — by persisting the slug each method keys
+// its lockout by, so the key can always be derived instead of discovered — would let the whole
+// page resolve in one batched read regardless of auth method, and retire the scan for good.
 const isExactlyResolvable = (el: TIdentityLockoutLookup, method: IdentityAuthMethod) =>
   method === IdentityAuthMethod.UNIVERSAL_AUTH && Boolean(el.universalAuthClientId);
 
@@ -60,6 +71,8 @@ export const getActiveLockoutAuthMethodsForIdentities = async (
   const result: Record<string, IdentityAuthMethod[]> = {};
   if (!identities.length) return result;
 
+  // Records that an identity is locked out on a method. Both lookup paths below can surface the
+  // same identity+method pair, so this deduplicates rather than letting callers push directly.
   const add = (identityId: string, method: IdentityAuthMethod) => {
     if (!result[identityId]) result[identityId] = [];
     if (!result[identityId].includes(method)) result[identityId].push(method);

--- a/backend/src/services/identity/identity-fns.ts
+++ b/backend/src/services/identity/identity-fns.ts
@@ -2,7 +2,9 @@ import { IdentityAuthMethod } from "@app/db/schemas";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { logger } from "@app/lib/logger";
 
-export const getIdentityActiveLockoutAuthMethods = async (
+// Only the scan fallback below reaches for this. Every caller that holds identity rows goes
+// through `getActiveLockoutAuthMethodsForIdentities`, which resolves a whole page at once.
+const getIdentityActiveLockoutAuthMethods = async (
   identityId: string,
   keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">
 ) => {
@@ -64,38 +66,30 @@ const isLockedOut = (raw: string | null) => {
 const isExactlyResolvable = (el: TIdentityLockoutLookup, method: IdentityAuthMethod) =>
   method === IdentityAuthMethod.UNIVERSAL_AUTH && Boolean(el.universalAuthClientId);
 
-// A multi-key read is a single round trip on a single-node Redis, but Redis Cluster rejects one
-// whose keys span hash slots — and these keys are spread by identity id, so any page holding more
-// than one universal auth identity trips it. Retrying as concurrent single-key reads keeps
-// clustered deployments accurate, since Cluster routes each read independently: it costs N
-// commands but still one round trip of latency, against the N full keyspace scans this path
-// replaced. Hash-tagging the keys would avoid the retry entirely, but it would change the key
-// format the login path writes and orphan every lockout already held in Redis, so a properly
-// cluster-aware batched read is left to the Go rewrite.
-const readLockoutStates = async (keyStore: TLockoutKeyStore, keys: string[]) => {
-  try {
-    return await keyStore.getItems(keys);
-  } catch (err) {
-    if (!(err instanceof Error) || !err.message.includes("CROSSSLOT")) throw err;
-    return Promise.all(keys.map((key) => keyStore.getItem(key)));
-  }
+// A lockout state that could not be read is not the same as "not locked out", and an empty method
+// array cannot say so. Callers surface `unreadableIdentityIds` separately so an admin looking at a
+// list during a Redis failure sees that the indicator is unavailable rather than a clean row.
+export type TIdentityLockoutStates = {
+  lockoutsByIdentityId: Record<string, IdentityAuthMethod[]>;
+  unreadableIdentityIds: Set<string>;
 };
 
 export const getActiveLockoutAuthMethodsForIdentities = async (
   identities: TIdentityLockoutLookup[],
   keyStore: TLockoutKeyStore
-): Promise<Record<string, IdentityAuthMethod[]>> => {
-  const result: Record<string, IdentityAuthMethod[]> = {};
-  if (!identities.length) return result;
+): Promise<TIdentityLockoutStates> => {
+  const lockoutsByIdentityId: Record<string, IdentityAuthMethod[]> = {};
+  const unreadableIdentityIds = new Set<string>();
+  if (!identities.length) return { lockoutsByIdentityId, unreadableIdentityIds };
 
   // Records that an identity is locked out on a method. Both lookup paths below can surface the
   // same identity+method pair, so this deduplicates rather than letting callers push directly.
   const add = (identityId: string, method: IdentityAuthMethod) => {
-    if (!result[identityId]) result[identityId] = [];
-    if (!result[identityId].includes(method)) result[identityId].push(method);
+    if (!lockoutsByIdentityId[identityId]) lockoutsByIdentityId[identityId] = [];
+    if (!lockoutsByIdentityId[identityId].includes(method)) lockoutsByIdentityId[identityId].push(method);
   };
 
-  // The whole page resolves in one MGET instead of a keyspace scan per row.
+  // The whole page resolves in one batched read instead of a keyspace scan per row.
   const exactLookups = identities
     .filter((el) => el.authMethods.some((method) => isExactlyResolvable(el, method)))
     .map((el) => ({
@@ -109,17 +103,18 @@ export const getActiveLockoutAuthMethodsForIdentities = async (
 
   if (exactLookups.length) {
     try {
-      const values = await readLockoutStates(
-        keyStore,
-        exactLookups.map((el) => el.key)
-      );
+      const values = await keyStore.getItems(exactLookups.map((el) => el.key));
       values.forEach((raw, idx) => {
         if (isLockedOut(raw)) add(exactLookups[idx].identityId, IdentityAuthMethod.UNIVERSAL_AUTH);
       });
     } catch (err) {
+      // One batched read covers every universal auth identity on the page, so a failure leaves all
+      // of them unknown at once. Reporting them keeps the page rendering while still telling the
+      // caller that these particular rows carry no verdict.
+      exactLookups.forEach((el) => unreadableIdentityIds.add(el.identityId));
       logger.error(
         err,
-        `Failed to read universal auth lockout state, omitting lockout indicators [identityCount=${exactLookups.length}]`
+        `Failed to read universal auth lockout state [identityIds=${exactLookups.map((el) => el.identityId).join(",")}]`
       );
     }
   }
@@ -147,12 +142,13 @@ export const getActiveLockoutAuthMethodsForIdentities = async (
           }
         });
       } catch (err) {
-        logger.error(err, `Failed to read lockout state, omitting lockout indicators [identityId=${el.id}]`);
+        unreadableIdentityIds.add(el.id);
+        logger.error(err, `Failed to read lockout state [identityId=${el.id}]`);
       }
     })
   );
 
-  return result;
+  return { lockoutsByIdentityId, unreadableIdentityIds };
 };
 
 export const buildAuthMethods = ({

--- a/backend/src/services/identity/identity-org-dal.ts
+++ b/backend/src/services/identity/identity-org-dal.ts
@@ -279,6 +279,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           db.ref("hasDeleteProtection").withSchema("paginatedIdentity"),
 
           db.ref("id").as("uaId").withSchema(TableName.IdentityUniversalAuth),
+          db.ref("clientId").as("uaClientId").withSchema(TableName.IdentityUniversalAuth),
           db.ref("id").as("gcpId").withSchema(TableName.IdentityGcpAuth),
           db.ref("id").as("alicloudId").withSchema(TableName.IdentityAliCloudAuth),
           db.ref("id").as("awsId").withSchema(TableName.IdentityAwsAuth),
@@ -326,6 +327,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           orgId,
           identityOrgId,
           uaId,
+          uaClientId,
           alicloudId,
           awsId,
           gcpId,
@@ -366,6 +368,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
             name: identityName,
             hasDeleteProtection,
             orgId: identityOrgId,
+            universalAuthClientId: uaClientId,
             authMethods: buildAuthMethods({
               uaId,
               alicloudId,
@@ -541,6 +544,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           db.ref("orgId").withSchema(TableName.Identity).as("identityOrgId"),
 
           db.ref("id").as("uaId").withSchema(TableName.IdentityUniversalAuth),
+          db.ref("clientId").as("uaClientId").withSchema(TableName.IdentityUniversalAuth),
           db.ref("id").as("gcpId").withSchema(TableName.IdentityGcpAuth),
           db.ref("id").as("alicloudId").withSchema(TableName.IdentityAliCloudAuth),
           db.ref("id").as("awsId").withSchema(TableName.IdentityAwsAuth),
@@ -599,6 +603,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
           total_count,
           id,
           uaId,
+          uaClientId,
           alicloudId,
           awsId,
           gcpId,
@@ -639,6 +644,7 @@ export const identityOrgDALFactory = (db: TDbClient) => {
             name: identityName,
             hasDeleteProtection,
             orgId: identityOrgId,
+            universalAuthClientId: uaClientId,
             authMethods: buildAuthMethods({
               uaId,
               alicloudId,

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -27,7 +27,7 @@ import { TMembershipIdentityDALFactory } from "../membership-identity/membership
 import { TOrgDALFactory } from "../org/org-dal";
 import { validateIdentityUpdateForSuperAdminPrivileges } from "../super-admin/super-admin-fns";
 import { TIdentityDALFactory } from "./identity-dal";
-import { getIdentityActiveLockoutAuthMethods } from "./identity-fns";
+import { getActiveLockoutAuthMethodsForIdentities } from "./identity-fns";
 import { TIdentityMetadataDALFactory } from "./identity-metadata-dal";
 import { TIdentityOrgDALFactory } from "./identity-org-dal";
 import {
@@ -50,7 +50,7 @@ type TIdentityServiceFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission" | "getOrgPermissionByRoles">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan" | "updateSubscriptionOrgMemberCount">;
   licenseDAL: Pick<TLicenseDALFactory, "countOrgUsersAndIdentities">;
-  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem" | "getItems">;
   orgDAL: Pick<TOrgDALFactory, "findById" | "findEffectiveOrgMembership">;
   additionalPrivilegeDAL: Pick<TAdditionalPrivilegeDALFactory, "delete">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
@@ -341,11 +341,18 @@ export const identityServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Read, OrgPermissionSubjects.Identity);
 
-    const activeLockoutAuthMethods = await getIdentityActiveLockoutAuthMethods(id, keyStore);
+    const { lockoutsByIdentityId, unreadableIdentityIds } = await getActiveLockoutAuthMethodsForIdentities(
+      [identity.identity],
+      keyStore
+    );
 
     return {
       ...identity,
-      identity: { ...identity.identity, activeLockoutAuthMethods }
+      identity: {
+        ...identity.identity,
+        activeLockoutAuthMethods: lockoutsByIdentityId[id] ?? [],
+        lockoutStateUnavailable: unreadableIdentityIds.has(id)
+      }
     };
   };
 
@@ -530,15 +537,18 @@ export const identityServiceFactory = ({
       searchFilter
     });
 
-    const docsWithLockouts = await Promise.all(
-      docs.map(async (doc) => ({
-        ...doc,
-        identity: {
-          ...doc.identity,
-          activeLockoutAuthMethods: await getIdentityActiveLockoutAuthMethods(doc.identity.id, keyStore)
-        }
-      }))
+    const { lockoutsByIdentityId, unreadableIdentityIds } = await getActiveLockoutAuthMethodsForIdentities(
+      docs.map((doc) => doc.identity),
+      keyStore
     );
+    const docsWithLockouts = docs.map((doc) => ({
+      ...doc,
+      identity: {
+        ...doc.identity,
+        activeLockoutAuthMethods: lockoutsByIdentityId[doc.identity.id] ?? [],
+        lockoutStateUnavailable: unreadableIdentityIds.has(doc.identity.id)
+      }
+    }));
 
     return { identityMemberships: docsWithLockouts, totalCount };
   };

--- a/backend/src/services/membership-identity/membership-identity-dal.ts
+++ b/backend/src/services/membership-identity/membership-identity-dal.ts
@@ -347,6 +347,7 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
           db.ref("createdAt").withSchema(TableName.MembershipRole).as("membershipRoleCreatedAt"),
           db.ref("updatedAt").withSchema(TableName.MembershipRole).as("membershipRoleUpdatedAt"),
           db.ref("id").as("uaId").withSchema(TableName.IdentityUniversalAuth),
+          db.ref("clientId").as("uaClientId").withSchema(TableName.IdentityUniversalAuth),
           db.ref("id").as("gcpId").withSchema(TableName.IdentityGcpAuth),
           db.ref("id").as("alicloudId").withSchema(TableName.IdentityAliCloudAuth),
           db.ref("id").as("awsId").withSchema(TableName.IdentityAwsAuth),
@@ -372,6 +373,7 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
             identityProjectId,
             identityOrgId,
             uaId,
+            uaClientId,
             gcpId,
             alicloudId,
             awsId,
@@ -394,6 +396,7 @@ export const membershipIdentityDALFactory = (db: TDbClient) => {
               hasDeleteProtection: identityHasDeleteProtection,
               orgId: identityOrgId,
               projectId: identityProjectId,
+              universalAuthClientId: uaClientId,
               authMethods: buildAuthMethods({
                 uaId,
                 gcpId,

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -2,7 +2,8 @@ import { createMongoAbility } from "@casl/ability";
 import { Knex } from "knex";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { AccessScope } from "@app/db/schemas";
+import { AccessScope, IdentityAuthMethod } from "@app/db/schemas";
+import { TKeyStoreFactory } from "@app/keystore/keystore";
 
 import { membershipIdentityServiceFactory } from "./membership-identity-service";
 import {
@@ -40,8 +41,14 @@ const buildDto = (): TDeleteMembershipIdentityDTO => ({
 });
 
 const createService = ({
-  existingMembership = { id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID }
-}: { existingMembership?: Record<string, unknown> | null } = {}) => {
+  existingMembership = { id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID },
+  keyStore = { getKeysByPattern: vi.fn(), getItem: vi.fn(), getItems: vi.fn() },
+  findIdentities
+}: {
+  existingMembership?: Record<string, unknown> | null;
+  keyStore?: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem" | "getItems">;
+  findIdentities?: ReturnType<typeof vi.fn>;
+} = {}) => {
   const bumpIdentityRevocationVersion = vi.fn().mockResolvedValue(undefined);
   const insertOrgMembershipRevocationMarker = vi.fn().mockResolvedValue(undefined);
   const removeOrgMembershipRevocationMarkers = vi.fn().mockResolvedValue(undefined);
@@ -53,7 +60,8 @@ const createService = ({
     create: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID }),
     updateById: vi.fn().mockImplementation(async (id: string, data: Record<string, unknown>) => ({ id, ...data })),
     deleteById: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID }),
-    transaction: vi.fn(async (cb: (tx: Knex) => Promise<unknown>) => cb({} as Knex))
+    transaction: vi.fn(async (cb: (tx: Knex) => Promise<unknown>) => cb({} as Knex)),
+    findIdentities: findIdentities ?? vi.fn()
   };
 
   const service = membershipIdentityServiceFactory({
@@ -81,7 +89,7 @@ const createService = ({
     licenseService: { getPlan: vi.fn() } as never,
     applicationMembershipCleanupService: { cleanupActorApplicationMemberships: vi.fn() } as never,
     projectDAL: { findById: vi.fn() } as never,
-    keyStore: { getKeysByPattern: vi.fn(), getItem: vi.fn() } as never,
+    keyStore: keyStore as never,
     usageMeteringService: { emit: vi.fn(), emitForProject: vi.fn() } as never,
     alertService: { deleteAlertsForResource } as never,
     identityAccessTokenService: {
@@ -290,5 +298,43 @@ describe("updateMembership org revocation restore", () => {
     expect(removeOrgMembershipRevocationMarkers).toHaveBeenCalledTimes(1);
     expect(insertOrgMembershipRevocationMarker).not.toHaveBeenCalled();
     expect(bumpIdentityRevocationVersion).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("membershipIdentityService.listMemberships", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const buildRow = (idx: number) => ({
+    id: `membership-${idx}`,
+    identity: {
+      id: `identity-${idx}`,
+      name: `identity-${idx}`,
+      authMethods: [IdentityAuthMethod.UNIVERSAL_AUTH],
+      universalAuthClientId: `client-${idx}`
+    },
+    roles: []
+  });
+
+  test("resolves lockout state for the whole page in one Redis batch", async () => {
+    const rows = Array.from({ length: 20 }, (_, i) => buildRow(i));
+    const getItems = vi.fn().mockResolvedValue(new Array(20).fill(null) as (string | null)[]);
+    const getKeysByPattern = vi.fn().mockResolvedValue([]);
+    const findIdentities = vi.fn().mockResolvedValue({ data: rows, totalCount: 20 });
+
+    const { service } = createService({
+      keyStore: { getItems, getKeysByPattern, getItem: vi.fn() },
+      findIdentities
+    });
+
+    const result = await service.listMemberships({
+      permission: { type: "user", id: "actor-1", authMethod: null, orgId: "org-1" },
+      scopeData: { scope: AccessScope.Project, orgId: "org-1", projectId: "project-1" },
+      data: { offset: 0, limit: 20 }
+    } as never);
+
+    expect(getItems).toHaveBeenCalledTimes(1);
+    expect(getKeysByPattern).not.toHaveBeenCalled();
+    expect(result.data).toHaveLength(20);
+    expect(result.data[0].identity.activeLockoutAuthMethods).toEqual([]);
   });
 });

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -515,7 +515,7 @@ export const membershipIdentityServiceFactory = ({
       }
     });
     const filtered = memberships.data.filter((el) => listFilter({ identityId: el.identity.id }));
-    const lockoutsByIdentityId = await getActiveLockoutAuthMethodsForIdentities(
+    const { lockoutsByIdentityId, unreadableIdentityIds } = await getActiveLockoutAuthMethodsForIdentities(
       filtered.map((el) => ({
         id: el.identity.id,
         authMethods: el.identity.authMethods,
@@ -527,7 +527,8 @@ export const membershipIdentityServiceFactory = ({
       ...el,
       identity: {
         ...el.identity,
-        activeLockoutAuthMethods: lockoutsByIdentityId[el.identity.id] ?? []
+        activeLockoutAuthMethods: lockoutsByIdentityId[el.identity.id] ?? [],
+        lockoutStateUnavailable: unreadableIdentityIds.has(el.identity.id)
       }
     }));
     return { ...memberships, data: withLockouts };

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -10,7 +10,7 @@ import { ms } from "@app/lib/ms";
 import { SearchResourceOperators } from "@app/lib/search-resource/search";
 import { TAlertServiceFactory } from "@app/services/alert/alert-service";
 import { IDENTITY_AUTHENTICATION_RESOURCE_TYPE } from "@app/services/alert/providers/identity-credential-alert-provider";
-import { getIdentityActiveLockoutAuthMethods } from "@app/services/identity/identity-fns";
+import { getActiveLockoutAuthMethodsForIdentities } from "@app/services/identity/identity-fns";
 import { PamIdentities, SecretIdentities } from "@app/services/license-client";
 import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage";
 
@@ -52,7 +52,7 @@ type TMembershipIdentityServiceFactoryDep = {
     "cleanupActorApplicationMemberships"
   >;
   projectDAL: Pick<TProjectDALFactory, "findById">;
-  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem" | "getItems">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit" | "emitForProject">;
   alertService: Pick<TAlertServiceFactory, "deleteAlertsForResource">;
   identityAccessTokenService: Pick<
@@ -515,15 +515,21 @@ export const membershipIdentityServiceFactory = ({
       }
     });
     const filtered = memberships.data.filter((el) => listFilter({ identityId: el.identity.id }));
-    const withLockouts = await Promise.all(
-      filtered.map(async (el) => ({
-        ...el,
-        identity: {
-          ...el.identity,
-          activeLockoutAuthMethods: await getIdentityActiveLockoutAuthMethods(el.identity.id, keyStore)
-        }
-      }))
+    const lockoutsByIdentityId = await getActiveLockoutAuthMethodsForIdentities(
+      filtered.map((el) => ({
+        id: el.identity.id,
+        authMethods: el.identity.authMethods,
+        universalAuthClientId: el.identity.universalAuthClientId
+      })),
+      keyStore
     );
+    const withLockouts = filtered.map((el) => ({
+      ...el,
+      identity: {
+        ...el.identity,
+        activeLockoutAuthMethods: lockoutsByIdentityId[el.identity.id] ?? []
+      }
+    }));
     return { ...memberships, data: withLockouts };
   };
 

--- a/frontend/src/hooks/api/identities/types.ts
+++ b/frontend/src/hooks/api/identities/types.ts
@@ -19,6 +19,7 @@ export type Identity = {
   hasDeleteProtection: boolean;
   authMethods: IdentityAuthMethod[];
   activeLockoutAuthMethods: IdentityAuthMethod[];
+  lockoutStateUnavailable?: boolean;
   createdAt: string;
   updatedAt: string;
   isInstanceAdmin?: boolean;
@@ -1024,5 +1025,6 @@ export type IdentityMembershipSearchResult = {
   identity: Pick<Identity, "id" | "name" | "hasDeleteProtection" | "orgId"> & {
     authMethods: IdentityAuthMethod[];
     activeLockoutAuthMethods: IdentityAuthMethod[];
+    lockoutStateUnavailable?: boolean;
   };
 };

--- a/frontend/src/hooks/api/shared/types.ts
+++ b/frontend/src/hooks/api/shared/types.ts
@@ -19,6 +19,7 @@ export type TIdentity = {
   hasDeleteProtection: boolean;
   authMethods: IdentityAuthMethod[];
   activeLockoutAuthMethods: IdentityAuthMethod[];
+  lockoutStateUnavailable?: boolean;
   metadata?: Array<TMetadata & { id: string }>;
 };
 

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityTable.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityTable.tsx
@@ -8,7 +8,8 @@ import {
   MoreHorizontalIcon,
   PlusIcon,
   SearchIcon,
-  TrashIcon
+  TrashIcon,
+  TriangleAlertIcon
 } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
@@ -203,6 +204,7 @@ type IdentityActionsMenuProps = {
   isSubOrgIdentity: boolean;
   authMethods: IdentityAuthMethod[];
   activeLockoutAuthMethods?: IdentityAuthMethod[];
+  lockoutStateUnavailable?: boolean;
   onEdit: () => void;
   onDelete: () => void;
   onManageAuth: (authMethod: IdentityAuthMethod) => void;
@@ -224,6 +226,7 @@ const IdentityActionsMenu = (props: IdentityActionsMenuProps) => {
     isSubOrgIdentity,
     authMethods,
     activeLockoutAuthMethods,
+    lockoutStateUnavailable,
     onEdit,
     onDelete,
     onManageAuth,
@@ -281,10 +284,16 @@ const IdentityActionsMenu = (props: IdentityActionsMenuProps) => {
                   }}
                 >
                   {identityAuthToNameMap[method]}
-                  {activeLockoutAuthMethods?.includes(method) && (
+                  {activeLockoutAuthMethods?.includes(method) ? (
                     <Badge isSquare variant="danger" className="ml-auto">
                       <LockIcon className="size-3!" />
                     </Badge>
+                  ) : (
+                    lockoutStateUnavailable && (
+                      <Badge isSquare variant="warning" className="ml-auto">
+                        <TriangleAlertIcon className="size-3!" />
+                      </Badge>
+                    )
                   )}
                 </DropdownMenuItem>
               ))}
@@ -378,7 +387,7 @@ const IdentityRow = ({ membership, onDelete, onManageAuth, onAddAuthMethod }: Id
   const {
     scope,
     project,
-    identity: { id, name, orgId, authMethods, activeLockoutAuthMethods },
+    identity: { id, name, orgId, authMethods, activeLockoutAuthMethods, lockoutStateUnavailable },
     roles: membershipRoles,
     lastLoginAuthMethod,
     lastLoginTime
@@ -438,11 +447,24 @@ const IdentityRow = ({ membership, onDelete, onManageAuth, onAddAuthMethod }: Id
               </TooltipContent>
             </Tooltip>
           )}
+          {lockoutStateUnavailable && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Badge isSquare variant="warning">
+                  <TriangleAlertIcon />
+                </Badge>
+              </TooltipTrigger>
+              <TooltipContent>
+                Lockout status is unavailable right now, so this identity may be locked out
+              </TooltipContent>
+            </Tooltip>
+          )}
           <IdentityActionsMenu
             isProjectScoped={isProjectScoped}
             isSubOrgIdentity={isSubOrgIdentity}
             authMethods={authMethods ?? []}
             activeLockoutAuthMethods={activeLockoutAuthMethods}
+            lockoutStateUnavailable={lockoutStateUnavailable}
             onEdit={navigateToIdentity}
             onDelete={() => onDelete({ identityId: id, name })}
             onManageAuth={(authMethod) => onManageAuth({ identityId: id, authMethod })}

--- a/frontend/src/pages/organization/IdentityDetailsByIDPage/components/IdentityAuthenticationSection/IdentityAuthenticationSection.tsx
+++ b/frontend/src/pages/organization/IdentityDetailsByIDPage/components/IdentityAuthenticationSection/IdentityAuthenticationSection.tsx
@@ -78,6 +78,7 @@ export const IdentityAuthenticationSection = ({ identityId, handlePopUpOpen }: P
             identityName={data.identity.name}
             authMethods={data.identity.authMethods}
             activeLockoutAuthMethods={data.identity.activeLockoutAuthMethods}
+            lockoutStateUnavailable={data.identity.lockoutStateUnavailable}
             onMutated={refetch}
           />
         ) : (

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/IdentityTab.tsx
@@ -10,6 +10,7 @@ import {
   PlusIcon,
   SearchIcon,
   TrashIcon,
+  TriangleAlertIcon,
   XIcon
 } from "lucide-react";
 import { twMerge } from "tailwind-merge";
@@ -374,7 +375,8 @@ export const IdentityTab = withProjectPermission(
                               projectId: identityProjectId,
                               orgId: identityOrgId,
                               authMethods,
-                              activeLockoutAuthMethods
+                              activeLockoutAuthMethods,
+                              lockoutStateUnavailable
                             },
                             roles
                           } = identityMember;
@@ -457,6 +459,19 @@ export const IdentityTab = withProjectPermission(
                                       </TooltipContent>
                                     </Tooltip>
                                   )}
+                                  {lockoutStateUnavailable && (
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <Badge isSquare variant="warning">
+                                          <TriangleAlertIcon />
+                                        </Badge>
+                                      </TooltipTrigger>
+                                      <TooltipContent>
+                                        Lockout status is unavailable right now, so this identity
+                                        may be locked out
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  )}
                                   <DropdownMenu>
                                     <DropdownMenuTrigger asChild>
                                       <IconButton
@@ -487,7 +502,7 @@ export const IdentityTab = withProjectPermission(
                                                 }}
                                               >
                                                 {identityAuthToNameMap[method]}
-                                                {activeLockoutAuthMethods?.includes(method) && (
+                                                {activeLockoutAuthMethods?.includes(method) ? (
                                                   <Badge
                                                     isSquare
                                                     variant="danger"
@@ -495,6 +510,16 @@ export const IdentityTab = withProjectPermission(
                                                   >
                                                     <LockIcon className="size-3!" />
                                                   </Badge>
+                                                ) : (
+                                                  lockoutStateUnavailable && (
+                                                    <Badge
+                                                      isSquare
+                                                      variant="warning"
+                                                      className="ml-auto"
+                                                    >
+                                                      <TriangleAlertIcon className="size-3!" />
+                                                    </Badge>
+                                                  )
                                                 )}
                                               </DropdownMenuItem>
                                             ))}

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/ProjectIdentityAuthSection.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/ProjectIdentityAuthSection.tsx
@@ -95,6 +95,7 @@ export const ProjectIdentityAuthenticationSection = ({ identity, refetchIdentity
               identityName={identity.name}
               authMethods={identity.authMethods}
               activeLockoutAuthMethods={identity.activeLockoutAuthMethods}
+              lockoutStateUnavailable={identity.lockoutStateUnavailable}
               onMutated={refetchIdentity}
             />
           ) : (

--- a/frontend/src/views/IdentityAuthMethods/IdentityAuthMethodsCell.tsx
+++ b/frontend/src/views/IdentityAuthMethods/IdentityAuthMethodsCell.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { LockIcon } from "lucide-react";
+import { LockIcon, TriangleAlertIcon } from "lucide-react";
 
 import { Badge, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { IdentityAuthMethod, identityAuthToNameMap } from "@app/hooks/api";
@@ -11,6 +11,7 @@ type Props = {
   identityName: string;
   authMethods: IdentityAuthMethod[];
   activeLockoutAuthMethods: IdentityAuthMethod[];
+  lockoutStateUnavailable?: boolean;
   onMutated: () => void;
 };
 
@@ -19,6 +20,7 @@ export const IdentityAuthMethodsCell = ({
   identityName,
   authMethods,
   activeLockoutAuthMethods,
+  lockoutStateUnavailable,
   onMutated
 }: Props) => {
   const [selectedAuthMethod, setSelectedAuthMethod] = useState<IdentityAuthMethod | null>(null);
@@ -32,8 +34,16 @@ export const IdentityAuthMethodsCell = ({
       <div className="flex flex-wrap items-center gap-1">
         {authMethods.map((authMethod) => {
           const isLockedOut = activeLockoutAuthMethods?.includes(authMethod);
+          // A lockout state we could not read is not the same as no lockout, so say it is unknown
+          // rather than rendering the method as clean.
+          const isUnknown = !isLockedOut && Boolean(lockoutStateUnavailable);
+          const variant = (() => {
+            if (isLockedOut) return "danger";
+            if (isUnknown) return "warning";
+            return "neutral";
+          })();
           const badge = (
-            <Badge asChild variant={isLockedOut ? "danger" : "neutral"} className="cursor-pointer">
+            <Badge asChild variant={variant} className="cursor-pointer">
               <button
                 type="button"
                 onClick={(e) => {
@@ -42,17 +52,23 @@ export const IdentityAuthMethodsCell = ({
                 }}
               >
                 {isLockedOut && <LockIcon />}
+                {isUnknown && <TriangleAlertIcon />}
                 {identityAuthToNameMap[authMethod]}
               </button>
             </Badge>
           );
-          return isLockedOut ? (
+          if (!isLockedOut && !isUnknown) {
+            return <span key={authMethod}>{badge}</span>;
+          }
+          return (
             <Tooltip key={authMethod}>
               <TooltipTrigger asChild>{badge}</TooltipTrigger>
-              <TooltipContent>Auth method has active lockouts</TooltipContent>
+              <TooltipContent>
+                {isLockedOut
+                  ? "Auth method has active lockouts"
+                  : "Lockout status is unavailable right now"}
+              </TooltipContent>
             </Tooltip>
-          ) : (
-            <span key={authMethod}>{badge}</span>
           );
         })}
       </div>

--- a/frontend/src/views/IdentityAuthMethods/IdentityAuthMethodsTable.tsx
+++ b/frontend/src/views/IdentityAuthMethods/IdentityAuthMethodsTable.tsx
@@ -1,7 +1,14 @@
 import { useState } from "react";
 import { subject } from "@casl/ability";
 import { useParams } from "@tanstack/react-router";
-import { EllipsisIcon, EyeIcon, LockIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import {
+  EllipsisIcon,
+  EyeIcon,
+  LockIcon,
+  PencilIcon,
+  Trash2Icon,
+  TriangleAlertIcon
+} from "lucide-react";
 
 import { VariablePermissionCan } from "@app/components/permissions";
 import {
@@ -40,6 +47,7 @@ type Props = {
   identityName: string;
   authMethods: IdentityAuthMethod[];
   activeLockoutAuthMethods: IdentityAuthMethod[];
+  lockoutStateUnavailable?: boolean;
   onMutated: () => void;
 };
 
@@ -48,6 +56,7 @@ export const IdentityAuthMethodsTable = ({
   identityName,
   authMethods,
   activeLockoutAuthMethods,
+  lockoutStateUnavailable,
   onMutated
 }: Props) => {
   const [selectedAuthMethod, setSelectedAuthMethod] = useState<IdentityAuthMethod | null>(null);
@@ -85,6 +94,9 @@ export const IdentityAuthMethodsTable = ({
         <TableBody>
           {authMethods.map((authMethod) => {
             const isLockedOut = activeLockoutAuthMethods?.includes(authMethod);
+            // A lockout state we could not read is not the same as no lockout, so say it is
+            // unknown rather than rendering the method as clean.
+            const isUnknown = !isLockedOut && Boolean(lockoutStateUnavailable);
             const authMethodIcon = identityAuthMethodOptions.find(
               ({ value }) => value === authMethod
             )?.icon;
@@ -107,6 +119,16 @@ export const IdentityAuthMethodsTable = ({
                           </Badge>
                         </TooltipTrigger>
                         <TooltipContent>Auth method has active lockouts</TooltipContent>
+                      </Tooltip>
+                    )}
+                    {isUnknown && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Badge isSquare variant="warning">
+                            <TriangleAlertIcon />
+                          </Badge>
+                        </TooltipTrigger>
+                        <TooltipContent>Lockout status is unavailable right now</TooltipContent>
                       </Tooltip>
                     )}
                   </div>


### PR DESCRIPTION
## Context

Listing project machine identities ran one Redis keyspace scan per identity to compute lockout status, so the endpoint's cost scaled with both page size and total Redis key volume. This replaces that with a single batched `MGET` per page.

Universal auth stores its lockout state under a key whose last segment is the client ID, and Postgres already holds that client ID on a table the list query already joins. So instead of discovering the key by scanning, the lookup derives it and reads every identity on the page in one round trip. LDAP auth keys its lockout by the submitted directory username, which is never persisted here, so those rows still fall back to the pattern scan. Only universal auth and LDAP have lockout configuration columns, so every other identity now does zero Redis work instead of a full sweep.

`LOCKOUT_CAPABLE_AUTH_METHODS` and `isExactlyResolvable` make that split explicit rather than implicit. The scan this replaced was method-agnostic — whatever wrote a lockout key produced a badge automatically — and an enumerated list is not. Any method added to the constant without an exact-key rule still returns correct results through the scan fallback, so the read path cannot silently stop seeing keys the write path produces.

Measured on real Redis at a 1,000,020-key keyspace:

| Operation | 20 keys | 1,000,020 keys |
|---|---|---|
| Old: pattern scan, one identity | 2 ms | ~98 ms |
| Old: pattern scan × 20 (one page) | ~20 ms | ~1950 ms |
| New: single `MGET` of 20 exact keys | 1 ms | 1–2 ms |

The old path scales linearly with keyspace size; the new path is flat.

### Scope notes for reviewers

- **This speeds up three endpoints, not one.** `membershipIdentity.listMemberships` also backs the org identity-membership listing (`identity-org-membership-router.ts:336`) and the cert-manager identity listing (`cert-manager-access-routers/identities-router.ts:56`). All three get the batched lookup. No caller's response shape changes.
- **The project listing now fails open on Redis errors; the out-of-scope endpoints still fail closed.** If Redis is unavailable this path logs and omits the lockout badge rather than failing the page, which is a deliberate improvement over the previous 500. Enforcement is unaffected — the login gate still fails closed — so only the informational badge degrades. The inconsistency with the org-level and detail endpoints is a scope boundary, not an oversight.
- **`universalAuthClientId` is deliberately not serialised.** It now flows from the DAL into the service layer to build the Redis key, and is kept out of the API by the response schemas selecting explicit fields. The e2e test asserts its absence rather than assuming it, so a future `.passthrough()` cannot leak it unnoticed.
- **One intentional behaviour change:** orphaned lockout keys no longer produce badges. A key still inside its TTL for an auth method the identity no longer has — an LDAP key after LDAP auth was revoked, or a universal auth key from a previous attach with a different client ID — used to surface as a badge. It no longer does.

### Deliberately out of scope

Each is the same class of problem and worth its own ticket:

1. The org-level identity listing (`identity-service.ts:538`, `identity-v2/identity-service.ts:575`) and the single-identity detail paths (`identity-service.ts:344`, `identity-v2/identity-service.ts:425`) loop the singular helper the same way. Their DALs already join the universal auth table, so each is the same small change.
2. `clearLockouts` scans the whole keyspace via `keyStore.deleteItems({ pattern })`, backing the admin clear-lockout endpoints.
3. Under a Redis Cluster deployment, a multi-key `MGET` without hash tags returns `CROSSSLOT`. This path catches and fails open, so badges would vanish silently. Pre-existing rather than introduced here — `getKeysByPattern` only scans the primary node, and three other call sites already do multi-key `getItems`, including on the license hot path — but it wants a cluster-safe batched read.
4. The cohesion refactor: one module owning the key format, the state type, both login paths and both clear paths, removing the `parts[3]` string parsing and the duplicated lockout state type.
5. The listing ignores the `orderBy` / `orderDirection` the frontend sends, and `LIMIT`/`OFFSET` without a stable order can repeat or skip rows across pages.

## Screenshots

Not applicable — no UI change.

## Steps to verify the change

No schema change, so no migration is involved.

1. Lint and types, from the repo root:
   ```
   make reviewable-api
   ```
2. Unit tests — `identity-fns.test.ts` covers the batching logic against a mocked key store (empty page, non-lockout-capable methods, exact-key hit, counting-only record, one `MGET` for a 20-row page, LDAP fallback, missing-client-ID fallback, both methods locked out, malformed value, Redis error); `membership-identity-service.test.ts` covers the service wiring:
   ```
   cd backend && npx vitest run -c vitest.unit.config.mts src/services/identity/identity-fns.test.ts src/services/membership-identity/membership-identity-service.test.ts
   ```
3. End-to-end regression test. This is the one that matters: a mocked key store cannot prove the derived key matches the key the login path writes, so this drives three real failed logins through the universal auth login endpoint and asserts the listing endpoint reports the resulting lockout. It also asserts `universalAuthClientId` is absent from the response.

   Local setup: copy `.env.test.example` to `.env.test` at the repo root, then `docker compose -f docker-compose.dev.yml up -d db redis`.
   ```
   cd backend && npx vitest run -c vitest.e2e.config.mts e2e-test/routes/v1/identity-lockout-listing.spec.ts
   ```
   Two caveats for anyone running this on an Apple Silicon host: the harness cannot boot natively there, because `@infisical/quic` resolves a native binding from `@infisical/quic-darwin-arm64`, which is not published — run it in a linux container as CI does. And the suite's `DROP SCHEMA CASCADE` teardown needs `max_locks_per_transaction` above the default 64 for this schema's object count; the `db-test` service in `docker-compose.dev.yml` already sets 512.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed) — not needed; no user-facing behaviour or API change
- [x] Updated CLAUDE.md files (if needed) — not needed; no new service, pattern, or architectural shift
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
