### PR TITLE
improvement(secrets): unify overview navigation and query state

### DIFF
--- a/frontend/src/hooks/useNavigationBlocker.tsx
+++ b/frontend/src/hooks/useNavigationBlocker.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useBlocker } from "@tanstack/react-router";
+import { type ShouldBlockFn, useBlocker } from "@tanstack/react-router";
 
 import {
   BatchContext,
@@ -12,27 +12,37 @@ type TNavigationBlockerReturn = {
 
 export const useNavigationBlocker = ({
   shouldBlock = false,
+  shouldBlockNavigation,
   message = "Are you sure you want to leave? You may have unsaved changes.",
   context
 }: {
   shouldBlock: boolean;
+  shouldBlockNavigation?: ShouldBlockFn;
   message: string;
   context: BatchContext;
 }): TNavigationBlockerReturn => {
   const { clearAllPendingChanges } = useBatchModeActions();
-  const blockerFn = useCallback(() => {
-    if (!shouldBlock) return false;
+  const blockerFn: ShouldBlockFn = useCallback(
+    async (args) => {
+      if (!shouldBlock) return false;
+      if (shouldBlockNavigation && !(await shouldBlockNavigation(args))) return false;
 
-    // eslint-disable-next-line no-alert
-    const confirmed = window.confirm(message);
-    if (confirmed) {
-      clearAllPendingChanges(context);
-    }
+      // eslint-disable-next-line no-alert
+      const confirmed = window.confirm(message);
+      if (confirmed) {
+        clearAllPendingChanges(context);
+      }
 
-    return !confirmed;
-  }, [shouldBlock, message, context]);
+      return !confirmed;
+    },
+    [shouldBlock, shouldBlockNavigation, message, context, clearAllPendingChanges]
+  );
 
-  useBlocker(blockerFn, shouldBlock);
+  useBlocker({
+    shouldBlockFn: blockerFn,
+    disabled: !shouldBlock,
+    enableBeforeUnload: shouldBlock
+  });
 
   return {
     isBlocked: shouldBlock

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -250,10 +250,12 @@ import {
 } from "./components";
 import {
   hasOverviewScopeChanged,
+  hasSensitiveOverviewSearchState,
   normalizeOverviewEnvironments,
+  parseOverviewTags,
   resolveOverviewEnvironmentSlugs,
   serializeOverviewResourceFilter,
-  serializeOverviewTags,
+  stripSensitiveOverviewSearchState,
   updateOverviewSecretPath
 } from "./overviewSearchState";
 
@@ -337,7 +339,8 @@ const OverviewPageContent = () => {
     ) ?? false;
   const isProjectV3 = currentProject?.version === ProjectVersion.V3;
   const projectSlug = currentProject?.slug as string;
-  const searchFilter = routerSearch.search;
+  const [searchFilter, setSearchFilter] = useState(routerSearch.search);
+  const [tagFilter, setTagFilter] = useState(() => parseOverviewTags(routerSearch.tags));
   const secretPath = (routerSearch?.secretPath as string) || "/";
   const { subscription } = useSubscription();
   const { mutateAsync: importVaultSecrets } = useImportVaultSecrets();
@@ -375,20 +378,10 @@ const OverviewPageContent = () => {
         nextFilter[rowType] = true;
       });
 
-    if (routerSearch.tags) nextFilter[RowType.Secret] = true;
+    if (Object.keys(tagFilter).length > 0) nextFilter[RowType.Secret] = true;
 
     return nextFilter;
-  }, [routerSearch.filterBy, routerSearch.tags]);
-
-  const tagFilter = useMemo(
-    () =>
-      (routerSearch.tags ?? "").split(",").reduce<Record<string, boolean>>((acc, tag) => {
-        const tagSlug = tag.trim();
-        if (tagSlug) acc[tagSlug] = true;
-        return acc;
-      }, {}),
-    [routerSearch.tags]
-  );
+  }, [routerSearch.filterBy, tagFilter]);
 
   const [selectedEntries, setSelectedEntries] = useState<{
     // selectedEntries[name/key][envSlug][resource]
@@ -493,8 +486,11 @@ const OverviewPageContent = () => {
   );
 
   useEffect(() => {
-    if (userAvailableEnvs.length === 0) return;
+    if (routerSearch.search) setSearchFilter(routerSearch.search);
+    if (routerSearch.tags !== undefined) setTagFilter(parseOverviewTags(routerSearch.tags));
+  }, [routerSearch.search, routerSearch.tags]);
 
+  useEffect(() => {
     const requestedSlugs = normalizeOverviewEnvironments(
       routerSearch.environments,
       userAvailableEnvs.map((env) => env.slug)
@@ -502,17 +498,30 @@ const OverviewPageContent = () => {
     const isCanonical =
       requestedSlugs.length === routerSearch.environments.length &&
       requestedSlugs.join(",") === selectedEnvironmentSlugs.join(",");
+    const shouldNormalizeEnvironments = userAvailableEnvs.length > 0 && !isCanonical;
+    const shouldStripSensitiveState = hasSensitiveOverviewSearchState(routerSearch);
+    const normalizedEnvironments = selectedEnvironmentSlugs.length
+      ? selectedEnvironmentSlugs
+      : undefined;
 
-    if (isCanonical) return;
+    if (!shouldNormalizeEnvironments && !shouldStripSensitiveState) return;
 
     navigate({
-      search: (prev) => ({
-        ...prev,
-        environments: selectedEnvironmentSlugs.length > 0 ? selectedEnvironmentSlugs : undefined
-      }),
+      search: (prev) => {
+        const nextSearch = shouldStripSensitiveState
+          ? stripSensitiveOverviewSearchState(prev)
+          : prev;
+
+        return {
+          ...nextSearch,
+          environments: shouldNormalizeEnvironments
+            ? normalizedEnvironments
+            : nextSearch.environments
+        };
+      },
       replace: true
     });
-  }, [navigate, routerSearch.environments, selectedEnvironmentSlugs, userAvailableEnvs]);
+  }, [navigate, routerSearch, selectedEnvironmentSlugs, userAvailableEnvs]);
 
   const filteredEnvs = useMemo(
     () => userAvailableEnvs.filter((env) => selectedEnvironmentSlugs.includes(env.slug)),
@@ -2206,28 +2215,21 @@ const OverviewPageContent = () => {
     });
   };
 
