### PR TITLE
fix: remove redundant toast notifcations when erroring on creating an identity

### DIFF
--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/CreateProjectIdentity/CreateProjectIdentityForm.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/CreateProjectIdentity/CreateProjectIdentityForm.tsx
@@ -3,7 +3,6 @@ import { Controller, FormProvider, useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { AxiosError } from "axios";
 
 import { createNotification } from "@app/components/notifications";
 import { RoleOption } from "@app/components/roles";
@@ -262,16 +261,8 @@ export const CreateProjectIdentityForm = ({
           params: { identityId }
         });
       }
-    } catch (err) {
-      const message = (err as AxiosError<{ message?: string }>)?.response?.data?.message;
-      createNotification({
-        text:
-          message ??
-          (data.mode === CreateProjectIdentityMode.Assign
-            ? "Failed to add machine identity"
-            : "Failed to create machine identity"),
-        type: "error"
-      });
+    } catch {
+      // Error is handled by the mutation's onError handler
     }
   };
 

--- a/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectIdentityModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/IdentityTab/components/ProjectIdentityModal.tsx
@@ -81,15 +81,8 @@ export const ProjectIdentityModal = ({ onClose, identity }: ContentProps) => {
       });
 
       reset();
-    } catch (err) {
-      console.error(err);
-      const error = err as any;
-      const text = error?.response?.data?.message ?? "Failed to update machine identity";
-
-      createNotification({
-        text,
-        type: "error"
-      });
+    } catch {
+      // Error is handled by the mutation's onError handler
     }
   };
 


### PR DESCRIPTION
## Context

This PR removes the duplicate error toast notifications when creating/updating a project identity

## Screenshots

N/A

## Steps to verify the change

- [ ] fail to create/update a machine identity - confirm single toast

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)