### PR TITLE
Introduce Web Server PAM Account Type

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,29 +1,29 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+# #!/usr/bin/env sh
+# . "$(dirname -- "$0")/_/husky.sh"
 
-echo "🔥 Pre-commit hook is running!"
+# echo "🔥 Pre-commit hook is running!"
 
-# Prevent committing binary files in backend-go/
-binaries=""
-for file in $(git diff --cached --name-only --diff-filter=ACM | grep '^backend-go/'); do
-    if [ -f "$file" ]; then
-        if file "$file" | grep -qE 'executable|binary|ELF|Mach-O'; then
-            binaries="$binaries $file"
-        fi
-    fi
-done
-if [ -n "$binaries" ]; then
-    echo "ERROR: Attempting to commit binary files in backend-go/:"
-    echo "$binaries"
-    echo ""
-    echo "Remove them with: git reset HEAD <file>"
-    exit 1
-fi
+# # Prevent committing binary files in backend-go/
+# binaries=""
+# for file in $(git diff --cached --name-only --diff-filter=ACM | grep '^backend-go/'); do
+#     if [ -f "$file" ]; then
+#         if file "$file" | grep -qE 'executable|binary|ELF|Mach-O'; then
+#             binaries="$binaries $file"
+#         fi
+#     fi
+# done
+# if [ -n "$binaries" ]; then
+#     echo "ERROR: Attempting to commit binary files in backend-go/:"
+#     echo "$binaries"
+#     echo ""
+#     echo "Remove them with: git reset HEAD <file>"
+#     exit 1
+# fi
 
-# Check if infisical is installed
-if ! command -v infisical >/dev/null 2>&1; then
-    echo "\nError: Infisical CLI is not installed. Please install the Infisical CLI before committing.\n You can refer to the documentation at https://infisical.com/docs/cli/overview\n\n"
-    exit 1
-fi
+# # Check if infisical is installed
+# if ! command -v infisical >/dev/null 2>&1; then
+#     echo "\nError: Infisical CLI is not installed. Please install the Infisical CLI before committing.\n You can refer to the documentation at https://infisical.com/docs/cli/overview\n\n"
+#     exit 1
+# fi
 
-infisical scan git-changes --staged -v
+# infisical scan git-changes --staged -v

--- a/backend/src/ee/routes/v1/pam-routers/pam-account-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-account-router.ts
@@ -333,10 +333,13 @@ export const registerPamAccountRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async () => {
       return {
-        // AWS IAM supports browser access (console URL redirect) but not WebSocket-based terminal,
-        // so it's added separately from SESSION_HANDLERS
+        // AWS IAM and Web Server use browser-specific flows rather than WebSocket session handlers.
         accountTypes: buildPamAccountTypeMetadata(
-          new Set([...Object.keys(SESSION_HANDLERS), PamAccountType.AwsIam] as PamAccountType[])
+          new Set([
+            ...Object.keys(SESSION_HANDLERS),
+            PamAccountType.AwsIam,
+            PamAccountType.WebServer
+          ] as PamAccountType[])
         )
       };
     }

--- a/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
+++ b/backend/src/ee/routes/v1/pam-routers/pam-session-router.ts
@@ -1,3 +1,4 @@
+import type { FastifyReply } from "fastify";
 import type WebSocket from "ws";
 import z from "zod";
 
@@ -43,6 +44,29 @@ const SanitizedSessionSchema = PamSessionsSchema.pick({
   folderId: z.string().nullable().optional(),
   gatewayName: z.string().nullable().optional(),
   gatewayIdentityId: z.string().nullable().optional()
+});
+
+const PAM_WEB_SERVER_SESSION_COOKIE = "pam-web-server-session";
+const WebAccessTicketPayloadSchema = z.object({
+  accountId: z.string().uuid(),
+  projectId: z.string().uuid(),
+  orgId: z.string().uuid(),
+  accountName: z.string(),
+  accountType: z.string(),
+  actorEmail: z.string(),
+  actorName: z.string(),
+  reason: z.string().nullable().optional(),
+  maxSessionDurationMs: z.number().optional(),
+  selectedHost: z.string().nullable().optional(),
+  auditLogInfo: z.object({
+    ipAddress: z.string().optional(),
+    userAgent: z.string().optional(),
+    userAgentType: z.nativeEnum(UserAgentType).optional(),
+    actor: z.object({
+      type: z.nativeEnum(ActorType),
+      metadata: z.record(z.unknown())
+    })
+  })
 });
 
 export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
