### PR TITLE
feat(kms): add delete protection for KMS keys

### DIFF
--- a/backend/src/db/migrations/20260821094312_add-kms-key-delete-protection.ts
+++ b/backend/src/db/migrations/20260821094312_add-kms-key-delete-protection.ts
@@ -1,0 +1,21 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  const hasCol = await knex.schema.hasColumn(TableName.KmsKey, "hasDeleteProtection");
+  if (!hasCol) {
+    await knex.schema.alterTable(TableName.KmsKey, (t) => {
+      t.boolean("hasDeleteProtection").notNullable().defaultTo(false);
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const hasCol = await knex.schema.hasColumn(TableName.KmsKey, "hasDeleteProtection");
+  if (hasCol) {
+    await knex.schema.alterTable(TableName.KmsKey, (t) => {
+      t.dropColumn("hasDeleteProtection");
+    });
+  }
+}

--- a/backend/src/db/schemas/kms-keys.ts
+++ b/backend/src/db/schemas/kms-keys.ts
@@ -19,7 +19,8 @@ export const KmsKeysSchema = z.object({
   projectId: z.string().nullable().optional(),
   keyUsage: z.string().default("encrypt-decrypt"),
   kmipMetadata: z.unknown().nullable().optional(),
-  isExportable: z.boolean().default(true)
+  isExportable: z.boolean().default(true),
+  hasDeleteProtection: z.boolean().default(false)
 });
 
 export type TKmsKeys = z.infer<typeof KmsKeysSchema>;

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -4060,6 +4060,7 @@ interface CreateCmekEvent {
     description?: string;
     encryptionAlgorithm: SymmetricKeyAlgorithm | AsymmetricKeyAlgorithm | HmacAlgorithm;
     isExportable?: boolean;
+    hasDeleteProtection?: boolean;
   };
 }
 
@@ -4074,8 +4075,10 @@ interface UpdateCmekEvent {
   type: EventType.UPDATE_CMEK;
   metadata: {
     keyId: string;
+    keyName: string;
     name?: string;
     description?: string;
+    hasDeleteProtection?: boolean;
   };
 }
 

--- a/backend/src/ee/services/kmip/kmip-operation-service.ts
+++ b/backend/src/ee/services/kmip/kmip-operation-service.ts
@@ -132,6 +132,12 @@ export const kmipOperationServiceFactory = ({
       throw new BadRequestError({ message: "Cannot destroy reserved keys" });
     }
 
+    if (key.hasDeleteProtection) {
+      throw new BadRequestError({
+        message: `Key with ID ${id} has delete protection enabled. Disable delete protection on the key before destroying it.`
+      });
+    }
+
     const completeKeyDetails = await kmsDAL.findByIdWithAssociatedKms(id);
     if (!completeKeyDetails) {
       throw new NotFoundError({ message: `Key with ID '${id}' not found` });

--- a/backend/src/ee/services/kmip/kmip-operation-service.ts
+++ b/backend/src/ee/services/kmip/kmip-operation-service.ts
@@ -132,12 +132,6 @@ export const kmipOperationServiceFactory = ({
       throw new BadRequestError({ message: "Cannot destroy reserved keys" });
     }
 
-    if (key.hasDeleteProtection) {
-      throw new BadRequestError({
-        message: `Key with ID ${id} has delete protection enabled. Disable delete protection on the key before destroying it.`
-      });
-    }
-
     const completeKeyDetails = await kmsDAL.findByIdWithAssociatedKms(id);
     if (!completeKeyDetails) {
       throw new NotFoundError({ message: `Key with ID '${id}' not found` });
@@ -154,7 +148,13 @@ export const kmipOperationServiceFactory = ({
       });
     }
 
-    const kms = kmsDAL.deleteById(id);
+    const [kms] = await kmsDAL.delete({ id, hasDeleteProtection: false });
+
+    if (!kms) {
+      throw new BadRequestError({
+        message: `Key with ID ${id} has delete protection enabled. Disable delete protection on the key before destroying it.`
+      });
+    }
 
     recordKmipOperationMetric({
       operationType: KmipOperationType.DESTROY,

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2450,13 +2450,15 @@ export const KMS = {
     encryptionAlgorithm: "Deprecated: use 'algorithm' instead. Retained as an alias for backwards compatibility.",
     type: "The type of key to be created, either encrypt-decrypt or sign-verify, based on your intended use for the key.",
     isExportable:
-      "Whether the raw key material can be exported after creation. When set to false, the key can never be exported regardless of permissions. This cannot be changed after creation."
+      "Whether the raw key material can be exported after creation. When set to false, the key can never be exported regardless of permissions. This cannot be changed after creation.",
+    hasDeleteProtection: "Prevents deletion of the key when enabled."
   },
   UPDATE_KEY: {
     keyId: "The ID of the key to be updated.",
     name: "The updated name of this key. Must be slug-friendly.",
     description: "The updated description of this key.",
-    isDisabled: "The flag to enable or disable this key."
+    isDisabled: "The flag to enable or disable this key.",
+    hasDeleteProtection: "Enable or disable delete protection for this key."
   },
   ROTATE_KEY: {
     keyId: "The ID of the key to be rotated."

--- a/backend/src/server/routes/v1/cmek-router.ts
+++ b/backend/src/server/routes/v1/cmek-router.ts
@@ -94,7 +94,8 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
           algorithm: z.enum(AllowedKmsKeyAlgorithms).optional().describe(KMS.CREATE_KEY.algorithm),
           // Deprecated alias for `algorithm`, retained for backwards compatibility.
           encryptionAlgorithm: z.enum(AllowedKmsKeyAlgorithms).optional().describe(openApiHidden()),
-          isExportable: z.boolean().optional().default(true).describe(KMS.CREATE_KEY.isExportable)
+          isExportable: z.boolean().optional().default(true).describe(KMS.CREATE_KEY.isExportable),
+          hasDeleteProtection: z.boolean().optional().default(false).describe(KMS.CREATE_KEY.hasDeleteProtection)
         })
         .superRefine((data, ctx) => {
           const algorithm = data.algorithm ?? data.encryptionAlgorithm ?? SymmetricKeyAlgorithm.AES_GCM_256;
@@ -141,7 +142,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
       const {
-        body: { projectId, name, description, keyUsage, isExportable },
+        body: { projectId, name, description, keyUsage, isExportable, hasDeleteProtection },
         permission
       } = req;
 
@@ -157,7 +158,8 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
           description,
           encryptionAlgorithm: algorithm,
           keyUsage,
-          isExportable
+          isExportable,
+          hasDeleteProtection
         },
         permission
       );
@@ -172,7 +174,8 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
             name,
             description,
             encryptionAlgorithm: algorithm,
-            isExportable
+            isExportable,
+            hasDeleteProtection
           }
         }
       });
@@ -213,7 +216,8 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
       body: z.object({
         name: keyNameSchema.optional().describe(KMS.UPDATE_KEY.name),
         isDisabled: z.boolean().optional().describe(KMS.UPDATE_KEY.isDisabled),
-        description: keyDescriptionSchema.describe(KMS.UPDATE_KEY.description)
+        description: keyDescriptionSchema.describe(KMS.UPDATE_KEY.description),
+        hasDeleteProtection: z.boolean().optional().describe(KMS.UPDATE_KEY.hasDeleteProtection)
       }),
       response: {
         200: z.object({
@@ -238,6 +242,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
           type: EventType.UPDATE_CMEK,
           metadata: {
             keyId,
+            keyName: cmek.name,
             ...body
           }
         }
@@ -657,7 +662,8 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
                 // Deprecated alias for `algorithm`, retained for backwards compatibility.
                 encryptionAlgorithm: z.enum(AllowedKmsKeyAlgorithms).optional().describe(openApiHidden()),
                 keyMaterial: z.string().min(1),
-                isExportable: z.boolean().optional().default(true).describe(KMS.CREATE_KEY.isExportable)
+                isExportable: z.boolean().optional().default(true).describe(KMS.CREATE_KEY.isExportable),
+                hasDeleteProtection: z.boolean().optional().default(false).describe(KMS.CREATE_KEY.hasDeleteProtection)
               })
               .superRefine((data, ctx) => {
                 const algorithm = data.algorithm ?? data.encryptionAlgorithm;
@@ -730,7 +736,8 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
             algorithm: (k.algorithm ?? k.encryptionAlgorithm)! as TCmekKeyEncryptionAlgorithm,
             keyUsage: k.keyUsage,
             keyMaterial: k.keyMaterial,
-            isExportable: k.isExportable
+            isExportable: k.isExportable,
+            hasDeleteProtection: k.hasDeleteProtection
           }))
         },
         permission

