### PR TITLE
chore: enforce checking at least one type in a pr description

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,8 @@
 
 ## Type
 
+<!-- Tick at least one. CI fails if none are ticked. -->
+
 - [ ] Fix
 - [ ] Feature
 - [ ] Improvement

--- a/.github/workflows/generate-upgrade-impact.yml
+++ b/.github/workflows/generate-upgrade-impact.yml
@@ -121,4 +121,13 @@ jobs:
             "${REVIEWER_FLAG[@]}" \
             --body "Generated self-hosted upgrade impact data for \`${TAG_NAME}\`.
 
-          Review the generated YAML for self-hosted upgrade accuracy before merging."
+          Review the generated YAML for self-hosted upgrade accuracy before merging.
+
+          ## Type
+
+          - [ ] Fix
+          - [ ] Feature
+          - [ ] Improvement
+          - [ ] Breaking
+          - [ ] Docs
+          - [x] Chore"

--- a/.github/workflows/validate-pr-description.yml
+++ b/.github/workflows/validate-pr-description.yml
@@ -1,0 +1,85 @@
+name: Validate PR Description
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+jobs:
+  validate-pr-description:
+    name: Validate PR Description
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Type section is filled out
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Automation that opens PRs from a fixed body template it does not
+            // control. Snyk opens under a real user's account, so it is matched
+            // on its branch prefix rather than the actor.
+            const exemptActors = ['dependabot[bot]', 'renovate[bot]'];
+            const exemptBranchPrefixes = ['snyk-fix-', 'snyk-upgrade-'];
+
+            if (
+              exemptActors.includes(pr.user.login) ||
+              exemptBranchPrefixes.some((prefix) => pr.head.ref.startsWith(prefix))
+            ) {
+              console.log(`✅ Skipping automated PR from ${pr.user.login} (${pr.head.ref})`);
+              return;
+            }
+
+            // Strip HTML comments so the template's own guidance, and any
+            // commented-out checkboxes, cannot satisfy the check.
+            const body = (pr.body || '').replace(/\r\n/g, '\n').replace(/<!--[\s\S]*?-->/g, '');
+            const lines = body.split('\n');
+
+            const headingStart = lines.findIndex((line) => /^\s{0,3}#{1,6}\s*type\b/i.test(line));
+
+            const failureFooter = `
+            **How to fix:** edit the PR description and tick at least one box under the \`## Type\` heading:
+
+            \`\`\`markdown
+            ## Type
+
+            - [x] Fix
+            - [ ] Feature
+            - [ ] Improvement
+            - [ ] Breaking
+            - [ ] Docs
+            - [ ] Chore
+            \`\`\`
+
+            Tick more than one if the change genuinely spans types (e.g. a feature that is also breaking). This check re-runs automatically once the description is saved.
+            `;
+
+            if (headingStart === -1) {
+              core.setFailed(`
+            ❌ **PR description is missing the Type section**
+
+            Your PR description has no \`## Type\` heading, so it is not possible to tell what kind of change this is.
+
+            Use the repository's [pull request template](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/.github/pull_request_template.md) rather than deleting it.
+            ${failureFooter}`);
+              return;
+            }
+
+            const afterHeading = lines.slice(headingStart + 1);
+            const nextHeading = afterHeading.findIndex((line) => /^\s{0,3}#{1,6}\s+\S/.test(line));
+            const section = nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
+
+            const checked = section
+              .filter((line) => /^\s*[-*]\s*\[[xX]\]/.test(line))
+              .map((line) => line.replace(/^\s*[-*]\s*\[[xX]\]\s*/, '').trim())
+              .filter(Boolean);
+
+            if (checked.length === 0) {
+              core.setFailed(`
+            ❌ **No type selected for this PR**
+
+            The \`## Type\` section is present but every box is still unticked.
+            ${failureFooter}`);
+              return;
+            }
+
+            console.log(`✅ Type selected: ${checked.join(', ')}`);


### PR DESCRIPTION
## Context

This PR adds a check to enforce PR authors to check at least one "Type" in the PR description

## Screenshots

<img width="2258" height="1590" alt="CleanShot 2026-08-21 at 15 11 13@2x" src="https://github.com/user-attachments/assets/1018c0f0-f1cc-43df-b41b-7d23e21b4334" />

## Steps to verify the change

this PR

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)