### PR TITLE
feat: first improvement in gc for secrets

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -662,10 +662,11 @@ export const secretApprovalRequestServiceFactory = ({
     ) {
       throw new ForbiddenRequestError({ message: "User has insufficient privileges" });
     }
-    const reviewers = secretApprovalRequest.reviewers.reduce<Record<string, ApprovalStatus>>(
-      (prev, curr) => ({ ...prev, [curr.userId.toString()]: curr.status as ApprovalStatus }),
-      {}
-    );
+    const reviewers = secretApprovalRequest.reviewers.reduce<Record<string, ApprovalStatus>>((prev, curr) => {
+      // eslint-disable-next-line no-param-reassign
+      prev[curr.userId.toString()] = curr.status as ApprovalStatus;
+      return prev;
+    }, {});
     const hasMinApproval =
       secretApprovalRequest.policy.approvals <=
       secretApprovalRequest.policy.approvers.filter(({ userId: approverId }) =>

--- a/backend/src/lib/crypto/cipher/cipher.ts
+++ b/backend/src/lib/crypto/cipher/cipher.ts
@@ -13,14 +13,18 @@ export const symmetricCipherService = (
     const iv = crypto.randomBytes(IV_LENGTH);
     const cipher = crypto.nativeCrypto.createCipheriv(type, key, iv);
 
-    let encrypted = cipher.update(text);
-    encrypted = Buffer.concat([encrypted, cipher.final()]);
+    const encrypted = cipher.update(text);
+    // AES-GCM is unpadded, so final() is always zero-length. Folding it into the single
+    // concat below rather than its own avoids a full-size copy of the ciphertext.
+    const final = cipher.final();
 
     // Get the authentication tag
     const tag = cipher.getAuthTag();
 
     // Concatenate IV, encrypted text, and tag into a single buffer
-    const ciphertextBlob = Buffer.concat([iv, encrypted, tag]);
+    const ciphertextBlob = final.length
+      ? Buffer.concat([iv, encrypted, final, tag])
+      : Buffer.concat([iv, encrypted, tag]);
     return ciphertextBlob;
   };
 
@@ -33,8 +37,11 @@ export const symmetricCipherService = (
     const decipher = crypto.nativeCrypto.createDecipheriv(type, key, iv);
     decipher.setAuthTag(tag);
 
-    const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
-    return decrypted;
+    // final() must still be called since that is what verifies the auth tag, but AES-GCM is
+    // unpadded so it returns zero bytes. Concatenating it would copy the whole plaintext again.
+    const decrypted = decipher.update(encrypted);
+    const final = decipher.final();
+    return final.length ? Buffer.concat([decrypted, final]) : decrypted;
   };
 
   return {

--- a/backend/src/services/secret-folder/secret-folder-version-dal.ts
+++ b/backend/src/services/secret-folder/secret-folder-version-dal.ts
@@ -61,10 +61,11 @@ export const secretFolderVersionDALFactory = (db: TDbClient) => {
             );
           }
         );
-      return docs.reduce<Record<string, TSecretFolderVersions>>(
-        (prev, curr) => ({ ...prev, [curr.folderId || ""]: curr }),
-        {}
-      );
+      return docs.reduce<Record<string, TSecretFolderVersions>>((prev, curr) => {
+        // eslint-disable-next-line no-param-reassign
+        prev[curr.folderId || ""] = curr;
+        return prev;
+      }, {});
     } catch (error) {
       throw new DatabaseError({ error, name: "FindLatestFolderVersions" });
     }
@@ -177,10 +178,11 @@ export const secretFolderVersionDALFactory = (db: TDbClient) => {
       const allDocs = [...latestVersions, ...specificVersionsWithLatest];
 
       // Convert array to record with folderId as key
-      return allDocs.reduce<Record<string, TSecretFolderVersions>>(
-        (prev, curr) => ({ ...prev, [curr.folderId || ""]: curr }),
-        {}
-      );
+      return allDocs.reduce<Record<string, TSecretFolderVersions>>((prev, curr) => {
+        // eslint-disable-next-line no-param-reassign
+        prev[curr.folderId || ""] = curr;
+        return prev;
+      }, {});
     } catch (error) {
       throw new DatabaseError({ error, name: "FindByIdsWithLatestVersion" });
     }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -1519,6 +1519,9 @@ export const secretV2BridgeServiceFactory = ({
             secretTags: secret.tags.map((i) => i.slug)
           });
 
