### PR TITLE
fix(ui): make machine identity auth method menu scrollable

### DIFF
--- a/frontend/src/components/v3/generic/Combobox/Combobox.tsx
+++ b/frontend/src/components/v3/generic/Combobox/Combobox.tsx
@@ -58,8 +58,8 @@ type ComboboxMultipleProps<TOption> = ComboboxSharedProps<TOption> &
 
 type ComboboxProps<TOption> = ComboboxSingleProps<TOption> | ComboboxMultipleProps<TOption>;
 
-const SINGLE_LIST_MAX_HEIGHT = "min(18.75rem, var(--available-height))";
-const MULTIPLE_LIST_MAX_HEIGHT = "min(18.75rem, var(--available-height))";
+const SINGLE_LIST_MAX_HEIGHT = "min(18.75rem, var(--available-height, 50dvh))";
+const MULTIPLE_LIST_MAX_HEIGHT = "min(18.75rem, var(--available-height, 50dvh))";
 
 const normalizeSearchText = (value: string) =>
   value
@@ -125,6 +125,7 @@ const ComboboxList = <TOption,>({
     <ComboboxPrimitive.List
       aria-label={ariaLabel}
       aria-busy={isLoading || undefined}
+      onWheel={(event) => event.stopPropagation()}
       className="thin-scrollbar scroll-py-1 overflow-y-auto overscroll-contain p-1 outline-none"
       style={{ maxHeight }}
     >

--- a/frontend/src/components/v3/generic/Combobox/Combobox.tsx
+++ b/frontend/src/components/v3/generic/Combobox/Combobox.tsx
@@ -306,7 +306,12 @@ const SingleCombobox = <TOption,>({
           {...inputProps}
         />
         {!open && value != null && renderValue && (
-          <span className="pointer-events-none absolute inset-y-0 right-9 left-2.5 flex min-w-0 items-center truncate text-sm text-foreground">
+          <span
+            className={cn(
+              "pointer-events-none absolute inset-y-0 right-9 left-2.5 flex min-w-0 items-center truncate text-sm text-foreground",
+              isDisabled && "opacity-50"
+            )}
+          >
             {renderValue(value)}
           </span>
         )}

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityAuthMethodModalContent.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityAuthMethodModalContent.tsx
@@ -1,15 +1,9 @@
 import { type ReactNode, useCallback } from "react";
 import { Controller, useForm } from "react-hook-form";
-import {
-  components as ReactSelectComponents,
-  type OptionProps,
-  type SingleValueProps
-} from "react-select";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   BadgeCheckIcon,
   BracesIcon,
-  CheckIcon,
   FileKeyIcon,
   GlobeIcon,
   KeyIcon,
@@ -18,7 +12,7 @@ import {
 import { z } from "zod";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
-import { Badge, Field, FieldError, FieldLabel, FilterableSelect } from "@app/components/v3";
+import { Badge, Combobox, Field, FieldError, FieldLabel } from "@app/components/v3";
 import { MAX_IDENTITY_ACCESS_TOKEN_TTL_FALLBACK } from "@app/helpers/identityAuthSchemas";
 import { IdentityAuthMethod } from "@app/hooks/api/identities";
 import { useFetchServerStatus } from "@app/hooks/api/serverDetails";
@@ -156,41 +150,6 @@ export const identityAuthMethodOptions = [
   ...commonIdentityAuthMethods,
   ...otherIdentityAuthMethods
 ];
-
-const AuthMethodOption = (props: OptionProps<TIdentityAuthMethodSelectOption>) => {
-  const { data, isDisabled, isSelected } = props;
-  const option = (
-    <ReactSelectComponents.Option {...props}>
-      <div
-        className={`flex items-center justify-between gap-2 ${
-          isDisabled ? "cursor-not-allowed opacity-50" : ""
-        }`}
-      >
-        <span className="flex min-w-0 items-center gap-2">
-          {data.icon}
-          <span className="truncate">{data.label}</span>
-          {data.showConfiguredBadge && <Badge variant="info">Configured</Badge>}
-        </span>
-        {isSelected && <CheckIcon className="size-4 shrink-0" />}
-      </div>
-    </ReactSelectComponents.Option>
-  );
-
-  return option;
-};
-
-const AuthMethodSingleValue = (props: SingleValueProps<TIdentityAuthMethodSelectOption>) => {
-  const { data } = props;
-
-  return (
-    <ReactSelectComponents.SingleValue {...props}>
-      <span className="flex min-w-0 items-center gap-2">
-        {data.icon}
-        <span className="truncate">{data.label}</span>
-      </span>
-    </ReactSelectComponents.SingleValue>
-  );
-};
 
 const schema = z
   .object({
@@ -452,8 +411,8 @@ export const IdentityAuthMethodModalContent = ({
           return (
             <Field className="mb-2">
               <FieldLabel htmlFor="auth-method">Auth Method</FieldLabel>
-              <FilterableSelect<TIdentityAuthMethodSelectOption>
-                inputId="auth-method"
+              <Combobox<TIdentityAuthMethodSelectOption>
+                id="auth-method"
                 value={selectedAuthMethod}
                 options={authMethodOptions}
                 isDisabled={isSelectedAuthAlreadyConfigured}
@@ -461,19 +420,30 @@ export const IdentityAuthMethodModalContent = ({
                 isOptionDisabled={({ isConfigured }) => isConfigured}
                 getOptionLabel={({ label }) => label}
                 getOptionValue={({ value: methodValue }) => methodValue}
-                components={{
-                  Option: AuthMethodOption,
-                  SingleValue: AuthMethodSingleValue
-                }}
-                placeholder="Select auth method"
-                onChange={(next) => {
-                  const nextAuthMethod = next as TIdentityAuthMethodSelectOption | null;
-
-                  if (nextAuthMethod && !nextAuthMethod.isConfigured) {
+                placeholder="Select auth method..."
+                searchPlaceholder="Search auth methods..."
+                searchAriaLabel="Search auth methods"
+                emptyMessage="No auth methods found."
+                modal
+                onValueChange={(nextAuthMethod) => {
+                  if (!nextAuthMethod.isConfigured) {
                     setSelectedAuthMethod(nextAuthMethod.value);
                     onChange(nextAuthMethod.value);
                   }
                 }}
+                renderOption={(option) => (
+                  <span className="flex min-w-0 items-center gap-2">
+                    {option.icon}
+                    <span className="truncate">{option.label}</span>
+                    {option.showConfiguredBadge && <Badge variant="info">Configured</Badge>}
+                  </span>
+                )}
+                renderValue={(option) => (
+                  <span className="flex min-w-0 items-center gap-2">
+                    {option.icon}
+                    <span className="truncate">{option.label}</span>
+                  </span>
+                )}
               />
               <FieldError>{error?.message}</FieldError>
             </Field>


### PR DESCRIPTION
## Context

The machine identity “Add Auth Method” menu used the legacy React Select implementation, whose long option list did not scroll correctly inside the Sheet.

This replaces it with the v3 Combobox, preserving configured-method disabling and custom auth-method icons/badges. The shared Combobox list now has a viewport-height fallback and keeps mouse-wheel events within the popup so the list scrolls correctly in overlays.

No related ticket was provided.

## Screenshots

<img width="1110" height="940" alt="CleanShot 2026-08-20 at 16 12 34@2x" src="https://github.com/user-attachments/assets/f718f13d-9f25-4434-b34c-25b071bdb0c7" />

## Steps to verify the change

1. Start the Infisical preview with this branch.
2. Open a machine identity and select **Add Auth Method**.
3. Open the **Auth Method** Combobox.
4. Confirm the list has an internal scroll region.
5. Use the mouse wheel over the options list and verify it scrolls through all auth methods.
6. Confirm keyboard navigation, configured badges, disabled configured methods, and selection behavior remain intact.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)