### PR TITLE
fix: resolved dev server reloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ up-prod:
 down:
 	docker compose -f docker-compose.dev.yml down
 
+# Wipes the persisted Vite dep-prebundle cache. Reach for this when the dev server serves
+# stale or broken /node_modules/.vite/deps chunks; it re-optimizes on the next `make up-dev`.
+COMPOSE_PROJECT_NAME ?= $(notdir $(CURDIR))
+clear-frontend-cache:
+	docker compose -f docker-compose.dev.yml rm -sf frontend
+	docker volume rm -f $(COMPOSE_PROJECT_NAME)_frontend_vite_cache
+
 reviewable-ui:
 	cd frontend && \
 	npm run lint:fix && \

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,12 @@ down:
 # Wipes the persisted Vite dep-prebundle cache. Reach for this when the dev server serves
 # stale or broken /node_modules/.vite/deps chunks; it re-optimizes on the next `make up-dev`.
 COMPOSE_PROJECT_NAME ?= $(notdir $(CURDIR))
+# docker compose normalizes the project name (lowercased, chars outside [a-z0-9_-] dropped)
+# before prefixing volume names, so normalize it the same way to match dirs like PLATFOR-532.
+COMPOSE_VOLUME_PREFIX = $(shell echo '$(COMPOSE_PROJECT_NAME)' | tr '[:upper:]' '[:lower:]' | tr -cd 'a-z0-9_-')
 clear-frontend-cache:
 	docker compose -f docker-compose.dev.yml rm -sf frontend
-	docker volume rm -f $(COMPOSE_PROJECT_NAME)_frontend_vite_cache
+	docker volume rm -f $(COMPOSE_VOLUME_PREFIX)_frontend_vite_cache
 
 reviewable-ui:
 	cd frontend && \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -178,6 +178,10 @@ services:
       - ./frontend/src:/app/src/ # mounted whole src to avoid missing reload on new files
       - ./frontend/public:/app/public
       - ./frontend/index.html:/app/index.html
+      # Persist Vite's optimized dep cache across container recreation. Without it a fresh
+      # container re-prebundles and hands out new chunk hashes, so an open tab 404s on
+      # /node_modules/.vite/deps/chunk-*.js ("error loading dynamically imported module").
+      - frontend_vite_cache:/app/node_modules/.vite
     env_file: .env
 
   backend-go:
@@ -437,4 +441,6 @@ volumes:
   softhsm_tokens:
     driver: local
   authentik_postgres:
+    driver: local
+  frontend_vite_cache:
     driver: local

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -66,6 +66,22 @@ export default defineConfig(({ mode }) => {
         }
       }
     },
+    optimizeDeps: {
+      // Deps that the initial esbuild scan can't reach: `react/jsx-runtime` is injected by the
+      // SWC transform (the scanner reads pre-transform source), and the rest are only imported
+      // from lazy route components. Discovering them mid-session re-runs optimizeDeps, which
+      // rotates the ?v= hash on every /node_modules/.vite/deps URL and force-reloads the page.
+      include: [
+        "react/jsx-runtime",
+        "crypto",
+        "react-icons/bs",
+        "react-icons/di",
+        "react-icons/si",
+        "react-icons/vsc",
+        "@fortawesome/free-brands-svg-icons",
+        "@fortawesome/free-regular-svg-icons"
+      ]
+    },
     experimental: {
       renderBuiltUrl(filename, { hostType }) {
         if (hostType === "js") {


### PR DESCRIPTION
## Context

In development sometimes the dev server just reloads the full page and this would happen when you visit each page. This was due to two things
1. Vite saves the cache in `.vite` inside node modules. When you do a docker compose rebuild, that cache is lost and the frontend cache links gets broken. This is now avoided by having a volume cache to hold it like a CDN
2. Vite would do a full reload when a new dependency is found. The crypto, some icons, and packages are found later stage by Vite, and this causes the page to reload. I have added those ones as optimizeDeps so the first scanner picks it up. The cold start is not high to be even noticed.

## Screenshots


## Steps to verify the change

1. Remove the present dev image for frontend
2. Now do a docker compose up and go through pages
3. Do a rebuild or compose down and it should still work fine.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)