-  const handleSearchChange = useCallback(
-    (search: string) => {
-      navigate({
-        search: (prev) => ({ ...prev, search: search || undefined }),
-        replace: true
-      });
-    },
-    [navigate]
-  );
+  const handleSearchChange = useCallback((search: string) => setSearchFilter(search), []);
 
   const handleClearTags = useCallback(() => {
-    navigate({ search: (prev) => ({ ...prev, tags: undefined }) });
-  }, [navigate]);
+    setTagFilter({});
+  }, []);
 
   const handleToggleRowType = useCallback(
     (rowType: RowType) => {
       const nextFilter = { ...filter, [rowType]: !filter[rowType] };
+      if (rowType === RowType.Secret && filter[rowType]) setTagFilter({});
+
       navigate({
         search: (prev) => ({
           ...prev,
-          filterBy: serializeOverviewResourceFilter(nextFilter, Object.values(RowType)),
-          tags: rowType === RowType.Secret && filter[rowType] ? undefined : prev.tags
+          filterBy: serializeOverviewResourceFilter(nextFilter, Object.values(RowType))
         })
       });
     },
@@ -2236,19 +2238,25 @@ const OverviewPageContent = () => {
 
   const handleToggleTag = useCallback(
     (tagSlug: string) => {
-      const nextTags = Object.keys(tagFilter).filter((tag) => tag !== tagSlug);
-      if (!tagFilter[tagSlug]) nextTags.push(tagSlug);
-
-      navigate({
-        search: (prev) => ({
-          ...prev,
-          tags: serializeOverviewTags(nextTags),
-          filterBy:
-            !tagFilter[tagSlug] && !filter[RowType.Secret]
-              ? [...Object.values(RowType).filter((type) => filter[type]), RowType.Secret].join(",")
-              : prev.filterBy
-        })
+      const isEnabling = !tagFilter[tagSlug];
+      setTagFilter((prev) => {
+        const next = { ...prev };
+        if (next[tagSlug]) delete next[tagSlug];
+        else next[tagSlug] = true;
+        return next;
       });
+
+      if (isEnabling && !filter[RowType.Secret]) {
+        navigate({
+          search: (prev) => ({
+            ...prev,
+            filterBy: [
+              ...Object.values(RowType).filter((type) => filter[type]),
+              RowType.Secret
+            ].join(",")
+          })
+        });
+      }
     },
     [filter, navigate, tagFilter]
   );
@@ -2677,6 +2685,17 @@ const OverviewPageContent = () => {
                   value={searchFilter}
                   tags={tags}
                   onChange={handleSearchChange}
+                  onSelectResult={({ search, tags: selectedTags }) => {
+                    setSearchFilter(search);
+                    if (selectedTags !== undefined) {
+                      setTagFilter(
+                        selectedTags.reduce<Record<string, boolean>>((acc, tag) => {
+                          acc[tag] = true;
+                          return acc;
+                        }, {})
+                      );
+                    }
+                  }}
                   environments={userAvailableEnvs}
                   projectId={currentProject?.id}
                 />

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -479,10 +479,15 @@ const OverviewPageContent = () => {
     userAvailableEnvs?.[0]?.id ? [userAvailableEnvs[0].id] : []
   );
 
-  const hasInitializedEnvironmentFromPreference = useRef(false);
+  const initializedEnvironmentProjectId = useRef<string | null>(null);
   useEffect(() => {
-    if (hasInitializedEnvironmentFromPreference.current || userAvailableEnvs.length === 0) return;
-    hasInitializedEnvironmentFromPreference.current = true;
+    if (
+      initializedEnvironmentProjectId.current === projectId ||
+      userAvailableEnvs.length === 0
+    ) {
+      return;
+    }
+    initializedEnvironmentProjectId.current = projectId;
 
     const requestedSlugs = normalizeOverviewEnvironments(
       routerSearch.environments,
@@ -512,10 +517,11 @@ const OverviewPageContent = () => {
           environments: userAvailableEnvs
             .filter((env) => initialPreference.includes(env.id))
             .map((env) => env.slug)
-        })
+        }),
+        replace: true
       });
     }
-  }, [navigate, routerSearch.environments, storedEnvIds, userAvailableEnvs]);
+  }, [navigate, projectId, routerSearch.environments, storedEnvIds, userAvailableEnvs]);
 
   const filteredEnvs = useMemo(
     () => userAvailableEnvs.filter((env) => routerSearch.environments.includes(env.slug)),
@@ -2211,7 +2217,8 @@ const OverviewPageContent = () => {
   const handleSearchChange = useCallback(
     (search: string) => {
       navigate({
-        search: (prev) => ({ ...prev, search: search || undefined })
+        search: (prev) => ({ ...prev, search: search || undefined }),
+        replace: true
       });
     },
     [navigate]

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -249,7 +249,9 @@ import {
   SecretTableRow
 } from "./components";
 import {
+  hasOverviewScopeChanged,
   normalizeOverviewEnvironments,
+  resolveOverviewEnvironmentSlugs,
   serializeOverviewResourceFilter,
   serializeOverviewTags,
   updateOverviewSecretPath
@@ -430,8 +432,13 @@ const OverviewPageContent = () => {
   }, []);
 
   useEffect(() => {
-    const onRouteChangeStart = () => {
-      resetSelectedEntries();
+    const onRouteChangeStart = (event: {
+      fromLocation: { pathname: string; search: unknown };
+      toLocation: { pathname: string; search: unknown };
+    }) => {
+      if (hasOverviewScopeChanged(event.fromLocation, event.toLocation)) {
+        resetSelectedEntries();
+      }
     };
 
     const unsubscribeRouterEvent = router.subscribe("onLoad", onRouteChangeStart);
@@ -479,50 +486,37 @@ const OverviewPageContent = () => {
     userAvailableEnvs?.[0]?.id ? [userAvailableEnvs[0].id] : []
   );
 
-  const initializedEnvironmentProjectId = useRef<string | null>(null);
+  const selectedEnvironmentSlugs = useMemo(
+    () =>
+      resolveOverviewEnvironmentSlugs(routerSearch.environments, storedEnvIds, userAvailableEnvs),
+    [routerSearch.environments, storedEnvIds, userAvailableEnvs]
+  );
+
   useEffect(() => {
-    if (initializedEnvironmentProjectId.current === projectId || userAvailableEnvs.length === 0) {
-      return;
-    }
-    initializedEnvironmentProjectId.current = projectId;
+    if (userAvailableEnvs.length === 0) return;
 
     const requestedSlugs = normalizeOverviewEnvironments(
       routerSearch.environments,
       userAvailableEnvs.map((env) => env.slug)
     );
+    const isCanonical =
+      requestedSlugs.length === routerSearch.environments.length &&
+      requestedSlugs.join(",") === selectedEnvironmentSlugs.join(",");
 
-    if (routerSearch.environments.length > 0) {
-      if (requestedSlugs.length !== routerSearch.environments.length) {
-        navigate({
-          search: (prev) => ({
-            ...prev,
-            environments: requestedSlugs.length > 0 ? requestedSlugs : undefined
-          }),
-          replace: true
-        });
-      }
-      return;
-    }
+    if (isCanonical) return;
 
-    const initialPreference = storedEnvIds.filter((id) =>
-      userAvailableEnvs.some((env) => env.id === id)
-    );
-    if (initialPreference.length > 0) {
-      navigate({
-        search: (prev) => ({
-          ...prev,
-          environments: userAvailableEnvs
-            .filter((env) => initialPreference.includes(env.id))
-            .map((env) => env.slug)
-        }),
-        replace: true
-      });
-    }
-  }, [navigate, projectId, routerSearch.environments, storedEnvIds, userAvailableEnvs]);
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        environments: selectedEnvironmentSlugs.length > 0 ? selectedEnvironmentSlugs : undefined
+      }),
+      replace: true
+    });
+  }, [navigate, routerSearch.environments, selectedEnvironmentSlugs, userAvailableEnvs]);
 
   const filteredEnvs = useMemo(
-    () => userAvailableEnvs.filter((env) => routerSearch.environments.includes(env.slug)),
-    [routerSearch.environments, userAvailableEnvs]
+    () => userAvailableEnvs.filter((env) => selectedEnvironmentSlugs.includes(env.slug)),
+    [selectedEnvironmentSlugs, userAvailableEnvs]
   );
 
   const setFilteredEnvs = useCallback(
@@ -851,6 +845,7 @@ const OverviewPageContent = () => {
   useNavigationBlocker({
     shouldBlock:
       isBatchModeActive && (pendingChanges.secrets.length > 0 || pendingChanges.folders.length > 0),
+    shouldBlockNavigation: ({ current, next }) => hasOverviewScopeChanged(current, next),
     message:
       "You have unsaved changes. If you leave now, your work will be lost. Do you want to continue?",
     context: {

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -231,12 +231,6 @@ import { SecretV2MigrationSection } from "./components/SecretV2MigrationSection"
 import { MoveSecretsModal } from "./components/SelectionPanel/components";
 import { SelectionPanel } from "./components/SelectionPanel/SelectionPanel";
 import {
-  normalizeOverviewEnvironments,
-  serializeOverviewResourceFilter,
-  serializeOverviewTags,
-  updateOverviewSecretPath
-} from "./overviewSearchState";
-import {
   DownloadEnvButton,
   DynamicSecretTableRow,
   EmptyResourceDisplay,
@@ -254,6 +248,12 @@ import {
   SecretSyncStatusBadgeOverview,
   SecretTableRow
 } from "./components";
+import {
+  normalizeOverviewEnvironments,
+  serializeOverviewResourceFilter,
+  serializeOverviewTags,
+  updateOverviewSecretPath
+} from "./overviewSearchState";
 
 type TParsedEnv = { value: string; comments: string[]; secretPath?: string; secretKey: string }[];
 type TParsedFolderEnv = Record<
@@ -278,10 +278,6 @@ export enum RowType {
   HoneyToken = "honeyToken",
   ProxiedService = "proxiedService"
 }
-
-type Filter = {
-  [key in RowType]: boolean;
-};
 
 const DEFAULT_FILTER_STATE = {
   [RowType.Folder]: false,

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -481,10 +481,7 @@ const OverviewPageContent = () => {
 
   const initializedEnvironmentProjectId = useRef<string | null>(null);
   useEffect(() => {
-    if (
-      initializedEnvironmentProjectId.current === projectId ||
-      userAvailableEnvs.length === 0
-    ) {
+    if (initializedEnvironmentProjectId.current === projectId || userAvailableEnvs.length === 0) {
       return;
     }
     initializedEnvironmentProjectId.current = projectId;

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -2230,7 +2230,8 @@ const OverviewPageContent = () => {
         search: (prev) => ({
           ...prev,
           filterBy: serializeOverviewResourceFilter(nextFilter, Object.values(RowType))
-        })
+        }),
+        replace: true
       });
     },
     [filter, navigate]
@@ -2254,7 +2255,8 @@ const OverviewPageContent = () => {
               ...Object.values(RowType).filter((type) => filter[type]),
               RowType.Secret
             ].join(",")
-          })
+          }),
+          replace: true
         });
       }
     },

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -231,6 +231,12 @@ import { SecretV2MigrationSection } from "./components/SecretV2MigrationSection"
 import { MoveSecretsModal } from "./components/SelectionPanel/components";
 import { SelectionPanel } from "./components/SelectionPanel/SelectionPanel";
 import {
+  normalizeOverviewEnvironments,
+  serializeOverviewResourceFilter,
+  serializeOverviewTags,
+  updateOverviewSecretPath
+} from "./overviewSearchState";
+import {
   DownloadEnvButton,
   DynamicSecretTableRow,
   EmptyResourceDisplay,
@@ -333,7 +339,7 @@ const OverviewPageContent = () => {
     ) ?? false;
   const isProjectV3 = currentProject?.version === ProjectVersion.V3;
   const projectSlug = currentProject?.slug as string;
-  const [searchFilter, setSearchFilter] = useState("");
+  const searchFilter = routerSearch.search;
   const secretPath = (routerSearch?.secretPath as string) || "/";
   const { subscription } = useSubscription();
   const { mutateAsync: importVaultSecrets } = useImportVaultSecrets();
@@ -360,11 +366,31 @@ const OverviewPageContent = () => {
   //   }
   // };
 
-  const [filter, setFilter] = useState<Filter>(DEFAULT_FILTER_STATE);
-  const [tagFilter, setTagFilter] = useState<Record<string, boolean>>({});
-  const [filterHistory, setFilterHistory] = useState<
-    Map<string, { filter: Filter; searchFilter: string }>
-  >(new Map());
+  const filter = useMemo(() => {
+    const nextFilter = { ...DEFAULT_FILTER_STATE };
+
+    routerSearch.filterBy
+      ?.split(",")
+      .map((value) => value.trim())
+      .filter((value): value is RowType => Object.values(RowType).includes(value as RowType))
+      .forEach((rowType) => {
+        nextFilter[rowType] = true;
+      });
+
+    if (routerSearch.tags) nextFilter[RowType.Secret] = true;
+
+    return nextFilter;
+  }, [routerSearch.filterBy, routerSearch.tags]);
+
+  const tagFilter = useMemo(
+    () =>
+      (routerSearch.tags ?? "").split(",").reduce<Record<string, boolean>>((acc, tag) => {
+        const tagSlug = tag.trim();
+        if (tagSlug) acc[tagSlug] = true;
+        return acc;
+      }, {}),
+    [routerSearch.tags]
+  );
 
   const [selectedEntries, setSelectedEntries] = useState<{
     // selectedEntries[name/key][envSlug][resource]
@@ -457,85 +483,61 @@ const OverviewPageContent = () => {
     userAvailableEnvs?.[0]?.id ? [userAvailableEnvs[0].id] : []
   );
 
-  // Apply one-shot deep-link inputs to local filters, then strip them from the URL in a SINGLE
-  // navigate. These arrive from notifications, legacy dashboard bookmarks (`tags`, `filterBy`),
-  // or the secret reference tree (`environments` + `search`). Handling them in one effect/navigate
-  // (rather than two racing effects) guarantees every param is cleared after it's applied. That
-  // matters most for `environments`: re-selecting the same environment from the reference tree
-  // changes the param again and re-fires this effect instead of being a no-op. Runs reactively
-  // (not mount-only) because the tree is rendered inside this page, so navigating from a node
-  // updates the params without remounting.
+  const hasInitializedEnvironmentFromPreference = useRef(false);
   useEffect(() => {
-    const { search, tags, filterBy, environments: envSlugs, ...query } = routerSearch;
-    const hasEnvLink = Boolean(envSlugs?.length);
+    if (hasInitializedEnvironmentFromPreference.current || userAvailableEnvs.length === 0) return;
+    hasInitializedEnvironmentFromPreference.current = true;
 
-    if (!search && !tags && !filterBy && !hasEnvLink) return;
-    // Env link present but envs not loaded yet → wait so we don't strip it before applying.
-    if (hasEnvLink && userAvailableEnvs.length === 0) return;
+    const requestedSlugs = normalizeOverviewEnvironments(
+      routerSearch.environments,
+      userAvailableEnvs.map((env) => env.slug)
+    );
 
-    if (envSlugs && envSlugs.length > 0) {
-      const envIds = userAvailableEnvs
-        .filter((env) => envSlugs.includes(env.slug))
-        .map((env) => env.id);
-      if (envIds.length > 0) {
-        setStoredEnvIds(envIds);
+    if (routerSearch.environments.length > 0) {
+      if (requestedSlugs.length !== routerSearch.environments.length) {
+        navigate({
+          search: (prev) => ({
+            ...prev,
+            environments: requestedSlugs.length > 0 ? requestedSlugs : undefined
+          }),
+          replace: true
+        });
       }
+      return;
     }
 
-    if (search || tags || filterBy) {
-      const initialFilter = { ...DEFAULT_FILTER_STATE };
-      if (filterBy) {
-        filterBy
-          .split(",")
-          .map((value) => value.trim())
-          .filter((value): value is RowType => Object.values(RowType).includes(value as RowType))
-          .forEach((rowType) => {
-            initialFilter[rowType] = true;
-          });
-      }
-
-      const initialTagFilter = (tags ?? "")
-        .split(",")
-        .reduce<Record<string, boolean>>((acc, tag) => {
-          const tagSlug = tag.trim();
-          if (tagSlug) acc[tagSlug] = true;
-          return acc;
-        }, {});
-      if (Object.keys(initialTagFilter).length > 0) {
-        initialFilter[RowType.Secret] = true;
-      }
-
-      setFilter(initialFilter);
-      setTagFilter(initialTagFilter);
-
-      if (search) {
-        setSearchFilter(search as string);
-      }
+    const initialPreference = storedEnvIds.filter((id) =>
+      userAvailableEnvs.some((env) => env.id === id)
+    );
+    if (initialPreference.length > 0) {
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          environments: userAvailableEnvs
+            .filter((env) => initialPreference.includes(env.id))
+            .map((env) => env.slug)
+        })
+      });
     }
+  }, [navigate, routerSearch.environments, storedEnvIds, userAvailableEnvs]);
 
-    navigate({ search: query, replace: true });
-  }, [
-    routerSearch.search,
-    routerSearch.tags,
-    routerSearch.filterBy,
-    routerSearch.environments?.join(","),
-    userAvailableEnvs.length
-  ]);
-
-  const filteredEnvs = useMemo(() => {
-    if (!storedEnvIds.length) return [];
-    return userAvailableEnvs.filter((env) => storedEnvIds.includes(env.id));
-  }, [storedEnvIds, userAvailableEnvs]);
+  const filteredEnvs = useMemo(
+    () => userAvailableEnvs.filter((env) => routerSearch.environments.includes(env.slug)),
+    [routerSearch.environments, userAvailableEnvs]
+  );
 
   const setFilteredEnvs = useCallback(
     (value: SetStateAction<ProjectEnv[]>) => {
-      setStoredEnvIds((prev) => {
-        const prevEnvs = userAvailableEnvs.filter((env) => prev.includes(env.id));
-        const next = typeof value === "function" ? value(prevEnvs) : value;
-        return next.map((env) => env.id);
+      const next = typeof value === "function" ? value(filteredEnvs) : value;
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          environments: next.length > 0 ? next.map((env) => env.slug) : undefined
+        })
       });