--- a/backend/src/services/cmek/cmek-service.ts
+++ b/backend/src/services/cmek/cmek-service.ts
@@ -173,6 +173,12 @@ export const cmekServiceFactory = ({
 
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionCmekActions.Delete, ProjectPermissionSub.Cmek);
 
+    if (key.hasDeleteProtection) {
+      throw new BadRequestError({
+        message: `Key with ID ${keyId} has delete protection enabled. Disable delete protection on the key before deleting it.`
+      });
+    }
+
     await kmsDAL.deleteById(keyId);
 
     return key;
@@ -681,6 +687,7 @@ export const cmekServiceFactory = ({
           name: entry.name,
           isReserved: false,
           isExportable: entry.isExportable,
+          hasDeleteProtection: entry.hasDeleteProtection,
           projectId,
           orgId: actor.orgId,
           keyUsage: entry.keyUsage

--- a/backend/src/services/cmek/cmek-service.ts
+++ b/backend/src/services/cmek/cmek-service.ts
@@ -173,13 +173,13 @@ export const cmekServiceFactory = ({
 
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionCmekActions.Delete, ProjectPermissionSub.Cmek);
 
-    if (key.hasDeleteProtection) {
+    const [deletedKey] = await kmsDAL.delete({ id: keyId, hasDeleteProtection: false });
+
+    if (!deletedKey) {
       throw new BadRequestError({
         message: `Key with ID ${keyId} has delete protection enabled. Disable delete protection on the key before deleting it.`
       });
     }
-
-    await kmsDAL.deleteById(keyId);
 
     return key;
   };

--- a/backend/src/services/cmek/cmek-types.ts
+++ b/backend/src/services/cmek/cmek-types.ts
@@ -15,6 +15,7 @@ export type TCreateCmekDTO = {
   encryptionAlgorithm: TCmekKeyEncryptionAlgorithm;
   keyUsage: KmsKeyUsage;
   isExportable?: boolean;
+  hasDeleteProtection?: boolean;
 };
 
 export type TUpdabteCmekByIdDTO = {
@@ -22,6 +23,7 @@ export type TUpdabteCmekByIdDTO = {
   name?: string;
   isDisabled?: boolean;
   description?: string;
+  hasDeleteProtection?: boolean;
 };
 
 export type TListCmeksByProjectIdDTO = {
@@ -69,6 +71,7 @@ export type TCmekBulkImportKeyEntry = {
   keyUsage: KmsKeyUsage;
   keyMaterial: string;
   isExportable?: boolean;
+  hasDeleteProtection?: boolean;
 };
 
 export type TCmekBulkImportKeysDTO = {

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -136,6 +136,7 @@ export const kmsServiceFactory = ({
     orgId,
     isReserved = true,
     isExportable = true,
+    hasDeleteProtection = false,
     tx,
     name,
     projectId,
@@ -180,6 +181,7 @@ export const kmsServiceFactory = ({
           orgId,
           isReserved,
           isExportable,
+          hasDeleteProtection,
           projectId,
           description
         },
@@ -603,6 +605,7 @@ export const kmsServiceFactory = ({
       name,
       isReserved,
       isExportable = true,
+      hasDeleteProtection = false,
       projectId,
       orgId,
       keyUsage,
@@ -685,6 +688,7 @@ export const kmsServiceFactory = ({
           orgId,
           isReserved,
           isExportable,
+          hasDeleteProtection,
           projectId,
           kmipMetadata
         },

--- a/backend/src/services/kms/kms-types.ts
+++ b/backend/src/services/kms/kms-types.ts
@@ -37,6 +37,7 @@ export type TGenerateKMSDTO = {
   keyUsage?: KmsKeyUsage;
   isReserved?: boolean;
   isExportable?: boolean;
+  hasDeleteProtection?: boolean;
   name?: string;
   description?: string;
   tx?: Knex;
@@ -115,6 +116,7 @@ export type TImportKeyMaterialDTO = {
   name?: string;
   isReserved: boolean;
   isExportable?: boolean;
+  hasDeleteProtection?: boolean;
   projectId: string;
   orgId: string;
   keyUsage: KmsKeyUsage;

--- a/docs/documentation/platform/kms/overview.mdx
+++ b/docs/documentation/platform/kms/overview.mdx
@@ -50,6 +50,7 @@ In the following steps, we explore how to generate a key and use it to encrypt d
                 - Algorithm: The encryption algorithm associated with the key (e.g. `AES-GCM-256`).
                 - Description: An optional description of what the intended usage is for the key.
                 - Allow Export: Whether the raw key material can be exported later. When disabled, the key material can never leave Infisical, regardless of permissions. This cannot be changed after the key is created.
+                - Delete Protection: Whether the key is protected from deletion. While enabled, the key cannot be deleted on its own. You can turn this off at any time by editing the key. Deleting the whole project still removes its keys.
 
                 ![kms add key modal](/images/platform/kms/infisical-kms/kms-add-key-modal.png)
             </Step>
@@ -388,6 +389,7 @@ In the following steps, we explore how to generate a key and use it to produce a
                 - Algorithm: The HMAC algorithm associated with the key (e.g. `HMAC_SHA_256`). Supported algorithms are `HMAC_SHA_1`, `HMAC_SHA_224`, `HMAC_SHA_256`, `HMAC_SHA_384`, and `HMAC_SHA_512`.
                 - Description: An optional description of what the intended usage is for the key.
                 - Allow Export: Whether the raw key material can be exported later. When disabled, the key material can never leave Infisical, regardless of permissions. This cannot be changed after the key is created.
+                - Delete Protection: Whether the key is protected from deletion. While enabled, the key cannot be deleted on its own. You can turn this off at any time by editing the key. Deleting the whole project still removes its keys.
             </Step>
             <Step title="Generating a MAC with the KMS key">
                 Once your key is generated, open the options menu for the newly created key and select generate MAC.

--- a/frontend/src/hooks/api/cmeks/mutations.tsx
+++ b/frontend/src/hooks/api/cmeks/mutations.tsx
@@ -43,11 +43,18 @@ export const useCreateCmek = () => {
 export const useUpdateCmek = () => {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ keyId, name, description, isDisabled }: TUpdateCmek) => {
+    mutationFn: async ({
+      keyId,
+      name,
+      description,
+      isDisabled,
+      hasDeleteProtection
+    }: TUpdateCmek) => {
       const { data } = await apiRequest.patch(`/api/v1/kms/keys/${keyId}`, {
         name,
         description,
-        isDisabled
+        isDisabled,
+        hasDeleteProtection
       });
 
       return data;

--- a/frontend/src/hooks/api/cmeks/types.ts
+++ b/frontend/src/hooks/api/cmeks/types.ts
@@ -12,12 +12,13 @@ export type TCmek = {
   id: string;
   keyUsage: KmsKeyUsage;
   name: string;
-  description?: string;
+  description?: string | null;
   algorithm: AsymmetricKeyAlgorithm | SymmetricKeyAlgorithm | HmacAlgorithm;
   projectId: string;
   isDisabled: boolean;
   isReserved: boolean;
   isExportable: boolean;
+  hasDeleteProtection: boolean;
   orgId: string;
   version: number;
   createdAt: string;
@@ -28,10 +29,10 @@ type ProjectRef = { projectId: string };
 type KeyRef = { keyId: string };
 
 export type TCreateCmek = Pick<TCmek, "name" | "description" | "algorithm" | "keyUsage"> &
-  Partial<Pick<TCmek, "isExportable">> &
+  Partial<Pick<TCmek, "isExportable" | "hasDeleteProtection">> &
   ProjectRef;
 export type TUpdateCmek = KeyRef &
-  Partial<Pick<TCmek, "name" | "description" | "isDisabled">> &
+  Partial<Pick<TCmek, "name" | "description" | "isDisabled" | "hasDeleteProtection">> &
   ProjectRef;
 export type TDeleteCmek = KeyRef & ProjectRef;
 export type TRotateCmek = KeyRef & ProjectRef;
@@ -134,6 +135,7 @@ export type TCmekBulkImportKeyEntry = {
   algorithm: AsymmetricKeyAlgorithm | SymmetricKeyAlgorithm | HmacAlgorithm;
   keyMaterial: string;
   isExportable?: boolean;
+  hasDeleteProtection?: boolean;
 };
 
 export type TCmekBulkImportKeysDTO = {

--- a/frontend/src/pages/kms/OverviewPage/components/CmekBulkImportModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekBulkImportModal.tsx
@@ -51,6 +51,7 @@ type ParsedKey = {
   privateKey?: string;
   publicKey?: string;
   isExportable?: boolean;
+  hasDeleteProtection?: boolean;
 };
 
 const MIN_HMAC_KEY_BYTE_LENGTH = 16;
@@ -121,6 +122,9 @@ const validateEntry = (entry: unknown, index: number): ValidationError | null =>
   }
   if (e.isExportable !== undefined && typeof e.isExportable !== "boolean") {
     return { index, message: '"isExportable" must be a boolean' };
+  }
+  if (e.hasDeleteProtection !== undefined && typeof e.hasDeleteProtection !== "boolean") {
+    return { index, message: '"hasDeleteProtection" must be a boolean' };
   }
   if (e.keyType === KmsKeyUsage.ENCRYPT_DECRYPT) {
     const validSymmetric = Object.values(SymmetricKeyAlgorithm) as string[];
@@ -282,7 +286,8 @@ export const CmekBulkImportModal = ({ isOpen, onOpenChange, projectId }: Props) 
           algorithm: k.algorithm as never,
           keyMaterial:
             k.keyType === KmsKeyUsage.SIGN_VERIFY ? (k.privateKey ?? "") : (k.keyMaterial ?? ""),
-          isExportable: k.isExportable
+          isExportable: k.isExportable,
+          hasDeleteProtection: k.hasDeleteProtection
         }))
       });
       if (errors.length === 0) {

--- a/frontend/src/pages/kms/OverviewPage/components/CmekModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekModal.tsx
@@ -41,7 +41,8 @@ const formSchema = z.object({
   description: z.string().max(500).optional(),
   algorithm: z.enum(AllowedEncryptionKeyAlgorithms),
   keyUsage: z.nativeEnum(KmsKeyUsage),
-  isExportable: z.boolean()
+  isExportable: z.boolean(),
+  hasDeleteProtection: z.boolean()
 });
 
 export type FormData = z.infer<typeof formSchema>;
@@ -75,10 +76,11 @@ const CmekForm = ({ onComplete, cmek }: FormProps) => {
     resolver: zodResolver(formSchema),
     defaultValues: {
       name: cmek?.name,
-      description: cmek?.description,
+      description: cmek?.description ?? undefined,
       algorithm: SymmetricKeyAlgorithm.AES_GCM_256,
       keyUsage: KmsKeyUsage.ENCRYPT_DECRYPT,
-      isExportable: cmek?.isExportable ?? true
+      isExportable: cmek?.isExportable ?? true,
+      hasDeleteProtection: cmek?.hasDeleteProtection ?? false
     }
   });
 
@@ -87,17 +89,25 @@ const CmekForm = ({ onComplete, cmek }: FormProps) => {
     name,
     description,
     keyUsage,
-    isExportable
+    isExportable,
+    hasDeleteProtection
   }: FormData) => {
     const mutation = isUpdate
-      ? updateCmek.mutateAsync({ keyId: cmek.id, projectId, name, description })
+      ? updateCmek.mutateAsync({
+          keyId: cmek.id,
+          projectId,
+          name,
+          description,
+          hasDeleteProtection
+        })
       : createCmek.mutateAsync({
           projectId,
           name,
           description,
           keyUsage,
           algorithm: algorithm as AsymmetricKeyAlgorithm | SymmetricKeyAlgorithm | HmacAlgorithm,
-          isExportable
+          isExportable,
+          hasDeleteProtection
         });
 
     await mutation;
@@ -264,6 +274,26 @@ const CmekForm = ({ onComplete, cmek }: FormProps) => {
           )}
         />
       )}
+      <Controller
+        control={control}
+        name="hasDeleteProtection"
+        render={({ field: { onChange, value } }) => (
+          <Field orientation="horizontal" className="mb-6">
+            <FieldContent>
+              <FieldTitle>Delete Protection</FieldTitle>
+              <FieldDescription>
+                Prevents this key from being deleted while enabled.
+              </FieldDescription>
+            </FieldContent>
+            <Switch
+              id="has-delete-protection"
+              variant="project"
+              checked={value}
+              onCheckedChange={onChange}
+            />
+          </Field>
+        )}
+      />
       <div className="flex items-center">
         <Button
           className="mr-4"

--- a/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
@@ -474,6 +474,7 @@ export const CmekTable = () => {
                       algorithm,
                       isDisabled,
                       isExportable,
+                      hasDeleteProtection,
                       keyUsage
                     } = cmek;
                     const { variant, label } = getStatusBadgeProps(isDisabled);
@@ -695,14 +696,27 @@ export const CmekTable = () => {
                                   )}
                                   {isDisabled ? "Enable" : "Disable"} Key
                                 </DropdownMenuItem>
-                                <DropdownMenuItem
-                                  onClick={() => handlePopUpOpen("deleteKey", cmek)}
-                                  isDisabled={cannotDeleteKey}
-                                  variant="danger"
+                                <Tooltip
+                                  open={cannotDeleteKey || hasDeleteProtection ? undefined : false}
                                 >
-                                  <TrashIcon className="mr-2 size-4" />
-                                  Delete Key
-                                </DropdownMenuItem>
+                                  <TooltipTrigger asChild>
+                                    <div>
+                                      <DropdownMenuItem
+                                        onClick={() => handlePopUpOpen("deleteKey", cmek)}
+                                        isDisabled={cannotDeleteKey || hasDeleteProtection}
+                                        variant="danger"
+                                      >
+                                        <TrashIcon className="mr-2 size-4" />
+                                        Delete Key
+                                      </DropdownMenuItem>
+                                    </div>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="left">
+                                    {cannotDeleteKey
+                                      ? "Access Restricted"
+                                      : "Disable delete protection on this key before deleting it"}
+                                  </TooltipContent>
+                                </Tooltip>
                               </DropdownMenuContent>
                             </DropdownMenu>
                           </div>


### PR DESCRIPTION
## Context

Add delete protection for KMS keys to reduce the risk of accidental destructive actions.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)