### PR TITLE
feat: add RFC 8693 token exchange grant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ seed-dev-ldap:
 	docker compose -f docker-compose.dev.yml exec -T backend npx tsx ./src/db/seed-ldap.ts $(ORG_ID)
 
 seed-dev-oidc:
-	# Sets up the Infisical side for OIDC SSO testing: an oidc@infisical.com admin, a verified
+	# Sets up the Infisical side for OIDC SSO testing: an admin@oidc.com admin, a verified
 	# domain, and an active OIDC config. With ORG_ID=<uuid> it configures that existing org;
 	# otherwise it bootstraps a dedicated `oidc` org. Needs the stack up (`make up-dev-oidc`).
 	docker compose -f docker-compose.dev.yml exec -T backend npx tsx ./src/db/seed-oidc.ts $(ORG_ID)

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -198,6 +198,13 @@ without it, any token that issuer signed for any application in the customer's e
 Enabling the grant or changing the audience therefore requires `OrgPermissionSsoActions.Edit` on top of
 the usual `OauthClients` check.
 
+**That gate covers secret rotation too, and leaving it off any one path defeats it.** Rotation returns
+the new secret in its response, so on an exchange application it hands the caller a working credential
+for acting as any of the org's users — the same authority as enabling the grant. `OauthClients` Edit
+alone would otherwise be enough to rotate an existing exchange application's secret and use it, making
+the check on create/update a speed bump. Any future operation that establishes this trust or hands out a
+credential for it goes through `checkSsoConfigPermission` (`oauth-client-service.ts`) as well.
+
 **Deprecated auth modes (do not use in new code):**
 - **API_KEY** — user API keys (from `x-api-key` header). Deprecated — use identity access tokens instead.
 - **SERVICE_TOKEN** — service tokens (Bearer tokens starting with `st.` prefix). Deprecated — use identity access tokens instead.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -173,6 +173,30 @@ Auth extraction happens in `src/server/plugins/auth/`:
 - **JWT** — user browser sessions (decoded from `Authorization: Bearer` header)
 - **IDENTITY_ACCESS_TOKEN** — machine-to-machine identity tokens
 - **SCIM_TOKEN** — SCIM provisioning tokens
+- **OAUTH**: delegated user tokens minted by the `oauth-client` module. Same JWT shape and session
+  binding as `JWT`, distinguished only by an `oauthClientId` claim. **Opt-in per route**: `verify-auth.ts`
+  rejects them on every route that does not list `AuthMode.OAUTH`, because a route that authenticates on
+  bare `userId` (account self-management) never builds the permission that enforces delegation.
+
+**Delegated OAuth tokens carry exactly one delegation marker, never both** (`oauth-client-types.ts`):
+- `scopes: [...]`: from the authorization code grant. `permission-service` intersects the user's CASL
+  rules with these (`applyOauthScopeToOrgRules` / `applyOauthScopeToProjectRules`).
+- `delegation: "full"`: from the RFC 8693 token exchange grant, which has no scope concept and carries
+  the user's effective authorization unnarrowed.
+
+**Absence of both must keep meaning zero permissions.** `inject-identity.ts` sets
+`RequestContextKey.OauthScopes` for every scope-narrowed token (even to `[]`, which denies everything)
+and leaves it unset only for `delegation: "full"`. `getDelegatedOauthScopes` in `permission-service.ts`
+reads an unset key as "no narrowing". Matching the full-delegation marker positively is what makes a
+dropped claim fail closed instead of silently promoting the token to unrestricted.
+
+**Token exchange's trust anchor is the org's OIDC SSO config**, not per-client configuration
+(`oauth-token-exchange-fns.ts`). The set of issuers that can vouch for a user through exchange is
+exactly the set that can already log them in, under the permission that already governs it. The one
+per-application field is `tokenExchangeAudience`, and it is the control that does the security work:
+without it, any token that issuer signed for any application in the customer's estate is exchangeable.
+Enabling the grant or changing the audience therefore requires `OrgPermissionSsoActions.Edit` on top of
+the usual `OauthClients` check.
 
 **Deprecated auth modes (do not use in new code):**
 - **API_KEY** — user API keys (from `x-api-key` header). Deprecated — use identity access tokens instead.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -205,6 +205,21 @@ alone would otherwise be enough to rotate an existing exchange application's sec
 the check on create/update a speed bump. Any future operation that establishes this trust or hands out a
 credential for it goes through `checkSsoConfigPermission` (`oauth-client-service.ts`) as well.
 
+**Everything the exchange fetches from the identity provider is cached for 10 minutes, and nothing read
+from our own database is.** Token exchange sits on the caller's hot path (a middleware typically exchanges
+per request it serves), so the discovery document and the `JwksClient` are both cached per URL in
+`oauth-token-exchange-fns.ts`; without that, the provider is a synchronous dependency of every Infisical
+API call the middleware makes. Consequences to keep in mind when extending it:
+- **Don't widen the cache to the resolved trust anchor.** The signature algorithm and the preferred issuer
+  come from `oidc_configs`, and an admin editing either has to take effect on the next request.
+- **Failed discovery fetches are evicted, not cached**, so a provider blip lasts as long as the blip
+  rather than the TTL. Keep that property in anything similar; caching the failure turns a 5-second
+  outage into 10 minutes of them.
+- **Cache entries hold the in-flight promise**, so concurrent requests on a cold entry coalesce onto one
+  fetch instead of stampeding the provider.
+- Entries expiring also rebuilds the SSRF-pinned agent, which is what lets a legitimate DNS change at the
+  provider be picked up at all.
+
 **Deprecated auth modes (do not use in new code):**
 - **API_KEY** — user API keys (from `x-api-key` header). Deprecated — use identity access tokens instead.
 - **SERVICE_TOKEN** — service tokens (Bearer tokens starting with `st.` prefix). Deprecated — use identity access tokens instead.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -176,7 +176,19 @@ Auth extraction happens in `src/server/plugins/auth/`:
 - **OAUTH**: delegated user tokens minted by the `oauth-client` module. Same JWT shape and session
   binding as `JWT`, distinguished only by an `oauthClientId` claim. **Opt-in per route**: `verify-auth.ts`
   rejects them on every route that does not list `AuthMode.OAUTH`, because a route that authenticates on
-  bare `userId` (account self-management) never builds the permission that enforces delegation.
+  bare `userId` never builds the permission that enforces delegation. In practice every `AuthMode.JWT`
+  route now also lists `AuthMode.OAUTH` **except** three families that cannot be scope-narrowed and so
+  stay first-party only: account self-management (`v1`/`v2` user, password, MFA session, login, signup,
+  user action/activation/engagement, notifications, announcements), instance super-admin
+  (`v1/admin-router.ts`, `ee/v1/rate-limit-router.ts`, gated by `verifySuperAdmin`, which reads
+  `user.superAdmin` rather than a CASL ability), and the OAuth client CRUD + consent routes
+  (`v1/oauth-router.ts`) plus `ee/v1/assume-privilege-router.ts`, where a delegated token would be able
+  to widen its own grant. Three routes are held back individually rather than by file, and carry a
+  comment saying so: `GET /v1/organization`, `GET /v1/organization/accessible-with-sub-orgs`, and
+  `POST /v2/organization`. A new route follows the default; adding `AuthMode.OAUTH` to a handler that
+  never builds an org/project/resource permission is the one thing to check before copying it. The
+  quick proxy is `requireOrg: false` — with no org in context there is no ability to narrow, so no such
+  route lists `AuthMode.OAUTH`.
 
 **Delegated OAuth tokens carry exactly one delegation marker, never both** (`oauth-client-types.ts`):
 - `scopes: [...]`: from the authorization code grant. `permission-service` intersects the user's CASL

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -198,6 +198,15 @@ without it, any token that issuer signed for any application in the customer's e
 Enabling the grant or changing the audience therefore requires `OrgPermissionSsoActions.Edit` on top of
 the usual `OauthClients` check.
 
+**`getOrgPermission` is not a membership check, and token exchange is the one user-token path that
+cannot borrow login's.** It builds a CASL ability out of the actor's roles; the org-scope query in
+`permission-dal.ts` filters on org, actor and scope and never reads `Membership.isActive` or
+`Membership.status`. Every other route holding a user token got it from a browser login, and
+`selectOrganization` (`auth-login-service.ts`) rejects an inactive membership there. Token exchange
+mints a user token with no login in front of it, so it checks membership state itself
+(`exchangeSubjectToken` in `oauth-client-service.ts`) — without that, deactivating a member stops
+revoking their access. Any future non-interactive way of minting a user token needs the same check.
+
 **That gate covers secret rotation too, and leaving it off any one path defeats it.** Rotation returns
 the new secret in its response, so on an exchange application it hands the caller a working credential
 for acting as any of the org's users — the same authority as enabling the grant. `OauthClients` Edit

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -183,12 +183,24 @@ Auth extraction happens in `src/server/plugins/auth/`:
   (`v1/admin-router.ts`, `ee/v1/rate-limit-router.ts`, gated by `verifySuperAdmin`, which reads
   `user.superAdmin` rather than a CASL ability), and the OAuth client CRUD + consent routes
   (`v1/oauth-router.ts`) plus `ee/v1/assume-privilege-router.ts`, where a delegated token would be able
-  to widen its own grant. Three routes are held back individually rather than by file, and carry a
-  comment saying so: `GET /v1/organization`, `GET /v1/organization/accessible-with-sub-orgs`, and
-  `POST /v2/organization`. A new route follows the default; adding `AuthMode.OAUTH` to a handler that
-  never builds an org/project/resource permission is the one thing to check before copying it. The
-  quick proxy is `requireOrg: false` — with no org in context there is no ability to narrow, so no such
-  route lists `AuthMode.OAUTH`.
+  to widen its own grant. Four routes are held back individually rather than by file, and carry a
+  comment saying so: `GET /v1/organization`, `GET /v1/organization/accessible-with-sub-orgs`,
+  `POST /v2/organization`, and `GET /v1/organization/:organizationId`. A new route follows the default;
+  adding `AuthMode.OAUTH` to a handler that never builds an org/project/resource permission is the one
+  thing to check before copying it. The quick proxy is `requireOrg: false` — with no org in context there
+  is no ability to narrow, so no such route lists `AuthMode.OAUTH`.
+
+  **Building a permission is not the same as checking one, and only the check is scope-narrowed.** A
+  handler that calls `getOrgPermission`/`getProjectPermission` and discards the ability is using it as a
+  membership gate; the intersection with the granted scopes happens inside, but nothing consults the
+  result, so a scoped token passes exactly as a first-party session does. `findOrganizationById` was the
+  reason `GET /v1/organization/:organizationId` came back off the list. The membership-only reads that
+  keep `AuthMode.OAUTH` are the ones a secrets-reading client needs to operate and whose payload is
+  project metadata rather than org or security configuration — `getAProject` (`GET /v1/projects/:projectId`
+  and `/slug/:slug`, where a client resolves environment slugs before reading secrets) and
+  `getProjectKmsKeys`. Adding a CASL gate to those is not the fix: the operation has no subject, they are
+  already open to any member holding an identity token, and a gate would change first-party behaviour.
+  A route in this position gets weighed on what it returns, not waved through by the blanket rule.
 
 **Delegated OAuth tokens carry exactly one delegation marker, never both** (`oauth-client-types.ts`):
 - `scopes: [...]`: from the authorization code grant. `permission-service` intersects the user's CASL

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -224,6 +224,20 @@ authorization code or refresh token and blanket revocation would just sign every
 per client, not per grant, so a client holding both grants loses its redirect-flow tokens too — the safe
 direction, and only reachable via the API.
 
+**That sweep only reaps sessions that already exist, so the exchange rechecks the client after creating
+its own.** `exchangeSubjectToken` authenticates the client, then spends provider discovery, JWKS
+verification and several DB reads before inserting a session — long enough for a revocation to land in
+between and delete nothing. So after the session exists it re-reads the client via
+`oauthClientDAL.findByIdOnPrimary` and rejects (re-running the sweep) if the secret hash changed, the
+grant is gone, or the row is. Two things make that sufficient and are load-bearing: each withdrawal path
+commits its write to the client *before* deleting the sessions, so a session that survived the delete
+belongs to a request whose client row is already stale; and the re-read is on the **primary**, because the
+replica that `authenticateClient` reads can still be serving the pre-revocation row. Only the exchange
+grant needs this — the authorization code and refresh branches read an existing session instead of
+creating one, so a racing revoke either fails them closed or kills the session behind the token they just
+signed. Any future non-interactive path that mints a user token after authenticating a client needs the
+same recheck.
+
 **Everything the exchange fetches from the identity provider is cached for 10 minutes, and nothing read
 from our own database is.** Token exchange sits on the caller's hot path (a middleware typically exchanges
 per request it serves), so the discovery document and the `JwksClient` are both cached per URL in

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -241,7 +241,10 @@ its own.** `exchangeSubjectToken` authenticates the client, then spends provider
 verification and several DB reads before inserting a session — long enough for a revocation to land in
 between and delete nothing. So after the session exists it re-reads the client via
 `oauthClientDAL.findByIdOnPrimary` and rejects (re-running the sweep) if the secret hash changed, the
-grant is gone, or the row is. Two things make that sufficient and are load-bearing: each withdrawal path
+grant is gone, the row is, or either of the two fields carrying the exchange's federation trust has been
+narrowed — `tokenExchangeAudience` and `tokenExchangeIdpSatisfiesMfa`, which the exchange itself read off
+the replica. Anything a future field grants the exchange belongs in `hasClientAuthorityChanged` for the
+same reason. Two things make that sufficient and are load-bearing: each withdrawal path
 commits its write to the client *before* deleting the sessions, so a session that survived the delete
 belongs to a request whose client row is already stale; and the re-read is on the **primary**, because the
 replica that `authenticateClient` reads can still be serving the pre-revocation row. Only the exchange

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -173,112 +173,98 @@ Auth extraction happens in `src/server/plugins/auth/`:
 - **JWT** — user browser sessions (decoded from `Authorization: Bearer` header)
 - **IDENTITY_ACCESS_TOKEN** — machine-to-machine identity tokens
 - **SCIM_TOKEN** — SCIM provisioning tokens
-- **OAUTH**: delegated user tokens minted by the `oauth-client` module. Same JWT shape and session
-  binding as `JWT`, distinguished only by an `oauthClientId` claim. **Opt-in per route**: `verify-auth.ts`
-  rejects them on every route that does not list `AuthMode.OAUTH`, because a route that authenticates on
-  bare `userId` never builds the permission that enforces delegation. In practice every `AuthMode.JWT`
-  route now also lists `AuthMode.OAUTH` **except** three families that cannot be scope-narrowed and so
-  stay first-party only: account self-management (`v1`/`v2` user, password, MFA session, login, signup,
-  user action/activation/engagement, notifications, announcements), instance super-admin
-  (`v1/admin-router.ts`, `ee/v1/rate-limit-router.ts`, gated by `verifySuperAdmin`, which reads
-  `user.superAdmin` rather than a CASL ability), and the OAuth client CRUD + consent routes
-  (`v1/oauth-router.ts`) plus `ee/v1/assume-privilege-router.ts`, where a delegated token would be able
-  to widen its own grant. Four routes are held back individually rather than by file, and carry a
-  comment saying so: `GET /v1/organization`, `GET /v1/organization/accessible-with-sub-orgs`,
-  `POST /v2/organization`, and `GET /v1/organization/:organizationId`. A new route follows the default;
-  adding `AuthMode.OAUTH` to a handler that never builds an org/project/resource permission is the one
-  thing to check before copying it. The quick proxy is `requireOrg: false` — with no org in context there
-  is no ability to narrow, so no such route lists `AuthMode.OAUTH`.
+- **OAUTH**: delegated user tokens from the `oauth-client` module. Same JWT shape and session binding as
+  `JWT`, told apart by an `oauthClientId` claim. Opt-in per route: `verify-auth.ts` rejects them anywhere
+  that doesn't list `AuthMode.OAUTH`, because a route authenticating on bare `userId` never builds the
+  permission that enforces delegation. Most `AuthMode.JWT` routes now list `AuthMode.OAUTH` too. The
+  exceptions, none of which can be scope-narrowed, stay first-party only:
+  - account self-management (user, password, MFA, sessions, login, signup, notifications, announcements)
+  - super-admin routes (`v1/admin-router.ts`, `ee/v1/rate-limit-router.ts`), gated by `verifySuperAdmin`,
+    which reads `user.superAdmin` rather than a CASL ability
+  - OAuth client CRUD + consent (`v1/oauth-router.ts`) and `ee/v1/assume-privilege-router.ts`, where a
+    delegated token could widen its own grant
+  - four org routes held back individually and commented as such: `GET /v1/organization`,
+    `GET /v1/organization/accessible-with-sub-orgs`, `POST /v2/organization`, `GET /v1/organization/:organizationId`
 
-  **Building a permission is not the same as checking one, and only the check is scope-narrowed.** A
-  handler that calls `getOrgPermission`/`getProjectPermission` and discards the ability is using it as a
-  membership gate; the intersection with the granted scopes happens inside, but nothing consults the
-  result, so a scoped token passes exactly as a first-party session does. `findOrganizationById` was the
-  reason `GET /v1/organization/:organizationId` came back off the list. The membership-only reads that
-  keep `AuthMode.OAUTH` are the ones a secrets-reading client needs to operate and whose payload is
-  project metadata rather than org or security configuration — `getAProject` (`GET /v1/projects/:projectId`
-  and `/slug/:slug`, where a client resolves environment slugs before reading secrets) and
-  `getProjectKmsKeys`. Adding a CASL gate to those is not the fix: the operation has no subject, they are
-  already open to any member holding an identity token, and a gate would change first-party behaviour.
-  A route in this position gets weighed on what it returns, not waved through by the blanket rule.
+  Rough proxy: nothing passing `requireOrg: false` accepts `AuthMode.OAUTH`, since with no org there's no
+  ability to narrow. Before adding `AuthMode.OAUTH` to a route, check the handler actually builds an
+  org/project/resource permission.
 
-**Delegated OAuth tokens carry exactly one delegation marker, never both** (`oauth-client-types.ts`):
-- `scopes: [...]`: from the authorization code grant. `permission-service` intersects the user's CASL
-  rules with these (`applyOauthScopeToOrgRules` / `applyOauthScopeToProjectRules`).
-- `delegation: "full"`: from the RFC 8693 token exchange grant, which has no scope concept and carries
-  the user's effective authorization unnarrowed.
+  **Building a permission isn't the same as checking one, and only the check is narrowed.** A handler that
+  calls `getOrgPermission`/`getProjectPermission` and throws the ability away is using it as a membership
+  gate: the intersection with granted scopes happens inside, but nothing reads the result, so a scoped
+  token passes like a first-party session. That's why `GET /v1/organization/:organizationId` came back off
+  the list. The membership-only reads that keep `AuthMode.OAUTH` return project metadata a secrets client
+  needs to operate rather than org or security config: `getAProject` (clients resolve environment slugs
+  before reading secrets) and `getProjectKmsKeys`. A CASL gate isn't the fix there, since the operation has
+  no subject, any member with an identity token can already call it, and a gate would change first-party
+  behaviour. Weigh a route in this position on what it returns.
 
-**Absence of both must keep meaning zero permissions.** `inject-identity.ts` sets
-`RequestContextKey.OauthScopes` for every scope-narrowed token (even to `[]`, which denies everything)
-and leaves it unset only for `delegation: "full"`. `getDelegatedOauthScopes` in `permission-service.ts`
-reads an unset key as "no narrowing". Matching the full-delegation marker positively is what makes a
-dropped claim fail closed instead of silently promoting the token to unrestricted.
+**Delegated tokens carry exactly one delegation marker, never both** (`oauth-client-types.ts`):
+- `scopes: [...]` from the authorization code grant. `permission-service` intersects the user's CASL rules
+  with them (`applyOauthScopeToOrgRules` / `applyOauthScopeToProjectRules`).
+- `delegation: "full"` from the RFC 8693 token exchange grant, which has no scopes and carries the user's
+  authorization unnarrowed.
 
-**Token exchange's trust anchor is the org's OIDC SSO config**, not per-client configuration
-(`oauth-token-exchange-fns.ts`). The set of issuers that can vouch for a user through exchange is
-exactly the set that can already log them in, under the permission that already governs it. The one
-per-application field is `tokenExchangeAudience`, and it is the control that does the security work:
-without it, any token that issuer signed for any application in the customer's estate is exchangeable.
-Enabling the grant or changing the audience therefore requires `OrgPermissionSsoActions.Edit` on top of
-the usual `OauthClients` check.
+**Absence of both has to keep meaning zero permissions.** `inject-identity.ts` sets
+`RequestContextKey.OauthScopes` for every scope-narrowed token (even `[]`, which denies everything) and
+leaves it unset only for `delegation: "full"`; `getDelegatedOauthScopes` reads an unset key as "no
+narrowing". Matching full delegation positively is what makes a dropped claim fail closed instead of
+quietly promoting the token.
 
-**`getOrgPermission` is not a membership check, and token exchange is the one user-token path that
-cannot borrow login's.** It builds a CASL ability out of the actor's roles; the org-scope query in
-`permission-dal.ts` filters on org, actor and scope and never reads `Membership.isActive` or
-`Membership.status`. Every other route holding a user token got it from a browser login, and
-`selectOrganization` (`auth-login-service.ts`) rejects an inactive membership there. Token exchange
-mints a user token with no login in front of it, so it checks membership state itself
-(`exchangeSubjectToken` in `oauth-client-service.ts`) — without that, deactivating a member stops
-revoking their access. Any future non-interactive way of minting a user token needs the same check.
+**Token exchange trusts the org's OIDC SSO config, not per-client configuration**
+(`oauth-token-exchange-fns.ts`), so the issuers that can vouch for a user through exchange are exactly the
+ones that can already log them in. The one per-application field is `tokenExchangeAudience`, and it does
+the security work: without it, any token that issuer signed for any application in the customer's estate
+is exchangeable. Enabling the grant, changing the audience, or rotating the secret of an exchange
+application all need `OrgPermissionSsoActions.Edit` on top of the usual `OauthClients` check
+(`checkSsoConfigPermission`). Rotation counts because its response hands back a working credential for
+acting as any of the org's users, so leaving it out would make the create/update check a speed bump. Any
+future operation that establishes this trust or hands out a credential for it goes through the same gate.
 
-**That gate covers secret rotation too, and leaving it off any one path defeats it.** Rotation returns
-the new secret in its response, so on an exchange application it hands the caller a working credential
-for acting as any of the org's users — the same authority as enabling the grant. `OauthClients` Edit
-alone would otherwise be enough to rotate an existing exchange application's secret and use it, making
-the check on create/update a speed bump. Any future operation that establishes this trust or hands out a
-credential for it goes through `checkSsoConfigPermission` (`oauth-client-service.ts`) as well.
+**`getOrgPermission` is not a membership check.** It builds a CASL ability from the actor's roles, and the
+org-scope query in `permission-dal.ts` filters on org, actor and scope without ever reading
+`Membership.isActive` or `Membership.status`. Every other user-token route got its token from a browser
+login, where `selectOrganization` (`auth-login-service.ts`) rejects an inactive membership. Token exchange
+mints a user token with no login in front of it, so `exchangeSubjectToken` checks membership state itself.
+Without that, deactivating a member doesn't revoke their access. Any future non-interactive way of minting
+a user token needs the same check.
 
-**Withdrawing an exchange application's authority has to revoke the tokens it already issued, not just
-stop it getting new ones.** Deleting the client, rotating its secret, and removing the token-exchange
-grant all call `revokeSessionsByUserAgent` (`oauth-client-service.ts`) — the sessions are tagged with
-`getOauthClientSessionUserAgent(clientId)`, which is the only handle we have on them. Rotation revokes
-**only** on exchange applications: there the secret alone mints tokens for any user, so rotating after a
-leak would contain nothing otherwise, whereas in the redirect flow the secret has to be paired with an
-authorization code or refresh token and blanket revocation would just sign every user out. The tag is
-per client, not per grant, so a client holding both grants loses its redirect-flow tokens too — the safe
-direction, and only reachable via the API.
+**Withdrawing an exchange application's authority has to revoke the tokens it already issued.** Deleting
+the client, rotating its secret, and removing the token-exchange grant all call
+`revokeSessionsByUserAgent`; sessions are tagged with `getOauthClientSessionUserAgent(clientId)`, the only
+handle we have on them. Rotation revokes only on exchange applications: there the secret alone mints
+tokens for any user, whereas in the redirect flow it has to be paired with an authorization code or
+refresh token and blanket revocation would just sign everyone out. The tag is per client, not per grant,
+so a client holding both grants loses its redirect-flow tokens too (the safe direction, and only
+reachable through the API).
 
 **That sweep only reaps sessions that already exist, so the exchange rechecks the client after creating
 its own.** `exchangeSubjectToken` authenticates the client, then spends provider discovery, JWKS
-verification and several DB reads before inserting a session — long enough for a revocation to land in
-between and delete nothing. So after the session exists it re-reads the client via
+verification and several DB reads before inserting a session, long enough for a revocation to land in
+between and delete nothing. So once the session exists it re-reads the client via
 `oauthClientDAL.findByIdOnPrimary` and rejects (re-running the sweep) if the secret hash changed, the
-grant is gone, the row is, or either of the two fields carrying the exchange's federation trust has been
-narrowed — `tokenExchangeAudience` and `tokenExchangeIdpSatisfiesMfa`, which the exchange itself read off
-the replica. Anything a future field grants the exchange belongs in `hasClientAuthorityChanged` for the
-same reason. Two things make that sufficient and are load-bearing: each withdrawal path
-commits its write to the client *before* deleting the sessions, so a session that survived the delete
-belongs to a request whose client row is already stale; and the re-read is on the **primary**, because the
-replica that `authenticateClient` reads can still be serving the pre-revocation row. Only the exchange
-grant needs this — the authorization code and refresh branches read an existing session instead of
-creating one, so a racing revoke either fails them closed or kills the session behind the token they just
-signed. Any future non-interactive path that mints a user token after authenticating a client needs the
-same recheck.
+grant is gone, the row is gone, or either field carrying the exchange's federation trust has been narrowed
+(`tokenExchangeAudience` and `tokenExchangeIdpSatisfiesMfa`, both read off the replica). Anything a future
+field grants the exchange belongs in `hasClientAuthorityChanged` for the same reason. Two things make this
+sufficient: every withdrawal path commits its write to the client *before* deleting sessions, so a session
+that survived the delete belongs to a request whose client row is already stale; and the re-read hits the
+**primary**, since the replica `authenticateClient` reads can still be serving the pre-revocation row.
+Only the exchange grant needs it, because the authorization code and refresh branches read an existing
+session instead of creating one, so a racing revoke either fails them closed or kills the session behind
+the token they just signed.
 
-**Everything the exchange fetches from the identity provider is cached for 10 minutes, and nothing read
-from our own database is.** Token exchange sits on the caller's hot path (a middleware typically exchanges
-per request it serves), so the discovery document and the `JwksClient` are both cached per URL in
-`oauth-token-exchange-fns.ts`; without that, the provider is a synchronous dependency of every Infisical
-API call the middleware makes. Consequences to keep in mind when extending it:
-- **Don't widen the cache to the resolved trust anchor.** The signature algorithm and the preferred issuer
-  come from `oidc_configs`, and an admin editing either has to take effect on the next request.
-- **Failed discovery fetches are evicted, not cached**, so a provider blip lasts as long as the blip
-  rather than the TTL. Keep that property in anything similar; caching the failure turns a 5-second
-  outage into 10 minutes of them.
-- **Cache entries hold the in-flight promise**, so concurrent requests on a cold entry coalesce onto one
-  fetch instead of stampeding the provider.
-- Entries expiring also rebuilds the SSRF-pinned agent, which is what lets a legitimate DNS change at the
-  provider be picked up at all.
+**Everything the exchange fetches from the IdP is cached for 10 minutes, and nothing read from our own
+database is.** A middleware typically exchanges once per request it serves, so the discovery document and
+the `JwksClient` are cached per URL in `oauth-token-exchange-fns.ts`; without that the provider becomes a
+synchronous dependency of every Infisical call the middleware makes. When extending it:
+- **Don't cache the resolved trust anchor.** The signature algorithm and preferred issuer come from
+  `oidc_configs`, and an admin editing either has to take effect on the next request.
+- **Failed fetches are evicted, not cached**, so a provider blip lasts as long as the blip. Caching the
+  failure turns a 5-second outage into 10 minutes of them.
+- **Entries hold the in-flight promise**, so concurrent callers on a cold entry coalesce onto one fetch.
+- Expiry also rebuilds the SSRF-pinned agent, which is what lets a legitimate DNS change at the provider
+  get picked up at all.
 
 **Deprecated auth modes (do not use in new code):**
 - **API_KEY** — user API keys (from `x-api-key` header). Deprecated — use identity access tokens instead.

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -214,6 +214,16 @@ alone would otherwise be enough to rotate an existing exchange application's sec
 the check on create/update a speed bump. Any future operation that establishes this trust or hands out a
 credential for it goes through `checkSsoConfigPermission` (`oauth-client-service.ts`) as well.
 
+**Withdrawing an exchange application's authority has to revoke the tokens it already issued, not just
+stop it getting new ones.** Deleting the client, rotating its secret, and removing the token-exchange
+grant all call `revokeSessionsByUserAgent` (`oauth-client-service.ts`) — the sessions are tagged with
+`getOauthClientSessionUserAgent(clientId)`, which is the only handle we have on them. Rotation revokes
+**only** on exchange applications: there the secret alone mints tokens for any user, so rotating after a
+leak would contain nothing otherwise, whereas in the redirect flow the secret has to be paired with an
+authorization code or refresh token and blanket revocation would just sign every user out. The tag is
+per client, not per grant, so a client holding both grants loses its redirect-flow tokens too — the safe
+direction, and only reachable via the API.
+
 **Everything the exchange fetches from the identity provider is cached for 10 minutes, and nothing read
 from our own database is.** Token exchange sits on the caller's hot path (a middleware typically exchanges
 per request it serves), so the discovery document and the `JwksClient` are both cached per URL in

--- a/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
+++ b/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
@@ -116,8 +116,8 @@ describe("OAuth client grant type registration", async () => {
     expect(res.payload).toContain("audience only applies");
   });
 
-  // Duplicates used to be silently accepted below the array bound and reported as "too many items" above
-  // it, so the same mistake failed differently depending on how many times it was repeated.
+  // Duplicates used to slip through below the array bound and come back as "too many items" above it,
+  // so the same mistake failed differently depending on how often it was repeated.
   test("reports duplicate grant types as duplicates, however many there are", async () => {
     const res = await createClient({
       name: "e2e-duplicate-grants",
@@ -134,9 +134,9 @@ describe("OAuth client grant type registration", async () => {
     expect(res.payload).toContain("duplicate");
   });
 
-  // Rotation on a token exchange application needs SSO edit permission on top of OauthClients edit, but
-  // it must stay a plain OauthClients operation for every other application. The seed actor holds both
-  // permissions, so this pins the non-exchange path rather than the denial.
+  // Rotation needs SSO edit on top of OauthClients edit for token exchange applications, but must stay a
+  // plain OauthClients operation for everything else. The seed actor holds both, so this pins the
+  // non-exchange path, not the denial.
   test("rotating a redirect-flow application's secret needs no SSO permission", async () => {
     const created = await createClient({
       name: "e2e-rotate-redirect-client",
@@ -157,7 +157,7 @@ describe("OAuth client grant type registration", async () => {
     await deleteClient(client.id);
   });
 
-  // The seed org has no OIDC config, and that config is the only trust anchor token exchange has.
+  // The seed org has no OIDC config, which is the only trust anchor token exchange has.
   test("the token exchange grant cannot be enabled without an active OIDC SSO configuration", async () => {
     const res = await createClient({
       name: "e2e-exchange-no-sso",
@@ -247,8 +247,8 @@ describe("POST /api/v1/oauth/token, token exchange grant", async () => {
     expect(res.payload).toContain("requested_token_type");
   });
 
-  // RFC 8693 permits both, but this grant has no scope concept and its audience is fixed per
-  // application, so silently dropping them is worse than a clear error.
+  // RFC 8693 allows both, but this grant has no scopes and its audience is fixed per application, so
+  // silently ignoring them is worse than a clear error.
   test("rejects a scope parameter rather than ignoring it", async () => {
     const res = await postToken(exchangeBody({ scope: "secrets:read" }));
 
@@ -264,8 +264,8 @@ describe("POST /api/v1/oauth/token, token exchange grant", async () => {
   });
 });
 
-// Mints a delegated token for the seed user on the same session as the working jwtAuthToken, so it
-// passes signature and session validation and differs only by its delegation marker.
+// Same session as the working jwtAuthToken, so it passes signature and session validation and differs
+// only by its delegation marker.
 const signDelegatedToken = (markers: { scopes?: string[]; delegation?: OauthDelegationMode }) =>
   jwt.sign(
     {
@@ -302,7 +302,7 @@ describe("Full delegation marker on a delegated OAuth token", async () => {
     expect(res.statusCode).toBe(200);
   });
 
-  // The invariant that makes the marker safe: dropping the claim by mistake cannot promote a token.
+  // The invariant that makes the marker safe: dropping the claim by mistake can't promote a token.
   test("a token carrying neither marker is denied", async () => {
     const token = signDelegatedToken({});
 
@@ -317,8 +317,8 @@ describe("Full delegation marker on a delegated OAuth token", async () => {
     expect(res.statusCode).toBe(403);
   });
 
-  // Account self-management routes authenticate on userId alone and build no permission, so they must
-  // stay unreachable whatever delegation marker the token carries.
+  // Account routes authenticate on userId alone and build no permission, so they have to stay
+  // unreachable whatever delegation marker the token carries.
   test("a fully-delegated token is still rejected on a JWT-only account route", async () => {
     const token = signDelegatedToken({ delegation: OauthDelegationMode.Full });
 
@@ -332,8 +332,8 @@ describe("Full delegation marker on a delegated OAuth token", async () => {
   });
 });
 
-// A refresh token is only usable if the application holds the refresh_token grant, so issuing one to an
-// application without it hands back a credential the token endpoint rejects on use.
+// A refresh token only works if the application holds the refresh_token grant, so issuing one without it
+// hands back a credential the token endpoint rejects on use.
 describe("Refresh token issuance follows the registered grants", async () => {
   const REDIRECT_URI = "https://app.example.com/callback";
 
@@ -367,10 +367,7 @@ describe("Refresh token issuance follows the registered grants", async () => {
   };
 
   test("issues a refresh token when the application holds the refresh_token grant", async () => {
-    const { clientDbId, token } = await runCodeFlow([
-      OauthGrantType.AuthorizationCode,
-      OauthGrantType.RefreshToken
-    ]);
+    const { clientDbId, token } = await runCodeFlow([OauthGrantType.AuthorizationCode, OauthGrantType.RefreshToken]);
 
     expect(token.statusCode).toBe(200);
     expect(JSON.parse(token.payload)).toHaveProperty("refresh_token");

--- a/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
+++ b/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
@@ -1,0 +1,277 @@
+import jwt from "jsonwebtoken";
+
+import { seedData1 } from "@app/db/seed-data";
+import { AuthMethod, AuthTokenType } from "@app/services/auth/auth-type";
+import { OauthDelegationMode, OauthGrantType, OauthTokenType } from "@app/services/oauth-client/oauth-client-types";
+
+const TOKEN_EXCHANGE_GRANT = OauthGrantType.TokenExchange;
+
+const createClient = async (body: Record<string, unknown>) =>
+  testServer.inject({
+    method: "POST",
+    url: "/api/v1/oauth/clients",
+    headers: { authorization: `Bearer ${jwtAuthToken}` },
+    body
+  });
+
+const deleteClient = async (clientDbId: string) =>
+  testServer.inject({
+    method: "DELETE",
+    url: `/api/v1/oauth/clients/${clientDbId}`,
+    headers: { authorization: `Bearer ${jwtAuthToken}` }
+  });
+
+const postToken = async (body: Record<string, string>) =>
+  testServer.inject({
+    method: "POST",
+    url: "/api/v1/oauth/token",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    payload: new URLSearchParams(body).toString()
+  });
+
+describe("OAuth client grant type registration", async () => {
+  test("registering a redirect-flow application still works without sending grantTypes", async () => {
+    const res = await createClient({
+      name: "e2e-legacy-redirect-client",
+      redirectUris: ["https://app.example.com/callback"]
+    });
+
+    expect(res.statusCode).toBe(200);
+    const { client } = JSON.parse(res.payload) as { client: { id: string; grantTypes: string[] } };
+    expect(client.grantTypes).toEqual([OauthGrantType.AuthorizationCode, OauthGrantType.RefreshToken]);
+
+    await deleteClient(client.id);
+  });
+
+  test("the authorization code grant still requires a redirect URI", async () => {
+    const res = await createClient({
+      name: "e2e-no-redirect-uri",
+      grantTypes: [OauthGrantType.AuthorizationCode],
+      redirectUris: []
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("At least one redirect URI is required");
+  });
+
+  test("the refresh token grant cannot be registered on its own", async () => {
+    const res = await createClient({
+      name: "e2e-refresh-only",
+      grantTypes: [OauthGrantType.RefreshToken],
+      redirectUris: ["https://app.example.com/callback"]
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("requires the 'authorization_code' grant");
+  });
+
+  test("the token exchange grant requires an audience", async () => {
+    const res = await createClient({
+      name: "e2e-exchange-no-audience",
+      grantTypes: [TOKEN_EXCHANGE_GRANT],
+      redirectUris: []
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("token exchange audience is required");
+  });
+
+  test("PKCE cannot be required on an exchange-only application", async () => {
+    const res = await createClient({
+      name: "e2e-exchange-pkce",
+      grantTypes: [TOKEN_EXCHANGE_GRANT],
+      redirectUris: [],
+      requirePkce: true,
+      tokenExchangeAudience: "api://e2e-mcp"
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("PKCE only applies");
+  });
+
+  test("an audience cannot be set on a redirect-only application", async () => {
+    const res = await createClient({
+      name: "e2e-redirect-with-audience",
+      grantTypes: [OauthGrantType.AuthorizationCode],
+      redirectUris: ["https://app.example.com/callback"],
+      tokenExchangeAudience: "api://e2e-mcp"
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("audience only applies");
+  });
+
+  // The seed org has no OIDC config, and that config is the only trust anchor token exchange has.
+  test("the token exchange grant cannot be enabled without an active OIDC SSO configuration", async () => {
+    const res = await createClient({
+      name: "e2e-exchange-no-sso",
+      grantTypes: [TOKEN_EXCHANGE_GRANT],
+      redirectUris: [],
+      tokenExchangeAudience: "api://e2e-mcp"
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("OIDC SSO");
+  });
+});
+
+describe("POST /api/v1/oauth/token, token exchange grant", async () => {
+  let clientId: string;
+  let clientSecret: string;
+  let clientDbId: string;
+
+  beforeAll(async () => {
+    // Authenticates fine but is not registered for the exchange grant, which the cases below need.
+    const res = await createClient({
+      name: "e2e-token-endpoint-client",
+      redirectUris: ["https://app.example.com/callback"]
+    });
+
+    const { client, clientSecret: secret } = JSON.parse(res.payload) as {
+      client: { id: string; clientId: string };
+      clientSecret: string;
+    };
+
+    clientDbId = client.id;
+    clientId = client.clientId;
+    clientSecret = secret;
+  });
+
+  afterAll(async () => {
+    await deleteClient(clientDbId);
+  });
+
+  const exchangeBody = (overrides: Record<string, string> = {}) => ({
+    grant_type: TOKEN_EXCHANGE_GRANT,
+    subject_token: "eyJhbGciOiJSUzI1NiJ9.e30.signature",
+    subject_token_type: OauthTokenType.Jwt,
+    client_id: clientId,
+    client_secret: clientSecret,
+    ...overrides
+  });
+
+  test("rejects invalid client credentials", async () => {
+    const res = await postToken(exchangeBody({ client_secret: "not-the-secret" }));
+
+    expect(res.statusCode).toBe(401);
+    expect(res.payload).toContain("Invalid OAuth client credentials");
+  });
+
+  test("rejects a client that is not registered for the exchange grant", async () => {
+    const res = await postToken(exchangeBody());
+
+    expect(res.statusCode).toBe(401);
+    expect(res.payload).toContain(TOKEN_EXCHANGE_GRANT);
+  });
+
+  test("requires a subject token", async () => {
+    const body = exchangeBody();
+    delete (body as Record<string, string>).subject_token;
+
+    const res = await postToken(body);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("subject_token");
+  });
+
+  test("requires a subject token type", async () => {
+    const body = exchangeBody();
+    delete (body as Record<string, string>).subject_token_type;
+
+    const res = await postToken(body);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("subject_token_type");
+  });
+
+  test("rejects an unsupported requested token type", async () => {
+    const res = await postToken(exchangeBody({ requested_token_type: OauthTokenType.IdToken }));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("requested_token_type");
+  });
+
+  // RFC 8693 permits both, but this grant has no scope concept and its audience is fixed per
+  // application, so silently dropping them is worse than a clear error.
+  test("rejects a scope parameter rather than ignoring it", async () => {
+    const res = await postToken(exchangeBody({ scope: "secrets:read" }));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("'scope' parameter is not supported");
+  });
+
+  test("rejects an audience parameter rather than ignoring it", async () => {
+    const res = await postToken(exchangeBody({ audience: "api://something-else" }));
+
+    expect(res.statusCode).toBe(400);
+    expect(res.payload).toContain("not supported");
+  });
+});
+
+// Mints a delegated token for the seed user on the same session as the working jwtAuthToken, so it
+// passes signature and session validation and differs only by its delegation marker.
+const signDelegatedToken = (markers: { scopes?: string[]; delegation?: OauthDelegationMode }) =>
+  jwt.sign(
+    {
+      authTokenType: AuthTokenType.ACCESS_TOKEN,
+      userId: seedData1.id,
+      tokenVersionId: seedData1.token.id,
+      authMethod: AuthMethod.OIDC,
+      organizationId: seedData1.organization.id,
+      accessVersion: 1,
+      oauthClientId: "oauth_client_e2e_exchange",
+      ...markers
+    },
+    process.env.AUTH_SECRET ?? "something-random",
+    { expiresIn: "1h" }
+  );
+
+const readSecrets = async (token: string) =>
+  testServer.inject({
+    method: "GET",
+    url: `/api/v3/secrets/raw`,
+    headers: { authorization: `Bearer ${token}` },
+    query: {
+      workspaceId: seedData1.projectV3.id,
+      environment: seedData1.environment.slug,
+      secretPath: "/"
+    }
+  });
+
+describe("Full delegation marker on a delegated OAuth token", async () => {
+  test("a fully-delegated token carries the user's own permissions, unnarrowed", async () => {
+    const token = signDelegatedToken({ delegation: OauthDelegationMode.Full });
+
+    const res = await readSecrets(token);
+    expect(res.statusCode).toBe(200);
+  });
+
+  // The invariant that makes the marker safe: dropping the claim by mistake cannot promote a token.
+  test("a token carrying neither marker is denied", async () => {
+    const token = signDelegatedToken({});
+
+    const res = await readSecrets(token);
+    expect(res.statusCode).toBe(403);
+  });
+
+  test("an empty scope list is still denied", async () => {
+    const token = signDelegatedToken({ scopes: [] });
+
+    const res = await readSecrets(token);
+    expect(res.statusCode).toBe(403);
+  });
+
+  // Account self-management routes authenticate on userId alone and build no permission, so they must
+  // stay unreachable whatever delegation marker the token carries.
+  test("a fully-delegated token is still rejected on a JWT-only account route", async () => {
+    const token = signDelegatedToken({ delegation: OauthDelegationMode.Full });
+
+    const res = await testServer.inject({
+      method: "GET",
+      url: `/api/v1/user/me/totp`,
+      headers: { authorization: `Bearer ${token}` }
+    });
+
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
+++ b/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
@@ -28,6 +28,14 @@ const rotateClientSecret = async (clientDbId: string) =>
     headers: { authorization: `Bearer ${jwtAuthToken}` }
   });
 
+const consent = async (body: Record<string, string>) =>
+  testServer.inject({
+    method: "POST",
+    url: "/api/v1/oauth/authorize/consent",
+    headers: { authorization: `Bearer ${jwtAuthToken}` },
+    body
+  });
+
 const postToken = async (body: Record<string, string>) =>
   testServer.inject({
     method: "POST",
@@ -303,5 +311,63 @@ describe("Full delegation marker on a delegated OAuth token", async () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+});
+
+// A refresh token is only usable if the application holds the refresh_token grant, so issuing one to an
+// application without it hands back a credential the token endpoint rejects on use.
+describe("Refresh token issuance follows the registered grants", async () => {
+  const REDIRECT_URI = "https://app.example.com/callback";
+
+  const runCodeFlow = async (grantTypes: OauthGrantType[]) => {
+    const created = await createClient({
+      name: `e2e-refresh-issuance-${grantTypes.length}`,
+      grantTypes,
+      redirectUris: [REDIRECT_URI]
+    });
+
+    const { client, clientSecret } = JSON.parse(created.payload) as {
+      client: { id: string; clientId: string };
+      clientSecret: string;
+    };
+
+    const consented = await consent({ client_id: client.clientId, redirect_uri: REDIRECT_URI });
+    expect(consented.statusCode).toBe(200);
+
+    const { callbackUrl } = JSON.parse(consented.payload) as { callbackUrl: string };
+    const code = new URL(callbackUrl).searchParams.get("code") as string;
+
+    const token = await postToken({
+      grant_type: OauthGrantType.AuthorizationCode,
+      code,
+      redirect_uri: REDIRECT_URI,
+      client_id: client.clientId,
+      client_secret: clientSecret
+    });
+
+    return { clientDbId: client.id, token };
+  };
+
+  test("issues a refresh token when the application holds the refresh_token grant", async () => {
+    const { clientDbId, token } = await runCodeFlow([
+      OauthGrantType.AuthorizationCode,
+      OauthGrantType.RefreshToken
+    ]);
+
+    expect(token.statusCode).toBe(200);
+    expect(JSON.parse(token.payload)).toHaveProperty("refresh_token");
+
+    await deleteClient(clientDbId);
+  });
+
+  test("omits the refresh token when the application does not", async () => {
+    const { clientDbId, token } = await runCodeFlow([OauthGrantType.AuthorizationCode]);
+
+    expect(token.statusCode).toBe(200);
+    const body = JSON.parse(token.payload) as Record<string, unknown>;
+    expect(body).not.toHaveProperty("refresh_token");
+    expect(body).toHaveProperty("access_token");
+
+    await deleteClient(clientDbId);
   });
 });

--- a/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
+++ b/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
@@ -21,6 +21,13 @@ const deleteClient = async (clientDbId: string) =>
     headers: { authorization: `Bearer ${jwtAuthToken}` }
   });
 
+const rotateClientSecret = async (clientDbId: string) =>
+  testServer.inject({
+    method: "POST",
+    url: `/api/v1/oauth/clients/${clientDbId}/rotate-secret`,
+    headers: { authorization: `Bearer ${jwtAuthToken}` }
+  });
+
 const postToken = async (body: Record<string, string>) =>
   testServer.inject({
     method: "POST",
@@ -99,6 +106,29 @@ describe("OAuth client grant type registration", async () => {
 
     expect(res.statusCode).toBe(400);
     expect(res.payload).toContain("audience only applies");
+  });
+
+  // Rotation on a token exchange application needs SSO edit permission on top of OauthClients edit, but
+  // it must stay a plain OauthClients operation for every other application. The seed actor holds both
+  // permissions, so this pins the non-exchange path rather than the denial.
+  test("rotating a redirect-flow application's secret needs no SSO permission", async () => {
+    const created = await createClient({
+      name: "e2e-rotate-redirect-client",
+      redirectUris: ["https://app.example.com/callback"]
+    });
+
+    const { client, clientSecret } = JSON.parse(created.payload) as {
+      client: { id: string };
+      clientSecret: string;
+    };
+
+    const rotated = await rotateClientSecret(client.id);
+
+    expect(rotated.statusCode).toBe(200);
+    const { clientSecret: rotatedSecret } = JSON.parse(rotated.payload) as { clientSecret: string };
+    expect(rotatedSecret).not.toBe(clientSecret);
+
+    await deleteClient(client.id);
   });
 
   // The seed org has no OIDC config, and that config is the only trust anchor token exchange has.

--- a/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
+++ b/backend/e2e-test/routes/v1/oauth-token-exchange.spec.ts
@@ -116,6 +116,24 @@ describe("OAuth client grant type registration", async () => {
     expect(res.payload).toContain("audience only applies");
   });
 
+  // Duplicates used to be silently accepted below the array bound and reported as "too many items" above
+  // it, so the same mistake failed differently depending on how many times it was repeated.
+  test("reports duplicate grant types as duplicates, however many there are", async () => {
+    const res = await createClient({
+      name: "e2e-duplicate-grants",
+      grantTypes: [
+        OauthGrantType.AuthorizationCode,
+        OauthGrantType.AuthorizationCode,
+        OauthGrantType.AuthorizationCode,
+        OauthGrantType.RefreshToken
+      ],
+      redirectUris: ["https://app.example.com/callback"]
+    });
+
+    expect(res.statusCode).toBe(422);
+    expect(res.payload).toContain("duplicate");
+  });
+
   // Rotation on a token exchange application needs SSO edit permission on top of OauthClients edit, but
   // it must stay a plain OauthClients operation for every other application. The seed actor holds both
   // permissions, so this pins the non-exchange path rather than the denial.

--- a/backend/src/db/migrations/20260806120000_add-oauth-client-grant-types.ts
+++ b/backend/src/db/migrations/20260806120000_add-oauth-client-grant-types.ts
@@ -16,20 +16,20 @@ export async function up(knex: Knex): Promise<void> {
   if (hasGrantTypes && hasTokenExchangeAudience && hasTokenExchangeIdpSatisfiesMfa) return;
 
   await knex.schema.alterTable(TableName.OauthClient, (t) => {
-    // The default only exists to backfill existing rows. It is dropped below so an insert that omits
-    // the column fails instead of silently picking a grant set.
+    // The default is only here to backfill existing rows, and gets dropped below so an insert that
+    // omits the column fails instead of silently picking a grant set.
     if (!hasGrantTypes) {
       t.specificType("grantTypes", "text[]").notNullable().defaultTo(knex.raw(REDIRECT_FLOW_GRANT_TYPES));
     }
 
-    // Expected `aud` of subject tokens. This is the application's own registration in the org's IdP,
-    // not Infisical's, so it cannot be read from oidc_configs.
+    // Expected `aud` of subject tokens. It's the application's own registration in the org's IdP, not
+    // Infisical's, so it can't be read off oidc_configs.
     if (!hasTokenExchangeAudience) {
       t.text("tokenExchangeAudience");
     }
 
-    // Token exchange has no Infisical MFA challenge to run, so an admin declares that the IdP
-    // enforces it. Without the declaration, exchanges fail for any user who requires MFA.
+    // Token exchange has no Infisical MFA challenge to run, so an admin vouches that the IdP enforces
+    // it. Without that, exchanges fail for any user who requires MFA.
     if (!hasTokenExchangeIdpSatisfiesMfa) {
       t.boolean("tokenExchangeIdpSatisfiesMfa").notNullable().defaultTo(false);
     }

--- a/backend/src/db/migrations/20260806120000_add-oauth-client-grant-types.ts
+++ b/backend/src/db/migrations/20260806120000_add-oauth-client-grant-types.ts
@@ -1,0 +1,58 @@
+import { Knex } from "knex";
+
+import { TableName } from "@app/db/schemas";
+
+// Every client registered before this migration was created for the redirect flow.
+const REDIRECT_FLOW_GRANT_TYPES = "'{authorization_code,refresh_token}'::text[]";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasGrantTypes = await knex.schema.hasColumn(TableName.OauthClient, "grantTypes");
+  const hasTokenExchangeAudience = await knex.schema.hasColumn(TableName.OauthClient, "tokenExchangeAudience");
+  const hasTokenExchangeIdpSatisfiesMfa = await knex.schema.hasColumn(
+    TableName.OauthClient,
+    "tokenExchangeIdpSatisfiesMfa"
+  );
+
+  if (hasGrantTypes && hasTokenExchangeAudience && hasTokenExchangeIdpSatisfiesMfa) return;
+
+  await knex.schema.alterTable(TableName.OauthClient, (t) => {
+    // The default only exists to backfill existing rows. It is dropped below so an insert that omits
+    // the column fails instead of silently picking a grant set.
+    if (!hasGrantTypes) {
+      t.specificType("grantTypes", "text[]").notNullable().defaultTo(knex.raw(REDIRECT_FLOW_GRANT_TYPES));
+    }
+
+    // Expected `aud` of subject tokens. This is the application's own registration in the org's IdP,
+    // not Infisical's, so it cannot be read from oidc_configs.
+    if (!hasTokenExchangeAudience) {
+      t.text("tokenExchangeAudience");
+    }
+
+    // Token exchange has no Infisical MFA challenge to run, so an admin declares that the IdP
+    // enforces it. Without the declaration, exchanges fail for any user who requires MFA.
+    if (!hasTokenExchangeIdpSatisfiesMfa) {
+      t.boolean("tokenExchangeIdpSatisfiesMfa").notNullable().defaultTo(false);
+    }
+  });
+
+  if (!hasGrantTypes) {
+    await knex.raw('ALTER TABLE ?? ALTER COLUMN "grantTypes" DROP DEFAULT', [TableName.OauthClient]);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasGrantTypes = await knex.schema.hasColumn(TableName.OauthClient, "grantTypes");
+  const hasTokenExchangeAudience = await knex.schema.hasColumn(TableName.OauthClient, "tokenExchangeAudience");
+  const hasTokenExchangeIdpSatisfiesMfa = await knex.schema.hasColumn(
+    TableName.OauthClient,
+    "tokenExchangeIdpSatisfiesMfa"
+  );
+
+  if (!hasGrantTypes && !hasTokenExchangeAudience && !hasTokenExchangeIdpSatisfiesMfa) return;
+
+  await knex.schema.alterTable(TableName.OauthClient, (t) => {
+    if (hasGrantTypes) t.dropColumn("grantTypes");
+    if (hasTokenExchangeAudience) t.dropColumn("tokenExchangeAudience");
+    if (hasTokenExchangeIdpSatisfiesMfa) t.dropColumn("tokenExchangeIdpSatisfiesMfa");
+  });
+}

--- a/backend/src/db/schemas/oauth-clients.ts
+++ b/backend/src/db/schemas/oauth-clients.ts
@@ -18,7 +18,10 @@ export const OauthClientsSchema = z.object({
   redirectUris: z.string().array(),
   requirePkce: z.boolean().default(false),
   createdAt: z.date(),
-  updatedAt: z.date()
+  updatedAt: z.date(),
+  grantTypes: z.string().array(),
+  tokenExchangeAudience: z.string().nullable().optional(),
+  tokenExchangeIdpSatisfiesMfa: z.boolean().default(false)
 });
 
 export type TOauthClients = z.infer<typeof OauthClientsSchema>;

--- a/backend/src/ee/routes/scep/pki-scep-router.ts
+++ b/backend/src/ee/routes/scep/pki-scep-router.ts
@@ -130,7 +130,7 @@ export const registerPkiScepRouter = async (server: FastifyZodProvider) => {
         profileId: z.string().uuid()
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req, res) => {
       const { profileId } = req.params;
 
@@ -172,7 +172,7 @@ export const registerPkiScepRouter = async (server: FastifyZodProvider) => {
         profileId: z.string().uuid()
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req, res) => {
       const { applicationId, profileId } = req.params;
 

--- a/backend/src/ee/routes/v1/access-approval-policy-router.ts
+++ b/backend/src/ee/routes/v1/access-approval-policy-router.ts
@@ -146,7 +146,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.accessApprovalPolicy.createAccessApprovalPolicy({
         actor: req.permission.type,
@@ -216,7 +216,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const approvals = await server.services.accessApprovalPolicy.getAccessApprovalPolicyByProjectSlug({
         actor: req.permission.type,
@@ -245,7 +245,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
       }
     },
 
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { count } = await server.services.accessApprovalPolicy.getAccessPolicyCountByEnvSlug({
         actor: req.permission.type,
@@ -327,7 +327,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.accessApprovalPolicy.updateAccessApprovalPolicy({
         policyId: req.params.policyId,
@@ -365,7 +365,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.accessApprovalPolicy.deleteAccessApprovalPolicy({
         actor: req.permission.type,
@@ -431,7 +431,7 @@ export const registerAccessApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.accessApprovalPolicy.getAccessApprovalPolicyById({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/access-approval-request-router.ts
+++ b/backend/src/ee/routes/v1/access-approval-request-router.ts
@@ -59,7 +59,7 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { request, projectId } = await server.services.accessApprovalRequest.createAccessApprovalRequest({
         actor: req.permission.type,
@@ -124,7 +124,7 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { count } = await server.services.accessApprovalRequest.getCount({
         projectSlug: req.query.projectSlug,
@@ -201,7 +201,7 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { requests } = await server.services.accessApprovalRequest.listApprovalRequests({
         projectSlug: req.query.projectSlug,
@@ -234,7 +234,7 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId, policyId, isBypass, ...review } =
         await server.services.accessApprovalRequest.reviewAccessRequest({
@@ -297,7 +297,7 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.accessApprovalRequest.revokeAccessRequest({
         requestId: req.params.requestId,
@@ -353,7 +353,7 @@ export const registerAccessApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { request, projectId } = await server.services.accessApprovalRequest.updateAccessApprovalRequest({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/app-connection-routers/chef-connection-router.ts
+++ b/backend/src/ee/routes/v1/app-connection-routers/chef-connection-router.ts
@@ -38,7 +38,7 @@ export const registerChefConnectionRouter = async (server: FastifyZodProvider) =
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const dataBags = await server.services.appConnection.chef.listDataBags(connectionId, req.permission);
@@ -68,7 +68,7 @@ export const registerChefConnectionRouter = async (server: FastifyZodProvider) =
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { dataBagName } = req.query;

--- a/backend/src/ee/routes/v1/app-connection-routers/oci-connection-router.ts
+++ b/backend/src/ee/routes/v1/app-connection-routers/oci-connection-router.ts
@@ -41,7 +41,7 @@ export const registerOCIConnectionRouter = async (server: FastifyZodProvider) =>
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -72,7 +72,7 @@ export const registerOCIConnectionRouter = async (server: FastifyZodProvider) =>
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { compartmentOcid } = req.query;
@@ -108,7 +108,7 @@ export const registerOCIConnectionRouter = async (server: FastifyZodProvider) =>
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { compartmentOcid, vaultOcid } = req.query;

--- a/backend/src/ee/routes/v1/audit-log-stream-routers/audit-log-stream-endpoints.ts
+++ b/backend/src/ee/routes/v1/audit-log-stream-routers/audit-log-stream-endpoints.ts
@@ -49,7 +49,7 @@ export const registerAuditLogStreamEndpoints = <T extends TAuditLogStream>({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { logStreamId } = req.params;
 
@@ -73,7 +73,7 @@ export const registerAuditLogStreamEndpoints = <T extends TAuditLogStream>({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { credentials, filters } = req.body;
 
@@ -116,7 +116,7 @@ export const registerAuditLogStreamEndpoints = <T extends TAuditLogStream>({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { logStreamId } = req.params;
       const { credentials, streamMode, filters } = req.body;
@@ -161,7 +161,7 @@ export const registerAuditLogStreamEndpoints = <T extends TAuditLogStream>({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { logStreamId } = req.params;
 

--- a/backend/src/ee/routes/v1/audit-log-stream-routers/audit-log-stream-router.ts
+++ b/backend/src/ee/routes/v1/audit-log-stream-routers/audit-log-stream-router.ts
@@ -60,7 +60,7 @@ export const registerAuditLogStreamRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: () => {
       const providerOptions = server.services.auditLogStream.listProviderOptions();
 
@@ -81,7 +81,7 @@ export const registerAuditLogStreamRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const auditLogStreams = await server.services.auditLogStream.list(req.permission);
 

--- a/backend/src/ee/routes/v1/deprecated-project-role-router.ts
+++ b/backend/src/ee/routes/v1/deprecated-project-role-router.ts
@@ -50,7 +50,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const stringifiedPermissions = JSON.stringify(
         packRules(backfillPermissionV1SchemaToV2Schema(req.body.permissions, true))
@@ -140,7 +140,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const stringifiedPermissions = req.body.permissions
         ? JSON.stringify(packRules(backfillPermissionV1SchemaToV2Schema(req.body.permissions, true)))
@@ -223,7 +223,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id: projectId } = await server.services.convertor.projectSlugToId({
         slug: req.params.projectSlug,
@@ -294,7 +294,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id: projectId } = await server.services.convertor.projectSlugToId({
         slug: req.params.projectSlug,
@@ -331,7 +331,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id: projectId } = await server.services.convertor.projectSlugToId({
         slug: req.params.projectSlug,

--- a/backend/src/ee/routes/v1/deprecated-project-router.ts
+++ b/backend/src/ee/routes/v1/deprecated-project-router.ts
@@ -97,7 +97,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const auditLogs = await server.services.auditLog.listAuditLogs({
         actorId: req.permission.id,

--- a/backend/src/ee/routes/v1/deprecated-secret-approval-policy-router.ts
+++ b/backend/src/ee/routes/v1/deprecated-secret-approval-policy-router.ts
@@ -62,7 +62,7 @@ export const registerDeprecatedSecretApprovalPolicyRouter = async (server: Fasti
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalPolicy.createSecretApprovalPolicy({
         actor: req.permission.type,
@@ -123,7 +123,7 @@ export const registerDeprecatedSecretApprovalPolicyRouter = async (server: Fasti
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalPolicy.updateSecretApprovalPolicy({
         actor: req.permission.type,
@@ -153,7 +153,7 @@ export const registerDeprecatedSecretApprovalPolicyRouter = async (server: Fasti
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalPolicy.deleteSecretApprovalPolicy({
         actor: req.permission.type,
@@ -197,7 +197,7 @@ export const registerDeprecatedSecretApprovalPolicyRouter = async (server: Fasti
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const approvals = await server.services.secretApprovalPolicy.getSecretApprovalPolicyByProjectId({
         actor: req.permission.type,
@@ -241,7 +241,7 @@ export const registerDeprecatedSecretApprovalPolicyRouter = async (server: Fasti
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalPolicy.getSecretApprovalPolicyById({
         actor: req.permission.type,
@@ -277,7 +277,7 @@ export const registerDeprecatedSecretApprovalPolicyRouter = async (server: Fasti
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const policy = await server.services.secretApprovalPolicy.getSecretApprovalPolicyOfFolder({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/dynamic-secret-lease-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-lease-router.ts
@@ -49,7 +49,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { data, lease, dynamicSecret, projectId, environment, secretPath } =
         await server.services.dynamicSecretLease.create({
@@ -130,7 +130,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { lease, dynamicSecret, projectId, environment, secretPath } =
         await server.services.dynamicSecretLease.revokeLease({
@@ -222,7 +222,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { lease, dynamicSecret, projectId, environment, secretPath } =
         await server.services.dynamicSecretLease.renewLease({
@@ -303,7 +303,7 @@ export const registerDynamicSecretLeaseRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { lease, dynamicSecret, projectId, environment, secretPath } =
         await server.services.dynamicSecretLease.getLeaseDetails({

--- a/backend/src/ee/routes/v1/dynamic-secret-lease-routers/kubernetes-lease-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-lease-routers/kubernetes-lease-router.ts
@@ -50,7 +50,7 @@ export const registerKubernetesDynamicSecretLeaseRouter = async (server: Fastify
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { data, lease, dynamicSecret } = await server.services.dynamicSecretLease.create({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/dynamic-secret-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-router.ts
@@ -96,7 +96,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const dynamicSecretCfg = await server.services.dynamicSecret.create({
         actor: req.permission.type,
@@ -203,7 +203,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dynamicSecret, updatedFields, projectId, environment, secretPath } =
         await server.services.dynamicSecret.updateByName({
@@ -272,7 +272,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const dynamicSecretCfg = await server.services.dynamicSecret.deleteByName({
         actor: req.permission.type,
@@ -343,7 +343,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const dynamicSecretCfg = await server.services.dynamicSecret.getDetails({
         actor: req.permission.type,
@@ -394,7 +394,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dynamicSecrets, environment, secretPath, projectId } =
         await server.services.dynamicSecret.listDynamicSecretsByEnv({
@@ -450,7 +450,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { leases, dynamicSecret, projectId, environment, secretPath } =
         await server.services.dynamicSecretLease.listLeases({
@@ -499,7 +499,7 @@ export const registerDynamicSecretRouter = async (server: FastifyZodProvider) =>
         200: z.string()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req, reply) => {
       const { caPublicKey } = await server.services.dynamicSecret.getSshCaPublicKey({
         dynamicSecretId: req.params.dynamicSecretId,
@@ -600,7 +600,7 @@ echo ""
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { caPublicKey } = await server.services.dynamicSecret.getSshCaPublicKey({
         dynamicSecretId: req.params.dynamicSecretId,
@@ -640,7 +640,7 @@ echo ""
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.dynamicSecret.fetchIbmApiConnectOrgs({
         instanceUrl: req.body.instanceUrl,
@@ -686,7 +686,7 @@ echo ""
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.dynamicSecret.fetchIbmApiConnectOrgCatalogs({
         instanceUrl: req.body.instanceUrl,
@@ -735,7 +735,7 @@ echo ""
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.dynamicSecret.fetchIbmApiConnectOrgApps({
         instanceUrl: req.body.instanceUrl,
@@ -779,7 +779,7 @@ echo ""
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.dynamicSecret.fetchAzureEntraIdUsers({
         tenantId: req.body.tenantId,

--- a/backend/src/ee/routes/v1/email-domain-router.ts
+++ b/backend/src/ee/routes/v1/email-domain-router.ts
@@ -15,7 +15,7 @@ export const registerEmailDomainRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       body: z.object({
         domain: z.string().trim().toLowerCase().min(1).describe("The domain to verify (e.g., company.com)")
@@ -67,7 +67,7 @@ export const registerEmailDomainRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         emailDomainId: z.string().uuid().describe("The ID of the email domain to verify")
@@ -122,7 +122,7 @@ export const registerEmailDomainRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       response: {
         200: z.object({
@@ -149,7 +149,7 @@ export const registerEmailDomainRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         emailDomainId: z.string().uuid().describe("The ID of the email domain to delete")

--- a/backend/src/ee/routes/v1/external-kms-router.ts
+++ b/backend/src/ee/routes/v1/external-kms-router.ts
@@ -72,7 +72,7 @@ export const registerExternalKmsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const externalKms = await server.services.externalKms.create({
         actor: req.permission.type,
@@ -123,7 +123,7 @@ export const registerExternalKmsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const externalKms = await server.services.externalKms.updateById({
         actor: req.permission.type,
@@ -170,7 +170,7 @@ export const registerExternalKmsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const externalKms = await server.services.externalKms.deleteById({
         actor: req.permission.type,
@@ -212,7 +212,7 @@ export const registerExternalKmsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const externalKms = await server.services.externalKms.findById({
         actor: req.permission.type,
@@ -251,7 +251,7 @@ export const registerExternalKmsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const externalKmsList = await server.services.externalKms.list({
         actor: req.permission.type,
@@ -279,7 +279,7 @@ export const registerExternalKmsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const externalKms = await server.services.externalKms.findByName({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/external-kms-routers/external-kms-endpoints.ts
+++ b/backend/src/ee/routes/v1/external-kms-routers/external-kms-endpoints.ts
@@ -55,7 +55,7 @@ export const registerExternalKmsEndpoints = <
         200: sanitizedExternalSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const externalKms = await server.services.externalKms.findById({
         actor: req.permission.type,
@@ -115,7 +115,7 @@ export const registerExternalKmsEndpoints = <
         200: sanitizedExternalSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { name, description, configuration } = req.body as {
         name: string;
@@ -186,7 +186,7 @@ export const registerExternalKmsEndpoints = <
         200: sanitizedExternalSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { name, description, configuration } = req.body as {
         name?: string;
@@ -253,7 +253,7 @@ export const registerExternalKmsEndpoints = <
         200: sanitizedExternalSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const externalKms = await server.services.externalKms.deleteById({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/external-kms-routers/gcp-kms-router.ts
+++ b/backend/src/ee/routes/v1/external-kms-routers/gcp-kms-router.ts
@@ -47,7 +47,7 @@ export const registerGcpKmsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { region, authMethod } = req.body;
       let credentialJson: TExternalKmsGcpCredentialSchema | undefined;

--- a/backend/src/ee/routes/v1/gateway-pool-router.ts
+++ b/backend/src/ee/routes/v1/gateway-pool-router.ts
@@ -37,7 +37,7 @@ export const registerGatewayPoolRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const pool = await server.services.gatewayPool.createGatewayPool({
         name: req.body.name,
@@ -78,7 +78,7 @@ export const registerGatewayPoolRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.gatewayPool.listGatewayPools(req.permission);
     }
@@ -100,7 +100,7 @@ export const registerGatewayPoolRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.gatewayPool.getGatewayPoolById({
         poolId: req.params.poolId,
@@ -126,7 +126,7 @@ export const registerGatewayPoolRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const pool = await server.services.gatewayPool.updateGatewayPool({
         poolId: req.params.poolId,
@@ -164,7 +164,7 @@ export const registerGatewayPoolRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const pool = await server.services.gatewayPool.deleteGatewayPool({
         poolId: req.params.poolId,
@@ -209,7 +209,7 @@ export const registerGatewayPoolRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { membership, poolName, gatewayName } = await server.services.gatewayPool.addGatewayToPool({
         poolId: req.params.poolId,
@@ -255,7 +255,7 @@ export const registerGatewayPoolRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { membership, poolName, gatewayName } = await server.services.gatewayPool.removeGatewayFromPool({
         poolId: req.params.poolId,
@@ -331,7 +331,7 @@ export const registerGatewayPoolRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.gatewayPool.getConnectedResources({
         poolId: req.params.poolId,

--- a/backend/src/ee/routes/v1/gateway-router.ts
+++ b/backend/src/ee/routes/v1/gateway-router.ts
@@ -63,7 +63,7 @@ export const registerGatewayRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const gateways = await server.services.gateway.listGateways({
         orgPermission: req.permission
@@ -93,7 +93,7 @@ export const registerGatewayRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const gateways = await server.services.gateway.listGateways({
         orgPermission: req.permission
@@ -123,7 +123,7 @@ export const registerGatewayRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const gateway = await server.services.gateway.getGatewayById({
         orgPermission: req.permission,
@@ -152,7 +152,7 @@ export const registerGatewayRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const gateway = await server.services.gateway.updateGatewayById({
         orgPermission: req.permission,
@@ -191,7 +191,7 @@ export const registerGatewayRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const gateway = await server.services.gateway.deleteGatewayById({
         orgPermission: req.permission,

--- a/backend/src/ee/routes/v1/github-org-sync-router.ts
+++ b/backend/src/ee/routes/v1/github-org-sync-router.ts
@@ -25,7 +25,7 @@ export const registerGithubOrgSyncRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       body: z.object({
         githubOrgName: GithubOrgNameCreateSchema,
@@ -65,7 +65,7 @@ export const registerGithubOrgSyncRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       body: z
         .object({
@@ -110,7 +110,7 @@ export const registerGithubOrgSyncRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       response: {
         200: z.object({
@@ -144,7 +144,7 @@ export const registerGithubOrgSyncRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       response: {
         200: z.object({
@@ -167,7 +167,7 @@ export const registerGithubOrgSyncRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       response: {
         200: z.object({

--- a/backend/src/ee/routes/v1/group-router.ts
+++ b/backend/src/ee/routes/v1/group-router.ts
@@ -55,7 +55,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createGroup",
@@ -114,7 +114,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getGroupById",
@@ -147,7 +147,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listGroups",
@@ -175,7 +175,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateGroup",
@@ -240,7 +240,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteGroup",
@@ -308,7 +308,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listGroupUsers",
@@ -368,7 +368,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listGroupMachineIdentities",
@@ -422,7 +422,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listGroupMembers",
@@ -513,7 +513,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listGroupProjects",
@@ -579,7 +579,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "addUserToGroup",
@@ -641,7 +641,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "addMachineIdentityToGroup",
@@ -698,7 +698,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "removeUserFromGroup",
@@ -763,7 +763,7 @@ export const registerGroupRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "removeMachineIdentityFromGroup",

--- a/backend/src/ee/routes/v1/honey-token-router.ts
+++ b/backend/src/ee/routes/v1/honey-token-router.ts
@@ -75,7 +75,7 @@ export const registerHoneyTokenGenericRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       querystring: z.object({
         projectId: z.string().trim()
@@ -98,7 +98,7 @@ export const registerHoneyTokenGenericRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       body: z.object({
         projectId: z.string().trim(),
@@ -164,7 +164,7 @@ export const registerHoneyTokenGenericRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         id: z.string().uuid()
@@ -190,7 +190,7 @@ export const registerHoneyTokenGenericRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         id: z.string().uuid()
@@ -256,7 +256,7 @@ export const registerHoneyTokenGenericRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         id: z.string().uuid()
@@ -301,7 +301,7 @@ export const registerHoneyTokenGenericRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         id: z.string().uuid()
@@ -356,7 +356,7 @@ export const registerHoneyTokenGenericRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         id: z.string().uuid()
@@ -383,7 +383,7 @@ export const registerHoneyTokenGenericRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         id: z.string().uuid()

--- a/backend/src/ee/routes/v1/honey-token-routers/honey-token-endpoints.ts
+++ b/backend/src/ee/routes/v1/honey-token-routers/honey-token-endpoints.ts
@@ -48,7 +48,7 @@ export const registerHoneyTokenEndpoints = <TType extends HoneyTokenType>({
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       body: upsertBodySchema,
       response: {
@@ -77,7 +77,7 @@ export const registerHoneyTokenEndpoints = <TType extends HoneyTokenType>({
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       response: {
         200: routeTestConnectionResponseSchema
@@ -98,7 +98,7 @@ export const registerHoneyTokenEndpoints = <TType extends HoneyTokenType>({
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       response: {
         200: z.object({

--- a/backend/src/ee/routes/v1/identity-project-additional-privilege-router.ts
+++ b/backend/src/ee/routes/v1/identity-project-additional-privilege-router.ts
@@ -50,7 +50,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { permissions, privilegePermission } = req.body;
       if (!permissions && !privilegePermission) {
@@ -143,7 +143,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { permissions, privilegePermission } = req.body;
       if (!permissions && !privilegePermission) {
@@ -242,7 +242,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { permissions, privilegePermission, ...updatedInfo } = req.body.privilegeDetails;
       if (!permissions && !privilegePermission) {
@@ -332,7 +332,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id: projectId } = await server.services.convertor.projectSlugToId({
         orgId: req.permission.orgId,
@@ -398,7 +398,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id: projectId } = await server.services.convertor.projectSlugToId({
         orgId: req.permission.orgId,
@@ -461,7 +461,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id: projectId } = await server.services.convertor.projectSlugToId({
         orgId: req.permission.orgId,

--- a/backend/src/ee/routes/v1/identity-template-router.ts
+++ b/backend/src/ee/routes/v1/identity-template-router.ts
@@ -26,7 +26,7 @@ export const registerIdentityTemplateRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "Create identity auth template",
@@ -83,7 +83,7 @@ export const registerIdentityTemplateRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "Update identity auth template",
@@ -143,7 +143,7 @@ export const registerIdentityTemplateRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "Delete identity auth template",
@@ -192,7 +192,7 @@ export const registerIdentityTemplateRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "Get identity auth template by ID",
@@ -229,7 +229,7 @@ export const registerIdentityTemplateRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "List identity auth templates",
@@ -273,7 +273,7 @@ export const registerIdentityTemplateRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "Get identity auth templates by authentication method",
@@ -310,7 +310,7 @@ export const registerIdentityTemplateRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "Get template usage by template ID",
@@ -350,7 +350,7 @@ export const registerIdentityTemplateRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "Unlink identity auth template usage",

--- a/backend/src/ee/routes/v1/insights-router.ts
+++ b/backend/src/ee/routes/v1/insights-router.ts
@@ -91,7 +91,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "getSecretsSummary",
       description: "Get secrets management usage counts for the requesting organization.",
@@ -130,7 +130,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "getSecretsProjects",
       description: "List the organization's secret management projects, ordered by severity.",
@@ -180,7 +180,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "getSecretsAccessVolume",
       description:
@@ -211,7 +211,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "getSecretsUsageAuthMethods",
       description:
@@ -253,7 +253,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "getStaticSecretsUsage",
       description:
@@ -292,7 +292,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         200: OrgAuditReportSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const report = await server.services.auditReport.generateOrgReport(req.body, req.permission);
       await server.services.auditLog.createAuditLog({
@@ -325,7 +325,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         200: z.object({ reports: z.array(OrgAuditReportSchema), totalCount: z.number() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { offset, limit } = req.query;
       const { reports, totalCount } = await server.services.auditReport.listOrgReports(
@@ -355,7 +355,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         200: OrgAuditReportSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const report = await server.services.auditReport.deleteOrgReport(req.params.reportId, req.permission);
       await server.services.auditLog.createAuditLog({
@@ -416,7 +416,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.params;
       const { month, year } = req.query;
@@ -453,7 +453,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.params;
       const result = await server.services.insights.getAccessVolume({ projectId }, req.permission);
@@ -486,7 +486,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.params;
       const { days } = req.query;
@@ -531,7 +531,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req, reply) => {
       const { projectId } = req.params;
       const { result, remainingTTL } = await server.services.insights.getSecretsDuplication(
@@ -611,7 +611,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.params;
       const { staleSecretsOffset, staleSecretsLimit } = req.query;
@@ -649,7 +649,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.params;
       const result = await server.services.insights.getCounts({ projectId }, req.permission);
@@ -679,7 +679,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         200: AuditReportSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const report = await server.services.auditReport.generateReport(
         { projectId: req.params.projectId, ...req.body },
@@ -719,7 +719,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         200: z.object({ reports: z.array(AuditReportSchema), totalCount: z.number() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.params;
       const { offset, limit } = req.query;
@@ -747,7 +747,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         200: AuditReportSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const report = await server.services.auditReport.getReportById(
         req.params.reportId,
@@ -777,7 +777,7 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
         200: AuditReportSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const report = await server.services.auditReport.deleteReport(
         req.params.reportId,

--- a/backend/src/ee/routes/v1/kmip-router.ts
+++ b/backend/src/ee/routes/v1/kmip-router.ts
@@ -41,7 +41,7 @@ export const registerKmipRouter = async (server: FastifyZodProvider) => {
         200: KmipClientResponseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const kmipClient = await server.services.kmip.createKmipClient({
         actor: req.permission.type,
@@ -97,7 +97,7 @@ export const registerKmipRouter = async (server: FastifyZodProvider) => {
         200: KmipClientResponseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const kmipClient = await server.services.kmip.updateKmipClient({
         actor: req.permission.type,
@@ -152,7 +152,7 @@ export const registerKmipRouter = async (server: FastifyZodProvider) => {
         200: KmipClientResponseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const kmipClient = await server.services.kmip.deleteKmipClient({
         actor: req.permission.type,
@@ -204,7 +204,7 @@ export const registerKmipRouter = async (server: FastifyZodProvider) => {
         200: KmipClientResponseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const kmipClient = await server.services.kmip.getKmipClient({
         actor: req.permission.type,
@@ -253,7 +253,7 @@ export const registerKmipRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { kmipClients, totalCount } = await server.services.kmip.listKmipClientsByProjectId({
         actor: req.permission.type,
@@ -312,7 +312,7 @@ export const registerKmipRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificate = await server.services.kmip.createKmipClientCertificate({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/kmip-server-router.ts
+++ b/backend/src/ee/routes/v1/kmip-server-router.ts
@@ -132,7 +132,7 @@ export const registerKmipServerRouter = async (server: FastifyZodProvider) => {
         200: KmipServerWithAuthMethodSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { authMethod: authMethodInput, name, hostnamesOrIps, ttl, keyAlgorithm } = req.body;
       const authMethodArg =
@@ -192,7 +192,7 @@ export const registerKmipServerRouter = async (server: FastifyZodProvider) => {
         200: KmipServerWithAuthMethodSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const kmipServer = await server.services.kmipServer.getOrgKmipServer({
         kmipServerId: req.params.kmipServerId,
@@ -222,7 +222,7 @@ export const registerKmipServerRouter = async (server: FastifyZodProvider) => {
         200: z.array(SanitizedKmipServerSchema.omit({ canRevoke: true }))
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.kmipServer.listKmipServers({ actor: req.permission });
     }
@@ -250,7 +250,7 @@ export const registerKmipServerRouter = async (server: FastifyZodProvider) => {
         200: KmipServerWithAuthMethodSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { hostnamesOrIps, ttl, keyAlgorithm } = req.body;
       const hasFieldUpdate = hostnamesOrIps !== undefined || ttl !== undefined || keyAlgorithm !== undefined;
@@ -338,7 +338,7 @@ export const registerKmipServerRouter = async (server: FastifyZodProvider) => {
         200: z.object({ token: z.string(), expiresAt: z.date() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.resourceAuthMethod.mintToken({
         resource: { type: "kmip", id: req.params.kmipServerId },
@@ -371,7 +371,7 @@ export const registerKmipServerRouter = async (server: FastifyZodProvider) => {
         200: z.object({ method: z.string() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.resourceAuthMethod.revokeAccess({
         resource: { type: "kmip", id: req.params.kmipServerId },
@@ -409,7 +409,7 @@ export const registerKmipServerRouter = async (server: FastifyZodProvider) => {
         200: SanitizedKmipServerSchema.omit({ canRevoke: true })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const kmipServer = await server.services.kmipServer.deleteKmipServer({
         kmipServerId: req.params.kmipServerId,

--- a/backend/src/ee/routes/v1/ldap-router.ts
+++ b/backend/src/ee/routes/v1/ldap-router.ts
@@ -157,7 +157,7 @@ export const registerLdapRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.LdapSso],
@@ -207,7 +207,7 @@ export const registerLdapRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.LdapSso],
@@ -273,7 +273,7 @@ export const registerLdapRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.LdapSso],
@@ -337,7 +337,7 @@ export const registerLdapRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         configId: z.string().trim()
@@ -376,7 +376,7 @@ export const registerLdapRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         configId: z.string().trim()
@@ -409,7 +409,7 @@ export const registerLdapRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         configId: z.string().trim(),
@@ -439,7 +439,7 @@ export const registerLdapRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       body: z.object({
         url: z.string().trim(),

--- a/backend/src/ee/routes/v1/license-router.ts
+++ b/backend/src/ee/routes/v1/license-router.ts
@@ -21,7 +21,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgPlansTableByBillCycle({
         actorId: req.permission.id,
@@ -53,7 +53,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.object({ plan: z.any() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const plan = await server.services.license.getOrgPlan({
         actorId: req.permission.id,
@@ -81,7 +81,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgPlan({
         actorId: req.permission.id,
@@ -108,7 +108,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.startOrgTrial({
         actorId: req.permission.id,
@@ -134,7 +134,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.createOrganizationPortalSession({
         actorId: req.permission.id,
@@ -159,7 +159,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgBillingInfo({
         actorId: req.permission.id,
@@ -184,7 +184,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgPlanTable({
         actorId: req.permission.id,
@@ -209,7 +209,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgBillingDetails({
         actorId: req.permission.id,
@@ -238,7 +238,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.updateOrgBillingDetails({
         actorId: req.permission.id,
@@ -265,7 +265,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgPmtMethods({
         actorId: req.permission.id,
@@ -294,7 +294,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.addOrgPmtMethods({
         actorId: req.permission.id,
@@ -324,7 +324,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.delOrgPmtMethods({
         actorId: req.permission.id,
@@ -352,7 +352,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgTaxIds({
         actorId: req.permission.id,
@@ -383,7 +383,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.addOrgTaxId({
         actorId: req.permission.id,
@@ -413,7 +413,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.delOrgTaxId({
         actorId: req.permission.id,
@@ -441,7 +441,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgTaxInvoices({
         actorId: req.permission.id,
@@ -468,7 +468,7 @@ export const registerLicenseRouter = async (server: FastifyZodProvider) => {
         200: z.any()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.license.getOrgLicenses({
         actorId: req.permission.id,

--- a/backend/src/ee/routes/v1/license-v2-router.ts
+++ b/backend/src/ee/routes/v1/license-v2-router.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { NotFoundError } from "@app/lib/errors";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { isUserSessionAuth } from "@app/server/plugins/auth/inject-identity";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 
@@ -228,7 +229,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: z.object({ overview: BillingV2OverviewSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.getOverview({
         orgId: req.params.organizationId,
@@ -249,7 +250,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: z.object({ success: z.boolean() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.refreshEntitlements({
         orgId: req.params.organizationId,
@@ -270,7 +271,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: z.object({ products: BillingV2CatalogProductSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.getCatalog({
         orgId: req.params.organizationId,
@@ -292,7 +293,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: z.object({ url: z.string() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.portalSession({
         orgId: req.params.organizationId,
@@ -315,7 +316,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: z.object({ url: z.string() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.addPaymentMethod({
         orgId: req.params.organizationId,
@@ -349,7 +350,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: z.object({ preview: BillingV2PreviewSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.previewChange({
         orgId: req.params.organizationId,
@@ -387,11 +388,11 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       // A first-touch org has no Stripe customer yet, so the server needs an email. Take it from the
       // authenticated user (JWT-only route) rather than trusting a client-supplied value.
-      const email = req.auth.authMode === AuthMode.JWT ? (req.auth.user.email ?? undefined) : undefined;
+      const email = isUserSessionAuth(req.auth) ? (req.auth.user.email ?? undefined) : undefined;
       return server.services.licenseV2.buyProduct({
         orgId: req.params.organizationId,
         actor: buildActor(req.permission),
@@ -417,7 +418,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: BillingV2MutationResultSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.removeProduct({
         orgId: req.params.organizationId,
@@ -449,7 +450,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.changeCommitments({
         orgId: req.params.organizationId,
@@ -479,11 +480,11 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       // A trial has no Stripe customer yet, so the server needs an email. Take it from the authenticated
       // user (this route is JWT-only) rather than trusting a client-supplied value.
-      const email = req.auth.authMode === AuthMode.JWT ? (req.auth.user.email ?? undefined) : undefined;
+      const email = isUserSessionAuth(req.auth) ? (req.auth.user.email ?? undefined) : undefined;
       return server.services.licenseV2.startTrial({
         orgId: req.params.organizationId,
         actor: buildActor(req.permission),
@@ -511,7 +512,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.cancelTrial({
         orgId: req.params.organizationId,
@@ -533,7 +534,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: BillingV2MutationResultSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.cancelSubscription({
         orgId: req.params.organizationId,
@@ -554,7 +555,7 @@ export const registerLicenseV2Router = async (server: FastifyZodProvider) => {
         200: BillingV2MutationResultSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.licenseV2.resumeSubscription({
         orgId: req.params.organizationId,

--- a/backend/src/ee/routes/v1/oidc-router.ts
+++ b/backend/src/ee/routes/v1/oidc-router.ts
@@ -192,7 +192,7 @@ export const registerOidcRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.OidcSso],
@@ -246,7 +246,7 @@ export const registerOidcRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.OidcSso],
@@ -339,7 +339,7 @@ export const registerOidcRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.OidcSso],
@@ -484,7 +484,7 @@ export const registerOidcRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const isEnabled = await server.services.oidc.isOidcManageGroupMembershipsEnabled(req.query.orgId, req.permission);
 

--- a/backend/src/ee/routes/v1/org-role-router.ts
+++ b/backend/src/ee/routes/v1/org-role-router.ts
@@ -69,7 +69,7 @@ export const registerOrgRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const isSubOrganization = req.permission.rootOrgId !== req.permission.orgId;
       if (isSubOrganization) {
@@ -144,7 +144,7 @@ export const registerOrgRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const role = await server.services.role.getRoleById({
         permission: req.permission,
@@ -196,7 +196,7 @@ export const registerOrgRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const isSubOrganization = req.permission.rootOrgId !== req.permission.orgId;
       if (isSubOrganization && req.body.permissions) {
@@ -275,7 +275,7 @@ export const registerOrgRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const role = await server.services.role.deleteRole({
         permission: req.permission,
@@ -334,7 +334,7 @@ export const registerOrgRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { roles } = await server.services.role.listRoles({
         permission: req.permission,
@@ -372,7 +372,7 @@ export const registerOrgRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const role = await server.services.role.getRoleBySlug({
         permission: req.permission,
@@ -412,7 +412,7 @@ export const registerOrgRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { permissions, memberships } = await server.services.role.getUserPermission({
         permission: req.permission,

--- a/backend/src/ee/routes/v1/pam-routers/pam-access-request-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-access-request-router.ts
@@ -39,7 +39,7 @@ export const registerPamAccessRequestRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.createRequest({
         accountId: req.body.accountId,
@@ -103,7 +103,7 @@ export const registerPamAccessRequestRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.listRequests({
         projectId: req.internalPamProjectId,
@@ -134,7 +134,7 @@ export const registerPamAccessRequestRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.listPendingMyApproval({
         projectId: req.internalPamProjectId,
@@ -160,7 +160,7 @@ export const registerPamAccessRequestRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.getCount({
         projectId: req.internalPamProjectId,
@@ -198,7 +198,7 @@ export const registerPamAccessRequestRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.getAccountApprovers({
         accountId: req.params.accountId,
@@ -230,7 +230,7 @@ export const registerPamAccessRequestRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.reviewRequest({
         requestId: req.params.requestId,
@@ -293,7 +293,7 @@ export const registerPamAccessRequestRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.revokeGrant({
         requestId: req.params.requestId,

--- a/backend/src/ee/routes/v1/pam-routers/pam-account-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-account-router.ts
@@ -130,7 +130,7 @@ const registerPerTypeEndpoints = (
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { corsProbeUrl, ...account } = await server.services.pamAccount.create({
         accountType,
@@ -210,7 +210,7 @@ const registerPerTypeEndpoints = (
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { corsProbeUrl, ...account } = await server.services.pamAccount.update({
         accountId: req.params.accountId,
@@ -273,7 +273,7 @@ const registerPerTypeEndpoints = (
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const account = await server.services.pamAccount.deleteAccount({
         accountId: req.params.accountId,
@@ -330,7 +330,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async () => {
       return {
         // AWS IAM supports browser access (console URL redirect) but not WebSocket-based terminal,
@@ -360,7 +360,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const accounts = await server.services.pamAccount.list({
         projectId: req.internalPamProjectId,
@@ -426,7 +426,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { accounts, totalCount } = await server.services.pamAccount.listAccessible({
         projectId: req.internalPamProjectId,
@@ -471,7 +471,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.pamAccount.getAccountPermissions({
         accountId: req.params.accountId,
@@ -509,7 +509,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       response: { 200: z.object({ rotation: RotationViewSchema }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const rotation = await server.services.pamAccountRotation.getRotation({
         accountId: req.params.accountId,
@@ -550,7 +550,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const dependencies = await server.services.pamDiscovery.listAccountDependencies({
         accountId: req.params.accountId,
@@ -582,7 +582,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       response: { 200: z.object({ rotationAccountId: z.string().nullable() }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccountRotation.setRotationAccount({
         accountId: req.params.accountId,
@@ -633,7 +633,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       response: { 200: z.object({ rotationStatus: z.string() }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccountRotation.rotateNow({
         accountId: req.params.accountId,
@@ -703,7 +703,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.pamAccountRotation.listRotationCandidates({
         accountId: req.params.accountId,
@@ -731,7 +731,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const account = await server.services.pamAccount.getById({
         accountId: req.params.accountId,
@@ -758,7 +758,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccount.getOrCreateSshCa({
         accountId: req.params.accountId,
@@ -801,7 +801,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccount.getOrCreateSshCa({
         accountId: req.params.accountId,
@@ -844,7 +844,7 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req, reply) => {
       const result = await server.services.pamAccount.getOrCreateSshCa({
         accountId: req.params.accountId,

--- a/backend/src/ee/routes/v1/pam-routers/pam-account-template-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-account-template-router.ts
@@ -45,7 +45,7 @@ export const registerPamAccountTemplateRouter = async (server: FastifyZodProvide
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const templates = await server.services.pamAccountTemplate.list({
         projectId: req.internalPamProjectId,
@@ -80,7 +80,7 @@ export const registerPamAccountTemplateRouter = async (server: FastifyZodProvide
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const template = await server.services.pamAccountTemplate.getById({
         templateId: req.params.templateId,
@@ -119,7 +119,7 @@ export const registerPamAccountTemplateRouter = async (server: FastifyZodProvide
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { corsProbeUrl, ...template } = await server.services.pamAccountTemplate.create({
         ...req.body,
@@ -187,7 +187,7 @@ export const registerPamAccountTemplateRouter = async (server: FastifyZodProvide
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { corsProbeUrl, ...template } = await server.services.pamAccountTemplate.update({
         templateId: req.params.templateId,
@@ -243,7 +243,7 @@ export const registerPamAccountTemplateRouter = async (server: FastifyZodProvide
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const template = await server.services.pamAccountTemplate.deleteTemplate({
         templateId: req.params.templateId,

--- a/backend/src/ee/routes/v1/pam-routers/pam-approval-configuration-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-approval-configuration-router.ts
@@ -58,7 +58,7 @@ export const registerPamApprovalConfigurationRouter = async (server: FastifyZodP
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.getApprovalConfiguration({
         folderId: req.params.folderId,
@@ -90,7 +90,7 @@ export const registerPamApprovalConfigurationRouter = async (server: FastifyZodP
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamAccessRequest.setApprovalConfiguration({
         folderId: req.params.folderId,

--- a/backend/src/ee/routes/v1/pam-routers/pam-discovery-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-discovery-router.ts
@@ -78,7 +78,7 @@ const registerPerTypeEndpoints = (
       response: { 200: z.object({ source: SourceSchema }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const source = await server.services.pamDiscovery.create({
         discoveryType,
@@ -137,7 +137,7 @@ const registerPerTypeEndpoints = (
       response: { 200: z.object({ source: SourceSchema }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const source = await server.services.pamDiscovery.update({
         sourceId: req.params.sourceId,
@@ -184,7 +184,7 @@ const registerPerTypeEndpoints = (
       response: { 200: z.object({ source: SourceSchema }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const source = await server.services.pamDiscovery.getById({
         sourceId: req.params.sourceId,
@@ -210,7 +210,7 @@ const registerPerTypeEndpoints = (
       response: { 200: z.object({ source: SourceSchema }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const source = await server.services.pamDiscovery.deleteSource({
         sourceId: req.params.sourceId,
@@ -256,7 +256,7 @@ const registerPerTypeEndpoints = (
       response: { 200: z.object({ message: z.string() }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamDiscovery.triggerScan({
         sourceId: req.params.sourceId,
@@ -303,7 +303,7 @@ export const registerPamDiscoveryRouter = async (server: FastifyZodProvider) => 
       response: { 200: z.object({ discoveryTypes: z.array(PamDiscoveryTypeMetadataSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async () => ({ discoveryTypes: buildPamDiscoveryTypeMetadata() })
   });
 
@@ -318,7 +318,7 @@ export const registerPamDiscoveryRouter = async (server: FastifyZodProvider) => 
       response: { 200: z.object({ sources: z.array(SourceSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const sources = await server.services.pamDiscovery.list({
         projectId: req.internalPamProjectId,
@@ -347,7 +347,7 @@ export const registerPamDiscoveryRouter = async (server: FastifyZodProvider) => 
       response: { 200: z.object({ runs: z.array(PamDiscoverySourceRunsSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const runs = await server.services.pamDiscovery.listRuns({
         sourceId: req.params.sourceId,
@@ -381,7 +381,7 @@ export const registerPamDiscoveryRouter = async (server: FastifyZodProvider) => 
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { discoveredAccounts, totalCount } = await server.services.pamDiscovery.listDiscovered({
         sourceId: req.params.sourceId,
@@ -429,7 +429,7 @@ export const registerPamDiscoveryRouter = async (server: FastifyZodProvider) => 
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { accounts, totalCount } = await server.services.pamDiscovery.listStale({
         sourceId: req.params.sourceId,
@@ -481,7 +481,7 @@ export const registerPamDiscoveryRouter = async (server: FastifyZodProvider) => 
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { results } = await server.services.pamDiscovery.importAccounts({
         sourceId: req.params.sourceId,

--- a/backend/src/ee/routes/v1/pam-routers/pam-folder-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-folder-router.ts
@@ -50,7 +50,7 @@ export const registerPamFolderRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const folders = await server.services.pamFolder.list({
         projectId: req.internalPamProjectId,
@@ -94,7 +94,7 @@ export const registerPamFolderRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.pamFolder.getFolderPermissions({
         folderId: req.params.folderId,
@@ -127,7 +127,7 @@ export const registerPamFolderRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const folder = await server.services.pamFolder.getById({
         folderId: req.params.folderId,
@@ -157,7 +157,7 @@ export const registerPamFolderRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const folder = await server.services.pamFolder.create({
         ...req.body,
@@ -216,7 +216,7 @@ export const registerPamFolderRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const folder = await server.services.pamFolder.update({
         folderId: req.params.folderId,
@@ -272,7 +272,7 @@ export const registerPamFolderRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const folder = await server.services.pamFolder.deleteFolder({
         folderId: req.params.folderId,

--- a/backend/src/ee/routes/v1/pam-routers/pam-membership-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-membership-router.ts
@@ -91,7 +91,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.pamMembership.getAccessCapabilities(actorCtx(req));
     }
@@ -107,7 +107,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: z.object({ members: z.array(MemberSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const all = await server.services.pamMembership.listProductMembers(actorCtx(req));
       return { members: all.filter((m) => m.userId) };
@@ -124,7 +124,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: z.object({ members: z.array(MemberSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const all = await server.services.pamMembership.listProductMembers(actorCtx(req));
       return { members: all.filter((m) => m.groupId) };
@@ -161,7 +161,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamMembership.addProductUserMembers({
         ...actorCtx(req),
@@ -195,7 +195,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: MemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateProductMemberRole({
         ...actorCtx(req),
@@ -224,7 +224,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: MemberResultSchema.pick({ membershipId: true, userId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeProductMember({
         ...actorCtx(req),
@@ -250,7 +250,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: MemberResultSchema }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.addProductMember({
         ...actorCtx(req),
@@ -280,7 +280,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: MemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateProductMemberRole({
         ...actorCtx(req),
@@ -309,7 +309,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: MemberResultSchema.pick({ membershipId: true, groupId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeProductMember({
         ...actorCtx(req),
@@ -343,7 +343,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const members = await server.services.pamMembership.listProductIdentityMembers(actorCtx(req));
       return { members };
@@ -362,7 +362,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: MemberResultSchema }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.addProductMember({
         ...actorCtx(req),
@@ -392,7 +392,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: MemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateProductMemberRole({
         ...actorCtx(req),
@@ -421,7 +421,7 @@ export const registerPamProductMembershipRouter = async (server: FastifyZodProvi
       response: { 200: MemberResultSchema.pick({ membershipId: true, identityId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeProductMember({
         ...actorCtx(req),
@@ -451,7 +451,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: z.object({ members: z.array(MemberSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const all = await server.services.pamMembership.listFolderMembers({
         ...actorCtx(req),
@@ -472,7 +472,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: z.object({ members: z.array(MemberSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const all = await server.services.pamMembership.listFolderMembers({
         ...actorCtx(req),
@@ -501,7 +501,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.addFolderMember({
         ...actorCtx(req),
@@ -533,7 +533,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateFolderMemberRole({
         ...actorCtx(req),
@@ -562,7 +562,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema.pick({ membershipId: true, folderId: true, userId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeFolderMember({
         ...actorCtx(req),
@@ -597,7 +597,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.addFolderMember({
         ...actorCtx(req),
@@ -629,7 +629,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateFolderMemberRole({
         ...actorCtx(req),
@@ -658,7 +658,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema.pick({ membershipId: true, folderId: true, groupId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeFolderMember({
         ...actorCtx(req),
@@ -685,7 +685,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: z.object({ members: z.array(MemberSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const all = await server.services.pamMembership.listFolderMembers({
         ...actorCtx(req),
@@ -714,7 +714,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.addFolderMember({
         ...actorCtx(req),
@@ -746,7 +746,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateFolderMemberRole({
         ...actorCtx(req),
@@ -775,7 +775,7 @@ export const registerPamFolderMembershipRouter = async (server: FastifyZodProvid
       response: { 200: FolderMemberResultSchema.pick({ membershipId: true, folderId: true, identityId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeFolderMember({
         ...actorCtx(req),
@@ -807,7 +807,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: z.object({ members: z.array(MemberSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const all = await server.services.pamMembership.listAccountMembers({
         ...actorCtx(req),
@@ -828,7 +828,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: z.object({ members: z.array(MemberSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const all = await server.services.pamMembership.listAccountMembers({
         ...actorCtx(req),
@@ -857,7 +857,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.addAccountMember({
         ...actorCtx(req),
@@ -889,7 +889,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateAccountMemberRole({
         ...actorCtx(req),
@@ -918,7 +918,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema.pick({ membershipId: true, accountId: true, userId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeAccountMember({
         ...actorCtx(req),
@@ -953,7 +953,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.addAccountMember({
         ...actorCtx(req),
@@ -985,7 +985,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateAccountMemberRole({
         ...actorCtx(req),
@@ -1014,7 +1014,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema.pick({ membershipId: true, accountId: true, groupId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeAccountMember({
         ...actorCtx(req),
@@ -1041,7 +1041,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: z.object({ members: z.array(MemberSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const all = await server.services.pamMembership.listAccountMembers({
         ...actorCtx(req),
@@ -1070,7 +1070,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.addAccountMember({
         ...actorCtx(req),
@@ -1102,7 +1102,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema.omit({ createdAt: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.updateAccountMemberRole({
         ...actorCtx(req),
@@ -1131,7 +1131,7 @@ export const registerPamAccountMembershipRouter = async (server: FastifyZodProvi
       response: { 200: AccountMemberResultSchema.pick({ membershipId: true, accountId: true, identityId: true }) }
     },
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pamMembership.removeAccountMember({
         ...actorCtx(req),

--- a/backend/src/ee/routes/v1/pam-routers/pam-project-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-project-router.ts
@@ -22,7 +22,7 @@ export const registerPamProjectRouter = async (server: FastifyZodProvider) => {
       }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     // injectPamProjectId (preValidation) has already resolved/bootstrapped the project by now.
     handler: async (req) => ({ projectId: req.internalPamProjectId })
   });

--- a/backend/src/ee/routes/v1/pam-routers/pam-resource-role-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-resource-role-router.ts
@@ -45,7 +45,7 @@ export const registerPamResourceRoleRouter = async (server: FastifyZodProvider) 
       response: { 200: z.object({ roles: z.array(ResourceRoleSchema) }) }
     },
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async () => {
       return { roles: DEFAULT_RESOURCE_ROLES };
     }

--- a/backend/src/ee/routes/v1/pam-routers/pam-session-chunk-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-session-chunk-router.ts
@@ -221,7 +221,7 @@ export const registerPamSessionChunkRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pamSessionChunk.getSessionPlayback(req.params.sessionId, req.permission);
       return {
@@ -247,7 +247,7 @@ export const registerPamSessionChunkRouter = async (server: FastifyZodProvider) 
         chunkIndex: z.coerce.number().int().nonnegative().max(999999).describe("The chunk index to retrieve")
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req, reply) => {
       const { ciphertext } = await server.services.pamSessionChunk.getChunkCiphertext(
         req.params.sessionId,
@@ -274,7 +274,12 @@ export const registerPamSessionChunkRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.GATEWAY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.GATEWAY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async () => ({
       backends: Object.values(PamRecordingStorageBackend)
     })

--- a/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
@@ -11,6 +11,7 @@ import { ApiDocsTags } from "@app/lib/api-docs/constants";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
+import { isUserSessionAuth } from "@app/server/plugins/auth/inject-identity";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
 import { TokenType } from "@app/services/auth-token/auth-token-types";
@@ -74,7 +75,7 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
         200: z.object({ sessions: SanitizedSessionSchema.array(), totalCount: z.number() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { sessions, totalCount } = await server.services.pamSession.listSessions(
         req.internalPamProjectId,
@@ -105,7 +106,7 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
         200: z.object({ session: SanitizedSessionSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const session = await server.services.pamSession.getSessionById(req.params.sessionId, {
         actor: req.permission.type,
@@ -246,7 +247,7 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
         200: z.object({ session: SanitizedSessionSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { session, projectId, accountName } = await server.services.pamSession.terminateSession(
         req.params.sessionId,
@@ -341,11 +342,11 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       let actorEmail = "";
       let actorName = "";
-      if (req.auth.authMode === AuthMode.JWT) {
+      if (isUserSessionAuth(req.auth)) {
         actorEmail = req.auth.user.email ?? "";
         actorName = `${req.auth.user.firstName ?? ""} ${req.auth.user.lastName ?? ""}`.trim();
       } else if (req.auth.authMode === AuthMode.IDENTITY_ACCESS_TOKEN) {
@@ -444,10 +445,10 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
         200: z.object({ ticket: z.string() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
-      if (req.auth.authMode !== AuthMode.JWT) {
-        throw new BadRequestError({ message: "Web access requires JWT authentication" });
+      if (!isUserSessionAuth(req.auth)) {
+        throw new BadRequestError({ message: "Web access requires user authentication" });
       }
 
       const { ticket } = await server.services.pamWebAccess.issueWebSocketTicket({

--- a/backend/src/ee/routes/v1/pit-router.ts
+++ b/backend/src/ee/routes/v1/pit-router.ts
@@ -82,7 +82,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.getCommitsCount({
         actor: req.permission?.type,
@@ -147,7 +147,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.getCommitsForFolder({
         actor: req.permission?.type,
@@ -209,7 +209,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.getCommitAuthorsForFolder({
         actor: req.permission?.type,
@@ -256,7 +256,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         200: commitChangesResponseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.getCommitChanges({
         actor: req.permission?.type,
@@ -312,7 +312,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         )
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.compareCommitChanges({
         actor: req.permission?.type,
@@ -374,7 +374,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.rollbackToCommit({
         actor: req.permission?.type,
@@ -446,7 +446,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.revertCommit({
         actor: req.permission?.type,
@@ -506,7 +506,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         200: folderStateSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.getFolderStateAtCommit({
         actor: req.permission?.type,
@@ -646,7 +646,7 @@ export const registerPITRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pit.processNewCommitRaw({
         actorId: req.permission.id,

--- a/backend/src/ee/routes/v1/pki-discovery-router.ts
+++ b/backend/src/ee/routes/v1/pki-discovery-router.ts
@@ -38,7 +38,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],
@@ -71,7 +71,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],
@@ -167,7 +167,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],
@@ -225,7 +225,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],
@@ -273,7 +273,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],
@@ -394,7 +394,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],
@@ -448,7 +448,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],
@@ -504,7 +504,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],
@@ -535,7 +535,7 @@ export const registerPkiDiscoveryRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiDiscovery],

--- a/backend/src/ee/routes/v1/pki-installation-router.ts
+++ b/backend/src/ee/routes/v1/pki-installation-router.ts
@@ -15,7 +15,7 @@ export const registerPkiInstallationRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiInstallations],
@@ -78,7 +78,7 @@ export const registerPkiInstallationRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiInstallations],
@@ -145,7 +145,7 @@ export const registerPkiInstallationRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiInstallations],
@@ -193,7 +193,7 @@ export const registerPkiInstallationRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiInstallations],

--- a/backend/src/ee/routes/v1/project-role-router.ts
+++ b/backend/src/ee/routes/v1/project-role-router.ts
@@ -52,7 +52,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const stringifiedPermissions = JSON.stringify(packRules(req.body.permissions));
 
@@ -141,7 +141,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const stringifiedPermissions = req.body.permissions ? JSON.stringify(packRules(req.body.permissions)) : undefined;
       const role = await server.services.role.updateRole({
@@ -218,7 +218,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const role = await server.services.role.deleteRole({
         permission: req.permission,
@@ -286,7 +286,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { roles } = await server.services.role.listRoles({
         permission: req.permission,
@@ -320,7 +320,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const role = await server.services.role.getRoleBySlug({
         permission: req.permission,
@@ -362,7 +362,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const role = await server.services.role.getProjectRoleById({
         permission: req.permission,
@@ -413,7 +413,7 @@ export const registerProjectRoleRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { permissions, memberships, assumedPrivilegeDetails } = await server.services.role.getUserPermission({
         permission: req.permission,

--- a/backend/src/ee/routes/v1/project-router.ts
+++ b/backend/src/ee/routes/v1/project-router.ts
@@ -27,7 +27,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const kmsKey = await server.services.project.getProjectKmsKeys({
         actor: req.permission.type,
@@ -67,7 +67,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secretManagerKmsKey } = await server.services.project.updateProjectKmsKey({
         actor: req.permission.type,
@@ -114,7 +114,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const backup = await server.services.project.getProjectKmsBackup({
         actor: req.permission.type,
@@ -160,7 +160,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const backup = await server.services.project.loadProjectKmsBackup({
         actor: req.permission.type,
@@ -201,7 +201,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const migration = await server.services.secret.startSecretV2Migration({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/project-template-router.ts
+++ b/backend/src/ee/routes/v1/project-template-router.ts
@@ -225,7 +225,7 @@ export const registerProjectTemplateRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectTemplates = await server.services.projectTemplate.listProjectTemplatesByOrg(
         req.permission,
@@ -269,7 +269,7 @@ export const registerProjectTemplateRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectTemplate = await server.services.projectTemplate.findProjectTemplateById(
         req.params.templateId,
@@ -328,7 +328,7 @@ export const registerProjectTemplateRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectTemplate = await server.services.projectTemplate.createProjectTemplate(req.body, req.permission);
 
@@ -396,7 +396,7 @@ export const registerProjectTemplateRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectTemplate = await server.services.projectTemplate.updateProjectTemplateById(
         req.params.templateId,
@@ -449,7 +449,7 @@ export const registerProjectTemplateRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectTemplate = await server.services.projectTemplate.deleteProjectTemplateById(
         req.params.templateId,

--- a/backend/src/ee/routes/v1/proxied-service-router.ts
+++ b/backend/src/ee/routes/v1/proxied-service-router.ts
@@ -22,7 +22,7 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
     method: "POST",
     url: "/",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProxiedServices],
@@ -99,7 +99,7 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
     method: "GET",
     url: "/",
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProxiedServices],
@@ -126,7 +126,7 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
     method: "GET",
     url: "/:serviceId",
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProxiedServices],
@@ -150,7 +150,7 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
     method: "GET",
     url: "/slug/:name",
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProxiedServices],
@@ -187,7 +187,7 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
     method: "PATCH",
     url: "/:serviceId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProxiedServices],
@@ -237,7 +237,7 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
     method: "POST",
     url: "/:serviceId/report-usage",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: true,
       tags: [ApiDocsTags.ProxiedServices],
@@ -257,7 +257,7 @@ export const registerProxiedServiceRouter = async (server: FastifyZodProvider) =
     method: "DELETE",
     url: "/:serviceId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProxiedServices],

--- a/backend/src/ee/routes/v1/relay-router.ts
+++ b/backend/src/ee/routes/v1/relay-router.ts
@@ -116,7 +116,12 @@ export const registerRelayRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.GATEWAY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.GATEWAY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       return server.services.relay.getRelays({
         actorId: req.permission.id,
@@ -142,7 +147,7 @@ export const registerRelayRouter = async (server: FastifyZodProvider) => {
         200: RelaysSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const relay = await server.services.relay.deleteRelay({
         id: req.params.id,

--- a/backend/src/ee/routes/v1/saml-router.ts
+++ b/backend/src/ee/routes/v1/saml-router.ts
@@ -398,7 +398,7 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.SamlSso],
@@ -445,7 +445,7 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.SamlSso],
@@ -509,7 +509,7 @@ export const registerSamlRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.SamlSso],

--- a/backend/src/ee/routes/v1/scim-router.ts
+++ b/backend/src/ee/routes/v1/scim-router.ts
@@ -52,7 +52,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       body: z.object({
         organizationId: z.string().trim(),
@@ -86,7 +86,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       querystring: z.object({
         organizationId: z.string().trim()
@@ -116,7 +116,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         scimTokenId: z.string().trim()
@@ -146,7 +146,7 @@ export const registerScimRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       querystring: z.object({
         since: z.string().trim().optional(),

--- a/backend/src/ee/routes/v1/secret-approval-request-router.ts
+++ b/backend/src/ee/routes/v1/secret-approval-request-router.ts
@@ -74,7 +74,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { approvals, totalCount } = await server.services.secretApprovalRequest.getSecretApprovals({
         actor: req.permission.type,
@@ -108,7 +108,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const approvals = await server.services.secretApprovalRequest.requestCount({
         actor: req.permission.type,
@@ -141,7 +141,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { approval, projectId, secretMutationEvents, isMergedViaBypass, requestedByActor } =
         await server.services.secretApprovalRequest.mergeSecretApprovalRequest({
@@ -219,7 +219,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const review = await server.services.secretApprovalRequest.reviewApproval({
         actorId: req.permission.id,
@@ -283,7 +283,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalRequest.updateApprovalStatus({
         actorId: req.permission.id,
@@ -418,7 +418,7 @@ export const registerSecretApprovalRequestRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalRequest.getSecretApprovalDetails({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/secret-router.ts
+++ b/backend/src/ee/routes/v1/secret-router.ts
@@ -57,7 +57,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secretName } = req.params;
       const { secretPath, environment, projectId, includeAllEntities } = req.query;

--- a/backend/src/ee/routes/v1/secret-scanning-router.ts
+++ b/backend/src/ee/routes/v1/secret-scanning-router.ts
@@ -28,7 +28,7 @@ export const registerSecretScanningRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       if (!canUseSecretScanning(req.auth.orgId)) {
         throw new BadRequestError({
@@ -63,7 +63,7 @@ export const registerSecretScanningRouter = async (server: FastifyZodProvider) =
         200: GitAppOrgSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { installatedApp } = await server.services.secretScanning.linkInstallationToOrg({
         actor: req.permission.type,
@@ -88,7 +88,7 @@ export const registerSecretScanningRouter = async (server: FastifyZodProvider) =
         200: z.object({ appInstallationCompleted: z.boolean() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const appInstallationCompleted = await server.services.secretScanning.getOrgInstallationStatus({
         actor: req.permission.type,
@@ -123,7 +123,7 @@ export const registerSecretScanningRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const risks = await server.services.secretScanning.getAllRisksByOrg({
         actor: req.permission.type,
@@ -170,7 +170,7 @@ export const registerSecretScanningRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { risks, totalCount, repos } = await server.services.secretScanning.getRisksByOrg({
         actor: req.permission.type,
@@ -204,7 +204,7 @@ export const registerSecretScanningRouter = async (server: FastifyZodProvider) =
         200: SecretScanningGitRisksSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { risk } = await server.services.secretScanning.updateRiskStatus({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/secret-version-router.ts
+++ b/backend/src/ee/routes/v1/secret-version-router.ts
@@ -30,7 +30,7 @@ export const registerSecretVersionRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const secretVersions = await server.services.secret.getSecretVersions({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v1/sub-org-router.ts
+++ b/backend/src/ee/routes/v1/sub-org-router.ts
@@ -49,7 +49,7 @@ export const registerSubOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { organization } = await server.services.subOrganization.createSubOrg({
         name: req.body.name,
@@ -121,7 +121,7 @@ export const registerSubOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { organizations, totalCount } = await server.services.subOrganization.listSubOrgs({
         permission: req.permission,
@@ -172,7 +172,7 @@ export const registerSubOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { organization } = await server.services.subOrganization.updateSubOrg({
         subOrgId: req.params.subOrgId,
@@ -222,7 +222,7 @@ export const registerSubOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { organization } = await server.services.subOrganization.joinSubOrg({
         subOrgId: req.params.subOrgId,
@@ -270,7 +270,7 @@ export const registerSubOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { organization } = await server.services.subOrganization.deleteSubOrg({
         subOrgId: req.params.subOrgId,

--- a/backend/src/ee/routes/v1/trusted-ip-router.ts
+++ b/backend/src/ee/routes/v1/trusted-ip-router.ts
@@ -23,7 +23,7 @@ export const registerTrustedIpRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const trustedIps = await server.services.trustedIp.listIpsByProjectId({
         actorAuthMethod: req.permission.authMethod,
@@ -57,7 +57,7 @@ export const registerTrustedIpRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { trustedIp, project } = await server.services.trustedIp.addProjectIp({
         actorAuthMethod: req.permission.authMethod,
@@ -105,7 +105,7 @@ export const registerTrustedIpRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { trustedIp, project } = await server.services.trustedIp.updateProjectIp({
         projectId: req.params.projectId,
@@ -150,7 +150,7 @@ export const registerTrustedIpRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { trustedIp, project } = await server.services.trustedIp.deleteProjectIp({
         projectId: req.params.projectId,

--- a/backend/src/ee/routes/v1/user-additional-privilege-router.ts
+++ b/backend/src/ee/routes/v1/user-additional-privilege-router.ts
@@ -54,7 +54,7 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId, membership } = await server.services.convertor.userMembershipIdToUserId(
         req.body.projectMembershipId,
@@ -126,7 +126,7 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.convertor.additionalPrivilegeIdToDoc(req.params.privilegeId);
       if (!data.privilege.actorUserId)
@@ -192,7 +192,7 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.convertor.additionalPrivilegeIdToDoc(req.params.privilegeId);
       if (!data.privilege.actorUserId)
@@ -254,7 +254,7 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId, membership } = await server.services.convertor.userMembershipIdToUserId(
         req.query.projectMembershipId,
@@ -303,7 +303,7 @@ export const registerUserAdditionalPrivilegeRouter = async (server: FastifyZodPr
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.convertor.additionalPrivilegeIdToDoc(req.params.privilegeId);
       if (!data.privilege.actorUserId)

--- a/backend/src/ee/routes/v2/deprecated-project-role-router.ts
+++ b/backend/src/ee/routes/v2/deprecated-project-role-router.ts
@@ -53,7 +53,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const stringifiedPermissions = JSON.stringify(packRules(req.body.permissions));
 
@@ -143,7 +143,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const stringifiedPermissions = req.body.permissions ? JSON.stringify(packRules(req.body.permissions)) : undefined;
       const role = await server.services.role.updateRole({
@@ -221,7 +221,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const role = await server.services.role.deleteRole({
         permission: req.permission,
@@ -290,7 +290,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { roles } = await server.services.role.listRoles({
         permission: req.permission,
@@ -325,7 +325,7 @@ export const registerDeprecatedProjectRoleRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const role = await server.services.role.getRoleBySlug({
         permission: req.permission,

--- a/backend/src/ee/routes/v2/gateway-router.ts
+++ b/backend/src/ee/routes/v2/gateway-router.ts
@@ -110,7 +110,7 @@ export const registerGatewayV2Router = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const gateways = await server.services.gatewayV2.listGateways({
         orgPermission: req.permission
@@ -135,7 +135,7 @@ export const registerGatewayV2Router = async (server: FastifyZodProvider) => {
         200: SanitizedGatewayV2Schema
       }
     },
-    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const gateway = await server.services.gatewayV2.deleteGatewayById({
         orgPermission: req.permission,
@@ -162,7 +162,7 @@ export const registerGatewayV2Router = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.gatewayV2.triggerHeartbeat({
         orgPermission: req.permission,
@@ -245,7 +245,7 @@ export const registerGatewayV2Router = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const resources = await server.services.gatewayV2.getConnectedResources({
         orgPermission: req.permission,

--- a/backend/src/ee/routes/v2/identity-project-additional-privilege-router.ts
+++ b/backend/src/ee/routes/v2/identity-project-additional-privilege-router.ts
@@ -64,7 +64,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { additionalPrivilege: privilege } = await server.services.additionalPrivilege.createAdditionalPrivilege({
         permission: req.permission,
@@ -142,7 +142,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { privilege: privilegeDoc } = await server.services.convertor.additionalPrivilegeIdToDoc(req.params.id);
 
@@ -206,7 +206,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { privilege: privilegeDoc } = await server.services.convertor.additionalPrivilegeIdToDoc(req.params.id);
 
@@ -264,7 +264,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { privilege: privilegeDoc } = await server.services.convertor.additionalPrivilegeIdToDoc(req.params.id);
 
@@ -326,7 +326,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id: projectId } = await server.services.convertor.projectSlugToId({
         slug: req.query.projectSlug,
@@ -386,7 +386,7 @@ export const registerIdentityProjectAdditionalPrivilegeRouter = async (server: F
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { additionalPrivileges: privileges } = await server.services.additionalPrivilege.listAdditionalPrivileges({
         permission: req.permission,

--- a/backend/src/ee/routes/v2/relay-router.ts
+++ b/backend/src/ee/routes/v2/relay-router.ts
@@ -88,7 +88,7 @@ export const registerRelayV2Router = async (server: FastifyZodProvider) => {
         200: RelayWithAuthMethodSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { authMethod: authMethodInput, ...rest } = req.body;
       const authMethodArg =
@@ -143,7 +143,7 @@ export const registerRelayV2Router = async (server: FastifyZodProvider) => {
         200: RelayWithAuthMethodSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const relay = await server.services.relay.getOrgRelay({
         relayId: req.params.relayId,
@@ -179,7 +179,7 @@ export const registerRelayV2Router = async (server: FastifyZodProvider) => {
         )
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.relay.getConnectedGateways({
         relayId: req.params.relayId,
@@ -203,7 +203,7 @@ export const registerRelayV2Router = async (server: FastifyZodProvider) => {
         200: RelayWithAuthMethodSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       let relay;
 
@@ -285,7 +285,7 @@ export const registerRelayV2Router = async (server: FastifyZodProvider) => {
         200: z.object({ token: z.string(), expiresAt: z.date() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.resourceAuthMethod.mintToken({
         resource: { type: "relay", id: req.params.relayId },
@@ -316,7 +316,7 @@ export const registerRelayV2Router = async (server: FastifyZodProvider) => {
         200: z.object({ method: z.string() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.resourceAuthMethod.revokeAccess({
         resource: { type: "relay", id: req.params.relayId },

--- a/backend/src/ee/routes/v2/secret-approval-policy-router.ts
+++ b/backend/src/ee/routes/v2/secret-approval-policy-router.ts
@@ -65,7 +65,7 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalPolicy.createSecretApprovalPolicy({
         actor: req.permission.type,
@@ -144,7 +144,7 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalPolicy.updateSecretApprovalPolicy({
         actor: req.permission.type,
@@ -185,7 +185,7 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalPolicy.deleteSecretApprovalPolicy({
         actor: req.permission.type,
@@ -244,7 +244,7 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const approvals = await server.services.secretApprovalPolicy.getSecretApprovalPolicyByProjectId({
         actor: req.permission.type,
@@ -289,7 +289,7 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const approval = await server.services.secretApprovalPolicy.getSecretApprovalPolicyById({
         actor: req.permission.type,
@@ -326,7 +326,7 @@ export const registerSecretApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const policy = await server.services.secretApprovalPolicy.getSecretApprovalPolicyOfFolder({
         actor: req.permission.type,

--- a/backend/src/ee/routes/v2/secret-rotation-v2-routers/hp-ilo-rotation-router.ts
+++ b/backend/src/ee/routes/v2/secret-rotation-v2-routers/hp-ilo-rotation-router.ts
@@ -48,7 +48,7 @@ export const registerHpIloRotationRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
 

--- a/backend/src/ee/routes/v2/secret-rotation-v2-routers/secret-rotation-v2-endpoints.ts
+++ b/backend/src/ee/routes/v2/secret-rotation-v2-routers/secret-rotation-v2-endpoints.ts
@@ -81,7 +81,7 @@ export const registerSecretRotationEndpoints = <
         200: z.object({ secretRotations: responseSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId }
@@ -127,7 +127,7 @@ export const registerSecretRotationEndpoints = <
         200: z.object({ secretRotation: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
 
@@ -193,7 +193,7 @@ export const registerSecretRotationEndpoints = <
         200: z.object({ secretRotation: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationName } = req.params;
       const { projectId, secretPath, environment } = req.query;
@@ -239,7 +239,7 @@ export const registerSecretRotationEndpoints = <
         200: z.object({ secretRotation: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const secretRotation = (await server.services.secretRotationV2.createSecretRotation(
         { ...req.body, type },
@@ -297,7 +297,7 @@ export const registerSecretRotationEndpoints = <
         200: z.object({ secretRotation: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
 
@@ -369,7 +369,7 @@ export const registerSecretRotationEndpoints = <
         200: z.object({ secretRotation: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
       const { deleteSecrets, revokeGeneratedCredentials } = req.query;
@@ -435,7 +435,7 @@ export const registerSecretRotationEndpoints = <
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
 
@@ -491,7 +491,7 @@ export const registerSecretRotationEndpoints = <
         200: z.object({ secretRotation: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
       const { destinationEnvironment, destinationSecretPath, overwriteDestination } = req.body;
@@ -542,7 +542,7 @@ export const registerSecretRotationEndpoints = <
         200: z.object({ secretRotation: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
 
@@ -594,7 +594,7 @@ export const registerSecretRotationEndpoints = <
         204: z.string().length(0)
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req, res) => {
       const { rotationId } = req.params;
 

--- a/backend/src/ee/routes/v2/secret-rotation-v2-routers/secret-rotation-v2-router.ts
+++ b/backend/src/ee/routes/v2/secret-rotation-v2-routers/secret-rotation-v2-router.ts
@@ -84,7 +84,7 @@ export const registerSecretRotationV2Router = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: () => {
       const secretRotationOptions = server.services.secretRotationV2.listSecretRotationOptions();
       return { secretRotationOptions };
@@ -109,7 +109,7 @@ export const registerSecretRotationV2Router = async (server: FastifyZodProvider)
         200: z.object({ secretRotations: SecretRotationV2Schema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId },

--- a/backend/src/ee/routes/v2/secret-rotation-v2-routers/unix-linux-local-account-rotation-router.ts
+++ b/backend/src/ee/routes/v2/secret-rotation-v2-routers/unix-linux-local-account-rotation-router.ts
@@ -50,7 +50,7 @@ export const registerUnixLinuxLocalAccountRotationRouter = async (server: Fastif
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
 

--- a/backend/src/ee/routes/v2/secret-rotation-v2-routers/windows-local-account-rotation-router.ts
+++ b/backend/src/ee/routes/v2/secret-rotation-v2-routers/windows-local-account-rotation-router.ts
@@ -50,7 +50,7 @@ export const registerWindowsLocalAccountRotationRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { rotationId } = req.params;
 

--- a/backend/src/ee/routes/v2/secret-scanning-v2-routers/secret-scanning-v2-endpoints.ts
+++ b/backend/src/ee/routes/v2/secret-scanning-v2-routers/secret-scanning-v2-endpoints.ts
@@ -72,7 +72,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ dataSources: responseSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId }
@@ -118,7 +118,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ dataSource: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId } = req.params;
 
@@ -172,7 +172,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ dataSource: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { sourceName } = req.params;
       const { projectId } = req.query;
@@ -216,7 +216,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ dataSource: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const dataSource = (await server.services.secretScanningV2.createSecretScanningDataSource(
         { ...req.body, type },
@@ -272,7 +272,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ dataSource: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId } = req.params;
 
@@ -316,7 +316,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ dataSource: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId } = req.params;
 
@@ -359,7 +359,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ dataSource: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId } = req.params;
 
@@ -403,7 +403,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ dataSource: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId, resourceId } = req.params;
 
@@ -447,7 +447,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ resources: SecretScanningResourcesSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId } = req.params;
 
@@ -492,7 +492,7 @@ export const registerSecretScanningEndpoints = <
         200: z.object({ scans: SecretScanningScansSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId } = req.params;
 
@@ -542,7 +542,7 @@ export const registerSecretScanningEndpoints = <
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId } = req.params;
 
@@ -592,7 +592,7 @@ export const registerSecretScanningEndpoints = <
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { dataSourceId } = req.params;
 

--- a/backend/src/ee/routes/v2/secret-scanning-v2-routers/secret-scanning-v2-router.ts
+++ b/backend/src/ee/routes/v2/secret-scanning-v2-routers/secret-scanning-v2-router.ts
@@ -49,7 +49,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: () => {
       const dataSourceOptions = server.services.secretScanningV2.listSecretScanningDataSourceOptions();
       return { dataSourceOptions };
@@ -74,7 +74,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         200: z.object({ dataSources: SecretScanningDataSourceSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId },
@@ -120,7 +120,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         200: z.object({ findings: SecretScanningFindingSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId },
@@ -170,7 +170,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         200: z.object({ finding: SecretScanningFindingSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { findingId },
@@ -233,7 +233,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         200: z.object({ findings: SecretScanningFindingSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { body, permission } = req;
 
@@ -285,7 +285,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId },
@@ -327,7 +327,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         200: z.object({ config: SecretScanningConfigsSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId },
@@ -381,7 +381,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId },
@@ -425,7 +425,7 @@ export const registerSecretScanningV2Router = async (server: FastifyZodProvider)
         200: z.object({ unresolvedFindings: z.number() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId },

--- a/backend/src/ee/routes/v2/secret-version-router.ts
+++ b/backend/src/ee/routes/v2/secret-version-router.ts
@@ -23,7 +23,7 @@ export const registerSecretVersionRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secretVersion, projectId, environment, secretPath, secretKey, secretId } =
         await server.services.secret.redactSecretVersionValue({

--- a/backend/src/ee/routes/v3/gateway-router.ts
+++ b/backend/src/ee/routes/v3/gateway-router.ts
@@ -100,7 +100,7 @@ export const registerGatewayV3Router = async (server: FastifyZodProvider) => {
         200: GatewayWithAuthMethodSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const authMethodArg =
         req.body.authMethod.method === ResourceAuthMethodType.Aws
@@ -153,7 +153,7 @@ export const registerGatewayV3Router = async (server: FastifyZodProvider) => {
       params: z.object({ gatewayId: z.string().trim().uuid() }),
       response: { 200: GatewayWithAuthMethodSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const gateway = await server.services.gatewayV2.getGatewayById({ gatewayId: req.params.gatewayId });
       const view = await server.services.resourceAuthMethod.getByGatewayId({
@@ -180,7 +180,7 @@ export const registerGatewayV3Router = async (server: FastifyZodProvider) => {
       }),
       response: { 200: GatewayWithAuthMethodSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       if (req.body.authMethod) {
         const setInput =
@@ -264,7 +264,7 @@ export const registerGatewayV3Router = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.resourceAuthMethod.mintToken({
         resource: { type: "gateway", id: req.params.gatewayId },
@@ -300,7 +300,7 @@ export const registerGatewayV3Router = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.resourceAuthMethod.revokeAccess({
         resource: { type: "gateway", id: req.params.gatewayId },

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -6736,6 +6736,8 @@ interface CreateOauthClientEvent {
     clientId: string;
     name: string;
     grantTypes: string[];
+    tokenExchangeAudience?: string | null;
+    tokenExchangeIdpSatisfiesMfa: boolean;
   };
 }
 

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -844,6 +844,7 @@ export enum EventType {
   DELETE_OAUTH_CLIENT = "delete-oauth-client",
   ROTATE_OAUTH_CLIENT_SECRET = "rotate-oauth-client-secret",
   OAUTH_CLIENT_AUTHORIZE = "oauth-client-authorize",
+  OAUTH_CLIENT_TOKEN_EXCHANGE = "oauth-client-token-exchange",
 
   // Email Domains
   CREATE_EMAIL_DOMAIN = "create-email-domain",
@@ -6733,6 +6734,7 @@ interface CreateOauthClientEvent {
     clientDbId: string;
     clientId: string;
     name: string;
+    grantTypes: string[];
   };
 }
 
@@ -6742,6 +6744,9 @@ interface UpdateOauthClientEvent {
     clientDbId: string;
     clientId: string;
     name: string;
+    grantTypes: string[];
+    tokenExchangeAudience?: string | null;
+    tokenExchangeIdpSatisfiesMfa: boolean;
   };
 }
 
@@ -6768,6 +6773,18 @@ interface OauthClientAuthorizeEvent {
   metadata: {
     clientId: string;
     clientName: string;
+  };
+}
+
+interface OauthClientTokenExchangeEvent {
+  type: EventType.OAUTH_CLIENT_TOKEN_EXCHANGE;
+  metadata: {
+    clientDbId: string;
+    clientId: string;
+    clientName: string;
+    subjectUserId: string;
+    subjectExternalId: string;
+    tokenVersionId: string;
   };
 }
 
@@ -7683,6 +7700,7 @@ export type Event =
   | DeleteOauthClientEvent
   | RotateOauthClientSecretEvent
   | OauthClientAuthorizeEvent
+  | OauthClientTokenExchangeEvent
   | CreateEmailDomainEvent
   | VerifyEmailDomainEvent
   | DeleteEmailDomainEvent

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -929,6 +929,7 @@ interface UserActorMetadata {
   username: string;
   permission?: Record<string, unknown>;
   authMethod?: string;
+  oauthClientId?: string;
 }
 
 interface ServiceActorMetadata {

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -89,9 +89,12 @@ import {
   ProjectPermissionSub
 } from "./project-permission";
 
-// Returns the delegated OAuth scopes for the current request, or undefined when this is not an
-// OAuth-delegated request. The distinction matters: a returned array (even empty) means scope
-// narrowing applies, while undefined means a first-party session / background job is untouched.
+// Returns the scopes to narrow this request to, or undefined when no narrowing applies. A returned
+// array, even empty, means narrowing applies, so [] denies all scope-guarded access.
+//
+// undefined covers a first-party session or background job, and a fully-delegated token from the RFC
+// 8693 exchange grant. inject-identity leaves the key unset only for the latter and sets it for every
+// scope-narrowed delegation, so a token carrying neither marker still ends up with zero permissions.
 const getDelegatedOauthScopes = (): OauthScope[] | undefined => {
   const raw = requestContext.get(RequestContextKey.OauthScopes);
   if (!raw) return undefined;

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -89,12 +89,12 @@ import {
   ProjectPermissionSub
 } from "./project-permission";
 
-// Returns the scopes to narrow this request to, or undefined when no narrowing applies. A returned
-// array, even empty, means narrowing applies, so [] denies all scope-guarded access.
+// Returns the scopes to narrow this request to, or undefined when no narrowing applies. Any array, even
+// an empty one, means narrowing applies, so [] denies all scope-guarded access.
 //
-// undefined covers a first-party session or background job, and a fully-delegated token from the RFC
-// 8693 exchange grant. inject-identity leaves the key unset only for the latter and sets it for every
-// scope-narrowed delegation, so a token carrying neither marker still ends up with zero permissions.
+// undefined covers first-party sessions, background jobs and fully-delegated RFC 8693 tokens.
+// inject-identity leaves the key unset only for those and always sets it for scope-narrowed delegation,
+// so a token carrying neither marker still ends up with zero permissions.
 const getDelegatedOauthScopes = (): OauthScope[] | undefined => {
   const raw = requestContext.get(RequestContextKey.OauthScopes);
   if (!raw) return undefined;

--- a/backend/src/server/config/rateLimiter.ts
+++ b/backend/src/server/config/rateLimiter.ts
@@ -3,7 +3,6 @@ import type { RateLimitOptions, RateLimitPluginOptions } from "@fastify/rate-lim
 import { getConfig } from "@app/lib/config/env";
 import { buildRedisFromConfig } from "@app/lib/config/redis";
 import { RateLimitError } from "@app/lib/errors";
-import { parseBasicAuthHeader } from "@app/services/oauth-client/oauth-client-fns";
 
 export const globalRateLimiterCfg = (): RateLimitPluginOptions => {
   const appCfg = getConfig();
@@ -55,19 +54,11 @@ export const authRateLimit: RateLimitOptions = {
   keyGenerator: (req) => req.realIp
 };
 
-// Keyed per IP *and* client, so one noisy integration cannot exhaust the budget of every other client
-// behind the same egress IP. The hook runs before validation, so the body is still unparsed.
 export const oauthTokenLimit: RateLimitOptions = {
   timeWindow: 60 * 1000,
   hook: "preValidation",
   max: (req) => req.rateLimits.writeLimit,
-  keyGenerator: (req) => {
-    const suppliedClientId = (req.body as { client_id?: unknown } | undefined)?.client_id;
-    const clientId =
-      parseBasicAuthHeader(req.headers.authorization)?.clientId ??
-      (typeof suppliedClientId === "string" ? suppliedClientId : undefined);
-    return clientId ? `${req.realIp}:${clientId.slice(0, 256)}` : req.realIp;
-  }
+  keyGenerator: (req) => req.realIp
 };
 
 export const inviteUserRateLimit: RateLimitOptions = {

--- a/backend/src/server/config/rateLimiter.ts
+++ b/backend/src/server/config/rateLimiter.ts
@@ -54,6 +54,13 @@ export const authRateLimit: RateLimitOptions = {
   keyGenerator: (req) => req.realIp
 };
 
+export const oauthTokenLimit = ({ keyGenerator }: Pick<RateLimitOptions, "keyGenerator">): RateLimitOptions => ({
+  timeWindow: 60 * 1000,
+  hook: "preValidation",
+  max: (req) => req.rateLimits.writeLimit,
+  keyGenerator
+});
+
 export const inviteUserRateLimit: RateLimitOptions = {
   timeWindow: 60 * 1000,
   hook: "preValidation",

--- a/backend/src/server/config/rateLimiter.ts
+++ b/backend/src/server/config/rateLimiter.ts
@@ -3,6 +3,7 @@ import type { RateLimitOptions, RateLimitPluginOptions } from "@fastify/rate-lim
 import { getConfig } from "@app/lib/config/env";
 import { buildRedisFromConfig } from "@app/lib/config/redis";
 import { RateLimitError } from "@app/lib/errors";
+import { parseBasicAuthHeader } from "@app/services/oauth-client/oauth-client-fns";
 
 export const globalRateLimiterCfg = (): RateLimitPluginOptions => {
   const appCfg = getConfig();
@@ -54,12 +55,20 @@ export const authRateLimit: RateLimitOptions = {
   keyGenerator: (req) => req.realIp
 };
 
-export const oauthTokenLimit = ({ keyGenerator }: Pick<RateLimitOptions, "keyGenerator">): RateLimitOptions => ({
+// Keyed per IP *and* client, so one noisy integration cannot exhaust the budget of every other client
+// behind the same egress IP. The hook runs before validation, so the body is still unparsed.
+export const oauthTokenLimit: RateLimitOptions = {
   timeWindow: 60 * 1000,
   hook: "preValidation",
   max: (req) => req.rateLimits.writeLimit,
-  keyGenerator
-});
+  keyGenerator: (req) => {
+    const suppliedClientId = (req.body as { client_id?: unknown } | undefined)?.client_id;
+    const clientId =
+      parseBasicAuthHeader(req.headers.authorization)?.clientId ??
+      (typeof suppliedClientId === "string" ? suppliedClientId : undefined);
+    return clientId ? `${req.realIp}:${clientId.slice(0, 256)}` : req.realIp;
+  }
+};
 
 export const inviteUserRateLimit: RateLimitOptions = {
   timeWindow: 60 * 1000,

--- a/backend/src/server/plugins/audit-log.ts
+++ b/backend/src/server/plugins/audit-log.ts
@@ -4,7 +4,7 @@ import fp from "fastify-plugin";
 import { UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import { BadRequestError } from "@app/lib/errors";
 import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
-import { ActorType } from "@app/services/auth/auth-type";
+import { ActorType, AuthMode } from "@app/services/auth/auth-type";
 
 export const getUserAgentType = (userAgent: string | undefined) => {
   if (userAgent === undefined) {
@@ -57,6 +57,9 @@ export const injectAuditLogInfo = fp(async (server: FastifyZodProvider) => {
         type: ActorType.USER,
         metadata: {
           ...(req.auth.authMethod ? { authMethod: req.auth.authMethod } : {}),
+          ...(req.auth.authMode === AuthMode.OAUTH && req.auth.oauthClientId
+            ? { oauthClientId: req.auth.oauthClientId }
+            : {}),
           email: req.auth.user.email,
           username: req.auth.user.username,
           userId: req.permission.id

--- a/backend/src/server/plugins/auth/inject-identity.ts
+++ b/backend/src/server/plugins/auth/inject-identity.ts
@@ -114,6 +114,14 @@ export type TAuthMode =
       token: TKmipServerAccessTokenJwtPayload;
     };
 
+// A first-party session and a delegated OAuth token share the same auth shape, so a handler that
+// only needs the acting user (name, email, session id) should accept both rather than narrowing on
+// AuthMode.JWT alone — otherwise an OAuth caller silently loses the audit trail or actor metadata.
+export const isUserSessionAuth = (
+  auth: TAuthMode
+): auth is Extract<TAuthMode, { authMode: AuthMode.JWT | AuthMode.OAUTH }> =>
+  auth.authMode === AuthMode.JWT || auth.authMode === AuthMode.OAUTH;
+
 export const extractAuth = async (req: FastifyRequest, jwtSecret: string) => {
   const apiKey = req.headers?.["x-api-key"];
   if (apiKey) {

--- a/backend/src/server/plugins/auth/inject-identity.ts
+++ b/backend/src/server/plugins/auth/inject-identity.ts
@@ -21,6 +21,7 @@ import {
   TRelayAccessTokenJwtPayload
 } from "@app/services/auth/auth-type";
 import { TIdentityAccessTokenJwtPayload } from "@app/services/identity-access-token/identity-access-token-types";
+import { OauthDelegationMode } from "@app/services/oauth-client/oauth-client-types";
 import { getServerCfg } from "@app/services/super-admin/super-admin-service";
 
 export type TAuthMode =
@@ -306,9 +307,9 @@ export const injectIdentity = fp(
             await server.services.authToken.fnValidateJwtIdentity(token);
           requestContext.set(RequestContextKey.OrgId, orgId);
           requestContext.set(RequestContextKey.OrgName, orgName);
-          // Always set (even as []) so permission-service can distinguish a delegated OAuth request
-          // that must be scope-narrowed from a first-party session that must not be.
-          requestContext.set(RequestContextKey.OauthScopes, token.scopes ?? []);
+          if (token.delegation !== OauthDelegationMode.Full) {
+            requestContext.set(RequestContextKey.OauthScopes, token.scopes ?? []);
+          }
           requestContext.set(RequestContextKey.UserAuthInfo, { userId: user.id, email: user.email || "" });
           req.auth = {
             authMode: AuthMode.OAUTH,

--- a/backend/src/server/plugins/auth/inject-identity.ts
+++ b/backend/src/server/plugins/auth/inject-identity.ts
@@ -114,9 +114,9 @@ export type TAuthMode =
       token: TKmipServerAccessTokenJwtPayload;
     };
 
-// A first-party session and a delegated OAuth token share the same auth shape, so a handler that
-// only needs the acting user (name, email, session id) should accept both rather than narrowing on
-// AuthMode.JWT alone — otherwise an OAuth caller silently loses the audit trail or actor metadata.
+// A first-party session and a delegated OAuth token have the same auth shape, so a handler that only
+// needs the acting user (name, email, session id) should take both instead of narrowing on AuthMode.JWT.
+// Narrowing silently costs the OAuth caller its audit trail or actor metadata.
 export const isUserSessionAuth = (
   auth: TAuthMode
 ): auth is Extract<TAuthMode, { authMode: AuthMode.JWT | AuthMode.OAUTH }> =>

--- a/backend/src/server/plugins/auth/verify-auth.ts
+++ b/backend/src/server/plugins/auth/verify-auth.ts
@@ -17,19 +17,15 @@ export const verifyAuth =
     if (!Array.isArray(authStrategies)) throw new Error("Auth strategy must be array");
     if (!req.auth) throw new UnauthorizedError({ message: "Token missing" });
 
-    // Delegated OAuth access tokens are a distinct auth mode and must be opted into explicitly: a
-    // route only accepts them when it lists AuthMode.OAUTH. They are deliberately NOT accepted on
-    // the strength of AuthMode.JWT alone. OAuth scopes are enforced later, when a handler builds an
-    // org/project permission (the ability is intersected with the granted scopes). A route that
-    // authenticates on userId without building a permission never runs that scope narrowing, so
-    // letting a delegated token through on JWT alone would bypass scopes entirely. Listing
-    // AuthMode.OAUTH is therefore only safe when the handler performs a scope-narrowed permission
-    // check, and the route families that cannot are the ones still listing AuthMode.JWT alone:
-    // account self-management (/me, password, MFA, sessions, login, signup, notifications),
-    // instance super-admin routes (verifySuperAdmin reads user.superAdmin, not a CASL ability), and
-    // the OAuth client/consent routes themselves, where a delegated token could widen its own grant.
-    // A useful proxy: no route passing `requireOrg: false` accepts AuthMode.OAUTH, because without an
-    // org in context there is no ability to intersect the granted scopes against.
+    // Delegated OAuth access tokens are a separate auth mode a route has to opt into by listing
+    // AuthMode.OAUTH, deliberately not accepted on AuthMode.JWT alone. Scopes are only enforced when a
+    // handler builds an org/project permission, since that's where the ability gets intersected with
+    // them, so a route that authenticates on userId and builds no permission would skip the narrowing
+    // entirely. The families that can't do that check stay on AuthMode.JWT alone: account
+    // self-management (/me, password, MFA, sessions, login, signup, notifications), super-admin routes
+    // (verifySuperAdmin reads user.superAdmin, not a CASL ability), and the OAuth client/consent routes
+    // themselves, where a delegated token could widen its own grant. Rough proxy: nothing passing
+    // `requireOrg: false` accepts AuthMode.OAUTH, since with no org there's no ability to intersect.
     const isAccessAllowed = authStrategies.some((strategy) => strategy === req.auth.authMode);
     if (!isAccessAllowed) {
       throw new ForbiddenRequestError({ name: `Forbidden access to ${req.url}` });

--- a/backend/src/server/plugins/auth/verify-auth.ts
+++ b/backend/src/server/plugins/auth/verify-auth.ts
@@ -20,11 +20,16 @@ export const verifyAuth =
     // Delegated OAuth access tokens are a distinct auth mode and must be opted into explicitly: a
     // route only accepts them when it lists AuthMode.OAUTH. They are deliberately NOT accepted on
     // the strength of AuthMode.JWT alone. OAuth scopes are enforced later, when a handler builds an
-    // org/project permission (the ability is intersected with the granted scopes). A JWT-only route
-    // that authenticates on userId without building a permission — e.g. account routes like
-    // GET/DELETE /me/totp, session revocation, MFA — never runs that scope narrowing, so letting a
-    // delegated token through on JWT alone would bypass scopes entirely. Adding AuthMode.OAUTH to a
-    // route is therefore only safe when its handler performs a scope-narrowed permission check.
+    // org/project permission (the ability is intersected with the granted scopes). A route that
+    // authenticates on userId without building a permission never runs that scope narrowing, so
+    // letting a delegated token through on JWT alone would bypass scopes entirely. Listing
+    // AuthMode.OAUTH is therefore only safe when the handler performs a scope-narrowed permission
+    // check, and the route families that cannot are the ones still listing AuthMode.JWT alone:
+    // account self-management (/me, password, MFA, sessions, login, signup, notifications),
+    // instance super-admin routes (verifySuperAdmin reads user.superAdmin, not a CASL ability), and
+    // the OAuth client/consent routes themselves, where a delegated token could widen its own grant.
+    // A useful proxy: no route passing `requireOrg: false` accepts AuthMode.OAUTH, because without an
+    // org in context there is no ability to intersect the granted scopes against.
     const isAccessAllowed = authStrategies.some((strategy) => strategy === req.auth.authMode);
     if (!isAccessAllowed) {
       throw new ForbiddenRequestError({ name: `Forbidden access to ${req.url}` });

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -851,14 +851,6 @@ export const registerRoutes = async (
   });
 
   const oauthClientDAL = oauthClientDALFactory(db);
-  const oauthClientService = oauthClientServiceFactory({
-    oauthClientDAL,
-    permissionService,
-    keyStore,
-    tokenService,
-    orgDAL,
-    userDAL
-  });
 
   const alertChannelRecipientDAL = alertChannelRecipientDALFactory(db);
 
@@ -1104,6 +1096,19 @@ export const registerRoutes = async (
       pamAccountDAL
     })
   });
+
+  const oauthClientService = oauthClientServiceFactory({
+    oauthClientDAL,
+    permissionService,
+    keyStore,
+    tokenService,
+    orgDAL,
+    userDAL,
+    oidcConfigDAL,
+    userAliasDAL,
+    auditLogService
+  });
+
   const secretApprovalPolicyService = secretApprovalPolicyServiceFactory({
     projectEnvDAL,
     secretApprovalPolicyApproverDAL: sapApproverDAL,

--- a/backend/src/server/routes/v1/alert-router.ts
+++ b/backend/src/server/routes/v1/alert-router.ts
@@ -78,7 +78,7 @@ export const registerAlertRouter = async (server: FastifyZodProvider) => {
       }),
       response: { 200: z.object({ alert: AlertResponseSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const alert = await server.services.alert.createAlert({
         ...req.body,
@@ -130,7 +130,7 @@ export const registerAlertRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.alertChannelTest.testChannel({
         ...req.body,
@@ -178,7 +178,7 @@ export const registerAlertRouter = async (server: FastifyZodProvider) => {
       }),
       response: { 200: z.object({ alerts: AlertResponseSchema.array() }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const alerts = await server.services.alert.listAlerts({
         ...req.query,
@@ -200,7 +200,7 @@ export const registerAlertRouter = async (server: FastifyZodProvider) => {
       params: z.object({ alertId: z.string().uuid() }),
       response: { 200: z.object({ alert: AlertResponseSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const alert = await server.services.alert.getAlertById({
         alertId: req.params.alertId,
@@ -229,7 +229,7 @@ export const registerAlertRouter = async (server: FastifyZodProvider) => {
       }),
       response: { 200: z.object({ alert: AlertResponseSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const alert = await server.services.alert.updateAlert({
         alertId: req.params.alertId,
@@ -267,7 +267,7 @@ export const registerAlertRouter = async (server: FastifyZodProvider) => {
       params: z.object({ alertId: z.string().uuid() }),
       response: { 200: z.object({ alert: z.object({ id: z.string().uuid() }) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const alert = await server.services.alert.deleteAlert({
         alertId: req.params.alertId,

--- a/backend/src/server/routes/v1/app-connection-routers/1password-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/1password-connection-router.ts
@@ -51,7 +51,7 @@ export const registerOnePassConnectionRouter = async (server: FastifyZodProvider
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const vaults = await server.services.appConnection.onepass.listVaults(connectionId, req.permission);

--- a/backend/src/server/routes/v1/app-connection-routers/adcs-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/adcs-connection-router.ts
@@ -41,7 +41,7 @@ export const registerADCSConnectionRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { caName } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/app-connection-endpoints.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/app-connection-endpoints.ts
@@ -86,7 +86,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         200: z.object({ appConnections: sanitizedResponseSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.query;
       const appConnections = (await server.services.appConnection.listAppConnections(
@@ -141,7 +141,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.query;
       const appConnections = await server.services.appConnection.listAvailableAppConnectionsForUser(
@@ -186,7 +186,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         200: z.object({ appConnection: sanitizedResponseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -237,7 +237,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         200: z.object({ appConnection: sanitizedResponseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionName } = req.params;
       const { projectId } = req.query;
@@ -283,7 +283,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         200: z.object({ appConnection: sanitizedResponseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         name,
@@ -369,7 +369,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         200: z.object({ appConnection: sanitizedResponseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         name,
@@ -447,7 +447,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         200: z.object({ appConnection: sanitizedResponseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -503,7 +503,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
         200: z.object({ appConnection: sanitizedResponseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -583,7 +583,7 @@ export const registerAppConnectionEndpoints = <T extends TAppConnection, I exten
   //       })
   //     }
   //   },
-  //   onRequest: verifyAuth([AuthMode.JWT]),
+  //   onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
   //   handler: async (req) => {
   //     const { connectionId } = req.params;
   //

--- a/backend/src/server/routes/v1/app-connection-routers/app-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/app-connection-router.ts
@@ -455,7 +455,7 @@ export const registerAppConnectionRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: (req) => {
       const appConnectionOptions = server.services.appConnection.listAppConnectionOptions(req.query.projectType);
       return { appConnectionOptions };
@@ -480,7 +480,7 @@ export const registerAppConnectionRouter = async (server: FastifyZodProvider) =>
         200: z.object({ appConnections: SanitizedAppConnectionSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.query;
       const appConnections = await server.services.appConnection.listAppConnections(

--- a/backend/src/server/routes/v1/app-connection-routers/auth0-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/auth0-connection-router.ts
@@ -40,7 +40,7 @@ export const registerAuth0ConnectionRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/aws-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/aws-connection-router.ts
@@ -45,7 +45,7 @@ export const registerAwsConnectionRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -83,7 +83,7 @@ export const registerAwsConnectionRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/azure-adcs-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/azure-adcs-connection-router.ts
@@ -38,7 +38,7 @@ export const registerAzureADCSConnectionRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/azure-client-secrets-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/azure-client-secrets-connection-router.ts
@@ -38,7 +38,7 @@ export const registerAzureClientSecretsConnectionRouter = async (server: Fastify
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/azure-devops-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/azure-devops-connection-router.ts
@@ -38,7 +38,7 @@ export const registerAzureDevOpsConnectionRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/azure-dns-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/azure-dns-connection-router.ts
@@ -41,7 +41,7 @@ export const registerAzureDnsConnectionRouter = async (server: FastifyZodProvide
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const zones = await server.services.appConnection.azureDns.listZones(connectionId, req.permission);

--- a/backend/src/server/routes/v1/app-connection-routers/azure-entra-id-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/azure-entra-id-connection-router.ts
@@ -41,7 +41,7 @@ export const registerAzureEntraIdConnectionRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { search } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/bitbucket-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/bitbucket-connection-router.ts
@@ -43,7 +43,7 @@ export const registerBitbucketConnectionRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId },
@@ -81,7 +81,7 @@ export const registerBitbucketConnectionRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId },
@@ -119,7 +119,7 @@ export const registerBitbucketConnectionRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId },

--- a/backend/src/server/routes/v1/app-connection-routers/camunda-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/camunda-connection-router.ts
@@ -40,7 +40,7 @@ export const registerCamundaConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/checkly-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/checkly-connection-router.ts
@@ -45,7 +45,7 @@ export const registerChecklyConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -78,7 +78,7 @@ export const registerChecklyConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, accountId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/circleci-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/circleci-connection-router.ts
@@ -43,7 +43,7 @@ export const registerCircleCIConnectionRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const organizations = await server.services.appConnection.circleci.listOrganizations(

--- a/backend/src/server/routes/v1/app-connection-routers/cloud-66-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/cloud-66-connection-router.ts
@@ -43,7 +43,7 @@ export const registerCloud66ConnectionRouter = async (server: FastifyZodProvider
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/cloudflare-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/cloudflare-connection-router.ts
@@ -43,7 +43,7 @@ export const registerCloudflareConnectionRouter = async (server: FastifyZodProvi
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -71,7 +71,7 @@ export const registerCloudflareConnectionRouter = async (server: FastifyZodProvi
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -100,7 +100,7 @@ export const registerCloudflareConnectionRouter = async (server: FastifyZodProvi
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -130,7 +130,7 @@ export const registerCloudflareConnectionRouter = async (server: FastifyZodProvi
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -162,7 +162,7 @@ export const registerCloudflareConnectionRouter = async (server: FastifyZodProvi
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/databricks-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/databricks-connection-router.ts
@@ -40,7 +40,7 @@ export const registerDatabricksConnectionRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -76,7 +76,7 @@ export const registerDatabricksConnectionRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/datadog-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/datadog-connection-router.ts
@@ -40,7 +40,7 @@ export const registerDatadogConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId }

--- a/backend/src/server/routes/v1/app-connection-routers/dbt-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/dbt-connection-router.ts
@@ -46,7 +46,7 @@ export const registerDbtConnectionRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId }

--- a/backend/src/server/routes/v1/app-connection-routers/digicert-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/digicert-connection-router.ts
@@ -43,7 +43,7 @@ export const registerDigiCertConnectionRouter = async (server: FastifyZodProvide
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       return server.services.appConnection.digicert.listOrganizations(connectionId, req.permission);
@@ -72,7 +72,7 @@ export const registerDigiCertConnectionRouter = async (server: FastifyZodProvide
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       return server.services.appConnection.digicert.listProducts(connectionId, req.permission);
@@ -100,7 +100,7 @@ export const registerDigiCertConnectionRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, organizationId } = req.params;
       const { productNameId } = req.query;
@@ -140,7 +140,7 @@ export const registerDigiCertConnectionRouter = async (server: FastifyZodProvide
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, organizationId } = req.params;
       const { productNameId } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/digital-ocean-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/digital-ocean-connection-router.ts
@@ -46,7 +46,7 @@ export const registerDigitalOceanConnectionRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/dns-made-easy-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/dns-made-easy-connection-router.ts
@@ -42,7 +42,7 @@ export const registerDNSMadeEasyConnectionRouter = async (server: FastifyZodProv
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const zones = await server.services.appConnection.dnsMadeEasy.listZones(connectionId, req.permission);

--- a/backend/src/server/routes/v1/app-connection-routers/external-infisical-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/external-infisical-connection-router.ts
@@ -55,7 +55,7 @@ export const registerExternalInfisicalConnectionRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const projects = await server.services.appConnection.externalInfisical.listProjects(connectionId, req.permission);
@@ -79,7 +79,7 @@ export const registerExternalInfisicalConnectionRouter = async (server: FastifyZ
         200: RemoteEnvironmentFolderTreeSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, projectId } = req.params;
       return server.services.appConnection.externalInfisical.getEnvironmentFolderTree(

--- a/backend/src/server/routes/v1/app-connection-routers/fireworks-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/fireworks-connection-router.ts
@@ -48,7 +48,7 @@ export const registerFireworksConnectionRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/flyio-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/flyio-connection-router.ts
@@ -42,7 +42,7 @@ export const registerFlyioConnectionRouter = async (server: FastifyZodProvider) 
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const apps = await server.services.appConnection.flyio.listApps(connectionId, req.permission);

--- a/backend/src/server/routes/v1/app-connection-routers/gcp-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/gcp-connection-router.ts
@@ -37,7 +37,7 @@ export const registerGcpConnectionRouter = async (server: FastifyZodProvider) =>
         200: z.object({ id: z.string(), name: z.string() }).array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -65,7 +65,7 @@ export const registerGcpConnectionRouter = async (server: FastifyZodProvider) =>
         200: z.object({ displayName: z.string(), locationId: z.string() }).array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId },

--- a/backend/src/server/routes/v1/app-connection-routers/github-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/github-connection-router.ts
@@ -42,7 +42,7 @@ export const registerGitHubConnectionRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -69,7 +69,7 @@ export const registerGitHubConnectionRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -100,7 +100,7 @@ export const registerGitHubConnectionRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { repo, owner } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/github-radar-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/github-radar-connection-router.ts
@@ -40,7 +40,7 @@ export const registerGitHubRadarConnectionRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/gitlab-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/gitlab-connection-router.ts
@@ -48,7 +48,7 @@ export const registerGitLabConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { search, limit } = req.query;
@@ -90,7 +90,7 @@ export const registerGitLabConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { search, limit } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/hasura-cloud-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/hasura-cloud-connection-router.ts
@@ -44,7 +44,7 @@ export const registerHasuraCloudConnectionRouter = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/hc-vault-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/hc-vault-connection-router.ts
@@ -37,7 +37,7 @@ export const registerHCVaultConnectionRouter = async (server: FastifyZodProvider
         200: z.string().array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/heroku-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/heroku-connection-router.ts
@@ -43,7 +43,7 @@ export const registerHerokuConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/humanitec-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/humanitec-connection-router.ts
@@ -55,7 +55,7 @@ export const registerHumanitecConnectionRouter = async (server: FastifyZodProvid
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/laravel-forge-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/laravel-forge-connection-router.ts
@@ -41,7 +41,7 @@ export const registerLaravelForgeConnectionRouter = async (server: FastifyZodPro
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const organizations = await server.services.appConnection.laravelForge.listOrganizations(
@@ -76,7 +76,7 @@ export const registerLaravelForgeConnectionRouter = async (server: FastifyZodPro
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { organizationSlug } = req.query;
@@ -114,7 +114,7 @@ export const registerLaravelForgeConnectionRouter = async (server: FastifyZodPro
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { organizationSlug, serverId } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/litellm-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/litellm-connection-router.ts
@@ -45,7 +45,7 @@ export const registerLiteLLMConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId },
@@ -77,7 +77,7 @@ export const registerLiteLLMConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId },
@@ -106,7 +106,7 @@ export const registerLiteLLMConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId }

--- a/backend/src/server/routes/v1/app-connection-routers/netlify-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/netlify-connection-router.ts
@@ -44,7 +44,7 @@ export const registerNetlifyConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -77,7 +77,7 @@ export const registerNetlifyConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, accountId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/northflank-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/northflank-connection-router.ts
@@ -44,7 +44,7 @@ export const registerNorthflankConnectionRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const projects = await server.services.appConnection.northflank.listProjects(connectionId, req.permission);
@@ -75,7 +75,7 @@ export const registerNorthflankConnectionRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, projectId } = req.params;
       const secretGroups = await server.services.appConnection.northflank.listSecretGroups(

--- a/backend/src/server/routes/v1/app-connection-routers/nutanix-prism-central-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/nutanix-prism-central-connection-router.ts
@@ -43,7 +43,7 @@ export const registerNutanixPrismCentralConnectionRouter = async (server: Fastif
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const clusters = await server.services.appConnection.nutanixPrismCentral.listClusters(
         { connectionId: req.params.connectionId },

--- a/backend/src/server/routes/v1/app-connection-routers/octopus-deploy-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/octopus-deploy-connection-router.ts
@@ -44,7 +44,7 @@ export const registerOctopusDeployConnectionRouter = async (server: FastifyZodPr
         )
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -78,7 +78,7 @@ export const registerOctopusDeployConnectionRouter = async (server: FastifyZodPr
         )
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { spaceId } = req.query;
@@ -149,7 +149,7 @@ export const registerOctopusDeployConnectionRouter = async (server: FastifyZodPr
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { spaceId, projectId } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/okta-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/okta-connection-router.ts
@@ -40,7 +40,7 @@ export const registerOktaConnectionRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId }

--- a/backend/src/server/routes/v1/app-connection-routers/ona-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/ona-connection-router.ts
@@ -42,7 +42,7 @@ export const registerOnaConnectionRouter = async (server: FastifyZodProvider) =>
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/openai-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/openai-connection-router.ts
@@ -40,7 +40,7 @@ export const registerOpenAIConnectionRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/qovery-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/qovery-connection-router.ts
@@ -39,7 +39,7 @@ export const registerQoveryConnectionRouter = async (server: FastifyZodProvider)
         200: qoveryResourceListSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -63,7 +63,7 @@ export const registerQoveryConnectionRouter = async (server: FastifyZodProvider)
         200: qoveryResourceListSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, organizationId } = req.params;
 
@@ -87,7 +87,7 @@ export const registerQoveryConnectionRouter = async (server: FastifyZodProvider)
         200: qoveryResourceListSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, projectId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/railway-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/railway-connection-router.ts
@@ -56,7 +56,7 @@ export const registerRailwayConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/render-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/render-connection-router.ts
@@ -42,7 +42,7 @@ export const registerRenderConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const services = await server.services.appConnection.render.listServices(connectionId, req.permission);
@@ -71,7 +71,7 @@ export const registerRenderConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const groups = await server.services.appConnection.render.listEnvironmentGroups(connectionId, req.permission);

--- a/backend/src/server/routes/v1/app-connection-routers/rundeck-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/rundeck-connection-router.ts
@@ -43,7 +43,7 @@ export const registerRundeckConnectionRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/salesforce-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/salesforce-connection-router.ts
@@ -40,7 +40,7 @@ export const registerSalesforceConnectionRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/snowflake-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/snowflake-connection-router.ts
@@ -40,7 +40,7 @@ export const registerSnowflakeConnectionRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -70,7 +70,7 @@ export const registerSnowflakeConnectionRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { connectionId },
@@ -100,7 +100,7 @@ export const registerSnowflakeConnectionRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/spacelift-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/spacelift-connection-router.ts
@@ -40,7 +40,7 @@ export const registerSpaceliftConnectionRouter = async (server: FastifyZodProvid
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/supabase-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/supabase-connection-router.ts
@@ -44,7 +44,7 @@ export const registerSupabaseConnectionRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/teamcity-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/teamcity-connection-router.ts
@@ -50,7 +50,7 @@ export const registerTeamCityConnectionRouter = async (server: FastifyZodProvide
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const projects = await server.services.appConnection.teamcity.listProjects(connectionId, req.permission);

--- a/backend/src/server/routes/v1/app-connection-routers/terraform-cloud-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/terraform-cloud-router.ts
@@ -57,7 +57,7 @@ export const registerTerraformCloudConnectionRouter = async (server: FastifyZodP
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/travis-ci-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/travis-ci-connection-router.ts
@@ -43,7 +43,7 @@ export const registerTravisCIConnectionRouter = async (server: FastifyZodProvide
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -76,7 +76,7 @@ export const registerTravisCIConnectionRouter = async (server: FastifyZodProvide
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { repositoryId } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/trigger-dev-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/trigger-dev-connection-router.ts
@@ -47,7 +47,7 @@ export const registerTriggerDevConnectionRouter = async (server: FastifyZodProvi
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const projects = await server.services.appConnection.triggerDev.listProjects(connectionId, req.permission);
@@ -79,7 +79,7 @@ export const registerTriggerDevConnectionRouter = async (server: FastifyZodProvi
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { projectRef } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/venafi-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/venafi-connection-router.ts
@@ -41,7 +41,7 @@ export const registerVenafiConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 
@@ -73,7 +73,7 @@ export const registerVenafiConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { applicationId } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/vercel-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/vercel-connection-router.ts
@@ -66,7 +66,7 @@ export const registerVercelConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const { projectSearch } = req.query;

--- a/backend/src/server/routes/v1/app-connection-routers/windmill-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/windmill-connection-router.ts
@@ -42,7 +42,7 @@ export const registerWindmillConnectionRouter = async (server: FastifyZodProvide
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
 

--- a/backend/src/server/routes/v1/app-connection-routers/zabbix-connection-router.ts
+++ b/backend/src/server/routes/v1/app-connection-routers/zabbix-connection-router.ts
@@ -42,7 +42,7 @@ export const registerZabbixConnectionRouter = async (server: FastifyZodProvider)
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.params;
       const hosts = await server.services.appConnection.zabbix.listHosts(connectionId, req.permission);

--- a/backend/src/server/routes/v1/approval-policy-routers/approval-policy-endpoints.ts
+++ b/backend/src/server/routes/v1/approval-policy-routers/approval-policy-endpoints.ts
@@ -4,6 +4,7 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { BadRequestError } from "@app/lib/errors";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
+import { isUserSessionAuth } from "@app/server/plugins/auth/inject-identity";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ApprovalPolicyScope, ApprovalPolicyType } from "@app/services/approval-policy/approval-policy-enums";
 import {
@@ -80,7 +81,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { policy } = await server.services.approvalPolicy.create(
         policyType,
@@ -137,7 +138,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { policies, projectId } = await server.services.approvalPolicy.list(
         policyType,
@@ -181,7 +182,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { policy } = await server.services.approvalPolicy.getById(req.params.policyId, req.permission);
 
@@ -222,7 +223,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { policy } = await server.services.approvalPolicy.updateById(
         req.params.policyId,
@@ -279,7 +280,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { policyId, projectId } = await server.services.approvalPolicy.deleteById(
         req.params.policyId,
@@ -336,7 +337,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { requests, projectId } = await server.services.approvalPolicy.listRequests(
         policyType,
@@ -383,13 +384,13 @@ export const registerApprovalPolicyEndpoints = ({
           })
         }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         let requesterName: string;
         let requesterEmail: string;
         let machineIdentityId: string | undefined;
 
-        if (req.auth.authMode === AuthMode.JWT) {
+        if (isUserSessionAuth(req.auth)) {
           requesterName = `${req.auth.user.firstName ?? ""} ${req.auth.user.lastName ?? ""}`.trim();
           requesterEmail = req.auth.user.email ?? "";
         } else if (req.auth.authMode === AuthMode.IDENTITY_ACCESS_TOKEN) {
@@ -461,7 +462,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { request } = await server.services.approvalPolicy.getRequestById(req.params.requestId, req.permission);
 
@@ -505,7 +506,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { request, bypassMetadata } = await server.services.approvalPolicy.approveRequest(
         req.params.requestId,
@@ -584,7 +585,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { request } = await server.services.approvalPolicy.rejectRequest(
         req.params.requestId,
@@ -641,7 +642,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { request } = await server.services.approvalPolicy.cancelRequest(req.params.requestId, req.permission);
 
@@ -682,7 +683,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { grants, projectId } = await server.services.approvalPolicy.listGrants(
         policyType,
@@ -726,7 +727,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { grant } = await server.services.approvalPolicy.getGrantById(req.params.grantId, req.permission);
 
@@ -769,7 +770,7 @@ export const registerApprovalPolicyEndpoints = ({
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { grant } = await server.services.approvalPolicy.revokeGrant(req.params.grantId, req.body, req.permission);
 
@@ -808,7 +809,7 @@ export const registerApprovalPolicyEndpoints = ({
         200: checkPolicyMatchResponseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.approvalPolicy.checkPolicyMatch(policyType, req.body, req.permission);
 

--- a/backend/src/server/routes/v1/bot-router.ts
+++ b/backend/src/server/routes/v1/bot-router.ts
@@ -29,7 +29,7 @@ export const registerProjectBotRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const bot = await server.services.projectBot.findBotByProjectId({
         actor: req.permission.type,
@@ -74,7 +74,7 @@ export const registerProjectBotRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const bot = await server.services.projectBot.setBotActiveState({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/cert-manager-access-routers/groups-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/groups-router.ts
@@ -48,7 +48,7 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
     method: "GET",
     url: "/groups",
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "listCertManagerGroups",
       response: { 200: z.object({ groupMemberships: z.array(certManagerGroupMembershipSchema) }) }
@@ -74,7 +74,7 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
     method: "GET",
     url: "/groups/:groupId",
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "getCertManagerGroup",
       params: z.object({ groupId: z.string().uuid() }),
@@ -101,7 +101,7 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
     method: "POST",
     url: "/groups/:groupId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "addCertManagerGroup",
       params: z.object({ groupId: z.string().uuid() }),
@@ -181,7 +181,7 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
     method: "PATCH",
     url: "/groups/:groupId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "updateCertManagerGroup",
       params: z.object({ groupId: z.string().uuid() }),
@@ -228,7 +228,7 @@ export const registerCertManagerAccessGroupsRouter = async (server: FastifyZodPr
     method: "DELETE",
     url: "/groups/:groupId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "removeCertManagerGroup",
       params: z.object({ groupId: z.string().uuid() }),

--- a/backend/src/server/routes/v1/cert-manager-access-routers/identities-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/identities-router.ts
@@ -50,7 +50,7 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { data: identityMemberships, totalCount } = await server.services.membershipIdentity.listMemberships({
@@ -84,7 +84,7 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { identities } = await server.services.membershipIdentity.listAvailableIdentities({
@@ -137,7 +137,7 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const identityMembership = await server.services.membershipIdentity.getMembershipByIdentityId({
@@ -153,7 +153,7 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
     method: "POST",
     url: "/identities/:identityId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "addCertManagerIdentity",
       params: z.object({ identityId: z.string().trim().uuid() }),
@@ -225,7 +225,7 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
     method: "PATCH",
     url: "/identities/:identityId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "updateCertManagerIdentity",
       params: z.object({ identityId: z.string().trim().uuid() }),
@@ -271,7 +271,7 @@ export const registerCertManagerAccessIdentitiesRouter = async (server: FastifyZ
     method: "DELETE",
     url: "/identities/:identityId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "removeCertManagerIdentity",
       params: z.object({ identityId: z.string().trim().uuid() }),

--- a/backend/src/server/routes/v1/cert-manager-access-routers/roles-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/roles-router.ts
@@ -28,7 +28,7 @@ export const registerCertManagerAccessRolesRouter = async (server: FastifyZodPro
     method: "GET",
     url: "/roles",
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "listCertManagerRoles",
       response: {
@@ -64,7 +64,7 @@ export const registerCertManagerAccessRolesRouter = async (server: FastifyZodPro
     method: "GET",
     url: "/roles/slug/:roleSlug",
     config: { rateLimit: readLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "getCertManagerRoleBySlug",
       params: z.object({ roleSlug: z.string().trim().min(1) }),
@@ -93,7 +93,7 @@ export const registerCertManagerAccessRolesRouter = async (server: FastifyZodPro
     method: "POST",
     url: "/roles",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: { operationId: "createCertManagerRole" },
     handler: async () => {
       throw new BadRequestError({ message: CERT_MANAGER_CUSTOM_ROLE_ERROR });
@@ -104,7 +104,7 @@ export const registerCertManagerAccessRolesRouter = async (server: FastifyZodPro
     method: "PATCH",
     url: "/roles/:roleId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "updateCertManagerRole",
       params: z.object({ roleId: z.string().trim().uuid() })
@@ -118,7 +118,7 @@ export const registerCertManagerAccessRolesRouter = async (server: FastifyZodPro
     method: "DELETE",
     url: "/roles/:roleId",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "deleteCertManagerRole",
       params: z.object({ roleId: z.string().trim().uuid() })

--- a/backend/src/server/routes/v1/cert-manager-access-routers/users-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-access-routers/users-router.ts
@@ -39,7 +39,7 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { data: memberships } = await server.services.membershipUser.listMemberships({
@@ -72,7 +72,7 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { userId } = req.params;
@@ -112,7 +112,7 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
         200: z.object({ memberships: ProjectMembershipsSchema.omit({ projectId: true }).array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const usernamesAndEmails = [...req.body.emails, ...req.body.usernames];
@@ -183,7 +183,7 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
       body: RolesUpdateBodySchema,
       response: { 200: z.object({ roles: ProjectUserMembershipRolesSchema.array() }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { userId } = req.params;
@@ -241,7 +241,7 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
       }),
       response: { 200: z.object({ memberships: ProjectMembershipsSchema.omit({ projectId: true }).array() }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const memberships = await server.services.projectMembership.deleteProjectMemberships({
@@ -293,7 +293,7 @@ export const registerCertManagerAccessUsersRouter = async (server: FastifyZodPro
       params: z.object({ userId: z.string().trim().uuid() }),
       response: { 200: z.object({ membership: ProjectMembershipsSchema.omit({ projectId: true }) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { userId } = req.params;

--- a/backend/src/server/routes/v1/cert-manager-export-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-export-router.ts
@@ -53,7 +53,7 @@ export const registerCertManagerExportRouter = async (server: FastifyZodProvider
         200: ExportResultSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.certManagerExport.exportCertManagerProject({
         sourceProjectId: req.body.sourceProjectId,

--- a/backend/src/server/routes/v1/cert-manager-instance-router.ts
+++ b/backend/src/server/routes/v1/cert-manager-instance-router.ts
@@ -39,7 +39,7 @@ export const registerCertManagerInstanceRouter = async (server: FastifyZodProvid
       tags: [ApiDocsTags.CertManagerInstance],
       response: { 200: InstanceStateSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const state = await server.services.certManagerInstance.getInstanceState({
         actor: req.permission.type,
@@ -82,7 +82,7 @@ export const registerCertManagerInstanceRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.certManagerInstance.listLegacyInstances({
         actor: req.permission.type,
@@ -112,7 +112,7 @@ export const registerCertManagerInstanceRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.certManagerInstance.setActiveProject(
         {

--- a/backend/src/server/routes/v1/certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-router.ts
@@ -31,7 +31,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createCertificateAuthorityV1",
@@ -127,7 +127,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCertificateAuthorityV1",
@@ -206,7 +206,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateCertificateAuthorityV1",
@@ -265,7 +265,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteCertificateAuthorityV1",
@@ -314,7 +314,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCertificateAuthorityCsr",
@@ -362,7 +362,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "renewCertificateAuthority",
@@ -420,7 +420,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listCertificateAuthorityCertificates",
@@ -471,7 +471,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCertificateAuthorityCertificate",
@@ -524,7 +524,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "signIntermediateCertificateAuthority",
@@ -590,7 +590,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "importCertificateAuthorityCertificate",
@@ -646,7 +646,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "issueCertificateFromAuthority",
       tags: [ApiDocsTags.PkiCertificateAuthorities],
@@ -741,7 +741,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "signCertificateFromAuthority",
       tags: [ApiDocsTags.PkiCertificateAuthorities],
@@ -836,7 +836,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "listCertificateAuthorityTemplates",
       tags: [ApiDocsTags.PkiCertificateAuthorities],
@@ -886,7 +886,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "listCertificateAuthorityCrls",
       tags: [ApiDocsTags.PkiCertificateAuthorities],
@@ -935,7 +935,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
   //   config: {
   //     rateLimit: writeLimit
   //   },
-  //   onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+  //   onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
   //   schema: {
   //     description: "Rotate CRLs of the CA",
   //     params: z.object({

--- a/backend/src/server/routes/v1/certificate-authority-routers/adcs-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-routers/adcs-certificate-authority-router.ts
@@ -46,7 +46,7 @@ export const registerADCSCertificateAuthorityRouter = async (server: FastifyZodP
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const templates = await server.services.certificateAuthority.getADCSTemplates({

--- a/backend/src/server/routes/v1/certificate-authority-routers/azure-ad-cs-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-routers/azure-ad-cs-certificate-authority-router.ts
@@ -51,7 +51,7 @@ export const registerAzureAdCsCertificateAuthorityRouter = async (server: Fastif
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const templates = await server.services.certificateAuthority.getAzureAdcsTemplates({

--- a/backend/src/server/routes/v1/certificate-authority-routers/certificate-authority-endpoints.ts
+++ b/backend/src/server/routes/v1/certificate-authority-routers/certificate-authority-endpoints.ts
@@ -59,7 +59,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema.array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.query.projectId ?? req.internalCertManagerProjectId;
 
@@ -100,7 +100,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id } = req.params;
 
@@ -140,7 +140,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const body = req.body as {
         projectId?: string;
@@ -198,7 +198,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id } = req.params;
 
@@ -257,7 +257,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id } = req.params;
 

--- a/backend/src/server/routes/v1/certificate-authority-routers/general-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-routers/general-certificate-authority-router.ts
@@ -36,7 +36,7 @@ export const registerGeneralCertificateAuthorityRouter = async (server: FastifyZ
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listCertificateAuthoritiesV1General",

--- a/backend/src/server/routes/v1/certificate-authority-routers/internal-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/certificate-authority-routers/internal-certificate-authority-router.ts
@@ -48,7 +48,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCaCsr",
@@ -96,7 +96,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "renewCaCertificate",
@@ -167,7 +167,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificateAuthorities],
@@ -401,7 +401,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "signIntermediateCa",
@@ -467,7 +467,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "importCaCertificate",
@@ -522,7 +522,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCaCrls",
@@ -601,7 +601,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "installCaCertificateVenafi",
@@ -655,7 +655,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "installCaCertificateAdcs",
@@ -709,7 +709,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "installCaCertificateAdcsNative",
@@ -763,7 +763,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createCaSigningConfig",
@@ -834,7 +834,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCaSigningConfig",
@@ -878,7 +878,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateCaSigningConfig",
@@ -932,7 +932,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCaAutoRenewalConfig",
@@ -976,7 +976,7 @@ export const registerInternalCertificateAuthorityRouter = async (server: Fastify
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateCaAutoRenewalConfig",

--- a/backend/src/server/routes/v1/certificate-cleanup-router.ts
+++ b/backend/src/server/routes/v1/certificate-cleanup-router.ts
@@ -17,7 +17,7 @@ export const registerCertificateCleanupRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCertificateCleanupConfig",
@@ -50,7 +50,7 @@ export const registerCertificateCleanupRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateCertificateCleanupConfig",

--- a/backend/src/server/routes/v1/certificate-inventory-view-router.ts
+++ b/backend/src/server/routes/v1/certificate-inventory-view-router.ts
@@ -97,7 +97,7 @@ export const registerCertificateInventoryViewRouter = async (server: FastifyZodP
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.certificateInventoryView.listViews({
         projectId: req.internalCertManagerProjectId,
@@ -135,7 +135,7 @@ export const registerCertificateInventoryViewRouter = async (server: FastifyZodP
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const view = await server.services.certificateInventoryView.createView({
         projectId: req.internalCertManagerProjectId,
@@ -195,7 +195,7 @@ export const registerCertificateInventoryViewRouter = async (server: FastifyZodP
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const view = await server.services.certificateInventoryView.updateView({
         viewId: req.params.viewId,
@@ -248,7 +248,7 @@ export const registerCertificateInventoryViewRouter = async (server: FastifyZodP
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const view = await server.services.certificateInventoryView.deleteView({
         viewId: req.params.viewId,

--- a/backend/src/server/routes/v1/certificate-policy-router.ts
+++ b/backend/src/server/routes/v1/certificate-policy-router.ts
@@ -202,7 +202,7 @@ export const registerCertificatePolicyRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificatePolicy = await server.services.certificatePolicy.createPolicy({
         actor: req.permission.type,
@@ -263,7 +263,7 @@ export const registerCertificatePolicyRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { policies, totalCount } = await server.services.certificatePolicy.listPolicies({
@@ -312,7 +312,7 @@ export const registerCertificatePolicyRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificatePolicy = await server.services.certificatePolicy.getPolicyById({
         actor: req.permission.type,
@@ -359,7 +359,7 @@ export const registerCertificatePolicyRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificatePolicy = await server.services.certificatePolicy.updatePolicy({
         actor: req.permission.type,
@@ -415,7 +415,7 @@ export const registerCertificatePolicyRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificatePolicy = await server.services.certificatePolicy.deletePolicy({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/certificate-profiles-router.ts
+++ b/backend/src/server/routes/v1/certificate-profiles-router.ts
@@ -258,7 +258,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateProfile = await server.services.certificateProfile.createProfile({
         actor: req.permission.type,
@@ -385,7 +385,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { profiles, totalCount } = await server.services.certificateProfile.listProfiles({
         actor: req.permission.type,
@@ -489,7 +489,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateProfile = await server.services.certificateProfile.getProfileByIdWithConfigs({
         actor: req.permission.type,
@@ -537,7 +537,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateProfile = await server.services.certificateProfile.getProfileBySlug({
         actor: req.permission.type,
@@ -662,7 +662,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateProfile = await server.services.certificateProfile.updateProfile({
         actor: req.permission.type,
@@ -722,7 +722,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateProfile = await server.services.certificateProfile.deleteProfile({
         actor: req.permission.type,
@@ -794,7 +794,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificates = await server.services.certificateProfile.getProfileCertificates({
         actor: req.permission.type,
@@ -832,7 +832,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const response = await server.services.certificateProfile.getLatestActiveCertificateBundle({
         actor: req.permission.type,
@@ -895,7 +895,7 @@ export const registerCertificateProfilesRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { eabKid, eabSecret } = await server.services.certificateProfile.revealAcmeEabSecret({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/certificate-router.ts
+++ b/backend/src/server/routes/v1/certificate-router.ts
@@ -206,7 +206,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { csr, attributes, metadata, ...requestBody } = req.body;
       const profile = await server.services.certificateProfile.getProfileById({
@@ -473,7 +473,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { certificateRequest, projectId } = await server.services.certificateRequest.getCertificateFromRequest({
         actor: req.permission.type,
@@ -518,7 +518,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.certificateAuthority.triggerCertificateRequestValidation({
         actor: req.permission.type,
@@ -612,7 +612,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
 
@@ -735,7 +735,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { metadata, ...filters } = req.body;
       const projectId = req.internalCertManagerProjectId;
@@ -817,7 +817,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { certificateRequest, projectId, cancelled, previousStatus, previousPendingMessage } =
         await server.services.certificateRequest.cancelCertificateRequest({
@@ -908,7 +908,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateRequestForService: CertificateRequestForService = {
         commonName: req.body.commonName,
@@ -1015,7 +1015,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.certificateV3.signCertificateFromProfile({
         actor: req.permission.type,
@@ -1118,7 +1118,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateOrderObject = {
         altNames: req.body.subjectAlternativeNames,
@@ -1190,7 +1190,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const originalCertificate = await server.services.certificate.getCert({
         actor: req.permission.type,
@@ -1276,7 +1276,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       if (req.body.enableAutoRenewal === false) {
         const data = await server.services.certificateV3.disableRenewalConfig({
@@ -1367,7 +1367,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCertificate",
@@ -1445,7 +1445,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateCertificate",
@@ -1509,7 +1509,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCertificatePrivateKey",
@@ -1566,7 +1566,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCertificateBundle",
@@ -1635,7 +1635,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "importCertificate",
@@ -1709,7 +1709,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "revokeCertificate",
@@ -1778,7 +1778,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteCertificate",
@@ -1835,7 +1835,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     method: "POST",
     url: "/:id/application",
     config: { rateLimit: writeLimit },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "assignCertificateToApplication",
@@ -1889,7 +1889,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getCertificateBody",
@@ -1942,7 +1942,7 @@ export const registerCertificateRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: true,
       operationId: "exportCertificatePkcs12",

--- a/backend/src/server/routes/v1/cmek-router.ts
+++ b/backend/src/server/routes/v1/cmek-router.ts
@@ -138,7 +138,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         body: { projectId, name, description, keyUsage, isExportable },
@@ -221,7 +221,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -268,7 +268,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -314,7 +314,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -369,7 +369,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId, ...dto },
@@ -413,7 +413,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -460,7 +460,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyName },
@@ -510,7 +510,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -565,7 +565,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -611,7 +611,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -715,7 +715,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         body: { projectId, keys },
@@ -783,7 +783,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         body: { keyIds },
@@ -827,7 +827,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { keyId } = req.params;
 
@@ -879,7 +879,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId: inputKeyId },
@@ -937,7 +937,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -994,7 +994,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -1048,7 +1048,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },
@@ -1100,7 +1100,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         params: { keyId },

--- a/backend/src/server/routes/v1/dashboard-router.ts
+++ b/backend/src/server/routes/v1/dashboard-router.ts
@@ -127,7 +127,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const rawQueryString = req.url.includes("?") ? req.url.slice(req.url.indexOf("?") + 1) : "";
       const { filters, operator } = SecretMetadataSearchQuerySchema.parse(qs.parse(rawQueryString));
@@ -327,7 +327,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         secretPath,
@@ -1003,7 +1003,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         secretPath,
@@ -1543,7 +1543,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secretPath, projectId, search } = req.query;
 
@@ -1755,7 +1755,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId, environment, secretPath, filterByAction, recursive } = req.query;
 
@@ -1810,7 +1810,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secretPath, projectId, environment, viewSecretValue } = req.query;
 
@@ -1896,7 +1896,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secretPath, projectId, environment, secretKey, isOverride } = req.query;
 
@@ -1970,7 +1970,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const importedSecrets = await server.services.secretImport.getRawSecretsFromImports({
         actorId: req.permission.id,
@@ -2043,7 +2043,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const secretVersions = await server.services.secret.getSecretVersions({
         actor: req.permission.type,
@@ -2078,7 +2078,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { version, secretId } = req.params;
 
@@ -2147,7 +2147,7 @@ export const registerDashboardRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) =>
       server.services.folder.getFolderMoveEligibility({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/deprecated-certificate-authority-routers/azure-ad-cs-certificate-authority-router.ts
+++ b/backend/src/server/routes/v1/deprecated-certificate-authority-routers/azure-ad-cs-certificate-authority-router.ts
@@ -49,7 +49,7 @@ export const registerAzureAdCsCertificateAuthorityRouter = async (server: Fastif
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const templates = await server.services.certificateAuthority.getAzureAdcsTemplates({
         caId: req.params.caId,

--- a/backend/src/server/routes/v1/deprecated-certificate-authority-routers/certificate-authority-endpoints.ts
+++ b/backend/src/server/routes/v1/deprecated-certificate-authority-routers/certificate-authority-endpoints.ts
@@ -55,7 +55,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema.array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId }
@@ -100,7 +100,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { caName } = req.params;
       const { projectId } = req.query;
@@ -141,7 +141,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateAuthority = (await server.services.certificateAuthority.createCertificateAuthority(
         { ...req.body, type: caType },
@@ -181,7 +181,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { caName } = req.params;
 
@@ -230,7 +230,7 @@ export const registerCertificateAuthorityEndpoints = <
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { caName } = req.params;
       const { projectId } = req.body;

--- a/backend/src/server/routes/v1/deprecated-certificate-router.ts
+++ b/backend/src/server/routes/v1/deprecated-certificate-router.ts
@@ -25,7 +25,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -74,7 +74,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -121,7 +121,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -178,7 +178,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -292,7 +292,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -354,7 +354,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -468,7 +468,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -524,7 +524,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -572,7 +572,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificates],
@@ -624,7 +624,7 @@ export const registerDeprecatedCertRouter = async (server: FastifyZodProvider) =
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: true,
       tags: [ApiDocsTags.PkiCertificates],

--- a/backend/src/server/routes/v1/deprecated-certificate-template-router.ts
+++ b/backend/src/server/routes/v1/deprecated-certificate-template-router.ts
@@ -36,7 +36,7 @@ export const registerDeprecatedCertificateTemplateRouter = async (server: Fastif
         200: sanitizedCertificateTemplate
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateTemplate = await server.services.certificateTemplate.getCertTemplate({
         id: req.params.certificateTemplateId,
@@ -88,7 +88,7 @@ export const registerDeprecatedCertificateTemplateRouter = async (server: Fastif
         200: sanitizedCertificateTemplate
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateTemplate = await server.services.certificateTemplate.createCertTemplate({
         actor: req.permission.type,
@@ -138,7 +138,7 @@ export const registerDeprecatedCertificateTemplateRouter = async (server: Fastif
         200: sanitizedCertificateTemplate
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateTemplate = await server.services.certificateTemplate.updateCertTemplate({
         ...req.body,
@@ -169,7 +169,7 @@ export const registerDeprecatedCertificateTemplateRouter = async (server: Fastif
         200: sanitizedCertificateTemplate
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateTemplate = await server.services.certificateTemplate.deleteCertTemplate({
         id: req.params.certificateTemplateId,
@@ -189,7 +189,7 @@ export const registerDeprecatedCertificateTemplateRouter = async (server: Fastif
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificateTemplates],
@@ -245,7 +245,7 @@ export const registerDeprecatedCertificateTemplateRouter = async (server: Fastif
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificateTemplates],
@@ -295,7 +295,7 @@ export const registerDeprecatedCertificateTemplateRouter = async (server: Fastif
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificateTemplates],

--- a/backend/src/server/routes/v1/deprecated-identity-project-membership-router.ts
+++ b/backend/src/server/routes/v1/deprecated-identity-project-membership-router.ts
@@ -26,7 +26,7 @@ export const registerDeprecatedIdentityProjectMembershipRouter = async (server: 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -108,7 +108,7 @@ export const registerDeprecatedIdentityProjectMembershipRouter = async (server: 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -187,7 +187,7 @@ export const registerDeprecatedIdentityProjectMembershipRouter = async (server: 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -232,7 +232,7 @@ export const registerDeprecatedIdentityProjectMembershipRouter = async (server: 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -327,7 +327,7 @@ export const registerDeprecatedIdentityProjectMembershipRouter = async (server: 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -391,7 +391,7 @@ export const registerDeprecatedIdentityProjectMembershipRouter = async (server: 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],

--- a/backend/src/server/routes/v1/deprecated-pki-alert-router.ts
+++ b/backend/src/server/routes/v1/deprecated-pki-alert-router.ts
@@ -15,7 +15,7 @@ export const registerDeprecatedPkiAlertRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       tags: [ApiDocsTags.PkiAlerting],
       description: "Create PKI alert",
@@ -69,7 +69,7 @@ export const registerDeprecatedPkiAlertRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       tags: [ApiDocsTags.PkiAlerting],
       description: "Get PKI alert",
@@ -110,7 +110,7 @@ export const registerDeprecatedPkiAlertRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       tags: [ApiDocsTags.PkiAlerting],
       description: "Update PKI alert",
@@ -168,7 +168,7 @@ export const registerDeprecatedPkiAlertRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       tags: [ApiDocsTags.PkiAlerting],
       description: "Delete PKI alert",

--- a/backend/src/server/routes/v1/deprecated-project-env-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-env-router.ts
@@ -35,7 +35,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.getEnvironmentById({
         actorId: req.permission.id,
@@ -84,7 +84,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.getEnvironmentById({
         actorId: req.permission.id,
@@ -140,7 +140,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.createEnvironment({
         actorId: req.permission.id,
@@ -202,7 +202,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { environment, old } = await server.services.projectEnv.updateEnvironment({
         actorId: req.permission.id,
@@ -265,7 +265,7 @@ export const registerDeprecatedProjectEnvRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.deleteEnvironment({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/deprecated-project-membership-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-membership-router.ts
@@ -61,7 +61,7 @@ export const registerDeprecatedProjectMembershipRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { data: memberships } = await server.services.membershipUser.listMemberships({
         permission: req.permission,
@@ -122,7 +122,7 @@ export const registerDeprecatedProjectMembershipRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId } = await server.services.convertor.userMembershipIdToUserId(
         req.params.membershipId,
@@ -194,7 +194,7 @@ export const registerDeprecatedProjectMembershipRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.projectMembership.getProjectMembershipByUsername({
         actorId: req.permission.id,
@@ -235,7 +235,7 @@ export const registerDeprecatedProjectMembershipRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.projectMembership.addUsersToProject({
         actorId: req.permission.id,
@@ -318,7 +318,7 @@ export const registerDeprecatedProjectMembershipRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId } = await server.services.convertor.userMembershipIdToUserId(
         req.params.membershipId,
@@ -368,7 +368,7 @@ export const registerDeprecatedProjectMembershipRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId } = await server.services.convertor.userMembershipIdToUserId(
         req.params.membershipId,

--- a/backend/src/server/routes/v1/deprecated-project-router.ts
+++ b/backend/src/server/routes/v1/deprecated-project-router.ts
@@ -54,7 +54,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspaces = await server.services.project.getProjects({
         includeRoles: req.query.includeRoles,
@@ -92,7 +92,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspace = await server.services.project.getAProject({
         filter: {
@@ -132,7 +132,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspace = await server.services.project.deleteProject({
         filter: {
@@ -216,7 +216,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspace = await server.services.project.updateProject({
         filter: {
@@ -276,7 +276,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspace = await server.services.project.updateAuditLogsRetention({
         actorId: req.permission.id,
@@ -340,7 +340,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const integrations = await server.services.integration.listIntegrationByProject({
         actorId: req.permission.id,
@@ -377,7 +377,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const authorizations = await server.services.integrationAuth.listIntegrationAuthByProjectId({
         actorId: req.permission.id,
@@ -430,7 +430,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const config = await server.services.project.getProjectWorkflowIntegrationConfig({
         actorId: req.permission.id,
@@ -477,7 +477,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const deletedIntegration = await server.services.project.deleteProjectWorkflowIntegration({
         actorId: req.permission.id,
@@ -557,7 +557,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workflowIntegrationConfig = await server.services.project.updateProjectWorkflowIntegration({
         actorId: req.permission.id,
@@ -620,7 +620,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { docs: projects, totalCount } = await server.services.project.searchProjects({
         permission: req.permission,

--- a/backend/src/server/routes/v1/deprecated-secret-folder-router.ts
+++ b/backend/src/server/routes/v1/deprecated-secret-folder-router.ts
@@ -64,7 +64,13 @@ export const registerDeprecatedSecretFolderRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const path = req.body.path || req.body.directory || "/";
       const folder = await server.services.folder.createFolder({
@@ -151,7 +157,13 @@ export const registerDeprecatedSecretFolderRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const path = req.body.path || req.body.directory || "/";
       const { folder, old } = await server.services.folder.updateFolder({
@@ -228,7 +240,13 @@ export const registerDeprecatedSecretFolderRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { newFolders, oldFolders, projectId } = await server.services.folder.updateManyFolders({
         ...req.body,
@@ -307,7 +325,13 @@ export const registerDeprecatedSecretFolderRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const path = req.body.path || req.body.directory || "/";
       const folder = await server.services.folder.deleteFolder({
@@ -382,7 +406,13 @@ export const registerDeprecatedSecretFolderRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const path = req.query.path || req.query.directory || "/";
       const folders = await server.services.folder.getFolders({
@@ -430,7 +460,13 @@ export const registerDeprecatedSecretFolderRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const folder = await server.services.folder.getFolderById({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/deprecated-secret-import-router.ts
+++ b/backend/src/server/routes/v1/deprecated-secret-import-router.ts
@@ -47,7 +47,13 @@ export const registerDeprecatedSecretImportRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImport = await server.services.secretImport.createImport({
         actorId: req.permission.id,
@@ -122,7 +128,13 @@ export const registerDeprecatedSecretImportRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImport = await server.services.secretImport.updateImport({
         actorId: req.permission.id,
@@ -188,7 +200,13 @@ export const registerDeprecatedSecretImportRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImport = await server.services.secretImport.deleteImport({
         actorId: req.permission.id,
@@ -246,7 +264,7 @@ export const registerDeprecatedSecretImportRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { message } = await server.services.secretImport.resyncSecretImportReplication({
         actorId: req.permission.id,
@@ -293,7 +311,13 @@ export const registerDeprecatedSecretImportRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImports = await server.services.secretImport.getImports({
         actorId: req.permission.id,
@@ -354,7 +378,13 @@ export const registerDeprecatedSecretImportRouter = async (server: FastifyZodPro
       }
     },
 
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImport = await server.services.secretImport.getImportById({
         actorId: req.permission.id,
@@ -410,7 +440,13 @@ export const registerDeprecatedSecretImportRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const importedSecrets = await server.services.secretImport.getSecretsFromImports({
         actorId: req.permission.id,
@@ -456,7 +492,13 @@ export const registerDeprecatedSecretImportRouter = async (server: FastifyZodPro
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const importedSecrets = await server.services.secretImport.getRawSecretsFromImports({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/deprecated-secret-tag-router.ts
+++ b/backend/src/server/routes/v1/deprecated-secret-tag-router.ts
@@ -26,7 +26,7 @@ export const registerDeprecatedSecretTagRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspaceTags = await server.services.secretTag.getProjectTags({
         actor: req.permission.type,
@@ -59,7 +59,7 @@ export const registerDeprecatedSecretTagRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspaceTag = await server.services.secretTag.getTagById({
         actor: req.permission.type,
@@ -92,7 +92,7 @@ export const registerDeprecatedSecretTagRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspaceTag = await server.services.secretTag.getTagBySlug({
         actor: req.permission.type,
@@ -128,7 +128,7 @@ export const registerDeprecatedSecretTagRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspaceTag = await server.services.secretTag.createTag({
         actor: req.permission.type,
@@ -165,7 +165,7 @@ export const registerDeprecatedSecretTagRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspaceTag = await server.services.secretTag.updateTag({
         actor: req.permission.type,
@@ -198,7 +198,7 @@ export const registerDeprecatedSecretTagRouter = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspaceTag = await server.services.secretTag.deleteTag({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/event-router.ts
+++ b/backend/src/server/routes/v1/event-router.ts
@@ -30,7 +30,7 @@ export const registerEventRouter = async (server: FastifyZodProvider) => {
       }),
       produces: ["text/event-stream"]
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req, reply) => {
       const client = await server.services.projectEventsSSE.subscribe({
         projectId: req.body.projectId,

--- a/backend/src/server/routes/v1/external-group-org-role-mapping-router.ts
+++ b/backend/src/server/routes/v1/external-group-org-role-mapping-router.ts
@@ -24,7 +24,7 @@ export const registerExternalGroupOrgRoleMappingRouter = async (server: FastifyZ
         200: ExternalGroupOrgRoleMappingsSchema.array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const mappings = server.services.externalGroupOrgRoleMapping.listExternalGroupOrgRoleMappings(req.permission);
 
@@ -63,7 +63,7 @@ export const registerExternalGroupOrgRoleMappingRouter = async (server: FastifyZ
         200: ExternalGroupOrgRoleMappingsSchema.array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { body, permission } = req;
 

--- a/backend/src/server/routes/v1/github-app-router.ts
+++ b/backend/src/server/routes/v1/github-app-router.ts
@@ -13,7 +13,7 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       body: z
         .object({
@@ -88,7 +88,7 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       querystring: z.object({
         projectId: z.string().trim().optional()
@@ -115,7 +115,7 @@ export const registerGitHubAppRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         id: z.string().uuid()

--- a/backend/src/server/routes/v1/group-org-membership-router.ts
+++ b/backend/src/server/routes/v1/group-org-membership-router.ts
@@ -12,7 +12,7 @@ export const registerGroupOrgMembershipRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listAvailableOrganizationGroups",

--- a/backend/src/server/routes/v1/group-project-router.ts
+++ b/backend/src/server/routes/v1/group-project-router.ts
@@ -25,7 +25,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
   server.route({
     method: "POST",
     url: "/:projectId/groups/:groupIdOrName",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: writeLimit
     },
@@ -144,7 +144,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
   server.route({
     method: "PATCH",
     url: "/:projectId/groups/:groupId",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       deprecated: true,
@@ -231,7 +231,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
   server.route({
     method: "DELETE",
     url: "/:projectId/groups/:groupId",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: writeLimit
     },
@@ -295,7 +295,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
   server.route({
     method: "GET",
     url: "/:projectId/groups",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: readLimit
     },
@@ -365,7 +365,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
   server.route({
     method: "GET",
     url: "/:projectId/groups/:groupId",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: readLimit
     },
@@ -437,7 +437,7 @@ export const registerGroupProjectRouter = async (server: FastifyZodProvider) => 
   server.route({
     method: "GET",
     url: "/:projectId/groups/:groupId/users",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: readLimit
     },

--- a/backend/src/server/routes/v1/hsm-connector-router.ts
+++ b/backend/src/server/routes/v1/hsm-connector-router.ts
@@ -35,7 +35,7 @@ export const createHsmConnectorRouter =
         body: CreateHsmConnectorBodySchema,
         response: { 200: z.object({ hsmConnector: HsmConnectorSanitizedSchema }) }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         const hsmConnector = await server.services.hsmConnector.createHsmConnector(
           {
@@ -75,7 +75,7 @@ export const createHsmConnectorRouter =
         tags: [ApiDocsTags.HsmConnectors],
         response: { 200: z.object({ hsmConnectors: HsmConnectorSanitizedSchema.array() }) }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         const hsmConnectors = await server.services.hsmConnector.listHsmConnectors(
           { projectId: resolveProjectId(req) },
@@ -96,7 +96,7 @@ export const createHsmConnectorRouter =
         params: HsmConnectorIdParamSchema,
         response: { 200: z.object({ hsmConnector: HsmConnectorSanitizedSchema }) }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         const hsmConnector = await server.services.hsmConnector.getHsmConnectorById(
           { connectorId: req.params.connectorId },
@@ -118,7 +118,7 @@ export const createHsmConnectorRouter =
         body: UpdateHsmConnectorBodySchema,
         response: { 200: z.object({ hsmConnector: HsmConnectorSanitizedSchema }) }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         const hsmConnector = await server.services.hsmConnector.updateHsmConnector(
           {
@@ -159,7 +159,7 @@ export const createHsmConnectorRouter =
         params: HsmConnectorIdParamSchema,
         response: { 200: z.object({ id: z.string().uuid() }) }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         const deleted = await server.services.hsmConnector.deleteHsmConnector(
           { connectorId: req.params.connectorId },
@@ -188,7 +188,7 @@ export const createHsmConnectorRouter =
         params: HsmConnectorIdParamSchema,
         response: { 200: HsmConnectorTestResultSchema }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         const { projectId, name, result } = await server.services.hsmConnector.testHsmConnector(
           { connectorId: req.params.connectorId },
@@ -223,7 +223,7 @@ export const createHsmConnectorRouter =
         querystring: HsmConnectorLinkedResourcesQuerySchema,
         response: { 200: HsmConnectorLinkedResourcesResponseSchema }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         return server.services.hsmConnector.listLinkedResources(
           {

--- a/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-alicloud-auth-router.ts
@@ -163,7 +163,7 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachAlicloudAuth",
@@ -271,7 +271,7 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateAlicloudAuth",
@@ -380,7 +380,7 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getAlicloudAuth",
@@ -429,7 +429,7 @@ export const registerIdentityAliCloudAuthRouter = async (server: FastifyZodProvi
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteAlicloudAuth",

--- a/backend/src/server/routes/v1/identity-aws-iam-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-aws-iam-auth-router.ts
@@ -130,7 +130,7 @@ export const registerIdentityAwsAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachAwsAuth",
@@ -242,7 +242,7 @@ export const registerIdentityAwsAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateAwsAuth",
@@ -343,7 +343,7 @@ export const registerIdentityAwsAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getAwsAuth",
@@ -392,7 +392,7 @@ export const registerIdentityAwsAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteAwsAuth",

--- a/backend/src/server/routes/v1/identity-azure-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-azure-auth-router.ts
@@ -125,7 +125,7 @@ export const registerIdentityAzureAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachAzureAuth",
@@ -236,7 +236,7 @@ export const registerIdentityAzureAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateAzureAuth",
@@ -343,7 +343,7 @@ export const registerIdentityAzureAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getAzureAuth",
@@ -393,7 +393,7 @@ export const registerIdentityAzureAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteAzureAuth",

--- a/backend/src/server/routes/v1/identity-gcp-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-gcp-auth-router.ts
@@ -125,7 +125,7 @@ export const registerIdentityGcpAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachGcpAuth",
@@ -234,7 +234,7 @@ export const registerIdentityGcpAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateGcpAuth",
@@ -337,7 +337,7 @@ export const registerIdentityGcpAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getGcpAuth",
@@ -387,7 +387,7 @@ export const registerIdentityGcpAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteGcpAuth",

--- a/backend/src/server/routes/v1/identity-jwt-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-jwt-auth-router.ts
@@ -201,7 +201,7 @@ export const registerIdentityJwtAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachJwtAuth",
@@ -286,7 +286,7 @@ export const registerIdentityJwtAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateJwtAuth",
@@ -369,7 +369,7 @@ export const registerIdentityJwtAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getJwtAuth",
@@ -419,7 +419,7 @@ export const registerIdentityJwtAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteJwtAuth",

--- a/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-kubernetes-auth-router.ts
@@ -148,7 +148,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachKubernetesAuth",
@@ -348,7 +348,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateKubernetesAuth",
@@ -518,7 +518,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getKubernetesAuth",
@@ -568,7 +568,7 @@ export const registerIdentityKubernetesRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteKubernetesAuth",

--- a/backend/src/server/routes/v1/identity-ldap-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-ldap-auth-router.ts
@@ -274,7 +274,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachLdapAuth",
@@ -481,7 +481,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateLdapAuth",
@@ -619,7 +619,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getLdapAuth",
@@ -678,7 +678,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteLdapAuth",
@@ -748,7 +748,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "clearLdapAuthLockouts",

--- a/backend/src/server/routes/v1/identity-oci-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-oci-auth-router.ts
@@ -142,7 +142,7 @@ export const registerIdentityOciAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachOciAuth",
@@ -247,7 +247,7 @@ export const registerIdentityOciAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateOciAuth",
@@ -347,7 +347,7 @@ export const registerIdentityOciAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getOciAuth",
@@ -396,7 +396,7 @@ export const registerIdentityOciAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteOciAuth",

--- a/backend/src/server/routes/v1/identity-oidc-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-oidc-auth-router.ts
@@ -153,7 +153,7 @@ export const registerIdentityOidcAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachOidcAuth",
@@ -270,7 +270,7 @@ export const registerIdentityOidcAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateOidcAuth",
@@ -386,7 +386,7 @@ export const registerIdentityOidcAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getOidcAuth",
@@ -436,7 +436,7 @@ export const registerIdentityOidcAuthRouter = async (server: FastifyZodProvider)
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteOidcAuth",

--- a/backend/src/server/routes/v1/identity-org-membership-router.ts
+++ b/backend/src/server/routes/v1/identity-org-membership-router.ts
@@ -23,7 +23,7 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: true,
       operationId: "createOrganizationIdentityMembership",
@@ -113,7 +113,7 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: true,
       operationId: "updateOrganizationIdentityMembership",
@@ -205,7 +205,7 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: true,
       operationId: "deleteOrganizationIdentityMembership",
@@ -260,7 +260,7 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: true,
       operationId: "listOrganizationIdentityMemberships",
@@ -357,7 +357,7 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: true,
       operationId: "getOrganizationIdentityMembershipById",
@@ -420,7 +420,7 @@ export const registerIdentityOrgMembershipRouter = async (server: FastifyZodProv
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listAvailableOrganizationIdentities",

--- a/backend/src/server/routes/v1/identity-project-membership-router.ts
+++ b/backend/src/server/routes/v1/identity-project-membership-router.ts
@@ -22,7 +22,7 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createProjectIdentityMembership",
@@ -118,7 +118,7 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateProjectIdentityMembership",
@@ -211,7 +211,7 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteProjectIdentityMembership",
@@ -269,7 +269,7 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listProjectIdentityMemberships",
@@ -371,7 +371,7 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getProjectIdentityMembershipById",
@@ -446,7 +446,7 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: true,
       params: z.object({
@@ -503,7 +503,7 @@ export const registerIdentityProjectMembershipRouter = async (server: FastifyZod
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listAvailableProjectIdentities",

--- a/backend/src/server/routes/v1/identity-router.ts
+++ b/backend/src/server/routes/v1/identity-router.ts
@@ -34,7 +34,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: identityCreationLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createMachineIdentity",
@@ -110,7 +110,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateMachineIdentity",
@@ -191,7 +191,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteMachineIdentity",
@@ -256,7 +256,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getMachineIdentityById",
@@ -315,7 +315,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listMachineIdentities",
@@ -366,7 +366,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "searchMachineIdentities",
@@ -467,7 +467,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "getMachineIdentityMemberships",
       description: "List project memberships that machine identity with id is part of",

--- a/backend/src/server/routes/v1/identity-spiffe-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-spiffe-auth-router.ts
@@ -197,7 +197,7 @@ export const registerIdentitySpiffeAuthRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachSpiffeAuth",
@@ -260,7 +260,7 @@ export const registerIdentitySpiffeAuthRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateSpiffeAuth",
@@ -321,7 +321,7 @@ export const registerIdentitySpiffeAuthRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getSpiffeAuth",
@@ -371,7 +371,7 @@ export const registerIdentitySpiffeAuthRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "refreshSpiffeBundle",
@@ -421,7 +421,7 @@ export const registerIdentitySpiffeAuthRouter = async (server: FastifyZodProvide
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteSpiffeAuth",

--- a/backend/src/server/routes/v1/identity-tls-cert-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-tls-cert-auth-router.ts
@@ -196,7 +196,7 @@ export const registerIdentityTlsCertAuthRouter = async (server: FastifyZodProvid
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachTlsCertAuth",
@@ -325,7 +325,7 @@ export const registerIdentityTlsCertAuthRouter = async (server: FastifyZodProvid
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateTlsCertAuth",
@@ -455,7 +455,7 @@ export const registerIdentityTlsCertAuthRouter = async (server: FastifyZodProvid
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getTlsCertAuth",
@@ -508,7 +508,7 @@ export const registerIdentityTlsCertAuthRouter = async (server: FastifyZodProvid
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteTlsCertAuth",

--- a/backend/src/server/routes/v1/identity-token-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-token-auth-router.ts
@@ -20,7 +20,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachTokenAuth",
@@ -128,7 +128,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateTokenAuth",
@@ -230,7 +230,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getTokenAuth",
@@ -280,7 +280,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteTokenAuth",
@@ -346,7 +346,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createTokenAuthToken",
@@ -428,7 +428,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getTokenAuthTokens",
@@ -485,7 +485,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: true,
       operationId: "getTokenAuthTokenByIdDeprecated",
@@ -538,7 +538,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getTokenAuthTokenById",
@@ -590,7 +590,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateTokenAuthToken",
@@ -647,7 +647,7 @@ export const registerIdentityTokenAuthRouter = async (server: FastifyZodProvider
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "revokeTokenAuthToken",

--- a/backend/src/server/routes/v1/identity-universal-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-universal-auth-router.ts
@@ -152,7 +152,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "attachUniversalAuth",
@@ -286,7 +286,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateUniversalAuth",
@@ -426,7 +426,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getUniversalAuth",
@@ -476,7 +476,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteUniversalAuth",
@@ -542,7 +542,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createUniversalAuthClientSecret",
@@ -621,7 +621,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listUniversalAuthClientSecrets",
@@ -672,7 +672,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getUniversalAuthClientSecret",
@@ -725,7 +725,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "revokeUniversalAuthClientSecret",
@@ -793,7 +793,7 @@ export const registerIdentityUaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "clearUniversalAuthLockouts",

--- a/backend/src/server/routes/v1/integration-auth-router.ts
+++ b/backend/src/server/routes/v1/integration-auth-router.ts
@@ -17,7 +17,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.Integrations],
@@ -57,7 +57,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getIntegrationAuth",
@@ -95,7 +95,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateIntegrationAuth",
@@ -159,7 +159,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteIntegrationAuths",
@@ -211,7 +211,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteIntegrationAuth",
@@ -261,7 +261,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "exchangeOauthToken",
       body: z.object({
@@ -307,7 +307,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createIntegrationAuth",
@@ -369,7 +369,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -410,7 +410,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -444,7 +444,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -477,7 +477,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -510,7 +510,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -541,7 +541,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -575,7 +575,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -612,7 +612,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -641,7 +641,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -674,7 +674,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -707,7 +707,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -740,7 +740,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -773,7 +773,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -806,7 +806,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -839,7 +839,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -874,7 +874,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -907,7 +907,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -940,7 +940,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -979,7 +979,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -1021,7 +1021,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -1059,7 +1059,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -1097,7 +1097,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -1176,7 +1176,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       querystring: z.object({
         teamId: z.string().trim()
@@ -1220,7 +1220,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()
@@ -1255,7 +1255,7 @@ export const registerIntegrationAuthRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       params: z.object({
         integrationAuthId: z.string().trim()

--- a/backend/src/server/routes/v1/integration-router.ts
+++ b/backend/src/server/routes/v1/integration-router.ts
@@ -73,7 +73,7 @@ export const registerIntegrationRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     // Native integrations are closed to new creation ahead of the deprecation date. The route stays registered so
     // existing callers get an explanation pointing at Secret Syncs rather than a 404. Everything else on this router
     // (read, update, delete, manual sync) keeps working until the cutoff. See integration-deprecation-fns.ts.
@@ -130,7 +130,7 @@ export const registerIntegrationRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const integration = await server.services.integration.updateIntegration({
         actorId: req.permission.id,
@@ -175,7 +175,7 @@ export const registerIntegrationRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const integration = await server.services.integration.getIntegration({
         actorId: req.permission.id,
@@ -247,7 +247,7 @@ export const registerIntegrationRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const integration = await server.services.integration.deleteIntegration({
         actorId: req.permission.id,
@@ -328,7 +328,7 @@ export const registerIntegrationRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const integration = await server.services.integration.syncIntegration({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/invite-org-router.ts
+++ b/backend/src/server/routes/v1/invite-org-router.ts
@@ -57,7 +57,7 @@ export const registerInviteOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       if (req.auth.actor !== ActorType.USER) return;
 
@@ -202,7 +202,7 @@ export const registerInviteOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.org.resendOrgMemberInvitation({
         orgId: req.permission.orgId,

--- a/backend/src/server/routes/v1/microsoft-teams-router.ts
+++ b/backend/src/server/routes/v1/microsoft-teams-router.ts
@@ -36,7 +36,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const clientId = await server.services.microsoftTeams.getClientId({
         actor: req.permission.type,
@@ -68,7 +68,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
       })
     },
 
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.microsoftTeams.completeMicrosoftTeamsIntegration({
         tenantId: req.body.tenantId,
@@ -114,7 +114,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
         200: sanitizedMicrosoftTeamsIntegrationSchema.array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const microsoftTeamsIntegrations = await server.services.microsoftTeams.getMicrosoftTeamsIntegrationsByOrg({
         actor: req.permission.type,
@@ -148,7 +148,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
         id: z.string()
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const microsoftTeamsIntegration = await server.services.microsoftTeams.checkInstallationStatus({
         actor: req.permission.type,
@@ -192,7 +192,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
         200: sanitizedMicrosoftTeamsIntegrationSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const deletedMicrosoftTeamsIntegration = await server.services.microsoftTeams.deleteMicrosoftTeamsIntegration({
         actor: req.permission.type,
@@ -239,7 +239,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
         200: sanitizedMicrosoftTeamsIntegrationSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const microsoftTeamsIntegration = await server.services.microsoftTeams.getMicrosoftTeamsIntegrationById({
         actor: req.permission.type,
@@ -290,7 +290,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
         200: sanitizedMicrosoftTeamsIntegrationSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const microsoftTeamsIntegration = await server.services.microsoftTeams.updateMicrosoftTeamsIntegration({
         actor: req.permission.type,
@@ -346,7 +346,7 @@ export const registerMicrosoftTeamsRouter = async (server: FastifyZodProvider) =
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const microsoftTeamsIntegration = await server.services.microsoftTeams.getTeams({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/oauth-router.ts
+++ b/backend/src/server/routes/v1/oauth-router.ts
@@ -7,6 +7,12 @@ import { authRateLimit, readLimit, writeLimit } from "@app/server/config/rateLim
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 import { isAllowedRedirectUri, parseBasicAuthHeader } from "@app/services/oauth-client/oauth-client-fns";
+import {
+  ACCEPTED_SUBJECT_TOKEN_TYPES,
+  DEFAULT_OAUTH_GRANT_TYPES,
+  OauthGrantType,
+  OauthTokenType
+} from "@app/services/oauth-client/oauth-client-types";
 
 const SanitizedOauthClientSchema = OauthClientsSchema.omit({ clientSecretHash: true });
 
@@ -16,6 +22,28 @@ const redirectUriSchema = z
   .refine(
     isAllowedRedirectUri,
     "Redirect URI must use https:// (http:// is only allowed for loopback addresses such as localhost)"
+  );
+
+const grantTypesSchema = z
+  .nativeEnum(OauthGrantType)
+  .array()
+  .min(1)
+  .max(Object.keys(OauthGrantType).length)
+  .describe(
+    "The OAuth grant types this application may use. Redirect URIs apply only to authorization_code; the token exchange audience applies only to the token-exchange grant."
+  );
+
+const tokenExchangeAudienceSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(255)
+  .describe("The expected 'aud' claim of subject tokens presented to the token exchange grant.");
+
+const tokenExchangeIdpSatisfiesMfaSchema = z
+  .boolean()
+  .describe(
+    "Declares that authentication at the identity provider satisfies this organization's MFA requirement. Required for token exchange in an organization that enforces MFA."
   );
 
 export const registerOAuthRouter = async (server: FastifyZodProvider) => {
@@ -30,8 +58,11 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
       body: z.object({
         name: z.string().trim().min(1).max(64),
         description: z.string().trim().max(256).optional(),
-        redirectUris: redirectUriSchema.array().min(1),
-        requirePkce: z.boolean().optional()
+        grantTypes: grantTypesSchema.default([...DEFAULT_OAUTH_GRANT_TYPES]),
+        redirectUris: redirectUriSchema.array().max(32).default([]),
+        requirePkce: z.boolean().optional(),
+        tokenExchangeAudience: tokenExchangeAudienceSchema.optional(),
+        tokenExchangeIdpSatisfiesMfa: tokenExchangeIdpSatisfiesMfaSchema.optional()
       }),
       response: {
         200: z.object({
@@ -52,7 +83,8 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
           metadata: {
             clientDbId: client.id,
             clientId: client.clientId,
-            name: client.name
+            name: client.name,
+            grantTypes: client.grantTypes
           }
         }
       });
@@ -69,6 +101,12 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
     },
     schema: {
       operationId: "listOauthClients",
+      querystring: z.object({
+        grantType: z
+          .nativeEnum(OauthGrantType)
+          .optional()
+          .describe("Return only applications registered for this grant type.")
+      }),
       response: {
         200: z.object({
           clients: SanitizedOauthClientSchema.array()
@@ -77,7 +115,7 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
-      const clients = await server.services.oauthClient.listOauthClients(req.permission);
+      const clients = await server.services.oauthClient.listOauthClients(req.permission, req.query.grantType);
       return { clients };
     }
   });
@@ -120,8 +158,11 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
       body: z.object({
         name: z.string().trim().min(1).max(64).optional(),
         description: z.string().trim().max(256).nullable().optional(),
-        redirectUris: redirectUriSchema.array().min(1).optional(),
-        requirePkce: z.boolean().optional()
+        grantTypes: grantTypesSchema.optional(),
+        redirectUris: redirectUriSchema.array().max(32).optional(),
+        requirePkce: z.boolean().optional(),
+        tokenExchangeAudience: tokenExchangeAudienceSchema.nullable().optional(),
+        tokenExchangeIdpSatisfiesMfa: tokenExchangeIdpSatisfiesMfaSchema.optional()
       }),
       response: {
         200: z.object({
@@ -144,7 +185,10 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
           metadata: {
             clientDbId: client.id,
             clientId: client.clientId,
-            name: client.name
+            name: client.name,
+            grantTypes: client.grantTypes,
+            tokenExchangeAudience: client.tokenExchangeAudience,
+            tokenExchangeIdpSatisfiesMfa: client.tokenExchangeIdpSatisfiesMfa
           }
         }
       });
@@ -371,21 +415,28 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
     },
     schema: {
       body: z.object({
-        grant_type: z.enum(["authorization_code", "refresh_token"]),
-        code: z.string().optional(),
-        redirect_uri: z.string().optional(),
-        code_verifier: z.string().optional(),
-        refresh_token: z.string().optional(),
-        client_id: z.string().optional(),
-        client_secret: z.string().optional()
+        grant_type: z.nativeEnum(OauthGrantType),
+        code: z.string().max(256).optional(),
+        redirect_uri: z.string().max(2048).optional(),
+        code_verifier: z.string().max(256).optional(),
+        refresh_token: z.string().max(8192).optional(),
+        client_id: z.string().max(256).optional(),
+        client_secret: z.string().max(256).optional(),
+        subject_token: z.string().max(8192).optional(),
+        subject_token_type: z.nativeEnum(OauthTokenType).optional(),
+        requested_token_type: z.nativeEnum(OauthTokenType).optional(),
+        audience: z.string().max(255).optional(),
+        resource: z.string().max(2048).optional(),
+        scope: z.string().max(2048).optional()
       }),
       response: {
         200: z.object({
           access_token: z.string(),
           token_type: z.string(),
           expires_in: z.number(),
-          refresh_token: z.string(),
-          scope: z.string()
+          refresh_token: z.string().optional(),
+          scope: z.string().optional(),
+          issued_token_type: z.nativeEnum(OauthTokenType).optional()
         })
       }
     },
@@ -397,11 +448,11 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
       void res.header("Cache-Control", "no-store");
       void res.header("Pragma", "no-cache");
 
-      if (req.body.grant_type === "authorization_code") {
+      if (req.body.grant_type === OauthGrantType.AuthorizationCode) {
         if (!req.body.code) throw new BadRequestError({ message: "Missing authorization code" });
 
         return server.services.oauthClient.exchangeToken({
-          grantType: "authorization_code",
+          grantType: OauthGrantType.AuthorizationCode,
           code: req.body.code,
           redirectUri: req.body.redirect_uri,
           codeVerifier: req.body.code_verifier,
@@ -410,10 +461,56 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
         });
       }
 
+      if (req.body.grant_type === OauthGrantType.TokenExchange) {
+        if (!req.body.subject_token) {
+          throw new BadRequestError({ message: "Missing 'subject_token'" });
+        }
+
+        if (!req.body.subject_token_type) {
+          throw new BadRequestError({ message: "Missing 'subject_token_type'" });
+        }
+
+        if (!ACCEPTED_SUBJECT_TOKEN_TYPES.includes(req.body.subject_token_type)) {
+          throw new BadRequestError({
+            message: `Unsupported 'subject_token_type'. Supported values are: ${ACCEPTED_SUBJECT_TOKEN_TYPES.join(", ")}`
+          });
+        }
+
+        if (req.body.requested_token_type && req.body.requested_token_type !== OauthTokenType.AccessToken) {
+          throw new BadRequestError({
+            message: `Unsupported 'requested_token_type'. Only '${OauthTokenType.AccessToken}' can be issued.`
+          });
+        }
+
+        if (req.body.scope) {
+          throw new BadRequestError({
+            message:
+              "The 'scope' parameter is not supported on the token exchange grant. The issued token carries the user's own permissions."
+          });
+        }
+
+        if (req.body.audience || req.body.resource) {
+          throw new BadRequestError({
+            message:
+              "The 'audience' and 'resource' parameters are not supported. The expected subject token audience is configured on the application."
+          });
+        }
+
+        return server.services.oauthClient.exchangeToken({
+          grantType: OauthGrantType.TokenExchange,
+          subjectToken: req.body.subject_token,
+          subjectTokenType: req.body.subject_token_type,
+          clientId,
+          clientSecret,
+          ip: req.realIp,
+          userAgent: req.headers["user-agent"]
+        });
+      }
+
       if (!req.body.refresh_token) throw new BadRequestError({ message: "Missing refresh token" });
 
       return server.services.oauthClient.exchangeToken({
-        grantType: "refresh_token",
+        grantType: OauthGrantType.RefreshToken,
         refreshToken: req.body.refresh_token,
         clientId,
         clientSecret

--- a/backend/src/server/routes/v1/oauth-router.ts
+++ b/backend/src/server/routes/v1/oauth-router.ts
@@ -28,7 +28,10 @@ const grantTypesSchema = z
   .nativeEnum(OauthGrantType)
   .array()
   .min(1)
-  .max(Object.keys(OauthGrantType).length)
+  .max(32)
+  .refine((grantTypes) => new Set(grantTypes).size === grantTypes.length, {
+    message: "Grant types must not contain duplicate values"
+  })
   .describe(
     "The OAuth grant types this application may use. Redirect URIs apply only to authorization_code; the token exchange audience applies only to the token-exchange grant."
   );

--- a/backend/src/server/routes/v1/oauth-router.ts
+++ b/backend/src/server/routes/v1/oauth-router.ts
@@ -87,7 +87,9 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
             clientDbId: client.id,
             clientId: client.clientId,
             name: client.name,
-            grantTypes: client.grantTypes
+            grantTypes: client.grantTypes,
+            tokenExchangeAudience: client.tokenExchangeAudience,
+            tokenExchangeIdpSatisfiesMfa: client.tokenExchangeIdpSatisfiesMfa
           }
         }
       });
@@ -414,15 +416,7 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
     method: "POST",
     url: "/token",
     config: {
-      rateLimit: oauthTokenLimit({
-        keyGenerator: (req) => {
-          const suppliedClientId = (req.body as { client_id?: unknown } | undefined)?.client_id;
-          const clientId =
-            parseBasicAuthHeader(req.headers.authorization)?.clientId ??
-            (typeof suppliedClientId === "string" ? suppliedClientId : undefined);
-          return clientId ? `${req.realIp}:${clientId.slice(0, 256)}` : req.realIp;
-        }
-      })
+      rateLimit: oauthTokenLimit
     },
     schema: {
       body: z.object({

--- a/backend/src/server/routes/v1/oauth-router.ts
+++ b/backend/src/server/routes/v1/oauth-router.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { OauthClientsSchema } from "@app/db/schemas";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { BadRequestError } from "@app/lib/errors";
-import { authRateLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { authRateLimit, oauthTokenLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 import { isAllowedRedirectUri, parseBasicAuthHeader } from "@app/services/oauth-client/oauth-client-fns";
@@ -414,7 +414,15 @@ export const registerOAuthRouter = async (server: FastifyZodProvider) => {
     method: "POST",
     url: "/token",
     config: {
-      rateLimit: authRateLimit
+      rateLimit: oauthTokenLimit({
+        keyGenerator: (req) => {
+          const suppliedClientId = (req.body as { client_id?: unknown } | undefined)?.client_id;
+          const clientId =
+            parseBasicAuthHeader(req.headers.authorization)?.clientId ??
+            (typeof suppliedClientId === "string" ? suppliedClientId : undefined);
+          return clientId ? `${req.realIp}:${clientId.slice(0, 256)}` : req.realIp;
+        }
+      })
     },
     schema: {
       body: z.object({

--- a/backend/src/server/routes/v1/org-admin-router.ts
+++ b/backend/src/server/routes/v1/org-admin-router.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { ProjectMembershipsSchema } from "@app/db/schemas";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { isUserSessionAuth } from "@app/server/plugins/auth/inject-identity";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 
@@ -29,7 +30,7 @@ export const registerOrgAdminRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projects, count } = await server.services.orgAdmin.listOrgProjects({
         limit: req.query.limit,
@@ -61,7 +62,7 @@ export const registerOrgAdminRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { membership } = await server.services.orgAdmin.grantProjectAdminAccess({
         actorOrgId: req.permission.orgId,
@@ -70,7 +71,7 @@ export const registerOrgAdminRouter = async (server: FastifyZodProvider) => {
         actor: req.permission.type,
         projectId: req.params.projectId
       });
-      if (req.auth.authMode === AuthMode.JWT) {
+      if (isUserSessionAuth(req.auth)) {
         await server.services.auditLog.createAuditLog({
           ...req.auditLogInfo,
           projectId: req.params.projectId,

--- a/backend/src/server/routes/v1/org-identity-router.ts
+++ b/backend/src/server/routes/v1/org-identity-router.ts
@@ -33,7 +33,7 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "createOrganizationMachineIdentity",
       tags: [ApiDocsTags.Identities],
@@ -92,7 +92,7 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "updateOrganizationMachineIdentity",
       tags: [ApiDocsTags.Identities],
@@ -158,7 +158,7 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "deleteOrganizationMachineIdentity",
       tags: [ApiDocsTags.Identities],
@@ -211,7 +211,7 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "getOrganizationMachineIdentityById",
       tags: [ApiDocsTags.Identities],
@@ -252,7 +252,7 @@ export const registerOrgIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "listOrganizationMachineIdentities",
       tags: [ApiDocsTags.Identities],

--- a/backend/src/server/routes/v1/organization-memberships-router.ts
+++ b/backend/src/server/routes/v1/organization-memberships-router.ts
@@ -48,7 +48,7 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listOrganizationGroupMemberships",
@@ -107,7 +107,7 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createOrganizationGroupMembership",
@@ -200,7 +200,7 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getOrganizationGroupMembership",
@@ -239,7 +239,7 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateOrganizationGroupMembership",
@@ -325,7 +325,7 @@ export const registerOrganizationMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteOrganizationGroupMembership",

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -45,9 +45,9 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    // Deliberately not open to AuthMode.OAUTH, unlike the rest of this router. There is no org in
-    // context to build a permission against, so nothing narrows the result to what the token was
-    // delegated — a token issued for one org would enumerate every org the user belongs to.
+    // Not open to AuthMode.OAUTH, unlike the rest of this router: with no org in context there's no
+    // permission to build, so nothing narrows the result and a token issued for one org would
+    // enumerate every org the user belongs to.
     onRequest: verifyAuth([AuthMode.JWT], { requireOrg: false }),
     handler: async (req) => {
       const organizations = await server.services.org.findAllOrganizationOfUser(req.permission.id);
@@ -72,9 +72,9 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    // Deliberately not open to AuthMode.OAUTH, unlike the rest of this router. There is no org in
-    // context to build a permission against, so nothing narrows the result to what the token was
-    // delegated — a token issued for one org would enumerate every org the user belongs to.
+    // Not open to AuthMode.OAUTH, unlike the rest of this router: with no org in context there's no
+    // permission to build, so nothing narrows the result and a token issued for one org would
+    // enumerate every org the user belongs to.
     onRequest: verifyAuth([AuthMode.JWT], { requireOrg: false }),
     handler: async (req) => {
       const organizations = await server.services.org.findAllAccessibleOrganizationsWithSubOrgs(req.permission.id);

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -719,7 +719,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
+    onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
       const stats = await server.services.orgProductStats.getOrgProductStats({
         actorOrgId: req.permission.orgId

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -45,6 +45,9 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
+    // Deliberately not open to AuthMode.OAUTH, unlike the rest of this router. There is no org in
+    // context to build a permission against, so nothing narrows the result to what the token was
+    // delegated — a token issued for one org would enumerate every org the user belongs to.
     onRequest: verifyAuth([AuthMode.JWT], { requireOrg: false }),
     handler: async (req) => {
       const organizations = await server.services.org.findAllOrganizationOfUser(req.permission.id);
@@ -69,6 +72,9 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
+    // Deliberately not open to AuthMode.OAUTH, unlike the rest of this router. There is no org in
+    // context to build a permission against, so nothing narrows the result to what the token was
+    // delegated — a token issued for one org would enumerate every org the user belongs to.
     onRequest: verifyAuth([AuthMode.JWT], { requireOrg: false }),
     handler: async (req) => {
       const organizations = await server.services.org.findAllAccessibleOrganizationsWithSubOrgs(req.permission.id);
@@ -95,7 +101,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const organization = await server.services.org.findOrganizationById({
         userId: req.permission.id,
@@ -125,7 +131,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const authorizations = await server.services.integrationAuth.listOrgIntegrationAuth({
         actorId: req.permission.id,
@@ -243,7 +249,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const auditLogs = await server.services.auditLog.listAuditLogs({
         filter: {
@@ -317,7 +323,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.auditLog.getAuditLogPostgresStorageStatus({
         actor: req.permission.type,
@@ -358,7 +364,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const users = await server.services.org.findAllOrgMembers({
         actor: req.permission.type,
@@ -456,7 +462,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const organization = await server.services.org.updateOrg({
         actor: req.permission.type,
@@ -498,7 +504,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const incidentContactsOrg = await req.server.services.org.findIncidentContacts(
         req.permission.id,
@@ -526,7 +532,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const incidentContactsOrg = await req.server.services.org.createIncidentContact(
         req.permission.id,
@@ -554,7 +560,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const incidentContactsOrg = await req.server.services.org.deleteIncidentContact(
         req.permission.id,
@@ -593,7 +599,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const groups = await server.services.org.getOrgGroups({
         actor: req.permission.type,
@@ -626,7 +632,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { users } = await server.services.membershipUser.listAvailableUsers({
         permission: req.permission,
@@ -658,7 +664,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { identities } = await server.services.membershipIdentity.listAvailableIdentities({
         permission: req.permission,
@@ -713,7 +719,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const stats = await server.services.orgProductStats.getOrgProductStats({
         actorOrgId: req.permission.orgId

--- a/backend/src/server/routes/v1/organization-router.ts
+++ b/backend/src/server/routes/v1/organization-router.ts
@@ -101,7 +101,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
+    onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
       const organization = await server.services.org.findOrganizationById({
         userId: req.permission.id,

--- a/backend/src/server/routes/v1/pki-alert-router.ts
+++ b/backend/src/server/routes/v1/pki-alert-router.ts
@@ -24,7 +24,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createPkiAlertV1",
@@ -98,7 +98,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listPkiAlertsV1",
@@ -171,7 +171,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getPkiAlertV1",
@@ -240,7 +240,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updatePkiAlertV1",
@@ -314,7 +314,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deletePkiAlertV1",
@@ -383,7 +383,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       description: "List certificates that match an alert's filter rules",
@@ -434,7 +434,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "previewPkiAlertCertificatesV1",

--- a/backend/src/server/routes/v1/pki-application-alert-router.ts
+++ b/backend/src/server/routes/v1/pki-application-alert-router.ts
@@ -41,7 +41,7 @@ export const registerPkiApplicationAlertRoutes = async (server: FastifyZodProvid
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiAlertV2.listAlerts({
         actor: req.permission.type,
@@ -74,7 +74,7 @@ export const registerPkiApplicationAlertRoutes = async (server: FastifyZodProvid
       body: BasePkiAlertV2Schema,
       response: { 200: z.object({ alert: PkiAlertV2ResponseSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const alert = await server.services.pkiAlertV2.createAlert({
         actor: req.permission.type,
@@ -133,7 +133,7 @@ export const registerPkiApplicationAlertRoutes = async (server: FastifyZodProvid
       body: UpdatePkiAlertV2Schema,
       response: { 200: z.object({ alert: PkiAlertV2ResponseSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const alert = await server.services.pkiAlertV2.updateAlert({
         actor: req.permission.type,
@@ -190,7 +190,7 @@ export const registerPkiApplicationAlertRoutes = async (server: FastifyZodProvid
       }),
       response: { 200: z.object({ alert: PkiAlertV2ResponseSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const alert = await server.services.pkiAlertV2.deleteAlert({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-enrollment-routers/acme-enrollment-router.ts
+++ b/backend/src/server/routes/v1/pki-application-enrollment-routers/acme-enrollment-router.ts
@@ -40,7 +40,7 @@ export const registerPkiApplicationAcmeEnrollmentRouter = async (server: Fastify
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.setAcmeEnrollment({
         actor: req.permission.type,
@@ -95,7 +95,7 @@ export const registerPkiApplicationAcmeEnrollmentRouter = async (server: Fastify
       params: z.object({ applicationId: z.string().uuid(), profileId: z.string().uuid() }),
       response: { 200: z.object({ applicationId: z.string().uuid(), profileId: z.string().uuid() }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.clearAcmeEnrollment({
         actor: req.permission.type,
@@ -147,7 +147,7 @@ export const registerPkiApplicationAcmeEnrollmentRouter = async (server: Fastify
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.revealAcmeEabSecret({
         actor: req.permission.type,
@@ -182,7 +182,7 @@ export const registerPkiApplicationAcmeEnrollmentRouter = async (server: Fastify
       params: z.object({ applicationId: z.string().uuid(), profileId: z.string().uuid() }),
       response: { 200: z.object({ applicationId: z.string().uuid(), profileId: z.string().uuid() }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.rotateAcmeEabSecret({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-enrollment-routers/api-enrollment-router.ts
+++ b/backend/src/server/routes/v1/pki-application-enrollment-routers/api-enrollment-router.ts
@@ -40,7 +40,7 @@ export const registerPkiApplicationApiEnrollmentRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.setApiEnrollment({
         actor: req.permission.type,
@@ -105,7 +105,7 @@ export const registerPkiApplicationApiEnrollmentRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.clearApiEnrollment({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-enrollment-routers/enrollment-state-router.ts
+++ b/backend/src/server/routes/v1/pki-application-enrollment-routers/enrollment-state-router.ts
@@ -71,7 +71,7 @@ export const registerPkiApplicationEnrollmentStateRouter = async (server: Fastif
       }),
       response: { 200: EnrollmentStateSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.getEnrollment({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-enrollment-routers/est-enrollment-router.ts
+++ b/backend/src/server/routes/v1/pki-application-enrollment-routers/est-enrollment-router.ts
@@ -32,7 +32,7 @@ export const registerPkiApplicationEstEnrollmentRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.setEstEnrollment({
         actor: req.permission.type,
@@ -89,7 +89,7 @@ export const registerPkiApplicationEstEnrollmentRouter = async (server: FastifyZ
         200: z.object({ applicationId: z.string().uuid(), profileId: z.string().uuid() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.clearEstEnrollment({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-enrollment-routers/scep-enrollment-router.ts
+++ b/backend/src/server/routes/v1/pki-application-enrollment-routers/scep-enrollment-router.ts
@@ -38,7 +38,7 @@ export const registerPkiApplicationScepEnrollmentRouter = async (server: Fastify
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.setScepEnrollment({
         actor: req.permission.type,
@@ -96,7 +96,7 @@ export const registerPkiApplicationScepEnrollmentRouter = async (server: Fastify
       params: z.object({ applicationId: z.string().uuid(), profileId: z.string().uuid() }),
       response: { 200: z.object({ applicationId: z.string().uuid(), profileId: z.string().uuid() }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationEnrollment.clearScepEnrollment({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-membership-routers/groups-router.ts
+++ b/backend/src/server/routes/v1/pki-application-membership-routers/groups-router.ts
@@ -30,7 +30,7 @@ export const registerPkiApplicationGroupMembershipRouter = async (server: Fastif
       params: ApplicationIdParamsSchema,
       response: { 200: z.object({ memberships: z.array(ApplicationMemberSchema) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.pkiApplicationMembership.listMembers({
         actor: req.permission.type,
@@ -68,7 +68,7 @@ export const registerPkiApplicationGroupMembershipRouter = async (server: Fastif
       body: RoleBodySchema,
       response: { 200: z.object({ membership: ApplicationMemberSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pkiApplicationMembership.addMember({
         actor: req.permission.type,
@@ -127,7 +127,7 @@ export const registerPkiApplicationGroupMembershipRouter = async (server: Fastif
       body: RoleBodySchema,
       response: { 200: z.object({ membership: ApplicationMemberSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pkiApplicationMembership.updateMemberRole({
         actor: req.permission.type,
@@ -186,7 +186,7 @@ export const registerPkiApplicationGroupMembershipRouter = async (server: Fastif
       params: GroupParamsSchema,
       response: { 200: RemoveResponseSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationMembership.removeMember({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-membership-routers/identities-router.ts
+++ b/backend/src/server/routes/v1/pki-application-membership-routers/identities-router.ts
@@ -30,7 +30,7 @@ export const registerPkiApplicationIdentityMembershipRouter = async (server: Fas
       params: ApplicationIdParamsSchema,
       response: { 200: z.object({ memberships: z.array(ApplicationMemberSchema) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.pkiApplicationMembership.listMembers({
         actor: req.permission.type,
@@ -68,7 +68,7 @@ export const registerPkiApplicationIdentityMembershipRouter = async (server: Fas
       body: RoleBodySchema,
       response: { 200: z.object({ membership: ApplicationMemberSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pkiApplicationMembership.addMember({
         actor: req.permission.type,
@@ -127,7 +127,7 @@ export const registerPkiApplicationIdentityMembershipRouter = async (server: Fas
       body: RoleBodySchema,
       response: { 200: z.object({ membership: ApplicationMemberSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pkiApplicationMembership.updateMemberRole({
         actor: req.permission.type,
@@ -186,7 +186,7 @@ export const registerPkiApplicationIdentityMembershipRouter = async (server: Fas
       params: IdentityParamsSchema,
       response: { 200: RemoveResponseSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationMembership.removeMember({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-membership-routers/users-router.ts
+++ b/backend/src/server/routes/v1/pki-application-membership-routers/users-router.ts
@@ -51,7 +51,7 @@ export const registerPkiApplicationUserMembershipRouter = async (server: Fastify
       params: ApplicationIdParamsSchema,
       response: { 200: z.object({ memberships: z.array(ApplicationMemberSchema) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.pkiApplicationMembership.listMembers({
         actor: req.permission.type,
@@ -90,7 +90,7 @@ export const registerPkiApplicationUserMembershipRouter = async (server: Fastify
       body: AddUsersBodySchema,
       response: { 200: AddUsersResponseSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
       const { emails } = req.body;
@@ -157,7 +157,7 @@ export const registerPkiApplicationUserMembershipRouter = async (server: Fastify
       body: RoleBodySchema,
       response: { 200: z.object({ membership: ApplicationMemberSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.pkiApplicationMembership.updateMemberRole({
         actor: req.permission.type,
@@ -217,7 +217,7 @@ export const registerPkiApplicationUserMembershipRouter = async (server: Fastify
       params: UserParamsSchema,
       response: { 200: RemoveResponseSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplicationMembership.removeMember({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-profile-router.ts
+++ b/backend/src/server/routes/v1/pki-application-profile-router.ts
@@ -25,7 +25,7 @@ export const registerPkiApplicationProfileRoutes = async (server: FastifyZodProv
         200: z.object({ profiles: z.array(ApplicationProfileSchema) })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const profiles = await server.services.pkiApplication.listApplicationProfiles({
         actor: req.permission.type,
@@ -57,7 +57,7 @@ export const registerPkiApplicationProfileRoutes = async (server: FastifyZodProv
         200: z.object({ profiles: z.array(ApplicationProfileSchema) })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const profiles = await server.services.pkiApplication.attachProfiles({
         actor: req.permission.type,
@@ -116,7 +116,7 @@ export const registerPkiApplicationProfileRoutes = async (server: FastifyZodProv
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplication.detachProfile({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-application-router.ts
+++ b/backend/src/server/routes/v1/pki-application-router.ts
@@ -45,7 +45,7 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         200: z.object({ application: PkiApplicationsSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const application = await server.services.pkiApplication.createApplication({
         actor: req.permission.type,
@@ -119,7 +119,7 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiApplication.listApplications({
         actor: req.permission.type,
@@ -160,7 +160,7 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         200: z.object({ application: PkiApplicationsSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const application = await server.services.pkiApplication.getApplicationById({
         actor: req.permission.type,
@@ -198,7 +198,7 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         200: z.object({ application: PkiApplicationsSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const application = await server.services.pkiApplication.getApplicationByName({
         actor: req.permission.type,
@@ -249,7 +249,7 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.pkiApplication.getApplicationPermissions({
         actor: req.permission.type,
@@ -283,7 +283,7 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
         }),
       response: { 200: z.object({ application: PkiApplicationsSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const application = await server.services.pkiApplication.updateApplication({
         actor: req.permission.type,
@@ -332,7 +332,7 @@ export const registerPkiApplicationRouter = async (server: FastifyZodProvider) =
       params: ApplicationIdParamsSchema,
       response: { 200: z.object({ application: PkiApplicationsSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const application = await server.services.pkiApplication.deleteApplication({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/pki-collection-router.ts
+++ b/backend/src/server/routes/v1/pki-collection-router.ts
@@ -15,7 +15,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.PkiCertificateCollections],
@@ -60,7 +60,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getPkiCollection",
@@ -103,7 +103,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updatePkiCollection",
@@ -152,7 +152,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deletePkiCollection",
@@ -195,7 +195,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listPkiCollectionItems",
@@ -259,7 +259,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "addItemToPkiCollection",
@@ -313,7 +313,7 @@ export const registerPkiCollectionRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "removeItemFromPkiCollection",

--- a/backend/src/server/routes/v1/pki-subscriber-router.ts
+++ b/backend/src/server/routes/v1/pki-subscriber-router.ts
@@ -39,7 +39,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
         200: sanitizedPkiSubscriber
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const subscriber = await server.services.pkiSubscriber.getSubscriber({
         subscriberName: req.params.subscriberName,
@@ -202,7 +202,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
         200: sanitizedPkiSubscriber
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const subscriber = await server.services.pkiSubscriber.createSubscriber({
         ...req.body,
@@ -240,7 +240,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updatePkiSubscriber",
@@ -423,7 +423,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
         200: sanitizedPkiSubscriber
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const subscriber = await server.services.pkiSubscriber.deleteSubscriber({
         subscriberName: req.params.subscriberName,
@@ -456,7 +456,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "orderPkiSubscriberCertificate",
@@ -519,7 +519,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "issuePkiSubscriberCertificate",
@@ -592,7 +592,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "signPkiSubscriberCertificate",
@@ -689,7 +689,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req, reply) => {
       const { certificate, certificateChain, serialNumber, cert, privateKey, subscriber } =
         await server.services.pkiSubscriber.getSubscriberActiveCertBundle({
@@ -752,7 +752,7 @@ export const registerPkiSubscriberRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { totalCount, certificates } = await server.services.pkiSubscriber.listSubscriberCerts({
         subscriberName: req.params.subscriberName,

--- a/backend/src/server/routes/v1/pki-sync-routers/aws-elastic-load-balancer-pki-sync-router.ts
+++ b/backend/src/server/routes/v1/pki-sync-routers/aws-elastic-load-balancer-pki-sync-router.ts
@@ -63,7 +63,7 @@ export const registerAwsElasticLoadBalancerPkiSyncRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, region } = req.query;
 
@@ -113,7 +113,7 @@ export const registerAwsElasticLoadBalancerPkiSyncRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId, region, loadBalancerArn } = req.query;
 
@@ -149,7 +149,7 @@ export const registerAwsElasticLoadBalancerPkiSyncRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
       const { certificateId } = req.body;
@@ -197,7 +197,7 @@ export const registerAwsElasticLoadBalancerPkiSyncRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
 

--- a/backend/src/server/routes/v1/pki-sync-routers/kemp-loadmaster-pki-sync-router.ts
+++ b/backend/src/server/routes/v1/pki-sync-routers/kemp-loadmaster-pki-sync-router.ts
@@ -57,7 +57,7 @@ export const registerKempLoadMasterPkiSyncRouter = async (
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { connectionId } = req.query;
 

--- a/backend/src/server/routes/v1/pki-sync-routers/pki-sync-endpoints.ts
+++ b/backend/src/server/routes/v1/pki-sync-routers/pki-sync-endpoints.ts
@@ -74,7 +74,7 @@ export const registerSyncPkiEndpoints = ({
         200: z.object({ pkiSyncs: responseSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.internalCertManagerProjectId;
 
@@ -113,7 +113,7 @@ export const registerSyncPkiEndpoints = ({
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
 
@@ -152,7 +152,7 @@ export const registerSyncPkiEndpoints = ({
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const pkiSync = await server.services.pkiSync.createPkiSync(
         { ...req.body, projectId: req.body.projectId ?? req.internalCertManagerProjectId, destination },
@@ -211,7 +211,7 @@ export const registerSyncPkiEndpoints = ({
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
 
@@ -265,7 +265,7 @@ export const registerSyncPkiEndpoints = ({
         200: responseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
 
@@ -318,7 +318,7 @@ export const registerSyncPkiEndpoints = ({
         200: z.object({ message: z.string() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
 
@@ -353,7 +353,7 @@ export const registerSyncPkiEndpoints = ({
           200: z.object({ message: z.string() })
         }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         const { pkiSyncId } = req.params;
 
@@ -389,7 +389,7 @@ export const registerSyncPkiEndpoints = ({
           200: z.object({ message: z.string() })
         }
       },
-      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+      onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
       handler: async (req) => {
         const { pkiSyncId } = req.params;
 

--- a/backend/src/server/routes/v1/pki-sync-routers/pki-sync-router.ts
+++ b/backend/src/server/routes/v1/pki-sync-routers/pki-sync-router.ts
@@ -124,7 +124,7 @@ export const registerPkiSyncRouter = async (server: FastifyZodProvider, enableOp
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: () => {
       const pkiSyncOptions = server.services.pkiSync.getPkiSyncOptions();
       return { pkiSyncOptions };
@@ -151,7 +151,7 @@ export const registerPkiSyncRouter = async (server: FastifyZodProvider, enableOp
         200: z.object({ pkiSyncs: PkiSyncSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { certificateId, applicationId },
@@ -197,7 +197,7 @@ export const registerPkiSyncRouter = async (server: FastifyZodProvider, enableOp
         200: PkiSyncSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
 
@@ -245,7 +245,7 @@ export const registerPkiSyncRouter = async (server: FastifyZodProvider, enableOp
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
       const { offset, limit } = req.query;
@@ -308,7 +308,7 @@ export const registerPkiSyncRouter = async (server: FastifyZodProvider, enableOp
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
       const { certificateIds } = req.body;
@@ -358,7 +358,7 @@ export const registerPkiSyncRouter = async (server: FastifyZodProvider, enableOp
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiSyncId } = req.params;
       const { certificateIds } = req.body;

--- a/backend/src/server/routes/v1/project-env-router.ts
+++ b/backend/src/server/routes/v1/project-env-router.ts
@@ -39,7 +39,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.getEnvironmentById({
         actorId: req.permission.id,
@@ -90,7 +90,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.getEnvironmentBySlug({
         actorId: req.permission.id,
@@ -148,7 +148,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.createEnvironment({
         actorId: req.permission.id,
@@ -223,7 +223,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { environment, old } = await server.services.projectEnv.updateEnvironment({
         actorId: req.permission.id,
@@ -299,7 +299,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.deleteEnvironment({
         actorId: req.permission.id,
@@ -369,7 +369,7 @@ export const registerProjectEnvRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environment = await server.services.projectEnv.restoreEnvironment({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/project-folder-grant-router.ts
+++ b/backend/src/server/routes/v1/project-folder-grant-router.ts
@@ -28,7 +28,7 @@ export const registerProjectFolderGrantRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const grants = await server.services.projectFolderGrant.listGrantsByProject({
         actorId: req.permission.id,
@@ -63,7 +63,7 @@ export const registerProjectFolderGrantRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const grants = await server.services.projectFolderGrant.listGrantsForTargetProject({
         actorId: req.permission.id,
@@ -91,7 +91,7 @@ export const registerProjectFolderGrantRouter = async (server: FastifyZodProvide
         200: z.object({ grant: ProjectFolderGrantsSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const grant = await server.services.projectFolderGrant.createGrant({
         actorId: req.permission.id,
@@ -138,7 +138,7 @@ export const registerProjectFolderGrantRouter = async (server: FastifyZodProvide
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.projectFolderGrant.getGrantUsage({
         actorId: req.permission.id,
@@ -166,7 +166,7 @@ export const registerProjectFolderGrantRouter = async (server: FastifyZodProvide
         200: z.object({ grant: ProjectFolderGrantsSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const grant = await server.services.projectFolderGrant.deleteGrant({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/project-group-memberships-router.ts
+++ b/backend/src/server/routes/v1/project-group-memberships-router.ts
@@ -53,7 +53,7 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listProjectGroupMemberships",
@@ -97,7 +97,7 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createProjectGroupMembership",
@@ -198,7 +198,7 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getProjectGroupMembership",
@@ -243,7 +243,7 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateProjectGroupMembership",
@@ -325,7 +325,7 @@ export const registerProjectGroupMembershipsRouter = async (server: FastifyZodPr
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "removeProjectGroupMembership",

--- a/backend/src/server/routes/v1/project-identity-router.ts
+++ b/backend/src/server/routes/v1/project-identity-router.ts
@@ -42,7 +42,7 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "createProjectMachineIdentity",
@@ -135,7 +135,7 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "updateProjectMachineIdentity",
@@ -204,7 +204,7 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "deleteProjectMachineIdentity",
@@ -260,7 +260,7 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "getProjectMachineIdentityById",
@@ -304,7 +304,7 @@ export const registerProjectIdentityRouter = async (server: FastifyZodProvider) 
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listProjectMachineIdentities",

--- a/backend/src/server/routes/v1/project-key-router.ts
+++ b/backend/src/server/routes/v1/project-key-router.ts
@@ -29,7 +29,7 @@ export const registerProjectKeyRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.projectKey.uploadProjectKeys({
         projectId: req.params.workspaceId,

--- a/backend/src/server/routes/v1/project-membership-router.ts
+++ b/backend/src/server/routes/v1/project-membership-router.ts
@@ -61,7 +61,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { data: memberships } = await server.services.membershipUser.listMemberships({
         permission: req.permission,
@@ -107,7 +107,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId } = await server.services.convertor.userMembershipIdToUserId(
         req.params.membershipId,
@@ -161,7 +161,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.membershipUser.getMembershipByUserId({
         permission: req.permission,
@@ -216,7 +216,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId } = await server.services.convertor.userMembershipIdToUserId(
         req.params.membershipId,
@@ -277,7 +277,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.projectMembership.getProjectMembershipByUsername({
         actorId: req.permission.id,
@@ -332,7 +332,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const usernamesAndEmails = [...req.body.emails, ...req.body.usernames];
 
@@ -444,7 +444,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId } = await server.services.convertor.userMembershipIdToUserId(
         req.params.membershipId,
@@ -522,7 +522,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.projectMembership.deleteProjectMemberships({
         actorId: req.permission.id,
@@ -593,7 +593,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { userId } = await server.services.convertor.userMembershipIdToUserId(
         req.params.membershipId,
@@ -663,7 +663,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
       }
     },
 
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.projectMembership.leaveProject({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/project-membership-router.ts
+++ b/backend/src/server/routes/v1/project-membership-router.ts
@@ -663,7 +663,7 @@ export const registerProjectMembershipRouter = async (server: FastifyZodProvider
       }
     },
 
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
+    onRequest: verifyAuth([AuthMode.JWT]),
     handler: async (req) => {
       const membership = await server.services.projectMembership.leaveProject({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -97,7 +97,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.project.getMyPendingProjectAccessRequests({
         permission: req.permission
@@ -168,7 +168,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const roles = (req.query.roles?.split(",") || []).filter(Boolean);
       const users = await server.services.projectMembership.getProjectMemberships({
@@ -229,7 +229,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const project = await server.services.project.createProject({
         actorId: req.permission.id,
@@ -308,7 +308,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projects = await server.services.project.getProjects({
         includeRoles: req.query.includeRoles,
@@ -347,7 +347,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const project = await server.services.project.getAProject({
         filter: {
@@ -386,7 +386,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         200: projectWithEnv
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const project = await server.services.project.getAProject({
         filter: {
@@ -429,7 +429,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       // Soft delete: returns fast (single UPDATE). The async cleanup worker hard-deletes the project
       // after its grace period.
@@ -524,7 +524,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const project = await server.services.project.updateProject({
         filter: {
@@ -590,7 +590,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.project.enableSecretBlindIndex({
         projectId: req.params.projectId,
@@ -630,7 +630,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.project.getSecretBlindIndexMigrationStatus({
         projectId: req.params.projectId,
@@ -663,7 +663,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const project = await server.services.project.updateAuditLogsRetention({
         actorId: req.permission.id,
@@ -727,7 +727,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const integrations = await server.services.integration.listIntegrationByProject({
         actorId: req.permission.id,
@@ -765,7 +765,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const authorizations = await server.services.integrationAuth.listIntegrationAuthByProjectId({
         actorId: req.permission.id,
@@ -795,7 +795,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const serviceTokenData = await server.services.serviceToken.getProjectServiceTokens({
         actorId: req.permission.id,
@@ -851,7 +851,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const config = await server.services.project.getProjectWorkflowIntegrationConfig({
         actorId: req.permission.id,
@@ -899,7 +899,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const deletedIntegration = await server.services.project.deleteProjectWorkflowIntegration({
         actorId: req.permission.id,
@@ -979,7 +979,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workflowIntegrationConfig = await server.services.project.updateProjectWorkflowIntegration({
         actorId: req.permission.id,
@@ -1028,7 +1028,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         )
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const environmentsFolders = await server.services.folder.getProjectEnvironmentsFolders(
         req.params.projectId,
@@ -1072,7 +1072,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { docs: projects, totalCount } = await server.services.project.searchProjects({
         permission: req.permission,
@@ -1103,7 +1103,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.project.requestProjectAccess({
         permission: req.permission,
@@ -1149,7 +1149,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         200: z.void()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.project.upgradeProject({
         actorId: req.permission.id,
@@ -1180,7 +1180,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const status = await server.services.project.getProjectUpgradeStatus({
         actorAuthMethod: req.permission.authMethod,
@@ -1220,7 +1220,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const cas = await server.services.project.listProjectCas({
         filter: {
@@ -1279,7 +1279,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { certificates, totalCount } = await server.services.project.listProjectCertificates({
         filter: {
@@ -1377,7 +1377,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { metadata, sortBy, sortOrder, ...filters } = req.body;
       const { certificates, totalCount } = await server.services.project.listProjectCertificates({
@@ -1434,7 +1434,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.project.getDashboardStats({
         filter: {
@@ -1480,7 +1480,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.project.getActivityTrend({
         filter: {
@@ -1525,7 +1525,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.project.getPqcTrend({
         filter: {
@@ -1560,7 +1560,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { alerts } = await server.services.project.listProjectAlerts({
         projectId: req.params.projectId,
@@ -1593,7 +1593,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiCollections } = await server.services.project.listProjectPkiCollections({
         projectId: req.params.projectId,
@@ -1626,7 +1626,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const subscribers = await server.services.project.listProjectPkiSubscribers({
         actorId: req.permission.id,
@@ -1659,7 +1659,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { certificateTemplates } = await server.services.project.listProjectCertificateTemplates({
         projectId: req.params.projectId,

--- a/backend/src/server/routes/v1/reminder-routers/secret-reminder-router.ts
+++ b/backend/src/server/routes/v1/reminder-routers/secret-reminder-router.ts
@@ -36,7 +36,7 @@ export const registerSecretReminderRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.reminder.createReminder({
         actorId: req.permission.id,
@@ -105,7 +105,7 @@ export const registerSecretReminderRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const reminder = await server.services.reminder.getReminder({
         actorId: req.permission.id,
@@ -146,7 +146,7 @@ export const registerSecretReminderRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.reminder.deleteReminder({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/secret-requests-router.ts
+++ b/backend/src/server/routes/v1/secret-requests-router.ts
@@ -178,7 +178,7 @@ export const registerSecretRequestsRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const secretRequest = await req.server.services.secretSharing.revealSecretRequestValue({
         id: req.params.id,
@@ -215,7 +215,7 @@ export const registerSecretRequestsRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const secretRequest = await req.server.services.secretSharing.deleteSharedSecretById({
         actorOrgId: req.permission.orgId,
@@ -260,7 +260,7 @@ export const registerSecretRequestsRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secrets, totalCount } = await req.server.services.secretSharing.getSharedSecrets({
         actor: req.permission.type,
@@ -325,7 +325,7 @@ export const registerSecretRequestsRouter = async (server: FastifyZodProvider) =
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const shareRequest = await req.server.services.secretSharing.createSecretRequest({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -59,7 +59,7 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secrets, totalCount } = await req.server.services.secretSharing.getSharedSecrets({
         actor: req.permission.type,
@@ -347,7 +347,7 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { authorizedEmails, ...restBody } = req.body;
       const sharedSecret = await req.server.services.secretSharing.createSharedSecret({
@@ -410,7 +410,7 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
         200: SanitizedSecretSharingSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { id } = req.params;
       const deletedSharedSecret = await req.server.services.secretSharing.deleteSharedSecretById({
@@ -493,7 +493,7 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { assetType } = req.params;
       const file = await req.file();
@@ -555,7 +555,7 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { assetType } = req.params;
 
@@ -628,7 +628,7 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
         assetType: z.enum(["brand-logo", "brand-favicon"])
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req, res) => {
       const { assetType } = req.params;
 

--- a/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
+++ b/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
@@ -76,7 +76,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSyncs: responseSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId }
@@ -122,7 +122,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSync: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { syncId } = req.params;
 
@@ -172,7 +172,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSync: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { syncName } = req.params;
       const { projectId } = req.query;
@@ -216,7 +216,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSync: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const secretSync = (await server.services.secretSync.createSecretSync(
         { ...req.body, destination },
@@ -276,7 +276,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSync: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { syncId } = req.params;
 
@@ -344,7 +344,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSync: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { syncId } = req.params;
       const { removeSecrets } = req.query;
@@ -406,7 +406,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSync: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { syncId } = req.params;
 
@@ -446,7 +446,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSync: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { syncId } = req.params;
       const { importBehavior } = req.query;
@@ -483,7 +483,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         200: z.object({ secretSync: responseSchema })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { syncId } = req.params;
 
@@ -523,7 +523,7 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { destinationConfig, connectionId, excludeSyncId, projectId } = req.body;
 

--- a/backend/src/server/routes/v1/secret-sync-routers/secret-sync-router.ts
+++ b/backend/src/server/routes/v1/secret-sync-routers/secret-sync-router.ts
@@ -201,7 +201,7 @@ export const registerSecretSyncRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: () => {
       const secretSyncOptions = server.services.secretSync.listSecretSyncOptions();
       return { secretSyncOptions };
@@ -226,7 +226,7 @@ export const registerSecretSyncRouter = async (server: FastifyZodProvider) => {
         200: z.object({ secretSyncs: SecretSyncSchema.array() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const {
         query: { projectId },

--- a/backend/src/server/routes/v1/secret-tag-router.ts
+++ b/backend/src/server/routes/v1/secret-tag-router.ts
@@ -29,7 +29,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const tags = await server.services.secretTag.getProjectTags({
         actor: req.permission.type,
@@ -63,7 +63,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const tag = await server.services.secretTag.getTagById({
         actor: req.permission.type,
@@ -97,7 +97,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const tag = await server.services.secretTag.getTagBySlug({
         actor: req.permission.type,
@@ -134,7 +134,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const tag = await server.services.secretTag.createTag({
         actor: req.permission.type,
@@ -182,7 +182,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const tag = await server.services.secretTag.updateTag({
         actor: req.permission.type,
@@ -229,7 +229,7 @@ export const registerSecretTagRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const tag = await server.services.secretTag.deleteTag({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/secret-validation-rule-router.ts
+++ b/backend/src/server/routes/v1/secret-validation-rule-router.ts
@@ -32,7 +32,7 @@ export const registerSecretValidationRuleRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const rules = await server.services.secretValidationRule.listByProjectId({
         actor: req.permission.type,
@@ -77,7 +77,7 @@ export const registerSecretValidationRuleRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const rule = await server.services.secretValidationRule.createRule({
         actor: req.permission.type,
@@ -163,7 +163,7 @@ export const registerSecretValidationRuleRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const rule = await server.services.secretValidationRule.updateRule({
         actor: req.permission.type,
@@ -227,7 +227,7 @@ export const registerSecretValidationRuleRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const rule = await server.services.secretValidationRule.deleteRule({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/signer-membership-routers/groups-router.ts
+++ b/backend/src/server/routes/v1/signer-membership-routers/groups-router.ts
@@ -30,7 +30,7 @@ export const registerSignerGroupMembershipRouter = async (server: FastifyZodProv
       params: SignerIdParamsSchema,
       response: { 200: z.object({ memberships: z.array(SignerMemberSchema) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.signerMembership.listMembers({
         actor: req.permission.type,
@@ -58,7 +58,7 @@ export const registerSignerGroupMembershipRouter = async (server: FastifyZodProv
       body: z.object({ groupId: z.string().uuid(), role: SignerRoleSchema.default("operator") }),
       response: { 200: SignerMemberSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.signerMembership.addMember({
         actor: req.permission.type,
@@ -115,7 +115,7 @@ export const registerSignerGroupMembershipRouter = async (server: FastifyZodProv
       body: RoleBodySchema,
       response: { 200: z.object({ membership: SignerMemberSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.signerMembership.updateMemberRole({
         actor: req.permission.type,
@@ -172,7 +172,7 @@ export const registerSignerGroupMembershipRouter = async (server: FastifyZodProv
       params: z.object({ signerId: z.string().uuid(), groupId: z.string().uuid() }),
       response: { 200: RemoveSignerMemberResponseSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.signerMembership.removeMember({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/signer-membership-routers/identities-router.ts
+++ b/backend/src/server/routes/v1/signer-membership-routers/identities-router.ts
@@ -31,7 +31,7 @@ export const registerSignerIdentityMembershipRouter = async (server: FastifyZodP
       params: SignerIdParamsSchema,
       response: { 200: z.object({ memberships: z.array(SignerMemberSchema) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.signerMembership.listMembers({
         actor: req.permission.type,
@@ -59,7 +59,7 @@ export const registerSignerIdentityMembershipRouter = async (server: FastifyZodP
       body: z.object({ identityId: z.string().uuid(), role: SignerRoleSchema.default("operator") }),
       response: { 200: SignerMemberSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.signerMembership.addMember({
         actor: req.permission.type,
@@ -116,7 +116,7 @@ export const registerSignerIdentityMembershipRouter = async (server: FastifyZodP
       body: RoleBodySchema,
       response: { 200: z.object({ membership: SignerMemberSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.signerMembership.updateMemberRole({
         actor: req.permission.type,
@@ -173,7 +173,7 @@ export const registerSignerIdentityMembershipRouter = async (server: FastifyZodP
       params: z.object({ signerId: z.string().uuid(), identityId: z.string().uuid() }),
       response: { 200: RemoveSignerMemberResponseSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.signerMembership.removeMember({
         actor: req.permission.type,
@@ -224,7 +224,7 @@ export const registerSignerIdentityMembershipRouter = async (server: FastifyZodP
       params: SignerIdParamsSchema,
       response: { 200: z.object({ members: z.array(EffectiveSignerMemberSchema) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const members = await server.services.signerMembership.listEffectiveMembers({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/signer-membership-routers/users-router.ts
+++ b/backend/src/server/routes/v1/signer-membership-routers/users-router.ts
@@ -31,7 +31,7 @@ export const registerSignerUserMembershipRouter = async (server: FastifyZodProvi
       params: SignerIdParamsSchema,
       response: { 200: z.object({ memberships: z.array(SignerMemberSchema) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.signerMembership.listMembers({
         actor: req.permission.type,
@@ -78,7 +78,7 @@ export const registerSignerUserMembershipRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.signerMembership.addUserMembers({
         actor: req.permission.type,
@@ -137,7 +137,7 @@ export const registerSignerUserMembershipRouter = async (server: FastifyZodProvi
       body: RoleBodySchema,
       response: { 200: z.object({ membership: SignerMemberSchema }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.signerMembership.updateMemberRole({
         actor: req.permission.type,
@@ -194,7 +194,7 @@ export const registerSignerUserMembershipRouter = async (server: FastifyZodProvi
       params: z.object({ signerId: z.string().uuid(), userId: z.string().uuid() }),
       response: { 200: RemoveSignerMemberResponseSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.signerMembership.removeMember({
         actor: req.permission.type,
@@ -245,7 +245,7 @@ export const registerSignerUserMembershipRouter = async (server: FastifyZodProvi
       params: SignerIdParamsSchema,
       response: { 200: z.object({ members: z.array(EffectiveSignerMemberSchema) }) }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const members = await server.services.signerMembership.listEffectiveMembers({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/signer-routers/approval-policy-router.ts
+++ b/backend/src/server/routes/v1/signer-routers/approval-policy-router.ts
@@ -32,7 +32,7 @@ export const registerSignerApprovalPolicyRouter = async (server: FastifyZodProvi
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.signerPolicy.getPolicy({
         signerId: req.params.signerId,
@@ -56,7 +56,7 @@ export const registerSignerApprovalPolicyRouter = async (server: FastifyZodProvi
       params: SignerIdParamsSchema,
       body: ApprovalPolicyBodySchema
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const policy = await server.services.signerPolicy.updatePolicy({
         signerId: req.params.signerId,

--- a/backend/src/server/routes/v1/signer-routers/certificate-router.ts
+++ b/backend/src/server/routes/v1/signer-routers/certificate-router.ts
@@ -59,7 +59,7 @@ export const registerSignerCertificateRouter = async (server: FastifyZodProvider
         }),
       response: { 200: PkiSignersSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const signer = await server.services.pkiSigner.reissueCertificate({
         signerId: req.params.signerId,
@@ -110,7 +110,7 @@ export const registerSignerCertificateRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { certificatePem, serialNumber, signerName, projectId } = await server.services.pkiSigner.exportCertificate(
         {

--- a/backend/src/server/routes/v1/signer-routers/lifecycle-router.ts
+++ b/backend/src/server/routes/v1/signer-routers/lifecycle-router.ts
@@ -101,7 +101,7 @@ export const registerSignerLifecycleRouter = async (server: FastifyZodProvider) 
         200: PkiSignersSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const signer = await server.services.pkiSigner.create({
         ...req.body,
@@ -173,7 +173,7 @@ export const registerSignerLifecycleRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const projectId = req.query.projectId ?? req.internalCertManagerProjectId;
       const { signers, totalCount } = await server.services.pkiSigner.list({
@@ -216,7 +216,7 @@ export const registerSignerLifecycleRouter = async (server: FastifyZodProvider) 
         200: SignerWithCertificateResponseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const signer = await server.services.pkiSigner.getById({
         signerId: req.params.signerId,
@@ -269,7 +269,7 @@ export const registerSignerLifecycleRouter = async (server: FastifyZodProvider) 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.pkiSigner.getMyPermissions({
         signerId: req.params.signerId,
@@ -297,7 +297,7 @@ export const registerSignerLifecycleRouter = async (server: FastifyZodProvider) 
         200: SignerWithCertificateResponseSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const signer = await server.services.pkiSigner.checkIssuanceNow({
         signerId: req.params.signerId,
@@ -329,7 +329,7 @@ export const registerSignerLifecycleRouter = async (server: FastifyZodProvider) 
         200: PkiSignersSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const signer = await server.services.pkiSigner.update({
         signerId: req.params.signerId,
@@ -381,7 +381,7 @@ export const registerSignerLifecycleRouter = async (server: FastifyZodProvider) 
         200: PkiSignersSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const signer = await server.services.pkiSigner.delete({
         signerId: req.params.signerId,
@@ -431,7 +431,7 @@ export const registerSignerLifecycleRouter = async (server: FastifyZodProvider) 
       body: z.object({ status: z.enum(["active", "disabled"]) }),
       response: { 200: PkiSignersSchema }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const wantDisabled = req.body.status === "disabled";
       const signer = wantDisabled

--- a/backend/src/server/routes/v1/signer-routers/operations-router.ts
+++ b/backend/src/server/routes/v1/signer-routers/operations-router.ts
@@ -38,7 +38,7 @@ export const registerSignerOperationsRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiSigner.listOperations({
         signerId: req.params.signerId,

--- a/backend/src/server/routes/v1/signer-routers/requests-router.ts
+++ b/backend/src/server/routes/v1/signer-routers/requests-router.ts
@@ -37,7 +37,7 @@ export const registerSignerRequestsRouter = async (server: FastifyZodProvider) =
         limit: z.coerce.number().int().min(1).max(100).default(25)
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       return server.services.signerPolicy.listRequests({
         signerId: req.params.signerId,
@@ -69,7 +69,7 @@ export const registerSignerRequestsRouter = async (server: FastifyZodProvider) =
         requestedWindowEnd: z.string().datetime().optional()
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const request = await server.services.signerPolicy.requestToSign({
         signerId: req.params.signerId,
@@ -112,7 +112,7 @@ export const registerSignerRequestsRouter = async (server: FastifyZodProvider) =
         requestedWindowEnd: z.string().datetime().optional()
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.signerPolicy.preApproveSigning({
         signerId: req.params.signerId,
@@ -152,7 +152,7 @@ export const registerSignerRequestsRouter = async (server: FastifyZodProvider) =
       description: "Revoke a pending or active signing request",
       params: z.object({ signerId: z.string().uuid(), requestId: z.string().uuid() })
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.signerPolicy.revokeRequest({
         signerId: req.params.signerId,

--- a/backend/src/server/routes/v1/signer-routers/signing-router.ts
+++ b/backend/src/server/routes/v1/signer-routers/signing-router.ts
@@ -5,6 +5,7 @@ import { ApiDocsTags } from "@app/lib/api-docs";
 import { SigningAlgorithm } from "@app/lib/crypto/sign/types";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
+import { isUserSessionAuth } from "@app/server/plugins/auth/inject-identity";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
@@ -42,10 +43,10 @@ export const registerSignerSigningRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       let actorName: string | undefined;
-      if (req.auth.authMode === AuthMode.JWT) {
+      if (isUserSessionAuth(req.auth)) {
         actorName = `${req.auth.user.firstName ?? ""} ${req.auth.user.lastName ?? ""}`.trim() || undefined;
       } else if (req.auth.authMode === AuthMode.IDENTITY_ACCESS_TOKEN) {
         actorName = req.auth.identityName ?? undefined;
@@ -106,7 +107,7 @@ export const registerSignerSigningRouter = async (server: FastifyZodProvider) =>
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.pkiSigner.getPublicKey({
         signerId: req.params.signerId,

--- a/backend/src/server/routes/v1/slack-router.ts
+++ b/backend/src/server/routes/v1/slack-router.ts
@@ -43,7 +43,7 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
         200: z.string()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const url = await server.services.slack.getInstallUrl({
         actor: req.permission.type,
@@ -89,7 +89,7 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
         200: z.string()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const url = await server.services.slack.getReinstallUrl({
         actor: req.permission.type,
@@ -131,7 +131,7 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
         200: sanitizedSlackIntegrationSchema.array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const slackIntegrations = await server.services.slack.getSlackIntegrationsByOrg({
         actor: req.permission.type,
@@ -164,7 +164,7 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
         200: sanitizedSlackIntegrationSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const deletedSlackIntegration = await server.services.slack.deleteSlackIntegration({
         actor: req.permission.type,
@@ -209,7 +209,7 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
         200: sanitizedSlackIntegrationSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const slackIntegration = await server.services.slack.getSlackIntegrationById({
         actor: req.permission.type,
@@ -259,7 +259,7 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
           .array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const slackChannels = await server.services.slack.getSlackIntegrationChannels({
         actor: req.permission.type,
@@ -297,7 +297,7 @@ export const registerSlackRouter = async (server: FastifyZodProvider) => {
         200: sanitizedSlackIntegrationSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const slackIntegration = await server.services.slack.updateSlackIntegration({
         actor: req.permission.type,

--- a/backend/src/server/routes/v1/webhook-router.ts
+++ b/backend/src/server/routes/v1/webhook-router.ts
@@ -45,7 +45,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "createWebhook",
       body: z
@@ -133,7 +133,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "updateWebhook",
       params: z.object({
@@ -208,7 +208,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "deleteWebhook",
       params: z.object({
@@ -257,7 +257,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "testWebhook",
       params: z.object({
@@ -288,7 +288,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "getWebhookById",
       params: z.object({
@@ -318,7 +318,7 @@ export const registerWebhookRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "listWebhooks",
       querystring: z.object({

--- a/backend/src/server/routes/v1/workflow-integration-router.ts
+++ b/backend/src/server/routes/v1/workflow-integration-router.ts
@@ -29,7 +29,7 @@ export const registerWorkflowIntegrationRouter = async (server: FastifyZodProvid
         200: sanitizedWorkflowIntegrationSchema.array()
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workflowIntegrations = await server.services.workflowIntegration.getIntegrationsByOrg({
         actor: req.permission.type,

--- a/backend/src/server/routes/v2/certificate-authority-router.ts
+++ b/backend/src/server/routes/v2/certificate-authority-router.ts
@@ -36,7 +36,7 @@ export const registerCaRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listCertificateAuthoritiesV2",

--- a/backend/src/server/routes/v2/deprecated-group-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-group-project-router.ts
@@ -23,7 +23,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
   server.route({
     method: "POST",
     url: "/:projectId/groups/:groupIdOrName",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: writeLimit
     },
@@ -130,7 +130,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
   server.route({
     method: "PATCH",
     url: "/:projectId/groups/:groupId",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectGroups],
@@ -214,7 +214,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
   server.route({
     method: "DELETE",
     url: "/:projectId/groups/:groupId",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: writeLimit
     },
@@ -275,7 +275,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
   server.route({
     method: "GET",
     url: "/:projectId/groups",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: readLimit
     },
@@ -337,7 +337,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
   server.route({
     method: "GET",
     url: "/:projectId/groups/:groupId",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: readLimit
     },
@@ -406,7 +406,7 @@ export const registerDeprecatedGroupProjectRouter = async (server: FastifyZodPro
   server.route({
     method: "GET",
     url: "/:projectId/groups/:groupId/users",
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     config: {
       rateLimit: readLimit
     },

--- a/backend/src/server/routes/v2/deprecated-identity-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-identity-project-router.ts
@@ -26,7 +26,7 @@ export const registerDeprecatedIdentityProjectRouter = async (server: FastifyZod
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -108,7 +108,7 @@ export const registerDeprecatedIdentityProjectRouter = async (server: FastifyZod
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -187,7 +187,7 @@ export const registerDeprecatedIdentityProjectRouter = async (server: FastifyZod
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -232,7 +232,7 @@ export const registerDeprecatedIdentityProjectRouter = async (server: FastifyZod
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -327,7 +327,7 @@ export const registerDeprecatedIdentityProjectRouter = async (server: FastifyZod
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],
@@ -389,7 +389,7 @@ export const registerDeprecatedIdentityProjectRouter = async (server: FastifyZod
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       tags: [ApiDocsTags.ProjectIdentities],

--- a/backend/src/server/routes/v2/deprecated-project-membership-router.ts
+++ b/backend/src/server/routes/v2/deprecated-project-membership-router.ts
@@ -48,7 +48,7 @@ export const registerDeprecatedProjectMembershipRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const usernamesAndEmails = [...req.body.emails, ...req.body.usernames];
 
@@ -141,7 +141,7 @@ export const registerDeprecatedProjectMembershipRouter = async (server: FastifyZ
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.projectMembership.deleteProjectMemberships({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v2/deprecated-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-project-router.ts
@@ -53,7 +53,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         )
       }
     },
-    onResponse: verifyAuth([AuthMode.JWT, AuthMode.API_KEY]),
+    onResponse: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.OAUTH]),
     handler: async (req) => {
       const key = await server.services.projectKey.getLatestProjectKey({
         actor: req.permission.type,
@@ -122,7 +122,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const project = await server.services.project.createProject({
         actorId: req.permission.id,
@@ -191,7 +191,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         200: SanitizedProjectSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
 
     handler: async (req) => {
       const project = await server.services.project.deleteProject({
@@ -244,7 +244,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         200: projectWithEnv
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const project = await server.services.project.getAProject({
         filter: {
@@ -293,7 +293,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         200: SanitizedProjectSchema
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const project = await server.services.project.updateProject({
         filter: {
@@ -352,7 +352,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const cas = await server.services.project.listProjectCas({
         filter: {
@@ -397,7 +397,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { certificates, totalCount } = await server.services.project.listProjectCertificates({
         filter: {
@@ -433,7 +433,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { alerts } = await server.services.project.listProjectAlerts({
         projectId: req.params.projectId,
@@ -465,7 +465,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { pkiCollections } = await server.services.project.listProjectPkiCollections({
         projectId: req.params.projectId,
@@ -497,7 +497,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const subscribers = await server.services.project.listProjectPkiSubscribers({
         actorId: req.permission.id,
@@ -529,7 +529,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { certificateTemplates } = await server.services.project.listProjectCertificateTemplates({
         projectId: req.params.projectId,

--- a/backend/src/server/routes/v2/identity-org-router.ts
+++ b/backend/src/server/routes/v2/identity-org-router.ts
@@ -15,7 +15,7 @@ export const registerIdentityOrgRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "listOrgIdentityMemberships",

--- a/backend/src/server/routes/v2/identity-router.ts
+++ b/backend/src/server/routes/v2/identity-router.ts
@@ -65,7 +65,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "searchMachineIdentitiesV2",
@@ -166,7 +166,7 @@ export const registerIdentityRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       hide: false,
       operationId: "countMachineIdentitiesV2",

--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -427,9 +427,9 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    // Deliberately not open to AuthMode.OAUTH, unlike the rest of this router. Creating an org needs
-    // no org permission, so nothing here is scope-narrowed and a delegated token would be able to
-    // stand up an org the client was never granted anything in.
+    // Not open to AuthMode.OAUTH, unlike the rest of this router: creating an org needs no org
+    // permission, so nothing here is scope-narrowed and a delegated token could stand up an org the
+    // client was never granted anything in.
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY], { requireOrg: false }),
     handler: async (req) => {
       if (req.auth.actor !== ActorType.USER) return;

--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -46,7 +46,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const users = await server.services.org.findAllOrgMembers({
         actor: req.permission.type,
@@ -98,7 +98,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const workspaces = await server.services.org.findAllWorkspaces({
         actor: req.permission.type,
@@ -147,7 +147,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const membership = await server.services.org.getOrgMembership({
         actor: req.permission.type,
@@ -198,7 +198,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       if (req.auth.actor !== ActorType.USER) return;
 
@@ -260,7 +260,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       if (req.auth.actor !== ActorType.USER) return;
 
@@ -320,7 +320,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       if (req.auth.actor !== ActorType.USER) return;
 
@@ -396,7 +396,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const memberships = await server.services.org.listProjectMembershipsByOrgMembershipId({
         actor: req.permission.type,
@@ -427,6 +427,9 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
+    // Deliberately not open to AuthMode.OAUTH, unlike the rest of this router. Creating an org needs
+    // no org permission, so nothing here is scope-narrowed and a delegated token would be able to
+    // stand up an org the client was never granted anything in.
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY], { requireOrg: false }),
     handler: async (req) => {
       if (req.auth.actor !== ActorType.USER) return;
@@ -468,7 +471,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.OAUTH]),
     handler: async (req, res) => {
       if (req.auth.actor !== ActorType.USER) return;
 
@@ -511,7 +514,7 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const organization = await server.services.org.upgradePrivilegeSystem({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v2/pki-alert-router.ts
+++ b/backend/src/server/routes/v2/pki-alert-router.ts
@@ -24,7 +24,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "createPkiAlert",
       description: "Create a new PKI alert",
@@ -96,7 +96,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "listPkiAlerts",
       description: "List PKI alerts for a project",
@@ -169,7 +169,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "getPkiAlert",
       description: "Get a PKI alert by ID",
@@ -236,7 +236,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "updatePkiAlert",
       description: "Update a PKI alert",
@@ -308,7 +308,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "deletePkiAlert",
       description: "Delete a PKI alert",
@@ -375,7 +375,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: readLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "listPkiAlertCertificates",
       description: "List certificates that match an alert's filter rules",
@@ -426,7 +426,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "previewPkiAlertCertificates",
       description: "Preview certificates that would match the given filter rules",
@@ -481,7 +481,7 @@ export const registerPkiAlertRouter = async (server: FastifyZodProvider) => {
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     schema: {
       operationId: "testPkiAlertWebhook",
       description: "Test a webhook configuration by sending a test payload",

--- a/backend/src/server/routes/v2/pki-templates-router.ts
+++ b/backend/src/server/routes/v2/pki-templates-router.ts
@@ -45,7 +45,7 @@ export const registerPkiTemplatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateTemplate = await server.services.pkiTemplate.createTemplate({
         actor: req.permission.type,
@@ -95,7 +95,7 @@ export const registerPkiTemplatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateTemplate = await server.services.pkiTemplate.updateTemplate({
         actor: req.permission.type,
@@ -132,7 +132,7 @@ export const registerPkiTemplatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateTemplate = await server.services.pkiTemplate.deleteTemplate({
         actor: req.permission.type,
@@ -171,7 +171,7 @@ export const registerPkiTemplatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateTemplate = await server.services.pkiTemplate.getTemplateByName({
         actor: req.permission.type,
@@ -210,7 +210,7 @@ export const registerPkiTemplatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { certificateTemplates, totalCount } = await server.services.pkiTemplate.listTemplate({
         actor: req.permission.type,
@@ -257,7 +257,7 @@ export const registerPkiTemplatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.pkiTemplate.issueCertificate({
         actor: req.permission.type,
@@ -299,7 +299,7 @@ export const registerPkiTemplatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.pkiTemplate.signCertificate({
         actor: req.permission.type,

--- a/backend/src/server/routes/v2/secret-folder-router.ts
+++ b/backend/src/server/routes/v2/secret-folder-router.ts
@@ -57,7 +57,13 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const folder = await server.services.folder.createFolder({
         actorId: req.permission.id,
@@ -145,7 +151,13 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { folder, old } = await server.services.folder.updateFolder({
         actorId: req.permission.id,
@@ -234,7 +246,13 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { newFolders, oldFolders, projectId } = await server.services.folder.updateManyFolders({
         ...req.body,
@@ -305,7 +323,13 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const folder = await server.services.folder.deleteFolder({
         actorId: req.permission.id,
@@ -383,7 +407,13 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const folders = await server.services.folder.getFolders({
         actorId: req.permission.id,
@@ -429,7 +459,13 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const folder = await server.services.folder.getFolderById({
         actorId: req.permission.id,
@@ -474,7 +510,7 @@ export const registerSecretFolderRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.folder.moveFolder({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v2/secret-import-router.ts
+++ b/backend/src/server/routes/v2/secret-import-router.ts
@@ -51,7 +51,13 @@ export const registerSecretImportRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImport = await server.services.secretImport.createImport({
         actorId: req.permission.id,
@@ -141,7 +147,13 @@ export const registerSecretImportRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImport = await server.services.secretImport.updateImport({
         actorId: req.permission.id,
@@ -217,7 +229,13 @@ export const registerSecretImportRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImport = await server.services.secretImport.deleteImport({
         actorId: req.permission.id,
@@ -286,7 +304,7 @@ export const registerSecretImportRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { message } = await server.services.secretImport.resyncSecretImportReplication({
         actorId: req.permission.id,
@@ -340,7 +358,13 @@ export const registerSecretImportRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImports = await server.services.secretImport.getImports({
         actorId: req.permission.id,
@@ -402,7 +426,13 @@ export const registerSecretImportRouter = async (server: FastifyZodProvider) => 
       }
     },
 
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretImport = await server.services.secretImport.getImportById({
         actorId: req.permission.id,
@@ -461,7 +491,13 @@ export const registerSecretImportRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const importedSecrets = await server.services.secretImport.getRawSecretsFromImports({
         actorId: req.permission.id,

--- a/backend/src/server/routes/v2/service-token-router.ts
+++ b/backend/src/server/routes/v2/service-token-router.ts
@@ -82,7 +82,7 @@ export const registerServiceTokenRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "createServiceToken",
       body: z.object({
@@ -139,7 +139,7 @@ export const registerServiceTokenRouter = async (server: FastifyZodProvider) => 
     config: {
       rateLimit: writeLimit
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     schema: {
       operationId: "deleteServiceToken",
       params: z.object({

--- a/backend/src/server/routes/v3/deprecated-certificates-router.ts
+++ b/backend/src/server/routes/v3/deprecated-certificates-router.ts
@@ -111,7 +111,7 @@ export const registerCertificatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateRequestForService: CertificateRequestForService = {
         commonName: req.body.commonName,
@@ -240,7 +240,7 @@ export const registerCertificatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await server.services.certificateV3.signCertificateFromProfile({
         actor: req.permission.type,
@@ -371,7 +371,7 @@ export const registerCertificatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const certificateOrderObject = {
         altNames: req.body.subjectAlternativeNames,
@@ -465,7 +465,7 @@ export const registerCertificatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const originalCertificate = await server.services.certificate.getCert({
         actor: req.permission.type,
@@ -540,7 +540,7 @@ export const registerCertificatesRouter = async (server: FastifyZodProvider) => 
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       if (req.body.enableAutoRenewal === false) {
         const data = await server.services.certificateV3.disableRenewalConfig({

--- a/backend/src/server/routes/v3/deprecated-secret-router.ts
+++ b/backend/src/server/routes/v3/deprecated-secret-router.ts
@@ -91,7 +91,7 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const secret = await server.services.secret.attachTags({
         secretName: req.params.secretName,
@@ -612,7 +612,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const projectId = await server.services.project.extractProjectIdFromSlug({
         projectSlug: req.body.projectSlug,
@@ -767,7 +773,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const projectId = await server.services.project.extractProjectIdFromSlug({
         projectSlug: req.body.projectSlug,
@@ -902,7 +914,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const projectId = await server.services.project.extractProjectIdFromSlug({
         projectSlug: req.body.projectSlug,
@@ -1032,7 +1050,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { secrets, imports } = await server.services.secret.getSecrets({
         actorId: req.permission.id,
@@ -1121,7 +1145,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secret = await server.services.secret.getSecretByName({
         actorId: req.permission.id,
@@ -1214,7 +1244,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const {
         workspaceId: projectId,
@@ -1397,7 +1433,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const {
         secretValueCiphertext,
@@ -1573,7 +1615,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { secretPath, type, workspaceId: projectId, secretId, environment } = req.body;
       if (req.body.type !== SecretType.Personal && req.permission.type === ActorType.USER) {
@@ -1696,7 +1744,7 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId, isSourceUpdated, isDestinationUpdated } = await server.services.secret.moveSecrets({
         actorId: req.permission.id,
@@ -1766,7 +1814,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { environment, workspaceId: projectId, secretPath, secrets: inputSecrets } = req.body;
       if (req.permission.type === ActorType.USER) {
@@ -1898,7 +1952,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { environment, workspaceId: projectId, secretPath, secrets: inputSecrets } = req.body;
       if (req.permission.type === ActorType.USER) {
@@ -2025,7 +2085,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { environment, workspaceId: projectId, secretPath, secrets: inputSecrets } = req.body;
       if (req.permission.type === ActorType.USER) {
@@ -2169,7 +2235,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { environment, projectSlug, secretPath, secrets: inputSecrets } = req.body;
 
@@ -2325,7 +2397,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { environment, projectSlug, secretPath, secrets: inputSecrets } = req.body;
       const secretOperation = await server.services.secret.updateManySecretsRaw({
@@ -2504,7 +2582,13 @@ export const registerDeprecatedSecretRouter = async (server: FastifyZodProvider)
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const { environment, projectSlug, secretPath, secrets: inputSecrets } = req.body;
       const secretOperation = await server.services.secret.deleteManySecretsRaw({

--- a/backend/src/server/routes/v3/external-migration-router.ts
+++ b/backend/src/server/routes/v3/external-migration-router.ts
@@ -28,7 +28,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
     schema: {
       operationId: "importEnvKeyDataV3"
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const data = await req.file({
         limits: {
@@ -90,7 +90,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         gatewayPoolId: z.string().optional()
       })
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       await server.services.migration.importVaultData({
         actorId: req.permission.id,
@@ -128,7 +128,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const enabled = await server.services.migration.hasCustomVaultMigration({
         actorId: req.permission.id,
@@ -158,7 +158,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const namespaces = await server.services.migration.getVaultNamespaces({
         actor: req.permission,
@@ -187,7 +187,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const policies = await server.services.migration.getVaultPolicies({
         actor: req.permission,
@@ -217,7 +217,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const mounts = await server.services.migration.getVaultMounts({
         actor: req.permission,
@@ -248,7 +248,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const mounts = await server.services.migration.getVaultAuthMounts({
         actor: req.permission,
@@ -283,7 +283,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.migration.importVaultSecrets({
         actor: req.permission,
@@ -335,7 +335,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const roles = await server.services.migration.getVaultKubernetesRoles({
         actor: req.permission,
@@ -387,7 +387,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const roles = await server.services.migration.getVaultDatabaseRoles({
         actor: req.permission,
@@ -420,7 +420,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.migration.getVaultSecretPaths({
         actor: req.permission,
@@ -478,7 +478,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const roles = await server.services.migration.getVaultKubernetesAuthRoles({
         actor: req.permission,
@@ -526,7 +526,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const roles = await server.services.migration.getVaultLdapRoles({
         actor: req.permission,
@@ -563,7 +563,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const projects = await server.services.migration.getDopplerProjects({
         connectionId: req.query.connectionId,
@@ -597,7 +597,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const environments = await server.services.migration.getDopplerEnvironments({
         connectionId: req.query.connectionId,
@@ -632,7 +632,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const configs = await server.services.migration.getDopplerConfigs({
         connectionId: req.query.connectionId,
@@ -661,7 +661,7 @@ export const registerExternalMigrationRouter = async (server: FastifyZodProvider
         200: z.object({ status: z.string(), imported: z.number() })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const result = await server.services.migration.importDopplerSecrets({
         ...req.body,

--- a/backend/src/server/routes/v4/secret-router.ts
+++ b/backend/src/server/routes/v4/secret-router.ts
@@ -478,7 +478,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const secretOperation = await server.services.secret.createSecretRaw({
         actorId: req.permission.id,
@@ -642,7 +642,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const secretOperation = await server.services.secret.updateSecretRaw({
         actorId: req.permission.id,
@@ -789,7 +789,13 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([
+      AuthMode.JWT,
+      AuthMode.API_KEY,
+      AuthMode.SERVICE_TOKEN,
+      AuthMode.IDENTITY_ACCESS_TOKEN,
+      AuthMode.OAUTH
+    ]),
     handler: async (req) => {
       const secretOperation = await server.services.secret.deleteSecretRaw({
         actorId: req.permission.id,
@@ -885,7 +891,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId, isSourceUpdated, isDestinationUpdated } = await server.services.secret.moveSecrets({
         actorId: req.permission.id,
@@ -974,7 +980,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId, results } = await server.services.secret.duplicateSecrets({
         actorId: req.permission.id,
@@ -1070,7 +1076,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { environment, secretPath, secrets: inputSecrets } = req.body;
 
@@ -1225,7 +1231,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { environment, secretPath, secrets: inputSecrets } = req.body;
 
@@ -1382,7 +1388,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         ])
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.SERVICE_TOKEN, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
     handler: async (req) => {
       const { environment, secretPath, secrets: inputSecrets } = req.body;
 
@@ -1493,7 +1499,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secretName } = req.params;
       const { secretPath, environment, projectId } = req.query;
@@ -1549,7 +1555,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { secretName } = req.params;
       const { secretPath, environment, projectId } = req.query;
@@ -1606,7 +1612,7 @@ export const registerSecretRouter = async (server: FastifyZodProvider) => {
         })
       }
     },
-    onRequest: verifyAuth([AuthMode.JWT]),
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.OAUTH]),
     handler: async (req) => {
       const { projectId } = req.body;
       const message = await server.services.secret.backfillSecretReferences({

--- a/backend/src/services/auth/auth-type.ts
+++ b/backend/src/services/auth/auth-type.ts
@@ -107,6 +107,9 @@ export type AuthModeJwtTokenPayload = {
   // Granted OAuth delegation scopes (see OauthScope). The delegated ability is intersected with
   // these in permission-service; an empty/absent list denies all scope-guarded resource access.
   scopes?: string[];
+  // Present instead of `scopes` on RFC 8693 token exchange tokens, which carry the user's authorization
+  // unnarrowed. A token has this or `scopes`, never both. See OauthDelegationMode.
+  delegation?: string;
 };
 
 export type AuthModeMfaJwtTokenPayload = {

--- a/backend/src/services/auth/auth-type.ts
+++ b/backend/src/services/auth/auth-type.ts
@@ -107,8 +107,8 @@ export type AuthModeJwtTokenPayload = {
   // Granted OAuth delegation scopes (see OauthScope). The delegated ability is intersected with
   // these in permission-service; an empty/absent list denies all scope-guarded resource access.
   scopes?: string[];
-  // Present instead of `scopes` on RFC 8693 token exchange tokens, which carry the user's authorization
-  // unnarrowed. A token has this or `scopes`, never both. See OauthDelegationMode.
+  // Set instead of `scopes` on RFC 8693 token exchange tokens, which carry the user's authorization
+  // unnarrowed. Never both. See OauthDelegationMode.
   delegation?: string;
 };
 

--- a/backend/src/services/oauth-client/oauth-client-dal.ts
+++ b/backend/src/services/oauth-client/oauth-client-dal.ts
@@ -1,5 +1,6 @@
 import { TDbClient } from "@app/db";
 import { TableName } from "@app/db/schemas";
+import { DatabaseError } from "@app/lib/errors";
 import { ormify } from "@app/lib/knex";
 
 export type TOauthClientDALFactory = ReturnType<typeof oauthClientDALFactory>;
@@ -7,5 +8,13 @@ export type TOauthClientDALFactory = ReturnType<typeof oauthClientDALFactory>;
 export const oauthClientDALFactory = (db: TDbClient) => {
   const oauthClientOrm = ormify(db, TableName.OauthClient);
 
-  return oauthClientOrm;
+  const findByIdOnPrimary = async (id: string) => {
+    try {
+      return await db(TableName.OauthClient).where({ id }).first();
+    } catch (error) {
+      throw new DatabaseError({ error, name: "FindOauthClientByIdOnPrimary" });
+    }
+  };
+
+  return { ...oauthClientOrm, findByIdOnPrimary };
 };

--- a/backend/src/services/oauth-client/oauth-client-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.test.ts
@@ -3,7 +3,6 @@ import crypto from "node:crypto";
 import {
   assertValidOauthClientGrantConfig,
   computePkceChallenge,
-  dedupeGrantTypes,
   isAllowedRedirectUri,
   isRegisteredRedirectUri,
   parseBasicAuthHeader
@@ -120,18 +119,6 @@ describe("isRegisteredRedirectUri", () => {
         "https://coder.example.com/external-auth/other"
       )
     ).toBe(false);
-  });
-});
-
-describe("dedupeGrantTypes", () => {
-  test("removes duplicates while preserving order", () => {
-    expect(
-      dedupeGrantTypes([
-        OauthGrantType.AuthorizationCode,
-        OauthGrantType.RefreshToken,
-        OauthGrantType.AuthorizationCode
-      ])
-    ).toEqual([OauthGrantType.AuthorizationCode, OauthGrantType.RefreshToken]);
   });
 });
 

--- a/backend/src/services/oauth-client/oauth-client-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.test.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import {
   assertValidOauthClientGrantConfig,
   computePkceChallenge,
+  hasClientAuthorityChanged,
   isAllowedRedirectUri,
   isRegisteredRedirectUri,
   parseBasicAuthHeader
@@ -117,6 +118,51 @@ describe("isRegisteredRedirectUri", () => {
       isRegisteredRedirectUri(
         ["https://coder.example.com/external-auth"],
         "https://coder.example.com/external-auth/other"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("hasClientAuthorityChanged", () => {
+  const authenticated = {
+    clientSecretHash: "$2b$10$oldhasholdhasholdhashol",
+    grantTypes: [OauthGrantType.TokenExchange]
+  };
+
+  test("reports no change when the client is untouched", () => {
+    expect(hasClientAuthorityChanged(authenticated, { ...authenticated }, OauthGrantType.TokenExchange)).toBe(false);
+  });
+
+  test("reports a change when the client secret was rotated", () => {
+    expect(
+      hasClientAuthorityChanged(
+        authenticated,
+        { ...authenticated, clientSecretHash: "$2b$10$newhashnewhashnewhashne" },
+        OauthGrantType.TokenExchange
+      )
+    ).toBe(true);
+  });
+
+  test("reports a change when the grant was withdrawn", () => {
+    expect(
+      hasClientAuthorityChanged(
+        authenticated,
+        { ...authenticated, grantTypes: [OauthGrantType.AuthorizationCode] },
+        OauthGrantType.TokenExchange
+      )
+    ).toBe(true);
+  });
+
+  test("reports a change when the client was deleted", () => {
+    expect(hasClientAuthorityChanged(authenticated, undefined, OauthGrantType.TokenExchange)).toBe(true);
+  });
+
+  test("reports no change when an unrelated grant was added", () => {
+    expect(
+      hasClientAuthorityChanged(
+        authenticated,
+        { ...authenticated, grantTypes: [OauthGrantType.TokenExchange, OauthGrantType.AuthorizationCode] },
+        OauthGrantType.TokenExchange
       )
     ).toBe(false);
   });

--- a/backend/src/services/oauth-client/oauth-client-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.test.ts
@@ -126,7 +126,9 @@ describe("isRegisteredRedirectUri", () => {
 describe("hasClientAuthorityChanged", () => {
   const authenticated = {
     clientSecretHash: "$2b$10$oldhasholdhasholdhashol",
-    grantTypes: [OauthGrantType.TokenExchange]
+    grantTypes: [OauthGrantType.TokenExchange],
+    tokenExchangeAudience: "https://coder.example.com",
+    tokenExchangeIdpSatisfiesMfa: true
   };
 
   test("reports no change when the client is untouched", () => {
@@ -163,6 +165,37 @@ describe("hasClientAuthorityChanged", () => {
         authenticated,
         { ...authenticated, grantTypes: [OauthGrantType.TokenExchange, OauthGrantType.AuthorizationCode] },
         OauthGrantType.TokenExchange
+      )
+    ).toBe(false);
+  });
+
+  test("reports a change when the token exchange audience was narrowed", () => {
+    expect(
+      hasClientAuthorityChanged(
+        authenticated,
+        { ...authenticated, tokenExchangeAudience: "https://other.example.com" },
+        OauthGrantType.TokenExchange
+      )
+    ).toBe(true);
+  });
+
+  test("reports a change when the IdP MFA declaration was withdrawn", () => {
+    expect(
+      hasClientAuthorityChanged(
+        authenticated,
+        { ...authenticated, tokenExchangeIdpSatisfiesMfa: false },
+        OauthGrantType.TokenExchange
+      )
+    ).toBe(true);
+  });
+
+  test("ignores the token exchange fields for other grants", () => {
+    const redirectClient = { ...authenticated, grantTypes: [OauthGrantType.AuthorizationCode] };
+    expect(
+      hasClientAuthorityChanged(
+        redirectClient,
+        { ...redirectClient, tokenExchangeAudience: null, tokenExchangeIdpSatisfiesMfa: false },
+        OauthGrantType.AuthorizationCode
       )
     ).toBe(false);
   });

--- a/backend/src/services/oauth-client/oauth-client-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.test.ts
@@ -1,11 +1,14 @@
 import crypto from "node:crypto";
 
 import {
+  assertValidOauthClientGrantConfig,
   computePkceChallenge,
+  dedupeGrantTypes,
   isAllowedRedirectUri,
   isRegisteredRedirectUri,
   parseBasicAuthHeader
 } from "./oauth-client-fns";
+import { OauthGrantType } from "./oauth-client-types";
 
 describe("parseBasicAuthHeader", () => {
   test("parses a valid Basic auth header", () => {
@@ -117,5 +120,146 @@ describe("isRegisteredRedirectUri", () => {
         "https://coder.example.com/external-auth/other"
       )
     ).toBe(false);
+  });
+});
+
+describe("dedupeGrantTypes", () => {
+  test("removes duplicates while preserving order", () => {
+    expect(
+      dedupeGrantTypes([
+        OauthGrantType.AuthorizationCode,
+        OauthGrantType.RefreshToken,
+        OauthGrantType.AuthorizationCode
+      ])
+    ).toEqual([OauthGrantType.AuthorizationCode, OauthGrantType.RefreshToken]);
+  });
+});
+
+describe("assertValidOauthClientGrantConfig", () => {
+  const redirectFlow = {
+    grantTypes: [OauthGrantType.AuthorizationCode, OauthGrantType.RefreshToken],
+    resolved: { redirectUris: ["https://app.example.com/callback"] },
+    supplied: { redirectUris: ["https://app.example.com/callback"], requirePkce: true }
+  };
+
+  const exchangeFlow = {
+    grantTypes: [OauthGrantType.TokenExchange],
+    resolved: { redirectUris: [], tokenExchangeAudience: "api://mcp" },
+    supplied: { tokenExchangeAudience: "api://mcp", tokenExchangeIdpSatisfiesMfa: true }
+  };
+
+  test("accepts a redirect-flow application", () => {
+    expect(() => assertValidOauthClientGrantConfig(redirectFlow)).not.toThrow();
+  });
+
+  test("accepts a token-exchange-only application", () => {
+    expect(() => assertValidOauthClientGrantConfig(exchangeFlow)).not.toThrow();
+  });
+
+  test("accepts an application registered for both grants", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.AuthorizationCode, OauthGrantType.RefreshToken, OauthGrantType.TokenExchange],
+        resolved: { redirectUris: ["https://app.example.com/callback"], tokenExchangeAudience: "api://mcp" },
+        supplied: { redirectUris: ["https://app.example.com/callback"], tokenExchangeAudience: "api://mcp" }
+      })
+    ).not.toThrow();
+  });
+
+  test("rejects an empty grant type list", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({ grantTypes: [], resolved: { redirectUris: [] }, supplied: {} })
+    ).toThrow(/At least one grant type/);
+  });
+
+  test("rejects refresh_token without authorization_code", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.RefreshToken],
+        resolved: { redirectUris: ["https://app.example.com/callback"] },
+        supplied: {}
+      })
+    ).toThrow(/requires the 'authorization_code' grant/);
+  });
+
+  test("rejects authorization_code with no redirect URI", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.AuthorizationCode],
+        resolved: { redirectUris: [] },
+        supplied: {}
+      })
+    ).toThrow(/At least one redirect URI is required/);
+  });
+
+  test("rejects redirect URIs supplied without a redirect-based grant", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.TokenExchange],
+        resolved: { redirectUris: ["https://app.example.com/callback"], tokenExchangeAudience: "api://mcp" },
+        supplied: { redirectUris: ["https://app.example.com/callback"] }
+      })
+    ).toThrow(/Redirect URIs only apply/);
+  });
+
+  test("rejects requirePkce supplied without a redirect-based grant", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.TokenExchange],
+        resolved: { redirectUris: [], tokenExchangeAudience: "api://mcp" },
+        supplied: { requirePkce: true }
+      })
+    ).toThrow(/PKCE only applies/);
+  });
+
+  test("rejects the token exchange grant with no audience", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.TokenExchange],
+        resolved: { redirectUris: [] },
+        supplied: {}
+      })
+    ).toThrow(/token exchange audience is required/);
+  });
+
+  test("rejects a whitespace-only audience", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.TokenExchange],
+        resolved: { redirectUris: [], tokenExchangeAudience: "   " },
+        supplied: { tokenExchangeAudience: "   " }
+      })
+    ).toThrow(/token exchange audience is required/);
+  });
+
+  test("rejects an audience supplied without the token exchange grant", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.AuthorizationCode],
+        resolved: { redirectUris: ["https://app.example.com/callback"], tokenExchangeAudience: "api://mcp" },
+        supplied: { tokenExchangeAudience: "api://mcp" }
+      })
+    ).toThrow(/audience only applies/);
+  });
+
+  test("rejects the IdP MFA declaration without the token exchange grant", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.AuthorizationCode],
+        resolved: { redirectUris: ["https://app.example.com/callback"] },
+        supplied: { tokenExchangeIdpSatisfiesMfa: true }
+      })
+    ).toThrow(/MFA declaration only applies/);
+  });
+
+  // Dropping a grant must not force the caller to null out that grant's fields in the same request.
+  test("allows dropping the token exchange grant while its stored audience is still set", () => {
+    expect(() =>
+      assertValidOauthClientGrantConfig({
+        grantTypes: [OauthGrantType.AuthorizationCode],
+        resolved: { redirectUris: ["https://app.example.com/callback"], tokenExchangeAudience: "api://mcp" },
+        supplied: { grantTypes: [OauthGrantType.AuthorizationCode] } as never
+      })
+    ).not.toThrow();
   });
 });

--- a/backend/src/services/oauth-client/oauth-client-fns.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 
 import { BadRequestError } from "@app/lib/errors";
 
-import { OauthGrantType, REDIRECT_BASED_GRANT_TYPES } from "./oauth-client-types";
+import { OauthGrantType } from "./oauth-client-types";
 
 export const parseBasicAuthHeader = (
   authorizationHeader?: string
@@ -80,14 +80,6 @@ export const isRegisteredRedirectUri = (registeredUris: string[], redirectUri: s
     }
   });
 
-export const dedupeGrantTypes = (grantTypes: OauthGrantType[]) => [...new Set(grantTypes)];
-
-export const hasRedirectBasedGrant = (grantTypes: OauthGrantType[]) =>
-  grantTypes.some((grantType) => REDIRECT_BASED_GRANT_TYPES.includes(grantType));
-
-export const hasTokenExchangeGrant = (grantTypes: OauthGrantType[]) =>
-  grantTypes.includes(OauthGrantType.TokenExchange);
-
 type TOauthClientGrantConfig = {
   grantTypes: OauthGrantType[];
   resolved: {
@@ -107,8 +99,8 @@ export const assertValidOauthClientGrantConfig = ({ grantTypes, resolved, suppli
     throw new BadRequestError({ message: "At least one grant type must be enabled for an application." });
   }
 
-  const isRedirectBased = hasRedirectBasedGrant(grantTypes);
-  const isTokenExchange = hasTokenExchangeGrant(grantTypes);
+  const isRedirectBased = grantTypes.includes(OauthGrantType.AuthorizationCode);
+  const isTokenExchange = grantTypes.includes(OauthGrantType.TokenExchange);
 
   if (grantTypes.includes(OauthGrantType.RefreshToken) && !grantTypes.includes(OauthGrantType.AuthorizationCode)) {
     throw new BadRequestError({

--- a/backend/src/services/oauth-client/oauth-client-fns.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.ts
@@ -76,15 +76,15 @@ type TOauthClientAuthority = Pick<
   "clientSecretHash" | "grantTypes" | "tokenExchangeAudience" | "tokenExchangeIdpSatisfiesMfa"
 >;
 
-// Whether the client an exchange authenticated against has since lost the authority it was granted:
-// deleted, secret rotated, or the grant withdrawn. Comparing the stored hashes is enough, because a
-// rotation writes a fresh bcrypt hash with a new salt, so no second compareHash is needed.
+// Whether the client has lost the authority it was granted mid-request: deleted, secret rotated, or the
+// grant withdrawn. Comparing the stored hashes is enough, since a rotation writes a fresh bcrypt hash
+// with a new salt.
 //
-// Token exchange also compares the two fields that carry its federation trust. The audience is the
-// only thing standing between the caller and any token the issuer signs, and the IdP-MFA declaration
-// is what lets an exchange skip an MFA requirement, so an admin narrowing either one has withdrawn
-// authority just as much as one rotating the secret. The exchange reads them off a replica, so
-// without this they would survive the change for the length of the replication lag.
+// Token exchange also compares the two fields carrying its federation trust. The audience is all that
+// stands between the caller and any token the issuer signs, and the IdP-MFA flag is what lets an
+// exchange skip an MFA requirement, so narrowing either withdraws authority just as much as rotating the
+// secret. The exchange reads them off a replica, so without this they'd survive the change for the
+// length of the replication lag.
 export const hasClientAuthorityChanged = (
   authenticated: TOauthClientAuthority,
   current: TOauthClientAuthority | undefined,

--- a/backend/src/services/oauth-client/oauth-client-fns.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.ts
@@ -78,10 +78,7 @@ export const hasClientAuthorityChanged = (
   authenticated: Pick<TOauthClients, "clientSecretHash" | "grantTypes">,
   current: Pick<TOauthClients, "clientSecretHash" | "grantTypes"> | undefined,
   grantType: OauthGrantType
-) =>
-  !current ||
-  current.clientSecretHash !== authenticated.clientSecretHash ||
-  !current.grantTypes.includes(grantType);
+) => !current || current.clientSecretHash !== authenticated.clientSecretHash || !current.grantTypes.includes(grantType);
 
 export const isRegisteredRedirectUri = (registeredUris: string[], redirectUri: string) =>
   registeredUris.some((uri) => {

--- a/backend/src/services/oauth-client/oauth-client-fns.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.ts
@@ -71,14 +71,38 @@ export const isAllowedRedirectUri = (uri: string) => {
 // so the format must stay in sync between session creation and revocation.
 export const getOauthClientSessionUserAgent = (clientId: string) => `Infisical OAuth - ${clientId}`;
 
+type TOauthClientAuthority = Pick<
+  TOauthClients,
+  "clientSecretHash" | "grantTypes" | "tokenExchangeAudience" | "tokenExchangeIdpSatisfiesMfa"
+>;
+
 // Whether the client an exchange authenticated against has since lost the authority it was granted:
 // deleted, secret rotated, or the grant withdrawn. Comparing the stored hashes is enough, because a
 // rotation writes a fresh bcrypt hash with a new salt, so no second compareHash is needed.
+//
+// Token exchange also compares the two fields that carry its federation trust. The audience is the
+// only thing standing between the caller and any token the issuer signs, and the IdP-MFA declaration
+// is what lets an exchange skip an MFA requirement, so an admin narrowing either one has withdrawn
+// authority just as much as one rotating the secret. The exchange reads them off a replica, so
+// without this they would survive the change for the length of the replication lag.
 export const hasClientAuthorityChanged = (
-  authenticated: Pick<TOauthClients, "clientSecretHash" | "grantTypes">,
-  current: Pick<TOauthClients, "clientSecretHash" | "grantTypes"> | undefined,
+  authenticated: TOauthClientAuthority,
+  current: TOauthClientAuthority | undefined,
   grantType: OauthGrantType
-) => !current || current.clientSecretHash !== authenticated.clientSecretHash || !current.grantTypes.includes(grantType);
+) => {
+  if (!current) return true;
+  if (current.clientSecretHash !== authenticated.clientSecretHash) return true;
+  if (!current.grantTypes.includes(grantType)) return true;
+
+  if (grantType === OauthGrantType.TokenExchange) {
+    return (
+      current.tokenExchangeAudience !== authenticated.tokenExchangeAudience ||
+      Boolean(current.tokenExchangeIdpSatisfiesMfa) !== Boolean(authenticated.tokenExchangeIdpSatisfiesMfa)
+    );
+  }
+
+  return false;
+};
 
 export const isRegisteredRedirectUri = (registeredUris: string[], redirectUri: string) =>
   registeredUris.some((uri) => {

--- a/backend/src/services/oauth-client/oauth-client-fns.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 
+import { TOauthClients } from "@app/db/schemas";
 import { BadRequestError } from "@app/lib/errors";
 
 import { OauthGrantType } from "./oauth-client-types";
@@ -69,6 +70,18 @@ export const isAllowedRedirectUri = (uri: string) => {
 // browser sessions and from other clients. Deleting a client revokes its sessions by this exact value,
 // so the format must stay in sync between session creation and revocation.
 export const getOauthClientSessionUserAgent = (clientId: string) => `Infisical OAuth - ${clientId}`;
+
+// Whether the client an exchange authenticated against has since lost the authority it was granted:
+// deleted, secret rotated, or the grant withdrawn. Comparing the stored hashes is enough, because a
+// rotation writes a fresh bcrypt hash with a new salt, so no second compareHash is needed.
+export const hasClientAuthorityChanged = (
+  authenticated: Pick<TOauthClients, "clientSecretHash" | "grantTypes">,
+  current: Pick<TOauthClients, "clientSecretHash" | "grantTypes"> | undefined,
+  grantType: OauthGrantType
+) =>
+  !current ||
+  current.clientSecretHash !== authenticated.clientSecretHash ||
+  !current.grantTypes.includes(grantType);
 
 export const isRegisteredRedirectUri = (registeredUris: string[], redirectUri: string) =>
   registeredUris.some((uri) => {

--- a/backend/src/services/oauth-client/oauth-client-fns.ts
+++ b/backend/src/services/oauth-client/oauth-client-fns.ts
@@ -1,5 +1,9 @@
 import crypto from "node:crypto";
 
+import { BadRequestError } from "@app/lib/errors";
+
+import { OauthGrantType, REDIRECT_BASED_GRANT_TYPES } from "./oauth-client-types";
+
 export const parseBasicAuthHeader = (
   authorizationHeader?: string
 ): { clientId: string; clientSecret: string } | null => {
@@ -75,3 +79,76 @@ export const isRegisteredRedirectUri = (registeredUris: string[], redirectUri: s
       return false;
     }
   });
+
+export const dedupeGrantTypes = (grantTypes: OauthGrantType[]) => [...new Set(grantTypes)];
+
+export const hasRedirectBasedGrant = (grantTypes: OauthGrantType[]) =>
+  grantTypes.some((grantType) => REDIRECT_BASED_GRANT_TYPES.includes(grantType));
+
+export const hasTokenExchangeGrant = (grantTypes: OauthGrantType[]) =>
+  grantTypes.includes(OauthGrantType.TokenExchange);
+
+type TOauthClientGrantConfig = {
+  grantTypes: OauthGrantType[];
+  resolved: {
+    redirectUris: string[];
+    tokenExchangeAudience?: string | null;
+  };
+  supplied: {
+    redirectUris?: string[];
+    requirePkce?: boolean;
+    tokenExchangeAudience?: string | null;
+    tokenExchangeIdpSatisfiesMfa?: boolean;
+  };
+};
+
+export const assertValidOauthClientGrantConfig = ({ grantTypes, resolved, supplied }: TOauthClientGrantConfig) => {
+  if (!grantTypes.length) {
+    throw new BadRequestError({ message: "At least one grant type must be enabled for an application." });
+  }
+
+  const isRedirectBased = hasRedirectBasedGrant(grantTypes);
+  const isTokenExchange = hasTokenExchangeGrant(grantTypes);
+
+  if (grantTypes.includes(OauthGrantType.RefreshToken) && !grantTypes.includes(OauthGrantType.AuthorizationCode)) {
+    throw new BadRequestError({
+      message: `The '${OauthGrantType.RefreshToken}' grant requires the '${OauthGrantType.AuthorizationCode}' grant, because refresh tokens are only issued by the authorization code flow.`
+    });
+  }
+
+  if (isRedirectBased && !resolved.redirectUris.length) {
+    throw new BadRequestError({
+      message: `At least one redirect URI is required for the '${OauthGrantType.AuthorizationCode}' grant.`
+    });
+  }
+
+  if (!isRedirectBased && supplied.redirectUris?.length) {
+    throw new BadRequestError({
+      message: `Redirect URIs only apply to the '${OauthGrantType.AuthorizationCode}' grant. Enable that grant or remove the redirect URIs.`
+    });
+  }
+
+  if (!isRedirectBased && supplied.requirePkce) {
+    throw new BadRequestError({
+      message: `PKCE only applies to the '${OauthGrantType.AuthorizationCode}' grant. Enable that grant or turn off the PKCE requirement.`
+    });
+  }
+
+  if (isTokenExchange && !resolved.tokenExchangeAudience?.trim()) {
+    throw new BadRequestError({
+      message: `A token exchange audience is required for the '${OauthGrantType.TokenExchange}' grant. Set it to the audience your identity provider puts in tokens it issues for this application.`
+    });
+  }
+
+  if (!isTokenExchange && supplied.tokenExchangeAudience?.trim()) {
+    throw new BadRequestError({
+      message: `The token exchange audience only applies to the '${OauthGrantType.TokenExchange}' grant. Enable that grant or remove the audience.`
+    });
+  }
+
+  if (!isTokenExchange && supplied.tokenExchangeIdpSatisfiesMfa) {
+    throw new BadRequestError({
+      message: `The identity provider MFA declaration only applies to the '${OauthGrantType.TokenExchange}' grant. Enable that grant or turn the declaration off.`
+    });
+  }
+};

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -1,7 +1,13 @@
 import { ForbiddenError } from "@casl/ability";
 
-import { OrganizationActionScope, TOauthClients } from "@app/db/schemas";
-import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
+import { OrganizationActionScope, TOauthClients, TOrganizations } from "@app/db/schemas";
+import { EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
+import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
+import {
+  OrgPermissionActions,
+  OrgPermissionSsoActions,
+  OrgPermissionSubjects
+} from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
@@ -15,16 +21,25 @@ import { ActorType, AuthMethod, AuthTokenType, MfaMethod } from "@app/services/a
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TUserDALFactory } from "@app/services/user/user-dal";
+import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
+import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TOauthClientDALFactory } from "./oauth-client-dal";
 import {
+  assertValidOauthClientGrantConfig,
   computePkceChallenge,
+  dedupeGrantTypes,
   getOauthClientSessionUserAgent,
+  hasRedirectBasedGrant,
+  hasTokenExchangeGrant,
   isRegisteredRedirectUri,
   PKCE_CODE_VERIFIER_REGEX
 } from "./oauth-client-fns";
 import {
   OauthAuthorizationCodePayloadSchema,
+  OauthDelegationMode,
+  OauthGrantType,
+  OauthTokenType,
   TCreateOauthClientDTO,
   TOauthAuthorizeInfoDTO,
   TOauthConsentDTO,
@@ -33,6 +48,7 @@ import {
   TUpdateOauthClientDTO
 } from "./oauth-client-types";
 import { getOauthScopeDescriptions, parseOauthScopeString } from "./oauth-scope";
+import { verifySubjectToken } from "./oauth-token-exchange-fns";
 
 type TOauthClientServiceFactoryDep = {
   oauthClientDAL: TOauthClientDALFactory;
@@ -48,6 +64,9 @@ type TOauthClientServiceFactoryDep = {
   >;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   userDAL: Pick<TUserDALFactory, "findById">;
+  oidcConfigDAL: Pick<TOidcConfigDALFactory, "findOne">;
+  userAliasDAL: Pick<TUserAliasDALFactory, "findOne">;
+  auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
 };
 
 export type TOauthClientServiceFactory = ReturnType<typeof oauthClientServiceFactory>;
@@ -67,8 +86,7 @@ type TOauthTokenClaims = {
   organizationId: string;
   isMfaVerified?: boolean;
   mfaMethod?: MfaMethod;
-  scopes: string[];
-};
+} & ({ scopes: string[]; delegation?: never } | { delegation: OauthDelegationMode.Full; scopes?: never });
 
 const signOauthToken = (
   claims: TOauthTokenClaims & {
@@ -95,9 +113,10 @@ const signOauthToken = (
       // Marks this as a delegated OAuth token. extractAuth maps tokens carrying this claim to
       // AuthMode.OAUTH so they are rejected by the default first-party JWT middleware.
       oauthClientId: claims.oauthClientId,
-      // Granted delegation scopes. permission-service intersects the user's ability with these,
-      // so the token can never exceed what the user consented to.
-      scopes: claims.scopes
+      // Exactly one delegation marker per token. `scopes` narrows the ability to what the user
+      // consented to, `delegation` carries it unnarrowed. Absence of both means zero permissions, so
+      // dropping either claim by mistake fails closed. See OauthDelegationMode.
+      ...(claims.delegation ? { delegation: claims.delegation } : { scopes: claims.scopes })
     },
     appCfg.AUTH_SECRET,
     { expiresIn }
@@ -110,7 +129,10 @@ export const oauthClientServiceFactory = ({
   keyStore,
   tokenService,
   orgDAL,
-  userDAL
+  userDAL,
+  oidcConfigDAL,
+  userAliasDAL,
+  auditLogService
 }: TOauthClientServiceFactoryDep) => {
   const checkOauthClientPermission = async (actor: OrgServiceActor, action: OrgPermissionActions) => {
     const { permission } = await permissionService.getOrgPermission({
@@ -125,6 +147,22 @@ export const oauthClientServiceFactory = ({
     ForbiddenError.from(permission).throwUnlessCan(action, OrgPermissionSubjects.OauthClients);
   };
 
+  // Enabling this grant, or changing the audience it accepts, decides whose externally-issued tokens
+  // become Infisical user tokens. That is a change to the org's federation trust, so it needs the
+  // permission that already owns the SSO configuration.
+  const checkSsoConfigPermission = async (actor: OrgServiceActor) => {
+    const { permission } = await permissionService.getOrgPermission({
+      actor: actor.type,
+      actorId: actor.id,
+      orgId: actor.orgId,
+      actorAuthMethod: actor.authMethod,
+      actorOrgId: actor.orgId,
+      scope: OrganizationActionScope.ParentOrganization
+    });
+
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionSsoActions.Edit, OrgPermissionSubjects.Sso);
+  };
+
   // Loads a client scoped to the actor's org (so one org can never address another's client) and
   // throws a 404 when it is missing. Shared by every management method that operates on an existing
   // client by its database id.
@@ -134,8 +172,63 @@ export const oauthClientServiceFactory = ({
     return client;
   };
 
+  // MFA enforcement, the OIDC SSO configuration and OIDC user aliases all live on the root
+  // organization, matching the login flow.
+  const getClientRootOrg = async (orgId: string): Promise<TOrganizations> => {
+    const clientOrg = await orgDAL.findById(orgId);
+    if (!clientOrg) throw new NotFoundError({ message: "OAuth client organization not found" });
+
+    const isSubOrganization = Boolean(clientOrg.rootOrgId && clientOrg.id !== clientOrg.rootOrgId);
+    if (!isSubOrganization) return clientOrg;
+
+    const rootOrg = await orgDAL.findById(clientOrg.rootOrgId as string);
+    if (!rootOrg) throw new NotFoundError({ message: "OAuth client organization not found" });
+    return rootOrg;
+  };
+
+  // Token exchange has nothing to verify a subject token against until federation is live. Failing at
+  // configuration time puts the message in front of the admin setting the application up.
+  const getActiveOidcConfigOrThrow = async (orgId: string) => {
+    const rootOrg = await getClientRootOrg(orgId);
+    const oidcConfig = await oidcConfigDAL.findOne({ orgId: rootOrg.id });
+
+    if (!oidcConfig) {
+      throw new BadRequestError({
+        message:
+          "Token exchange verifies user tokens against your organization's OIDC SSO issuer, and your organization has no OIDC SSO configuration. Set one up under Settings > SSO & Provisioning first."
+      });
+    }
+
+    if (!oidcConfig.isActive) {
+      throw new BadRequestError({
+        message:
+          "Token exchange verifies user tokens against your organization's OIDC SSO issuer, and your organization's OIDC SSO is disabled. Enable it under Settings > SSO & Provisioning first."
+      });
+    }
+
+    return { oidcConfig, rootOrg };
+  };
+
   const createOauthClient = async (dto: TCreateOauthClientDTO, actor: OrgServiceActor) => {
     await checkOauthClientPermission(actor, OrgPermissionActions.Create);
+
+    const grantTypes = dedupeGrantTypes(dto.grantTypes);
+    const enablesTokenExchange = hasTokenExchangeGrant(grantTypes);
+
+    if (enablesTokenExchange) await checkSsoConfigPermission(actor);
+
+    assertValidOauthClientGrantConfig({
+      grantTypes,
+      resolved: { redirectUris: dto.redirectUris, tokenExchangeAudience: dto.tokenExchangeAudience },
+      supplied: {
+        redirectUris: dto.redirectUris,
+        requirePkce: dto.requirePkce,
+        tokenExchangeAudience: dto.tokenExchangeAudience,
+        tokenExchangeIdpSatisfiesMfa: dto.tokenExchangeIdpSatisfiesMfa
+      }
+    });
+
+    if (enablesTokenExchange) await getActiveOidcConfigOrThrow(actor.orgId);
 
     const appCfg = getConfig();
     const clientId = `oauth_client_${crypto.randomBytes(16).toString("hex")}`;
@@ -149,18 +242,27 @@ export const oauthClientServiceFactory = ({
       clientId,
       clientSecretHash,
       clientSecretPrefix: clientSecret.slice(0, 4),
+      grantTypes,
       redirectUris: dto.redirectUris,
-      requirePkce: dto.requirePkce ?? false
+      requirePkce: dto.requirePkce ?? false,
+      tokenExchangeAudience: enablesTokenExchange ? dto.tokenExchangeAudience : null,
+      tokenExchangeIdpSatisfiesMfa: enablesTokenExchange ? (dto.tokenExchangeIdpSatisfiesMfa ?? false) : false
     });
 
     return { client: sanitizeOauthClient(client), clientSecret };
   };
 
-  const listOauthClients = async (actor: OrgServiceActor) => {
+  // `grantType` narrows the list to one grant. The SSO page uses it to show which applications depend
+  // on the org's OIDC issuer.
+  const listOauthClients = async (actor: OrgServiceActor, grantType?: OauthGrantType) => {
     await checkOauthClientPermission(actor, OrgPermissionActions.Read);
 
     const clients = await oauthClientDAL.find({ orgId: actor.orgId });
-    return clients.map(sanitizeOauthClient);
+    const filtered = grantType
+      ? clients.filter((client) => (client.grantTypes as OauthGrantType[]).includes(grantType))
+      : clients;
+
+    return filtered.map(sanitizeOauthClient);
   };
 
   const getOauthClientById = async (clientDbId: string, actor: OrgServiceActor) => {
@@ -176,11 +278,43 @@ export const oauthClientServiceFactory = ({
 
     const client = await getOrgClientOrThrow(dto.clientDbId, actor.orgId);
 
+    const grantTypes = dedupeGrantTypes(dto.grantTypes ?? (client.grantTypes as OauthGrantType[]));
+    const isTokenExchangeEnabled = hasTokenExchangeGrant(grantTypes);
+    const isRedirectBased = hasRedirectBasedGrant(grantTypes);
+
+    const resolvedRedirectUris = dto.redirectUris ?? client.redirectUris;
+    const resolvedTokenExchangeAudience =
+      dto.tokenExchangeAudience !== undefined ? dto.tokenExchangeAudience : client.tokenExchangeAudience;
+    const resolvedIdpSatisfiesMfa = dto.tokenExchangeIdpSatisfiesMfa ?? client.tokenExchangeIdpSatisfiesMfa;
+
+    const touchesTokenExchangeConfig =
+      dto.grantTypes !== undefined ||
+      dto.tokenExchangeAudience !== undefined ||
+      dto.tokenExchangeIdpSatisfiesMfa !== undefined;
+
+    if (isTokenExchangeEnabled && touchesTokenExchangeConfig) await checkSsoConfigPermission(actor);
+
+    assertValidOauthClientGrantConfig({
+      grantTypes,
+      resolved: { redirectUris: resolvedRedirectUris, tokenExchangeAudience: resolvedTokenExchangeAudience },
+      supplied: {
+        redirectUris: dto.redirectUris,
+        requirePkce: dto.requirePkce,
+        tokenExchangeAudience: dto.tokenExchangeAudience,
+        tokenExchangeIdpSatisfiesMfa: dto.tokenExchangeIdpSatisfiesMfa
+      }
+    });
+
+    if (isTokenExchangeEnabled && touchesTokenExchangeConfig) await getActiveOidcConfigOrThrow(actor.orgId);
+
     const updatedClient = await oauthClientDAL.updateById(client.id, {
       name: dto.name,
       description: dto.description,
-      redirectUris: dto.redirectUris,
-      requirePkce: dto.requirePkce
+      grantTypes: dto.grantTypes ? grantTypes : undefined,
+      redirectUris: isRedirectBased ? dto.redirectUris : [],
+      requirePkce: isRedirectBased ? dto.requirePkce : false,
+      tokenExchangeAudience: isTokenExchangeEnabled ? resolvedTokenExchangeAudience : null,
+      tokenExchangeIdpSatisfiesMfa: isTokenExchangeEnabled ? resolvedIdpSatisfiesMfa : false
     });
 
     return sanitizeOauthClient(updatedClient);
@@ -218,9 +352,19 @@ export const oauthClientServiceFactory = ({
     return { client: sanitizeOauthClient(updatedClient), clientSecret };
   };
 
+  const assertGrantEnabled = (client: TOauthClients, grantType: OauthGrantType) => {
+    if (!(client.grantTypes as OauthGrantType[]).includes(grantType)) {
+      throw new UnauthorizedError({
+        message: `This application is not registered for the '${grantType}' grant type`
+      });
+    }
+  };
+
   const getAuthorizeInfo = async ({ clientId, redirectUri, scope }: TOauthAuthorizeInfoDTO) => {
     const client = await oauthClientDAL.findOne({ clientId });
     if (!client) throw new UnauthorizedError({ message: "OAuth client not found" });
+
+    assertGrantEnabled(client, OauthGrantType.AuthorizationCode);
 
     if (!isRegisteredRedirectUri(client.redirectUris, redirectUri)) {
       throw new BadRequestError({ message: "Redirect URI is not registered for this OAuth client" });
@@ -245,6 +389,8 @@ export const oauthClientServiceFactory = ({
   const authorizeConsent = async (dto: TOauthConsentDTO) => {
     const client = await oauthClientDAL.findOne({ clientId: dto.clientId });
     if (!client) throw new UnauthorizedError({ message: "OAuth client not found" });
+
+    assertGrantEnabled(client, OauthGrantType.AuthorizationCode);
 
     if (!isRegisteredRedirectUri(client.redirectUris, dto.redirectUri)) {
       throw new BadRequestError({ message: "Redirect URI is not registered for this OAuth client" });
@@ -279,14 +425,8 @@ export const oauthClientServiceFactory = ({
     // completed). Issuing a delegation code from such a session would let anyone holding only the
     // password mint OAuth tokens, bypassing MFA entirely. So we re-derive whether MFA is required
     // for this user in the client's organization and reject the request unless the session actually
-    // completed the matching MFA challenge. MFA enforcement lives on the root organization (matching
-    // the login flow), so resolve it when the client belongs to a sub-organization.
-    const clientOrg = await orgDAL.findById(client.orgId);
-    if (!clientOrg) throw new NotFoundError({ message: "OAuth client organization not found" });
-
-    const isSubOrganization = Boolean(clientOrg.rootOrgId && clientOrg.id !== clientOrg.rootOrgId);
-    const rootOrg = isSubOrganization ? await orgDAL.findById(clientOrg.rootOrgId as string) : clientOrg;
-    if (!rootOrg) throw new NotFoundError({ message: "OAuth client organization not found" });
+    // completed the matching MFA challenge.
+    const rootOrg = await getClientRootOrg(client.orgId);
 
     const user = await userDAL.findById(dto.userId);
     if (!user) throw new UnauthorizedError({ message: "User not found" });
@@ -359,10 +499,134 @@ export const oauthClientServiceFactory = ({
     return { accessTokenExpiresIn, refreshTokenExpiresIn };
   };
 
+  // RFC 8693 token exchange: the SSO login path with the token supplied directly instead of collected
+  // through a browser redirect, and an access token issued instead of a session cookie. With no redirect
+  // URI, no PKCE and no browser session to anchor trust on, the audience check below is what stops any
+  // token the issuer signs, for any application, being replayed here.
+  const exchangeSubjectToken = async (
+    client: TOauthClients,
+    dto: Extract<TOauthTokenExchangeDTO, { grantType: OauthGrantType.TokenExchange }>
+  ) => {
+    assertGrantEnabled(client, OauthGrantType.TokenExchange);
+
+    if (!client.tokenExchangeAudience) {
+      throw new BadRequestError({
+        message:
+          "This application has no token exchange audience configured, so subject tokens cannot be verified. Set one on the application under Organization Settings > OAuth Applications."
+      });
+    }
+
+    const { oidcConfig, rootOrg } = await getActiveOidcConfigOrThrow(client.orgId);
+
+    const { subject } = await verifySubjectToken({
+      subjectToken: dto.subjectToken,
+      oidcConfig,
+      expectedAudience: client.tokenExchangeAudience
+    });
+
+    const userAlias = await userAliasDAL.findOne({
+      externalId: subject,
+      orgId: rootOrg.id,
+      aliasType: UserAliasType.OIDC
+    });
+
+    if (!userAlias) {
+      throw new UnauthorizedError({
+        message:
+          "The user this token identifies has not signed in to Infisical through your organization's OIDC SSO yet. They need to complete a browser sign-in once before an application can act on their behalf."
+      });
+    }
+
+    const user = await userDAL.findById(userAlias.userId);
+    if (!user) {
+      throw new UnauthorizedError({ message: "The user this token identifies no longer has an Infisical account." });
+    }
+
+    await permissionService.getOrgPermission({
+      actor: ActorType.USER,
+      actorId: user.id,
+      orgId: client.orgId,
+      actorAuthMethod: AuthMethod.OIDC,
+      actorOrgId: client.orgId,
+      scope: OrganizationActionScope.ParentOrganization
+    });
+
+    const { isMfaRequired } = getRequiredMfaMethod(rootOrg, user);
+    if (isMfaRequired && !client.tokenExchangeIdpSatisfiesMfa) {
+      throw new UnauthorizedError({
+        message:
+          "Multi-factor authentication is required for this user, and this application has not been marked as relying on an identity provider that enforces it. An organization admin can enable that on the application under Organization Settings > OAuth Applications."
+      });
+    }
+
+    const tokenSession = await tokenService.getUserTokenSession({
+      userId: user.id,
+      ip: dto.ip,
+      userAgent: getOauthClientSessionUserAgent(client.clientId)
+    });
+    if (!tokenSession) throw new BadRequestError({ message: "Failed to create user token session" });
+
+    const { accessTokenExpiresIn } = await getTokenLifetimes(client.orgId);
+
+    const accessToken = signOauthToken(
+      {
+        authMethod: AuthMethod.OIDC,
+        userId: user.id,
+        tokenVersionId: tokenSession.id,
+        organizationId: client.orgId,
+        isMfaVerified: client.tokenExchangeIdpSatisfiesMfa || undefined,
+        delegation: OauthDelegationMode.Full,
+        tokenType: AuthTokenType.ACCESS_TOKEN,
+        version: tokenSession.accessVersion,
+        oauthClientId: client.clientId
+      },
+      accessTokenExpiresIn
+    );
+
+    await auditLogService.createAuditLog({
+      ipAddress: dto.ip,
+      userAgent: dto.userAgent,
+      orgId: client.orgId,
+      actor: {
+        type: ActorType.USER,
+        metadata: {
+          userId: user.id,
+          email: user.email,
+          username: user.username,
+          authMethod: AuthMethod.OIDC
+        }
+      },
+      event: {
+        type: EventType.OAUTH_CLIENT_TOKEN_EXCHANGE,
+        metadata: {
+          clientDbId: client.id,
+          clientId: client.clientId,
+          clientName: client.name,
+          subjectUserId: user.id,
+          subjectExternalId: subject,
+          tokenVersionId: tokenSession.id
+        }
+      }
+    });
+
+    return {
+      access_token: accessToken,
+      issued_token_type: OauthTokenType.AccessToken,
+      token_type: "Bearer" as const,
+      expires_in: expiresInToSeconds(accessTokenExpiresIn)
+    };
+  };
+
   const exchangeToken = async (dto: TOauthTokenExchangeDTO) => {
     const client = await authenticateClient(dto.clientId, dto.clientSecret);
 
-    if (dto.grantType === "authorization_code") {
+    if (dto.grantType === OauthGrantType.TokenExchange) {
+      return exchangeSubjectToken(client, dto);
+    }
+
+    if (dto.grantType === OauthGrantType.AuthorizationCode) {
+      assertGrantEnabled(client, OauthGrantType.AuthorizationCode);
+
       const codeKey = KeyStorePrefixes.OauthAuthorizationCode(dto.code);
       const codePayloadRaw = await keyStore.getItem(codeKey);
       if (!codePayloadRaw) {
@@ -441,6 +705,8 @@ export const oauthClientServiceFactory = ({
         scope: grantedScopes.join(" ")
       };
     }
+
+    assertGrantEnabled(client, OauthGrantType.RefreshToken);
 
     const { decodedToken, tokenVersion, isGraceHit } = await tokenService.validateRefreshToken(dto.refreshToken, {
       allowOauthClientToken: true

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError } from "@casl/ability";
 
-import { OrganizationActionScope, TOauthClients, TOrganizations } from "@app/db/schemas";
+import { OrganizationActionScope, OrgMembershipStatus, TOauthClients, TOrganizations } from "@app/db/schemas";
 import { EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
 import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import {
@@ -62,7 +62,7 @@ type TOauthClientServiceFactoryDep = {
     | "rotateRefreshToken"
     | "revokeSessionsByUserAgent"
   >;
-  orgDAL: Pick<TOrgDALFactory, "findById">;
+  orgDAL: Pick<TOrgDALFactory, "findById" | "findEffectiveOrgMembership">;
   userDAL: Pick<TUserDALFactory, "findById">;
   oidcConfigDAL: Pick<TOidcConfigDALFactory, "findOne">;
   userAliasDAL: Pick<TUserAliasDALFactory, "findOne">;
@@ -577,6 +577,33 @@ export const oauthClientServiceFactory = ({
       throw new UnauthorizedError({
         message:
           "The Infisical account for the user this token identifies is locked, so an application cannot act on their behalf. They can unlock it by resetting their password."
+      });
+    }
+
+    const orgMembership = await orgDAL.findEffectiveOrgMembership({
+      actorType: ActorType.USER,
+      actorId: user.id,
+      orgId: client.orgId,
+      acceptAnyStatus: true
+    });
+
+    if (!orgMembership) {
+      throw new UnauthorizedError({
+        message: "The user this token identifies is not a member of this application's organization."
+      });
+    }
+
+    if (orgMembership.status === OrgMembershipStatus.Invited) {
+      throw new UnauthorizedError({
+        message:
+          "The user this token identifies has been invited to this application's organization but has not joined it yet."
+      });
+    }
+
+    if (!orgMembership.isActive) {
+      throw new UnauthorizedError({
+        message:
+          "The membership of the user this token identifies has been deactivated in this organization, so an application cannot act on their behalf."
       });
     }
 

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -74,8 +74,8 @@ const sanitizeOauthClient = (client: TOauthClients) => {
   return rest;
 };
 
-// The generated schema types the column as `string[]`, since it is a plain text[] in Postgres. Every
-// value written to it goes through the router's `grantTypesSchema`, so the narrowing holds.
+// The column is a plain text[] in Postgres, so the generated schema types it as `string[]`. Every write
+// goes through the router's `grantTypesSchema`, so the narrowing holds.
 const getGrantTypes = (client: TOauthClients) => client.grantTypes as OauthGrantType[];
 
 const expiresInToSeconds = (expiresIn: string | number) =>
@@ -123,9 +123,9 @@ const signOauthToken = (
       // Marks this as a delegated OAuth token. extractAuth maps tokens carrying this claim to
       // AuthMode.OAUTH so they are rejected by the default first-party JWT middleware.
       oauthClientId: claims.oauthClientId,
-      // Exactly one delegation marker per token. `scopes` narrows the ability to what the user
-      // consented to, `delegation` carries it unnarrowed. Absence of both means zero permissions, so
-      // dropping either claim by mistake fails closed. See OauthDelegationMode.
+      // Exactly one delegation marker per token: `scopes` narrows the ability to what the user
+      // consented to, `delegation` carries it unnarrowed. Neither claim means zero permissions, so
+      // dropping one by mistake fails closed. See OauthDelegationMode.
       ...(claims.delegation ? { delegation: claims.delegation } : { scopes: claims.scopes })
     },
     appCfg.AUTH_SECRET,
@@ -157,13 +157,12 @@ export const oauthClientServiceFactory = ({
     ForbiddenError.from(permission).throwUnlessCan(action, OrgPermissionSubjects.OauthClients);
   };
 
-  // The token exchange grant converts externally-issued tokens into Infisical user tokens, so anything
-  // that establishes that trust or hands out a working credential for it is a change to the org's
-  // federation posture, not just an application edit. Those operations need the permission that already
-  // owns the SSO configuration on top of the usual OauthClients check.
+  // Token exchange turns externally-issued tokens into Infisical user tokens, so establishing that
+  // trust (or handing out a credential for it) changes the org's federation posture, not just an
+  // application. Those operations need SSO Edit on top of the usual OauthClients check.
   //
-  // `action` names the operation in the error, because the reason an OAuth application change needs SSO
-  // permission is not self-evident to the admin who hits it.
+  // `action` goes in the error because it's not obvious why an OAuth application change wants SSO
+  // permission.
   const checkSsoConfigPermission = async (actor: OrgServiceActor, action: string) => {
     const { permission } = await permissionService.getOrgPermission({
       actor: actor.type,
@@ -190,15 +189,10 @@ export const oauthClientServiceFactory = ({
     return client;
   };
 
-  // An OAuth client always belongs to a root organization: every management method goes through
-  // checkOauthClientPermission, which is scoped to ParentOrganization, and an organization's rootOrgId
-  // is fixed when it is created. So the org that owns the client is also the one carrying everything
-  // these flows read off it — MFA enforcement, the OIDC SSO configuration and OIDC user aliases all
-  // live on the root organization, matching the login flow.
-  //
-  // Asserted rather than assumed. If sub-organizations are ever allowed to own clients, resolving the
-  // root organization has to become explicit here, or the exchange would silently verify subject tokens
-  // against a sub-organization's own OIDC configuration and look up aliases in the wrong org.
+  // Clients only ever live on a root org today, and that's where the things these flows read live too:
+  // MFA enforcement, the OIDC SSO config and OIDC user aliases, same as the login flow. Asserted rather
+  // than assumed, because if sub-orgs are ever allowed to own clients, an exchange would silently verify
+  // subject tokens against the sub-org's own OIDC config and look up aliases in the wrong org.
   const getClientOrg = async (orgId: string): Promise<TOrganizations> => {
     const org = await orgDAL.findById(orgId);
     if (!org) throw new NotFoundError({ message: "OAuth client organization not found" });
@@ -212,8 +206,8 @@ export const oauthClientServiceFactory = ({
     return org;
   };
 
-  // Token exchange has nothing to verify a subject token against until federation is live. Failing at
-  // configuration time puts the message in front of the admin setting the application up.
+  // Without a live OIDC config there's nothing to verify subject tokens against. Failing at config time
+  // puts the message in front of the admin setting the application up.
   const getActiveOidcConfigOrThrow = async (orgId: string) => {
     const org = await getClientOrg(orgId);
     const oidcConfig = await oidcConfigDAL.findOne({ orgId: org.id });
@@ -235,14 +229,11 @@ export const oauthClientServiceFactory = ({
     return { oidcConfig, org };
   };
 
-  // Registering and editing an application ask the same questions of a grant configuration: which grants
-  // the client ends up holding, whether the per-grant fields are coherent with them, and whether the
-  // actor may establish the federation trust that token exchange implies. An edit answers them against
-  // the stored client and a registration against nothing, so `client` is the only difference between the
-  // two callers.
+  // Register and update ask the same questions of a grant config, an update against the stored client
+  // and a register against nothing, so `client` is the only difference between the two callers.
   //
-  // The two token exchange gates run only when the request actually touches that configuration, so an
-  // admin holding OauthClients Edit alone can still rename an application that happens to use the grant.
+  // The token exchange gates only fire when the request actually touches that config, so an admin with
+  // just OauthClients Edit can still rename an application that happens to use the grant.
   const resolveGrantConfig = async ({
     dto,
     actor,
@@ -331,8 +322,7 @@ export const oauthClientServiceFactory = ({
     return { client: sanitizeOauthClient(client), clientSecret };
   };
 
-  // `grantType` narrows the list to one grant. The SSO page uses it to show which applications depend
-  // on the org's OIDC issuer.
+  // The SSO page passes `grantType` to show which applications depend on the org's OIDC issuer.
   const listOauthClients = async (actor: OrgServiceActor, grantType?: OauthGrantType) => {
     await checkOauthClientPermission(actor, OrgPermissionActions.Read);
 
@@ -576,10 +566,9 @@ export const oauthClientServiceFactory = ({
 
   const getTokenLifetimes = async (orgId: string) => resolveTokenLifetimes(await orgDAL.findById(orgId));
 
-  // RFC 8693 token exchange: the SSO login path with the token supplied directly instead of collected
-  // through a browser redirect, and an access token issued instead of a session cookie. With no redirect
-  // URI, no PKCE and no browser session to anchor trust on, the audience check below is what stops any
-  // token the issuer signs, for any application, being replayed here.
+  // RFC 8693 token exchange is the SSO login path with the token handed to us directly instead of
+  // collected through a browser redirect. With no redirect URI, no PKCE and no browser session to anchor
+  // trust on, the audience check is all that stops any token the issuer signed being replayed here.
   const exchangeSubjectToken = async (
     client: TOauthClients,
     dto: Extract<TOauthTokenExchangeDTO, { grantType: OauthGrantType.TokenExchange }>

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -28,10 +28,7 @@ import { TOauthClientDALFactory } from "./oauth-client-dal";
 import {
   assertValidOauthClientGrantConfig,
   computePkceChallenge,
-  dedupeGrantTypes,
   getOauthClientSessionUserAgent,
-  hasRedirectBasedGrant,
-  hasTokenExchangeGrant,
   isRegisteredRedirectUri,
   PKCE_CODE_VERIFIER_REGEX
 } from "./oauth-client-fns";
@@ -75,6 +72,10 @@ const sanitizeOauthClient = (client: TOauthClients) => {
   const { clientSecretHash, ...rest } = client;
   return rest;
 };
+
+// The generated schema types the column as `string[]`, since it is a plain text[] in Postgres. Every
+// value written to it goes through the router's `grantTypesSchema`, so the narrowing holds.
+const getGrantTypes = (client: TOauthClients) => client.grantTypes as OauthGrantType[];
 
 const expiresInToSeconds = (expiresIn: string | number) =>
   typeof expiresIn === "number" ? expiresIn : Math.floor(ms(expiresIn) / 1000);
@@ -252,12 +253,12 @@ export const oauthClientServiceFactory = ({
     client?: TOauthClients;
     ssoPermissionAction: string;
   }) => {
-    const storedGrantTypes = client ? (client.grantTypes as OauthGrantType[]) : [];
+    const storedGrantTypes = client ? getGrantTypes(client) : [];
 
-    const grantTypes = dedupeGrantTypes(dto.grantTypes ?? storedGrantTypes);
-    const wasTokenExchangeEnabled = hasTokenExchangeGrant(storedGrantTypes);
-    const isTokenExchangeEnabled = hasTokenExchangeGrant(grantTypes);
-    const isRedirectBased = hasRedirectBasedGrant(grantTypes);
+    const grantTypes = dto.grantTypes ?? storedGrantTypes;
+    const wasTokenExchangeEnabled = storedGrantTypes.includes(OauthGrantType.TokenExchange);
+    const isTokenExchangeEnabled = grantTypes.includes(OauthGrantType.TokenExchange);
+    const isRedirectBased = grantTypes.includes(OauthGrantType.AuthorizationCode);
 
     const redirectUris = dto.redirectUris ?? client?.redirectUris ?? [];
     const tokenExchangeAudience =
@@ -335,9 +336,7 @@ export const oauthClientServiceFactory = ({
     await checkOauthClientPermission(actor, OrgPermissionActions.Read);
 
     const clients = await oauthClientDAL.find({ orgId: actor.orgId });
-    const filtered = grantType
-      ? clients.filter((client) => (client.grantTypes as OauthGrantType[]).includes(grantType))
-      : clients;
+    const filtered = grantType ? clients.filter((client) => getGrantTypes(client).includes(grantType)) : clients;
 
     return filtered.map(sanitizeOauthClient);
   };
@@ -406,7 +405,7 @@ export const oauthClientServiceFactory = ({
 
     const client = await getOrgClientOrThrow(clientDbId, actor.orgId);
 
-    const usesTokenExchange = hasTokenExchangeGrant(client.grantTypes as OauthGrantType[]);
+    const usesTokenExchange = getGrantTypes(client).includes(OauthGrantType.TokenExchange);
 
     if (usesTokenExchange) {
       await checkSsoConfigPermission(actor, "rotate the secret of an OAuth application that uses token exchange");
@@ -428,11 +427,8 @@ export const oauthClientServiceFactory = ({
     return { client: sanitizeOauthClient(updatedClient), clientSecret };
   };
 
-  const isGrantEnabled = (client: TOauthClients, grantType: OauthGrantType) =>
-    (client.grantTypes as OauthGrantType[]).includes(grantType);
-
   const assertGrantEnabled = (client: TOauthClients, grantType: OauthGrantType) => {
-    if (!isGrantEnabled(client, grantType)) {
+    if (!getGrantTypes(client).includes(grantType)) {
       throw new UnauthorizedError({
         message: `This application is not registered for the '${grantType}' grant type`
       });
@@ -587,8 +583,6 @@ export const oauthClientServiceFactory = ({
     client: TOauthClients,
     dto: Extract<TOauthTokenExchangeDTO, { grantType: OauthGrantType.TokenExchange }>
   ) => {
-    assertGrantEnabled(client, OauthGrantType.TokenExchange);
-
     if (!client.tokenExchangeAudience) {
       throw new BadRequestError({
         message:
@@ -739,14 +733,13 @@ export const oauthClientServiceFactory = ({
 
   const exchangeToken = async (dto: TOauthTokenExchangeDTO) => {
     const client = await authenticateClient(dto.clientId, dto.clientSecret);
+    assertGrantEnabled(client, dto.grantType);
 
     if (dto.grantType === OauthGrantType.TokenExchange) {
       return exchangeSubjectToken(client, dto);
     }
 
     if (dto.grantType === OauthGrantType.AuthorizationCode) {
-      assertGrantEnabled(client, OauthGrantType.AuthorizationCode);
-
       const codeKey = KeyStorePrefixes.OauthAuthorizationCode(dto.code);
       const codePayloadRaw = await keyStore.getItem(codeKey);
       if (!codePayloadRaw) {
@@ -807,7 +800,7 @@ export const oauthClientServiceFactory = ({
         accessTokenExpiresIn
       );
 
-      const refreshToken = isGrantEnabled(client, OauthGrantType.RefreshToken)
+      const refreshToken = getGrantTypes(client).includes(OauthGrantType.RefreshToken)
         ? signOauthToken(
             {
               ...sharedClaims,
@@ -827,8 +820,6 @@ export const oauthClientServiceFactory = ({
         scope: grantedScopes.join(" ")
       };
     }
-
-    assertGrantEnabled(client, OauthGrantType.RefreshToken);
 
     const { decodedToken, tokenVersion, isGraceHit } = await tokenService.validateRefreshToken(dto.refreshToken, {
       allowOauthClientToken: true

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -180,30 +180,33 @@ export const oauthClientServiceFactory = ({
     return client;
   };
 
-  // MFA enforcement, the OIDC SSO configuration and OIDC user aliases all live on the root
-  // organization, matching the login flow.
-  // Both orgs are returned because callers on the exchange path need each of them: the root org for
-  // federation state, the client's own org for its token lifetime setting. They are the same row
-  // whenever the client does not belong to a sub-organization.
-  const getClientOrgs = async (orgId: string): Promise<{ clientOrg: TOrganizations; rootOrg: TOrganizations }> => {
-    const clientOrg = await orgDAL.findById(orgId);
-    if (!clientOrg) throw new NotFoundError({ message: "OAuth client organization not found" });
+  // An OAuth client always belongs to a root organization: every management method goes through
+  // checkOauthClientPermission, which is scoped to ParentOrganization, and an organization's rootOrgId
+  // is fixed when it is created. So the org that owns the client is also the one carrying everything
+  // these flows read off it — MFA enforcement, the OIDC SSO configuration and OIDC user aliases all
+  // live on the root organization, matching the login flow.
+  //
+  // Asserted rather than assumed. If sub-organizations are ever allowed to own clients, resolving the
+  // root organization has to become explicit here, or the exchange would silently verify subject tokens
+  // against a sub-organization's own OIDC configuration and look up aliases in the wrong org.
+  const getClientOrg = async (orgId: string): Promise<TOrganizations> => {
+    const org = await orgDAL.findById(orgId);
+    if (!org) throw new NotFoundError({ message: "OAuth client organization not found" });
 
-    const isSubOrganization = Boolean(clientOrg.rootOrgId && clientOrg.id !== clientOrg.rootOrgId);
-    if (!isSubOrganization) return { clientOrg, rootOrg: clientOrg };
+    if (org.rootOrgId && org.rootOrgId !== org.id) {
+      throw new BadRequestError({
+        message: "OAuth applications are managed on the parent organization, not on a sub-organization."
+      });
+    }
 
-    const rootOrg = await orgDAL.findById(clientOrg.rootOrgId as string);
-    if (!rootOrg) throw new NotFoundError({ message: "OAuth client organization not found" });
-    return { clientOrg, rootOrg };
+    return org;
   };
-
-  const getClientRootOrg = async (orgId: string) => (await getClientOrgs(orgId)).rootOrg;
 
   // Token exchange has nothing to verify a subject token against until federation is live. Failing at
   // configuration time puts the message in front of the admin setting the application up.
   const getActiveOidcConfigOrThrow = async (orgId: string) => {
-    const { clientOrg, rootOrg } = await getClientOrgs(orgId);
-    const oidcConfig = await oidcConfigDAL.findOne({ orgId: rootOrg.id });
+    const org = await getClientOrg(orgId);
+    const oidcConfig = await oidcConfigDAL.findOne({ orgId: org.id });
 
     if (!oidcConfig) {
       throw new BadRequestError({
@@ -219,7 +222,7 @@ export const oauthClientServiceFactory = ({
       });
     }
 
-    return { oidcConfig, rootOrg, clientOrg };
+    return { oidcConfig, org };
   };
 
   const createOauthClient = async (dto: TCreateOauthClientDTO, actor: OrgServiceActor) => {
@@ -450,12 +453,12 @@ export const oauthClientServiceFactory = ({
     // password mint OAuth tokens, bypassing MFA entirely. So we re-derive whether MFA is required
     // for this user in the client's organization and reject the request unless the session actually
     // completed the matching MFA challenge.
-    const rootOrg = await getClientRootOrg(client.orgId);
+    const org = await getClientOrg(client.orgId);
 
     const user = await userDAL.findById(dto.userId);
     if (!user) throw new UnauthorizedError({ message: "User not found" });
 
-    const { isMfaRequired, requiredMfaMethod } = getRequiredMfaMethod(rootOrg, user);
+    const { isMfaRequired, requiredMfaMethod } = getRequiredMfaMethod(org, user);
     if (isMfaRequired && (!dto.isMfaVerified || dto.mfaMethod !== requiredMfaMethod)) {
       throw new UnauthorizedError({
         message: "Multi-factor authentication is required before authorizing this application"
@@ -541,7 +544,7 @@ export const oauthClientServiceFactory = ({
       });
     }
 
-    const { oidcConfig, rootOrg, clientOrg } = await getActiveOidcConfigOrThrow(client.orgId);
+    const { oidcConfig, org } = await getActiveOidcConfigOrThrow(client.orgId);
 
     const { subject } = await verifySubjectToken({
       subjectToken: dto.subjectToken,
@@ -551,7 +554,7 @@ export const oauthClientServiceFactory = ({
 
     const userAlias = await userAliasDAL.findOne({
       externalId: subject,
-      orgId: rootOrg.id,
+      orgId: org.id,
       aliasType: UserAliasType.OIDC
     });
 
@@ -616,7 +619,7 @@ export const oauthClientServiceFactory = ({
       scope: OrganizationActionScope.ParentOrganization
     });
 
-    const { isMfaRequired } = getRequiredMfaMethod(rootOrg, user);
+    const { isMfaRequired } = getRequiredMfaMethod(org, user);
     if (isMfaRequired && !client.tokenExchangeIdpSatisfiesMfa) {
       throw new UnauthorizedError({
         message:
@@ -631,7 +634,7 @@ export const oauthClientServiceFactory = ({
     });
     if (!tokenSession) throw new BadRequestError({ message: "Failed to create user token session" });
 
-    const { accessTokenExpiresIn } = resolveTokenLifetimes(clientOrg);
+    const { accessTokenExpiresIn } = resolveTokenLifetimes(org);
 
     const accessToken = signOauthToken(
       {

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -297,6 +297,7 @@ export const oauthClientServiceFactory = ({
     const client = await getOrgClientOrThrow(dto.clientDbId, actor.orgId);
 
     const grantTypes = dedupeGrantTypes(dto.grantTypes ?? (client.grantTypes as OauthGrantType[]));
+    const wasTokenExchangeEnabled = hasTokenExchangeGrant(client.grantTypes as OauthGrantType[]);
     const isTokenExchangeEnabled = hasTokenExchangeGrant(grantTypes);
     const isRedirectBased = hasRedirectBasedGrant(grantTypes);
 
@@ -337,6 +338,10 @@ export const oauthClientServiceFactory = ({
       tokenExchangeIdpSatisfiesMfa: isTokenExchangeEnabled ? resolvedIdpSatisfiesMfa : false
     });
 
+    if (wasTokenExchangeEnabled && !isTokenExchangeEnabled) {
+      await tokenService.revokeSessionsByUserAgent(getOauthClientSessionUserAgent(client.clientId));
+    }
+
     return sanitizeOauthClient(updatedClient);
   };
 
@@ -360,7 +365,9 @@ export const oauthClientServiceFactory = ({
 
     const client = await getOrgClientOrThrow(clientDbId, actor.orgId);
 
-    if (hasTokenExchangeGrant(client.grantTypes as OauthGrantType[])) {
+    const usesTokenExchange = hasTokenExchangeGrant(client.grantTypes as OauthGrantType[]);
+
+    if (usesTokenExchange) {
       await checkSsoConfigPermission(actor, "rotate the secret of an OAuth application that uses token exchange");
     }
 
@@ -372,6 +379,10 @@ export const oauthClientServiceFactory = ({
       clientSecretHash,
       clientSecretPrefix: clientSecret.slice(0, 4)
     });
+
+    if (usesTokenExchange) {
+      await tokenService.revokeSessionsByUserAgent(getOauthClientSessionUserAgent(client.clientId));
+    }
 
     return { client: sanitizeOauthClient(updatedClient), clientSecret };
   };

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -29,6 +29,7 @@ import {
   assertValidOauthClientGrantConfig,
   computePkceChallenge,
   getOauthClientSessionUserAgent,
+  hasClientAuthorityChanged,
   isRegisteredRedirectUri,
   PKCE_CODE_VERIFIER_REGEX
 } from "./oauth-client-fns";
@@ -686,6 +687,15 @@ export const oauthClientServiceFactory = ({
       userAgent: getOauthClientSessionUserAgent(client.clientId)
     });
     if (!tokenSession) throw new BadRequestError({ message: "Failed to create user token session" });
+
+    const currentClient = await oauthClientDAL.findByIdOnPrimary(client.id);
+    if (hasClientAuthorityChanged(client, currentClient, OauthGrantType.TokenExchange)) {
+      await tokenService.revokeSessionsByUserAgent(getOauthClientSessionUserAgent(client.clientId));
+      throw new UnauthorizedError({
+        message:
+          "This application's credentials or configuration changed while the token was being issued. Retry with the application's current client secret."
+      });
+    }
 
     const { accessTokenExpiresIn } = resolveTokenLifetimes(org);
 

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -561,6 +561,19 @@ export const oauthClientServiceFactory = ({
       throw new UnauthorizedError({ message: "The user this token identifies no longer has an Infisical account." });
     }
 
+    if (!user.isAccepted) {
+      throw new UnauthorizedError({
+        message: "The user this token identifies has not completed Infisical account setup."
+      });
+    }
+
+    if (user.isLocked || (user.temporaryLockDateEnd && new Date() < user.temporaryLockDateEnd)) {
+      throw new UnauthorizedError({
+        message:
+          "The Infisical account for the user this token identifies is locked, so an application cannot act on their behalf. They can unlock it by resetting their password."
+      });
+    }
+
     await permissionService.getOrgPermission({
       actor: ActorType.USER,
       actorId: user.id,

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -182,22 +182,27 @@ export const oauthClientServiceFactory = ({
 
   // MFA enforcement, the OIDC SSO configuration and OIDC user aliases all live on the root
   // organization, matching the login flow.
-  const getClientRootOrg = async (orgId: string): Promise<TOrganizations> => {
+  // Both orgs are returned because callers on the exchange path need each of them: the root org for
+  // federation state, the client's own org for its token lifetime setting. They are the same row
+  // whenever the client does not belong to a sub-organization.
+  const getClientOrgs = async (orgId: string): Promise<{ clientOrg: TOrganizations; rootOrg: TOrganizations }> => {
     const clientOrg = await orgDAL.findById(orgId);
     if (!clientOrg) throw new NotFoundError({ message: "OAuth client organization not found" });
 
     const isSubOrganization = Boolean(clientOrg.rootOrgId && clientOrg.id !== clientOrg.rootOrgId);
-    if (!isSubOrganization) return clientOrg;
+    if (!isSubOrganization) return { clientOrg, rootOrg: clientOrg };
 
     const rootOrg = await orgDAL.findById(clientOrg.rootOrgId as string);
     if (!rootOrg) throw new NotFoundError({ message: "OAuth client organization not found" });
-    return rootOrg;
+    return { clientOrg, rootOrg };
   };
+
+  const getClientRootOrg = async (orgId: string) => (await getClientOrgs(orgId)).rootOrg;
 
   // Token exchange has nothing to verify a subject token against until federation is live. Failing at
   // configuration time puts the message in front of the admin setting the application up.
   const getActiveOidcConfigOrThrow = async (orgId: string) => {
-    const rootOrg = await getClientRootOrg(orgId);
+    const { clientOrg, rootOrg } = await getClientOrgs(orgId);
     const oidcConfig = await oidcConfigDAL.findOne({ orgId: rootOrg.id });
 
     if (!oidcConfig) {
@@ -214,7 +219,7 @@ export const oauthClientServiceFactory = ({
       });
     }
 
-    return { oidcConfig, rootOrg };
+    return { oidcConfig, rootOrg, clientOrg };
   };
 
   const createOauthClient = async (dto: TCreateOauthClientDTO, actor: OrgServiceActor) => {
@@ -504,12 +509,11 @@ export const oauthClientServiceFactory = ({
     return client;
   };
 
-  const getTokenLifetimes = async (orgId: string) => {
+  const resolveTokenLifetimes = (org?: TOrganizations) => {
     const appCfg = getConfig();
     let accessTokenExpiresIn: string | number = appCfg.JWT_AUTH_LIFETIME;
     let refreshTokenExpiresIn: string | number = appCfg.JWT_REFRESH_LIFETIME;
 
-    const org = await orgDAL.findById(orgId);
     if (org?.userTokenExpiration) {
       accessTokenExpiresIn = getMinExpiresIn(appCfg.JWT_AUTH_LIFETIME, org.userTokenExpiration);
       refreshTokenExpiresIn = org.userTokenExpiration;
@@ -517,6 +521,8 @@ export const oauthClientServiceFactory = ({
 
     return { accessTokenExpiresIn, refreshTokenExpiresIn };
   };
+
+  const getTokenLifetimes = async (orgId: string) => resolveTokenLifetimes(await orgDAL.findById(orgId));
 
   // RFC 8693 token exchange: the SSO login path with the token supplied directly instead of collected
   // through a browser redirect, and an access token issued instead of a session cookie. With no redirect
@@ -535,7 +541,7 @@ export const oauthClientServiceFactory = ({
       });
     }
 
-    const { oidcConfig, rootOrg } = await getActiveOidcConfigOrThrow(client.orgId);
+    const { oidcConfig, rootOrg, clientOrg } = await getActiveOidcConfigOrThrow(client.orgId);
 
     const { subject } = await verifySubjectToken({
       subjectToken: dto.subjectToken,
@@ -598,7 +604,7 @@ export const oauthClientServiceFactory = ({
     });
     if (!tokenSession) throw new BadRequestError({ message: "Failed to create user token session" });
 
-    const { accessTokenExpiresIn } = await getTokenLifetimes(client.orgId);
+    const { accessTokenExpiresIn } = resolveTokenLifetimes(clientOrg);
 
     const accessToken = signOauthToken(
       {

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -12,7 +12,7 @@ import { TPermissionServiceFactory } from "@app/ee/services/permission/permissio
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
-import { BadRequestError, NotFoundError, UnauthorizedError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, NotFoundError, UnauthorizedError } from "@app/lib/errors";
 import { getMinExpiresIn } from "@app/lib/fn";
 import { ms } from "@app/lib/ms";
 import { OrgServiceActor } from "@app/lib/types";
@@ -147,10 +147,14 @@ export const oauthClientServiceFactory = ({
     ForbiddenError.from(permission).throwUnlessCan(action, OrgPermissionSubjects.OauthClients);
   };
 
-  // Enabling this grant, or changing the audience it accepts, decides whose externally-issued tokens
-  // become Infisical user tokens. That is a change to the org's federation trust, so it needs the
-  // permission that already owns the SSO configuration.
-  const checkSsoConfigPermission = async (actor: OrgServiceActor) => {
+  // The token exchange grant converts externally-issued tokens into Infisical user tokens, so anything
+  // that establishes that trust or hands out a working credential for it is a change to the org's
+  // federation posture, not just an application edit. Those operations need the permission that already
+  // owns the SSO configuration on top of the usual OauthClients check.
+  //
+  // `action` names the operation in the error, because the reason an OAuth application change needs SSO
+  // permission is not self-evident to the admin who hits it.
+  const checkSsoConfigPermission = async (actor: OrgServiceActor, action: string) => {
     const { permission } = await permissionService.getOrgPermission({
       actor: actor.type,
       actorId: actor.id,
@@ -160,7 +164,11 @@ export const oauthClientServiceFactory = ({
       scope: OrganizationActionScope.ParentOrganization
     });
 
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionSsoActions.Edit, OrgPermissionSubjects.Sso);
+    if (permission.cannot(OrgPermissionSsoActions.Edit, OrgPermissionSubjects.Sso)) {
+      throw new ForbiddenRequestError({
+        message: `You do not have permission to ${action}. Applications using the '${OauthGrantType.TokenExchange}' grant turn tokens from your organization's identity provider into Infisical user tokens, so managing them also requires permission to edit the organization's SSO configuration.`
+      });
+    }
   };
 
   // Loads a client scoped to the actor's org (so one org can never address another's client) and
@@ -215,7 +223,9 @@ export const oauthClientServiceFactory = ({
     const grantTypes = dedupeGrantTypes(dto.grantTypes);
     const enablesTokenExchange = hasTokenExchangeGrant(grantTypes);
 
-    if (enablesTokenExchange) await checkSsoConfigPermission(actor);
+    if (enablesTokenExchange) {
+      await checkSsoConfigPermission(actor, "register an OAuth application that uses token exchange");
+    }
 
     assertValidOauthClientGrantConfig({
       grantTypes,
@@ -292,7 +302,9 @@ export const oauthClientServiceFactory = ({
       dto.tokenExchangeAudience !== undefined ||
       dto.tokenExchangeIdpSatisfiesMfa !== undefined;
 
-    if (isTokenExchangeEnabled && touchesTokenExchangeConfig) await checkSsoConfigPermission(actor);
+    if (isTokenExchangeEnabled && touchesTokenExchangeConfig) {
+      await checkSsoConfigPermission(actor, "change the token exchange configuration of an OAuth application");
+    }
 
     assertValidOauthClientGrantConfig({
       grantTypes,
@@ -339,6 +351,10 @@ export const oauthClientServiceFactory = ({
     await checkOauthClientPermission(actor, OrgPermissionActions.Edit);
 
     const client = await getOrgClientOrThrow(clientDbId, actor.orgId);
+
+    if (hasTokenExchangeGrant(client.grantTypes as OauthGrantType[])) {
+      await checkSsoConfigPermission(actor, "rotate the secret of an OAuth application that uses token exchange");
+    }
 
     const appCfg = getConfig();
     const clientSecret = crypto.randomBytes(32).toString("hex");

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -611,6 +611,13 @@ export const oauthClientServiceFactory = ({
       });
     }
 
+    if (!userAlias.isEmailVerified) {
+      throw new UnauthorizedError({
+        message:
+          "The user this token identifies has not verified their identity with your organization's OIDC SSO. They need to complete a browser sign-in once before an application can act on their behalf."
+      });
+    }
+
     const user = await userDAL.findById(userAlias.userId);
     if (!user) {
       throw new UnauthorizedError({ message: "The user this token identifies no longer has an Infisical account." });

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -368,8 +368,11 @@ export const oauthClientServiceFactory = ({
     return { client: sanitizeOauthClient(updatedClient), clientSecret };
   };
 
+  const isGrantEnabled = (client: TOauthClients, grantType: OauthGrantType) =>
+    (client.grantTypes as OauthGrantType[]).includes(grantType);
+
   const assertGrantEnabled = (client: TOauthClients, grantType: OauthGrantType) => {
-    if (!(client.grantTypes as OauthGrantType[]).includes(grantType)) {
+    if (!isGrantEnabled(client, grantType)) {
       throw new UnauthorizedError({
         message: `This application is not registered for the '${grantType}' grant type`
       });
@@ -703,21 +706,23 @@ export const oauthClientServiceFactory = ({
         accessTokenExpiresIn
       );
 
-      const refreshToken = signOauthToken(
-        {
-          ...sharedClaims,
-          tokenType: AuthTokenType.REFRESH_TOKEN,
-          version: tokenSession.refreshVersion,
-          oauthClientId: client.clientId
-        },
-        refreshTokenExpiresIn
-      );
+      const refreshToken = isGrantEnabled(client, OauthGrantType.RefreshToken)
+        ? signOauthToken(
+            {
+              ...sharedClaims,
+              tokenType: AuthTokenType.REFRESH_TOKEN,
+              version: tokenSession.refreshVersion,
+              oauthClientId: client.clientId
+            },
+            refreshTokenExpiresIn
+          )
+        : undefined;
 
       return {
         access_token: accessToken,
         token_type: "Bearer" as const,
         expires_in: expiresInToSeconds(accessTokenExpiresIn),
-        refresh_token: refreshToken,
+        ...(refreshToken ? { refresh_token: refreshToken } : {}),
         scope: grantedScopes.join(" ")
       };
     }

--- a/backend/src/services/oauth-client/oauth-client-service.ts
+++ b/backend/src/services/oauth-client/oauth-client-service.ts
@@ -88,6 +88,14 @@ type TOauthTokenClaims = {
   mfaMethod?: MfaMethod;
 } & ({ scopes: string[]; delegation?: never } | { delegation: OauthDelegationMode.Full; scopes?: never });
 
+type TGrantConfigInput = {
+  grantTypes?: OauthGrantType[];
+  redirectUris?: string[];
+  requirePkce?: boolean;
+  tokenExchangeAudience?: string | null;
+  tokenExchangeIdpSatisfiesMfa?: boolean;
+};
+
 const signOauthToken = (
   claims: TOauthTokenClaims & {
     oauthClientId: string;
@@ -225,19 +233,49 @@ export const oauthClientServiceFactory = ({
     return { oidcConfig, org };
   };
 
-  const createOauthClient = async (dto: TCreateOauthClientDTO, actor: OrgServiceActor) => {
-    await checkOauthClientPermission(actor, OrgPermissionActions.Create);
+  // Registering and editing an application ask the same questions of a grant configuration: which grants
+  // the client ends up holding, whether the per-grant fields are coherent with them, and whether the
+  // actor may establish the federation trust that token exchange implies. An edit answers them against
+  // the stored client and a registration against nothing, so `client` is the only difference between the
+  // two callers.
+  //
+  // The two token exchange gates run only when the request actually touches that configuration, so an
+  // admin holding OauthClients Edit alone can still rename an application that happens to use the grant.
+  const resolveGrantConfig = async ({
+    dto,
+    actor,
+    client,
+    ssoPermissionAction
+  }: {
+    dto: TGrantConfigInput;
+    actor: OrgServiceActor;
+    client?: TOauthClients;
+    ssoPermissionAction: string;
+  }) => {
+    const storedGrantTypes = client ? (client.grantTypes as OauthGrantType[]) : [];
 
-    const grantTypes = dedupeGrantTypes(dto.grantTypes);
-    const enablesTokenExchange = hasTokenExchangeGrant(grantTypes);
+    const grantTypes = dedupeGrantTypes(dto.grantTypes ?? storedGrantTypes);
+    const wasTokenExchangeEnabled = hasTokenExchangeGrant(storedGrantTypes);
+    const isTokenExchangeEnabled = hasTokenExchangeGrant(grantTypes);
+    const isRedirectBased = hasRedirectBasedGrant(grantTypes);
 
-    if (enablesTokenExchange) {
-      await checkSsoConfigPermission(actor, "register an OAuth application that uses token exchange");
-    }
+    const redirectUris = dto.redirectUris ?? client?.redirectUris ?? [];
+    const tokenExchangeAudience =
+      dto.tokenExchangeAudience !== undefined ? dto.tokenExchangeAudience : (client?.tokenExchangeAudience ?? null);
+    const tokenExchangeIdpSatisfiesMfa =
+      dto.tokenExchangeIdpSatisfiesMfa ?? client?.tokenExchangeIdpSatisfiesMfa ?? false;
+
+    const establishesTokenExchangeTrust =
+      isTokenExchangeEnabled &&
+      (dto.grantTypes !== undefined ||
+        dto.tokenExchangeAudience !== undefined ||
+        dto.tokenExchangeIdpSatisfiesMfa !== undefined);
+
+    if (establishesTokenExchangeTrust) await checkSsoConfigPermission(actor, ssoPermissionAction);
 
     assertValidOauthClientGrantConfig({
       grantTypes,
-      resolved: { redirectUris: dto.redirectUris, tokenExchangeAudience: dto.tokenExchangeAudience },
+      resolved: { redirectUris, tokenExchangeAudience },
       supplied: {
         redirectUris: dto.redirectUris,
         requirePkce: dto.requirePkce,
@@ -246,7 +284,28 @@ export const oauthClientServiceFactory = ({
       }
     });
 
-    if (enablesTokenExchange) await getActiveOidcConfigOrThrow(actor.orgId);
+    if (establishesTokenExchangeTrust) await getActiveOidcConfigOrThrow(actor.orgId);
+
+    return {
+      grantTypes,
+      isRedirectBased,
+      isTokenExchangeEnabled,
+      wasTokenExchangeEnabled,
+      redirectUris,
+      tokenExchangeAudience,
+      tokenExchangeIdpSatisfiesMfa
+    };
+  };
+
+  const createOauthClient = async (dto: TCreateOauthClientDTO, actor: OrgServiceActor) => {
+    await checkOauthClientPermission(actor, OrgPermissionActions.Create);
+
+    const { grantTypes, isTokenExchangeEnabled, redirectUris, tokenExchangeAudience, tokenExchangeIdpSatisfiesMfa } =
+      await resolveGrantConfig({
+        dto,
+        actor,
+        ssoPermissionAction: "register an OAuth application that uses token exchange"
+      });
 
     const appCfg = getConfig();
     const clientId = `oauth_client_${crypto.randomBytes(16).toString("hex")}`;
@@ -261,10 +320,10 @@ export const oauthClientServiceFactory = ({
       clientSecretHash,
       clientSecretPrefix: clientSecret.slice(0, 4),
       grantTypes,
-      redirectUris: dto.redirectUris,
+      redirectUris,
       requirePkce: dto.requirePkce ?? false,
-      tokenExchangeAudience: enablesTokenExchange ? dto.tokenExchangeAudience : null,
-      tokenExchangeIdpSatisfiesMfa: enablesTokenExchange ? (dto.tokenExchangeIdpSatisfiesMfa ?? false) : false
+      tokenExchangeAudience: isTokenExchangeEnabled ? tokenExchangeAudience : null,
+      tokenExchangeIdpSatisfiesMfa: isTokenExchangeEnabled ? tokenExchangeIdpSatisfiesMfa : false
     });
 
     return { client: sanitizeOauthClient(client), clientSecret };
@@ -296,37 +355,19 @@ export const oauthClientServiceFactory = ({
 
     const client = await getOrgClientOrThrow(dto.clientDbId, actor.orgId);
 
-    const grantTypes = dedupeGrantTypes(dto.grantTypes ?? (client.grantTypes as OauthGrantType[]));
-    const wasTokenExchangeEnabled = hasTokenExchangeGrant(client.grantTypes as OauthGrantType[]);
-    const isTokenExchangeEnabled = hasTokenExchangeGrant(grantTypes);
-    const isRedirectBased = hasRedirectBasedGrant(grantTypes);
-
-    const resolvedRedirectUris = dto.redirectUris ?? client.redirectUris;
-    const resolvedTokenExchangeAudience =
-      dto.tokenExchangeAudience !== undefined ? dto.tokenExchangeAudience : client.tokenExchangeAudience;
-    const resolvedIdpSatisfiesMfa = dto.tokenExchangeIdpSatisfiesMfa ?? client.tokenExchangeIdpSatisfiesMfa;
-
-    const touchesTokenExchangeConfig =
-      dto.grantTypes !== undefined ||
-      dto.tokenExchangeAudience !== undefined ||
-      dto.tokenExchangeIdpSatisfiesMfa !== undefined;
-
-    if (isTokenExchangeEnabled && touchesTokenExchangeConfig) {
-      await checkSsoConfigPermission(actor, "change the token exchange configuration of an OAuth application");
-    }
-
-    assertValidOauthClientGrantConfig({
+    const {
       grantTypes,
-      resolved: { redirectUris: resolvedRedirectUris, tokenExchangeAudience: resolvedTokenExchangeAudience },
-      supplied: {
-        redirectUris: dto.redirectUris,
-        requirePkce: dto.requirePkce,
-        tokenExchangeAudience: dto.tokenExchangeAudience,
-        tokenExchangeIdpSatisfiesMfa: dto.tokenExchangeIdpSatisfiesMfa
-      }
+      isRedirectBased,
+      isTokenExchangeEnabled,
+      wasTokenExchangeEnabled,
+      tokenExchangeAudience,
+      tokenExchangeIdpSatisfiesMfa
+    } = await resolveGrantConfig({
+      dto,
+      actor,
+      client,
+      ssoPermissionAction: "change the token exchange configuration of an OAuth application"
     });
-
-    if (isTokenExchangeEnabled && touchesTokenExchangeConfig) await getActiveOidcConfigOrThrow(actor.orgId);
 
     const updatedClient = await oauthClientDAL.updateById(client.id, {
       name: dto.name,
@@ -334,8 +375,8 @@ export const oauthClientServiceFactory = ({
       grantTypes: dto.grantTypes ? grantTypes : undefined,
       redirectUris: isRedirectBased ? dto.redirectUris : [],
       requirePkce: isRedirectBased ? dto.requirePkce : false,
-      tokenExchangeAudience: isTokenExchangeEnabled ? resolvedTokenExchangeAudience : null,
-      tokenExchangeIdpSatisfiesMfa: isTokenExchangeEnabled ? resolvedIdpSatisfiesMfa : false
+      tokenExchangeAudience: isTokenExchangeEnabled ? tokenExchangeAudience : null,
+      tokenExchangeIdpSatisfiesMfa: isTokenExchangeEnabled ? tokenExchangeIdpSatisfiesMfa : false
     });
 
     if (wasTokenExchangeEnabled && !isTokenExchangeEnabled) {

--- a/backend/src/services/oauth-client/oauth-client-types.ts
+++ b/backend/src/services/oauth-client/oauth-client-types.ts
@@ -10,9 +10,6 @@ export enum OauthGrantType {
   TokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
 }
 
-// Grants that mint tokens through a browser redirect, so they need registered redirect URIs.
-export const REDIRECT_BASED_GRANT_TYPES: readonly OauthGrantType[] = [OauthGrantType.AuthorizationCode];
-
 // Applied as the create default so an API caller written before this feature, which sends no
 // `grantTypes`, keeps registering redirect-flow applications.
 export const DEFAULT_OAUTH_GRANT_TYPES: readonly OauthGrantType[] = [

--- a/backend/src/services/oauth-client/oauth-client-types.ts
+++ b/backend/src/services/oauth-client/oauth-client-types.ts
@@ -2,19 +2,63 @@ import { z } from "zod";
 
 import { AuthMethod, AuthModeRefreshJwtTokenPayload, MfaMethod } from "@app/services/auth/auth-type";
 
+// RFC 7591 client metadata. A client can hold several grants, and each grant makes a different subset
+// of the client's fields meaningful. See assertValidOauthClientGrantConfig.
+export enum OauthGrantType {
+  AuthorizationCode = "authorization_code",
+  RefreshToken = "refresh_token",
+  TokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+}
+
+// Grants that mint tokens through a browser redirect, so they need registered redirect URIs.
+export const REDIRECT_BASED_GRANT_TYPES: readonly OauthGrantType[] = [OauthGrantType.AuthorizationCode];
+
+// Applied as the create default so an API caller written before this feature, which sends no
+// `grantTypes`, keeps registering redirect-flow applications.
+export const DEFAULT_OAUTH_GRANT_TYPES: readonly OauthGrantType[] = [
+  OauthGrantType.AuthorizationCode,
+  OauthGrantType.RefreshToken
+];
+
+// RFC 8693 section 3 token type identifiers.
+export enum OauthTokenType {
+  Jwt = "urn:ietf:params:oauth:token-type:jwt",
+  IdToken = "urn:ietf:params:oauth:token-type:id_token",
+  AccessToken = "urn:ietf:params:oauth:token-type:access_token"
+}
+
+// Both are verified identically, as a signed JWT from the org's OIDC SSO issuer, so the difference is
+// only what the caller declares.
+export const ACCEPTED_SUBJECT_TOKEN_TYPES: readonly OauthTokenType[] = [OauthTokenType.Jwt, OauthTokenType.IdToken];
+
+// Marks a token as carrying the user's authorization unnarrowed, as opposed to the consented scopes an
+// authorization-code token carries.
+//
+// Deliberately a positive marker rather than an absent `scopes` claim: absence has to keep meaning zero
+// permissions, so that dropping the claim by mistake fails closed.
+export enum OauthDelegationMode {
+  Full = "full"
+}
+
 export type TCreateOauthClientDTO = {
   name: string;
   description?: string;
+  grantTypes: OauthGrantType[];
   redirectUris: string[];
   requirePkce?: boolean;
+  tokenExchangeAudience?: string;
+  tokenExchangeIdpSatisfiesMfa?: boolean;
 };
 
 export type TUpdateOauthClientDTO = {
   clientDbId: string;
   name?: string;
   description?: string | null;
+  grantTypes?: OauthGrantType[];
   redirectUris?: string[];
   requirePkce?: boolean;
+  tokenExchangeAudience?: string | null;
+  tokenExchangeIdpSatisfiesMfa?: boolean;
 };
 
 export type TOauthAuthorizeInfoDTO = {
@@ -42,14 +86,21 @@ export type TOauthTokenExchangeDTO = {
   clientSecret?: string;
 } & (
   | {
-      grantType: "authorization_code";
+      grantType: OauthGrantType.AuthorizationCode;
       code: string;
       redirectUri?: string;
       codeVerifier?: string;
     }
   | {
-      grantType: "refresh_token";
+      grantType: OauthGrantType.RefreshToken;
       refreshToken: string;
+    }
+  | {
+      grantType: OauthGrantType.TokenExchange;
+      subjectToken: string;
+      subjectTokenType: OauthTokenType;
+      ip: string;
+      userAgent?: string;
     }
 );
 

--- a/backend/src/services/oauth-client/oauth-client-types.ts
+++ b/backend/src/services/oauth-client/oauth-client-types.ts
@@ -2,16 +2,16 @@ import { z } from "zod";
 
 import { AuthMethod, AuthModeRefreshJwtTokenPayload, MfaMethod } from "@app/services/auth/auth-type";
 
-// RFC 7591 client metadata. A client can hold several grants, and each grant makes a different subset
-// of the client's fields meaningful. See assertValidOauthClientGrantConfig.
+// RFC 7591 client metadata. A client can hold several grants, and each one makes a different subset of
+// the client's fields meaningful. See assertValidOauthClientGrantConfig.
 export enum OauthGrantType {
   AuthorizationCode = "authorization_code",
   RefreshToken = "refresh_token",
   TokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
 }
 
-// Applied as the create default so an API caller written before this feature, which sends no
-// `grantTypes`, keeps registering redirect-flow applications.
+// The create default, so callers written before this feature (which send no `grantTypes`) keep
+// registering redirect-flow applications.
 export const DEFAULT_OAUTH_GRANT_TYPES: readonly OauthGrantType[] = [
   OauthGrantType.AuthorizationCode,
   OauthGrantType.RefreshToken
@@ -24,15 +24,13 @@ export enum OauthTokenType {
   AccessToken = "urn:ietf:params:oauth:token-type:access_token"
 }
 
-// Both are verified identically, as a signed JWT from the org's OIDC SSO issuer, so the difference is
-// only what the caller declares.
+// Both are verified the same way, as a signed JWT from the org's OIDC SSO issuer, so the only
+// difference is what the caller declares.
 export const ACCEPTED_SUBJECT_TOKEN_TYPES: readonly OauthTokenType[] = [OauthTokenType.Jwt, OauthTokenType.IdToken];
 
-// Marks a token as carrying the user's authorization unnarrowed, as opposed to the consented scopes an
-// authorization-code token carries.
-//
-// Deliberately a positive marker rather than an absent `scopes` claim: absence has to keep meaning zero
-// permissions, so that dropping the claim by mistake fails closed.
+// Marks a token as carrying the user's authorization unnarrowed, unlike the consented scopes an
+// authorization-code token carries. A positive marker on purpose: absence has to keep meaning zero
+// permissions so a dropped claim fails closed.
 export enum OauthDelegationMode {
   Full = "full"
 }

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
@@ -446,4 +446,27 @@ describe("verifySubjectToken", () => {
 
     await expect(verify(signSubjectToken())).rejects.toThrow(/Could not load signing keys/);
   });
+
+  // Same reasoning as the discovery document: token exchange runs on every request the middleware makes,
+  // so building the pinned agent must not be per-exchange work.
+  test("builds the JWKS client once across repeated verifications", async () => {
+    const oidcConfig = buildOidcConfig();
+    const token = signSubjectToken();
+
+    await Promise.all([verify(token, oidcConfig), verify(token, oidcConfig), verify(token, oidcConfig)]);
+    await verify(token, oidcConfig);
+
+    expect(buildSsrfSafeAgent).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries after a failed JWKS client build instead of caching the failure", async () => {
+    const oidcConfig = buildOidcConfig();
+    const token = signSubjectToken();
+
+    buildSsrfSafeAgent.mockRejectedValueOnce(new Error("Local IPs not allowed as URL"));
+    await expect(verify(token, oidcConfig)).rejects.toThrow(/Could not load signing keys/);
+
+    await expect(verify(token, oidcConfig)).resolves.toMatchObject({ subject: SUBJECT });
+    expect(buildSsrfSafeAgent).toHaveBeenCalledTimes(2);
+  });
 });

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
@@ -83,7 +83,7 @@ type TSignOptions = {
   audience?: string | string[];
   issuer?: string;
   algorithm?: jwt.Algorithm;
-  expiresIn?: string | number;
+  expiresIn?: string | number | null;
   notBefore?: string | number;
   subject?: string | null;
   keyId?: string | null;
@@ -103,7 +103,7 @@ const signSubjectToken = ({
     algorithm,
     audience,
     issuer,
-    expiresIn,
+    ...(expiresIn !== null ? { expiresIn } : {}),
     ...(notBefore !== undefined ? { notBefore } : {}),
     ...(keyId ? { keyid: keyId } : {})
   });
@@ -336,6 +336,13 @@ describe("verifySubjectToken", () => {
     const token = signSubjectToken({ expiresIn: -60 });
 
     await expect(verify(token)).rejects.toThrow(/has expired/);
+  });
+
+  // 'exp' is optional in RFC 7519, so a token that omits it would otherwise stay exchangeable forever.
+  test("rejects a token with no exp claim", async () => {
+    const token = signSubjectToken({ expiresIn: null });
+
+    await expect(verify(token)).rejects.toThrow(/no 'exp' claim/);
   });
 
   test("rejects a token that is not yet valid", async () => {

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
@@ -40,7 +40,7 @@ vi.mock("@app/lib/logger", () => ({
 }));
 
 const ISSUER = "https://adfs.example.com/adfs";
-const AUDIENCE = "api://paychex-mcp";
+const AUDIENCE = "api://internal-mcp";
 const SUBJECT = "8f7d1c22-0000-4a7b-9b1e-aaaabbbbcccc";
 
 // A unique JWKS URI per test keeps the module-level JwksClient cache from carrying a client between

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
@@ -43,16 +43,15 @@ const ISSUER = "https://adfs.example.com/adfs";
 const AUDIENCE = "api://internal-mcp";
 const SUBJECT = "8f7d1c22-0000-4a7b-9b1e-aaaabbbbcccc";
 
-// A unique JWKS URI per test keeps the module-level JwksClient cache from carrying a client between
-// cases.
+// A unique JWKS URI per test keeps the module-level JwksClient cache from leaking between cases.
 let jwksUriCounter = 0;
 const nextJwksUri = () => {
   jwksUriCounter += 1;
   return `https://adfs.example.com/adfs/discovery/keys?case=${jwksUriCounter}`;
 };
 
-// Same reason, for the discovery document cache: a case that wants its own mocked document needs its own
-// URL, or it reads the previous case's cached one.
+// Same for the discovery cache: a case that mocks its own document needs its own URL, or it reads the
+// previous case's cached one.
 let discoveryCaseCounter = 0;
 const nextIssuerBase = () => {
   discoveryCaseCounter += 1;
@@ -108,7 +107,7 @@ const signSubjectToken = ({
     ...(keyId ? { keyid: keyId } : {})
   });
 
-// jsonwebtoken cannot sign EdDSA, so the EdDSA cases mint their tokens with jose.
+// jsonwebtoken can't sign EdDSA, so those cases mint their tokens with jose.
 const signEddsaSubjectToken = async ({
   audience = AUDIENCE,
   issuer = ISSUER
@@ -244,8 +243,7 @@ describe("resolveOidcTrustAnchor", () => {
     ).rejects.toThrow(/no discovery URL/);
   });
 
-  // Token exchange runs on every request the middleware makes, so the discovery document must not be a
-  // per-exchange round trip to the identity provider.
+  // Middlewares can exchange per request, so this must not be a round trip to the IdP every time.
   test("fetches the discovery document once across repeated resolutions", async () => {
     safeGet.mockResolvedValue({ data: { jwks_uri: nextJwksUri(), issuer: ISSUER } });
     const discoveryURL = nextDiscoveryUrl();
@@ -279,8 +277,7 @@ describe("resolveOidcTrustAnchor", () => {
     expect(safeGet).toHaveBeenCalledTimes(2);
   });
 
-  // The algorithm and the preferred issuer come from the org's own configuration, so only the fetch is
-  // cached: an admin editing either must not have to wait out the discovery TTL.
+  // Only the fetch is cached, so an admin editing the algorithm or issuer doesn't wait out the TTL.
   test("does not cache configuration read from the organization's own record", async () => {
     safeGet.mockResolvedValue({ data: { jwks_uri: nextJwksUri(), issuer: ISSUER } });
     const discoveryURL = nextDiscoveryUrl();
@@ -319,7 +316,7 @@ describe("verifySubjectToken", () => {
     await expect(verify(token)).resolves.toMatchObject({ subject: SUBJECT });
   });
 
-  // The control that stops any token the issuer signed, for any application, being replayed here.
+  // The audience is what stops any token the issuer signed being replayed here.
   test("rejects a token minted for a different application", async () => {
     const token = signSubjectToken({ audience: "api://expenses-app" });
 
@@ -373,8 +370,8 @@ describe("verifySubjectToken", () => {
     await expect(verify(token)).rejects.toThrow(/not signed with the algorithm/);
   });
 
-  // EdDSA is selectable in the OIDC SSO configuration and works for browser SSO login, so it has to work
-  // here too. jsonwebtoken cannot verify it at all, which is why verification runs through jose.
+  // EdDSA works for browser SSO login, so it has to work here too. jsonwebtoken can't verify it at all,
+  // which is why verification runs through jose.
   test("verifies an EdDSA-signed token for an EdDSA configuration", async () => {
     getSigningKey.mockResolvedValue({ getPublicKey: () => ED25519_PUBLIC_KEY_PEM });
     const token = await signEddsaSubjectToken();
@@ -393,8 +390,8 @@ describe("verifySubjectToken", () => {
     ).rejects.toThrow(/audience does not match/);
   });
 
-  // An RSA key cannot carry EdDSA. That is the provider's configuration disagreeing with itself, not a
-  // bad token, so it must not surface as an unhandled 500.
+  // An RSA key can't carry EdDSA. That's the provider's config disagreeing with itself, not a bad
+  // token, so it must not come out as a 500.
   test("reports a signing key that cannot carry the configured algorithm", async () => {
     const token = await signEddsaSubjectToken();
 
@@ -447,8 +444,7 @@ describe("verifySubjectToken", () => {
     await expect(verify(signSubjectToken())).rejects.toThrow(/Could not load signing keys/);
   });
 
-  // Same reasoning as the discovery document: token exchange runs on every request the middleware makes,
-  // so building the pinned agent must not be per-exchange work.
+  // Same as the discovery document: building the pinned agent must not be per-exchange work.
   test("builds the JWKS client once across repeated verifications", async () => {
     const oidcConfig = buildOidcConfig();
     const token = signSubjectToken();

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
@@ -1,0 +1,324 @@
+import nodeCrypto from "node:crypto";
+
+import jwt from "jsonwebtoken";
+
+import { TOidcConfigs } from "@app/db/schemas";
+import { OIDCConfigurationType, OIDCJWTSignatureAlgorithm } from "@app/ee/services/oidc/oidc-config-types";
+import { crypto } from "@app/lib/crypto";
+
+import { resolveOidcTrustAnchor, verifySubjectToken } from "./oauth-token-exchange-fns";
+
+const { publicKey, privateKey } = nodeCrypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+const otherKeyPair = nodeCrypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+
+const PUBLIC_KEY_PEM = publicKey.export({ type: "spki", format: "pem" }).toString();
+const PRIVATE_KEY_PEM = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+const OTHER_PRIVATE_KEY_PEM = otherKeyPair.privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+
+const getSigningKey = vi.fn<(kid: string) => Promise<{ getPublicKey: () => string }>>();
+
+vi.mock("jwks-rsa", () => ({
+  JwksClient: class {
+    getSigningKey = getSigningKey;
+  }
+}));
+
+const safeGet = vi.fn<(url: string) => Promise<{ data: { jwks_uri?: string; issuer?: string } }>>();
+const buildSsrfSafeAgent = vi.fn<(url: string) => Promise<undefined>>();
+vi.mock("@app/lib/validator/safe-request", () => ({
+  safeRequest: { get: (url: string) => safeGet(url) },
+  buildSsrfSafeAgent: (url: string) => buildSsrfSafeAgent(url)
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  sanitizeUrlForLog: (url: string) => url
+}));
+
+const ISSUER = "https://adfs.example.com/adfs";
+const AUDIENCE = "api://paychex-mcp";
+const SUBJECT = "8f7d1c22-0000-4a7b-9b1e-aaaabbbbcccc";
+
+// A unique JWKS URI per test keeps the module-level JwksClient cache from carrying a client between
+// cases.
+let jwksUriCounter = 0;
+const nextJwksUri = () => {
+  jwksUriCounter += 1;
+  return `https://adfs.example.com/adfs/discovery/keys?case=${jwksUriCounter}`;
+};
+
+const buildOidcConfig = (overrides: Partial<TOidcConfigs> = {}): TOidcConfigs =>
+  ({
+    id: "11111111-1111-1111-1111-111111111111",
+    orgId: "22222222-2222-2222-2222-222222222222",
+    configurationType: OIDCConfigurationType.CUSTOM,
+    issuer: ISSUER,
+    jwksUri: nextJwksUri(),
+    discoveryURL: null,
+    authorizationEndpoint: `${ISSUER}/authorize`,
+    tokenEndpoint: `${ISSUER}/token`,
+    userinfoEndpoint: `${ISSUER}/userinfo`,
+    allowedEmailDomains: null,
+    isActive: true,
+    manageGroupMemberships: false,
+    jwtSignatureAlgorithm: OIDCJWTSignatureAlgorithm.RS256,
+    ...overrides
+  }) as TOidcConfigs;
+
+type TSignOptions = {
+  privateKeyPem?: string;
+  audience?: string | string[];
+  issuer?: string;
+  algorithm?: jwt.Algorithm;
+  expiresIn?: string | number;
+  notBefore?: string | number;
+  subject?: string | null;
+  keyId?: string | null;
+};
+
+const signSubjectToken = ({
+  privateKeyPem = PRIVATE_KEY_PEM,
+  audience = AUDIENCE,
+  issuer = ISSUER,
+  algorithm = "RS256",
+  expiresIn = "10m",
+  notBefore,
+  subject = SUBJECT,
+  keyId = "adfs-key-1"
+}: TSignOptions = {}) =>
+  jwt.sign({ ...(subject ? { sub: subject } : {}) }, privateKeyPem, {
+    algorithm,
+    audience,
+    issuer,
+    expiresIn,
+    ...(notBefore !== undefined ? { notBefore } : {}),
+    ...(keyId ? { keyid: keyId } : {})
+  });
+
+beforeAll(async () => {
+  process.env.FIPS_ENABLED = "false";
+  await crypto.initialize({} as never, {} as never, {} as never);
+});
+
+afterAll(() => {
+  delete process.env.FIPS_ENABLED;
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  buildSsrfSafeAgent.mockResolvedValue(undefined);
+  getSigningKey.mockResolvedValue({ getPublicKey: () => PUBLIC_KEY_PEM });
+});
+
+describe("resolveOidcTrustAnchor", () => {
+  test("uses the stored issuer and JWKS URI for a custom configuration", async () => {
+    const oidcConfig = buildOidcConfig();
+
+    await expect(resolveOidcTrustAnchor(oidcConfig)).resolves.toEqual({
+      issuer: ISSUER,
+      jwksUri: oidcConfig.jwksUri,
+      algorithm: OIDCJWTSignatureAlgorithm.RS256
+    });
+  });
+
+  test("rejects a symmetric signature algorithm", async () => {
+    const oidcConfig = buildOidcConfig({ jwtSignatureAlgorithm: OIDCJWTSignatureAlgorithm.HS256 });
+
+    await expect(resolveOidcTrustAnchor(oidcConfig)).rejects.toThrow(/asymmetric JWT signature algorithm/);
+  });
+
+  test("rejects a custom configuration with no issuer", async () => {
+    await expect(resolveOidcTrustAnchor(buildOidcConfig({ issuer: null }))).rejects.toThrow(
+      /missing an issuer or JWKS URI/
+    );
+  });
+
+  test("rejects a custom configuration with no JWKS URI", async () => {
+    await expect(resolveOidcTrustAnchor(buildOidcConfig({ jwksUri: null }))).rejects.toThrow(
+      /missing an issuer or JWKS URI/
+    );
+  });
+
+  test("resolves the JWKS URI through discovery when configured that way", async () => {
+    const discoveredJwksUri = nextJwksUri();
+    safeGet.mockResolvedValue({ data: { jwks_uri: discoveredJwksUri, issuer: ISSUER } });
+
+    const oidcConfig = buildOidcConfig({
+      configurationType: OIDCConfigurationType.DISCOVERY_URL,
+      discoveryURL: `${ISSUER}/.well-known/openid-configuration`,
+      issuer: null,
+      jwksUri: null
+    });
+
+    await expect(resolveOidcTrustAnchor(oidcConfig)).resolves.toEqual({
+      issuer: ISSUER,
+      jwksUri: discoveredJwksUri,
+      algorithm: OIDCJWTSignatureAlgorithm.RS256
+    });
+    expect(safeGet).toHaveBeenCalledWith(oidcConfig.discoveryURL);
+  });
+
+  test("appends the well-known path when the discovery URL is an issuer base", async () => {
+    safeGet.mockResolvedValue({ data: { jwks_uri: nextJwksUri(), issuer: ISSUER } });
+
+    await resolveOidcTrustAnchor(
+      buildOidcConfig({ configurationType: OIDCConfigurationType.DISCOVERY_URL, discoveryURL: `${ISSUER}/` })
+    );
+
+    expect(safeGet).toHaveBeenCalledWith(`${ISSUER}/.well-known/openid-configuration`);
+  });
+
+  test("prefers the stored issuer over the discovered one", async () => {
+    safeGet.mockResolvedValue({ data: { jwks_uri: nextJwksUri(), issuer: "https://attacker.example.com" } });
+
+    const anchor = await resolveOidcTrustAnchor(
+      buildOidcConfig({
+        configurationType: OIDCConfigurationType.DISCOVERY_URL,
+        discoveryURL: `${ISSUER}/.well-known/openid-configuration`
+      })
+    );
+
+    expect(anchor.issuer).toEqual(ISSUER);
+  });
+
+  test("reports an unreachable identity provider without leaking the transport error", async () => {
+    safeGet.mockRejectedValue(new Error("ECONNREFUSED 10.0.0.5:443"));
+
+    await expect(
+      resolveOidcTrustAnchor(
+        buildOidcConfig({
+          configurationType: OIDCConfigurationType.DISCOVERY_URL,
+          discoveryURL: `${ISSUER}/.well-known/openid-configuration`
+        })
+      )
+    ).rejects.toThrow(/Could not reach your organization's identity provider/);
+  });
+
+  test("rejects a discovery document with no jwks_uri", async () => {
+    safeGet.mockResolvedValue({ data: { issuer: ISSUER } });
+
+    await expect(
+      resolveOidcTrustAnchor(
+        buildOidcConfig({
+          configurationType: OIDCConfigurationType.DISCOVERY_URL,
+          discoveryURL: `${ISSUER}/.well-known/openid-configuration`
+        })
+      )
+    ).rejects.toThrow(/did not publish a 'jwks_uri'/);
+  });
+
+  test("rejects a discovery configuration with no discovery URL", async () => {
+    await expect(
+      resolveOidcTrustAnchor(
+        buildOidcConfig({ configurationType: OIDCConfigurationType.DISCOVERY_URL, discoveryURL: null })
+      )
+    ).rejects.toThrow(/no discovery URL/);
+  });
+});
+
+describe("verifySubjectToken", () => {
+  const verify = (subjectToken: string, oidcConfig = buildOidcConfig(), expectedAudience = AUDIENCE) =>
+    verifySubjectToken({ subjectToken, oidcConfig, expectedAudience });
+
+  test("returns the subject of a valid token", async () => {
+    await expect(verify(signSubjectToken())).resolves.toEqual({ subject: SUBJECT, issuer: ISSUER });
+  });
+
+  test("accepts a token whose audience list contains the expected audience", async () => {
+    const token = signSubjectToken({ audience: ["api://other-app", AUDIENCE] });
+
+    await expect(verify(token)).resolves.toMatchObject({ subject: SUBJECT });
+  });
+
+  // The control that stops any token the issuer signed, for any application, being replayed here.
+  test("rejects a token minted for a different application", async () => {
+    const token = signSubjectToken({ audience: "api://expenses-app" });
+
+    await expect(verify(token)).rejects.toThrow(/audience does not match/);
+  });
+
+  test("rejects a token from a different issuer", async () => {
+    const token = signSubjectToken({ issuer: "https://attacker.example.com" });
+
+    await expect(verify(token)).rejects.toThrow(/not issued by your organization's configured OIDC SSO issuer/);
+  });
+
+  test("rejects an expired token", async () => {
+    const token = signSubjectToken({ expiresIn: -60 });
+
+    await expect(verify(token)).rejects.toThrow(/has expired/);
+  });
+
+  test("rejects a token that is not yet valid", async () => {
+    const token = signSubjectToken({ notBefore: 600 });
+
+    await expect(verify(token)).rejects.toThrow(/not valid yet/);
+  });
+
+  test("rejects a token signed by a key the provider does not publish", async () => {
+    const token = signSubjectToken({ privateKeyPem: OTHER_PRIVATE_KEY_PEM });
+
+    await expect(verify(token)).rejects.toThrow(/could not be verified against your organization/);
+  });
+
+  // Pinning `algorithms` closes this off. jsonwebtoken reports it as a missing signature rather than an
+  // algorithm mismatch, so assert on the generic message.
+  test("rejects an unsigned (alg: none) token", async () => {
+    const token = jwt.sign({ sub: SUBJECT, aud: AUDIENCE, iss: ISSUER }, "", {
+      algorithm: "none",
+      keyid: "adfs-key-1"
+    });
+
+    await expect(verify(token)).rejects.toThrow(/could not be verified against your organization/);
+  });
+
+  test("rejects a token signed with an algorithm the configuration does not expect", async () => {
+    const token = signSubjectToken({ algorithm: "RS512" });
+
+    await expect(verify(token)).rejects.toThrow(/not signed with the algorithm/);
+  });
+
+  test("rejects a token with no kid header", async () => {
+    const token = signSubjectToken({ keyId: null });
+
+    await expect(verify(token)).rejects.toThrow(/no 'kid' header/);
+  });
+
+  test("rejects a token whose kid the provider does not publish", async () => {
+    const notFound = new Error("key not found");
+    notFound.name = "SigningKeyNotFoundError";
+    getSigningKey.mockRejectedValue(notFound);
+
+    await expect(verify(signSubjectToken())).rejects.toThrow(/does not publish/);
+  });
+
+  test("reports a JWKS fetch failure without leaking the transport error", async () => {
+    getSigningKey.mockRejectedValue(new Error("connect ETIMEDOUT 10.0.0.5:443"));
+
+    await expect(verify(signSubjectToken())).rejects.toThrow(/Could not load signing keys/);
+  });
+
+  test("rejects a token with no sub claim", async () => {
+    const token = signSubjectToken({ subject: null });
+
+    await expect(verify(token)).rejects.toThrow(/no 'sub' claim/);
+  });
+
+  test("rejects a malformed token without echoing the parser error", async () => {
+    await expect(verify("not-a-jwt")).rejects.toThrow(/not a well-formed JWT/);
+  });
+
+  test("pins the JWKS connection to the validated IPs", async () => {
+    const oidcConfig = buildOidcConfig();
+
+    await verify(signSubjectToken(), oidcConfig);
+
+    expect(buildSsrfSafeAgent).toHaveBeenCalledWith(oidcConfig.jwksUri);
+  });
+
+  test("rejects a JWKS URI that resolves to a private address", async () => {
+    buildSsrfSafeAgent.mockRejectedValue(new Error("Local IPs not allowed as URL"));
+
+    await expect(verify(signSubjectToken())).rejects.toThrow(/Could not load signing keys/);
+  });
+});

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
@@ -1,5 +1,6 @@
 import nodeCrypto from "node:crypto";
 
+import { importPKCS8, SignJWT } from "jose";
 import jwt from "jsonwebtoken";
 
 import { TOidcConfigs } from "@app/db/schemas";
@@ -10,10 +11,13 @@ import { resolveOidcTrustAnchor, verifySubjectToken } from "./oauth-token-exchan
 
 const { publicKey, privateKey } = nodeCrypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
 const otherKeyPair = nodeCrypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+const ed25519KeyPair = nodeCrypto.generateKeyPairSync("ed25519");
 
 const PUBLIC_KEY_PEM = publicKey.export({ type: "spki", format: "pem" }).toString();
 const PRIVATE_KEY_PEM = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
 const OTHER_PRIVATE_KEY_PEM = otherKeyPair.privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+const ED25519_PUBLIC_KEY_PEM = ed25519KeyPair.publicKey.export({ type: "spki", format: "pem" }).toString();
+const ED25519_PRIVATE_KEY_PEM = ed25519KeyPair.privateKey.export({ type: "pkcs8", format: "pem" }).toString();
 
 const getSigningKey = vi.fn<(kid: string) => Promise<{ getPublicKey: () => string }>>();
 
@@ -94,6 +98,21 @@ const signSubjectToken = ({
     ...(notBefore !== undefined ? { notBefore } : {}),
     ...(keyId ? { keyid: keyId } : {})
   });
+
+// jsonwebtoken cannot sign EdDSA, so the EdDSA cases mint their tokens with jose.
+const signEddsaSubjectToken = async ({
+  audience = AUDIENCE,
+  issuer = ISSUER
+}: { audience?: string; issuer?: string } = {}) => {
+  const signingKey = await importPKCS8(ED25519_PRIVATE_KEY_PEM, OIDCJWTSignatureAlgorithm.EDDSA);
+
+  return new SignJWT({ sub: SUBJECT })
+    .setProtectedHeader({ alg: OIDCJWTSignatureAlgorithm.EDDSA, kid: "adfs-key-1" })
+    .setIssuer(issuer)
+    .setAudience(audience)
+    .setExpirationTime("10m")
+    .sign(signingKey);
+};
 
 beforeAll(async () => {
   process.env.FIPS_ENABLED = "false";
@@ -261,21 +280,50 @@ describe("verifySubjectToken", () => {
     await expect(verify(token)).rejects.toThrow(/could not be verified against your organization/);
   });
 
-  // Pinning `algorithms` closes this off. jsonwebtoken reports it as a missing signature rather than an
-  // algorithm mismatch, so assert on the generic message.
+  // Pinning `algorithms` closes this off before the signature is ever looked at.
   test("rejects an unsigned (alg: none) token", async () => {
     const token = jwt.sign({ sub: SUBJECT, aud: AUDIENCE, iss: ISSUER }, "", {
       algorithm: "none",
       keyid: "adfs-key-1"
     });
 
-    await expect(verify(token)).rejects.toThrow(/could not be verified against your organization/);
+    await expect(verify(token)).rejects.toThrow(/not signed with the algorithm/);
   });
 
   test("rejects a token signed with an algorithm the configuration does not expect", async () => {
     const token = signSubjectToken({ algorithm: "RS512" });
 
     await expect(verify(token)).rejects.toThrow(/not signed with the algorithm/);
+  });
+
+  // EdDSA is selectable in the OIDC SSO configuration and works for browser SSO login, so it has to work
+  // here too. jsonwebtoken cannot verify it at all, which is why verification runs through jose.
+  test("verifies an EdDSA-signed token for an EdDSA configuration", async () => {
+    getSigningKey.mockResolvedValue({ getPublicKey: () => ED25519_PUBLIC_KEY_PEM });
+    const token = await signEddsaSubjectToken();
+
+    await expect(
+      verify(token, buildOidcConfig({ jwtSignatureAlgorithm: OIDCJWTSignatureAlgorithm.EDDSA }))
+    ).resolves.toEqual({ subject: SUBJECT, issuer: ISSUER });
+  });
+
+  test("still enforces the audience on an EdDSA-signed token", async () => {
+    getSigningKey.mockResolvedValue({ getPublicKey: () => ED25519_PUBLIC_KEY_PEM });
+    const token = await signEddsaSubjectToken({ audience: "api://expenses-app" });
+
+    await expect(
+      verify(token, buildOidcConfig({ jwtSignatureAlgorithm: OIDCJWTSignatureAlgorithm.EDDSA }))
+    ).rejects.toThrow(/audience does not match/);
+  });
+
+  // An RSA key cannot carry EdDSA. That is the provider's configuration disagreeing with itself, not a
+  // bad token, so it must not surface as an unhandled 500.
+  test("reports a signing key that cannot carry the configured algorithm", async () => {
+    const token = await signEddsaSubjectToken();
+
+    await expect(
+      verify(token, buildOidcConfig({ jwtSignatureAlgorithm: OIDCJWTSignatureAlgorithm.EDDSA }))
+    ).rejects.toThrow(/cannot be used with the JWT signature algorithm/);
   });
 
   test("rejects a token with no kid header", async () => {

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.test.ts
@@ -51,6 +51,15 @@ const nextJwksUri = () => {
   return `https://adfs.example.com/adfs/discovery/keys?case=${jwksUriCounter}`;
 };
 
+// Same reason, for the discovery document cache: a case that wants its own mocked document needs its own
+// URL, or it reads the previous case's cached one.
+let discoveryCaseCounter = 0;
+const nextIssuerBase = () => {
+  discoveryCaseCounter += 1;
+  return `${ISSUER}/case-${discoveryCaseCounter}`;
+};
+const nextDiscoveryUrl = () => `${nextIssuerBase()}/.well-known/openid-configuration`;
+
 const buildOidcConfig = (overrides: Partial<TOidcConfigs> = {}): TOidcConfigs =>
   ({
     id: "11111111-1111-1111-1111-111111111111",
@@ -164,7 +173,7 @@ describe("resolveOidcTrustAnchor", () => {
 
     const oidcConfig = buildOidcConfig({
       configurationType: OIDCConfigurationType.DISCOVERY_URL,
-      discoveryURL: `${ISSUER}/.well-known/openid-configuration`,
+      discoveryURL: nextDiscoveryUrl(),
       issuer: null,
       jwksUri: null
     });
@@ -179,12 +188,13 @@ describe("resolveOidcTrustAnchor", () => {
 
   test("appends the well-known path when the discovery URL is an issuer base", async () => {
     safeGet.mockResolvedValue({ data: { jwks_uri: nextJwksUri(), issuer: ISSUER } });
+    const issuerBase = nextIssuerBase();
 
     await resolveOidcTrustAnchor(
-      buildOidcConfig({ configurationType: OIDCConfigurationType.DISCOVERY_URL, discoveryURL: `${ISSUER}/` })
+      buildOidcConfig({ configurationType: OIDCConfigurationType.DISCOVERY_URL, discoveryURL: `${issuerBase}/` })
     );
 
-    expect(safeGet).toHaveBeenCalledWith(`${ISSUER}/.well-known/openid-configuration`);
+    expect(safeGet).toHaveBeenCalledWith(`${issuerBase}/.well-known/openid-configuration`);
   });
 
   test("prefers the stored issuer over the discovered one", async () => {
@@ -193,7 +203,7 @@ describe("resolveOidcTrustAnchor", () => {
     const anchor = await resolveOidcTrustAnchor(
       buildOidcConfig({
         configurationType: OIDCConfigurationType.DISCOVERY_URL,
-        discoveryURL: `${ISSUER}/.well-known/openid-configuration`
+        discoveryURL: nextDiscoveryUrl()
       })
     );
 
@@ -207,7 +217,7 @@ describe("resolveOidcTrustAnchor", () => {
       resolveOidcTrustAnchor(
         buildOidcConfig({
           configurationType: OIDCConfigurationType.DISCOVERY_URL,
-          discoveryURL: `${ISSUER}/.well-known/openid-configuration`
+          discoveryURL: nextDiscoveryUrl()
         })
       )
     ).rejects.toThrow(/Could not reach your organization's identity provider/);
@@ -220,7 +230,7 @@ describe("resolveOidcTrustAnchor", () => {
       resolveOidcTrustAnchor(
         buildOidcConfig({
           configurationType: OIDCConfigurationType.DISCOVERY_URL,
-          discoveryURL: `${ISSUER}/.well-known/openid-configuration`
+          discoveryURL: nextDiscoveryUrl()
         })
       )
     ).rejects.toThrow(/did not publish a 'jwks_uri'/);
@@ -232,6 +242,66 @@ describe("resolveOidcTrustAnchor", () => {
         buildOidcConfig({ configurationType: OIDCConfigurationType.DISCOVERY_URL, discoveryURL: null })
       )
     ).rejects.toThrow(/no discovery URL/);
+  });
+
+  // Token exchange runs on every request the middleware makes, so the discovery document must not be a
+  // per-exchange round trip to the identity provider.
+  test("fetches the discovery document once across repeated resolutions", async () => {
+    safeGet.mockResolvedValue({ data: { jwks_uri: nextJwksUri(), issuer: ISSUER } });
+    const discoveryURL = nextDiscoveryUrl();
+    const build = () => buildOidcConfig({ configurationType: OIDCConfigurationType.DISCOVERY_URL, discoveryURL });
+
+    const [first, second, third] = await Promise.all([
+      resolveOidcTrustAnchor(build()),
+      resolveOidcTrustAnchor(build()),
+      resolveOidcTrustAnchor(build())
+    ]);
+    await resolveOidcTrustAnchor(build());
+
+    // Concurrent cold-entry callers coalesce onto one fetch rather than each opening their own.
+    expect(safeGet).toHaveBeenCalledTimes(1);
+    expect(second).toEqual(first);
+    expect(third).toEqual(first);
+  });
+
+  // Caching a failure would stretch a provider blip into a full TTL of failures.
+  test("retries after a failed discovery fetch instead of caching the failure", async () => {
+    const discoveryURL = nextDiscoveryUrl();
+    const build = () => buildOidcConfig({ configurationType: OIDCConfigurationType.DISCOVERY_URL, discoveryURL });
+
+    safeGet.mockRejectedValueOnce(new Error("ECONNREFUSED 10.0.0.5:443"));
+    await expect(resolveOidcTrustAnchor(build())).rejects.toThrow(/Could not reach/);
+
+    const discoveredJwksUri = nextJwksUri();
+    safeGet.mockResolvedValue({ data: { jwks_uri: discoveredJwksUri, issuer: ISSUER } });
+
+    await expect(resolveOidcTrustAnchor(build())).resolves.toMatchObject({ jwksUri: discoveredJwksUri });
+    expect(safeGet).toHaveBeenCalledTimes(2);
+  });
+
+  // The algorithm and the preferred issuer come from the org's own configuration, so only the fetch is
+  // cached: an admin editing either must not have to wait out the discovery TTL.
+  test("does not cache configuration read from the organization's own record", async () => {
+    safeGet.mockResolvedValue({ data: { jwks_uri: nextJwksUri(), issuer: ISSUER } });
+    const discoveryURL = nextDiscoveryUrl();
+
+    const before = await resolveOidcTrustAnchor(
+      buildOidcConfig({ configurationType: OIDCConfigurationType.DISCOVERY_URL, discoveryURL })
+    );
+    expect(before.algorithm).toEqual(OIDCJWTSignatureAlgorithm.RS256);
+
+    const after = await resolveOidcTrustAnchor(
+      buildOidcConfig({
+        configurationType: OIDCConfigurationType.DISCOVERY_URL,
+        discoveryURL,
+        jwtSignatureAlgorithm: OIDCJWTSignatureAlgorithm.RS512,
+        issuer: "https://adfs.example.com/updated"
+      })
+    );
+
+    expect(after.algorithm).toEqual(OIDCJWTSignatureAlgorithm.RS512);
+    expect(after.issuer).toEqual("https://adfs.example.com/updated");
+    expect(safeGet).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
@@ -30,6 +30,42 @@ const buildDiscoveryDocumentUrl = (discoveryUrl: string) => {
   return url.toString();
 };
 
+type TOidcDiscoveryMetadata = { jwks_uri?: string; issuer?: string };
+
+// Fetching the discovery document is a network round trip, and token exchange runs on every request the
+// middleware makes, so resolving it per exchange would put the identity provider in the path of every
+// Infisical API call that middleware makes, and make a blip at the provider fail all of them.
+//
+// Only the fetch is cached, never the resolved trust anchor. The algorithm and the preferred issuer come
+// from the org's own SSO configuration, so an admin changing either still takes effect on the next
+// request.
+//
+// Keyed on the document URL rather than the org, so orgs on a shared provider share one entry, and an
+// admin correcting the discovery URL moves to a different key instead of waiting out the TTL.
+const DISCOVERY_METADATA_TTL_MS = 10 * 60 * 1000;
+const MAX_CACHED_DISCOVERY_DOCUMENTS = 512;
+const discoveryMetadataCache = new Map<string, { metadata: Promise<TOidcDiscoveryMetadata>; expiresAt: number }>();
+
+const getDiscoveryMetadata = (documentUrl: string) => {
+  const now = Date.now();
+  const cached = discoveryMetadataCache.get(documentUrl);
+  if (cached && cached.expiresAt > now) return cached.metadata;
+
+  if (discoveryMetadataCache.size >= MAX_CACHED_DISCOVERY_DOCUMENTS) discoveryMetadataCache.clear();
+
+  const metadata = safeRequest.get<TOidcDiscoveryMetadata>(documentUrl, { timeout: 10_000 }).then(({ data }) => data);
+
+  discoveryMetadataCache.set(documentUrl, { metadata, expiresAt: now + DISCOVERY_METADATA_TTL_MS });
+
+  metadata.catch(() => {
+    if (discoveryMetadataCache.get(documentUrl)?.metadata === metadata) {
+      discoveryMetadataCache.delete(documentUrl);
+    }
+  });
+
+  return metadata;
+};
+
 // jwks-rsa caches signing keys per instance, so reusing one per JWKS URI keeps a network fetch off the
 // hot path. Token exchange runs on every request the middleware makes.
 //
@@ -87,13 +123,9 @@ export const resolveOidcTrustAnchor = async (oidcConfig: TOidcConfigs): Promise<
       });
     }
 
-    let metadata: { jwks_uri?: string; issuer?: string };
+    let metadata: TOidcDiscoveryMetadata;
     try {
-      const { data } = await safeRequest.get<{ jwks_uri?: string; issuer?: string }>(
-        buildDiscoveryDocumentUrl(oidcConfig.discoveryURL),
-        { timeout: 10_000 }
-      );
-      metadata = data;
+      metadata = await getDiscoveryMetadata(buildDiscoveryDocumentUrl(oidcConfig.discoveryURL));
     } catch (error) {
       logger.error(
         { error, orgId: oidcConfig.orgId },

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
@@ -32,9 +32,9 @@ const buildDiscoveryDocumentUrl = (discoveryUrl: string) => {
 
 type TOidcDiscoveryMetadata = { jwks_uri?: string; issuer?: string };
 
-// Fetching the discovery document is a network round trip, and token exchange runs on every request the
-// middleware makes, so resolving it per exchange would put the identity provider in the path of every
-// Infisical API call that middleware makes, and make a blip at the provider fail all of them.
+// Fetching the discovery document is a network round trip. Integrators are told to exchange once per
+// user and cache the token, but we cannot enforce that, and a middleware that exchanges per request
+// would otherwise make the identity provider a synchronous dependency of every Infisical call it serves.
 //
 // Only the fetch is cached, never the resolved trust anchor. The algorithm and the preferred issuer come
 // from the org's own SSO configuration, so an admin changing either still takes effect on the next

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
@@ -32,6 +32,44 @@ const buildDiscoveryDocumentUrl = (discoveryUrl: string) => {
 
 type TOidcDiscoveryMetadata = { jwks_uri?: string; issuer?: string };
 
+// Everything token exchange fetches from an identity provider is cached the same way, so the mechanics
+// live here once:
+//
+// - Entries hold the in-flight promise, so concurrent callers on a cold entry coalesce onto one fetch
+//   instead of stampeding the provider.
+// - A rejected entry is dropped rather than kept for its TTL, so a provider blip lasts as long as the
+//   blip. Caching the failure would turn a 5-second outage into 10 minutes of them.
+// - A full cache is cleared wholesale rather than evicted by age. A flush only costs a refetch, and the
+//   bound exists to cap memory against an org churning through provider URLs, not to be a working LRU.
+const createTtlCache = <T>({ ttlMs, maxEntries }: { ttlMs: number; maxEntries: number }) => {
+  const entries = new Map<string, { value: Promise<T>; expiresAt: number }>();
+
+  const getOrCreate = (key: string, create: () => Promise<T>) => {
+    const now = Date.now();
+    const cached = entries.get(key);
+    if (cached && cached.expiresAt > now) return cached.value;
+
+    if (entries.size >= maxEntries) entries.clear();
+
+    const value = create();
+    entries.set(key, { value, expiresAt: now + ttlMs });
+
+    value.catch(() => {
+      if (entries.get(key)?.value === value) entries.delete(key);
+    });
+
+    return value;
+  };
+
+  return { getOrCreate };
+};
+
+// Both caches are keyed on the URL rather than the org, so orgs on a shared provider share one entry,
+// and an admin correcting a URL moves to a different key instead of waiting out the TTL.
+const MAX_CACHED_PROVIDER_URLS = 512;
+const DISCOVERY_METADATA_TTL_MS = 10 * 60 * 1000;
+const JWKS_CLIENT_TTL_MS = 10 * 60 * 1000;
+
 // Fetching the discovery document is a network round trip. Integrators are told to exchange once per
 // user and cache the token, but we cannot enforce that, and a middleware that exchanges per request
 // would otherwise make the identity provider a synchronous dependency of every Infisical call it serves.
@@ -39,65 +77,41 @@ type TOidcDiscoveryMetadata = { jwks_uri?: string; issuer?: string };
 // Only the fetch is cached, never the resolved trust anchor. The algorithm and the preferred issuer come
 // from the org's own SSO configuration, so an admin changing either still takes effect on the next
 // request.
-//
-// Keyed on the document URL rather than the org, so orgs on a shared provider share one entry, and an
-// admin correcting the discovery URL moves to a different key instead of waiting out the TTL.
-const DISCOVERY_METADATA_TTL_MS = 10 * 60 * 1000;
-const MAX_CACHED_DISCOVERY_DOCUMENTS = 512;
-const discoveryMetadataCache = new Map<string, { metadata: Promise<TOidcDiscoveryMetadata>; expiresAt: number }>();
+const discoveryMetadataCache = createTtlCache<TOidcDiscoveryMetadata>({
+  ttlMs: DISCOVERY_METADATA_TTL_MS,
+  maxEntries: MAX_CACHED_PROVIDER_URLS
+});
 
-const getDiscoveryMetadata = (documentUrl: string) => {
-  const now = Date.now();
-  const cached = discoveryMetadataCache.get(documentUrl);
-  if (cached && cached.expiresAt > now) return cached.metadata;
-
-  if (discoveryMetadataCache.size >= MAX_CACHED_DISCOVERY_DOCUMENTS) discoveryMetadataCache.clear();
-
-  const metadata = safeRequest.get<TOidcDiscoveryMetadata>(documentUrl, { timeout: 10_000 }).then(({ data }) => data);
-
-  discoveryMetadataCache.set(documentUrl, { metadata, expiresAt: now + DISCOVERY_METADATA_TTL_MS });
-
-  metadata.catch(() => {
-    if (discoveryMetadataCache.get(documentUrl)?.metadata === metadata) {
-      discoveryMetadataCache.delete(documentUrl);
-    }
-  });
-
-  return metadata;
-};
+const getDiscoveryMetadata = (documentUrl: string) =>
+  discoveryMetadataCache.getOrCreate(documentUrl, () =>
+    safeRequest.get<TOidcDiscoveryMetadata>(documentUrl, { timeout: 10_000 }).then(({ data }) => data)
+  );
 
 // jwks-rsa caches signing keys per instance, so reusing one per JWKS URI keeps a network fetch off the
 // hot path. Token exchange runs on every request the middleware makes.
 //
 // Entries expire so the agent's pinned IPs are rebuilt periodically. Without that, a legitimate DNS
 // change at the identity provider would not be picked up for the lifetime of the process.
-const JWKS_CLIENT_TTL_MS = 10 * 60 * 1000;
-const MAX_CACHED_JWKS_CLIENTS = 512;
-const jwksClientCache = new Map<string, { client: JwksClient; expiresAt: number }>();
+const jwksClientCache = createTtlCache<JwksClient>({
+  ttlMs: JWKS_CLIENT_TTL_MS,
+  maxEntries: MAX_CACHED_PROVIDER_URLS
+});
 
-const getJwksClient = async (jwksUri: string) => {
-  const now = Date.now();
-  const cached = jwksClientCache.get(jwksUri);
-  if (cached && cached.expiresAt > now) return cached.client;
+const getJwksClient = (jwksUri: string) =>
+  jwksClientCache.getOrCreate(jwksUri, async () => {
+    const requestAgent = await buildSsrfSafeAgent(jwksUri, { keepAlive: true });
 
-  if (jwksClientCache.size >= MAX_CACHED_JWKS_CLIENTS) jwksClientCache.clear();
-
-  const requestAgent = await buildSsrfSafeAgent(jwksUri, { keepAlive: true });
-
-  const client = new JwksClient({
-    jwksUri,
-    requestAgent,
-    cache: true,
-    cacheMaxEntries: 5,
-    cacheMaxAge: JWKS_CLIENT_TTL_MS,
-    rateLimit: true,
-    jwksRequestsPerMinute: 30,
-    timeout: 10_000
+    return new JwksClient({
+      jwksUri,
+      requestAgent,
+      cache: true,
+      cacheMaxEntries: 5,
+      cacheMaxAge: JWKS_CLIENT_TTL_MS,
+      rateLimit: true,
+      jwksRequestsPerMinute: 30,
+      timeout: 10_000
+    });
   });
-
-  jwksClientCache.set(jwksUri, { client, expiresAt: now + JWKS_CLIENT_TTL_MS });
-  return client;
-};
 
 export type TOidcTrustAnchor = {
   issuer: string;

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
@@ -1,9 +1,8 @@
-import jwt, { JwtPayload } from "jsonwebtoken";
+import { decodeProtectedHeader, errors as joseErrors, importSPKI, JWTPayload, jwtVerify } from "jose";
 import { JwksClient } from "jwks-rsa";
 
 import { TOidcConfigs } from "@app/db/schemas";
 import { OIDCConfigurationType, OIDCJWTSignatureAlgorithm } from "@app/ee/services/oidc/oidc-config-types";
-import { crypto } from "@app/lib/crypto";
 import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { buildSsrfSafeAgent, safeRequest } from "@app/lib/validator/safe-request";
@@ -131,38 +130,42 @@ export const resolveOidcTrustAnchor = async (oidcConfig: TOidcConfigs): Promise<
   return { issuer: oidcConfig.issuer, jwksUri: oidcConfig.jwksUri, algorithm };
 };
 
-// jsonwebtoken reports failures with terse developer-facing text ("jwt audience invalid"). Translate to
-// something the caller can act on without leaking the raw message.
+// jose reports failures with terse developer-facing text ("unexpected \"aud\" claim value"). Translate to
+// something the caller can act on without leaking the raw message. Each branch keys off jose's error
+// class and its `claim` field rather than the message text, so a wording change upstream cannot silently
+// collapse a specific failure into the generic one.
 const toSubjectTokenError = (error: unknown, anchor: TOidcTrustAnchor, expectedAudience: string) => {
-  if (error instanceof jwt.TokenExpiredError) {
+  if (error instanceof joseErrors.JWTExpired) {
     return new UnauthorizedError({ message: "The subject token has expired." });
   }
 
-  if (error instanceof jwt.NotBeforeError) {
-    return new UnauthorizedError({ message: "The subject token is not valid yet (its 'nbf' claim is in the future)." });
-  }
-
-  if (error instanceof jwt.JsonWebTokenError) {
-    const reason = error.message;
-
-    if (reason.includes("audience")) {
+  if (error instanceof joseErrors.JWTClaimValidationFailed) {
+    if (error.claim === "aud") {
       return new UnauthorizedError({
         message: `The subject token's audience does not match this application's configured token exchange audience ('${expectedAudience}').`
       });
     }
 
-    if (reason.includes("issuer")) {
+    if (error.claim === "iss") {
       return new UnauthorizedError({
         message: `The subject token was not issued by your organization's configured OIDC SSO issuer ('${anchor.issuer}').`
       });
     }
 
-    if (reason.includes("algorithm")) {
+    if (error.claim === "nbf") {
       return new UnauthorizedError({
-        message: `The subject token is not signed with the algorithm your organization's OIDC SSO configuration expects ('${anchor.algorithm}').`
+        message: "The subject token is not valid yet (its 'nbf' claim is in the future)."
       });
     }
+  }
 
+  if (error instanceof joseErrors.JOSEAlgNotAllowed) {
+    return new UnauthorizedError({
+      message: `The subject token is not signed with the algorithm your organization's OIDC SSO configuration expects ('${anchor.algorithm}').`
+    });
+  }
+
+  if (error instanceof joseErrors.JOSEError) {
     return new UnauthorizedError({
       message: "The subject token could not be verified against your organization's identity provider."
     });
@@ -182,12 +185,14 @@ type TVerifySubjectTokenDTO = {
 export const verifySubjectToken = async ({ subjectToken, oidcConfig, expectedAudience }: TVerifySubjectTokenDTO) => {
   const anchor = await resolveOidcTrustAnchor(oidcConfig);
 
-  const decoded = crypto.jwt().decode(subjectToken, { complete: true });
-  if (!decoded) {
+  let header: ReturnType<typeof decodeProtectedHeader>;
+  try {
+    header = decodeProtectedHeader(subjectToken);
+  } catch {
     throw new UnauthorizedError({ message: "The subject token is not a well-formed JWT." });
   }
 
-  const { kid } = decoded.header;
+  const { kid } = header;
   if (!kid) {
     throw new UnauthorizedError({
       message:
@@ -216,13 +221,27 @@ export const verifySubjectToken = async ({ subjectToken, oidcConfig, expectedAud
     });
   }
 
-  let claims: JwtPayload;
+  let publicKey;
   try {
-    claims = crypto.jwt().verify(subjectToken, signingKey.getPublicKey(), {
+    publicKey = await importSPKI(signingKey.getPublicKey(), anchor.algorithm);
+  } catch (error) {
+    logger.error(
+      { error, orgId: oidcConfig.orgId, kid },
+      `Subject token signing key could not be imported during token exchange [orgId=${oidcConfig.orgId}] [kid=${kid}]`
+    );
+
+    throw new BadRequestError({
+      message: `Your organization's identity provider published a signing key ('${kid}') that cannot be used with the JWT signature algorithm its OIDC SSO configuration declares ('${anchor.algorithm}'). ${SSO_TAB_HINT}`
+    });
+  }
+
+  let claims: JWTPayload;
+  try {
+    ({ payload: claims } = await jwtVerify(subjectToken, publicKey, {
       issuer: anchor.issuer,
       audience: expectedAudience,
-      algorithms: [anchor.algorithm as jwt.Algorithm]
-    }) as JwtPayload;
+      algorithms: [anchor.algorithm]
+    }));
   } catch (error) {
     logger.error(
       { error, orgId: oidcConfig.orgId },

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
@@ -1,0 +1,241 @@
+import jwt, { JwtPayload } from "jsonwebtoken";
+import { JwksClient } from "jwks-rsa";
+
+import { TOidcConfigs } from "@app/db/schemas";
+import { OIDCConfigurationType, OIDCJWTSignatureAlgorithm } from "@app/ee/services/oidc/oidc-config-types";
+import { crypto } from "@app/lib/crypto";
+import { BadRequestError, UnauthorizedError } from "@app/lib/errors";
+import { logger } from "@app/lib/logger";
+import { buildSsrfSafeAgent, safeRequest } from "@app/lib/validator/safe-request";
+
+const SSO_TAB_HINT = "Check Settings > SSO & Provisioning.";
+
+// HS256 is excluded because it is symmetric: the verification key is the signing key, so anyone who
+// can read the JWKS could mint a token we would accept.
+const ASYMMETRIC_SIGNATURE_ALGORITHMS: readonly string[] = [
+  OIDCJWTSignatureAlgorithm.RS256,
+  OIDCJWTSignatureAlgorithm.RS512,
+  OIDCJWTSignatureAlgorithm.EDDSA
+];
+
+const WELL_KNOWN_OPENID_CONFIGURATION = "/.well-known/openid-configuration";
+
+// Mirrors what openid-client's Issuer.discover accepts, so a configuration that works for browser SSO
+// login resolves the same way here: a discovery URL may already point at the document, or be the
+// issuer base that the well-known path hangs off.
+const buildDiscoveryDocumentUrl = (discoveryUrl: string) => {
+  const url = new URL(discoveryUrl);
+  if (url.pathname.includes("/.well-known/")) return url.toString();
+
+  url.pathname = `${url.pathname.replace(/\/$/, "")}${WELL_KNOWN_OPENID_CONFIGURATION}`;
+  return url.toString();
+};
+
+// jwks-rsa caches signing keys per instance, so reusing one per JWKS URI keeps a network fetch off the
+// hot path. Token exchange runs on every request the middleware makes.
+//
+// Entries expire so the agent's pinned IPs are rebuilt periodically. Without that, a legitimate DNS
+// change at the identity provider would not be picked up for the lifetime of the process.
+const JWKS_CLIENT_TTL_MS = 10 * 60 * 1000;
+const MAX_CACHED_JWKS_CLIENTS = 512;
+const jwksClientCache = new Map<string, { client: JwksClient; expiresAt: number }>();
+
+const getJwksClient = async (jwksUri: string) => {
+  const now = Date.now();
+  const cached = jwksClientCache.get(jwksUri);
+  if (cached && cached.expiresAt > now) return cached.client;
+
+  if (jwksClientCache.size >= MAX_CACHED_JWKS_CLIENTS) jwksClientCache.clear();
+
+  const requestAgent = await buildSsrfSafeAgent(jwksUri, { keepAlive: true });
+
+  const client = new JwksClient({
+    jwksUri,
+    requestAgent,
+    cache: true,
+    cacheMaxEntries: 5,
+    cacheMaxAge: JWKS_CLIENT_TTL_MS,
+    rateLimit: true,
+    jwksRequestsPerMinute: 30,
+    timeout: 10_000
+  });
+
+  jwksClientCache.set(jwksUri, { client, expiresAt: now + JWKS_CLIENT_TTL_MS });
+  return client;
+};
+
+export type TOidcTrustAnchor = {
+  issuer: string;
+  jwksUri: string;
+  algorithm: string;
+};
+
+// Uses the same configuration that governs browser SSO login, so the issuers that can vouch for a user
+// through token exchange are exactly those that can already log them in.
+export const resolveOidcTrustAnchor = async (oidcConfig: TOidcConfigs): Promise<TOidcTrustAnchor> => {
+  const algorithm = oidcConfig.jwtSignatureAlgorithm || OIDCJWTSignatureAlgorithm.RS256;
+
+  if (!ASYMMETRIC_SIGNATURE_ALGORITHMS.includes(algorithm)) {
+    throw new BadRequestError({
+      message: `Token exchange requires an OIDC SSO configuration that uses an asymmetric JWT signature algorithm, but yours uses '${algorithm}'. Switch it to one of ${ASYMMETRIC_SIGNATURE_ALGORITHMS.join(", ")}. ${SSO_TAB_HINT}`
+    });
+  }
+
+  if (oidcConfig.configurationType === OIDCConfigurationType.DISCOVERY_URL) {
+    if (!oidcConfig.discoveryURL) {
+      throw new BadRequestError({
+        message: `Your organization's OIDC SSO configuration has no discovery URL, so the identity provider's signing keys cannot be located. ${SSO_TAB_HINT}`
+      });
+    }
+
+    let metadata: { jwks_uri?: string; issuer?: string };
+    try {
+      const { data } = await safeRequest.get<{ jwks_uri?: string; issuer?: string }>(
+        buildDiscoveryDocumentUrl(oidcConfig.discoveryURL),
+        { timeout: 10_000 }
+      );
+      metadata = data;
+    } catch (error) {
+      logger.error(
+        { error, orgId: oidcConfig.orgId },
+        `OIDC discovery failed during token exchange [orgId=${oidcConfig.orgId}]`
+      );
+      throw new BadRequestError({
+        message: `Could not reach your organization's identity provider to load its signing keys. ${SSO_TAB_HINT}`
+      });
+    }
+
+    const jwksUri = metadata.jwks_uri;
+    if (!jwksUri) {
+      throw new BadRequestError({
+        message: `Your organization's identity provider did not publish a 'jwks_uri' in its discovery document, so subject tokens cannot be verified. ${SSO_TAB_HINT}`
+      });
+    }
+
+    const issuer = oidcConfig.issuer || metadata.issuer;
+    if (!issuer) {
+      throw new BadRequestError({
+        message: `Your organization's identity provider did not publish an issuer in its discovery document. ${SSO_TAB_HINT}`
+      });
+    }
+
+    return { issuer, jwksUri, algorithm };
+  }
+
+  if (!oidcConfig.issuer || !oidcConfig.jwksUri) {
+    throw new BadRequestError({
+      message: `Your organization's OIDC SSO configuration is missing an issuer or JWKS URI, so subject tokens cannot be verified. ${SSO_TAB_HINT}`
+    });
+  }
+
+  return { issuer: oidcConfig.issuer, jwksUri: oidcConfig.jwksUri, algorithm };
+};
+
+// jsonwebtoken reports failures with terse developer-facing text ("jwt audience invalid"). Translate to
+// something the caller can act on without leaking the raw message.
+const toSubjectTokenError = (error: unknown, anchor: TOidcTrustAnchor, expectedAudience: string) => {
+  if (error instanceof jwt.TokenExpiredError) {
+    return new UnauthorizedError({ message: "The subject token has expired." });
+  }
+
+  if (error instanceof jwt.NotBeforeError) {
+    return new UnauthorizedError({ message: "The subject token is not valid yet (its 'nbf' claim is in the future)." });
+  }
+
+  if (error instanceof jwt.JsonWebTokenError) {
+    const reason = error.message;
+
+    if (reason.includes("audience")) {
+      return new UnauthorizedError({
+        message: `The subject token's audience does not match this application's configured token exchange audience ('${expectedAudience}').`
+      });
+    }
+
+    if (reason.includes("issuer")) {
+      return new UnauthorizedError({
+        message: `The subject token was not issued by your organization's configured OIDC SSO issuer ('${anchor.issuer}').`
+      });
+    }
+
+    if (reason.includes("algorithm")) {
+      return new UnauthorizedError({
+        message: `The subject token is not signed with the algorithm your organization's OIDC SSO configuration expects ('${anchor.algorithm}').`
+      });
+    }
+
+    return new UnauthorizedError({
+      message: "The subject token could not be verified against your organization's identity provider."
+    });
+  }
+
+  return null;
+};
+
+type TVerifySubjectTokenDTO = {
+  subjectToken: string;
+  oidcConfig: TOidcConfigs;
+  expectedAudience: string;
+};
+
+// Every check deciding whether we believe this token describes this user lives here: signature, issuer,
+// audience, expiry, not-before and algorithm.
+export const verifySubjectToken = async ({ subjectToken, oidcConfig, expectedAudience }: TVerifySubjectTokenDTO) => {
+  const anchor = await resolveOidcTrustAnchor(oidcConfig);
+
+  const decoded = crypto.jwt().decode(subjectToken, { complete: true });
+  if (!decoded) {
+    throw new UnauthorizedError({ message: "The subject token is not a well-formed JWT." });
+  }
+
+  const { kid } = decoded.header;
+  if (!kid) {
+    throw new UnauthorizedError({
+      message:
+        "The subject token has no 'kid' header, so the signing key to verify it with cannot be identified. Configure your identity provider to include a key id."
+    });
+  }
+
+  let signingKey;
+  try {
+    const jwksClient = await getJwksClient(anchor.jwksUri);
+    signingKey = await jwksClient.getSigningKey(kid);
+  } catch (error) {
+    logger.error(
+      { error, orgId: oidcConfig.orgId, kid },
+      `Subject token signing key lookup failed during token exchange [orgId=${oidcConfig.orgId}] [kid=${kid}]`
+    );
+
+    if (error instanceof Error && error.name === "SigningKeyNotFoundError") {
+      throw new UnauthorizedError({
+        message: `The subject token was signed with a key ('${kid}') that your organization's identity provider does not publish. The token may be from a different provider, or the provider's keys may have rotated.`
+      });
+    }
+
+    throw new BadRequestError({
+      message: `Could not load signing keys from your organization's identity provider. ${SSO_TAB_HINT}`
+    });
+  }
+
+  let claims: JwtPayload;
+  try {
+    claims = crypto.jwt().verify(subjectToken, signingKey.getPublicKey(), {
+      issuer: anchor.issuer,
+      audience: expectedAudience,
+      algorithms: [anchor.algorithm as jwt.Algorithm]
+    }) as JwtPayload;
+  } catch (error) {
+    logger.error(
+      { error, orgId: oidcConfig.orgId },
+      `Subject token verification failed during token exchange [orgId=${oidcConfig.orgId}]`
+    );
+    throw toSubjectTokenError(error, anchor, expectedAudience) ?? error;
+  }
+
+  if (!claims.sub) {
+    throw new UnauthorizedError({
+      message: "The subject token has no 'sub' claim, so it does not identify a user."
+    });
+  }
+
+  return { subject: claims.sub, issuer: anchor.issuer };
+};

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
@@ -172,6 +172,13 @@ const toSubjectTokenError = (error: unknown, anchor: TOidcTrustAnchor, expectedA
   }
 
   if (error instanceof joseErrors.JWTClaimValidationFailed) {
+    if (error.claim === "exp") {
+      return new UnauthorizedError({
+        message:
+          "The subject token has no 'exp' claim, so it never expires and cannot be accepted. Configure your identity provider to set an expiry on tokens it issues for this application."
+      });
+    }
+
     if (error.claim === "aud") {
       return new UnauthorizedError({
         message: `The subject token's audience does not match this application's configured token exchange audience ('${expectedAudience}').`
@@ -272,7 +279,10 @@ export const verifySubjectToken = async ({ subjectToken, oidcConfig, expectedAud
     ({ payload: claims } = await jwtVerify(subjectToken, publicKey, {
       issuer: anchor.issuer,
       audience: expectedAudience,
-      algorithms: [anchor.algorithm]
+      algorithms: [anchor.algorithm],
+      // 'exp' is optional in RFC 7519 and only checked when present, so without this a token that omits
+      // it is exchangeable forever.
+      requiredClaims: ["exp"]
     }));
   } catch (error) {
     logger.error(

--- a/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
+++ b/backend/src/services/oauth-client/oauth-token-exchange-fns.ts
@@ -9,8 +9,8 @@ import { buildSsrfSafeAgent, safeRequest } from "@app/lib/validator/safe-request
 
 const SSO_TAB_HINT = "Check Settings > SSO & Provisioning.";
 
-// HS256 is excluded because it is symmetric: the verification key is the signing key, so anyone who
-// can read the JWKS could mint a token we would accept.
+// HS256 is left out because it's symmetric: the verification key is the signing key, so anyone who can
+// read the JWKS could mint a token we'd accept.
 const ASYMMETRIC_SIGNATURE_ALGORITHMS: readonly string[] = [
   OIDCJWTSignatureAlgorithm.RS256,
   OIDCJWTSignatureAlgorithm.RS512,
@@ -19,9 +19,8 @@ const ASYMMETRIC_SIGNATURE_ALGORITHMS: readonly string[] = [
 
 const WELL_KNOWN_OPENID_CONFIGURATION = "/.well-known/openid-configuration";
 
-// Mirrors what openid-client's Issuer.discover accepts, so a configuration that works for browser SSO
-// login resolves the same way here: a discovery URL may already point at the document, or be the
-// issuer base that the well-known path hangs off.
+// Mirrors what openid-client's Issuer.discover accepts, so a config that works for browser SSO login
+// resolves the same way here: the URL may already point at the document, or be the issuer base.
 const buildDiscoveryDocumentUrl = (discoveryUrl: string) => {
   const url = new URL(discoveryUrl);
   if (url.pathname.includes("/.well-known/")) return url.toString();
@@ -32,15 +31,9 @@ const buildDiscoveryDocumentUrl = (discoveryUrl: string) => {
 
 type TOidcDiscoveryMetadata = { jwks_uri?: string; issuer?: string };
 
-// Everything token exchange fetches from an identity provider is cached the same way, so the mechanics
-// live here once:
-//
-// - Entries hold the in-flight promise, so concurrent callers on a cold entry coalesce onto one fetch
-//   instead of stampeding the provider.
-// - A rejected entry is dropped rather than kept for its TTL, so a provider blip lasts as long as the
-//   blip. Caching the failure would turn a 5-second outage into 10 minutes of them.
-// - A full cache is cleared wholesale rather than evicted by age. A flush only costs a refetch, and the
-//   bound exists to cap memory against an org churning through provider URLs, not to be a working LRU.
+// Entries hold the in-flight promise so concurrent callers on a cold entry coalesce onto one fetch.
+// Rejections are dropped instead of cached, otherwise a 5-second provider blip becomes 10 minutes of
+// them. A full cache is cleared wholesale: the bound is there to cap memory, not to be a real LRU.
 const createTtlCache = <T>({ ttlMs, maxEntries }: { ttlMs: number; maxEntries: number }) => {
   const entries = new Map<string, { value: Promise<T>; expiresAt: number }>();
 
@@ -64,19 +57,17 @@ const createTtlCache = <T>({ ttlMs, maxEntries }: { ttlMs: number; maxEntries: n
   return { getOrCreate };
 };
 
-// Both caches are keyed on the URL rather than the org, so orgs on a shared provider share one entry,
-// and an admin correcting a URL moves to a different key instead of waiting out the TTL.
+// Keyed on the URL, not the org, so orgs on a shared provider share an entry and an admin fixing a
+// typo'd URL moves to a new key instead of waiting out the TTL.
 const MAX_CACHED_PROVIDER_URLS = 512;
 const DISCOVERY_METADATA_TTL_MS = 10 * 60 * 1000;
 const JWKS_CLIENT_TTL_MS = 10 * 60 * 1000;
 
-// Fetching the discovery document is a network round trip. Integrators are told to exchange once per
-// user and cache the token, but we cannot enforce that, and a middleware that exchanges per request
-// would otherwise make the identity provider a synchronous dependency of every Infisical call it serves.
+// Nothing stops a middleware from exchanging on every request, and without this cache that would make
+// the identity provider a synchronous dependency of every Infisical call it serves.
 //
-// Only the fetch is cached, never the resolved trust anchor. The algorithm and the preferred issuer come
-// from the org's own SSO configuration, so an admin changing either still takes effect on the next
-// request.
+// Only the fetch is cached, never the resolved trust anchor: the algorithm and preferred issuer come
+// from the org's own SSO config, so changing either takes effect on the next request.
 const discoveryMetadataCache = createTtlCache<TOidcDiscoveryMetadata>({
   ttlMs: DISCOVERY_METADATA_TTL_MS,
   maxEntries: MAX_CACHED_PROVIDER_URLS
@@ -87,11 +78,9 @@ const getDiscoveryMetadata = (documentUrl: string) =>
     safeRequest.get<TOidcDiscoveryMetadata>(documentUrl, { timeout: 10_000 }).then(({ data }) => data)
   );
 
-// jwks-rsa caches signing keys per instance, so reusing one per JWKS URI keeps a network fetch off the
-// hot path. Token exchange runs on every request the middleware makes.
-//
-// Entries expire so the agent's pinned IPs are rebuilt periodically. Without that, a legitimate DNS
-// change at the identity provider would not be picked up for the lifetime of the process.
+// jwks-rsa caches signing keys per instance, so one client per JWKS URI keeps a fetch off the hot path.
+// Entries still expire so the agent's pinned IPs get rebuilt: otherwise a legitimate DNS change at the
+// provider would never be picked up for the life of the process.
 const jwksClientCache = createTtlCache<JwksClient>({
   ttlMs: JWKS_CLIENT_TTL_MS,
   maxEntries: MAX_CACHED_PROVIDER_URLS
@@ -119,8 +108,8 @@ export type TOidcTrustAnchor = {
   algorithm: string;
 };
 
-// Uses the same configuration that governs browser SSO login, so the issuers that can vouch for a user
-// through token exchange are exactly those that can already log them in.
+// Reuses the config that governs browser SSO login, so the issuers that can vouch for a user here are
+// exactly the ones that can already log them in.
 export const resolveOidcTrustAnchor = async (oidcConfig: TOidcConfigs): Promise<TOidcTrustAnchor> => {
   const algorithm = oidcConfig.jwtSignatureAlgorithm || OIDCJWTSignatureAlgorithm.RS256;
 
@@ -176,10 +165,9 @@ export const resolveOidcTrustAnchor = async (oidcConfig: TOidcConfigs): Promise<
   return { issuer: oidcConfig.issuer, jwksUri: oidcConfig.jwksUri, algorithm };
 };
 
-// jose reports failures with terse developer-facing text ("unexpected \"aud\" claim value"). Translate to
-// something the caller can act on without leaking the raw message. Each branch keys off jose's error
-// class and its `claim` field rather than the message text, so a wording change upstream cannot silently
-// collapse a specific failure into the generic one.
+// jose's messages are terse and developer-facing ("unexpected \"aud\" claim value"), so translate them
+// into something the caller can act on. Branches key off the error class and `claim` field, never the
+// message text, so a wording change upstream can't silently collapse a case into the generic one.
 const toSubjectTokenError = (error: unknown, anchor: TOidcTrustAnchor, expectedAudience: string) => {
   if (error instanceof joseErrors.JWTExpired) {
     return new UnauthorizedError({ message: "The subject token has expired." });
@@ -233,8 +221,6 @@ type TVerifySubjectTokenDTO = {
   expectedAudience: string;
 };
 
-// Every check deciding whether we believe this token describes this user lives here: signature, issuer,
-// audience, expiry, not-before and algorithm.
 export const verifySubjectToken = async ({ subjectToken, oidcConfig, expectedAudience }: TVerifySubjectTokenDTO) => {
   const anchor = await resolveOidcTrustAnchor(oidcConfig);
 
@@ -294,8 +280,8 @@ export const verifySubjectToken = async ({ subjectToken, oidcConfig, expectedAud
       issuer: anchor.issuer,
       audience: expectedAudience,
       algorithms: [anchor.algorithm],
-      // 'exp' is optional in RFC 7519 and only checked when present, so without this a token that omits
-      // it is exchangeable forever.
+      // 'exp' is optional in RFC 7519 and only checked when present, so without this a token that
+      // omits it is exchangeable forever.
       requiredClaims: ["exp"]
     }));
   } catch (error) {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -259,9 +259,9 @@ services:
 
   keycloak:
     # Admin console: http://localhost:8088 (admin / admin).
-    # On boot it imports the pre-seeded `infisical` realm (client `infisical-dev`,
-    # users jdoe/asmith) from the mounted realm file. The container has no volume,
-    # so the realm is re-imported fresh on every start. See sso.md.
+    # On boot it imports the pre-seeded `infisical` realm from the mounted realm file: clients
+    # `infisical-dev` (SSO login) and `infisical-mcp` (token exchange), users john/alice/admin.
+    # The container has no volume, so the realm is re-imported fresh on every start. See sso.md.
     image: quay.io/keycloak/keycloak:26.1.0
     restart: always
     environment:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -259,9 +259,9 @@ services:
 
   keycloak:
     # Admin console: http://localhost:8088 (admin / admin).
-    # On boot it imports the pre-seeded `infisical` realm from the mounted realm file: clients
-    # `infisical-dev` (SSO login) and `infisical-mcp` (token exchange), users john/alice/admin.
-    # The container has no volume, so the realm is re-imported fresh on every start. See sso.md.
+    # Imports the pre-seeded `infisical` realm on boot: clients `infisical-dev` (SSO login) and
+    # `infisical-mcp` (token exchange), users john/alice/admin. No volume, so it's fresh every start.
+    # See sso.md.
     image: quay.io/keycloak/keycloak:26.1.0
     restart: always
     environment:

--- a/docker/keycloak/realm-infisical.json
+++ b/docker/keycloak/realm-infisical.json
@@ -22,6 +22,18 @@
         "http://localhost:8080/*"
       ],
       "webOrigins": ["http://localhost:8080"]
+    },
+    {
+      "clientId": "infisical-mcp",
+      "name": "Infisical MCP (dev middleware)",
+      "description": "Stands in for trusted middleware in the OAuth token exchange flow. An ID token from this client carries aud=infisical-mcp, which is what an Infisical application's token exchange audience must match. See sso.md.",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "infisical-mcp-client-secret",
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": true
     }
   ],
   "users": [

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -87,6 +87,7 @@
                 ]
               },
               "documentation/platform/oauth-applications",
+              "documentation/platform/oauth-token-exchange",
               {
                 "group": "Access Control",
                 "pages": [

--- a/docs/documentation/platform/oauth-applications.mdx
+++ b/docs/documentation/platform/oauth-applications.mdx
@@ -7,6 +7,10 @@ description: "Let external platforms request delegated access to Infisical on a 
 
 A common use case is wiring Infisical into a developer platform as an External Auth provider, so that `infisical run` can fetch secrets at runtime inside a remote development environment using the developer's own permissions.
 
+<Info>
+  This page covers the browser-based authorization code flow, where each user approves the application on a consent screen. If you are registering trusted middleware that acts on behalf of many users and has no browser to redirect through, see [OAuth Token Exchange](/documentation/platform/oauth-token-exchange).
+</Info>
+
 <Note>
   A delegated OAuth token can never do more than the user who authorized it. Scopes only **narrow** what the token can do; they never grant access the user does not already have. When the user's access changes or their session is revoked, every token issued for them through OAuth is affected immediately.
 </Note>
@@ -62,10 +66,11 @@ OAuth applications are managed at the organization level. You need permission to
     Head to **Organization Settings** and open **OAuth Applications** from the sidebar.
   </Step>
   <Step title="Add an application">
-    Press **Add OAuth application** and fill in the details:
+    Press **Add Application** and fill in the details:
 
     - **Name** (required): A friendly name shown to users on the consent screen.
     - **Description** (optional): A short note about what the application is used for. Also shown on the consent screen.
+    - **Flow**: Leave **Authorization code** selected. See [OAuth Token Exchange](/documentation/platform/oauth-token-exchange) for the other flow.
     - **Redirect URIs** (required): One URI per line. The authorization flow will only ever redirect to one of these exact URIs. Each must use `https://`; `http://` is allowed only for loopback addresses such as `localhost`, `127.0.0.1`, and `::1`.
     - **Require PKCE (S256)**: When enabled, authorization requests that do not include a PKCE code challenge are rejected. Recommended for public clients.
   </Step>

--- a/docs/documentation/platform/oauth-applications.mdx
+++ b/docs/documentation/platform/oauth-applications.mdx
@@ -140,7 +140,7 @@ The response contains:
 
 Access token lifetime follows your organization's user token expiration setting (falling back to the platform default). Refresh tokens rotate on use, and a refresh never broadens the scopes originally granted.
 
-`refresh_token` is present only when the application is registered for the `refresh_token` grant, which applications created in the UI always are. If you registered one through the API with `grant_type` limited to `authorization_code`, the field is omitted and the client should exchange a new authorization code when the access token expires.
+`refresh_token` is present only when the application holds the `refresh_token` grant, which applications created in the UI always do. If you registered one through the API with `grantTypes` limited to `authorization_code`, the field is omitted and the client should exchange a new authorization code when the access token expires.
 
 ### Validation endpoint
 
@@ -177,4 +177,4 @@ The effective permissions are the **intersection** of the user's permissions and
 
 Deleting an OAuth application from the **OAuth Applications** tab immediately revokes every access and refresh token that application issued, so they stop working on the next request rather than living until expiry.
 
-Rotating the client secret invalidates the old secret for future token requests but leaves already-issued tokens working until they expire, so users of the integration are not signed out. The secret alone cannot mint a token in this flow: it has to be paired with an authorization code from a user's browser or with a refresh token. If you need to cut existing access off immediately, delete the application. (Rotation on a [token exchange](/documentation/platform/oauth-token-exchange) application behaves differently, because there the secret is sufficient on its own.)
+Rotating the client secret invalidates the old secret for future token requests but leaves already-issued tokens working until they expire, so users of the integration are not signed out. The secret alone cannot mint a token in this flow: it has to be paired with an authorization code from a user's browser or with a refresh token. To cut existing access off immediately, delete the application. Rotation on a [token exchange](/documentation/platform/oauth-token-exchange) application behaves differently, because there the secret is sufficient on its own.

--- a/docs/documentation/platform/oauth-applications.mdx
+++ b/docs/documentation/platform/oauth-applications.mdx
@@ -140,6 +140,8 @@ The response contains:
 
 Access token lifetime follows your organization's user token expiration setting (falling back to the platform default). Refresh tokens rotate on use, and a refresh never broadens the scopes originally granted.
 
+`refresh_token` is present only when the application is registered for the `refresh_token` grant, which applications created in the UI always are. If you registered one through the API with `grant_type` limited to `authorization_code`, the field is omitted and the client should exchange a new authorization code when the access token expires.
+
 ### Validation endpoint
 
 ```

--- a/docs/documentation/platform/oauth-applications.mdx
+++ b/docs/documentation/platform/oauth-applications.mdx
@@ -175,4 +175,6 @@ The effective permissions are the **intersection** of the user's permissions and
 
 ## Revoking access
 
-Deleting an OAuth application from the **OAuth Applications** tab immediately revokes every access and refresh token that application issued, so they stop working on the next request rather than living until expiry. Rotating the client secret invalidates the old secret for future token exchanges.
+Deleting an OAuth application from the **OAuth Applications** tab immediately revokes every access and refresh token that application issued, so they stop working on the next request rather than living until expiry.
+
+Rotating the client secret invalidates the old secret for future token requests but leaves already-issued tokens working until they expire, so users of the integration are not signed out. The secret alone cannot mint a token in this flow: it has to be paired with an authorization code from a user's browser or with a refresh token. If you need to cut existing access off immediately, delete the application. (Rotation on a [token exchange](/documentation/platform/oauth-token-exchange) application behaves differently, because there the secret is sufficient on its own.)

--- a/docs/documentation/platform/oauth-token-exchange.mdx
+++ b/docs/documentation/platform/oauth-token-exchange.mdx
@@ -191,7 +191,7 @@ Cache it keyed by user, and treat the exchange as the slow path:
 - Drop the entry when the user's session at your identity provider ends, so their Infisical access does not outlive it.
 
 <Note>
-  The token endpoint is rate limited per source IP. A middleware that caches correctly makes roughly one exchange per user per token lifetime and stays well inside it; one that exchanges per request will be throttled under load. If you have sized your caching and still expect to approach the limit, contact us before rolling out.
+  The token endpoint is rate limited per application per source IP. A middleware that caches correctly makes roughly one exchange per user per token lifetime and stays well inside it; one that exchanges per request will be throttled under load. If you have sized your caching and still expect to approach the limit, contact us before rolling out.
 </Note>
 
 ## What Infisical verifies

--- a/docs/documentation/platform/oauth-token-exchange.mdx
+++ b/docs/documentation/platform/oauth-token-exchange.mdx
@@ -222,6 +222,10 @@ The **SSO** page lists the applications that depend on the issuer, so you can se
 
 ## Revoking access
 
-Deleting the application from the **OAuth Applications** page immediately revokes every token it issued, so they stop working on the next request rather than living until expiry. Rotating the client secret stops the middleware obtaining new tokens until it is updated.
+Three actions revoke every token the application has issued, so they stop working on the next request rather than living until expiry:
 
-Because no refresh tokens are issued, the exposure from a compromised middleware is bounded by the remaining lifetime of the access tokens it currently holds.
+- **Deleting the application** from the **OAuth Applications** page.
+- **Rotating the client secret.** On a token exchange application the secret is the whole authority, so rotating it in response to a leak also cuts off whatever was minted with the old one. Plan for the middleware to be signed out of every user until it picks up the new secret.
+- **Turning off the token exchange grant** on the application.
+
+Because no refresh tokens are issued, the exposure from a compromised middleware is otherwise bounded by the remaining lifetime of the access tokens it currently holds.

--- a/docs/documentation/platform/oauth-token-exchange.mdx
+++ b/docs/documentation/platform/oauth-token-exchange.mdx
@@ -91,7 +91,7 @@ Two things it deliberately cannot do:
 
 ## Registering your middleware
 
-You need permission to manage both OAuth applications and SSO in the organization, because enabling token exchange decides whose externally issued tokens Infisical will convert into user tokens.
+You need permission to manage both OAuth applications and SSO in the organization, because enabling token exchange decides whose externally issued tokens Infisical will convert into user tokens. The same applies to changing an existing application's audience or rotating its client secret, since either one grants the ability to act as your users.
 
 <Steps>
   <Step title="Open the OAuth Applications page">

--- a/docs/documentation/platform/oauth-token-exchange.mdx
+++ b/docs/documentation/platform/oauth-token-exchange.mdx
@@ -175,6 +175,25 @@ curl https://app.infisical.com/api/v4/secrets \
   Delegated tokens are currently accepted on the read-only secret-fetch endpoints. Endpoint coverage is expanding; if your integration needs an endpoint that rejects a delegated token, let us know which one.
 </Note>
 
+## Cache the access token
+
+<Warning>
+  Exchange once per user and reuse the access token until it expires. Do not exchange on every request your middleware serves.
+</Warning>
+
+The access token is valid for `expires_in` seconds, usually an hour. Exchanging per request instead of per token throws away that whole window and makes your identity provider a hard dependency of every call you make to Infisical: a momentary blip there becomes a failure of your own request path, and both Infisical and your provider see traffic proportional to your request volume rather than to your user count.
+
+Cache it keyed by user, and treat the exchange as the slow path:
+
+- Keep the token in memory keyed by the subject token's `sub` claim, alongside its expiry.
+- Reuse it while it is valid, refreshing slightly early (say 60 seconds before `expires_in` elapses) so an in-flight request never carries a token that expires mid-call.
+- Exchange again when it is gone. No refresh token is issued, so re-exchange against the user's still-valid identity provider token.
+- Drop the entry when the user's session at your identity provider ends, so their Infisical access does not outlive it.
+
+<Note>
+  The token endpoint is rate limited per source IP. A middleware that caches correctly makes roughly one exchange per user per token lifetime and stays well inside it; one that exchanges per request will be throttled under load. If you have sized your caching and still expect to approach the limit, contact us before rolling out.
+</Note>
+
 ## What Infisical verifies
 
 Every exchange checks all of the following, and fails the request with a message naming the problem if any of them does not hold:

--- a/docs/documentation/platform/oauth-token-exchange.mdx
+++ b/docs/documentation/platform/oauth-token-exchange.mdx
@@ -3,26 +3,15 @@ title: OAuth Token Exchange
 description: "Let trusted middleware act on behalf of your users in Infisical using tokens from your own identity provider."
 ---
 
-**Token exchange** lets a trusted service you run present a user's token from your identity provider and receive an Infisical token for that same user. The service acts as the user rather than as a shared service account, so every action in Infisical is attributed to the real person and bounded by their own access.
-
-This is the pattern behind AI coding assistants, internal developer portals, API gateways, and any middleware that has to call Infisical "as the user who asked." Those tools have no browser to redirect through and no way to show each user a consent screen, so the standard [OAuth Applications](/documentation/platform/oauth-applications) authorization code flow does not fit them.
+**Token exchange** lets a trusted service you run present a user's token from your identity provider and receive an Infisical token for that same user. The service acts as the user rather than as a shared service account, so every action is attributed to the real person and bounded by their own access.
 
 <Info>
-  This page is for organization admins registering middleware that acts on behalf of many users. If you are wiring up a platform that can redirect a user's browser, use the authorization code flow on [OAuth Applications](/documentation/platform/oauth-applications) instead.
+  This page is for organization admins registering middleware that acts on behalf of many users. If your platform can redirect a user's browser to a consent screen, use the authorization code flow on [OAuth Applications](/documentation/platform/oauth-applications) instead.
 </Info>
 
 <Note>
-  Token exchange requires an active **OIDC** SSO configuration for your organization. Infisical verifies the tokens your middleware presents against that same identity provider, so there is nothing to trust until OIDC SSO is set up. See [SSO overview](/documentation/platform/sso/overview).
+  Token exchange requires an active **OIDC** SSO configuration for your organization. Infisical verifies the tokens your middleware presents against that same provider, so there is nothing to trust until OIDC SSO is set up. See [SSO overview](/documentation/platform/sso/overview).
 </Note>
-
-## Why not a shared machine identity
-
-A single [machine identity](/documentation/platform/identities/machine-identities) shared by every user of your middleware collapses the authorization boundary in two ways:
-
-- **Attribution is lost.** Every audit log entry reads as the service account, so you cannot tell which person triggered an action.
-- **Least privilege is lost.** Every user gets whatever the shared identity can reach, rather than what they personally can reach.
-
-Token exchange fixes both. The token Infisical issues belongs to one user, carries that user's permissions, and appears in the audit log under their name alongside the application that requested it.
 
 ## When to use token exchange
 
@@ -42,12 +31,6 @@ Token exchange fixes both. The token Infisical issues belongs to one user, carri
 </CardGroup>
 
 ## How it works
-
-Three parties are involved:
-
-- **Your identity provider** issues a token proving who the user is. This is the same provider your users already sign in to Infisical with.
-- **Your middleware** holds an Infisical client ID and client secret, and presents the user's token.
-- **Infisical** verifies that token, resolves it to the matching Infisical user, and issues a short-lived access token for them.
 
 ```mermaid
 sequenceDiagram
@@ -71,28 +54,28 @@ Structurally, this is your organization's OIDC sign-in with the token handed ove
 
 ### What the issued token can do
 
-The issued token carries the user's **full effective permissions**, not a narrowed subset. There is no consent screen and no scope list, so an organization admin approves the delegation once when registering the application rather than each user approving it individually.
+The issued token carries the user's **full effective permissions**, not a narrowed subset. There is no consent screen and no scope list: an organization admin approves the delegation once, when registering the application.
 
 Two things it deliberately cannot do:
 
-- **It cannot manage the user's account.** Changing MFA, revoking sessions, and other account self-management actions are never reachable with a delegated token, however it was obtained.
-- **It cannot outlive its access token.** No refresh token is issued. Your middleware exchanges again against the still-valid identity provider token.
+- **Manage the user's account.** Changing MFA, revoking sessions, and other account self-management actions are never reachable with a delegated token.
+- **Outlive its access token.** No refresh token is issued, so your middleware exchanges again against the still-valid identity provider token.
 
 <Warning>
-  A token issued through exchange is a bearer credential held by your middleware, protected by that service rather than by the user's hardware key or device trust. Treat the middleware as a system that can act as any of its users, and secure it accordingly.
+  The issued token is a bearer credential held by your middleware, protected by that service rather than by the user's hardware key or device trust. Treat the middleware as a system that can act as any of its users.
 </Warning>
 
 ## Before you start
 
-- **OIDC SSO must be configured and enabled** for your organization.
-- **Your identity provider must sign tokens with an asymmetric algorithm** (RS256, RS512, or EdDSA) and publish a key ID (`kid`) in the token header.
-- **The tokens it issues must carry an expiry (`exp`).** Standard OIDC providers always set one; a token without it would be replayable indefinitely, so Infisical rejects it.
-- **Each user must have signed in to Infisical through OIDC SSO at least once.** Infisical matches the token's subject to the account created on that first sign-in, so a user who has only ever used your middleware cannot be resolved yet. Treat one browser sign-in as an onboarding step.
-- **You need a dedicated registration for your middleware in your identity provider**, so its tokens carry an audience distinct from Infisical's own.
+- **OIDC SSO is configured and enabled** for your organization.
+- **Your identity provider signs tokens with an asymmetric algorithm** (RS256, RS512, or EdDSA) and publishes a key ID (`kid`) in the token header.
+- **Its tokens carry an expiry (`exp`).** Infisical rejects a token without one, since it would be replayable indefinitely.
+- **Each user has signed in to Infisical through OIDC SSO at least once.** Infisical matches the token's subject to the account created on that sign-in, so treat one browser sign-in as an onboarding step.
+- **Your middleware has its own registration in your identity provider**, so its tokens carry an audience distinct from Infisical's.
 
 ## Registering your middleware
 
-You need permission to manage both OAuth applications and SSO in the organization, because enabling token exchange decides whose externally issued tokens Infisical will convert into user tokens. The same applies to changing an existing application's audience or rotating its client secret, since either one grants the ability to act as your users.
+You need permission to manage both OAuth applications and SSO, because enabling token exchange decides whose externally issued tokens Infisical converts into user tokens. The same applies to changing an application's audience or rotating its client secret.
 
 <Steps>
   <Step title="Open the OAuth Applications page">
@@ -107,20 +90,20 @@ You need permission to manage both OAuth applications and SSO in the organizatio
     - **Audience** (required): The audience your identity provider puts in tokens it issues for this middleware, for example `api://internal-mcp`. Infisical rejects any token carrying a different audience.
     - **Identity provider enforces MFA**: Turn this on to declare that your identity provider already requires MFA. Without it, exchanges fail for any user who requires MFA, because there is no Infisical MFA challenge to run.
 
-    There is no issuer to set here. Infisical always verifies against your organization's OIDC SSO provider, which is configured once on the **SSO** page and cannot be overridden per application.
+    There is no issuer to set here. Infisical always verifies against your organization's OIDC SSO provider, which cannot be overridden per application.
   </Step>
   <Step title="Store the credentials">
-    On creation, Infisical shows the **Client ID** and **Client Secret**.
+    Infisical shows the **Client ID** and **Client Secret** on creation.
 
     <Warning>
-      The client secret is shown only once. Store it securely. If it is lost, you can rotate it from the application's menu, but you cannot retrieve the original value.
+      The client secret is shown only once. If it is lost you can rotate it from the application's menu, but you cannot retrieve the original value.
     </Warning>
   </Step>
 </Steps>
 
 ### Why the audience matters
 
-The audience is the control that does the real work. Your identity provider signs tokens for every application in your estate, and without an expected audience any of those tokens could be presented to Infisical and come back as a working Infisical token. Binding the application to one audience is what stops a token minted for an expenses app becoming a secrets-read credential.
+Your identity provider signs tokens for every application in your estate. Without an expected audience, any of them could be presented to Infisical and come back as a working Infisical token. Binding the application to one audience is what stops a token minted for an expenses app becoming a secrets-read credential.
 
 Set it to your middleware's own registration in your identity provider, never to Infisical's.
 
@@ -136,15 +119,13 @@ curl -X POST https://app.infisical.com/api/v1/oauth/token \
   --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:jwt"
 ```
 
-Parameters:
+| Parameter            | Value                                                                                |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| `grant_type`         | `urn:ietf:params:oauth:grant-type:token-exchange`                                     |
+| `subject_token`      | The user's token from your identity provider                                          |
+| `subject_token_type` | `urn:ietf:params:oauth:token-type:jwt` or `urn:ietf:params:oauth:token-type:id_token`  |
 
-| Parameter            | Value                                                                                                            |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `grant_type`         | `urn:ietf:params:oauth:grant-type:token-exchange`                                                                 |
-| `subject_token`      | The user's token from your identity provider                                                                      |
-| `subject_token_type` | `urn:ietf:params:oauth:token-type:jwt` or `urn:ietf:params:oauth:token-type:id_token`                              |
-
-The response is a short-lived access token for the user the subject token identified:
+The response is an access token for the user the subject token identified:
 
 ```json
 {
@@ -155,7 +136,7 @@ The response is a short-lived access token for the user the subject token identi
 }
 ```
 
-Access token lifetime follows your organization's user token expiration setting, falling back to the platform default.
+Access token lifetime follows your organization's **user token expiration** setting, falling back to the platform default of 10 days when that is not set. Because the middleware holds a credential that acts as the user, set a short expiration on the organization rather than relying on that default.
 
 <Note>
   `scope`, `audience`, and `resource` are rejected rather than ignored. This grant has no scope concept, and the expected audience is fixed on the application, so silently dropping those parameters would leave you believing a restriction was applied when it was not.
@@ -167,7 +148,7 @@ Use the access token as a standard Bearer token:
 curl https://app.infisical.com/api/v4/secrets \
   -H "Authorization: Bearer <access_token>" \
   --get \
-  --data-urlencode "workspaceId=<project-id>" \
+  --data-urlencode "projectId=<project-id>" \
   --data-urlencode "environment=dev"
 ```
 
@@ -181,51 +162,49 @@ curl https://app.infisical.com/api/v4/secrets \
   Exchange once per user and reuse the access token until it expires. Do not exchange on every request your middleware serves.
 </Warning>
 
-The access token is valid for `expires_in` seconds, usually an hour. Exchanging per request instead of per token throws away that whole window and makes your identity provider a hard dependency of every call you make to Infisical: a momentary blip there becomes a failure of your own request path, and both Infisical and your provider see traffic proportional to your request volume rather than to your user count.
-
-Cache it keyed by user, and treat the exchange as the slow path:
+Exchanging per request throws away that whole window and makes your identity provider a hard dependency of every Infisical call: a momentary blip there fails your own request path, and both Infisical and your provider see traffic proportional to your request volume rather than your user count.
 
 - Keep the token in memory keyed by the subject token's `sub` claim, alongside its expiry.
-- Reuse it while it is valid, refreshing slightly early (say 60 seconds before `expires_in` elapses) so an in-flight request never carries a token that expires mid-call.
-- Exchange again when it is gone. No refresh token is issued, so re-exchange against the user's still-valid identity provider token.
+- Refresh slightly early, say 60 seconds before `expires_in` elapses, so an in-flight request never carries a token that expires mid-call.
+- Exchange again when it is gone. No refresh token is issued.
 - Drop the entry when the user's session at your identity provider ends, so their Infisical access does not outlive it.
 
 <Note>
-  The token endpoint is rate limited per application per source IP. A middleware that caches correctly makes roughly one exchange per user per token lifetime and stays well inside it; one that exchanges per request will be throttled under load. If you have sized your caching and still expect to approach the limit, contact us before rolling out.
+  The token endpoint is rate limited per source IP, so every instance of your middleware behind one egress address shares a single budget. Caching correctly means roughly one exchange per user per token lifetime, which stays well inside it. Exchanging per request will be throttled under load.
 </Note>
 
 ## What Infisical verifies
 
-Every exchange checks all of the following, and fails the request with a message naming the problem if any of them does not hold:
+Every exchange checks all of the following and names the failure in its error:
 
 - The **signature** validates against your identity provider's published keys.
 - The **issuer** matches your organization's configured OIDC SSO issuer.
 - The **audience** matches the audience configured on the application.
-- The token **carries an `exp` claim and has not passed it**, and is not used before its `nbf` time. A token with no expiry is rejected rather than treated as valid forever.
+- The token **carries an `exp` claim and has not passed it**, and is not used before its `nbf` time.
 - The **signing algorithm** matches your OIDC SSO configuration.
-- The token's **subject** resolves to a user who has signed in through your organization's OIDC SSO and is an active member of the organization.
-- That user's **Infisical account is usable**: setup is complete and the account is not locked. A locked account fails the exchange outright rather than returning a token that stops working on first use.
+- The token's **subject** resolves to a user who has signed in through your organization's OIDC SSO and is an active member of it.
+- That user's **Infisical account is usable**: setup is complete and the account is not locked.
 - **MFA** requirements are satisfied, either because none apply or because the application declares that the identity provider enforces them.
 
 ## Audit trail
 
-Each exchange records an audit event attributed to the **subject user**, with the requesting application recorded alongside it. Because the issued token belongs to that user, every later action taken with it appears under the same person, and can be traced back to the exchange that authorized it.
+Each exchange records an audit event attributed to the **subject user**, with the requesting application in its metadata. Every later action taken with the issued token appears under the same person.
 
 ## Dependency on SSO
 
-Token exchange has no trust anchor of its own. It relies on your organization's OIDC SSO configuration, which means:
+Token exchange has no trust anchor of its own:
 
-- **Disabling OIDC SSO stops token exchange working.** So does deleting the configuration.
+- **Disabling or deleting the OIDC SSO configuration stops token exchange working.**
 - **Changing the issuer changes who can vouch for your users.** Migrating identity providers moves both browser sign-in and token exchange at once.
 
-The **SSO** page lists the applications that depend on the issuer, so you can see the blast radius before changing it.
+The **OAuth Applications** page lists which applications use token exchange, so you can see the blast radius before changing either.
 
 ## Revoking access
 
 Three actions revoke every token the application has issued, so they stop working on the next request rather than living until expiry:
 
-- **Deleting the application** from the **OAuth Applications** page.
-- **Rotating the client secret.** On a token exchange application the secret is the whole authority, so rotating it in response to a leak also cuts off whatever was minted with the old one. Plan for the middleware to be signed out of every user until it picks up the new secret.
-- **Turning off the token exchange grant** on the application.
+- **Deleting the application.**
+- **Rotating the client secret.** On a token exchange application the secret is the whole authority, so rotating it after a leak also cuts off whatever was minted with the old one. Expect the middleware to be signed out of every user until it picks up the new secret.
+- **Turning off the token exchange grant.**
 
-Because no refresh tokens are issued, the exposure from a compromised middleware is otherwise bounded by the remaining lifetime of the access tokens it currently holds.
+Because no refresh tokens are issued, exposure from a compromised middleware is otherwise bounded by the remaining lifetime of the access tokens it holds.

--- a/docs/documentation/platform/oauth-token-exchange.mdx
+++ b/docs/documentation/platform/oauth-token-exchange.mdx
@@ -86,6 +86,7 @@ Two things it deliberately cannot do:
 
 - **OIDC SSO must be configured and enabled** for your organization.
 - **Your identity provider must sign tokens with an asymmetric algorithm** (RS256, RS512, or EdDSA) and publish a key ID (`kid`) in the token header.
+- **The tokens it issues must carry an expiry (`exp`).** Standard OIDC providers always set one; a token without it would be replayable indefinitely, so Infisical rejects it.
 - **Each user must have signed in to Infisical through OIDC SSO at least once.** Infisical matches the token's subject to the account created on that first sign-in, so a user who has only ever used your middleware cannot be resolved yet. Treat one browser sign-in as an onboarding step.
 - **You need a dedicated registration for your middleware in your identity provider**, so its tokens carry an audience distinct from Infisical's own.
 
@@ -181,7 +182,7 @@ Every exchange checks all of the following, and fails the request with a message
 - The **signature** validates against your identity provider's published keys.
 - The **issuer** matches your organization's configured OIDC SSO issuer.
 - The **audience** matches the audience configured on the application.
-- The token is **not expired** and not used before its `nbf` time.
+- The token **carries an `exp` claim and has not passed it**, and is not used before its `nbf` time. A token with no expiry is rejected rather than treated as valid forever.
 - The **signing algorithm** matches your OIDC SSO configuration.
 - The token's **subject** resolves to a user who has signed in through your organization's OIDC SSO and is an active member of the organization.
 - **MFA** requirements are satisfied, either because none apply or because the application declares that the identity provider enforces them.

--- a/docs/documentation/platform/oauth-token-exchange.mdx
+++ b/docs/documentation/platform/oauth-token-exchange.mdx
@@ -1,0 +1,206 @@
+---
+title: OAuth Token Exchange
+description: "Let trusted middleware act on behalf of your users in Infisical using tokens from your own identity provider."
+---
+
+**Token exchange** lets a trusted service you run present a user's token from your identity provider and receive an Infisical token for that same user. The service acts as the user rather than as a shared service account, so every action in Infisical is attributed to the real person and bounded by their own access.
+
+This is the pattern behind AI coding assistants, internal developer portals, API gateways, and any middleware that has to call Infisical "as the user who asked." Those tools have no browser to redirect through and no way to show each user a consent screen, so the standard [OAuth Applications](/documentation/platform/oauth-applications) authorization code flow does not fit them.
+
+<Info>
+  This page is for organization admins registering middleware that acts on behalf of many users. If you are wiring up a platform that can redirect a user's browser, use the authorization code flow on [OAuth Applications](/documentation/platform/oauth-applications) instead.
+</Info>
+
+<Note>
+  Token exchange requires an active **OIDC** SSO configuration for your organization. Infisical verifies the tokens your middleware presents against that same identity provider, so there is nothing to trust until OIDC SSO is set up. See [SSO overview](/documentation/platform/sso/overview).
+</Note>
+
+## Why not a shared machine identity
+
+A single [machine identity](/documentation/platform/identities/machine-identities) shared by every user of your middleware collapses the authorization boundary in two ways:
+
+- **Attribution is lost.** Every audit log entry reads as the service account, so you cannot tell which person triggered an action.
+- **Least privilege is lost.** Every user gets whatever the shared identity can reach, rather than what they personally can reach.
+
+Token exchange fixes both. The token Infisical issues belongs to one user, carries that user's permissions, and appears in the audit log under their name alongside the application that requested it.
+
+## When to use token exchange
+
+<CardGroup cols={2}>
+  <Card title="AI assistants and agents" icon="robot">
+    An MCP server or agent platform reading secrets on behalf of the engineer who asked.
+  </Card>
+  <Card title="Internal developer portals" icon="window">
+    A portal that shows each developer the secrets they personally can see.
+  </Card>
+  <Card title="API gateways" icon="shield">
+    A gateway that already validates your identity provider's tokens and needs to forward the user's identity downstream.
+  </Card>
+  <Card title="CI middleware" icon="gears">
+    Automation that runs a step on a named person's behalf rather than as a shared account.
+  </Card>
+</CardGroup>
+
+## How it works
+
+Three parties are involved:
+
+- **Your identity provider** issues a token proving who the user is. This is the same provider your users already sign in to Infisical with.
+- **Your middleware** holds an Infisical client ID and client secret, and presents the user's token.
+- **Infisical** verifies that token, resolves it to the matching Infisical user, and issues a short-lived access token for them.
+
+```mermaid
+sequenceDiagram
+  participant User as User
+  participant MW as Your Middleware
+  participant IdP as Your Identity Provider
+  participant Infis as Infisical
+
+  User->>MW: Request (already signed in via your IdP)
+  MW->>IdP: Validate the user's token
+  MW->>Infis: POST /api/v1/oauth/token (client credentials + user's token)
+  Infis->>IdP: Fetch signing keys
+  Infis->>Infis: Verify signature, issuer, audience, expiry
+  Infis->>Infis: Resolve the token's subject to an Infisical user
+  Infis->>MW: Short-lived access token for that user
+  MW->>Infis: API request with the access token
+  Infis->>MW: Response, limited to that user's permissions
+```
+
+Structurally, this is your organization's OIDC sign-in with the token handed over directly instead of collected through a browser redirect.
+
+### What the issued token can do
+
+The issued token carries the user's **full effective permissions**, not a narrowed subset. There is no consent screen and no scope list, so an organization admin approves the delegation once when registering the application rather than each user approving it individually.
+
+Two things it deliberately cannot do:
+
+- **It cannot manage the user's account.** Changing MFA, revoking sessions, and other account self-management actions are never reachable with a delegated token, however it was obtained.
+- **It cannot outlive its access token.** No refresh token is issued. Your middleware exchanges again against the still-valid identity provider token.
+
+<Warning>
+  A token issued through exchange is a bearer credential held by your middleware, protected by that service rather than by the user's hardware key or device trust. Treat the middleware as a system that can act as any of its users, and secure it accordingly.
+</Warning>
+
+## Before you start
+
+- **OIDC SSO must be configured and enabled** for your organization.
+- **Your identity provider must sign tokens with an asymmetric algorithm** (RS256, RS512, or EdDSA) and publish a key ID (`kid`) in the token header.
+- **Each user must have signed in to Infisical through OIDC SSO at least once.** Infisical matches the token's subject to the account created on that first sign-in, so a user who has only ever used your middleware cannot be resolved yet. Treat one browser sign-in as an onboarding step.
+- **You need a dedicated registration for your middleware in your identity provider**, so its tokens carry an audience distinct from Infisical's own.
+
+## Registering your middleware
+
+You need permission to manage both OAuth applications and SSO in the organization, because enabling token exchange decides whose externally issued tokens Infisical will convert into user tokens.
+
+<Steps>
+  <Step title="Open the OAuth Applications page">
+    Head to **Organization Settings** and open **OAuth Applications**.
+  </Step>
+  <Step title="Add an application">
+    Press **Add Application** and fill in the details:
+
+    - **Name** (required): A friendly name for the middleware.
+    - **Description** (optional): A short note about what it is used for.
+    - **Flow**: Select **Token exchange**.
+    - **Audience** (required): The audience your identity provider puts in tokens it issues for this middleware, for example `api://internal-mcp`. Infisical rejects any token carrying a different audience.
+    - **Identity provider enforces MFA**: Turn this on to declare that your identity provider already requires MFA. Without it, exchanges fail for any user who requires MFA, because there is no Infisical MFA challenge to run.
+
+    There is no issuer to set here. Infisical always verifies against your organization's OIDC SSO provider, which is configured once on the **SSO** page and cannot be overridden per application.
+  </Step>
+  <Step title="Store the credentials">
+    On creation, Infisical shows the **Client ID** and **Client Secret**.
+
+    <Warning>
+      The client secret is shown only once. Store it securely. If it is lost, you can rotate it from the application's menu, but you cannot retrieve the original value.
+    </Warning>
+  </Step>
+</Steps>
+
+### Why the audience matters
+
+The audience is the control that does the real work. Your identity provider signs tokens for every application in your estate, and without an expected audience any of those tokens could be presented to Infisical and come back as a working Infisical token. Binding the application to one audience is what stops a token minted for an expenses app becoming a secrets-read credential.
+
+Set it to your middleware's own registration in your identity provider, never to Infisical's.
+
+## Exchanging a token
+
+Token exchange follows [RFC 8693](https://datatracker.ietf.org/doc/html/rfc8693) on the existing token endpoint, so any RFC 8693-aware client library works. Client credentials may be sent as HTTP Basic auth or in the request body.
+
+```bash
+curl -X POST https://app.infisical.com/api/v1/oauth/token \
+  -u "<client_id>:<client_secret>" \
+  --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  --data-urlencode "subject_token=<user's token from your identity provider>" \
+  --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:jwt"
+```
+
+Parameters:
+
+| Parameter            | Value                                                                                                            |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `grant_type`         | `urn:ietf:params:oauth:grant-type:token-exchange`                                                                 |
+| `subject_token`      | The user's token from your identity provider                                                                      |
+| `subject_token_type` | `urn:ietf:params:oauth:token-type:jwt` or `urn:ietf:params:oauth:token-type:id_token`                              |
+
+The response is a short-lived access token for the user the subject token identified:
+
+```json
+{
+  "access_token": "...",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+Access token lifetime follows your organization's user token expiration setting, falling back to the platform default.
+
+<Note>
+  `scope`, `audience`, and `resource` are rejected rather than ignored. This grant has no scope concept, and the expected audience is fixed on the application, so silently dropping those parameters would leave you believing a restriction was applied when it was not.
+</Note>
+
+Use the access token as a standard Bearer token:
+
+```bash
+curl https://app.infisical.com/api/v4/secrets \
+  -H "Authorization: Bearer <access_token>" \
+  --get \
+  --data-urlencode "workspaceId=<project-id>" \
+  --data-urlencode "environment=dev"
+```
+
+<Note>
+  Delegated tokens are currently accepted on the read-only secret-fetch endpoints. Endpoint coverage is expanding; if your integration needs an endpoint that rejects a delegated token, let us know which one.
+</Note>
+
+## What Infisical verifies
+
+Every exchange checks all of the following, and fails the request with a message naming the problem if any of them does not hold:
+
+- The **signature** validates against your identity provider's published keys.
+- The **issuer** matches your organization's configured OIDC SSO issuer.
+- The **audience** matches the audience configured on the application.
+- The token is **not expired** and not used before its `nbf` time.
+- The **signing algorithm** matches your OIDC SSO configuration.
+- The token's **subject** resolves to a user who has signed in through your organization's OIDC SSO and is an active member of the organization.
+- **MFA** requirements are satisfied, either because none apply or because the application declares that the identity provider enforces them.
+
+## Audit trail
+
+Each exchange records an audit event attributed to the **subject user**, with the requesting application recorded alongside it. Because the issued token belongs to that user, every later action taken with it appears under the same person, and can be traced back to the exchange that authorized it.
+
+## Dependency on SSO
+
+Token exchange has no trust anchor of its own. It relies on your organization's OIDC SSO configuration, which means:
+
+- **Disabling OIDC SSO stops token exchange working.** So does deleting the configuration.
+- **Changing the issuer changes who can vouch for your users.** Migrating identity providers moves both browser sign-in and token exchange at once.
+
+The **SSO** page lists the applications that depend on the issuer, so you can see the blast radius before changing it.
+
+## Revoking access
+
+Deleting the application from the **OAuth Applications** page immediately revokes every token it issued, so they stop working on the next request rather than living until expiry. Rotating the client secret stops the middleware obtaining new tokens until it is updated.
+
+Because no refresh tokens are issued, the exposure from a compromised middleware is bounded by the remaining lifetime of the access tokens it currently holds.

--- a/docs/documentation/platform/oauth-token-exchange.mdx
+++ b/docs/documentation/platform/oauth-token-exchange.mdx
@@ -185,6 +185,7 @@ Every exchange checks all of the following, and fails the request with a message
 - The token **carries an `exp` claim and has not passed it**, and is not used before its `nbf` time. A token with no expiry is rejected rather than treated as valid forever.
 - The **signing algorithm** matches your OIDC SSO configuration.
 - The token's **subject** resolves to a user who has signed in through your organization's OIDC SSO and is an active member of the organization.
+- That user's **Infisical account is usable**: setup is complete and the account is not locked. A locked account fails the exchange outright rather than returning a token that stops working on first use.
 - **MFA** requirements are satisfied, either because none apply or because the application declares that the identity provider enforces them.
 
 ## Audit trail

--- a/frontend/src/hooks/api/auditLogs/types.tsx
+++ b/frontend/src/hooks/api/auditLogs/types.tsx
@@ -29,6 +29,7 @@ export type TGetAuditLogsFilter = {
 interface UserActorMetadata {
   userId: string;
   email: string;
+  oauthClientId?: string;
 }
 
 interface ServiceActorMetadata {

--- a/frontend/src/hooks/api/oauthClients/index.tsx
+++ b/frontend/src/hooks/api/oauthClients/index.tsx
@@ -7,3 +7,4 @@ export {
 } from "./mutations";
 export { useGetOauthAuthorizeInfo, useGetOauthClients } from "./queries";
 export type { TOauthAuthorizeInfo, TOauthClient } from "./types";
+export { OauthGrantType } from "./types";

--- a/frontend/src/hooks/api/oauthClients/mutations.tsx
+++ b/frontend/src/hooks/api/oauthClients/mutations.tsx
@@ -24,7 +24,7 @@ export const useCreateOauthClient = () => {
     },
     onSuccess: ({ client }) => {
       queryClient.invalidateQueries({
-        queryKey: oauthClientKeys.list(client.orgId)
+        queryKey: oauthClientKeys.allLists(client.orgId)
       });
     }
   });
@@ -42,7 +42,7 @@ export const useUpdateOauthClient = () => {
     },
     onSuccess: ({ orgId }) => {
       queryClient.invalidateQueries({
-        queryKey: oauthClientKeys.list(orgId)
+        queryKey: oauthClientKeys.allLists(orgId)
       });
     }
   });
@@ -59,7 +59,7 @@ export const useDeleteOauthClient = () => {
     },
     onSuccess: ({ orgId }) => {
       queryClient.invalidateQueries({
-        queryKey: oauthClientKeys.list(orgId)
+        queryKey: oauthClientKeys.allLists(orgId)
       });
     }
   });
@@ -76,7 +76,7 @@ export const useRotateOauthClientSecret = () => {
     },
     onSuccess: ({ client }) => {
       queryClient.invalidateQueries({
-        queryKey: oauthClientKeys.list(client.orgId)
+        queryKey: oauthClientKeys.allLists(client.orgId)
       });
     }
   });

--- a/frontend/src/hooks/api/oauthClients/queries.tsx
+++ b/frontend/src/hooks/api/oauthClients/queries.tsx
@@ -2,19 +2,25 @@ import { useQuery } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
 
-import { TOauthAuthorizeInfo, TOauthClient } from "./types";
+import { OauthGrantType, TOauthAuthorizeInfo, TOauthClient } from "./types";
 
 export const oauthClientKeys = {
-  list: (orgId: string) => [{ orgId }, "oauth-clients"] as const,
+  allLists: (orgId: string) => [{ orgId }, "oauth-clients"] as const,
+  list: (orgId: string, grantType?: OauthGrantType) =>
+    [...oauthClientKeys.allLists(orgId), grantType ?? ""] as const,
   authorizeInfo: (clientId: string, redirectUri: string, scope?: string) =>
     ["oauth-authorize-info", clientId, redirectUri, scope ?? ""] as const
 };
 
-export const useGetOauthClients = (orgId: string) => {
+// `grantType` narrows the list to applications registered for one grant. The SSO page uses it to show
+// which applications depend on the org's OIDC issuer.
+export const useGetOauthClients = (orgId: string, grantType?: OauthGrantType) => {
   return useQuery({
-    queryKey: oauthClientKeys.list(orgId),
+    queryKey: oauthClientKeys.list(orgId, grantType),
     queryFn: async () => {
-      const { data } = await apiRequest.get<{ clients: TOauthClient[] }>("/api/v1/oauth/clients");
+      const { data } = await apiRequest.get<{ clients: TOauthClient[] }>("/api/v1/oauth/clients", {
+        params: grantType ? { grantType } : undefined
+      });
       return data.clients;
     },
     enabled: Boolean(orgId)

--- a/frontend/src/hooks/api/oauthClients/queries.tsx
+++ b/frontend/src/hooks/api/oauthClients/queries.tsx
@@ -12,8 +12,7 @@ export const oauthClientKeys = {
     ["oauth-authorize-info", clientId, redirectUri, scope ?? ""] as const
 };
 
-// `grantType` narrows the list to applications registered for one grant. The SSO page uses it to show
-// which applications depend on the org's OIDC issuer.
+// The SSO page passes `grantType` to show which applications depend on the org's OIDC issuer.
 export const useGetOauthClients = (orgId: string, grantType?: OauthGrantType) => {
   return useQuery({
     queryKey: oauthClientKeys.list(orgId, grantType),

--- a/frontend/src/hooks/api/oauthClients/types.ts
+++ b/frontend/src/hooks/api/oauthClients/types.ts
@@ -1,3 +1,10 @@
+// Redirect URIs and PKCE apply only to AuthorizationCode, the audience only to TokenExchange.
+export enum OauthGrantType {
+  AuthorizationCode = "authorization_code",
+  RefreshToken = "refresh_token",
+  TokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+}
+
 export type TOauthClient = {
   id: string;
   orgId: string;
@@ -5,8 +12,11 @@ export type TOauthClient = {
   description?: string | null;
   clientId: string;
   clientSecretPrefix: string;
+  grantTypes: OauthGrantType[];
   redirectUris: string[];
   requirePkce: boolean;
+  tokenExchangeAudience?: string | null;
+  tokenExchangeIdpSatisfiesMfa: boolean;
   createdAt: string;
   updatedAt: string;
 };
@@ -14,16 +24,22 @@ export type TOauthClient = {
 export type TCreateOauthClientDTO = {
   name: string;
   description?: string;
+  grantTypes: OauthGrantType[];
   redirectUris: string[];
   requirePkce?: boolean;
+  tokenExchangeAudience?: string;
+  tokenExchangeIdpSatisfiesMfa?: boolean;
 };
 
 export type TUpdateOauthClientDTO = {
   clientDbId: string;
   name?: string;
   description?: string | null;
+  grantTypes?: OauthGrantType[];
   redirectUris?: string[];
   requirePkce?: boolean;
+  tokenExchangeAudience?: string | null;
+  tokenExchangeIdpSatisfiesMfa?: boolean;
 };
 
 export type TDeleteOauthClientDTO = {

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
@@ -69,6 +69,9 @@ export const LogsTableRow = ({ auditLog, rowNumber, timezone, onClick }: Props) 
           {auditLog.actor.type === ActorType.USER && (
             <Tag label="user_email" value={auditLog.actor.metadata.email} />
           )}
+          {auditLog.actor.type === ActorType.USER && auditLog.actor.metadata.oauthClientId && (
+            <Tag label="oauth_application" value={auditLog.actor.metadata.oauthClientId} />
+          )}
           {auditLog.actor.type === ActorType.IDENTITY && (
             <Tag label="identity_name" value={auditLog.actor.metadata.name} />
           )}

--- a/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/LogsTableRow.tsx
@@ -67,10 +67,12 @@ export const LogsTableRow = ({ auditLog, rowNumber, timezone, onClick }: Props) 
           <Tag label="event" value={auditLog.event.type} />
           <Tag label="actor" value={auditLog.actor.type} />
           {auditLog.actor.type === ActorType.USER && (
-            <Tag label="user_email" value={auditLog.actor.metadata.email} />
-          )}
-          {auditLog.actor.type === ActorType.USER && auditLog.actor.metadata.oauthClientId && (
-            <Tag label="oauth_application" value={auditLog.actor.metadata.oauthClientId} />
+            <>
+              <Tag label="user_email" value={auditLog.actor.metadata.email} />
+              {auditLog.actor.metadata.oauthClientId && (
+                <Tag label="oauth_application" value={auditLog.actor.metadata.oauthClientId} />
+              )}
+            </>
           )}
           {auditLog.actor.type === ActorType.IDENTITY && (
             <Tag label="identity_name" value={auditLog.actor.metadata.name} />

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
@@ -155,6 +155,8 @@ export const OauthClientModal = ({
   });
 
   const flow = useWatch({ control, name: "flow" });
+  const isMissingOidcSso =
+    flow === OauthClientFlow.TokenExchange && !isOidcConfigPending && !hasActiveOidcSso;
 
   useEffect(() => {
     if (popUp?.clientForm?.isOpen) {
@@ -376,7 +378,7 @@ export const OauthClientModal = ({
                   />
                 </>
               )}
-              {flow === OauthClientFlow.TokenExchange && (
+              {flow === OauthClientFlow.TokenExchange && !isMissingOidcSso && (
                 <>
                   <Controller
                     control={control}
@@ -433,7 +435,7 @@ export const OauthClientModal = ({
               variant="org"
               type="submit"
               isPending={isCreating || isUpdating}
-              isDisabled={isCreating || isUpdating}
+              isDisabled={isCreating || isUpdating || isMissingOidcSso}
             >
               {isEditing ? "Save Changes" : "Create Application"}
             </Button>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
@@ -311,7 +311,7 @@ export const OauthClientModal = ({
                           params={{ orgId: currentOrg?.id ?? "" }}
                           className="underline underline-offset-2 hover:text-foreground"
                         >
-                          Organization Settings &gt; SSO
+                          Settings &gt; SSO & Provisioning
                         </Link>
                         . Disabling OIDC SSO stops token exchange working.
                       </p>
@@ -324,7 +324,7 @@ export const OauthClientModal = ({
                           params={{ orgId: currentOrg?.id ?? "" }}
                           className="underline underline-offset-2 hover:text-foreground"
                         >
-                          Organization Settings &gt; SSO
+                          Settings &gt; SSO & Provisioning
                         </Link>{" "}
                         first.
                       </p>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
@@ -288,11 +288,17 @@ export const OauthClientModal = ({
                   <Field>
                     <FieldLabel>Flow</FieldLabel>
                     <Tabs value={value} onValueChange={onChange}>
-                      <TabsList variant="filled" className="w-full">
-                        <TabsTrigger value={OauthClientFlow.AuthorizationCode}>
+                      <TabsList variant="org" aria-label="Flow">
+                        <TabsTrigger
+                          value={OauthClientFlow.AuthorizationCode}
+                          className="data-[orientation=horizontal]:group-data-[style=underline]/tabs-list:flex-1"
+                        >
                           Authorization code
                         </TabsTrigger>
-                        <TabsTrigger value={OauthClientFlow.TokenExchange}>
+                        <TabsTrigger
+                          value={OauthClientFlow.TokenExchange}
+                          className="data-[orientation=horizontal]:group-data-[style=underline]/tabs-list:flex-1"
+                        >
                           Token exchange
                         </TabsTrigger>
                       </TabsList>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
@@ -388,7 +388,7 @@ export const OauthClientModal = ({
                         </FieldLabel>
                         <Input
                           id="oauth-client-token-exchange-audience"
-                          placeholder="e.g. api://paychex-mcp"
+                          placeholder="e.g. api://internal-mcp"
                           isError={Boolean(error)}
                           {...field}
                         />

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
@@ -61,9 +61,8 @@ const splitRedirectUris = (value: string) =>
     .map((uri) => uri.trim())
     .filter(Boolean);
 
-// The UI models one flow per application even though the API allows a client to hold several grants.
-// The two flows share no configuration and delegate differently, so an application needing both is a
-// direct API call.
+// The API lets a client hold several grants, but the UI sticks to one flow per application: the two
+// share no config and delegate differently, so an application needing both goes through the API.
 enum OauthClientFlow {
   AuthorizationCode = "authorization-code",
   TokenExchange = "token-exchange"

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
@@ -1,28 +1,43 @@
 import { useEffect } from "react";
-import { Controller, useForm } from "react-hook-form";
+import { Controller, useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle, Info } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Alert,
+  AlertDescription,
   Button,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   Field,
   FieldContent,
   FieldDescription,
   FieldError,
+  FieldGroup,
   FieldLabel,
   FieldTitle,
   Input,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
   Switch,
+  Tabs,
+  TabsList,
+  TabsTrigger,
   TextArea
 } from "@app/components/v3";
-import { TOauthClient, useCreateOauthClient, useUpdateOauthClient } from "@app/hooks/api";
+import { useOrganization } from "@app/context";
+import {
+  TOauthClient,
+  useCreateOauthClient,
+  useGetOIDCConfig,
+  useUpdateOauthClient
+} from "@app/hooks/api";
+import { OauthGrantType } from "@app/hooks/api/oauthClients/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
@@ -40,30 +55,69 @@ const isValidRedirectUri = (uri: string) => {
   }
 };
 
-const oauthClientFormSchema = z.object({
-  name: z.string().trim().min(1, "Name is required").max(64),
-  description: z.string().trim().max(256).optional(),
-  redirectUris: z
-    .string()
-    .trim()
-    .min(1, "At least one redirect URI is required")
-    .superRefine((value, ctx) => {
-      const uris = value
-        .split("\n")
-        .map((uri) => uri.trim())
-        .filter(Boolean);
+const splitRedirectUris = (value: string) =>
+  value
+    .split("\n")
+    .map((uri) => uri.trim())
+    .filter(Boolean);
+
+// The UI models one flow per application even though the API allows a client to hold several grants.
+// The two flows share no configuration and delegate differently, so an application needing both is a
+// direct API call.
+enum OauthClientFlow {
+  AuthorizationCode = "authorization-code",
+  TokenExchange = "token-exchange"
+}
+
+const oauthClientFormSchema = z
+  .object({
+    name: z.string().trim().min(1, "Name is required").max(64),
+    description: z.string().trim().max(256).optional(),
+    flow: z.nativeEnum(OauthClientFlow),
+    redirectUris: z.string().trim(),
+    requirePkce: z.boolean(),
+    tokenExchangeAudience: z.string().trim().max(255),
+    tokenExchangeIdpSatisfiesMfa: z.boolean()
+  })
+  .superRefine((data, ctx) => {
+    if (data.flow === OauthClientFlow.AuthorizationCode) {
+      const uris = splitRedirectUris(data.redirectUris);
+
+      if (!uris.length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["redirectUris"],
+          message: "At least one redirect URI is required"
+        });
+      }
+
       const invalidUri = uris.find((uri) => !isValidRedirectUri(uri));
       if (invalidUri) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
+          path: ["redirectUris"],
           message: `Invalid redirect URI: ${invalidUri}`
         });
       }
-    }),
-  requirePkce: z.boolean()
-});
+    }
+
+    if (data.flow === OauthClientFlow.TokenExchange && !data.tokenExchangeAudience) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tokenExchangeAudience"],
+        message: "An audience is required"
+      });
+    }
+  });
 
 type TOauthClientForm = z.infer<typeof oauthClientFormSchema>;
+
+const FLOW_DESCRIPTIONS: Record<OauthClientFlow, string> = {
+  [OauthClientFlow.AuthorizationCode]:
+    "RFC 6749. The user signs in and approves the application in their browser. The token is limited to the scopes they consent to.",
+  [OauthClientFlow.TokenExchange]:
+    "RFC 8693. The application presents a user's token from your identity provider and receives that user's Infisical token. No browser and no consent screen, and the token carries that user's full permissions."
+};
 
 type Props = {
   popUp: UsePopUpState<["clientForm"]>;
@@ -81,23 +135,39 @@ export const OauthClientModal = ({
   const editingClient = popUp?.clientForm?.data as TOauthClient | undefined;
   const isEditing = Boolean(editingClient);
 
+  const { currentOrg } = useOrganization();
+  const { data: oidcConfig, isPending: isOidcConfigPending } = useGetOIDCConfig(
+    currentOrg?.id ?? ""
+  );
+  const hasActiveOidcSso = Boolean(oidcConfig?.isActive);
+
   const { control, handleSubmit, reset } = useForm<TOauthClientForm>({
     resolver: zodResolver(oauthClientFormSchema),
     defaultValues: {
       name: "",
       description: "",
+      flow: OauthClientFlow.AuthorizationCode,
       redirectUris: "",
-      requirePkce: false
+      requirePkce: false,
+      tokenExchangeAudience: "",
+      tokenExchangeIdpSatisfiesMfa: false
     }
   });
+
+  const flow = useWatch({ control, name: "flow" });
 
   useEffect(() => {
     if (popUp?.clientForm?.isOpen) {
       reset({
         name: editingClient?.name ?? "",
         description: editingClient?.description ?? "",
+        flow: editingClient?.grantTypes?.includes(OauthGrantType.TokenExchange)
+          ? OauthClientFlow.TokenExchange
+          : OauthClientFlow.AuthorizationCode,
         redirectUris: editingClient?.redirectUris?.join("\n") ?? "",
-        requirePkce: editingClient?.requirePkce ?? false
+        requirePkce: editingClient?.requirePkce ?? false,
+        tokenExchangeAudience: editingClient?.tokenExchangeAudience ?? "",
+        tokenExchangeIdpSatisfiesMfa: editingClient?.tokenExchangeIdpSatisfiesMfa ?? false
       });
     }
   }, [popUp?.clientForm?.isOpen]);
@@ -105,25 +175,26 @@ export const OauthClientModal = ({
   const { mutateAsync: createOauthClient, isPending: isCreating } = useCreateOauthClient();
   const { mutateAsync: updateOauthClient, isPending: isUpdating } = useUpdateOauthClient();
 
-  const onFormSubmit = async ({
-    name,
-    description,
-    redirectUris,
-    requirePkce
-  }: TOauthClientForm) => {
-    const parsedRedirectUris = redirectUris
-      .split("\n")
-      .map((uri) => uri.trim())
-      .filter(Boolean);
+  const onFormSubmit = async (form: TOauthClientForm) => {
+    const isTokenExchange = form.flow === OauthClientFlow.TokenExchange;
+
+    const payload = {
+      name: form.name,
+      grantTypes: isTokenExchange
+        ? [OauthGrantType.TokenExchange]
+        : [OauthGrantType.AuthorizationCode, OauthGrantType.RefreshToken],
+      redirectUris: isTokenExchange ? [] : splitRedirectUris(form.redirectUris),
+      requirePkce: isTokenExchange ? false : form.requirePkce,
+      tokenExchangeIdpSatisfiesMfa: isTokenExchange ? form.tokenExchangeIdpSatisfiesMfa : false
+    };
 
     try {
       if (isEditing && editingClient) {
         await updateOauthClient({
+          ...payload,
           clientDbId: editingClient.id,
-          name,
-          description: description || null,
-          redirectUris: parsedRedirectUris,
-          requirePkce
+          description: form.description || null,
+          tokenExchangeAudience: isTokenExchange ? form.tokenExchangeAudience : null
         });
         createNotification({
           text: "Successfully updated OAuth application",
@@ -131,10 +202,9 @@ export const OauthClientModal = ({
         });
       } else {
         const { client, clientSecret } = await createOauthClient({
-          name,
-          description: description || undefined,
-          redirectUris: parsedRedirectUris,
-          requirePkce
+          ...payload,
+          description: form.description || undefined,
+          tokenExchangeAudience: isTokenExchange ? form.tokenExchangeAudience : undefined
         });
         createNotification({
           text: "Successfully created OAuth application",
@@ -155,96 +225,207 @@ export const OauthClientModal = ({
   };
 
   return (
-    <Dialog
+    <Sheet
       open={popUp?.clientForm?.isOpen}
       onOpenChange={(isOpen) => {
         handlePopUpToggle("clientForm", isOpen);
         if (!isOpen) reset();
       }}
     >
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>
-            {isEditing ? "Edit OAuth application" : "Add OAuth application"}
-          </DialogTitle>
-          <DialogDescription>
-            External platforms use this application to request delegated access to Infisical on a
-            user&apos;s behalf via OAuth 2.0, limited to that user&apos;s permissions.
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-6">
-          <Controller
-            control={control}
-            name="name"
-            render={({ field, fieldState: { error } }) => (
-              <Field>
-                <FieldLabel htmlFor="oauth-client-name">Name</FieldLabel>
-                <Input
-                  id="oauth-client-name"
-                  placeholder="e.g. Coder"
-                  isError={Boolean(error)}
-                  {...field}
-                />
-                <FieldError>{error?.message}</FieldError>
-              </Field>
-            )}
-          />
-          <Controller
-            control={control}
-            name="description"
-            render={({ field, fieldState: { error } }) => (
-              <Field>
-                <FieldLabel htmlFor="oauth-client-description">Description (optional)</FieldLabel>
-                <Input
-                  id="oauth-client-description"
-                  placeholder="What this application is used for"
-                  isError={Boolean(error)}
-                  {...field}
-                />
-                <FieldError>{error?.message}</FieldError>
-              </Field>
-            )}
-          />
-          <Controller
-            control={control}
-            name="redirectUris"
-            render={({ field, fieldState: { error } }) => (
-              <Field>
-                <FieldLabel htmlFor="oauth-client-redirect-uris">Redirect URIs</FieldLabel>
-                <TextArea
-                  id="oauth-client-redirect-uris"
-                  placeholder="https://coder.example.com/external-auth/infisical/callback"
-                  rows={3}
-                  {...field}
-                />
-                <FieldDescription>
-                  One URI per line. The authorization flow only redirects to these exact URIs.
-                </FieldDescription>
-                <FieldError>{error?.message}</FieldError>
-              </Field>
-            )}
-          />
-          <Controller
-            control={control}
-            name="requirePkce"
-            render={({ field: { value, onChange } }) => (
-              <Field orientation="horizontal">
-                <FieldContent>
-                  <FieldTitle>Require PKCE (S256)</FieldTitle>
-                  <FieldDescription>
-                    Reject authorization requests that do not include a PKCE code challenge.
-                  </FieldDescription>
-                </FieldContent>
-                <Switch
-                  id="oauth-client-require-pkce"
-                  variant="org"
-                  checked={value}
-                  onCheckedChange={onChange}
-                />
-              </Field>
-            )}
-          />
-          <DialogFooter>
+      <SheetContent className="sm:max-w-xl">
+        <form onSubmit={handleSubmit(onFormSubmit)} className="flex h-full min-h-0 flex-col">
+          <SheetHeader>
+            <SheetTitle>
+              {isEditing ? "Edit OAuth application" : "Add OAuth application"}
+            </SheetTitle>
+            <SheetDescription>
+              External platforms use this application to request delegated access to Infisical on a
+              user&apos;s behalf via OAuth 2.0, limited to that user&apos;s permissions.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="min-h-0 thin-scrollbar flex-1 overflow-y-auto p-4">
+            <FieldGroup>
+              <Controller
+                control={control}
+                name="name"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-client-name">Name</FieldLabel>
+                    <Input
+                      id="oauth-client-name"
+                      placeholder="e.g. Coder"
+                      isError={Boolean(error)}
+                      {...field}
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+              <Controller
+                control={control}
+                name="description"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-client-description">
+                      Description (optional)
+                    </FieldLabel>
+                    <Input
+                      id="oauth-client-description"
+                      placeholder="What this application is used for"
+                      isError={Boolean(error)}
+                      {...field}
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+              <Controller
+                control={control}
+                name="flow"
+                render={({ field: { value, onChange } }) => (
+                  <Field>
+                    <FieldLabel>Flow</FieldLabel>
+                    <Tabs value={value} onValueChange={onChange}>
+                      <TabsList variant="filled" className="w-full">
+                        <TabsTrigger value={OauthClientFlow.AuthorizationCode}>
+                          Authorization code
+                        </TabsTrigger>
+                        <TabsTrigger value={OauthClientFlow.TokenExchange}>
+                          Token exchange
+                        </TabsTrigger>
+                      </TabsList>
+                    </Tabs>
+                    <FieldDescription>{FLOW_DESCRIPTIONS[value]}</FieldDescription>
+                  </Field>
+                )}
+              />
+              {flow === OauthClientFlow.TokenExchange && !isOidcConfigPending && (
+                <Alert variant={hasActiveOidcSso ? "default" : "warning"}>
+                  {hasActiveOidcSso ? <Info /> : <AlertTriangle />}
+                  <AlertDescription className="text-xs">
+                    {hasActiveOidcSso ? (
+                      <p>
+                        User tokens are verified against the OIDC SSO issuer configured under{" "}
+                        <Link
+                          to="/organizations/$orgId/sso"
+                          params={{ orgId: currentOrg?.id ?? "" }}
+                          className="underline underline-offset-2 hover:text-foreground"
+                        >
+                          Organization Settings &gt; SSO
+                        </Link>
+                        . Disabling OIDC SSO stops token exchange working.
+                      </p>
+                    ) : (
+                      <p>
+                        Token exchange verifies user tokens against your organization&apos;s OIDC
+                        SSO issuer. Set one up under{" "}
+                        <Link
+                          to="/organizations/$orgId/sso"
+                          params={{ orgId: currentOrg?.id ?? "" }}
+                          className="underline underline-offset-2 hover:text-foreground"
+                        >
+                          Organization Settings &gt; SSO
+                        </Link>{" "}
+                        first.
+                      </p>
+                    )}
+                  </AlertDescription>
+                </Alert>
+              )}
+              {flow === OauthClientFlow.AuthorizationCode && (
+                <>
+                  <Controller
+                    control={control}
+                    name="redirectUris"
+                    render={({ field, fieldState: { error } }) => (
+                      <Field>
+                        <FieldLabel htmlFor="oauth-client-redirect-uris">Redirect URIs</FieldLabel>
+                        <TextArea
+                          id="oauth-client-redirect-uris"
+                          placeholder="https://coder.example.com/external-auth/infisical/callback"
+                          rows={3}
+                          {...field}
+                        />
+                        <FieldDescription>
+                          One URI per line. The authorization flow only redirects to these exact
+                          URIs.
+                        </FieldDescription>
+                        <FieldError>{error?.message}</FieldError>
+                      </Field>
+                    )}
+                  />
+                  <Controller
+                    control={control}
+                    name="requirePkce"
+                    render={({ field: { value, onChange } }) => (
+                      <Field orientation="horizontal">
+                        <FieldContent>
+                          <FieldTitle>Require PKCE (S256)</FieldTitle>
+                          <FieldDescription>
+                            Reject authorization requests that do not include a PKCE code challenge.
+                          </FieldDescription>
+                        </FieldContent>
+                        <Switch
+                          id="oauth-client-require-pkce"
+                          variant="org"
+                          checked={value}
+                          onCheckedChange={onChange}
+                        />
+                      </Field>
+                    )}
+                  />
+                </>
+              )}
+              {flow === OauthClientFlow.TokenExchange && (
+                <>
+                  <Controller
+                    control={control}
+                    name="tokenExchangeAudience"
+                    render={({ field, fieldState: { error } }) => (
+                      <Field>
+                        <FieldLabel htmlFor="oauth-client-token-exchange-audience">
+                          Audience
+                        </FieldLabel>
+                        <Input
+                          id="oauth-client-token-exchange-audience"
+                          placeholder="e.g. api://paychex-mcp"
+                          isError={Boolean(error)}
+                          {...field}
+                        />
+                        <FieldDescription>
+                          The audience your identity provider puts in tokens it issues for this
+                          application.
+                        </FieldDescription>
+                        <FieldError>{error?.message}</FieldError>
+                      </Field>
+                    )}
+                  />
+                  <Controller
+                    control={control}
+                    name="tokenExchangeIdpSatisfiesMfa"
+                    render={({ field: { value, onChange } }) => (
+                      <Field orientation="horizontal">
+                        <FieldContent>
+                          <FieldTitle>Identity provider enforces MFA</FieldTitle>
+                          <FieldDescription>
+                            Token exchange has no Infisical MFA challenge to run. Turn this on to
+                            declare that your identity provider already enforces MFA.
+                          </FieldDescription>
+                        </FieldContent>
+                        <Switch
+                          id="oauth-client-token-exchange-idp-mfa"
+                          variant="org"
+                          checked={value}
+                          onCheckedChange={onChange}
+                        />
+                      </Field>
+                    )}
+                  />
+                </>
+              )}
+            </FieldGroup>
+          </div>
+          <SheetFooter className="justify-end border-t">
             <Button variant="ghost" type="button" onClick={() => handlePopUpClose("clientForm")}>
               Cancel
             </Button>
@@ -256,9 +437,9 @@ export const OauthClientModal = ({
             >
               {isEditing ? "Save Changes" : "Create Application"}
             </Button>
-          </DialogFooter>
+          </SheetFooter>
         </form>
-      </DialogContent>
-    </Dialog>
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OauthClientModal.tsx
@@ -32,12 +32,12 @@ import {
 } from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import {
+  OauthGrantType,
   TOauthClient,
   useCreateOauthClient,
   useGetOIDCConfig,
   useUpdateOauthClient
 } from "@app/hooks/api";
-import { OauthGrantType } from "@app/hooks/api/oauthClients/types";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OrgOauthClientsTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OrgOauthClientsTab.tsx
@@ -56,6 +56,7 @@ import {
   useGetOauthClients,
   useRotateOauthClientSecret
 } from "@app/hooks/api";
+import { OauthGrantType } from "@app/hooks/api/oauthClients/types";
 
 import { OauthClientModal } from "./OauthClientModal";
 import { OauthClientSecretModal } from "./OauthClientSecretModal";
@@ -188,6 +189,7 @@ export const OrgOauthClientsTab = () => {
                     <TableRow>
                       <TableHead>Name</TableHead>
                       <TableHead>Client ID</TableHead>
+                      <TableHead>Flow</TableHead>
                       <TableHead>PKCE</TableHead>
                       <TableHead>Created</TableHead>
                       <TableHead className="w-px text-right" aria-label="Actions" />
@@ -198,88 +200,111 @@ export const OrgOauthClientsTab = () => {
                       Array.from({ length: 3 }).map((_, idx) => (
                         // eslint-disable-next-line react/no-array-index-key
                         <TableRow key={`oauth-client-skeleton-${idx}`}>
-                          <TableCell colSpan={5}>
+                          <TableCell colSpan={6}>
                             <Skeleton className="h-5 w-full" />
                           </TableCell>
                         </TableRow>
                       ))}
-                    {filteredClients.map((client) => (
-                      <TableRow key={client.id}>
-                        <TableCell className="font-medium text-foreground">{client.name}</TableCell>
-                        <TableCell>
-                          <div className="flex items-center gap-1">
-                            <span className="font-mono text-xs">{client.clientId}</span>
-                            <CopyButton value={client.clientId} ariaLabel="Copy client ID" />
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {client.requirePkce ? (
-                            <Badge variant="success">Required</Badge>
-                          ) : (
-                            <span className="text-muted">Optional</span>
-                          )}
-                        </TableCell>
-                        <TableCell>{format(new Date(client.createdAt), "MMM d, yyyy")}</TableCell>
-                        <TableCell className="text-right">
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <IconButton
-                                variant="ghost"
-                                size="xs"
-                                aria-label={`Actions for ${client.name}`}
-                              >
-                                <MoreHorizontal />
-                              </IconButton>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" className="w-44">
-                              <OrgPermissionCan
-                                I={OrgPermissionActions.Edit}
-                                a={OrgPermissionSubjects.OauthClients}
-                              >
-                                {(isAllowed) => (
-                                  <DropdownMenuItem
-                                    isDisabled={!isAllowed}
-                                    onClick={() => handlePopUpOpen("clientForm", client)}
-                                  >
-                                    <Pencil />
-                                    Edit
-                                  </DropdownMenuItem>
-                                )}
-                              </OrgPermissionCan>
-                              <OrgPermissionCan
-                                I={OrgPermissionActions.Edit}
-                                a={OrgPermissionSubjects.OauthClients}
-                              >
-                                {(isAllowed) => (
-                                  <DropdownMenuItem
-                                    isDisabled={!isAllowed}
-                                    onClick={() => handlePopUpOpen("rotateSecret", client)}
-                                  >
-                                    <RefreshCw />
-                                    Rotate Secret
-                                  </DropdownMenuItem>
-                                )}
-                              </OrgPermissionCan>
-                              <OrgPermissionCan
-                                I={OrgPermissionActions.Delete}
-                                a={OrgPermissionSubjects.OauthClients}
-                              >
-                                {(isAllowed) => (
-                                  <DropdownMenuItem
-                                    variant="danger"
-                                    isDisabled={!isAllowed}
-                                    onClick={() => handlePopUpOpen("deleteClient", client)}
-                                  >
-                                    <Trash2 />
-                                    Delete
-                                  </DropdownMenuItem>
-                                )}
-                              </OrgPermissionCan>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </TableCell>
-                      </TableRow>
-                    ))}
+                    {filteredClients.map((client) => {
+                      const usesAuthorizationCode = client.grantTypes.includes(
+                        OauthGrantType.AuthorizationCode
+                      );
+                      const usesTokenExchange = client.grantTypes.includes(
+                        OauthGrantType.TokenExchange
+                      );
+
+                      return (
+                        <TableRow key={client.id}>
+                          <TableCell className="font-medium text-foreground">
+                            {client.name}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex items-center gap-1">
+                              <span className="font-mono text-xs">{client.clientId}</span>
+                              <CopyButton value={client.clientId} ariaLabel="Copy client ID" />
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-wrap gap-1">
+                              {usesAuthorizationCode && (
+                                <Badge variant="neutral">Authorization code</Badge>
+                              )}
+                              {usesTokenExchange && <Badge variant="info">Token exchange</Badge>}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            {!usesAuthorizationCode && (
+                              <span className="text-muted">Not applicable</span>
+                            )}
+                            {usesAuthorizationCode && client.requirePkce && (
+                              <Badge variant="success">Required</Badge>
+                            )}
+                            {usesAuthorizationCode && !client.requirePkce && (
+                              <span className="text-muted">Optional</span>
+                            )}
+                          </TableCell>
+                          <TableCell>{format(new Date(client.createdAt), "MMM d, yyyy")}</TableCell>
+                          <TableCell className="text-right">
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <IconButton
+                                  variant="ghost"
+                                  size="xs"
+                                  aria-label={`Actions for ${client.name}`}
+                                >
+                                  <MoreHorizontal />
+                                </IconButton>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end" className="w-44">
+                                <OrgPermissionCan
+                                  I={OrgPermissionActions.Edit}
+                                  a={OrgPermissionSubjects.OauthClients}
+                                >
+                                  {(isAllowed) => (
+                                    <DropdownMenuItem
+                                      isDisabled={!isAllowed}
+                                      onClick={() => handlePopUpOpen("clientForm", client)}
+                                    >
+                                      <Pencil />
+                                      Edit
+                                    </DropdownMenuItem>
+                                  )}
+                                </OrgPermissionCan>
+                                <OrgPermissionCan
+                                  I={OrgPermissionActions.Edit}
+                                  a={OrgPermissionSubjects.OauthClients}
+                                >
+                                  {(isAllowed) => (
+                                    <DropdownMenuItem
+                                      isDisabled={!isAllowed}
+                                      onClick={() => handlePopUpOpen("rotateSecret", client)}
+                                    >
+                                      <RefreshCw />
+                                      Rotate Secret
+                                    </DropdownMenuItem>
+                                  )}
+                                </OrgPermissionCan>
+                                <OrgPermissionCan
+                                  I={OrgPermissionActions.Delete}
+                                  a={OrgPermissionSubjects.OauthClients}
+                                >
+                                  {(isAllowed) => (
+                                    <DropdownMenuItem
+                                      variant="danger"
+                                      isDisabled={!isAllowed}
+                                      onClick={() => handlePopUpOpen("deleteClient", client)}
+                                    >
+                                      <Trash2 />
+                                      Delete
+                                    </DropdownMenuItem>
+                                  )}
+                                </OrgPermissionCan>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
                   </TableBody>
                 </Table>
               )}

--- a/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OrgOauthClientsTab.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgOauthClientsTab/OrgOauthClientsTab.tsx
@@ -51,12 +51,12 @@ import {
 } from "@app/context";
 import { usePopUp } from "@app/hooks";
 import {
+  OauthGrantType,
   TOauthClient,
   useDeleteOauthClient,
   useGetOauthClients,
   useRotateOauthClientSecret
 } from "@app/hooks/api";
-import { OauthGrantType } from "@app/hooks/api/oauthClients/types";
 
 import { OauthClientModal } from "./OauthClientModal";
 import { OauthClientSecretModal } from "./OauthClientSecretModal";

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgOIDCSection.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@tanstack/react-router";
 import { AlertTriangle, ArrowLeftRight, Info, MoreHorizontal, Pencil } from "lucide-react";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
@@ -8,7 +7,6 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
-  Badge,
   Card,
   CardAction,
   CardContent,
@@ -34,10 +32,9 @@ import {
   OrgPermissionActions,
   OrgPermissionSubjects,
   useOrganization,
-  useOrgPermission,
   useSubscription
 } from "@app/context";
-import { OauthGrantType, useGetOauthClients, useGetOIDCConfig } from "@app/hooks/api";
+import { useGetOIDCConfig } from "@app/hooks/api";
 import { useUpdateOIDCConfig } from "@app/hooks/api/oidcConfig/mutations";
 import { usePopUp } from "@app/hooks/usePopUp";
 
@@ -50,20 +47,9 @@ type Props = {
 export const OrgOIDCSection = ({ onSwitchProvider }: Props): JSX.Element => {
   const { currentOrg } = useOrganization();
   const { subscription } = useSubscription();
-  const { permission } = useOrgPermission();
 
   const { data, isPending } = useGetOIDCConfig(currentOrg?.id ?? "");
   const { mutateAsync } = useUpdateOIDCConfig();
-
-  const canReadApplications = permission.can(
-    OrgPermissionActions.Read,
-    OrgPermissionSubjects.OauthClients
-  );
-  const { data: tokenExchangeClients } = useGetOauthClients(
-    canReadApplications ? (currentOrg?.id ?? "") : "",
-    OauthGrantType.TokenExchange
-  );
-  const dependentClients = tokenExchangeClients ?? [];
 
   const { popUp, handlePopUpOpen, handlePopUpClose, handlePopUpToggle } = usePopUp([
     "addOIDC",
@@ -245,37 +231,6 @@ export const OrgOIDCSection = ({ onSwitchProvider }: Props): JSX.Element => {
                 )}
               </OrgPermissionCan>
             </Field>
-            {dependentClients.length > 0 && (
-              <Alert variant="info">
-                <Info />
-                <AlertTitle>
-                  {dependentClients.length === 1
-                    ? "1 application depends on this issuer"
-                    : `${dependentClients.length} applications depend on this issuer`}
-                </AlertTitle>
-                <AlertDescription>
-                  <p>
-                    These applications use OAuth token exchange to act on behalf of your users, and
-                    verify the tokens they present against this issuer. Disabling OIDC SSO or
-                    changing the issuer stops them working.
-                  </p>
-                  <div className="mt-2 flex flex-wrap gap-1">
-                    {dependentClients.map((client) => (
-                      <Badge key={client.id} variant="neutral">
-                        {client.name}
-                      </Badge>
-                    ))}
-                  </div>
-                  <Link
-                    to="/organizations/$orgId/oauth-applications"
-                    params={{ orgId: currentOrg?.id ?? "" }}
-                    className="mt-2 inline-block underline underline-offset-2 hover:text-foreground"
-                  >
-                    Manage OAuth applications
-                  </Link>
-                </AlertDescription>
-              </Alert>
-            )}
           </FieldGroup>
         </CardContent>
       </Card>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgOIDCSection.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import { AlertTriangle, ArrowLeftRight, Info, MoreHorizontal, Pencil } from "lucide-react";
 
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
@@ -7,6 +8,7 @@ import {
   Alert,
   AlertDescription,
   AlertTitle,
+  Badge,
   Card,
   CardAction,
   CardContent,
@@ -32,9 +34,11 @@ import {
   OrgPermissionActions,
   OrgPermissionSubjects,
   useOrganization,
+  useOrgPermission,
   useSubscription
 } from "@app/context";
-import { useGetOIDCConfig } from "@app/hooks/api";
+import { useGetOauthClients, useGetOIDCConfig } from "@app/hooks/api";
+import { OauthGrantType } from "@app/hooks/api/oauthClients/types";
 import { useUpdateOIDCConfig } from "@app/hooks/api/oidcConfig/mutations";
 import { usePopUp } from "@app/hooks/usePopUp";
 
@@ -47,9 +51,19 @@ type Props = {
 export const OrgOIDCSection = ({ onSwitchProvider }: Props): JSX.Element => {
   const { currentOrg } = useOrganization();
   const { subscription } = useSubscription();
+  const { permission } = useOrgPermission();
 
   const { data, isPending } = useGetOIDCConfig(currentOrg?.id ?? "");
   const { mutateAsync } = useUpdateOIDCConfig();
+
+  const canReadApplications = permission.can(
+    OrgPermissionActions.Read,
+    OrgPermissionSubjects.OauthClients
+  );
+  const { data: tokenExchangeClients } = useGetOauthClients(
+    canReadApplications ? (currentOrg?.id ?? "") : "",
+    OauthGrantType.TokenExchange
+  );
 
   const { popUp, handlePopUpOpen, handlePopUpClose, handlePopUpToggle } = usePopUp([
     "addOIDC",
@@ -231,6 +245,37 @@ export const OrgOIDCSection = ({ onSwitchProvider }: Props): JSX.Element => {
                 )}
               </OrgPermissionCan>
             </Field>
+            {Boolean(tokenExchangeClients?.length) && (
+              <Alert variant="info">
+                <Info />
+                <AlertTitle>
+                  {tokenExchangeClients?.length === 1
+                    ? "1 application depends on this issuer"
+                    : `${tokenExchangeClients?.length} applications depend on this issuer`}
+                </AlertTitle>
+                <AlertDescription>
+                  <p>
+                    These applications use OAuth token exchange to act on behalf of your users, and
+                    verify the tokens they present against this issuer. Disabling OIDC SSO or
+                    changing the issuer stops them working.
+                  </p>
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {tokenExchangeClients?.map((client) => (
+                      <Badge key={client.id} variant="neutral">
+                        {client.name}
+                      </Badge>
+                    ))}
+                  </div>
+                  <Link
+                    to="/organizations/$orgId/oauth-applications"
+                    params={{ orgId: currentOrg?.id ?? "" }}
+                    className="mt-2 inline-block underline underline-offset-2 hover:text-foreground"
+                  >
+                    Manage OAuth applications
+                  </Link>
+                </AlertDescription>
+              </Alert>
+            )}
           </FieldGroup>
         </CardContent>
       </Card>

--- a/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgOIDCSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgSsoTab/OrgOIDCSection.tsx
@@ -37,8 +37,7 @@ import {
   useOrgPermission,
   useSubscription
 } from "@app/context";
-import { useGetOauthClients, useGetOIDCConfig } from "@app/hooks/api";
-import { OauthGrantType } from "@app/hooks/api/oauthClients/types";
+import { OauthGrantType, useGetOauthClients, useGetOIDCConfig } from "@app/hooks/api";
 import { useUpdateOIDCConfig } from "@app/hooks/api/oidcConfig/mutations";
 import { usePopUp } from "@app/hooks/usePopUp";
 
@@ -64,6 +63,7 @@ export const OrgOIDCSection = ({ onSwitchProvider }: Props): JSX.Element => {
     canReadApplications ? (currentOrg?.id ?? "") : "",
     OauthGrantType.TokenExchange
   );
+  const dependentClients = tokenExchangeClients ?? [];
 
   const { popUp, handlePopUpOpen, handlePopUpClose, handlePopUpToggle } = usePopUp([
     "addOIDC",
@@ -245,13 +245,13 @@ export const OrgOIDCSection = ({ onSwitchProvider }: Props): JSX.Element => {
                 )}
               </OrgPermissionCan>
             </Field>
-            {Boolean(tokenExchangeClients?.length) && (
+            {dependentClients.length > 0 && (
               <Alert variant="info">
                 <Info />
                 <AlertTitle>
-                  {tokenExchangeClients?.length === 1
+                  {dependentClients.length === 1
                     ? "1 application depends on this issuer"
-                    : `${tokenExchangeClients?.length} applications depend on this issuer`}
+                    : `${dependentClients.length} applications depend on this issuer`}
                 </AlertTitle>
                 <AlertDescription>
                   <p>
@@ -260,7 +260,7 @@ export const OrgOIDCSection = ({ onSwitchProvider }: Props): JSX.Element => {
                     changing the issuer stops them working.
                   </p>
                   <div className="mt-2 flex flex-wrap gap-1">
-                    {tokenExchangeClients?.map((client) => (
+                    {dependentClients.map((client) => (
                       <Badge key={client.id} variant="neutral">
                         {client.name}
                       </Badge>

--- a/sso.md
+++ b/sso.md
@@ -97,6 +97,11 @@ A one-shot `keycloak-config` sidecar runs alongside it and sets the built-in `ma
 | JWT signature algorithm | `RS256` |
 | Redirect URI (registered) | `http://localhost:8080/api/v1/sso/oidc/callback` |
 | Seeded users | `john@oidc.com`, `alice@oidc.com`, `admin@oidc.com` (password `password123!`) |
+| Second client (token exchange only) | `infisical-mcp` / `infisical-mcp-client-secret` |
+
+The realm defines a second client, `infisical-mcp`, purely for
+[token exchange testing](#testing-oauth-token-exchange-rfc-8693). It stands in for trusted middleware:
+direct access grants only, no browser redirect, and it is never used for SSO login.
 
 ### Discovery URL (how the networking works)
 
@@ -154,6 +159,98 @@ Then test the login two ways:
    rejected. `make seed-dev-oidc` does this for you.
 4. Save, then enable OIDC.
 </details>
+
+### Testing OAuth token exchange (RFC 8693)
+
+Token exchange lets trusted middleware present a user's token from your IdP and receive that user's
+Infisical token. Its trust anchor is the org's OIDC SSO config, so everything above has to be working
+first. See [OAuth Token Exchange](docs/documentation/platform/oauth-token-exchange) for the product docs.
+
+No license is needed. `plan.oidcSSO` is only checked when creating or updating an OIDC config through
+the API, and `make seed-dev-oidc` writes the row directly.
+
+**1. Seed, then confirm the trust anchor resolves.** This is what decides whether the `iss` check
+passes, so check it rather than debugging a 401 later:
+
+```bash
+make seed-dev-oidc
+
+docker compose -f docker-compose.dev.yml exec -T backend \
+  sh -c 'curl -s http://keycloak:8080/realms/infisical/.well-known/openid-configuration' \
+  | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["issuer"]); print(d["jwks_uri"])'
+```
+
+Expect the issuer `http://localhost:8088/realms/infisical` (pinned by `KC_HOSTNAME`, and what tokens
+actually carry) and a `jwks_uri` on `keycloak:8080` that the backend can reach. The seeded config
+stores no issuer of its own, so the backend falls back to the discovered one.
+
+**2. Register the application.** Sign in at http://localhost:8080 as `admin@oidc.com` /
+`password123!`, then **Organization Settings > OAuth Applications > Add Application**. Choose flow
+**Token exchange**, set **Audience** to `infisical-mcp`, and leave the identity-provider MFA
+declaration off. Copy the client id and secret.
+
+**3. Get a subject token and exchange it.**
+
+```bash
+CLIENT_ID="<paste>"; CLIENT_SECRET="<paste>"
+
+SUBJECT_TOKEN=$(curl -s -X POST \
+  http://localhost:8088/realms/infisical/protocol/openid-connect/token \
+  -d grant_type=password -d scope=openid \
+  -d client_id=infisical-mcp -d client_secret=infisical-mcp-client-secret \
+  -d username=admin@oidc.com -d password='password123!' \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["id_token"])')
+
+curl -s -X POST http://localhost:8080/api/v1/oauth/token \
+  -u "$CLIENT_ID:$CLIENT_SECRET" \
+  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
+  -d subject_token="$SUBJECT_TOKEN" \
+  -d subject_token_type=urn:ietf:params:oauth:token-type:id_token | python3 -m json.tool
+```
+
+Use the **`id_token`**, not the access token. An ID token's `aud` is the requesting client by
+specification, so it is already `infisical-mcp`. The realm defines no audience mapper, so Keycloak's
+access token carries no `aud` at all (only `azp`) and is rejected.
+
+The response has `access_token`, `issued_token_type`, `token_type`, `expires_in`, and deliberately no
+`refresh_token` and no `scope`. Decode it and you should see `delegation: "full"`, no `scopes` claim,
+and the seeded admin's `userId`.
+
+**4. Check what the token can do.**
+
+```bash
+TOKEN="<paste access_token>"
+
+# Introspection: 200 {"active":true} means it authenticated as AuthMode.OAUTH on a live session.
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/api/v1/oauth/validate \
+  -H "Authorization: Bearer $TOKEN"
+
+# Account routes stay unreachable for delegated tokens, so this must be 403.
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/api/v1/user/me/totp \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Create a project and a secret in the `oidc` org, then read it with `GET /api/v3/secrets/raw` using the
+token. A 200 proves full delegation carries the user's real permissions. The org's **Audit Logs** should
+show the exchange attributed to `admin@oidc.com` with the acting application in the metadata.
+
+**5. Prove the alias requirement.** `john@oidc.com` has no seeded alias, so repeating step 3 with
+`username=john@oidc.com` is rejected. Complete one SSO login as john via
+`http://localhost:8080/api/v1/sso/oidc/login?orgSlug=oidc`, then retry: it now succeeds, because
+Keycloak issues the same `sub` to both clients and the browser login wrote the alias the exchange
+looks up.
+
+**Cases worth checking:**
+
+| Case | How | Expect |
+| --- | --- | --- |
+| Cross-application replay | subject token from `infisical-dev` | 401, audience does not match |
+| Access token instead of ID token | send `access_token` | 401, audience does not match |
+| Tampered signature | change a character in the third JWT segment | 401, could not be verified |
+| `scope` supplied | add `-d scope=secrets:read` | 400, scope not supported |
+| SSO disabled | `update oidc_configs set "isActive"=false;` | 400, naming the SSO settings |
+| MFA required | enforce org MFA, leave the application flag off | 401, MFA required |
+| Unregistered grant | use an authorization-code application's credentials | 401, not registered for the grant |
 
 ---
 
@@ -382,3 +479,6 @@ curl -sI "http://localhost:8080/api/v1/sso/redirect/saml2/organizations/saml" | 
 | SAML login fails with `assertion audience mismatch` | Authentik's SAML provider audience must equal `SITE_URL` (`http://localhost:8080`); the seed sets this. If you changed `SITE_URL`, re-run `make seed-dev-saml` so Authentik's audience and the SAML config agree. |
 | Authentik unreachable or `Token invalid/expired` during the seed | Authentik takes ~40s after `make up-dev-saml` to finish bootstrapping (the worker applies blueprints and creates the API token). Wait for http://localhost:9100 to load, then re-run `make seed-dev-saml`. |
 | Locked out after enforcing SSO | Recover via http://localhost:8080/login/admin. |
+| Token exchange: `audience does not match` | You sent Keycloak's **access** token. The realm has no audience mapper, so its access tokens carry no `aud` claim. Use the `id_token` from the same response, whose `aud` is the client id. Also check the application's audience is `infisical-mcp` and not `infisical-dev`. |
+| Token exchange: `has not signed in to Infisical through your organization's OIDC SSO yet` | That user has no `user_aliases` row. `make seed-dev-oidc` only seeds one for `admin@oidc.com` (the realm pins its subject). For any other user, complete one browser SSO login first: `http://localhost:8080/api/v1/sso/oidc/login?orgSlug=oidc`. |
+| Token exchange: `has no OIDC SSO configuration` / `OIDC SSO is disabled` | The org has no active `oidc_configs` row. Run `make seed-dev-oidc`, and note it targets the `oidc` org unless you pass `ORG_ID=<uuid>`. |


### PR DESCRIPTION
## Context

Middleware acting on behalf of users (MCP servers, AI agents, internal developer portals, API gateways) currently has to authenticate using a shared machine identity. This loses user attribution in the audit log and grants every user the full set of permissions assigned to that shared identity.

This change adds support for the RFC 8693 Token Exchange grant to the existing OAuth token endpoint. Trusted middleware can present a user's token issued by the organization's OIDC identity provider and receive a short-lived Infisical access token for that same user. The issued token carries the user's actual permissions and is fully attributed to them in the audit log. No refresh token is issued, and delegated tokens cannot access account self-management endpoints.

OAuth applications now explicitly declare their supported grant types. Existing applications and API clients that do not specify any grant types continue using the authorization code flow by default, so this change is fully backward compatible.

Token Exchange applications introduce one additional configuration field: the audience that the organization's identity provider issues for that middleware. This prevents tokens minted for unrelated applications from being exchanged.

The trust anchor is the organization's OIDC SSO configuration rather than per-application issuer settings. As a result, enabling Token Exchange, updating its audience, or rotating a Token Exchange application's client secret all require SSO edit permissions. Deleting a client, rotating its secret, or removing the Token Exchange grant immediately revokes any delegated tokens it has previously issued.

## Screenshots

## Steps to verify the change

1. In the UI, create an OAuth application with the **Token Exchange** flow. Verify that the **Audience** field is required and that the redirect URI fields are hidden.
2. Verify that the SSO page displays the "Applications depend on this issuer" callout once a Token Exchange application exists.
3. Verify that successful exchanges appear in the organization audit log, attributed to the end user, with the acting application included in the metadata.
4. Run the end-to-end flow below.

### Testing end to end locally

A complete walkthrough is available in `sso.md` under **Testing OAuth Token Exchange (RFC 8693)**. The abbreviated flow is:

```bash
make up-dev-oidc     # Starts the default stack plus Keycloak with the seeded Infisical realm
make seed-dev-oidc   # Creates the oidc org, admin@oidc.com / password123!, verified domain, and active OIDC configuration
```

The seeded realm also includes a second client, `infisical-mcp`, which represents the middleware.

Sign in to http://localhost:8080/ as `admin@oidc.com`, navigate to **Organization Settings → OAuth Applications**, create an application using the **Token Exchange** flow, set the audience to `infisical-mcp`, and copy the generated client credentials.

Then run:

```bash
CLIENT_ID="<paste>"
CLIENT_SECRET="<paste>"

SUBJECT_TOKEN=$(curl -s -X POST \
  http://localhost:8088/realms/infisical/protocol/openid-connect/token \
  -d grant_type=password -d scope=openid \
  -d client_id=infisical-mcp -d client_secret=infisical-mcp-client-secret \
  -d username=admin@oidc.com -d password='password123!' \
  | python3 -c 'import sys,json; print(json.load(sys.stdin)["id_token"])')

curl -s -X POST http://localhost:8080/api/v1/oauth/token \
  -u "$CLIENT_ID:$CLIENT_SECRET" \
  -d grant_type=urn:ietf:params:oauth:grant-type:token-exchange \
  -d subject_token="$SUBJECT_TOKEN" \
  -d subject_token_type=urn:ietf:params:oauth:token-type:id_token \
  | python3 -m json.tool
```

Use the `id_token`, not the access token. The seeded Keycloak realm does not include an audience mapper, so its access tokens do not contain an `aud` claim.

Finally, validate the issued token:

* `GET /api/v1/oauth/validate` returns `200`.
* `GET /api/v1/user/me/totp` returns `403`, confirming delegated tokens cannot access account management endpoints.
* Reading a secret in the `oidc` organization succeeds.

`sso.md` also documents the recommended negative test cases, including cross-application replay, invalid signatures, supplying a `scope`, SSO disabled, MFA required, unregistered grants, and the alias requirement for users who have never signed in through SSO.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)