### PR TITLE
feat(settings): add project tag editing

### DIFF
--- a/frontend/src/hooks/api/tags/index.tsx
+++ b/frontend/src/hooks/api/tags/index.tsx
@@ -1,3 +1,4 @@
 export { useGetWsTags } from "./queries";
 export { useCreateWsTag } from "./queries";
 export { useDeleteWsTag } from "./queries";
+export { useUpdateWsTag } from "./queries";

--- a/frontend/src/hooks/api/tags/queries.tsx
+++ b/frontend/src/hooks/api/tags/queries.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
 
-import { CreateTagDTO, DeleteTagDTO, UserWsTags, WsTag } from "./types";
+import { CreateTagDTO, DeleteTagDTO, UpdateTagDTO, UserWsTags, WsTag } from "./types";
 
 const projectTags = {
   getWsTags: (projectID: string) => ["project-tags", { projectID }] as const
@@ -51,6 +51,23 @@ export const useDeleteWsTag = () => {
     },
     onSuccess: (tagData) => {
       queryClient.invalidateQueries({ queryKey: projectTags.getWsTags(tagData?.projectId) });
+    }
+  });
+};
+
+export const useUpdateWsTag = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<WsTag, object, UpdateTagDTO>({
+    mutationFn: async ({ tagID, projectId, tagColor, tagSlug }) => {
+      const { data } = await apiRequest.patch<{ tag: WsTag }>(
+        `/api/v1/projects/${projectId}/tags/${tagID}`,
+        { color: tagColor, slug: tagSlug }
+      );
+      return data.tag;
+    },
+    onSuccess: (_tagData, { projectId }) => {
+      queryClient.invalidateQueries({ queryKey: projectTags.getWsTags(projectId) });
     }
   });
 };

--- a/frontend/src/hooks/api/tags/queries.tsx
+++ b/frontend/src/hooks/api/tags/queries.tsx
@@ -68,6 +68,26 @@ export const useUpdateWsTag = () => {
     },
     onSuccess: (_tagData, { projectId }) => {
       queryClient.invalidateQueries({ queryKey: projectTags.getWsTags(projectId) });
+      queryClient.invalidateQueries({
+        predicate: (query) => {
+          const [queryRoot, queryParams] = query.queryKey;
+
+          return (
+            queryRoot === "dashboard" &&
+            (queryParams as { projectId?: string } | undefined)?.projectId === projectId
+          );
+        }
+      });
+      queryClient.invalidateQueries({
+        predicate: (query) => {
+          const [queryParams, queryRoot] = query.queryKey;
+
+          return (
+            queryRoot === "secrets" &&
+            (queryParams as { projectId?: string } | undefined)?.projectId === projectId
+          );
+        }
+      });
     }
   });
 };

