### PR TITLE
fix(auth): accept array aud claims in JWT Auth audience checks

### DIFF
--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.test.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+
+import { doesAudValueMatchJwtPolicy, doesFieldValueMatchJwtPolicy, hasJwtAudienceClaim } from "./identity-jwt-auth-fns";
+
+describe("doesAudValueMatchJwtPolicy", () => {
+  test("matches a scalar audience string", () => {
+    expect(doesAudValueMatchJwtPolicy("infisical", "infisical")).toBe(true);
+  });
+
+  test("matches when the configured audience is a member of an array aud", () => {
+    expect(doesAudValueMatchJwtPolicy(["infisical"], "infisical")).toBe(true);
+    expect(doesAudValueMatchJwtPolicy(["other", "infisical"], "infisical")).toBe(true);
+  });
+
+  test("rejects an array aud that does not contain the configured audience", () => {
+    expect(doesAudValueMatchJwtPolicy(["other"], "infisical")).toBe(false);
+    expect(doesAudValueMatchJwtPolicy([], "infisical")).toBe(false);
+  });
+
+  test("matches glob policies against scalar and array aud", () => {
+    expect(doesAudValueMatchJwtPolicy("prod-eu", "prod-*")).toBe(true);
+    expect(doesAudValueMatchJwtPolicy(["staging", "prod-eu"], "prod-*")).toBe(true);
+    expect(doesAudValueMatchJwtPolicy(["staging"], "prod-*")).toBe(false);
+  });
+});
+
+describe("hasJwtAudienceClaim", () => {
+  test("accepts a non-empty string or string array", () => {
+    expect(hasJwtAudienceClaim("infisical")).toBe(true);
+    expect(hasJwtAudienceClaim(["infisical"])).toBe(true);
+  });
+
+  test("rejects missing or empty audience values", () => {
+    expect(hasJwtAudienceClaim(undefined)).toBe(false);
+    expect(hasJwtAudienceClaim("")).toBe(false);
+    expect(hasJwtAudienceClaim([])).toBe(false);
+  });
+});
+
+describe("doesFieldValueMatchJwtPolicy", () => {
+  test("still matches scalar strings used by subject and claims", () => {
+    expect(doesFieldValueMatchJwtPolicy("system:serviceaccount:ns:sa", "system:serviceaccount:ns:sa")).toBe(true);
+    expect(doesFieldValueMatchJwtPolicy("other", "infisical")).toBe(false);
+  });
+});

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-fns.ts
@@ -1,5 +1,8 @@
 import picomatch from "picomatch";
 
+const doesStringMatchJwtPolicy = (fieldValue: string, policyValue: string) =>
+  policyValue === fieldValue || picomatch.isMatch(fieldValue, policyValue, { bash: true });
+
 export const doesFieldValueMatchJwtPolicy = (fieldValue: string | boolean | number, policyValue: string) => {
   if (typeof fieldValue === "boolean") {
     return fieldValue === (policyValue === "true");
@@ -9,5 +12,18 @@ export const doesFieldValueMatchJwtPolicy = (fieldValue: string | boolean | numb
     return fieldValue === parseInt(policyValue, 10);
   }
 
-  return policyValue === fieldValue || picomatch.isMatch(fieldValue, policyValue, { bash: true });
+  return doesStringMatchJwtPolicy(fieldValue, policyValue);
+};
+
+export const doesAudValueMatchJwtPolicy = (fieldValue: string | string[], policyValue: string) => {
+  if (Array.isArray(fieldValue)) {
+    return fieldValue.some((entry) => typeof entry === "string" && doesStringMatchJwtPolicy(entry, policyValue));
+  }
+
+  return doesStringMatchJwtPolicy(fieldValue, policyValue);
+};
+
+export const hasJwtAudienceClaim = (aud: unknown): aud is string | string[] => {
+  if (typeof aud === "string") return aud.length > 0;
+  return Array.isArray(aud) && aud.length > 0;
 };

--- a/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
+++ b/backend/src/services/identity-jwt-auth/identity-jwt-auth-service.ts
@@ -53,7 +53,7 @@ import { recordIdentityLastLoginDebounced } from "../membership-identity/members
 import { TOrgDALFactory } from "../org/org-dal";
 import { validateIdentityUpdateForSuperAdminPrivileges } from "../super-admin/super-admin-fns";
 import { TIdentityJwtAuthDALFactory } from "./identity-jwt-auth-dal";
-import { doesFieldValueMatchJwtPolicy } from "./identity-jwt-auth-fns";
+import { doesAudValueMatchJwtPolicy, doesFieldValueMatchJwtPolicy, hasJwtAudienceClaim } from "./identity-jwt-auth-fns";
 import {
   JwtConfigurationType,
   TAttachJwtAuthDTO,
@@ -240,7 +240,8 @@ export const identityJwtAuthServiceFactory = ({
       }
 
       if (identityJwtAuth.boundAudiences) {
-        if (!tokenData.aud) {
+        const audience = tokenData.aud as string | string[] | undefined;
+        if (!hasJwtAudienceClaim(audience)) {
           throw new UnauthorizedError({
             message: "Access denied: token has no audience field",
             detail: {
@@ -255,7 +256,7 @@ export const identityJwtAuthServiceFactory = ({
         if (
           !identityJwtAuth.boundAudiences
             .split(", ")
-            .some((policyValue) => doesFieldValueMatchJwtPolicy(tokenData.aud, policyValue))
+            .some((policyValue) => doesAudValueMatchJwtPolicy(audience, policyValue))
         ) {
           throw new UnauthorizedError({
             message: "Access denied: token audience not allowed",


### PR DESCRIPTION
## Context

Fixes [#7462](https://github.com/Infisical/infisical/issues/7462).

JWT Auth with an Audiences bound claim returned HTTP 500 when the presented token's `aud` was a JSON array (RFC 7519 §4.1.3). Kubernetes ServiceAccount tokens always use that shape (`kubectl create token` → `"aud": ["infisical"]`). `doesFieldValueMatchJwtPolicy` only accepted scalars, so `picomatch.isMatch` threw on the array and the global handler turned that into a generic 500.

Audience matching now follows the existing OIDC helper: treat `aud` as a set, match if any entry equals or glob-matches a configured audience. Empty/missing `aud` stays 401 `missing_audience`. A real mismatch stays 401 `audience_not_allowed`. Subject and other claim checks are unchanged.

## Steps to verify the change

- [ ] `cd backend && npm run test:unit -- src/services/identity-jwt-auth/identity-jwt-auth-fns.test.ts`
- [ ] Create a machine identity with JWT Auth / JWKS and Audiences set to `infisical`
- [ ] Mint a Kubernetes SA token: `kubectl create token <sa> -n <ns> --audience infisical --duration 1h` (payload contains `"aud": ["infisical"]`)
- [ ] `POST /api/v1/auth/jwt-auth/login` with that JWT → **200**, not 500
- [ ] Repeat with an audience that is not in `aud` → **401** `audience_not_allowed`
- [ ] Scalar string `aud` still matches as before

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

Made with [Cursor](https://cursor.com)