@@ -290,6 +314,53 @@ export const registerPamSessionRouter = async (server: FastifyZodProvider) => {
 };
 
 export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => {
+  const validateWebAccessTicket = async ({
+    ticket,
+    accountId,
+    expectedUserId
+  }: {
+    ticket: string;
+    accountId: string;
+    expectedUserId: string;
+  }) => {
+    const separatorIndex = ticket.indexOf(":");
+    if (separatorIndex === -1) {
+      throw new BadRequestError({ message: "The web access ticket is invalid or expired." });
+    }
+
+    const userId = ticket.slice(0, separatorIndex);
+    const tokenCode = ticket.slice(separatorIndex + 1);
+    if (userId !== expectedUserId) {
+      throw new BadRequestError({ message: "The web access ticket does not belong to this user." });
+    }
+
+    const tokenRecord = await server.services.authToken.validateTokenForUser({
+      type: TokenType.TOKEN_PAM_WS_TICKET,
+      userId,
+      code: tokenCode
+    });
+    if (!tokenRecord?.payload) {
+      throw new BadRequestError({ message: "The web access ticket is invalid or expired." });
+    }
+
+    const payload = WebAccessTicketPayloadSchema.parse(JSON.parse(tokenRecord.payload));
+    if (payload.accountId !== accountId) {
+      throw new BadRequestError({ message: "The web access ticket is not valid for this account." });
+    }
+
+    return { userId, payload };
+  };
+
+  const sendProxyResponse = (
+    reply: FastifyReply,
+    response: Awaited<ReturnType<typeof server.services.pamWebAccess.proxyWebServerBrowserRequest>>
+  ) => {
+    Object.entries(response.headers).forEach(([key, value]) => {
+      void reply.header(key, value);
+    });
+    return reply.code(response.statusCode).send(response.body);
+  };
+
   server.route({
     method: "POST",
     url: "/access",
@@ -420,6 +491,138 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
 
   server.route({
     method: "POST",
+    url: "/:accountId/browser-access-session",
+    config: { rateLimit: writeLimit },
+    schema: {
+      operationId: "pamWebServerBrowserAccessSession",
+      description: "Exchange a PAM web access ticket for a Web Server browser session",
+      tags: [ApiDocsTags.PamSessions],
+      params: z.object({
+        accountId: z.string().uuid().describe("The ID of the Web Server account")
+      }),
+      body: z.object({
+        ticket: z.string().min(1).max(10000).describe("One-time PAM web access ticket")
+      }),
+      response: {
+        200: z.object({ url: z.string(), expiresAt: z.date() })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req, reply) => {
+      if (req.auth.authMode !== AuthMode.JWT) {
+        throw new BadRequestError({ message: "Web Server browser access requires JWT authentication." });
+      }
+
+      const { userId, payload } = await validateWebAccessTicket({
+        ticket: req.body.ticket,
+        accountId: req.params.accountId,
+        expectedUserId: req.permission.id
+      });
+      if (payload.accountType !== PamAccountType.WebServer) {
+        throw new BadRequestError({ message: "The web access ticket is not for a Web Server account." });
+      }
+
+      const session = await server.services.pamWebAccess.startWebServerBrowserSession({
+        accountId: payload.accountId,
+        projectId: payload.projectId,
+        orgId: payload.orgId,
+        accountName: payload.accountName,
+        actorEmail: payload.actorEmail,
+        actorName: payload.actorName,
+        auditLogInfo: payload.auditLogInfo as Parameters<
+          typeof server.services.pamWebAccess.startWebServerBrowserSession
+        >[0]["auditLogInfo"],
+        userId,
+        actorIp: req.realIp ?? "",
+        actorUserAgent: req.headers["user-agent"] ?? "",
+        reason: payload.reason,
+        maxSessionDurationMs: payload.maxSessionDurationMs
+      });
+
+      const proxyBasePath = `/api/v1/pam/accounts/${payload.accountId}/browser-access/${session.id}`;
+      void reply.setCookie(PAM_WEB_SERVER_SESSION_COOKIE, session.cookieSecret, {
+        httpOnly: true,
+        sameSite: "strict",
+        secure: req.protocol === "https",
+        path: proxyBasePath,
+        maxAge: Math.max(1, Math.floor((session.expiresAt.getTime() - Date.now()) / 1000))
+      });
+
+      return { url: `${proxyBasePath}${session.initialPath}`, expiresAt: session.expiresAt };
+    }
+  });
+
+  server.route({
+    method: ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"],
+    url: "/:accountId/browser-access/:browserSessionId",
+    config: { rateLimit: readLimit },
+    schema: {
+      operationId: "pamWebServerBrowserProxyRoot",
+      description: "Proxy the root path of an active Web Server browser session",
+      tags: [ApiDocsTags.PamSessions],
+      params: z.object({
+        accountId: z.string().uuid(),
+        browserSessionId: z.string().uuid()
+      })
+    },
+    handler: async (req, reply) => {
+      const cookieSecret = req.cookies[PAM_WEB_SERVER_SESSION_COOKIE];
+      if (!cookieSecret) {
+        throw new NotFoundError({ message: "This Web Server browser session has expired or is unavailable." });
+      }
+      const requestUrl = new URL(req.raw.url ?? "", "http://localhost");
+      const proxyBasePath = `/api/v1/pam/accounts/${req.params.accountId}/browser-access/${req.params.browserSessionId}`;
+      const response = await server.services.pamWebAccess.proxyWebServerBrowserRequest({
+        accountId: req.params.accountId,
+        browserSessionId: req.params.browserSessionId,
+        cookieSecret,
+        method: req.method,
+        upstreamPath: `/${requestUrl.search}`,
+        requestHeaders: req.headers,
+        body: req.body,
+        proxyBasePath
+      });
+      return sendProxyResponse(reply, response);
+    }
+  });
+
+  server.route({
+    method: ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"],
+    url: "/:accountId/browser-access/:browserSessionId/*",
+    config: { rateLimit: readLimit },
+    schema: {
+      operationId: "pamWebServerBrowserProxyPath",
+      description: "Proxy a path through an active Web Server browser session",
+      tags: [ApiDocsTags.PamSessions],
+      params: z.object({
+        accountId: z.string().uuid(),
+        browserSessionId: z.string().uuid(),
+        "*": z.string()
+      })
+    },
+    handler: async (req, reply) => {
+      const cookieSecret = req.cookies[PAM_WEB_SERVER_SESSION_COOKIE];
+      if (!cookieSecret) {
+        throw new NotFoundError({ message: "This Web Server browser session has expired or is unavailable." });
+      }
+      const requestUrl = new URL(req.raw.url ?? "", "http://localhost");
+      const proxyBasePath = `/api/v1/pam/accounts/${req.params.accountId}/browser-access/${req.params.browserSessionId}`;
+      const response = await server.services.pamWebAccess.proxyWebServerBrowserRequest({
+        accountId: req.params.accountId,
+        browserSessionId: req.params.browserSessionId,
+        cookieSecret,
+        method: req.method,
+        upstreamPath: `/${req.params["*"]}${requestUrl.search}`,
+        requestHeaders: req.headers,
+        body: req.body,
+        proxyBasePath
+      });
+      return sendProxyResponse(reply, response);
+    }
+  });
+
+  server.route({
+    method: "POST",
     url: "/:accountId/web-access-ticket",
     config: { rateLimit: writeLimit },
     schema: {
@@ -536,29 +739,7 @@ export const registerPamWebAccessRouter = async (server: FastifyZodProvider) => 
           return;
         }
 
-        const payload = z
-          .object({
-            accountId: z.string().uuid(),
-            projectId: z.string().uuid(),
-            orgId: z.string().uuid(),
-            accountName: z.string(),
-            accountType: z.string(),
-            actorEmail: z.string(),
-            actorName: z.string(),
-            reason: z.string().nullable().optional(),
-            maxSessionDurationMs: z.number().optional(),
-            selectedHost: z.string().nullable().optional(),
-            auditLogInfo: z.object({
-              ipAddress: z.string().optional(),
-              userAgent: z.string().optional(),
-              userAgentType: z.nativeEnum(UserAgentType).optional(),
-              actor: z.object({
-                type: z.nativeEnum(ActorType),
-                metadata: z.record(z.unknown())
-              })
-            })
-          })
-          .parse(JSON.parse(tokenRecord.payload));
+        const payload = WebAccessTicketPayloadSchema.parse(JSON.parse(tokenRecord.payload));
 
         if (payload.accountId !== req.params.accountId) {
           connection.off("message", preAuthHandler);

--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -55,7 +55,7 @@ export const getLicenseKeyConfig = (
 
 export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   _id: null,
-  slug: null,
+  slug: "enterprise",
   tier: -1,
   workspaceLimit: null,
   workspacesUsed: 0,
@@ -109,7 +109,7 @@ export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   enforceMfa: false,
   projectTemplates: false,
   kmip: false,
-  gateway: false,
+  gateway: true,
   gatewayPool: false,
   pamSlackNotifications: false,
   secretScanning: false,

--- a/backend/src/ee/services/license/license-fns.ts
+++ b/backend/src/ee/services/license/license-fns.ts
@@ -55,7 +55,7 @@ export const getLicenseKeyConfig = (
 
 export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   _id: null,
-  slug: "enterprise",
+  slug: null,
   tier: -1,
   workspaceLimit: null,
   workspacesUsed: 0,
@@ -109,7 +109,7 @@ export const getDefaultOnPremFeatures = (): TFeatureSet => ({
   enforceMfa: false,
   projectTemplates: false,
   kmip: false,
-  gateway: true,
+  gateway: false,
   gatewayPool: false,
   pamSlackNotifications: false,
   secretScanning: false,

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -101,7 +101,7 @@ export type TFeatureSet = {
   enforceMfa: false;
   projectTemplates: false;
   kmip: false;
-  gateway: true;
+  gateway: false;
   gatewayPool: false;
   pamSlackNotifications: boolean;
   secretScanning: false;

--- a/backend/src/ee/services/license/license-types.ts
+++ b/backend/src/ee/services/license/license-types.ts
@@ -101,7 +101,7 @@ export type TFeatureSet = {
   enforceMfa: false;
   projectTemplates: false;
   kmip: false;
-  gateway: false;
+  gateway: true;
   gatewayPool: false;
   pamSlackNotifications: boolean;
   secretScanning: false;

--- a/backend/src/ee/services/pam-account/pam-account-connection-test.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-connection-test.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { PamAccountType } from "../pam/pam-enums";
+import { buildGatewayConnectionTest, TestConnectionMode } from "./pam-account-connection-test";
+
+vi.mock("../pam-session/aws-iam/aws-iam-federation", () => ({
+  AWS_STS_MIN_DURATION_SECONDS: 900,
+  generateAwsIamSessionCredentials: vi.fn()
+}));
+vi.mock("../pam-session/azure/azure-federation", () => ({
+  AZURE_SCOPES: { arm: "https://management.azure.com/.default" },
+  getAzureAccessToken: vi.fn()
+}));
+vi.mock("../pam-session/gcp/gcp-federation", () => ({ mintGcpAccessToken: vi.fn() }));
+
+describe("buildGatewayConnectionTest", () => {
+  test("builds a TCP connection test from a Web Server URI", async () => {
+    await expect(
+      buildGatewayConnectionTest(
+        PamAccountType.WebServer,
+        { uri: "https://example.com/login" },
+        { user: "admin", password: "secret" }
+      )
+    ).resolves.toEqual({
+      host: "example.com",
+      port: 443,
+      request: { mode: TestConnectionMode.Tcp }
+    });
+  });
+});

--- a/backend/src/ee/services/pam-account/pam-account-connection-test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-connection-test.ts
@@ -243,6 +243,7 @@ export const buildGatewayConnectionTest = async (
       };
     }
     case PamAccountType.Windows:
+    case PamAccountType.WebServer:
       return tcp(host, port);
     default:
       return null;

--- a/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
@@ -8,7 +8,10 @@ import {
   isCredentialConfigured,
   PamAccountAccessibilityIssue,
   PamAccountTypeMetadataSchema,
-  PamFieldDescriptorSchema
+  PamFieldDescriptorSchema,
+  sanitizeCredentials,
+  validateConnectionDetails,
+  validateCredentials
 } from "./pam-account-schemas";
 
 // These assertions exercise the Zod-introspection path (buildPamAccountTypeMetadata reads schema internals to derive field descriptors)
@@ -75,6 +78,31 @@ describe("buildPamAccountTypeMetadata", () => {
       secret: false
     });
     expect(fieldByKey(postgres!.credentialFields, "password")).toMatchObject({
+      widget: "password",
+      secret: true,
+      required: false
+    });
+  });
+
+  test("derives Web Server connection and credential fields from the schema", () => {
+    const webServer = byType.get(PamAccountType.WebServer);
+    expect(webServer).toBeDefined();
+    expect(webServer?.name).toBe("Web Server");
+    expect(webServer?.icon).toBe("OpenAI.png");
+    expect(webServer?.connectionFields.map((field) => field.key)).toEqual(["uri"]);
+    expect(webServer?.credentialFields.map((field) => field.key)).toEqual(["user", "password"]);
+    expect(fieldByKey(webServer!.connectionFields, "uri")).toMatchObject({
+      label: "Web Server URI",
+      widget: "text",
+      required: true
+    });
+    expect(fieldByKey(webServer!.credentialFields, "user")).toMatchObject({
+      label: "User",
+      widget: "text",
+      required: true,
+      secret: false
+    });
+    expect(fieldByKey(webServer!.credentialFields, "password")).toMatchObject({
       widget: "password",
       secret: true,
       required: false
@@ -203,6 +231,28 @@ describe("buildPamAccountTypeMetadata", () => {
       widget: "textarea",
       secret: true,
       showWhen: { field: "authMethod", equals: "public-key" }
+    });
+  });
+});
+
+describe("Web Server account validation", () => {
+  test("accepts a URI and credentials", () => {
+    expect(validateConnectionDetails(PamAccountType.WebServer, { uri: "https://example.com/login" })).toEqual({
+      uri: "https://example.com/login"
+    });
+    expect(validateCredentials(PamAccountType.WebServer, { user: "admin", password: "secret" })).toEqual({
+      user: "admin",
+      password: "secret"
+    });
+  });
+
+  test("rejects an invalid URI", () => {
+    expect(() => validateConnectionDetails(PamAccountType.WebServer, { uri: "not-a-uri" })).toThrow();
+  });
+
+  test("sanitizes the password from credentials", () => {
+    expect(sanitizeCredentials(PamAccountType.WebServer, { user: "admin", password: "secret" })).toEqual({
+      user: "admin"
     });
   });
 });

--- a/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
@@ -17,7 +17,13 @@ import {
 // These assertions exercise the Zod-introspection path (buildPamAccountTypeMetadata reads schema internals to derive field descriptors)
 describe("buildPamAccountTypeMetadata", () => {
   const metadata = buildPamAccountTypeMetadata(
-    new Set([PamAccountType.Postgres, PamAccountType.MySQL, PamAccountType.SSH, PamAccountType.Redis])
+    new Set([
+      PamAccountType.Postgres,
+      PamAccountType.MySQL,
+      PamAccountType.SSH,
+      PamAccountType.Redis,
+      PamAccountType.WebServer
+    ])
   );
   const byType = new Map(metadata.map((m) => [m.type, m]));
 
@@ -25,6 +31,7 @@ describe("buildPamAccountTypeMetadata", () => {
     expect(byType.get(PamAccountType.Postgres)?.supportsWebAccess).toBe(true);
     expect(byType.get(PamAccountType.SSH)?.supportsWebAccess).toBe(true);
     expect(byType.get(PamAccountType.MySQL)?.supportsWebAccess).toBe(true);
+    expect(byType.get(PamAccountType.WebServer)?.supportsWebAccess).toBe(true);
     expect(byType.get(PamAccountType.Kubernetes)?.supportsWebAccess).toBe(false);
   });
 
@@ -248,6 +255,10 @@ describe("Web Server account validation", () => {
 
   test("rejects an invalid URI", () => {
     expect(() => validateConnectionDetails(PamAccountType.WebServer, { uri: "not-a-uri" })).toThrow();
+  });
+
+  test("rejects a non-HTTP URI", () => {
+    expect(() => validateConnectionDetails(PamAccountType.WebServer, { uri: "ftp://example.com" })).toThrow();
   });
 
   test("sanitizes the password from credentials", () => {

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -396,7 +396,14 @@ export const ACCOUNT_TYPE_CONFIGS = {
     name: "Web Server",
     icon: "OpenAI.png",
     connectionDetails: z.object({
-      uri: z.string().url().trim().max(500)
+      uri: z
+        .string()
+        .url()
+        .trim()
+        .max(500)
+        .refine((value) => ["http:", "https:"].includes(new URL(value).protocol), {
+          message: "Web Server URI must use HTTP or HTTPS"
+        })
     }),
     credentials: z.object({
       user: z.string().trim().min(1).max(256),

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -796,6 +796,12 @@ export const extractGatewayTarget = async (
       const defaultPort = parsed.protocol === "http:" ? 80 : 443;
       return { host: parsed.hostname, port: parsed.port ? Number(parsed.port) : defaultPort };
     }
+    case PamAccountType.WebServer: {
+      const { uri } = validated as { uri: string };
+      const parsed = new URL(uri);
+      const defaultPort = parsed.protocol === "http:" ? 80 : 443;
+      return { host: parsed.hostname, port: parsed.port ? Number(parsed.port) : defaultPort };
+    }
     case PamAccountType.MongoDB: {
       const { connectionString } = validated as { connectionString: string };
       const cs = new ConnectionString(connectionString);

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -392,6 +392,28 @@ export const ACCOUNT_TYPE_CONFIGS = {
       caKeyAlgorithm: z.string()
     })
   },
+  [PamAccountType.WebServer]: {
+    name: "Web Server",
+    icon: "OpenAI.png",
+    connectionDetails: z.object({
+      uri: z.string().url().trim().max(500)
+    }),
+    credentials: z.object({
+      user: z.string().trim().min(1).max(256),
+      password: z
+        .string()
+        .trim()
+        .max(256)
+        .transform((v) => v || undefined)
+        .optional()
+    }),
+    sanitizedCredentials: z.object({ user: z.string() }),
+    ui: {
+      uri: { label: "Web Server URI" },
+      user: { label: "User" },
+      password: { widget: PamFieldWidget.Password, secret: true }
+    }
+  },
 
   [PamAccountType.Kubernetes]: {
     name: "Kubernetes",

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -886,6 +886,12 @@ export const buildSessionGatewayConnectionDetails = (
     };
   }
 
+  if (accountType === PamAccountType.WebServer) {
+    return {
+      url: (validated as { uri: string }).uri
+    };
+  }
+
   return validated;
 };
 

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -255,6 +255,11 @@ export const pamSessionServiceFactory = ({
       delete credentials.clientSecret;
     }
 
+    if (account.accountType === PamAccountType.WebServer) {
+      credentials.username = credentials.user;
+      delete credentials.user;
+    }
+
     const sessionStarted = session.status === PamSessionStatus.Starting;
 
     let actorDistinctId: string | undefined;

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -51,6 +51,9 @@ import {
   WS_IDLE_TIMEOUT_MS,
   WS_PING_INTERVAL_MS
 } from "./pam-web-access-types";
+import { proxyPamWebServerRequest } from "./web-server/pam-web-server-proxy";
+import { buildBasicAuthorization } from "./web-server/pam-web-server-proxy-fns";
+import { createPamWebServerSessionManager } from "./web-server/pam-web-server-session-manager";
 
 type TPamWebAccessServiceFactoryDep = {
   pamAccountDAL: Pick<TPamAccountDALFactory, "findByIdWithDetails">;
@@ -95,6 +98,21 @@ type THandleWebSocketConnectionDTO = {
   preAuthHandler: (raw: Buffer | ArrayBuffer | Buffer[], isBinary: boolean) => void;
 };
 
+type TStartWebServerBrowserSessionDTO = {
+  accountId: string;
+  projectId: string;
+  orgId: string;
+  accountName: string;
+  auditLogInfo: AuditLogInfo;
+  userId: string;
+  actorEmail: string;
+  actorName: string;
+  actorIp: string;
+  actorUserAgent: string;
+  reason: string | null | undefined;
+  maxSessionDurationMs?: number;
+};
+
 export const pamWebAccessServiceFactory = ({
   pamAccountDAL,
   pamAccessRequestService,
@@ -110,6 +128,8 @@ export const pamWebAccessServiceFactory = ({
   orgDAL,
   telemetryService
 }: TPamWebAccessServiceFactoryDep) => {
+  const webServerSessionManager = createPamWebServerSessionManager();
+
   const decrypt = async (projectId: string, blob: Buffer): Promise<Record<string, unknown>> => {
     const { decryptor } = await kmsService.createCipherPairWithDataKey({ type: KmsDataKey.SecretManager, projectId });
     return JSON.parse(decryptor({ cipherTextBlob: blob }).toString("utf-8")) as Record<string, unknown>;
@@ -167,7 +187,7 @@ export const pamWebAccessServiceFactory = ({
       throw new NotFoundError({ message: `Account with ID '${accountId}' not found` });
     }
 
-    if (!SESSION_HANDLERS[account.accountType as PamAccountType]) {
+    if (!SESSION_HANDLERS[account.accountType as PamAccountType] && account.accountType !== PamAccountType.WebServer) {
       throw new BadRequestError({ message: "Web access is not supported for this account type" });
     }
 
@@ -281,6 +301,242 @@ export const pamWebAccessServiceFactory = ({
     });
 
     return { ticket: `${actor.id}:${token}` };
+  };
+
+  const startWebServerBrowserSession = async ({
+    accountId,
+    projectId,
+    orgId,
+    accountName,
+    auditLogInfo,
+    userId,
+    actorEmail,
+    actorName,
+    actorIp,
+    actorUserAgent,
+    reason,
+    maxSessionDurationMs
+  }: TStartWebServerBrowserSessionDTO) => {
+    let relayServer: { port: number; cleanup: () => Promise<void> } | null = null;
+    let pamSession: { id: string } | null = null;
+
+    const cleanupResources = async () => {
+      if (relayServer) {
+        const relay = relayServer;
+        relayServer = null;
+        await relay.cleanup().catch((err) => logger.error(err, "Failed to close Web Server browser relay"));
+      }
+      if (pamSession) {
+        const sessionId = pamSession.id;
+        pamSession = null;
+        try {
+          const updated = await pamSessionDAL.endSessionById(sessionId);
+          if (updated) {
+            void reportPamSessionEnded({
+              session: updated,
+              orgId,
+              endReason: PamSessionEndReason.Completed,
+              telemetryService,
+              userDAL
+            });
+          }
+        } catch (err) {
+          logger.error(err, `Failed to end Web Server browser session [sessionId=${sessionId}]`);
+        }
+      }
+    };
+
+    try {
+      const account = await pamAccountDAL.findByIdWithDetails(accountId);
+      if (!account || account.projectId !== projectId) {
+        throw new NotFoundError({ message: `Account with ID '${accountId}' not found` });
+      }
+      if (account.accountType !== PamAccountType.WebServer) {
+        throw new BadRequestError({ message: "Browser access is only supported for Web Server accounts." });
+      }
+
+      const { requiresApproval } = resolveAccessControls(account.templatePolicies);
+      let sessionDurationMs = maxSessionDurationMs || DEFAULT_WEB_SESSION_DURATION_MS;
+      if (requiresApproval) {
+        const grant = await pamAccessRequestService.checkGrant({
+          actorId: userId,
+          actor: ActorType.USER,
+          accountId,
+          accountFolderId: account.folderId,
+          projectId
+        });
+        if (!grant) {
+          throw new ForbiddenRequestError({
+            name: "PAM_APPROVAL_REQUIRED",
+            message: "Your approved access is no longer active."
+          });
+        }
+        if (grant.expiresAt) {
+          const grantRemainingMs = new Date(grant.expiresAt).getTime() - Date.now();
+          if (grantRemainingMs <= 0) {
+            throw new ForbiddenRequestError({
+              name: "PAM_GRANT_EXPIRED",
+              message: "Your approved access has expired."
+            });
+          }
+          sessionDurationMs = Math.min(sessionDurationMs, grantRemainingMs);
+        }
+      }
+
+      const effectiveGatewayId = await gatewayPoolService.resolveEffectiveGatewayId({
+        gatewayId: account.gatewayId ?? account.templateGatewayId,
+        gatewayPoolId: account.gatewayPoolId ?? account.templateGatewayPoolId
+      });
+      if (!effectiveGatewayId) {
+        throw new BadRequestError({ message: "Gateway not configured for this account" });
+      }
+
+      await pamSessionDAL.endExpiredWebSessions(userId, projectId);
+      const activeCount = await pamSessionDAL.countActiveWebSessions(userId, projectId);
+      if (activeCount >= MAX_WEB_SESSIONS_PER_USER) {
+        throw new BadRequestError({ message: SessionEndReason.SessionLimitReached });
+      }
+
+      const connectionDetails = await decrypt(projectId, account.encryptedConnectionDetails);
+      const credentials = await decrypt(projectId, account.encryptedCredentials);
+      const upstreamUrl = new URL(connectionDetails.uri as string);
+      const gatewayTarget = await extractGatewayTarget(PamAccountType.WebServer, connectionDetails);
+      if (gatewayTarget.port === undefined) {
+        throw new BadRequestError({ message: "The Web Server URI must resolve to a network port." });
+      }
+
+      const credentialUser = credentials.user;
+      const credentialPassword = credentials.password;
+      if (typeof credentialUser !== "string" || typeof credentialPassword !== "string" || !credentialPassword) {
+        throw new BadRequestError({ message: "The Web Server account must have a user and password configured." });
+      }
+
+      const expiresAt = new Date(Date.now() + sessionDurationMs);
+      pamSession = await pamSessionDAL.create({
+        status: PamSessionStatus.Starting,
+        accessMethod: PamAccessMethod.Web,
+        expiresAt,
+        accountName,
+        accountType: account.accountType,
+        actorEmail,
+        actorIp,
+        actorName,
+        actorUserAgent,
+        projectId,
+        accountId: account.id,
+        userId,
+        gatewayId: effectiveGatewayId,
+        reason: reason?.trim() || null,
+        folderName: account.folderName,
+        selectedHost: gatewayTarget.host
+      });
+
+      const connection = await gatewayV2Service.getPAMConnectionDetails({
+        gatewayId: effectiveGatewayId,
+        sessionId: pamSession.id,
+        accountType: PamAccountType.WebServer,
+        host: gatewayTarget.host,
+        port: gatewayTarget.port,
+        duration: sessionDurationMs,
+        actorMetadata: {
+          id: userId,
+          type: ActorType.USER,
+          name: actorEmail
+        }
+      });
+      if (!connection) {
+        throw new BadRequestError({ message: "Failed to obtain Gateway connection details for the Web Server." });
+      }
+
+      relayServer = await setupRelayServer({
+        protocol: GatewayProxyProtocol.Pam,
+        relayHost: connection.relayHost,
+        relay: connection.relay,
+        gateway: connection.gateway,
+        longLived: true
+      });
+
+      await pamSessionDAL.activateSession(pamSession.id);
+      await auditLogService.createAuditLog({
+        ...auditLogInfo,
+        orgId,
+        projectId,
+        event: {
+          type: EventType.PAM_ACCOUNT_ACCESS,
+          metadata: {
+            accountId,
+            resourceName: account.name,
+            accountName: account.name,
+            duration: expiresAt.toISOString(),
+            reason: reason ?? undefined
+          }
+        }
+      });
+
+      const sessionRelay = relayServer;
+      const sessionRecord = pamSession;
+      const browserSession = webServerSessionManager.createSession({
+        accountId,
+        userId,
+        pamSessionId: sessionRecord.id,
+        upstreamUrl,
+        relayPort: sessionRelay.port,
+        authorization: buildBasicAuthorization(credentialUser, credentialPassword),
+        expiresAt,
+        cleanup: cleanupResources
+      });
+
+      return {
+        id: browserSession.id,
+        cookieSecret: browserSession.cookieSecret,
+        initialPath: `${upstreamUrl.pathname}${upstreamUrl.search}${upstreamUrl.hash}`,
+        expiresAt
+      };
+    } catch (err) {
+      await cleanupResources();
+      if (err instanceof BadRequestError || err instanceof ForbiddenRequestError || err instanceof NotFoundError) {
+        throw err;
+      }
+      logger.error(err, "Failed to establish Web Server browser access session");
+      throw new BadRequestError({
+        message: "Failed to open the Web Server through the Gateway. Check the URI and Gateway connectivity."
+      });
+    }
+  };
+
+  const proxyWebServerBrowserRequest = async ({
+    accountId,
+    browserSessionId,
+    cookieSecret,
+    method,
+    upstreamPath,
+    requestHeaders,
+    body,
+    proxyBasePath
+  }: {
+    accountId: string;
+    browserSessionId: string;
+    cookieSecret: string;
+    method: string;
+    upstreamPath: string;
+    requestHeaders: Parameters<typeof proxyPamWebServerRequest>[0]["requestHeaders"];
+    body: unknown;
+    proxyBasePath: string;
+  }) => {
+    const session = webServerSessionManager.getSession(browserSessionId, accountId, cookieSecret);
+    if (!session) {
+      throw new NotFoundError({ message: "This Web Server browser session has expired or is no longer available." });
+    }
+
+    try {
+      return await proxyPamWebServerRequest({ session, method, upstreamPath, requestHeaders, body, proxyBasePath });
+    } catch (err) {
+      if (err instanceof BadRequestError) throw err;
+      logger.error(err, "Failed to proxy Web Server browser request");
+      throw new BadRequestError({
+        message: "The Web Server could not be reached through the Gateway."
+      });
+    }
   };
 
   const handleWebSocketConnection = async ({
@@ -654,6 +910,9 @@ export const pamWebAccessServiceFactory = ({
 
   return {
     issueWebSocketTicket,
-    handleWebSocketConnection
+    handleWebSocketConnection,
+    startWebServerBrowserSession,
+    proxyWebServerBrowserRequest,
+    closeWebServerBrowserSession: webServerSessionManager.closeSession
   };
 };

--- a/backend/src/ee/services/pam-web-access/web-server/pam-web-server-proxy-fns.test.ts
+++ b/backend/src/ee/services/pam-web-access/web-server/pam-web-server-proxy-fns.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  buildBasicAuthorization,
+  buildUpstreamRequestHeaders,
+  rewriteHtmlForProxy,
+  rewriteLocationForProxy,
+  serializeCookieJar,
+  updateCookieJar
+} from "./pam-web-server-proxy-fns";
+
+describe("PAM Web Server proxy helpers", () => {
+  test("builds an HTTP Basic Authentication header", () => {
+    expect(buildBasicAuthorization("admin", "secret")).toBe("Basic YWRtaW46c2VjcmV0");
+  });
+
+  test("builds upstream headers without leaking Infisical credentials", () => {
+    expect(
+      buildUpstreamRequestHeaders({
+        requestHeaders: {
+          accept: "text/html",
+          authorization: "Bearer infisical-token",
+          connection: "keep-alive",
+          cookie: "jid=infisical-session",
+          host: "app.infisical.test",
+          "user-agent": "Browser"
+        },
+        targetHost: "internal.example.com",
+        authorization: "Basic dXNlcjpwYXNz",
+        upstreamCookie: "theme=dark"
+      })
+    ).toEqual({
+      accept: "text/html",
+      authorization: "Basic dXNlcjpwYXNz",
+      cookie: "theme=dark",
+      host: "internal.example.com",
+      "user-agent": "Browser"
+    });
+  });
+
+  test("stores upstream cookies without forwarding cookie attributes", () => {
+    const cookieJar = new Map<string, string>();
+    updateCookieJar(cookieJar, ["session=abc; Path=/; HttpOnly", "theme=dark; Max-Age=3600"]);
+
+    expect(serializeCookieJar(cookieJar)).toBe("session=abc; theme=dark");
+  });
+
+  test("rewrites same-origin redirects and rejects cross-origin redirects", () => {
+    expect(
+      rewriteLocationForProxy({
+        location: "https://internal.example.com/dashboard?tab=1",
+        targetOrigin: "https://internal.example.com",
+        proxyBasePath: "/api/v1/pam/accounts/account-id/browser-access/session-id"
+      })
+    ).toBe("/api/v1/pam/accounts/account-id/browser-access/session-id/dashboard?tab=1");
+
+    expect(
+      rewriteLocationForProxy({
+        location: "https://external.example.com/login",
+        targetOrigin: "https://internal.example.com",
+        proxyBasePath: "/api/v1/pam/accounts/account-id/browser-access/session-id"
+      })
+    ).toBeNull();
+  });
+
+  test("rewrites common root-relative HTML attributes", () => {
+    expect(
+      rewriteHtmlForProxy(
+        '<a href="/dashboard">Home</a><img src="/assets/logo.png"><form action="/logout"></form>',
+        "/api/v1/pam/accounts/account-id/browser-access/session-id"
+      )
+    ).toBe(
+      '<a href="/api/v1/pam/accounts/account-id/browser-access/session-id/dashboard">Home</a>' +
+        '<img src="/api/v1/pam/accounts/account-id/browser-access/session-id/assets/logo.png">' +
+        '<form action="/api/v1/pam/accounts/account-id/browser-access/session-id/logout"></form>'
+    );
+  });
+});

--- a/backend/src/ee/services/pam-web-access/web-server/pam-web-server-proxy-fns.ts
+++ b/backend/src/ee/services/pam-web-access/web-server/pam-web-server-proxy-fns.ts
@@ -1,0 +1,81 @@
+import type { IncomingHttpHeaders } from "node:http";
+
+const FORWARDED_REQUEST_HEADERS = new Set([
+  "accept",
+  "accept-language",
+  "cache-control",
+  "content-type",
+  "if-match",
+  "if-modified-since",
+  "if-none-match",
+  "if-unmodified-since",
+  "pragma",
+  "range",
+  "user-agent"
+]);
+
+export const buildBasicAuthorization = (user: string, password: string): string =>
+  `Basic ${Buffer.from(`${user}:${password}`).toString("base64")}`;
+
+export const buildUpstreamRequestHeaders = ({
+  requestHeaders,
+  targetHost,
+  authorization,
+  upstreamCookie
+}: {
+  requestHeaders: IncomingHttpHeaders;
+  targetHost: string;
+  authorization: string;
+  upstreamCookie?: string;
+}): Record<string, string | string[]> => {
+  const headers: Record<string, string | string[]> = {};
+
+  Object.entries(requestHeaders).forEach(([key, value]) => {
+    if (!FORWARDED_REQUEST_HEADERS.has(key) || value === undefined) return;
+    headers[key] = value;
+  });
+
+  headers.host = targetHost;
+  headers.authorization = authorization;
+  if (upstreamCookie) headers.cookie = upstreamCookie;
+
+  return headers;
+};
+
+export const updateCookieJar = (cookieJar: Map<string, string>, setCookieHeaders?: string[]): void => {
+  setCookieHeaders?.forEach((header) => {
+    const [cookiePair, ...attributes] = header.split(";");
+    const separatorIndex = cookiePair.indexOf("=");
+    if (separatorIndex <= 0) return;
+
+    const name = cookiePair.slice(0, separatorIndex).trim();
+    const value = cookiePair.slice(separatorIndex + 1).trim();
+    const shouldDelete = value === "" || attributes.some((attribute) => attribute.trim().toLowerCase() === "max-age=0");
+
+    if (shouldDelete) {
+      cookieJar.delete(name);
+      return;
+    }
+    cookieJar.set(name, value);
+  });
+};
+
+export const serializeCookieJar = (cookieJar: Map<string, string>): string =>
+  [...cookieJar.entries()].map(([name, value]) => `${name}=${value}`).join("; ");
+
+export const rewriteLocationForProxy = ({
+  location,
+  targetOrigin,
+  proxyBasePath
+}: {
+  location: string;
+  targetOrigin: string;
+  proxyBasePath: string;
+}): string | null => {
+  const resolved = new URL(location, targetOrigin);
+  if (resolved.origin !== targetOrigin) return null;
+  return `${proxyBasePath}${resolved.pathname}${resolved.search}${resolved.hash}`;
+};
+
+export const rewriteHtmlForProxy = (html: string, proxyBasePath: string): string =>
+  html.replace(/\b(href|src|action)=(['"])\/(?!\/)/gi, `$1=$2${proxyBasePath}/`);

--- a/backend/src/ee/services/pam-web-access/web-server/pam-web-server-proxy.test.ts
+++ b/backend/src/ee/services/pam-web-access/web-server/pam-web-server-proxy.test.ts
@@ -1,0 +1,62 @@
+import http from "node:http";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { proxyPamWebServerRequest } from "./pam-web-server-proxy";
+import type { TPamWebServerBrowserSession } from "./pam-web-server-session-manager";
+
+describe("proxyPamWebServerRequest", () => {
+  let server: http.Server | undefined;
+
+  afterEach(async () => {
+    if (!server) return;
+    await new Promise<void>((resolve) => {
+      server?.close(() => resolve());
+    });
+    server = undefined;
+  });
+
+  test("proxies a request with Basic Authentication and rewrites the HTML response", async () => {
+    server = http.createServer((request, response) => {
+      expect(request.headers.authorization).toBe("Basic dXNlcjpwYXNz");
+      expect(request.headers.host).toBe("internal.example.com");
+      expect(request.url).toBe("/login?next=%2Fdashboard");
+      response.setHeader("content-type", "text/html; charset=utf-8");
+      response.setHeader("set-cookie", "session=abc; Path=/; HttpOnly");
+      response.end('<a href="/dashboard">Dashboard</a>');
+    });
+    await new Promise<void>((resolve) => {
+      server?.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("Expected the test server to use a TCP port");
+
+    const session: TPamWebServerBrowserSession = {
+      id: "browser-session-id",
+      accountId: "account-id",
+      userId: "user-id",
+      pamSessionId: "pam-session-id",
+      upstreamUrl: new URL("http://internal.example.com/login"),
+      relayPort: address.port,
+      authorization: "Basic dXNlcjpwYXNz",
+      expiresAt: new Date(Date.now() + 60_000),
+      cookieSecret: "cookie-secret",
+      cookieJar: new Map()
+    };
+
+    const response = await proxyPamWebServerRequest({
+      session,
+      method: "GET",
+      upstreamPath: "/login?next=%2Fdashboard",
+      requestHeaders: { accept: "text/html", cookie: "jid=infisical-session" },
+      body: undefined,
+      proxyBasePath: "/api/v1/pam/accounts/account-id/browser-access/browser-session-id"
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.toString()).toBe(
+      '<a href="/api/v1/pam/accounts/account-id/browser-access/browser-session-id/dashboard">Dashboard</a>'
+    );
+    expect(session.cookieJar.get("session")).toBe("abc");
+  });
+});

--- a/backend/src/ee/services/pam-web-access/web-server/pam-web-server-proxy.ts
+++ b/backend/src/ee/services/pam-web-access/web-server/pam-web-server-proxy.ts
@@ -1,0 +1,149 @@
+import http, { type IncomingHttpHeaders } from "node:http";
+import https from "node:https";
+
+import { BadRequestError } from "@app/lib/errors";
+
+import {
+  buildUpstreamRequestHeaders,
+  rewriteHtmlForProxy,
+  rewriteLocationForProxy,
+  serializeCookieJar,
+  updateCookieJar
+} from "./pam-web-server-proxy-fns";
+import type { TPamWebServerBrowserSession } from "./pam-web-server-session-manager";
+
+const MAX_PROXY_RESPONSE_BYTES = 10 * 1024 * 1024;
+const PROXY_REQUEST_TIMEOUT_MS = 30_000;
+const RESPONSE_HEADERS = new Set([
+  "accept-ranges",
+  "cache-control",
+  "content-disposition",
+  "content-language",
+  "content-type",
+  "etag",
+  "expires",
+  "last-modified"
+]);
+
+export type TPamWebServerProxyResponse = {
+  statusCode: number;
+  headers: Record<string, string | string[]>;
+  body: Buffer;
+};
+
+const serializeRequestBody = (body: unknown, contentType?: string): Buffer | undefined => {
+  if (body === undefined || body === null) return undefined;
+  if (Buffer.isBuffer(body)) return body;
+  if (typeof body === "string") return Buffer.from(body);
+  if (contentType?.includes("application/x-www-form-urlencoded") && typeof body === "object") {
+    const params = new URLSearchParams();
+    Object.entries(body as Record<string, unknown>).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) params.append(key, String(value));
+    });
+    return Buffer.from(params.toString());
+  }
+  return Buffer.from(JSON.stringify(body));
+};
+
+export const proxyPamWebServerRequest = async ({
+  session,
+  method,
+  upstreamPath,
+  requestHeaders,
+  body,
+  proxyBasePath
+}: {
+  session: TPamWebServerBrowserSession;
+  method: string;
+  upstreamPath: string;
+  requestHeaders: IncomingHttpHeaders;
+  body: unknown;
+  proxyBasePath: string;
+}): Promise<TPamWebServerProxyResponse> => {
+  const contentType = typeof requestHeaders["content-type"] === "string" ? requestHeaders["content-type"] : undefined;
+  const serializedBody = serializeRequestBody(body, contentType);
+  const headers = buildUpstreamRequestHeaders({
+    requestHeaders,
+    targetHost: session.upstreamUrl.host,
+    authorization: session.authorization,
+    upstreamCookie: serializeCookieJar(session.cookieJar) || undefined
+  });
+  if (serializedBody) headers["content-length"] = String(serializedBody.byteLength);
+
+  const requestFn = session.upstreamUrl.protocol === "https:" ? https.request : http.request;
+
+  return new Promise((resolve, reject) => {
+    const request = requestFn(
+      {
+        host: "127.0.0.1",
+        port: session.relayPort,
+        method,
+        path: upstreamPath,
+        headers,
+        ...(session.upstreamUrl.protocol === "https:"
+          ? { servername: session.upstreamUrl.hostname, rejectUnauthorized: true }
+          : {})
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        let totalBytes = 0;
+
+        response.on("data", (chunk: Buffer) => {
+          totalBytes += chunk.byteLength;
+          if (totalBytes > MAX_PROXY_RESPONSE_BYTES) {
+            response.destroy(
+              new BadRequestError({ message: "The Web Server response is too large to display in browser access." })
+            );
+            return;
+          }
+          chunks.push(chunk);
+        });
+
+        response.on("error", reject);
+        response.on("end", () => {
+          updateCookieJar(session.cookieJar, response.headers["set-cookie"]);
+
+          const responseHeaders: Record<string, string | string[]> = {};
+          Object.entries(response.headers).forEach(([key, value]) => {
+            if (!RESPONSE_HEADERS.has(key) || value === undefined) return;
+            responseHeaders[key] = value;
+          });
+
+          const statusCode = response.statusCode ?? 502;
+          const { location } = response.headers;
+          if (location && statusCode >= 300 && statusCode < 400) {
+            const rewrittenLocation = rewriteLocationForProxy({
+              location,
+              targetOrigin: session.upstreamUrl.origin,
+              proxyBasePath
+            });
+            if (!rewrittenLocation) {
+              resolve({
+                statusCode: 502,
+                headers: { "content-type": "text/plain; charset=utf-8" },
+                body: Buffer.from("Cross-origin redirects are not supported by this browser access prototype.")
+              });
+              return;
+            }
+            responseHeaders.location = rewrittenLocation;
+          }
+
+          let responseBody = Buffer.concat(chunks);
+          const responseContentType = response.headers["content-type"];
+          if (responseContentType?.includes("text/html")) {
+            responseBody = Buffer.from(rewriteHtmlForProxy(responseBody.toString("utf8"), proxyBasePath));
+          }
+
+          resolve({ statusCode, headers: responseHeaders, body: responseBody });
+        });
+      }
+    );
+
+    request.setTimeout(PROXY_REQUEST_TIMEOUT_MS, () => {
+      request.destroy(new BadRequestError({ message: "The Web Server did not respond before the request timed out." }));
+    });
+    request.on("error", reject);
+    if (serializedBody) request.write(serializedBody);
+    request.end();
+  });
+};

--- a/backend/src/ee/services/pam-web-access/web-server/pam-web-server-session-manager.test.ts
+++ b/backend/src/ee/services/pam-web-access/web-server/pam-web-server-session-manager.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { createPamWebServerSessionManager } from "./pam-web-server-session-manager";
+
+describe("PAM Web Server session manager", () => {
+  test("returns a session only for the matching account and cookie secret", async () => {
+    const manager = createPamWebServerSessionManager();
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    const created = manager.createSession({
+      accountId: "account-id",
+      userId: "user-id",
+      pamSessionId: "pam-session-id",
+      upstreamUrl: new URL("https://internal.example.com/login"),
+      relayPort: 12345,
+      authorization: "Basic dXNlcjpwYXNz",
+      expiresAt: new Date(Date.now() + 60_000),
+      cleanup
+    });
+
+    expect(manager.getSession(created.id, "account-id", created.cookieSecret)?.pamSessionId).toBe("pam-session-id");
+    expect(manager.getSession(created.id, "other-account", created.cookieSecret)).toBeNull();
+    expect(manager.getSession(created.id, "account-id", "wrong-secret")).toBeNull();
+
+    await manager.closeSession(created.id);
+  });
+
+  test("cleans up a session once when it is closed", async () => {
+    const manager = createPamWebServerSessionManager();
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    const created = manager.createSession({
+      accountId: "account-id",
+      userId: "user-id",
+      pamSessionId: "pam-session-id",
+      upstreamUrl: new URL("https://internal.example.com"),
+      relayPort: 12345,
+      authorization: "Basic dXNlcjpwYXNz",
+      expiresAt: new Date(Date.now() + 60_000),
+      cleanup
+    });
+
+    await manager.closeSession(created.id);
+    await manager.closeSession(created.id);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(manager.getSession(created.id, "account-id", created.cookieSecret)).toBeNull();
+  });
+
+  test("expires and cleans up a session", async () => {
+    vi.useFakeTimers();
+    const manager = createPamWebServerSessionManager();
+    const cleanup = vi.fn().mockResolvedValue(undefined);
+    const created = manager.createSession({
+      accountId: "account-id",
+      userId: "user-id",
+      pamSessionId: "pam-session-id",
+      upstreamUrl: new URL("https://internal.example.com"),
+      relayPort: 12345,
+      authorization: "Basic dXNlcjpwYXNz",
+      expiresAt: new Date(Date.now() + 1_000),
+      cleanup
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(manager.getSession(created.id, "account-id", created.cookieSecret)).toBeNull();
+    vi.useRealTimers();
+  });
+});

--- a/backend/src/ee/services/pam-web-access/web-server/pam-web-server-session-manager.ts
+++ b/backend/src/ee/services/pam-web-access/web-server/pam-web-server-session-manager.ts
@@ -1,0 +1,84 @@
+import { randomBytes, randomUUID } from "node:crypto";
+
+export type TPamWebServerBrowserSession = {
+  id: string;
+  accountId: string;
+  userId: string;
+  pamSessionId: string;
+  upstreamUrl: URL;
+  relayPort: number;
+  authorization: string;
+  expiresAt: Date;
+  cookieSecret: string;
+  cookieJar: Map<string, string>;
+};
+
+type TStoredSession = TPamWebServerBrowserSession & {
+  cleanup: () => Promise<void>;
+  expiryTimer: ReturnType<typeof setTimeout>;
+};
+
+export const createPamWebServerSessionManager = () => {
+  const sessions = new Map<string, TStoredSession>();
+
+  const closeSession = async (id: string): Promise<void> => {
+    const session = sessions.get(id);
+    if (!session) return;
+
+    sessions.delete(id);
+    clearTimeout(session.expiryTimer);
+    await session.cleanup();
+  };
+
+  const createSession = ({
+    accountId,
+    userId,
+    pamSessionId,
+    upstreamUrl,
+    relayPort,
+    authorization,
+    expiresAt,
+    cleanup
+  }: Omit<TPamWebServerBrowserSession, "id" | "cookieSecret" | "cookieJar"> & {
+    cleanup: () => Promise<void>;
+  }): TPamWebServerBrowserSession => {
+    const id = randomUUID();
+    const cookieSecret = randomBytes(32).toString("base64url");
+    const expiryTimer = setTimeout(
+      () => {
+        void closeSession(id).catch(() => undefined);
+      },
+      Math.max(0, expiresAt.getTime() - Date.now())
+    );
+
+    const session: TStoredSession = {
+      id,
+      accountId,
+      userId,
+      pamSessionId,
+      upstreamUrl,
+      relayPort,
+      authorization,
+      expiresAt,
+      cookieSecret,
+      cookieJar: new Map<string, string>(),
+      cleanup,
+      expiryTimer
+    };
+
+    sessions.set(id, session);
+    return session;
+  };
+
+  const getSession = (id: string, accountId: string, cookieSecret: string): TPamWebServerBrowserSession | null => {
+    const session = sessions.get(id);
+    if (!session || session.accountId !== accountId || session.cookieSecret !== cookieSecret) return null;
+    if (session.expiresAt.getTime() <= Date.now()) {
+      void closeSession(id).catch(() => undefined);
+      return null;
+    }
+    return session;
+  };
+
+  return { createSession, getSession, closeSession };
+};

--- a/backend/src/ee/services/pam/pam-enums.ts
+++ b/backend/src/ee/services/pam/pam-enums.ts
@@ -11,7 +11,8 @@ export enum PamAccountType {
   GcpServiceAccount = "gcp-service-account",
   AzureCli = "azure-cli",
   Windows = "windows",
-  WindowsAd = "windows-ad"
+  WindowsAd = "windows-ad",
+  WebServer = "web-server"
 }
 
 export enum PamResourceRole {

--- a/frontend/src/hooks/api/pam/enums.ts
+++ b/frontend/src/hooks/api/pam/enums.ts
@@ -11,7 +11,8 @@ export enum PamAccountType {
   GcpServiceAccount = "gcp-service-account",
   AzureCli = "azure-cli",
   Windows = "windows",
-  WindowsAd = "windows-ad"
+  WindowsAd = "windows-ad",
+  WebServer = "web-server"
 }
 
 export enum PamDiscoveryType {

--- a/frontend/src/hooks/api/pam/session-playback/queries.tsx
+++ b/frontend/src/hooks/api/pam/session-playback/queries.tsx
@@ -55,6 +55,15 @@ export type PlaybackDecryptState = {
   sessionComplete: boolean;
 };
 
+const createInitialPlaybackState = (): Omit<PlaybackDecryptState, "sessionComplete"> => ({
+  loading: true,
+  events: [],
+  brokenChunks: [],
+  missingChunks: [],
+  totalChunks: 0,
+  totalDurationMs: 0
+});
+
 const fallbackUrlBuilderFor = (sessionId: string) => (chunkIndex: number) =>
   `/api/v1/pam/sessions/${sessionId}/chunks/${chunkIndex}/ciphertext`;
 
@@ -65,14 +74,9 @@ export const useDecryptedSessionLogs = (
 ): PlaybackDecryptState => {
   const playbackQuery = useGetPamSessionPlayback(sessionId, enabled, isActive);
   const playback = playbackQuery.data;
-  const [state, setState] = useState<Omit<PlaybackDecryptState, "sessionComplete">>({
-    loading: true,
-    events: [],
-    brokenChunks: [],
-    missingChunks: [],
-    totalChunks: 0,
-    totalDurationMs: 0
-  });
+  const [state, setState] = useState<Omit<PlaybackDecryptState, "sessionComplete">>(
+    createInitialPlaybackState
+  );
 
   const fallbackUrlBuilder = useMemo(() => fallbackUrlBuilderFor(sessionId), [sessionId]);
 
@@ -83,8 +87,9 @@ export const useDecryptedSessionLogs = (
   const accEventCountRef = useRef(0);
   const accBrokenRef = useRef<TBrokenChunkMarker[]>([]);
   const prevSessionIdRef = useRef(sessionId);
+  const sessionChanged = prevSessionIdRef.current !== sessionId;
 
-  if (prevSessionIdRef.current !== sessionId) {
+  if (sessionChanged) {
     sessionKeyRef.current = null;
     decryptedIndicesRef.current = new Set();
     accChunkEventsRef.current = new Map();
@@ -92,6 +97,10 @@ export const useDecryptedSessionLogs = (
     accBrokenRef.current = [];
     prevSessionIdRef.current = sessionId;
   }
+
+  useEffect(() => {
+    setState(createInitialPlaybackState());
+  }, [sessionId]);
 
   useEffect(() => {
     if (!enabled || !playback) return undefined;
@@ -305,7 +314,7 @@ export const useDecryptedSessionLogs = (
   }, [playback, enabled, sessionId, fallbackUrlBuilder, isActive]);
 
   return {
-    ...state,
+    ...(sessionChanged ? createInitialPlaybackState() : state),
     sessionComplete: playback?.sessionComplete ?? false
   };
 };

--- a/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/PamAccountAccessPage.tsx
@@ -12,6 +12,7 @@ import { RdpLauncher } from "./RdpLauncher";
 import { SessionAccessGate } from "./ReasonGate";
 import { useWebAccessSession } from "./useWebAccessSession";
 import { WebAccessStatusCard } from "./WebAccessStatusCard";
+import { WebServerAccessContent } from "./WebServerAccessContent";
 
 const TerminalContent = ({
   account,
@@ -130,6 +131,11 @@ const PageContent = () => {
   return (
     <SessionAccessGate account={account}>
       {({ reason, mfaSessionId }) => {
+        if (account.accountType === PamAccountType.WebServer) {
+          return (
+            <WebServerAccessContent account={account} reason={reason} mfaSessionId={mfaSessionId} />
+          );
+        }
         if (
           account.accountType === PamAccountType.Postgres ||
           account.accountType === PamAccountType.MySQL

--- a/frontend/src/pages/pam/PamAccountAccessPage/WebServerAccessContent.tsx
+++ b/frontend/src/pages/pam/PamAccountAccessPage/WebServerAccessContent.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+import { Globe2, TriangleAlert } from "lucide-react";
+
+import { Button } from "@app/components/v3";
+import { apiRequest } from "@app/config/request";
+import { TPamAccount } from "@app/hooks/api/pam";
+
+import { WebAccessStatusCard } from "./WebAccessStatusCard";
+
+type Props = {
+  account: TPamAccount;
+  reason?: string;
+  mfaSessionId?: string;
+};
+
+export const WebServerAccessContent = ({ account, reason, mfaSessionId }: Props) => {
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const [retryCount, setRetryCount] = useState(0);
+  const launchInProgressRef = useRef(false);
+
+  useEffect(() => {
+    if (launchInProgressRef.current) return;
+    launchInProgressRef.current = true;
+    setErrorMessage(undefined);
+
+    const launch = async () => {
+      try {
+        const ticketResponse = await apiRequest.post<{ ticket: string }>(
+          `/api/v1/pam/accounts/${account.id}/web-access-ticket`,
+          { reason, mfaSessionId }
+        );
+        const sessionResponse = await apiRequest.post<{ url: string }>(
+          `/api/v1/pam/accounts/${account.id}/browser-access-session`,
+          { ticket: ticketResponse.data.ticket }
+        );
+        window.location.replace(sessionResponse.data.url);
+      } catch (err: unknown) {
+        const responseMessage = (
+          err as {
+            response?: { data?: { message?: string } };
+          }
+        ).response?.data?.message;
+        setErrorMessage(responseMessage ?? "Failed to open the Web Server through the Gateway.");
+        launchInProgressRef.current = false;
+      }
+    };
+
+    launch().catch(() => undefined);
+  }, [account.id, reason, mfaSessionId, retryCount]);
+
+  if (errorMessage) {
+    return (
+      <WebAccessStatusCard
+        tone="danger"
+        icon={TriangleAlert}
+        title="Could not open Web Server"
+        description={errorMessage}
+      >
+        <Button variant="pam" isFullWidth onClick={() => setRetryCount((value) => value + 1)}>
+          Try Again
+        </Button>
+      </WebAccessStatusCard>
+    );
+  }
+
+  return (
+    <WebAccessStatusCard
+      icon={Globe2}
+      title="Opening Web Server"
+      description="Connecting through the assigned Gateway and preparing HTTP Basic Authentication."
+    />
+  );
+};


### PR DESCRIPTION
## Context
This PR adds Web Server as a PAM account type and allows users to open HTTP Basic Auth-protected websites through an assigned
  Infisical Gateway.

  Web Server accounts accept:

  - An HTTP or HTTPS URI
  - A user
  - A password

  The change includes:

  - Web Server account metadata, validation, and frontend enum support.
  - Gateway-compatible field mapping from `uri` to `url` and `user` to `username`.
  - Gateway TCP connection testing during account creation.
  - A path-based browser proxy backed by the existing Gateway TCP relay.
  - Reuse of existing PAM permissions, approvals, reasons, MFA, session limits, and audit events.
  - Server-side HTTP Basic Auth injection so credentials are not exposed in browser JavaScript or URLs.
  - Scoped HTTP-only browser-session cookies.
  - In-memory browser proxy sessions with expiration and relay cleanup.
  - Server-side upstream cookie storage.
  - Rewriting for same-origin redirects and common root-relative HTML links.
  - A frontend launch flow with loading, failure, and retry states.
  - A fix that prevents logs from the previously selected PAM session from appearing when switching sessions.

  This is a path-based MVP. It does not support WebSocket proxying, multi-process session persistence, browser-session recording,
  service workers, or every possible SPA URL pattern.

  ## Screenshots


  ## Steps to verify the change

  1. Configure a Gateway that can reach an HTTP Basic Auth-protected website.
  2. Create a Web Server account template using the configured Gateway.
  3. Create a Web Server account with:
     - An HTTP or HTTPS URI
     - A valid user
     - A valid password
  4. Confirm account creation runs the Gateway TCP connection test.
  5. Click **Launch Session** for the Web Server account.
  6. Complete the reason, approval, or MFA requirements when configured.
  7. Confirm the website opens under the PAM browser proxy path.
  8. Confirm the Web Server credentials do not appear in the browser URL or frontend code.
  9. Confirm redirects and root-relative assets from the same target origin continue through the proxy.
  10. Stop the target Web Server and confirm browser access returns an actionable connection error.
  11. Open multiple entries on the PAM Sessions page and confirm logs from the previously selected session are not displayed.



  ## Type

  - [x] Fix
  - [x] Feature
  - [ ] Improvement
  - [ ] Breaking
  - [ ] Docs
  - [ ] Chore

  ## Checklist

  - [x] Title follows the conventional commit format.
  - [x] Tested locally
  - [x] Updated docs (not required for this prototype)
  - [x] Updated CLAUDE.md files (not required)
  - [ ] Read the contributing guide


## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)