### PR TITLE
feat: allow creation of cert profiles from inside applications

### DIFF
--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/ApplicationDetailsByIDPage.tsx
@@ -51,6 +51,7 @@ import { ApplicationMembersTab } from "./components/ApplicationMembersTab";
 import { ApplicationRequestsTab } from "./components/ApplicationRequestsTab";
 import { ApplicationSettingsTab } from "./components/ApplicationSettingsTab";
 import { ApplicationSyncsTab } from "./components/ApplicationSyncsTab";
+import { ApplicationTab } from "./application-tabs";
 
 type PermissionedTabProps = {
   value: string;
@@ -260,7 +261,7 @@ export const ApplicationDetailsByIDPage = () => {
                     applicationName: application.name
                   },
                   search: {
-                    selectedTab: v as "certificates" | "requests" | "syncs" | "members" | "settings"
+                    selectedTab: v as ApplicationTab
                   }
                 })
               }

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/application-tabs.ts
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/application-tabs.ts
@@ -1,0 +1,7 @@
+export enum ApplicationTab {
+  Certificates = "certificates",
+  Requests = "requests",
+  Syncs = "syncs",
+  Members = "members",
+  Settings = "settings"
+}

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationRequestsTab.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationRequestsTab.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useParams } from "@tanstack/react-router";
 
 import { CertificateRequestsSection } from "../../CertificateRequestsPage/components/CertificateRequestsSection";
+import { ApplicationTab } from "../application-tabs";
 
 type Props = {
   applicationId: string;
@@ -20,7 +21,7 @@ export const ApplicationRequestsTab = ({ applicationId, applicationName }: Props
         projectId: projectId ?? "",
         applicationName
       },
-      search: { selectedTab: "certificates", search: certificateId }
+      search: { selectedTab: ApplicationTab.Certificates, search: certificateId }
     });
   };
 

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationSettingsTab.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationSettingsTab.tsx
@@ -1,4 +1,5 @@
-import { ReactNode, useMemo, useState } from "react";
+import { ReactNode, useCallback, useMemo, useState } from "react";
+import { components, MenuListProps } from "react-select";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useQuery } from "@tanstack/react-query";
@@ -55,6 +56,11 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
+import { useProjectPermission } from "@app/context";
+import {
+  ProjectPermissionCertificateProfileActions,
+  ProjectPermissionSub
+} from "@app/context/ProjectPermissionContext/types";
 import { usePopUp } from "@app/hooks";
 import {
   approvalPolicyQuery,
@@ -82,6 +88,7 @@ import {
   useGetPkiApplicationPermissions
 } from "@app/hooks/api/pkiApplications";
 import { PolicyModal } from "@app/pages/cert-manager/ApprovalsPage/components/PolicyTab/components/PolicyModal";
+import { CreateProfileModal } from "@app/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal";
 import { CreatePkiAlertV2Modal } from "@app/views/PkiAlertsV2Page/components/CreatePkiAlertV2Modal";
 import { ViewPkiAlertV2Modal } from "@app/views/PkiAlertsV2Page/components/ViewPkiAlertV2Modal";
 import {
@@ -97,6 +104,8 @@ import {
 } from "./ConfigureEnrollmentModal";
 
 type Props = { application: TPkiApplication; profiles: TPkiApplicationProfile[] };
+
+type TProfileOption = { value: string; label: string };
 
 const methodBadges = (p: TPkiApplicationProfile) => {
   const methods: EnrollmentMethod[] = [];
@@ -399,7 +408,8 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
     appAbility?.can(PkiApplicationResourceActions.Delete, PkiApplicationResourceSub.PkiAlerts)
   );
   const [isAttachOpen, setIsAttachOpen] = useState(false);
-  const [profilesToAttach, setProfilesToAttach] = useState<{ value: string; label: string }[]>([]);
+  const [isCreateProfileOpen, setIsCreateProfileOpen] = useState(false);
+  const [profilesToAttach, setProfilesToAttach] = useState<TProfileOption[]>([]);
   const [profileToDetach, setProfileToDetach] = useState<TPkiApplicationProfile | null>(null);
   const [profileToConfigure, setProfileToConfigure] = useState<TPkiApplicationProfile | null>(null);
   const [enrollmentMethodToOpen, setEnrollmentMethodToOpen] = useState<EnrollmentMethod>();
@@ -408,6 +418,12 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
     setEnrollmentMethodToOpen(method);
     setProfileToConfigure(profile);
   };
+
+  const { permission } = useProjectPermission();
+  const canCreateProfile = permission.can(
+    ProjectPermissionCertificateProfileActions.Create,
+    ProjectPermissionSub.CertificateProfiles
+  );
 
   const { data: profileList } = useListCertificateProfiles({ limit: 100 });
   const attachMutation = useAttachPkiApplicationProfiles();
@@ -481,25 +497,35 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
     [profileList, attachedIds]
   );
   const totalProfileCount = profileList?.certificateProfiles?.length ?? 0;