+      setStoredEnvIds(next.map((env) => env.id));
     },
-    [setStoredEnvIds, userAvailableEnvs]
+    [filteredEnvs, navigate, setStoredEnvIds]
   );
 
   const visibleEnvs = filteredEnvs.length ? filteredEnvs : userAvailableEnvs;
@@ -2197,62 +2199,64 @@ const OverviewPageContent = () => {
     handlePopUpClose("confirmDisableBatchMode");
   }, [singleVisibleEnv, clearAllPendingChanges, projectId, secretPath, handlePopUpClose]);
 
-  const handleResetSearch = (path: string) => {
-    const restore = filterHistory.get(path);
-    setFilter(restore?.filter ?? DEFAULT_FILTER_STATE);
-    const el = restore?.searchFilter ?? "";
-    setSearchFilter(el);
-  };
-
   const handleFolderClick = (path: string) => {
     if (isOverviewFetching) return;
 
-    // store for breadcrumb nav to restore previously used filters
-    setFilterHistory((prev) => {
-      const curr = new Map(prev);
-      curr.set(secretPath, { filter, searchFilter });
-      return curr;
-    });
-
     navigate({
       search: (prev) => ({
-        ...prev,
-        secretPath: `${routerSearch.secretPath === "/" ? "" : routerSearch.secretPath}/${path}`
+        ...updateOverviewSecretPath(
+          prev,
+          `${routerSearch.secretPath === "/" ? "" : routerSearch.secretPath}/${path}`
+        )
       })
-    }).then(() => {
-      setFilter(DEFAULT_FILTER_STATE);
-      setSearchFilter("");
     });
   };
 
