### PR TITLE
fix(insights): revive dates to be Date so they are not string

### DIFF
--- a/backend/src/ee/services/insights/insights-fns.ts
+++ b/backend/src/ee/services/insights/insights-fns.ts
@@ -19,6 +19,17 @@ export const VALUE_EVENT_TYPES = [
 
 export const toUtcDateString = (date: Date) => date.toISOString().slice(0, 10);
 
+export const reviveDates = <T>(rows: T[], ...keys: (keyof T)[]) => {
+  for (const row of rows) {
+    for (const key of keys) {
+      const serialized = row[key] as Date | string | null;
+      if (typeof serialized === "string") {
+        row[key] = new Date(serialized) as T[typeof key];
+      }
+    }
+  }
+};
+
 const startOfUtcDay = (date: Date) => new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
 
 const startOfUtcWeek = (date: Date) => {

--- a/backend/src/ee/services/insights/insights-service.ts
+++ b/backend/src/ee/services/insights/insights-service.ts
@@ -45,6 +45,7 @@ import {
   buildStaticSecretUsageWindow,
   collapseAccessVolumeDays,
   resolveUserDisplayNames,
+  reviveDates,
   STALE_SECRET_THRESHOLD_DAYS,
   toUtcDateString,
   VALUE_EVENT_TYPES
@@ -236,6 +237,10 @@ export const insightsServiceFactory = ({
           })),
           reminders
         };
+      },
+      reviver: (parsed) => {
+        reviveDates(parsed.rotations, "nextRotationAt");
+        reviveDates(parsed.reminders, "nextReminderDate");
       }
     });
   };
@@ -463,6 +468,13 @@ export const insightsServiceFactory = ({
           staleSecrets,
           totalStaleCount
         };
+      },
+      reviver: (parsed) => {
+        reviveDates(parsed.upcomingRotations, "nextRotationAt");
+        reviveDates(parsed.failedRotations, "nextRotationAt");
+        reviveDates(parsed.upcomingReminders, "nextReminderDate");
+        reviveDates(parsed.overdueReminders, "nextReminderDate");
+        reviveDates(parsed.staleSecrets, "updatedAt");
       }
     });
   };


### PR DESCRIPTION
## Context
Cached data was not returning a date valid string, so this was breaking the zod validation

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- create a reminder and a rotation that happens on the next 7 days 
- perform a request more than once, so you get cached data
- check that nothing is breaking

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)