+  const hasAttachableProfiles = availableProfiles.length > 0;
   let attachDisabledReason: ReactNode | null = null;
-  if (availableProfiles.length === 0) {
+  if (!hasAttachableProfiles && !canCreateProfile) {
     attachDisabledReason =
-      totalProfileCount === 0 ? (
-        <span>
-          No certificate profiles exist yet. Create one in{" "}
-          <Link
-            to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles"
-            params={{ orgId: orgId ?? "", projectId: projectId ?? "" }}
-            className="text-primary underline hover:text-primary/80"
-          >
-            Certificate Profiles
-          </Link>{" "}
-          first.
-        </span>
-      ) : (
-        "All certificate profiles are already attached."
-      );
+      totalProfileCount === 0
+        ? "No certificate profiles exist yet, and you do not have permission to create one."
+        : "All certificate profiles are already attached.";
   }
+
+  // Pinned above the scrolling option list, so creating a profile is not a selectable option
+  // masquerading as one.
+  const ProfileMenuList = useCallback(
+    (menuProps: MenuListProps<TProfileOption, true>) => (
+      <>
+        {canCreateProfile ? (
+          <button
+            type="button"
+            onClick={() => setIsCreateProfileOpen(true)}
+            className="flex w-full cursor-pointer items-center gap-x-1.5 rounded-sm px-2 py-1.5 text-sm text-muted hover:bg-foreground/5"
+          >
+            <PlusIcon className="size-4 shrink-0" />
+            Add Certificate Profile
+          </button>
+        ) : null}
+        <components.MenuList {...menuProps} />
+      </>
+    ),
+    [canCreateProfile]
+  );
 
   const handleAttach = async () => {
     if (profilesToAttach.length === 0) return;
@@ -566,9 +592,14 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
                   </TooltipContent>
                 </Tooltip>
               ) : (
-                <Button variant="outline" onClick={() => setIsAttachOpen(true)}>
+                <Button
+                  variant="outline"
+                  onClick={() =>
+                    hasAttachableProfiles ? setIsAttachOpen(true) : setIsCreateProfileOpen(true)
+                  }
+                >
                   <PlusIcon />
-                  Attach Profile
+                  {hasAttachableProfiles ? "Attach Profile" : "Create Profile"}
                 </Button>
               )}
             </CardAction>
@@ -580,8 +611,9 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
               <EmptyHeader>
                 <EmptyTitle>No profiles attached</EmptyTitle>
                 <EmptyDescription>
-                  Attach a certificate profile, then configure how this application enrolls against
-                  it.
+                  {totalProfileCount === 0
+                    ? "Create a certificate profile, then configure how this application enrolls against it."
+                    : "Attach a certificate profile, then configure how this application enrolls against it."}
                 </EmptyDescription>
               </EmptyHeader>
             </Empty>
@@ -866,10 +898,9 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
             <FilterableSelect
               isMulti
               value={profilesToAttach}
-              onChange={(val) =>
-                setProfilesToAttach((val ?? []) as { value: string; label: string }[])
-              }
+              onChange={(val) => setProfilesToAttach((val ?? []) as TProfileOption[])}
               options={availableProfiles}
+              components={{ MenuList: ProfileMenuList }}
               placeholder="Select profiles..."
             />
           </div>
@@ -898,6 +929,28 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
           if (!open) setProfileToDetach(null);
         }}
         onDeleteApproved={handleDetach}