-  const handleClearTags = useCallback(() => {
-    setTagFilter({});
-  }, []);
-
-  const handleToggleRowType = useCallback(
-    (rowType: RowType) =>
-      setFilter((state) => {
-        const newValue = !state[rowType];
-        if (rowType === RowType.Secret && !newValue) {
-          setTagFilter({});
-        }
-        return {
-          ...state,
-          [rowType]: newValue
-        };
-      }),
-    []
+  const handleSearchChange = useCallback(
+    (search: string) => {
+      navigate({
+        search: (prev) => ({ ...prev, search: search || undefined })
+      });
+    },
+    [navigate]
   );
 
-  const handleToggleTag = useCallback((tagSlug: string) => {
-    setTagFilter((state) => {
-      const isActivating = !state[tagSlug];
-      if (isActivating) {
-        setFilter((filterState) => ({ ...filterState, [RowType.Secret]: true }));
-      }
-      return { ...state, [tagSlug]: isActivating };
-    });
-  }, []);
+  const handleClearTags = useCallback(() => {
+    navigate({ search: (prev) => ({ ...prev, tags: undefined }) });
+  }, [navigate]);
+
+  const handleToggleRowType = useCallback(
+    (rowType: RowType) => {
+      const nextFilter = { ...filter, [rowType]: !filter[rowType] };
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          filterBy: serializeOverviewResourceFilter(nextFilter, Object.values(RowType)),
+          tags: rowType === RowType.Secret && filter[rowType] ? undefined : prev.tags
+        })
+      });
+    },
+    [filter, navigate]
+  );
+
+  const handleToggleTag = useCallback(
+    (tagSlug: string) => {
+      const nextTags = Object.keys(tagFilter).filter((tag) => tag !== tagSlug);
+      if (!tagFilter[tagSlug]) nextTags.push(tagSlug);
+
+      navigate({
+        search: (prev) => ({
+          ...prev,
+          tags: serializeOverviewTags(nextTags),
+          filterBy:
+            !tagFilter[tagSlug] && !filter[RowType.Secret]
+              ? [...Object.values(RowType).filter((type) => filter[type]), RowType.Secret].join(",")
+              : prev.filterBy
+        })
+      });
+    },
+    [filter, navigate, tagFilter]
+  );
 
   const allRowsSelectedOnPage = useMemo(() => {
     if (
@@ -2654,7 +2658,7 @@ const OverviewPageContent = () => {
                     (pendingChanges.secrets.length > 0 || pendingChanges.folders.length > 0)
                   }
                 />
-                <FolderBreadcrumb secretPath={secretPath} onResetSearch={handleResetSearch} />
+                <FolderBreadcrumb secretPath={secretPath} />
               </div>
               <div className="flex flex-wrap items-center gap-3">
                 {userAvailableEnvs.length > 0 && (
@@ -2675,10 +2679,9 @@ const OverviewPageContent = () => {
                   />
                 )}
                 <ResourceSearchInput
-                  key={secretPath}
                   value={searchFilter}
                   tags={tags}
-                  onChange={setSearchFilter}
+                  onChange={handleSearchChange}
                   environments={userAvailableEnvs}
                   projectId={currentProject?.id}
                 />

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
@@ -23,7 +23,6 @@ import { useTimedReset } from "@app/hooks";
 
 type Props = {
   secretPath?: string;
-  onResetSearch: (secretPath: string) => void;
 };
 
 type Measurements = {
@@ -34,7 +33,7 @@ type Measurements = {
   separatorWidth: number;
 };
 
-export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
+export function FolderBreadcrumb({ secretPath = "" }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const measureContainerRef = useRef<HTMLDivElement>(null);
 
@@ -55,9 +54,8 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
     [secretPath]
   );
 
-  // The crumb is a real link, so the browser owns the navigation; this only restores the
-  // filters previously used at that depth, and must not run when the click is a new-tab
-  // gesture that leaves this tab where it is.
+  // The crumb is a real link, so the browser owns the navigation and preserves the other search
+  // parameters through the route transition.
   const onFolderCrumbClick = useCallback(
     (event: React.MouseEvent, index: number) => {
       if (event.defaultPrevented) return;
@@ -65,9 +63,8 @@ export function FolderBreadcrumb({ secretPath = "", onResetSearch }: Props) {
         return;
       const newSecPath = getCrumbPath(index);
       if (secretPath === newSecPath) return;
-      onResetSearch(newSecPath);
     },
-    [getCrumbPath, secretPath, onResetSearch]
+    [getCrumbPath, secretPath]
   );
 
   // Measure all elements and track container width

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderBreadcrumb/FolderBreadcrumb.tsx
@@ -56,17 +56,6 @@ export function FolderBreadcrumb({ secretPath = "" }: Props) {
 
   // The crumb is a real link, so the browser owns the navigation and preserves the other search
   // parameters through the route transition.
-  const onFolderCrumbClick = useCallback(
-    (event: React.MouseEvent, index: number) => {
-      if (event.defaultPrevented) return;
-      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0)
-        return;
-      const newSecPath = getCrumbPath(index);
-      if (secretPath === newSecPath) return;
-    },
-    [getCrumbPath, secretPath]
-  );
-
   // Measure all elements and track container width
   const measureElements = useCallback(() => {
     const container = containerRef.current;
@@ -261,7 +250,6 @@ export function FolderBreadcrumb({ secretPath = "" }: Props) {
                 from="/organizations/$orgId/projects/secret-management/$projectId/overview"
                 to="."
                 search={(prev) => ({ ...prev, secretPath: getCrumbPath(0) })}
-                onClick={(event) => onFolderCrumbClick(event, 0)}
                 aria-label="Root folder"
               >
                 <FolderIcon />
@@ -286,7 +274,6 @@ export function FolderBreadcrumb({ secretPath = "" }: Props) {
                       from="/organizations/$orgId/projects/secret-management/$projectId/overview"
                       to="."
                       search={(prev) => ({ ...prev, secretPath: getCrumbPath(index + 1) })}
-                      onClick={(event) => onFolderCrumbClick(event, index + 1)}
                     >
                       {path}
                     </Link>
@@ -327,7 +314,6 @@ export function FolderBreadcrumb({ secretPath = "" }: Props) {
                               ...prev,
                               secretPath: getCrumbPath(originalIndex + 1)
                             })}
-                            onClick={(event) => onFolderCrumbClick(event, originalIndex + 1)}
                           >
                             <div className="absolute top-1/2 -left-[3px] h-px w-2 bg-muted/50 transition-colors" />
 
@@ -366,7 +352,6 @@ export function FolderBreadcrumb({ secretPath = "" }: Props) {
                           ...prev,
                           secretPath: getCrumbPath(originalIndex + 1)
                         })}
-                        onClick={(event) => onFolderCrumbClick(event, originalIndex + 1)}
                       >
                         {path}
                       </Link>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/FolderTableRow/FolderTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/FolderTableRow/FolderTableRow.tsx
@@ -141,6 +141,7 @@ export const FolderTableRow = ({
             <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <IconButton
+                  aria-label="Move folder"
                   variant="ghost"
                   size="xs"
                   className="w-0 overflow-hidden border-0 transition-all duration-300 group-hover:w-7"
@@ -159,6 +160,7 @@ export const FolderTableRow = ({
             <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <IconButton
+                  aria-label="Edit folder"
                   variant="ghost"
                   size="xs"
                   className="w-0 overflow-hidden border-0 transition-all duration-300 group-hover:w-7"
@@ -177,6 +179,7 @@ export const FolderTableRow = ({
             <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <IconButton
+                  aria-label="Discard pending folder changes"
                   variant="ghost"
                   className="w-0 overflow-hidden border-0 transition-all duration-300 group-hover:w-7 hover:text-danger"
                   size="xs"
@@ -194,6 +197,7 @@ export const FolderTableRow = ({
             <Tooltip disableHoverableContent>
               <TooltipTrigger>
                 <IconButton
+                  aria-label="Delete folder"
                   variant="ghost"
                   size="xs"
                   className="w-0 overflow-hidden border-0 transition-all duration-300 group-hover:w-7 hover:text-danger"

--- a/frontend/src/pages/secret-manager/OverviewPage/components/ResourceFilter/ResourceFilter.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/ResourceFilter/ResourceFilter.tsx
@@ -77,16 +77,21 @@ export function ResourceFilter({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="outline-0">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <IconButton className="relative" size="md" variant={isActive ? "project" : "outline"}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              aria-label="Filter resources"
+              className="relative"
+              size="md"
+              variant={isActive ? "project" : "outline"}
+            >
               <FilterIcon />
             </IconButton>
-          </TooltipTrigger>
-          <TooltipContent>Filter resources</TooltipContent>
-        </Tooltip>
-      </DropdownMenuTrigger>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>Filter resources</TooltipContent>
+      </Tooltip>
       <DropdownMenuContent align="end">
         <ResourceFilterMenuContent
           resourceTypes={OVERVIEW_RESOURCE_TYPES}

--- a/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/ResourceSearchInput.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/ResourceSearchInput.tsx
@@ -163,9 +163,9 @@ export const ResourceSearchInput = ({
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         initialValue={inputValue}
-        onClose={() => {
+        onClose={(clearSearch = true) => {
           setIsOpen(false);
-          handleClear();
+          if (clearSearch) handleClear();
         }}
         {...props}
       />

--- a/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/ResourceSearchInput.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/ResourceSearchInput.tsx
@@ -17,6 +17,7 @@ import {
 import { useDebounce } from "@app/hooks";
 
 import { QuickSearchModal, QuickSearchModalProps } from "../SecretSearchInput/components";
+import { getResourceSearchStateTransition } from "./resourceSearchState";
 
 type Props = Omit<QuickSearchModalProps, "isOpen" | "onClose" | "onOpenChange" | "initialValue"> & {
   value: string;
@@ -40,21 +41,29 @@ export const ResourceSearchInput = ({
   // local input state so typing doesn't re-render the whole table
   const [inputValue, setInputValue] = useState(externalValue);
   const [debouncedInputValue] = useDebounce(inputValue);
+  const previousExternalValue = useRef(externalValue);
   const lastEmittedValue = useRef(externalValue);
 
   useEffect(() => {
-    if (externalValue !== lastEmittedValue.current) {
-      setInputValue(externalValue);
-      lastEmittedValue.current = externalValue;
-    }
-  }, [externalValue]);
+    const transition = getResourceSearchStateTransition({
+      externalValue,
+      previousExternalValue: previousExternalValue.current,
+      debouncedInputValue,
+      lastEmittedValue: lastEmittedValue.current
+    });
 
-  useEffect(() => {
-    if (debouncedInputValue !== lastEmittedValue.current) {
-      lastEmittedValue.current = debouncedInputValue;
-      onChange(debouncedInputValue);
+    if (!transition) return;
+
+    if (transition.type === "sync") {
+      previousExternalValue.current = transition.value;
+      lastEmittedValue.current = transition.value;
+      setInputValue(transition.value);
+      return;
     }
-  }, [debouncedInputValue, onChange]);
+
+    lastEmittedValue.current = transition.value;
+    onChange(transition.value);
+  }, [debouncedInputValue, externalValue, onChange]);
 
   const handleClear = () => {
     setInputValue("");

--- a/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/ResourceSearchInput.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/ResourceSearchInput.tsx
@@ -69,7 +69,11 @@ export const ResourceSearchInput = ({
       <ButtonGroup>
         <Tooltip>
           <TooltipTrigger asChild>
-            <IconButton variant="outline" onClick={() => setIsOpen(true)}>
+            <IconButton
+              aria-label="Search all folders"
+              variant="outline"
+              onClick={() => setIsOpen(true)}
+            >
               <SearchIcon />
             </IconButton>
           </TooltipTrigger>
@@ -117,7 +121,12 @@ export const ResourceSearchInput = ({
                 />
                 {hasSearch && (
                   <InputGroupAddon align="inline-end">
-                    <IconButton variant="ghost" size="xs" onClick={handleClear}>
+                    <IconButton
+                      aria-label="Clear search"
+                      variant="ghost"
+                      size="xs"
+                      onClick={handleClear}
+                    >
                       <XIcon />
                     </IconButton>
                   </InputGroupAddon>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/resourceSearchState.test.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/resourceSearchState.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getResourceSearchStateTransition } from "./resourceSearchState";
+
+describe("Resource search state", () => {
+  it("syncs an external navigation without re-emitting the stale debounced value", () => {
+    assert.deepEqual(
+      getResourceSearchStateTransition({
+        externalValue: "DATABASE_URL",
+        previousExternalValue: "api",
+        debouncedInputValue: "api",
+        lastEmittedValue: "api"
+      }),
+      { type: "sync", value: "DATABASE_URL" }
+    );
+  });
+
+  it("emits a locally debounced search change", () => {
+    assert.deepEqual(
+      getResourceSearchStateTransition({
+        externalValue: "api",
+        previousExternalValue: "api",
+        debouncedInputValue: "api-key",
+        lastEmittedValue: "api"
+      }),
+      { type: "emit", value: "api-key" }
+    );
+  });
+
+  it("does nothing when external and local search state are synchronized", () => {
+    assert.equal(
+      getResourceSearchStateTransition({
+        externalValue: "api",
+        previousExternalValue: "api",
+        debouncedInputValue: "api",
+        lastEmittedValue: "api"
+      }),
+      undefined
+    );
+  });
+});

--- a/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/resourceSearchState.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/resourceSearchState.ts
@@ -1,0 +1,27 @@
+type ResourceSearchState = {
+  externalValue: string;
+  previousExternalValue: string;
+  debouncedInputValue: string;
+  lastEmittedValue: string;
+};
+
+export type ResourceSearchStateTransition =
+  | { type: "sync"; value: string }
+  | { type: "emit"; value: string };
+
+export const getResourceSearchStateTransition = ({
+  externalValue,
+  previousExternalValue,
+  debouncedInputValue,
+  lastEmittedValue
+}: ResourceSearchState): ResourceSearchStateTransition | undefined => {
+  if (externalValue !== previousExternalValue) {
+    return { type: "sync", value: externalValue };
+  }
+
+  if (debouncedInputValue !== lastEmittedValue) {
+    return { type: "emit", value: debouncedInputValue };
+  }
+
+  return undefined;
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/SecretSearchInput.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/SecretSearchInput.tsx
@@ -10,7 +10,7 @@ import { QuickSearchModal, QuickSearchModalProps } from "./components";
 
 type ModalProps = Omit<
   QuickSearchModalProps,
-  "isOpen" | "onClose" | "onOpenChange" | "initialValue"
+  "isOpen" | "onClose" | "onOpenChange" | "initialValue" | "onSelectResult"
 > & {
   value: string;
   onChange: (search: string) => void;
@@ -109,9 +109,10 @@ export const SecretSearchInput = ({
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         initialValue={value}
-        onClose={() => {
+        onSelectResult={({ search }) => onChange(search)}
+        onClose={(clearSearch = true) => {
           setIsOpen(false);
-          onChange("");
+          if (clearSearch) onChange("");
         }}
         {...props}
       />

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchDynamicSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchDynamicSecretItem.tsx
@@ -4,23 +4,33 @@ import { ChevronRightIcon, FingerprintIcon } from "lucide-react";
 import { TableCell, TableRow, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 
+import { QuickSearchSelection } from "./quickSearchTypes";
+
 type Props = {
   dynamicSecret: TDynamicSecret & { environment: string; path: string };
   envSlug: string;
   onClose: (clearSearch?: boolean) => void;
+  onSelectResult: (selection: QuickSearchSelection) => void;
 };
 
-export const QuickSearchDynamicSecretItem = ({ dynamicSecret, envSlug, onClose }: Props) => {
+export const QuickSearchDynamicSecretItem = ({
+  dynamicSecret,
+  envSlug,
+  onClose,
+  onSelectResult
+}: Props) => {
   const navigate = useNavigate({
     from: "/organizations/$orgId/projects/secret-management/$projectId/overview"
   });
 
   const handleNavigate = () => {
+    onSelectResult({ search: dynamicSecret.name });
     navigate({
       search: (prev) => ({
         ...prev,
         secretPath: dynamicSecret.path,
-        search: dynamicSecret.name,
+        search: undefined,
+        tags: undefined,
         filterBy: "dynamic",
         environments: [envSlug]
       })

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchDynamicSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchDynamicSecretItem.tsx
@@ -25,7 +25,7 @@ export const QuickSearchDynamicSecretItem = ({ dynamicSecret, envSlug, onClose }
         environments: [envSlug]
       })
     });
-    onClose();
+    onClose(false);
   };
 
   return (

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchDynamicSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchDynamicSecretItem.tsx
@@ -7,7 +7,7 @@ import { TDynamicSecret } from "@app/hooks/api/dynamicSecret/types";
 type Props = {
   dynamicSecret: TDynamicSecret & { environment: string; path: string };
   envSlug: string;
-  onClose: () => void;
+  onClose: (clearSearch?: boolean) => void;
 };
 
 export const QuickSearchDynamicSecretItem = ({ dynamicSecret, envSlug, onClose }: Props) => {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchFolderItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchFolderItem.tsx
@@ -4,22 +4,27 @@ import { ChevronRightIcon, FolderIcon } from "lucide-react";
 import { TableCell, TableRow, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { TSecretFolder } from "@app/hooks/api/secretFolders/types";
 
+import { QuickSearchSelection } from "./quickSearchTypes";
+
 type Props = {
   folder: TSecretFolder & { envId: string; path: string };
   envSlug: string;
   onClose: (clearSearch?: boolean) => void;
+  onSelectResult: (selection: QuickSearchSelection) => void;
 };
 
-export const QuickSearchFolderItem = ({ folder, envSlug, onClose }: Props) => {
+export const QuickSearchFolderItem = ({ folder, envSlug, onClose, onSelectResult }: Props) => {
   const navigate = useNavigate({
     from: "/organizations/$orgId/projects/secret-management/$projectId/overview"
   });
 
   const handleNavigate = () => {
+    onSelectResult({ search: "" });
     navigate({
       search: (prev) => ({
         ...prev,
-        search: "",
+        search: undefined,
+        tags: undefined,
         filterBy: undefined,
         secretPath: folder.path,
         environments: [envSlug]

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchFolderItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchFolderItem.tsx
@@ -7,7 +7,7 @@ import { TSecretFolder } from "@app/hooks/api/secretFolders/types";
 type Props = {
   folder: TSecretFolder & { envId: string; path: string };
   envSlug: string;
-  onClose: () => void;
+  onClose: (clearSearch?: boolean) => void;
 };
 
 export const QuickSearchFolderItem = ({ folder, envSlug, onClose }: Props) => {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchFolderItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchFolderItem.tsx
@@ -25,7 +25,7 @@ export const QuickSearchFolderItem = ({ folder, envSlug, onClose }: Props) => {
         environments: [envSlug]
       })
     });
-    onClose();
+    onClose(false);
   };
 
   return (

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchMetadataSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchMetadataSecretItem.tsx
@@ -14,7 +14,7 @@ import { TMetadataMatchedSecret } from "@app/hooks/api/dashboard/types";
 type Props = {
   secret: TMetadataMatchedSecret;
   envSlug: string;
-  onClose: () => void;
+  onClose: (clearSearch?: boolean) => void;
 };
 
 const MAX_VISIBLE_BADGES = 3;

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchMetadataSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchMetadataSecretItem.tsx
@@ -11,25 +11,34 @@ import {
 } from "@app/components/v3";
 import { TMetadataMatchedSecret } from "@app/hooks/api/dashboard/types";
 
+import { QuickSearchSelection } from "./quickSearchTypes";
+
 type Props = {
   secret: TMetadataMatchedSecret;
   envSlug: string;
   onClose: (clearSearch?: boolean) => void;
+  onSelectResult: (selection: QuickSearchSelection) => void;
 };
 
 const MAX_VISIBLE_BADGES = 3;
 
-export const QuickSearchMetadataSecretItem = ({ secret, envSlug, onClose }: Props) => {
+export const QuickSearchMetadataSecretItem = ({
+  secret,
+  envSlug,
+  onClose,
+  onSelectResult
+}: Props) => {
   const navigate = useNavigate({
     from: "/organizations/$orgId/projects/secret-management/$projectId/overview"
   });
 
   const handleNavigate = () => {
+    onSelectResult({ search: secret.secretKey, tags: [] });
     navigate({
       search: (prev) => ({
         ...prev,
         secretPath: secret.secretPath,
-        search: secret.secretKey,
+        search: undefined,
         filterBy: "secret",
         environments: [envSlug],
         tags: undefined

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchMetadataSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchMetadataSecretItem.tsx
@@ -35,7 +35,7 @@ export const QuickSearchMetadataSecretItem = ({ secret, envSlug, onClose }: Prop
         tags: undefined
       })
     });
-    onClose();
+    onClose(false);
   };
 
   const visibleMetadata = secret.metadata.slice(0, MAX_VISIBLE_BADGES);

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchModal.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchModal.tsx
@@ -55,11 +55,14 @@ import { QuickSearchEnvTable } from "./QuickSearchEnvTable";
 import { QuickSearchFolderItem } from "./QuickSearchFolderItem";
 import { QuickSearchMetadataSecretItem } from "./QuickSearchMetadataSecretItem";
 import { QuickSearchSecretItem } from "./QuickSearchSecretItem";
+import { QuickSearchSelection } from "./quickSearchTypes";
 import {
   MetadataMatchType,
   MetadataSearchCondition,
   SecretMetadataSearchBuilder
 } from "./SecretMetadataSearchBuilder";
+
+export type { QuickSearchSelection } from "./quickSearchTypes";
 
 export type QuickSearchModalProps = {
   environments: ProjectEnv[];
@@ -67,6 +70,7 @@ export type QuickSearchModalProps = {
   tags?: WsTag[];
   isSingleEnv?: boolean;
   initialValue: string;
+  onSelectResult: (selection: QuickSearchSelection) => void;
   onClose: (clearSearch?: boolean) => void;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
@@ -97,6 +101,7 @@ const Content = ({
   environments,
   projectId,
   onClose,
+  onSelectResult,
   tags,
   initialValue = ""
 }: Omit<QuickSearchModalProps, "isOpen" | "onOpenChange" | "isSingleEnv">) => {
@@ -364,6 +369,7 @@ const Content = ({
                   secret={secret}
                   envSlug={env.slug}
                   onClose={onClose}
+                  onSelectResult={onSelectResult}
                 />
               ))}
             </QuickSearchEnvTable>
@@ -394,6 +400,7 @@ const Content = ({
                     folder={folder}
                     envSlug={env.slug}
                     onClose={onClose}
+                    onSelectResult={onSelectResult}
                   />
                 ))}
                 {envDynamic.map((ds) => (
@@ -402,6 +409,7 @@ const Content = ({
                     dynamicSecret={ds}
                     envSlug={env.slug}
                     onClose={onClose}
+                    onSelectResult={onSelectResult}
                   />
                 ))}
                 {envRotations.map((rotation) => (
@@ -410,6 +418,7 @@ const Content = ({
                     secretRotation={rotation}
                     envSlug={env.slug}
                     onClose={onClose}
+                    onSelectResult={onSelectResult}
                   />
                 ))}
                 {envSecrets.map((secret) => (
@@ -420,6 +429,7 @@ const Content = ({
                     search={debouncedSearch}
                     tags={Object.keys(filterTags)}
                     onClose={onClose}
+                    onSelectResult={onSelectResult}
                   />
                 ))}
               </QuickSearchEnvTable>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchModal.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchModal.tsx
@@ -67,7 +67,7 @@ export type QuickSearchModalProps = {
   tags?: WsTag[];
   isSingleEnv?: boolean;
   initialValue: string;
-  onClose: () => void;
+  onClose: (clearSearch?: boolean) => void;
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
 };

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretItem.tsx
@@ -16,15 +16,25 @@ import { useTimedReset } from "@app/hooks";
 import { fetchSecretValue } from "@app/hooks/api/dashboard/queries";
 import { SecretV3RawSanitized } from "@app/hooks/api/secrets/types";
 
+import { QuickSearchSelection } from "./quickSearchTypes";
+
 type Props = {
   secret: SecretV3RawSanitized;
   envSlug: string;
   onClose: (clearSearch?: boolean) => void;
   tags: string[];
   search: string;
+  onSelectResult: (selection: QuickSearchSelection) => void;
 };
 
-export const QuickSearchSecretItem = ({ secret, envSlug, onClose, tags, search }: Props) => {
+export const QuickSearchSecretItem = ({
+  secret,
+  envSlug,
+  onClose,
+  onSelectResult,
+  tags,
+  search
+}: Props) => {
   const navigate = useNavigate({
     from: "/organizations/$orgId/projects/secret-management/$projectId/overview"
   });
@@ -35,12 +45,13 @@ export const QuickSearchSecretItem = ({ secret, envSlug, onClose, tags, search }
   const { currentProject } = useProject();
 
   const handleNavigate = () => {
+    onSelectResult({ search: secret.key, tags });
     navigate({
       search: (prev) => ({
         ...prev,
         secretPath: secret.path,
-        search: secret.key,
-        tags: tags.length ? tags.join(",") : undefined,
+        search: undefined,
+        tags: undefined,
         filterBy: "secret",
         environments: [envSlug]
       })

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretItem.tsx
@@ -45,7 +45,7 @@ export const QuickSearchSecretItem = ({ secret, envSlug, onClose, tags, search }
         environments: [envSlug]
       })
     });
-    onClose();
+    onClose(false);
   };
 
   const handleCopy = async () => {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretItem.tsx
@@ -19,7 +19,7 @@ import { SecretV3RawSanitized } from "@app/hooks/api/secrets/types";
 type Props = {
   secret: SecretV3RawSanitized;
   envSlug: string;
-  onClose: () => void;
+  onClose: (clearSearch?: boolean) => void;
   tags: string[];
   search: string;
 };

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretRotationItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretRotationItem.tsx
@@ -25,7 +25,7 @@ export const QuickSearchSecretRotationItem = ({ secretRotation, envSlug, onClose
         environments: [envSlug]
       })
     });
-    onClose();
+    onClose(false);
   };
 
   return (

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretRotationItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretRotationItem.tsx
@@ -7,7 +7,7 @@ import { TSecretRotationV2 } from "@app/hooks/api/secretRotationsV2";
 type Props = {
   secretRotation: TSecretRotationV2;
   envSlug: string;
-  onClose: () => void;
+  onClose: (clearSearch?: boolean) => void;
 };
 
 export const QuickSearchSecretRotationItem = ({ secretRotation, envSlug, onClose }: Props) => {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretRotationItem.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/QuickSearchSecretRotationItem.tsx
@@ -4,23 +4,33 @@ import { ChevronRightIcon, RefreshCwIcon } from "lucide-react";
 import { TableCell, TableRow, Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3";
 import { TSecretRotationV2 } from "@app/hooks/api/secretRotationsV2";
 
+import { QuickSearchSelection } from "./quickSearchTypes";
+
 type Props = {
   secretRotation: TSecretRotationV2;
   envSlug: string;
   onClose: (clearSearch?: boolean) => void;
+  onSelectResult: (selection: QuickSearchSelection) => void;
 };
 
-export const QuickSearchSecretRotationItem = ({ secretRotation, envSlug, onClose }: Props) => {
+export const QuickSearchSecretRotationItem = ({
+  secretRotation,
+  envSlug,
+  onClose,
+  onSelectResult
+}: Props) => {
   const navigate = useNavigate({
     from: "/organizations/$orgId/projects/secret-management/$projectId/overview"
   });
 
   const handleNavigate = () => {
+    onSelectResult({ search: secretRotation.name });
     navigate({
       search: (prev) => ({
         ...prev,
         secretPath: secretRotation.folder.path,
-        search: secretRotation.name,
+        search: undefined,
+        tags: undefined,
         filterBy: "rotation",
         environments: [envSlug]
       })

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/quickSearchTypes.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretSearchInput/components/quickSearchTypes.ts
@@ -1,0 +1,4 @@
+export type QuickSearchSelection = {
+  search: string;
+  tags?: string[];
+};

--- a/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts
@@ -3,16 +3,21 @@ import { describe, it } from "node:test";
 
 import {
   hasOverviewScopeChanged,
+  hasSensitiveOverviewSearchState,
   normalizeOverviewEnvironments,
+  parseOverviewTags,
   resolveOverviewEnvironmentSlugs,
   serializeOverviewResourceFilter,
-  serializeOverviewTags,
+  stripSensitiveOverviewSearchState,
   updateOverviewSecretPath
 } from "./overviewSearchState";
 
 describe("Secrets overview query state", () => {
-  it("serializes tags and resource filters canonically", () => {
-    assert.equal(serializeOverviewTags(["team-b", " team-a ", "team-b"]), "team-a,team-b");
+  it("parses one-shot tag links and serializes resource filters canonically", () => {
+    assert.deepEqual(parseOverviewTags("team-b, team-a ,team-b"), {
+      "team-a": true,
+      "team-b": true
+    });
     assert.equal(
       serializeOverviewResourceFilter({ folder: true, secret: false, dynamic: true }, [
         "folder",
@@ -21,8 +26,33 @@ describe("Secrets overview query state", () => {
       ]),
       "folder,dynamic"
     );
-    assert.equal(serializeOverviewTags([]), undefined);
+    assert.deepEqual(parseOverviewTags(), {});
     assert.equal(serializeOverviewResourceFilter({}, ["folder", "secret"]), undefined);
+  });
+
+  it("removes secret identifiers from durable URL state while preserving navigation state", () => {
+    const current = {
+      secretPath: "/apps",
+      environments: ["prod"],
+      search: "DATABASE_URL",
+      tags: "team-a",
+      filterBy: "secret",
+      unrelated: "preserved"
+    };
+
+    assert.equal(hasSensitiveOverviewSearchState(current), true);
+    assert.deepEqual(stripSensitiveOverviewSearchState(current), {
+      secretPath: "/apps",
+      environments: ["prod"],
+      search: undefined,
+      tags: undefined,
+      filterBy: "secret",
+      unrelated: "preserved"
+    });
+    assert.equal(
+      hasSensitiveOverviewSearchState({ secretPath: "/apps", environments: ["prod"] }),
+      false
+    );
   });
 
   it("normalizes direct environment links to accessible project slugs", () => {

--- a/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
 import {
+  hasOverviewScopeChanged,
   normalizeOverviewEnvironments,
+  resolveOverviewEnvironmentSlugs,
   serializeOverviewResourceFilter,
   serializeOverviewTags,
   updateOverviewSecretPath
@@ -27,6 +29,51 @@ describe("Secrets overview query state", () => {
     assert.deepEqual(normalizeOverviewEnvironments(["removed", "prod", "prod"], ["dev", "prod"]), [
       "prod"
     ]);
+  });
+
+  it("resolves environment preferences before the URL is canonicalized", () => {
+    const environments = [
+      { id: "dev-id", slug: "dev" },
+      { id: "prod-id", slug: "prod" }
+    ];
+
+    assert.deepEqual(resolveOverviewEnvironmentSlugs([], ["prod-id"], environments), ["prod"]);
+    assert.deepEqual(resolveOverviewEnvironmentSlugs(["removed"], ["prod-id"], environments), [
+      "prod"
+    ]);
+    assert.deepEqual(
+      resolveOverviewEnvironmentSlugs(["dev", "removed"], ["prod-id"], environments),
+      ["dev"]
+    );
+  });
+
+  it("treats filters as view state and folders or environments as scope state", () => {
+    const current = {
+      pathname: "/organizations/org/projects/secret-management/project/overview",
+      search: { secretPath: "/", environments: ["prod"], search: "api" }
+    };
+
+    assert.equal(
+      hasOverviewScopeChanged(current, {
+        ...current,
+        search: { ...current.search, search: "token", filterBy: "secret" }
+      }),
+      false
+    );
+    assert.equal(
+      hasOverviewScopeChanged(current, {
+        ...current,
+        search: { ...current.search, secretPath: "/apps" }
+      }),
+      true
+    );
+    assert.equal(
+      hasOverviewScopeChanged(current, {
+        ...current,
+        search: { ...current.search, environments: ["dev"] }
+      }),
+      true
+    );
   });
 
   it("changes only secretPath during folder and breadcrumb transitions", () => {

--- a/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts
@@ -6,16 +6,17 @@ import {
   serializeOverviewResourceFilter,
   serializeOverviewTags,
   updateOverviewSecretPath
-} from "./overviewSearchState.ts";
+} from "./overviewSearchState";
 
 describe("Secrets overview query state", () => {
   it("serializes tags and resource filters canonically", () => {
     assert.equal(serializeOverviewTags(["team-b", " team-a ", "team-b"]), "team-a,team-b");
     assert.equal(
-      serializeOverviewResourceFilter(
-        { folder: true, secret: false, dynamic: true },
-        ["folder", "dynamic", "secret"]
-      ),
+      serializeOverviewResourceFilter({ folder: true, secret: false, dynamic: true }, [
+        "folder",
+        "dynamic",
+        "secret"
+      ]),
       "folder,dynamic"
     );
     assert.equal(serializeOverviewTags([]), undefined);
@@ -23,10 +24,9 @@ describe("Secrets overview query state", () => {
   });
 
   it("normalizes direct environment links to accessible project slugs", () => {
-    assert.deepEqual(
-      normalizeOverviewEnvironments(["removed", "prod", "prod"], ["dev", "prod"]),
-      ["prod"]
-    );
+    assert.deepEqual(normalizeOverviewEnvironments(["removed", "prod", "prod"], ["dev", "prod"]), [
+      "prod"
+    ]);
   });
 
   it("changes only secretPath during folder and breadcrumb transitions", () => {

--- a/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  normalizeOverviewEnvironments,
+  serializeOverviewResourceFilter,
+  serializeOverviewTags,
+  updateOverviewSecretPath
+} from "./overviewSearchState.ts";
+
+describe("Secrets overview query state", () => {
+  it("serializes tags and resource filters canonically", () => {
+    assert.equal(serializeOverviewTags(["team-b", " team-a ", "team-b"]), "team-a,team-b");
+    assert.equal(
+      serializeOverviewResourceFilter(
+        { folder: true, secret: false, dynamic: true },
+        ["folder", "dynamic", "secret"]
+      ),
+      "folder,dynamic"
+    );
+    assert.equal(serializeOverviewTags([]), undefined);
+    assert.equal(serializeOverviewResourceFilter({}, ["folder", "secret"]), undefined);
+  });
+
+  it("normalizes direct environment links to accessible project slugs", () => {
+    assert.deepEqual(
+      normalizeOverviewEnvironments(["removed", "prod", "prod"], ["dev", "prod"]),
+      ["prod"]
+    );
+  });
+
+  it("changes only secretPath during folder and breadcrumb transitions", () => {
+    const current = {
+      secretPath: "/",
+      environments: ["prod"],
+      search: "api",
+      tags: "team-a",
+      filterBy: "folder,secret",
+      unrelated: "preserved"
+    };
+
+    assert.deepEqual(updateOverviewSecretPath(current, "/apps"), {
+      ...current,
+      secretPath: "/apps"
+    });
+  });
+});

--- a/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.ts
@@ -30,6 +30,38 @@ export const normalizeOverviewEnvironments = (
   return [...new Set(normalized)];
 };
 
+export const resolveOverviewEnvironmentSlugs = (
+  requestedSlugs: string[],
+  storedIds: string[],
+  availableEnvironments: { id: string; slug: string }[]
+) => {
+  const requestedEnvironments = normalizeOverviewEnvironments(
+    requestedSlugs,
+    availableEnvironments.map(({ slug }) => slug)
+  );
+
+  if (requestedEnvironments.length > 0) return requestedEnvironments;
+
+  return availableEnvironments.filter(({ id }) => storedIds.includes(id)).map(({ slug }) => slug);
+};
+
+type OverviewLocation = {
+  pathname: string;
+  search: unknown;
+};
+
+export const hasOverviewScopeChanged = (current: OverviewLocation, next: OverviewLocation) => {
+  if (current.pathname !== next.pathname) return true;
+
+  const currentSearch = current.search as OverviewSearchState;
+  const nextSearch = next.search as OverviewSearchState;
+
+  return (
+    currentSearch.secretPath !== nextSearch.secretPath ||
+    (currentSearch.environments ?? []).join(",") !== (nextSearch.environments ?? []).join(",")
+  );
+};
+
 export const updateOverviewSecretPath = <T extends OverviewSearchState>(
   search: T,
   secretPath: string

--- a/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.ts
@@ -1,0 +1,34 @@
+export type OverviewSearchState = {
+  secretPath?: string;
+  environments?: string[];
+  search?: string;
+  tags?: string;
+  filterBy?: string;
+};
+
+export const serializeOverviewTags = (tags: string[]) => {
+  const serialized = [...new Set(tags.map((tag) => tag.trim()).filter(Boolean))].sort().join(",");
+  return serialized || undefined;
+};
+
+export const serializeOverviewResourceFilter = (
+  filter: Record<string, boolean>,
+  resourceTypes: string[]
+) => {
+  const serialized = resourceTypes.filter((resourceType) => filter[resourceType]).join(",");
+  return serialized || undefined;
+};
+
+export const normalizeOverviewEnvironments = (
+  requestedSlugs: string[],
+  availableSlugs: string[]
+) => {
+  const available = new Set(availableSlugs);
+  const normalized = availableSlugs.filter((slug) => requestedSlugs.includes(slug) && available.has(slug));
+  return [...new Set(normalized)];
+};
+
+export const updateOverviewSecretPath = <T extends OverviewSearchState>(
+  search: T,
+  secretPath: string
+): T => ({ ...search, secretPath });

--- a/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.ts
@@ -24,7 +24,9 @@ export const normalizeOverviewEnvironments = (
   availableSlugs: string[]
 ) => {
   const available = new Set(availableSlugs);
-  const normalized = availableSlugs.filter((slug) => requestedSlugs.includes(slug) && available.has(slug));
+  const normalized = availableSlugs.filter(
+    (slug) => requestedSlugs.includes(slug) && available.has(slug)
+  );
   return [...new Set(normalized)];
 };
 

--- a/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.ts
+++ b/frontend/src/pages/secret-manager/OverviewPage/overviewSearchState.ts
@@ -6,10 +6,21 @@ export type OverviewSearchState = {
   filterBy?: string;
 };
 
-export const serializeOverviewTags = (tags: string[]) => {
-  const serialized = [...new Set(tags.map((tag) => tag.trim()).filter(Boolean))].sort().join(",");
-  return serialized || undefined;
-};
+export const parseOverviewTags = (tags?: string) =>
+  (tags ?? "").split(",").reduce<Record<string, boolean>>((acc, tag) => {
+    const tagSlug = tag.trim();
+    if (tagSlug) acc[tagSlug] = true;
+    return acc;
+  }, {});
+
+export const hasSensitiveOverviewSearchState = (search: OverviewSearchState) =>
+  Boolean(search.search) || search.tags !== undefined;
+
+export const stripSensitiveOverviewSearchState = <T extends OverviewSearchState>(search: T): T => ({
+  ...search,
+  search: undefined,
+  tags: undefined
+});
 
 export const serializeOverviewResourceFilter = (
   filter: Record<string, boolean>,

--- a/frontend/src/pages/secret-manager/OverviewPage/route.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/route.tsx
@@ -22,7 +22,15 @@ export const Route = createFileRoute(
   component: OverviewPage,
   validateSearch: zodValidator(SecretOverviewPageQuerySchema),
   search: {
-    middlewares: [stripSearchParams({ secretPath: "/", search: "", environments: [] })]
+    middlewares: [
+      stripSearchParams({
+        secretPath: "/",
+        search: "",
+        environments: [],
+        tags: undefined,
+        filterBy: undefined
+      })
+    ]
   },
   beforeLoad: ({ context, params }) => ({
     ...context,


### PR DESCRIPTION
## Context

This PR implements the navigation and filter-state portion of the Secrets v3 migration tracked by [SECRETS-534](https://linear.app/infisical/issue/SECRETS-534/migrate-secrets-area-to-v3). [SECRETS-559](https://linear.app/infisical/issue/SECRETS-559/unify-secrets-overview-navigation-and-query-state) unifies the cohesive work from SECRETS-535, SECRETS-537, and SECRETS-543.

Previously, environment selection, search, tags, and resource filters were split between local state, localStorage, and transient one-shot URL ingestion. Folder rows and breadcrumbs also reset or restored transient filter history, which could lose view state during navigation. Filter navigation could additionally interrupt pending batch changes or clear bulk selections.

This change keeps shareable navigation state—environment slugs, secret path, and resource type filters—in the URL while keeping sensitive search text and tag slugs in local state. Existing links containing search or tag parameters are applied once and immediately stripped with replacement navigation. The overview resolves stored environment preferences before its first enabled query, normalizes inaccessible environments, preserves unrelated safe query parameters through folder and breadcrumb transitions, and keeps search, tag, batch-mode, and bulk-selection state intact during view-only filtering. Quick-search result navigation now carries only path, environment, and resource type in the URL. The change also corrects nested dropdown trigger composition and adds accessible names to icon-only controls.

## Screenshots

## Steps to verify the change

1. Install frontend dependencies using the repository's supported workflow.
2. Run the focused state contracts:
   `cd frontend && node --test --import tsx src/pages/secret-manager/OverviewPage/overviewSearchState.test.ts src/pages/secret-manager/OverviewPage/components/ResourceSearchInput/resourceSearchState.test.ts`
3. Run the repository frontend validation gate:
   `/Users/andrewhuang/Documents/Agent\ Workspace/skills/validate-infisical-frontend/scripts/frontend-validation-control gate --worktree "$PWD"`
4. In a project with multiple accessible environments, open Secrets Overview and verify:
   - selecting environments updates the canonical environment URL parameters;
   - resource type filters update `filterBy`, while search text and tag slugs do not remain in the URL;
   - incoming links with `search` or `tags` apply the filter once and then remove those parameters;
   - quick-search results navigate to the correct path and environment without exposing resource identifiers in the URL;
   - folder rows and breadcrumbs preserve local search/tag filters and unrelated safe query parameters;
   - search, filtering, and pagination continue to work with batch mode enabled and with bulk selections active;
   - a stored environment preference is used by the first enabled overview query;
   - an inaccessible environment slug is normalized safely.

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional-commit format.
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the contributing guide