### PR TITLE
chore(db): add additional privileges analytics view

### DIFF
--- a/backend/src/db/sanitized-schema.yaml
+++ b/backend/src/db/sanitized-schema.yaml
@@ -17,6 +17,23 @@ tables:
       - editedByUserId
       - editNote
 
+  - name: additional_privileges
+    source: public.additional_privileges
+    columns:
+      - id
+      - name
+      - isTemporary
+      - temporaryMode
+      - temporaryRange
+      - temporaryAccessStartTime
+      - temporaryAccessEndTime
+      - actorUserId
+      - actorIdentityId
+      - orgId
+      - projectId
+      - createdAt
+      - updatedAt
+
   - name: app_connections
     source: public.app_connections
     columns:


### PR DESCRIPTION
## Context

Adds the `additional_privileges` table to the sanitized analytics schema so privilege metadata is available for reporting. The sensitive `permissions` column is intentionally excluded from the view.

## Steps to verify the change

1. Load `backend/src/db/sanitized-schema.yaml` with `@infisical/pg-view-generator`.
2. Generate the analytics SQL and confirm it creates `analytics.additional_privileges`.
3. Confirm the generated view does not select the `permissions` column.
4. Run `make reviewable-api`.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (not needed)
- [x] Updated CLAUDE.md files (not needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

Made with [Cursor](https://cursor.com)