+      />
+
+      <CreateProfileModal
+        isOpen={isCreateProfileOpen}
+        onClose={() => setIsCreateProfileOpen(false)}
+        onComplete={(createdProfile) => {
+          setIsCreateProfileOpen(false);
+          // Created from inside the attach dialog: add it to the pending selection so it is
+          // attached alongside whatever else was picked. Created straight from the card, there is
+          // no selection to submit, so attach it now.
+          if (isAttachOpen) {
+            setProfilesToAttach((prev) => [
+              ...prev,
+              { value: createdProfile.id, label: createdProfile.slug }
+            ]);
+            return;
+          }
+          attachMutation.mutate({
+            applicationId: application.id,
+            profileIds: [createdProfile.id]
+          });
+        }}
       />
 
       <ConfigureEnrollmentModal

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationSettingsTab.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/components/ApplicationSettingsTab.tsx
@@ -496,8 +496,10 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
         .map((p) => ({ value: p.id, label: p.slug })),
     [profileList, attachedIds]
   );
-  const totalProfileCount = profileList?.certificateProfiles?.length ?? 0;
-  const hasAttachableProfiles = availableProfiles.length > 0;
+  // Project-wide count, not the length of the fetched page. The list is paginated, so a page whose
+  // profiles happen to all be attached says nothing about whether the project has others left.
+  const totalProfileCount = profileList?.totalCount ?? 0;
+  const hasAttachableProfiles = totalProfileCount > profiles.length;
   let attachDisabledReason: ReactNode | null = null;
   if (!hasAttachableProfiles && !canCreateProfile) {
     attachDisabledReason =
@@ -512,14 +514,17 @@ export const ApplicationSettingsTab = ({ application, profiles }: Props) => {
     (menuProps: MenuListProps<TProfileOption, true>) => (
       <>
         {canCreateProfile ? (
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="sm"
+            isFullWidth
+            className="justify-start"
             onClick={() => setIsCreateProfileOpen(true)}
-            className="flex w-full cursor-pointer items-center gap-x-1.5 rounded-sm px-2 py-1.5 text-sm text-muted hover:bg-foreground/5"
           >
-            <PlusIcon className="size-4 shrink-0" />
+            <PlusIcon />
             Add Certificate Profile
-          </button>
+          </Button>
         ) : null}
         <components.MenuList {...menuProps} />
       </>

--- a/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/route.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationDetailsByIDPage/route.tsx
@@ -2,9 +2,10 @@ import { createFileRoute, stripSearchParams } from "@tanstack/react-router";
 import { zodValidator } from "@tanstack/zod-adapter";
 import { z } from "zod";
 
+import { ApplicationTab } from "./application-tabs";
 import { ApplicationDetailsByIDPage } from "./ApplicationDetailsByIDPage";
 
-const ApplicationTabSchema = z.enum(["certificates", "requests", "syncs", "members", "settings"]);
+const ApplicationTabSchema = z.nativeEnum(ApplicationTab);
 
 const SearchSchema = z.object({
   selectedTab: ApplicationTabSchema.optional(),
@@ -16,7 +17,7 @@ export const Route = createFileRoute(
 )({
   component: ApplicationDetailsByIDPage,
   validateSearch: zodValidator(SearchSchema),
-  search: { middlewares: [stripSearchParams({ selectedTab: "certificates" })] },
+  search: { middlewares: [stripSearchParams({ selectedTab: ApplicationTab.Certificates })] },
   beforeLoad: ({ context }) => ({
     breadcrumbs: [...context.breadcrumbs, { label: "Applications" }, { label: "Application" }]
   })

--- a/frontend/src/pages/cert-manager/ApplicationsPage/components/PkiApplicationModal.tsx
+++ b/frontend/src/pages/cert-manager/ApplicationsPage/components/PkiApplicationModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Link, useParams } from "@tanstack/react-router";
+import { useNavigate, useParams } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
@@ -29,6 +29,7 @@ import {
   useUpdatePkiApplication
 } from "@app/hooks/api/pkiApplications";
 import { UsePopUpState } from "@app/hooks/usePopUp";
+import { ApplicationTab } from "@app/pages/cert-manager/ApplicationDetailsByIDPage/application-tabs";
 
 const SLUG_REGEX = /^[a-z0-9-]+$/;
 
@@ -52,13 +53,12 @@ type Props = {
 
 export const PkiApplicationModal = ({ popUp, handlePopUpToggle }: Props) => {
   const { projectId, orgId } = useParams({ strict: false });
+  const navigate = useNavigate();
   const editing = (popUp?.application?.data as TPkiApplication | undefined) ?? null;
   const create = useCreatePkiApplication();
   const update = useUpdatePkiApplication();
 
-  const { data: profilesData, isPending: profilesLoading } = useListCertificateProfiles({
-    limit: 100
-  });
+  const { data: profilesData } = useListCertificateProfiles({ limit: 100 });
 
   const profileOptions = useMemo(
     () =>
@@ -102,12 +102,25 @@ export const PkiApplicationModal = ({ popUp, handlePopUpToggle }: Props) => {
         createNotification({ type: "success", text: "Application updated" });
       } else {
         const selectedIds = (data.profileIds ?? []).map((p) => p.value);
-        await create.mutateAsync({
+        const created = await create.mutateAsync({
           name: data.name,
           description: data.description,
           profileIds: selectedIds
         });
         createNotification({ type: "success", text: "Application created" });
+        handlePopUpToggle("application", false);
+        // Land on Settings rather than the empty inventory: attaching a profile is the next step
+        // before the application can issue anything.
+        navigate({
+          to: "/organizations/$orgId/projects/cert-manager/$projectId/applications/$applicationName",
+          params: {
+            orgId: orgId ?? "",
+            projectId: projectId ?? "",
+            applicationName: created.name
+          },
+          search: { selectedTab: ApplicationTab.Settings }
+        });
+        return;
       }
       handlePopUpToggle("application", false);
     } catch (err) {
@@ -161,7 +174,7 @@ export const PkiApplicationModal = ({ popUp, handlePopUpToggle }: Props) => {
               </Field>
             )}
           />
-          {!editing ? (
+          {!editing && profileOptions.length > 0 ? (
             <Controller
               control={control}
               name="profileIds"
@@ -180,16 +193,8 @@ export const PkiApplicationModal = ({ popUp, handlePopUpToggle }: Props) => {
                     />
                   </FieldContent>
                   <FieldDescription>
-                    Select the profiles this application can issue certificates from.{" "}
-                    {!profilesLoading && !profileOptions.length && (
-                      <Link
-                        to="/organizations/$orgId/projects/cert-manager/$projectId/certificate-profiles"
-                        params={{ orgId: orgId ?? "", projectId: projectId ?? "" }}
-                        className="underline hover:text-yellow-400"
-                      >
-                        Create one in Certificate Profiles
-                      </Link>
-                    )}
+                    Select the profiles this application can issue certificates from. You can also
+                    attach them later from the application&apos;s settings.
                   </FieldDescription>
                   {error ? <FieldError>{error.message}</FieldError> : null}
                 </Field>

--- a/frontend/src/pages/cert-manager/ApprovalRequestDetailPage/ApprovalRequestDetailPage.tsx
+++ b/frontend/src/pages/cert-manager/ApprovalRequestDetailPage/ApprovalRequestDetailPage.tsx
@@ -25,6 +25,7 @@ import {
   codeSigningScopeFieldLabels,
   MONOSPACED_SCOPE_FIELDS
 } from "@app/hooks/api/signers";
+import { ApplicationTab } from "@app/pages/cert-manager/ApplicationDetailsByIDPage/application-tabs";
 
 import {
   ApprovalStepsSection,
@@ -165,7 +166,7 @@ const PageContent = () => {
                 projectId: currentProject.id,
                 applicationName
               },
-              search: { selectedTab: "requests" }
+              search: { selectedTab: ApplicationTab.Requests }
             });
             return;
           }
@@ -331,7 +332,7 @@ const PageContent = () => {
             projectId: currentProject.id,
             applicationName
           }}
-          search={{ selectedTab: "requests" }}
+          search={{ selectedTab: ApplicationTab.Requests }}
           className={linkClass}
         >
           <FontAwesomeIcon icon={faChevronLeft} />

--- a/frontend/src/pages/cert-manager/CertificateDetailsByIDPage/CertificateDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/CertificateDetailsByIDPage/CertificateDetailsByIDPage.tsx
@@ -41,6 +41,7 @@ import {
 } from "@app/hooks/api/pkiApplications/types";
 import { ProjectType } from "@app/hooks/api/projects/types";
 import { usePopUp } from "@app/hooks/usePopUp";
+import { ApplicationTab } from "@app/pages/cert-manager/ApplicationDetailsByIDPage/application-tabs";
 
 import { CertificateCertModal } from "../CertificatesPage/components/CertificateCertModal";
 import {
@@ -121,7 +122,7 @@ const Page = () => {
           projectId,
           applicationName: fromApplication
         },
-        search: { selectedTab: "certificates" }
+        search: { selectedTab: ApplicationTab.Certificates }
       });
     } else {
       navigate({
@@ -275,7 +276,7 @@ const Page = () => {
               projectId,
               applicationName: fromApplication
             }}
-            search={{ selectedTab: "certificates" }}
+            search={{ selectedTab: ApplicationTab.Certificates }}
             className="mb-4 flex w-fit items-center gap-x-1 text-sm text-mineshaft-400 transition duration-100 hover:text-mineshaft-400/80"
           >
             <ChevronLeftIcon size={16} />

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateManagePkiSyncsModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateManagePkiSyncsModal.tsx
@@ -27,6 +27,7 @@ import {
   useListPkiSyncsWithCertificate,
   useRemoveCertificatesFromPkiSync
 } from "@app/hooks/api/pkiSyncs";
+import { ApplicationTab } from "@app/pages/cert-manager/ApplicationDetailsByIDPage/application-tabs";
 import { IntegrationsListPageTabs } from "@app/types/integrations";
 
 type Props = {
@@ -103,7 +104,7 @@ export const CertificateManagePkiSyncsModal = ({
           projectId: currentProject.id,
           applicationName
         },
-        search: { selectedTab: "syncs" }
+        search: { selectedTab: ApplicationTab.Syncs }
       });
     } else {
       navigate({

--- a/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
+++ b/frontend/src/pages/cert-manager/PkiSyncDetailsByIDPage/PkiSyncDetailsByIDPage.tsx
@@ -24,6 +24,7 @@ import { ROUTE_PATHS } from "@app/const/routes";
 import { PKI_SYNC_MAP } from "@app/helpers/pkiSyncs";
 import { usePopUp } from "@app/hooks";
 import { useGetPkiSync } from "@app/hooks/api/pkiSyncs";
+import { ApplicationTab } from "@app/pages/cert-manager/ApplicationDetailsByIDPage/application-tabs";
 import { IntegrationsListPageTabs } from "@app/types/integrations";
 
 import {
@@ -81,7 +82,7 @@ const PageContent = () => {
       navigate({
         to: "/organizations/$orgId/projects/cert-manager/$projectId/applications/$applicationName",
         params: { orgId, projectId, applicationName },
-        search: { selectedTab: "syncs" }
+        search: { selectedTab: ApplicationTab.Syncs }
       });
       return;
     }

--- a/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
+++ b/frontend/src/pages/cert-manager/PoliciesPage/components/CertificateProfilesTab/CreateProfileModal.tsx
@@ -51,6 +51,7 @@ import {
 } from "@app/hooks/api/certificatePolicies";
 import {
   IssuerType,
+  TCertificateProfile,
   TCertificateProfileDefaults,
   TCertificateProfileWithDetails,
   TCreateCertificateProfileDTO,
@@ -463,9 +464,16 @@ interface Props {
   onClose: () => void;
   profile?: TCertificateProfileWithDetails;
   mode?: "create" | "edit" | "clone";
+  onComplete?: (profile: TCertificateProfile) => void;
 }
 
-export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }: Props) => {
+export const CreateProfileModal = ({
+  isOpen,
+  onClose,
+  profile,
+  mode = "create",
+  onComplete
+}: Props) => {
   const { currentProject } = useProject();
   const { permission } = useProjectPermission();
   const { orgId, projectId } = useParams({ strict: false }) as {
@@ -798,7 +806,8 @@ export const CreateProfileModal = ({ isOpen, onClose, profile, mode = "create" }
         createData.defaults = serializedDefaults;
       }
 
-      await createProfile.mutateAsync(createData);
+      const createdProfile = await createProfile.mutateAsync(createData);
+      onComplete?.(createdProfile);
     }
 
     createNotification({


### PR DESCRIPTION
## Context
Allow creation of cert profiles from within applications

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)