### PR TITLE
fix(gateway-helm): pass positional gateway name for default CLI

### DIFF
--- a/helm-charts/infisical-gateway/CHANGELOG.md
+++ b/helm-charts/infisical-gateway/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Added Kubernetes auth enrollment (`gateway.enrollment.method: kubernetes`). The gateway authenticates with the projected service account token of its own pod, so no enrollment token or cloud credential needs to be distributed to the cluster.
 * Added `gateway.enrollment.kubernetes.gatewayId` and `gateway.enrollment.kubernetes.serviceAccountTokenPath`.
 * Bumped the default CLI image from `0.43.84` to `0.43.123`, the first release containing `--enroll-method=kubernetes`.
+* The default CLI requires a positional gateway name. The legacy machine-identity flow now passes `gateway.name` as `gateway start <name>` when set.
 * Added `gateway.enrollment.kubernetes.externalTokenReview`. Installing with `serviceAccount.createAsAuthDelegator` disabled now fails unless this is set, since the gateway would otherwise start but never be able to have its token reviewed.
 
 ## 1.3.0 (August 5, 2026)

--- a/helm-charts/infisical-gateway/ci/default-values.yaml
+++ b/helm-charts/infisical-gateway/ci/default-values.yaml
@@ -1,6 +1,7 @@
 # Values applied automatically by chart-testing (ct install) in CI.
-# The CI secret holds a dummy token, so without an explicit relay name the
-# gateway exits on the relay-lookup API call and the pod crash-loops. With a
-# relay name it enters its reconnect-retry loop and the pod stays Running.
+# Dummy token + explicit name/relay: the gateway fails auth, then stays
+# in its reconnect loop so the pod remains Running.
+gateway:
+  name: ci-test-gateway
 extraArgs:
   - --target-relay-name=ci-test-relay

--- a/helm-charts/infisical-gateway/templates/deployment.yaml
+++ b/helm-charts/infisical-gateway/templates/deployment.yaml
@@ -151,6 +151,9 @@ spec:
           args:
             - gateway
             - start
+            {{- if .Values.gateway.name }}
+            - {{ .Values.gateway.name | quote }}
+            {{- end }}
             - --pam-session-recording-path={{ $sessionPath }}
             {{- with .Values.extraArgs }}
             {{- toYaml . | nindent 12 }}

--- a/helm-charts/infisical-gateway/values.yaml
+++ b/helm-charts/infisical-gateway/values.yaml
@@ -9,7 +9,8 @@ secret:
   name: "infisical-gateway-environment"
 
 gateway:
-  # Name of the gateway created in the Infisical UI. Required when enrollment.method is set.
+  # Name of the gateway created in the Infisical UI. Required by the default CLI
+  # image (positional `gateway start <name>`). Also required when enrollment.method is set.
   name: ""
 
   # Infisical instance URL (e.g. https://app.infisical.com). Required when enrollment.method is set.


### PR DESCRIPTION
## Context

This adds `gateway.name: ci-test-gateway` to `ci/default-values.yaml` so `ct install` supplies the name through values, and teaches the legacy path to pass `gateway.name` as the positional argument when it is set. The conditional keeps existing installs that supply the name via the Secret working, so `helm upgrade` does not start requiring a values change. The enrollment paths already required `gateway.name` and are unchanged.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)