--- a/frontend/src/hooks/api/tags/types.ts
+++ b/frontend/src/hooks/api/tags/types.ts
@@ -20,6 +20,13 @@ export type CreateTagDTO = {
 
 export type DeleteTagDTO = { tagID: string; projectId: string };
 
+export type UpdateTagDTO = {
+  tagID: string;
+  projectId: string;
+  tagSlug: string;
+  tagColor: string;
+};
+
 export type SecretTags = {
   id: string;
   slug: string;

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/EditSecretTagModal.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/EditSecretTagModal.tsx
@@ -26,7 +26,12 @@ import { slugSchema } from "@app/lib/schemas";
 
 const schema = z.object({
   slug: slugSchema({ min: 1, max: 64, field: "Tag Slug" }),
-  color: z.string().trim()
+  color: z
+    .string()
+    .trim()
+    .refine((value) => value === "" || /^#[0-9A-Fa-f]{6}$/.test(value), {
+      message: "Tag Color must be empty or a six-digit hex color"
+    })
 });
 
 type FormData = z.infer<typeof schema>;

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/EditSecretTagModal.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/EditSecretTagModal.tsx
@@ -1,0 +1,128 @@
+import { useEffect } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  ColorPicker,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input
+} from "@app/components/v3";
+import { useProject } from "@app/context";
+import { useUpdateWsTag } from "@app/hooks/api";
+import { WsTag } from "@app/hooks/api/tags/types";
+import { slugSchema } from "@app/lib/schemas";
+
+const schema = z.object({
+  slug: slugSchema({ min: 1, max: 64, field: "Tag Slug" }),
+  color: z.string().trim()
+});
+
+type FormData = z.infer<typeof schema>;
+
+type Props = {
+  tag?: WsTag;
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+};
+
+export const EditSecretTagModal = ({ tag, isOpen, onOpenChange }: Props) => {
+  const { currentProject } = useProject();
+  const updateWsTag = useUpdateWsTag();
+  const {
+    control,
+    reset,
+    handleSubmit,
+    formState: { isSubmitting }
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  useEffect(() => {
+    if (isOpen && tag) reset({ slug: tag.slug, color: tag.color ?? "" });
+  }, [isOpen, reset, tag]);
+
+  const onFormSubmit = async ({ slug, color }: FormData) => {
+    if (!currentProject?.id || !tag) return;
+
+    await updateWsTag.mutateAsync({
+      projectId: currentProject.id,
+      tagID: tag.id,
+      tagSlug: slug,
+      tagColor: color
+    });
+
+    onOpenChange(false);
+    createNotification({ text: "Successfully updated tag", type: "success" });
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        onOpenChange(open);
+        if (!open) reset();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Tag</DialogTitle>
+          <DialogDescription>Update the tag slug or color for this project.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-6">
+          <Controller
+            control={control}
+            name="slug"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="edit-tag-slug">Tag Slug</FieldLabel>
+                <Input
+                  id="edit-tag-slug"
+                  placeholder="Type your tag slug"
+                  isError={Boolean(error)}
+                  {...field}
+                />
+                <FieldError>{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+          <Controller
+            control={control}
+            name="color"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel>Tag Color</FieldLabel>
+                <ColorPicker {...field} isError={Boolean(error)} />
+                <FieldError>{error?.message}</FieldError>
+              </Field>
+            )}
+          />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="ghost" type="button">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              type="submit"
+              variant="project"
+              isPending={isSubmitting}
+              isDisabled={isSubmitting || !tag}
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/SecretTagsSection.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/SecretTagsSection.tsx
@@ -29,8 +29,10 @@ import {
 } from "@app/context";
 import { usePopUp } from "@app/hooks";
 import { useDeleteWsTag } from "@app/hooks/api";
+import { WsTag } from "@app/hooks/api/tags/types";
 
 import { AddSecretTagModal } from "./AddSecretTagModal";
+import { EditSecretTagModal } from "./EditSecretTagModal";
 import { SecretTagsTable } from "./SecretTagsTable";
 
 type DeleteModalData = { name: string; id: string };
@@ -38,7 +40,8 @@ type DeleteModalData = { name: string; id: string };
 export const SecretTagsSection = (): JSX.Element => {
   const { popUp, handlePopUpToggle, handlePopUpClose, handlePopUpOpen } = usePopUp([
     "CreateSecretTag",
-    "deleteTagConfirmation"
+    "deleteTagConfirmation",
+    "editSecretTag"
   ] as const);
   const { currentProject } = useProject();
   const { permission } = useProjectPermission();
@@ -46,6 +49,7 @@ export const SecretTagsSection = (): JSX.Element => {
 
   const deleteWsTag = useDeleteWsTag();
   const deleteTagData = popUp?.deleteTagConfirmation?.data as DeleteModalData | undefined;
+  const editTag = popUp?.editSecretTag?.data as WsTag | undefined;
 
   const onDeleteApproved = async () => {
     if (!deleteTagData?.id) return;
@@ -100,6 +104,11 @@ export const SecretTagsSection = (): JSX.Element => {
         popUp={popUp}
         handlePopUpClose={handlePopUpClose}
         handlePopUpToggle={handlePopUpToggle}
+      />
+      <EditSecretTagModal
+        tag={editTag}
+        isOpen={popUp.editSecretTag.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("editSecretTag", isOpen)}
       />
       <AlertDialog
         open={popUp.deleteTagConfirmation.isOpen}

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/SecretTagsTable.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/SecretTagsTable.tsx
@@ -167,7 +167,10 @@ export const SecretTagsTable = ({ handlePopUpOpen }: Props) => {
                     <TableCell>
                       <div className="flex items-center justify-end">
                         {permission.can(ProjectPermissionActions.Edit, ProjectPermissionSub.Tags) ||
-                        permission.can(ProjectPermissionActions.Delete, ProjectPermissionSub.Tags) ? (
+                        permission.can(
+                          ProjectPermissionActions.Delete,
+                          ProjectPermissionSub.Tags
+                        ) ? (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <IconButton aria-label="Tag options" variant="ghost" size="xs">
@@ -175,13 +178,21 @@ export const SecretTagsTable = ({ handlePopUpOpen }: Props) => {
                               </IconButton>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent sideOffset={2} align="end">
-                              {permission.can(ProjectPermissionActions.Edit, ProjectPermissionSub.Tags) && (
-                                <DropdownMenuItem onClick={() => handlePopUpOpen("editSecretTag", tag)}>
+                              {permission.can(
+                                ProjectPermissionActions.Edit,
+                                ProjectPermissionSub.Tags
+                              ) && (
+                                <DropdownMenuItem
+                                  onClick={() => handlePopUpOpen("editSecretTag", tag)}
+                                >
                                   <PencilIcon />
                                   Edit tag
                                 </DropdownMenuItem>
                               )}
-                              {permission.can(ProjectPermissionActions.Delete, ProjectPermissionSub.Tags) && (
+                              {permission.can(
+                                ProjectPermissionActions.Delete,
+                                ProjectPermissionSub.Tags
+                              ) && (
                                 <DropdownMenuItem
                                   variant="danger"
                                   onClick={() =>

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/SecretTagsTable.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/SecretTagsTable.tsx
@@ -3,11 +3,11 @@ import {
   ArrowDownIcon,
   ArrowUpIcon,
   MoreHorizontalIcon,
+  PencilIcon,
   SearchIcon,
   TrashIcon
 } from "lucide-react";
 
-import { ProjectPermissionCan } from "@app/components/permissions";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,7 +30,12 @@ import {
   TableHeader,
   TableRow
 } from "@app/components/v3";
-import { ProjectPermissionActions, ProjectPermissionSub, useProject } from "@app/context";
+import {
+  ProjectPermissionActions,
+  ProjectPermissionSub,
+  useProject,
+  useProjectPermission
+} from "@app/context";
 import {
   getUserTablePreference,
   PreferenceKey,
@@ -39,18 +44,13 @@ import {
 import { usePagination, useResetPageHelper } from "@app/hooks";
 import { OrderByDirection } from "@app/hooks/api/generic/types";
 import { useGetWsTags } from "@app/hooks/api/tags";
+import { WsTag } from "@app/hooks/api/tags/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 type Props = {
   handlePopUpOpen: (
-    popUpName: keyof UsePopUpState<["deleteTagConfirmation"]>,
-    {
-      name,
-      id
-    }: {
-      name: string;
-      id: string;
-    }
+    popUpName: keyof UsePopUpState<["deleteTagConfirmation", "editSecretTag"]>,
+    data: { name: string; id: string } | WsTag
   ) => void;
 };
 
@@ -60,6 +60,7 @@ enum TagsOrderBy {
 
 export const SecretTagsTable = ({ handlePopUpOpen }: Props) => {
   const { currentProject } = useProject();
+  const { permission } = useProjectPermission();
   const { data: tags = [], isPending } = useGetWsTags(currentProject?.id ?? "");
 
   const {
@@ -157,48 +158,51 @@ export const SecretTagsTable = ({ handlePopUpOpen }: Props) => {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredTags.slice(offset, perPage * page).map(({ id, slug }) => (
-                <TableRow key={id}>
-                  <TableCell>{slug}</TableCell>
-                  <TableCell>
-                    <div className="flex items-center justify-end">
-                      <ProjectPermissionCan
-                        I={ProjectPermissionActions.Delete}
-                        a={ProjectPermissionSub.Tags}
-                      >
-                        {(isAllowed) => (
+              {filteredTags.slice(offset, perPage * page).map((tag) => {
+                const { id, slug } = tag;
+
+                return (
+                  <TableRow key={id}>
+                    <TableCell>{slug}</TableCell>
+                    <TableCell>
+                      <div className="flex items-center justify-end">
+                        {permission.can(ProjectPermissionActions.Edit, ProjectPermissionSub.Tags) ||
+                        permission.can(ProjectPermissionActions.Delete, ProjectPermissionSub.Tags) ? (
                           <DropdownMenu>
-                            <DropdownMenuTrigger asChild disabled={!isAllowed}>
-                              <IconButton
-                                aria-label="Tag options"
-                                variant="ghost"
-                                size="xs"
-                                isDisabled={!isAllowed}
-                              >
+                            <DropdownMenuTrigger asChild>
+                              <IconButton aria-label="Tag options" variant="ghost" size="xs">
                                 <MoreHorizontalIcon className="size-4" />
                               </IconButton>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent sideOffset={2} align="end">
-                              <DropdownMenuItem
-                                variant="danger"
-                                onClick={() =>
-                                  handlePopUpOpen("deleteTagConfirmation", {
-                                    name: slug,
-                                    id
-                                  })
-                                }
-                              >
-                                <TrashIcon />
-                                Delete tag
-                              </DropdownMenuItem>
+                              {permission.can(ProjectPermissionActions.Edit, ProjectPermissionSub.Tags) && (
+                                <DropdownMenuItem onClick={() => handlePopUpOpen("editSecretTag", tag)}>
+                                  <PencilIcon />
+                                  Edit tag
+                                </DropdownMenuItem>
+                              )}
+                              {permission.can(ProjectPermissionActions.Delete, ProjectPermissionSub.Tags) && (
+                                <DropdownMenuItem
+                                  variant="danger"
+                                  onClick={() =>
+                                    handlePopUpOpen("deleteTagConfirmation", {
+                                      name: slug,
+                                      id
+                                    })
+                                  }
+                                >
+                                  <TrashIcon />
+                                  Delete tag
+                                </DropdownMenuItem>
+                              )}
                             </DropdownMenuContent>
                           </DropdownMenu>
-                        )}
-                      </ProjectPermissionCan>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
+                        ) : null}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
           <Pagination

--- a/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/SecretTagsTable.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/SecretTagsSection/SecretTagsTable.tsx
@@ -186,7 +186,7 @@ export const SecretTagsTable = ({ handlePopUpOpen }: Props) => {
                                   onClick={() => handlePopUpOpen("editSecretTag", tag)}
                                 >
                                   <PencilIcon />
-                                  Edit tag
+                                  Edit Tag
                                 </DropdownMenuItem>
                               )}
                               {permission.can(
@@ -203,7 +203,7 @@ export const SecretTagsTable = ({ handlePopUpOpen }: Props) => {
                                   }
                                 >
                                   <TrashIcon />
-                                  Delete tag
+                                  Delete Tag
                                 </DropdownMenuItem>
                               )}
                             </DropdownMenuContent>


### PR DESCRIPTION
## Context

Project Settings > Tags already supported listing, creating, and deleting tags, but existing tags could not be edited. This adds a v3 edit dialog for the supported tag slug and color fields and uses the existing PATCH contract. Related ticket: [PLATFOR-680](https://linear.app/infisical/issue/PLATFOR-680/migrate-project-tags-settings-to-v3).

## Screenshots


## Steps to verify the change

1. Open a Secret Manager project and navigate to Project Settings > Tags.
2. Open a tag's options menu and choose Edit tag.
3. Change the slug and/or color, save, and confirm the updated values remain after refresh.
4. Confirm the tag remains associated with any existing secrets.
5. Verify users without Tags edit permission do not see the Edit tag action.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`.
- [ ] Tested locally — frontend dependencies are unavailable in this worktree; CI validation is expected to run.
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)