### PR TITLE
docs(secrets-mgmt): add more guide links

### DIFF
--- a/docs/documentation/platform/secrets-mgmt/quick-starts/deliver-first-secret.mdx
+++ b/docs/documentation/platform/secrets-mgmt/quick-starts/deliver-first-secret.mdx
@@ -34,8 +34,35 @@ Select your application stack or runtime environment. Each guide covers the auth
   <Card title="Python" icon="python" href="/documentation/guides/python">
     Fetch secrets from a Python application with the SDK.
   </Card>
+  <Card title="Go" icon="golang" href="/sdks/languages/go">
+    Fetch secrets from a Go application with the SDK.
+  </Card>
+  <Card title=".NET" icon="microsoft" href="/sdks/languages/dotnet">
+    Fetch secrets from a .NET application with the SDK.
+  </Card>
+  <Card title="Java" icon="java" href="/sdks/languages/java">
+    Fetch secrets from a Java application with the SDK.
+  </Card>
+  <Card title="Rust" icon="rust" href="/sdks/languages/rust">
+    Fetch secrets from a Rust application with the SDK.
+  </Card>
   <Card title="Next.js + Vercel" icon="layer-group" href="/documentation/guides/nextjs-vercel">
     Use secrets during local development and on Vercel.
+  </Card>
+  <Card title="GitHub Actions" icon="github" href="/integrations/cicd/githubactions">
+    Inject secrets into a GitHub Actions workflow at runtime.
+  </Card>
+  <Card title="GitLab CI/CD" icon="gitlab" href="/integrations/cicd/gitlab">
+    Deliver secrets to GitLab projects and pipelines.
+  </Card>
+  <Card title="AWS Secrets Manager" icon="aws" href="/integrations/secret-syncs/aws-secrets-manager">
+    Sync secrets to AWS Secrets Manager.
+  </Card>
+  <Card title="Terraform" icon="cubes" href="/integrations/frameworks/terraform">
+    Fetch secrets in Terraform configurations with the provider.
+  </Card>
+  <Card title="Ansible" icon="gears" href="/integrations/platforms/ansible">
+    Manage secrets in playbooks with the Ansible collection.
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
## Context

Adds a few more links to the Secrets Management quickstart guide.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)