### PR TITLE
docs(style): switch prereqs to subheadings

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -139,11 +139,13 @@ Use `<Tabs>` when there are multiple ways to accomplish something:
 Use callouts to highlight important information:
 
 ```mdx
-<Note>Prerequisites or important context.</Note>
+<Note>Important context that applies to a specific part of the page.</Note>
 <Warning>Destructive actions or irreversible changes.</Warning>
 <Tip>Helpful suggestions or best practices.</Tip>
 <Info>Additional context that's good to know.</Info>
 ```
+
+Don't use callouts for page-level prerequisites. Put them under a `## Prerequisites` heading instead.
 
 ### Navigation
 
@@ -329,18 +331,16 @@ If new content doesn't fit the existing flow, consider whether it belongs on thi
 
 If a page assumes something is already set up — a Gateway deployed, permissions granted, a CLI installed — state it at the top. Readers shouldn't get stuck halfway through because they missed an unstated requirement.
 
-Use an `<Info>` callout for a short prerequisite list:
+Use a `## Prerequisites` section before the main content, even when the list is short:
 
 ```mdx
-<Info>
-Prerequisites:
+## Prerequisites
 
 - An Infisical account
 - A [Gateway](/documentation/platform/gateways/overview) that can reach your database
-</Info>
 ```
 
-Use a "Prerequisites" section before the main content when requirements need additional explanation. Reserve `<Note>` for prerequisite details that apply to a specific step rather than the whole page.
+Don't put page-level prerequisites in `<Info>` or other callouts. Reserve `<Note>` for requirement details that apply to a specific step rather than the whole page.
 
 ---
 

--- a/docs/documentation/platform/secrets-mgmt/quick-starts/deliver-first-secret.mdx
+++ b/docs/documentation/platform/secrets-mgmt/quick-starts/deliver-first-secret.mdx
@@ -8,11 +8,9 @@ import ConfigureProject from "/snippets/documentation/platform/secrets-mgmt/conf
 
 This quickstart walks you through the steps shared by every Infisical secrets delivery workflow. You'll create a [project](/documentation/platform/secrets-mgmt/project), add a secret, and then continue with instructions for your application or infrastructure.
 
-<Info>
-Prerequisites:
+## Prerequisites
 
 - An Infisical account on [Infisical Cloud](https://app.infisical.com) or a [self-hosted instance](/self-hosting/overview)
-</Info>
 
 <ConfigureProject />
 

--- a/docs/integrations/cicd/githubactions.mdx
+++ b/docs/integrations/cicd/githubactions.mdx
@@ -14,15 +14,12 @@ This guide walks you through fetching secrets from Infisical inside a GitHub Act
   Visual learner? Watch an [overview of using Infisical with GitHub Actions](https://www.youtube.com/watch?v=9PQmd_aoRWA).
 </Tip>
 
-<Info>
-Prerequisites:
+## Prerequisites
 
 - An Infisical account on [Infisical Cloud](https://app.infisical.com) or a [self-hosted instance](/self-hosting/overview)
 - A [project with secrets configured](/documentation/platform/secrets-mgmt/quick-starts/deliver-first-secret)
 - Permission to create machine identities in your Infisical organization
 - A GitHub repository with Actions enabled
-
-</Info>
 
 ## Setup
 

--- a/docs/integrations/platforms/docker.mdx
+++ b/docs/integrations/platforms/docker.mdx
@@ -10,15 +10,13 @@ This guide walks you through injecting secrets from Infisical into a Dockerized 
   Visual learner? Watch an [overview of managing secrets in Docker with Infisical](https://www.youtube.com/watch?v=oU2nNBwlOTA).
 </Tip>
 
-<Info>
-Prerequisites:
+## Prerequisites
 
 - An Infisical account on [Infisical Cloud](https://app.infisical.com) or a [self-hosted instance](/self-hosting/overview)
 - A [project with secrets configured](/documentation/platform/secrets-mgmt/quick-starts/deliver-first-secret)
 - [Docker](https://docs.docker.com/get-started/get-docker/) installed
 - The [Infisical CLI](/cli/overview) installed on the machine where you run Docker
 - An application or container image to run
-</Info>
 
 ## Setup
 


### PR DESCRIPTION
## Context

Switches existing guides to a **Prerequisites** subheading instead of putting them in an `<Info />` callout.

Context: While working on [this guide](https://infisical.com/docs/integrations/cicd/githubactions#inject-secrets-into-github-actions-workflows), I realized enforcing the callout might clutter the top of the page for more in-depth guides.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)