+        const isValueMasked = secretValueHidden && !isPersonalSecret;
+        const isValueDiscarded = isValueMasked && secret.type !== SecretType.Personal;
+
         return reshapeBridgeSecret(
           projectId,
           environment,
@@ -1532,14 +1535,17 @@ export const secretV2BridgeServiceFactory = ({
                 ? secretManagerDecryptor({ cipherTextBlob: el.encryptedValue }).toString()
                 : el.value || ""
             })),
-            value: secret.encryptedValue
-              ? secretManagerDecryptor({ cipherTextBlob: secret.encryptedValue }).toString()
-              : "",
+            // reshapeBridgeSecret still surfaces the real plaintext for Personal secrets even when
+            // masking, so the decrypt is only skippable when the value is certain to be discarded.
+            value:
+              !isValueDiscarded && secret.encryptedValue
+                ? secretManagerDecryptor({ cipherTextBlob: secret.encryptedValue }).toString()
+                : "",
             comment: secret.encryptedComment
               ? secretManagerDecryptor({ cipherTextBlob: secret.encryptedComment }).toString()
               : ""
           },
-          secretValueHidden && !isPersonalSecret
+          isValueMasked
         );
       });
 

--- a/backend/src/services/secret-v2-bridge/secret-version-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-version-dal.ts
@@ -163,10 +163,11 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
             );
           }
         );
-      return docs.reduce<Record<string, TSecretVersionsV2>>(
-        (prev, curr) => ({ ...prev, [curr.secretId || ""]: curr }),
-        {}
-      );
+      return docs.reduce<Record<string, TSecretVersionsV2>>((prev, curr) => {
+        // eslint-disable-next-line no-param-reassign
+        prev[curr.secretId || ""] = curr;
+        return prev;
+      }, {});
     } catch (error) {
       throw new DatabaseError({ error, name: "FindLatestVersionMany" });
     }
@@ -478,10 +479,11 @@ export const secretVersionV2BridgeDALFactory = (db: TDbClient) => {
       const allDocs = [...latestVersions, ...specificVersionsWithLatest];
 
       // Convert array to record with secretId as key
-      return allDocs.reduce<Record<string, TSecretVersionsV2>>(
-        (prev, curr) => ({ ...prev, [curr.secretId || ""]: curr }),
-        {}
-      );
+      return allDocs.reduce<Record<string, TSecretVersionsV2>>((prev, curr) => {
+        // eslint-disable-next-line no-param-reassign
+        prev[curr.secretId || ""] = curr;
+        return prev;
+      }, {});
     } catch (error) {
       throw new DatabaseError({ error, name: "FindByIdsWithLatestVersion" });
     }

--- a/backend/src/services/secret/secret-version-dal.ts
+++ b/backend/src/services/secret/secret-version-dal.ts
@@ -152,10 +152,11 @@ export const secretVersionDALFactory = (db: TDbClient) => {
             );
           }
         );
-      return docs.reduce<Record<string, TSecretVersions>>(
-        (prev, curr) => ({ ...prev, [curr.secretId || ""]: curr }),
-        {}
-      );
+      return docs.reduce<Record<string, TSecretVersions>>((prev, curr) => {
+        // eslint-disable-next-line no-param-reassign
+        prev[curr.secretId || ""] = curr;
+        return prev;
+      }, {});
     } catch (error) {
       throw new DatabaseError({ error, name: "FindLatestVersinMany" });
     }


### PR DESCRIPTION
## Context

This PR improves the GC load of secrets by following things
1. No decryption of value if it's gonna be masked
2. Removed a reducer pattern where we were discarding a lot of variables. (Profiler Info)
3. A simple optimization of kms system where the buffer is allocated for zero bytes

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)