### PR TITLE
fix(identity-lockout): replace Redis SCAN with sorted-set index for list reads

### DIFF
--- a/backend/e2e-test/identity-lockout-keystore.spec.ts
+++ b/backend/e2e-test/identity-lockout-keystore.spec.ts
@@ -26,7 +26,16 @@ const commandCalls = async (command: string) => {
   return line ? Number(/^[^:]+:calls=(\d+),/.exec(line)?.[1] ?? 0) : 0;
 };
 
-const lockoutFor = (identityId: string) => KeyStorePrefixes.IdentityLockoutStateHash(identityId);
+const lockoutFor = (id: string) => KeyStorePrefixes.IdentityLockoutStateHash(id);
+
+// Mirrors HASH_FIELD_REAP_THRESHOLD in the keystore: below this a hash is small enough that the
+// reap skips it entirely, so a handful of expired fields legitimately survive until the key's TTL.
+const REAP_THRESHOLD = 50;
+
+// The reap keeps its resume position in a field of the same hash, so it is excluded here: only
+// fields naming an auth method and slug are lockout state.
+const lockoutFieldCount = async (id: string) =>
+  Object.keys(await testRedis.hgetall(lockoutFor(id))).filter((field) => field.includes(":")).length;
 
 let identityId: string;
 
@@ -97,7 +106,7 @@ describe("identity lockout keystore", () => {
       sprayed[KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, `sprayed-${i}`)] = expired;
     }
     await testRedis.hset(lockoutFor(identityId), sprayed);
-    expect(await testRedis.hlen(lockoutFor(identityId))).toBe(60);
+    expect(await lockoutFieldCount(identityId)).toBe(60);
 
     await persistIdentityLockoutState(
       { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
@@ -105,7 +114,7 @@ describe("identity lockout keystore", () => {
       testKeyStore
     );
 
-    expect(await testRedis.hlen(lockoutFor(identityId))).toBe(1);
+    expect(await lockoutFieldCount(identityId)).toBe(1);
     await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
   });
 
@@ -138,19 +147,21 @@ describe("identity lockout keystore", () => {
       testKeyStore
     );
 
-    expect(await testRedis.hlen(lockoutFor(identityId))).toBe(4);
+    expect(await lockoutFieldCount(identityId)).toBe(4);
     await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual(
       expect.arrayContaining([IdentityAuthMethod.LDAP_AUTH, IdentityAuthMethod.TOKEN_AUTH])
     );
   });
 
-  test("the reap walks a bounded slice, so one write cannot be made to cost O(fields)", async () => {
-    // LDAP slugs are caller-supplied usernames, so the field count is attacker-driven. Walking the
-    // whole hash per write would make distributed attempts against one identity scale with the
-    // square of the number of sources, on the single-threaded server this change exists to protect.
+  test.each([
+    // Below hash-max-listpack-entries (512 by default) HSCAN ignores cursor and COUNT and returns
+    // the whole hash; above it, real cursor semantics apply. The reap has to make progress in both.
+    { label: "listpack-encoded", fields: 400 },
+    { label: "hashtable-encoded", fields: 1200 }
+  ])("the reap eventually covers the whole $label hash instead of one fixed segment", async ({ fields }) => {
     const expired = JSON.stringify({ lockedOut: false, failedAttempts: 1, expiresAt: Date.now() - 1_000 });
     const sprayed: Record<string, string> = {};
-    for (let i = 0; i < 400; i += 1) {
+    for (let i = 0; i < fields; i += 1) {
       sprayed[KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, `sprayed-${i}`)] = expired;
     }
     await testRedis.hset(lockoutFor(identityId), sprayed);
@@ -162,26 +173,29 @@ describe("identity lockout keystore", () => {
         testKeyStore
       );
 
+    // Counts lockout fields only: the reap keeps its resume position in a field of the same hash.
+    const lockoutFields = async () => lockoutFieldCount(identityId);
+
     await write();
-    const afterOne = await testRedis.hlen(lockoutFor(identityId));
+    const afterOne = await lockoutFields();
 
-    // Bounded: one write cannot have reclaimed all 400. If this ever reaches 1 the reap has gone
-    // back to walking the whole hash and the cost is caller-controlled again.
+    // Bounded: one write must not have walked the whole hash, or the cost is caller-controlled.
     expect(afterOne).toBeGreaterThan(1);
-    expect(afterOne).toBeLessThan(401);
 
-    // ...but it reclaims far more per write than the single field a write adds, so it converges
-    // rather than falling behind.
-    let previous = afterOne;
-    for (let i = 0; i < 12; i += 1) {
+    // ...and it must not stall. Scanning from a fixed start drains one segment and then returns the
+    // same live fields forever, leaving everything else resident until the key's TTL.
+    let remaining = afterOne;
+    for (let i = 0; i < 200 && remaining > REAP_THRESHOLD; i += 1) {
       // eslint-disable-next-line no-await-in-loop
       await write();
       // eslint-disable-next-line no-await-in-loop
-      const current = await testRedis.hlen(lockoutFor(identityId));
-      expect(current).toBeLessThanOrEqual(previous);
-      previous = current;
+      remaining = await lockoutFields();
     }
-    expect(previous).toBeLessThan(afterOne);
+
+    // Down to within the threshold below which the reap deliberately stops walking. What matters is
+    // that the plateau is that constant and not whatever size the caller managed to grow the hash
+    // to -- a fixed scan start plateaus at the latter.
+    expect(remaining).toBeLessThanOrEqual(REAP_THRESHOLD);
   });
 
   test("no lockout path issues a SCAN, whatever the keyspace holds", async () => {

--- a/backend/e2e-test/identity-lockout-keystore.spec.ts
+++ b/backend/e2e-test/identity-lockout-keystore.spec.ts
@@ -144,6 +144,46 @@ describe("identity lockout keystore", () => {
     );
   });
 
+  test("the reap walks a bounded slice, so one write cannot be made to cost O(fields)", async () => {
+    // LDAP slugs are caller-supplied usernames, so the field count is attacker-driven. Walking the
+    // whole hash per write would make distributed attempts against one identity scale with the
+    // square of the number of sources, on the single-threaded server this change exists to protect.
+    const expired = JSON.stringify({ lockedOut: false, failedAttempts: 1, expiresAt: Date.now() - 1_000 });
+    const sprayed: Record<string, string> = {};
+    for (let i = 0; i < 400; i += 1) {
+      sprayed[KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, `sprayed-${i}`)] = expired;
+    }
+    await testRedis.hset(lockoutFor(identityId), sprayed);
+
+    const write = async () =>
+      persistIdentityLockoutState(
+        { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
+        { lockedOut: false, failedAttempts: 1 },
+        testKeyStore
+      );
+
+    await write();
+    const afterOne = await testRedis.hlen(lockoutFor(identityId));
+
+    // Bounded: one write cannot have reclaimed all 400. If this ever reaches 1 the reap has gone
+    // back to walking the whole hash and the cost is caller-controlled again.
+    expect(afterOne).toBeGreaterThan(1);
+    expect(afterOne).toBeLessThan(401);
+
+    // ...but it reclaims far more per write than the single field a write adds, so it converges
+    // rather than falling behind.
+    let previous = afterOne;
+    for (let i = 0; i < 12; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await write();
+      // eslint-disable-next-line no-await-in-loop
+      const current = await testRedis.hlen(lockoutFor(identityId));
+      expect(current).toBeLessThanOrEqual(previous);
+      previous = current;
+    }
+    expect(previous).toBeLessThan(afterOne);
+  });
+
   test("no lockout path issues a SCAN, whatever the keyspace holds", async () => {
     // The incident: one SCAN MATCH walk of the whole keyspace per identity on every list row.
     // MATCH is a post-filter, so the cost tracked the keyspace, not the number of lockouts.

--- a/backend/e2e-test/identity-lockout-keystore.spec.ts
+++ b/backend/e2e-test/identity-lockout-keystore.spec.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from "node:crypto";
+
+import { Redis } from "ioredis";
+import { beforeEach, describe, expect, test } from "vitest";
+
+import { IdentityAuthMethod } from "@app/db/schemas";
+import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
+import {
+  clearIdentityLockoutsForAuthMethod,
+  getIdentityActiveLockoutAuthMethods,
+  getIdentityLockoutState,
+  persistIdentityLockoutState
+} from "@app/services/identity/identity-fns";
+
+// These run against the real Redis the e2e environment boots, because the behaviour under test is
+// server-side: the reap lives in a Lua script, and the regression this guards was a SCAN issued by
+// ioredis. The in-memory keystore the unit tests use fakes both, so it cannot see either.
+declare const testRedis: Redis;
+declare const testKeyStore: TKeyStoreFactory;
+
+const commandCalls = async (command: string) => {
+  const info = await testRedis.info("commandstats");
+  const line = info.split("\n").find((row) => row.startsWith(`cmdstat_${command}:`));
+  // Anchored on the first field: a greedy match picks up the trailing failed_calls= instead and
+  // reads every counter as zero, which makes an assertion built on this pass vacuously.
+  return line ? Number(/^[^:]+:calls=(\d+),/.exec(line)?.[1] ?? 0) : 0;
+};
+
+const lockoutFor = (identityId: string) => KeyStorePrefixes.IdentityLockoutStateHash(identityId);
+
+let identityId: string;
+
+beforeEach(async () => {
+  identityId = randomUUID();
+  await testRedis.del(lockoutFor(identityId));
+});
+
+describe("identity lockout keystore", () => {
+  test("a lockout round-trips through the hash and is reported by auth method", async () => {
+    await persistIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
+      { lockedOut: true, failedAttempts: 3 },
+      testKeyStore
+    );
+
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([
+      IdentityAuthMethod.UNIVERSAL_AUTH
+    ]);
+
+    // The key must expire on its own; a lockout hash that outlives its lockout is a leak.
+    const ttl = await testRedis.ttl(lockoutFor(identityId));
+    expect(ttl).toBeGreaterThan(0);
+    expect(ttl).toBeLessThanOrEqual(300);
+  });
+
+  test("the key TTL only ever grows, so a short write cannot cut a long lockout short", async () => {
+    await persistIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 3600 },
+      { lockedOut: true, failedAttempts: 9 },
+      testKeyStore
+    );
+    await persistIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice", expiryInSeconds: 30 },
+      { lockedOut: false, failedAttempts: 1 },
+      testKeyStore
+    );
+
+    expect(await testRedis.ttl(lockoutFor(identityId))).toBeGreaterThan(300);
+  });
+
+  test("a field past its own deadline is ignored even while the key is still alive", async () => {
+    // Redis cannot expire one field, so a long-lived sibling keeps an expired one resident. Reads
+    // have to honour expiresAt or a lockout outlives its duration.
+    await persistIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 3600 },
+      { lockedOut: false, failedAttempts: 1 },
+      testKeyStore
+    );
+    await testRedis.hset(
+      lockoutFor(identityId),
+      KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, "alice"),
+      JSON.stringify({ lockedOut: true, failedAttempts: 9, expiresAt: Date.now() - 1_000 })
+    );
+
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
+    await expect(
+      getIdentityLockoutState({ identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice" }, testKeyStore)
+    ).resolves.toBeUndefined();
+  });
+
+  test("expired fields are reaped on write, so the resident set tracks the counter window", async () => {
+    // Without the reap a field survives until the key TTL, which one 24h lockout can pin, rather
+    // than until its own deadline.
+    const expired = JSON.stringify({ lockedOut: true, failedAttempts: 1, expiresAt: Date.now() - 1_000 });
+    const sprayed: Record<string, string> = {};
+    for (let i = 0; i < 60; i += 1) {
+      sprayed[KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, `sprayed-${i}`)] = expired;
+    }
+    await testRedis.hset(lockoutFor(identityId), sprayed);
+    expect(await testRedis.hlen(lockoutFor(identityId))).toBe(60);
+
+    await persistIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
+      { lockedOut: false, failedAttempts: 1 },
+      testKeyStore
+    );
+
+    expect(await testRedis.hlen(lockoutFor(identityId))).toBe(1);
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
+  });
+
+  test("the reap leaves live fields and fields carrying no deadline alone", async () => {
+    const now = Date.now();
+    const fields: Record<string, string> = {
+      [KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, "live")]: JSON.stringify({
+        lockedOut: true,
+        failedAttempts: 9,
+        expiresAt: now + 600_000
+      }),
+      [KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.TOKEN_AUTH, "no-deadline")]: JSON.stringify({
+        lockedOut: true,
+        failedAttempts: 9
+      }),
+      [KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.AWS_AUTH, "unreadable")]: "{{{"
+    };
+    for (let i = 0; i < 60; i += 1) {
+      fields[KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, `dead-${i}`)] = JSON.stringify({
+        lockedOut: true,
+        failedAttempts: 1,
+        expiresAt: now - 1_000
+      });
+    }
+    await testRedis.hset(lockoutFor(identityId), fields);
+
+    await persistIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
+      { lockedOut: false, failedAttempts: 1 },
+      testKeyStore
+    );
+
+    expect(await testRedis.hlen(lockoutFor(identityId))).toBe(4);
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual(
+      expect.arrayContaining([IdentityAuthMethod.LDAP_AUTH, IdentityAuthMethod.TOKEN_AUTH])
+    );
+  });
+
+  test("no lockout path issues a SCAN, whatever the keyspace holds", async () => {
+    // The incident: one SCAN MATCH walk of the whole keyspace per identity on every list row.
+    // MATCH is a post-filter, so the cost tracked the keyspace, not the number of lockouts.
+    const decoys: string[] = [];
+    const pipeline = testRedis.pipeline();
+    for (let i = 0; i < 2_000; i += 1) {
+      const key = `lockout-scan-decoy:${identityId}:${i}`;
+      decoys.push(key);
+      pipeline.set(key, "1", "EX", 120);
+    }
+    await pipeline.exec();
+
+    await persistIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
+      { lockedOut: true, failedAttempts: 3 },
+      testKeyStore
+    );
+
+    const scanBefore = await commandCalls("scan");
+    const hgetallBefore = await commandCalls("hgetall");
+
+    // Every read shape the list, detail and admin paths use.
+    const LIST_READS = 10;
+    for (let i = 0; i < LIST_READS; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await getIdentityActiveLockoutAuthMethods(identityId, testKeyStore);
+    }
+    await getIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a" },
+      testKeyStore
+    );
+    await clearIdentityLockoutsForAuthMethod(identityId, IdentityAuthMethod.UNIVERSAL_AUTH, testKeyStore);
+
+    // Proves the counter is actually being read before the SCAN assertion leans on it: a broken
+    // parser reports zero for every command, which would make that assertion pass having measured
+    // nothing. It also pins the cost itself -- one keyed read per list row, plus the clear path's.
+    expect(await commandCalls("hgetall")).toBe(hgetallBefore + LIST_READS + 1);
+    expect(await commandCalls("scan")).toBe(scanBefore);
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
+
+    await testRedis.del(...decoys);
+  });
+});

--- a/backend/e2e-test/identity-lockout-keystore.spec.ts
+++ b/backend/e2e-test/identity-lockout-keystore.spec.ts
@@ -7,14 +7,15 @@ import { IdentityAuthMethod } from "@app/db/schemas";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import {
   clearIdentityLockoutsForAuthMethod,
+  clearIdentityLockoutState,
   getIdentityActiveLockoutAuthMethods,
   getIdentityLockoutState,
   persistIdentityLockoutState
 } from "@app/services/identity/identity-fns";
 
-// These run against the real Redis the e2e environment boots, because the behaviour under test is
-// server-side: the reap lives in a Lua script, and the regression this guards was a SCAN issued by
-// ioredis. The in-memory keystore the unit tests use fakes both, so it cannot see either.
+// Against the real Redis the e2e environment boots, because what is under test is server-side: the
+// write is a Lua script, expiry is Redis's own, and the regression this guards was a SCAN issued by
+// ioredis. The in-memory keystore the unit tests use fakes all three.
 declare const testRedis: Redis;
 declare const testKeyStore: TKeyStoreFactory;
 
@@ -26,181 +27,146 @@ const commandCalls = async (command: string) => {
   return line ? Number(/^[^:]+:calls=(\d+),/.exec(line)?.[1] ?? 0) : 0;
 };
 
-const lockoutFor = (id: string) => KeyStorePrefixes.IdentityLockoutStateHash(id);
+const indexKey = (id: string) => KeyStorePrefixes.IdentityLockoutIndex(id);
+const itemKey = (id: string, authMethod: string, slug: string) =>
+  KeyStorePrefixes.IdentityLockoutState(id, authMethod, slug);
 
-// Mirrors HASH_FIELD_REAP_THRESHOLD in the keystore: below this a hash is small enough that the
-// reap skips it entirely, so a handful of expired fields legitimately survive until the key's TTL.
-const REAP_THRESHOLD = 50;
-
-// The reap keeps its resume position in a field of the same hash, so it is excluded here: only
-// fields naming an auth method and slug are lockout state.
-const lockoutFieldCount = async (id: string) =>
-  Object.keys(await testRedis.hgetall(lockoutFor(id))).filter((field) => field.includes(":")).length;
+const lockout = (identityId: string, slug: string, expiryInSeconds: number, lockedOut: boolean) =>
+  persistIdentityLockoutState(
+    { identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug, expiryInSeconds },
+    { lockedOut, failedAttempts: lockedOut ? 3 : 1 },
+    testKeyStore
+  );
 
 let identityId: string;
 
 beforeEach(async () => {
   identityId = randomUUID();
-  await testRedis.del(lockoutFor(identityId));
+  await testRedis.del(indexKey(identityId));
 });
 
 describe("identity lockout keystore", () => {
-  test("a lockout round-trips through the hash and is reported by auth method", async () => {
+  test("a lockout round-trips, and both the item and the index expire on their own", async () => {
+    await lockout(identityId, "alice", 300, true);
+
+    await expect(
+      getIdentityLockoutState({ identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice" }, testKeyStore)
+    ).resolves.toEqual({ lockedOut: true, failedAttempts: 3 });
+
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
+
+    // Neither may outlive its lockout: a key with no TTL is a leak nothing reclaims.
+    const itemTtl = await testRedis.ttl(itemKey(identityId, IdentityAuthMethod.LDAP_AUTH, "alice"));
+    const idxTtl = await testRedis.ttl(indexKey(identityId));
+    expect(itemTtl).toBeGreaterThan(0);
+    expect(itemTtl).toBeLessThanOrEqual(300);
+    expect(idxTtl).toBeGreaterThan(0);
+  });
+
+  test("the index expiry only ever grows, so a short write cannot cut a long lockout short", async () => {
+    await lockout(identityId, "long", 3600, true);
+    await lockout(identityId, "short", 30, true);
+
+    expect(await testRedis.ttl(indexKey(identityId))).toBeGreaterThan(300);
+  });
+
+  test("a failure counter is never indexed, so spraying slugs cannot enlarge the list read", async () => {
+    // LDAP slugs are caller-supplied usernames. Counters are addressed directly by login and are of
+    // no use to the list endpoints, so keeping them out of the index is what bounds that read.
+    for (let i = 0; i < 500; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await lockout(identityId, `sprayed-${i}`, 60, false);
+    }
+
+    expect(await testRedis.zcard(indexKey(identityId))).toBe(0);
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
+
+    // The counters themselves are still readable by the login path that knows their slug.
+    await expect(
+      getIdentityLockoutState({ identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "sprayed-1" }, testKeyStore)
+    ).resolves.toEqual({ lockedOut: false, failedAttempts: 1 });
+
+    // ...and one real lockout among them is still found, without the spray inflating the index.
+    await lockout(identityId, "victim", 300, true);
+    expect(await testRedis.zcard(indexKey(identityId))).toBe(1);
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
+  });
+
+  test("a member that outlives its item is not reported, before anything prunes it", async () => {
+    // Redis expires the item on its own but cannot expire an index member, so the index is briefly
+    // stale. Reads range by score, which is why that staleness is never visible.
+    await lockout(identityId, "alice", 300, true);
+    await testRedis.del(itemKey(identityId, IdentityAuthMethod.LDAP_AUTH, "alice"));
+    await testRedis.zadd(indexKey(identityId), Date.now() - 1_000, `${IdentityAuthMethod.LDAP_AUTH}:alice`);
+
+    expect(await testRedis.zcard(indexKey(identityId))).toBe(1);
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
+  });
+
+  test("expired members are pruned on write, in one command and with nothing left behind", async () => {
+    const stale = Array.from({ length: 400 }, (_, i) => [
+      Date.now() - 1_000,
+      `${IdentityAuthMethod.LDAP_AUTH}:old-${i}`
+    ]);
+    await testRedis.zadd(indexKey(identityId), ...stale.flat());
+    expect(await testRedis.zcard(indexKey(identityId))).toBe(400);
+
+    // A single write, not a batch that has to be repeated: the index is ordered by deadline, so one
+    // range removal takes every expired member regardless of how many there are.
+    await lockout(identityId, "alice", 300, true);
+
+    expect(await testRedis.zcard(indexKey(identityId))).toBe(1);
+    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
+  });
+
+  test("clearing one slug removes the item and its index member together", async () => {
+    await lockout(identityId, "alice", 300, true);
+    await lockout(identityId, "bob", 300, true);
+
+    await clearIdentityLockoutState(
+      { identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice" },
+      testKeyStore
+    );
+
+    expect(await testRedis.exists(itemKey(identityId, IdentityAuthMethod.LDAP_AUTH, "alice"))).toBe(0);
+    expect(await testRedis.zscore(indexKey(identityId), `${IdentityAuthMethod.LDAP_AUTH}:alice`)).toBeNull();
+    expect(await testRedis.zscore(indexKey(identityId), `${IdentityAuthMethod.LDAP_AUTH}:bob`)).not.toBeNull();
+  });
+
+  test("clearing a method removes every locked slug for it, and leaves other methods alone", async () => {
+    await lockout(identityId, "alice", 300, true);
+    await lockout(identityId, "bob", 300, true);
     await persistIdentityLockoutState(
-      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
+      {
+        identityId,
+        authMethod: IdentityAuthMethod.UNIVERSAL_AUTH,
+        slug: "client-a",
+        expiryInSeconds: 300
+      },
       { lockedOut: true, failedAttempts: 3 },
       testKeyStore
     );
 
+    await expect(
+      clearIdentityLockoutsForAuthMethod(identityId, IdentityAuthMethod.LDAP_AUTH, testKeyStore)
+    ).resolves.toBe(2);
+
+    expect(await testRedis.exists(itemKey(identityId, IdentityAuthMethod.LDAP_AUTH, "alice"))).toBe(0);
+    expect(await testRedis.exists(itemKey(identityId, IdentityAuthMethod.LDAP_AUTH, "bob"))).toBe(0);
     await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([
       IdentityAuthMethod.UNIVERSAL_AUTH
     ]);
-
-    // The key must expire on its own; a lockout hash that outlives its lockout is a leak.
-    const ttl = await testRedis.ttl(lockoutFor(identityId));
-    expect(ttl).toBeGreaterThan(0);
-    expect(ttl).toBeLessThanOrEqual(300);
-  });
-
-  test("the key TTL only ever grows, so a short write cannot cut a long lockout short", async () => {
-    await persistIdentityLockoutState(
-      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 3600 },
-      { lockedOut: true, failedAttempts: 9 },
-      testKeyStore
-    );
-    await persistIdentityLockoutState(
-      { identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice", expiryInSeconds: 30 },
-      { lockedOut: false, failedAttempts: 1 },
-      testKeyStore
-    );
-
-    expect(await testRedis.ttl(lockoutFor(identityId))).toBeGreaterThan(300);
-  });
-
-  test("a field past its own deadline is ignored even while the key is still alive", async () => {
-    // Redis cannot expire one field, so a long-lived sibling keeps an expired one resident. Reads
-    // have to honour expiresAt or a lockout outlives its duration.
-    await persistIdentityLockoutState(
-      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 3600 },
-      { lockedOut: false, failedAttempts: 1 },
-      testKeyStore
-    );
-    await testRedis.hset(
-      lockoutFor(identityId),
-      KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, "alice"),
-      JSON.stringify({ lockedOut: true, failedAttempts: 9, expiresAt: Date.now() - 1_000 })
-    );
-
-    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
-    await expect(
-      getIdentityLockoutState({ identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice" }, testKeyStore)
-    ).resolves.toBeUndefined();
-  });
-
-  test("expired fields are reaped on write, so the resident set tracks the counter window", async () => {
-    // Without the reap a field survives until the key TTL, which one 24h lockout can pin, rather
-    // than until its own deadline.
-    const expired = JSON.stringify({ lockedOut: true, failedAttempts: 1, expiresAt: Date.now() - 1_000 });
-    const sprayed: Record<string, string> = {};
-    for (let i = 0; i < 60; i += 1) {
-      sprayed[KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, `sprayed-${i}`)] = expired;
-    }
-    await testRedis.hset(lockoutFor(identityId), sprayed);
-    expect(await lockoutFieldCount(identityId)).toBe(60);
-
-    await persistIdentityLockoutState(
-      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
-      { lockedOut: false, failedAttempts: 1 },
-      testKeyStore
-    );
-
-    expect(await lockoutFieldCount(identityId)).toBe(1);
-    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
-  });
-
-  test("the reap leaves live fields and fields carrying no deadline alone", async () => {
-    const now = Date.now();
-    const fields: Record<string, string> = {
-      [KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, "live")]: JSON.stringify({
-        lockedOut: true,
-        failedAttempts: 9,
-        expiresAt: now + 600_000
-      }),
-      [KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.TOKEN_AUTH, "no-deadline")]: JSON.stringify({
-        lockedOut: true,
-        failedAttempts: 9
-      }),
-      [KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.AWS_AUTH, "unreadable")]: "{{{"
-    };
-    for (let i = 0; i < 60; i += 1) {
-      fields[KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, `dead-${i}`)] = JSON.stringify({
-        lockedOut: true,
-        failedAttempts: 1,
-        expiresAt: now - 1_000
-      });
-    }
-    await testRedis.hset(lockoutFor(identityId), fields);
-
-    await persistIdentityLockoutState(
-      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
-      { lockedOut: false, failedAttempts: 1 },
-      testKeyStore
-    );
-
-    expect(await lockoutFieldCount(identityId)).toBe(4);
-    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual(
-      expect.arrayContaining([IdentityAuthMethod.LDAP_AUTH, IdentityAuthMethod.TOKEN_AUTH])
-    );
-  });
-
-  test.each([
-    // Below hash-max-listpack-entries (512 by default) HSCAN ignores cursor and COUNT and returns
-    // the whole hash; above it, real cursor semantics apply. The reap has to make progress in both.
-    { label: "listpack-encoded", fields: 400 },
-    { label: "hashtable-encoded", fields: 1200 }
-  ])("the reap eventually covers the whole $label hash instead of one fixed segment", async ({ fields }) => {
-    const expired = JSON.stringify({ lockedOut: false, failedAttempts: 1, expiresAt: Date.now() - 1_000 });
-    const sprayed: Record<string, string> = {};
-    for (let i = 0; i < fields; i += 1) {
-      sprayed[KeyStorePrefixes.IdentityLockoutStateField(IdentityAuthMethod.LDAP_AUTH, `sprayed-${i}`)] = expired;
-    }
-    await testRedis.hset(lockoutFor(identityId), sprayed);
-
-    const write = async () =>
-      persistIdentityLockoutState(
-        { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
-        { lockedOut: false, failedAttempts: 1 },
-        testKeyStore
-      );
-
-    // Counts lockout fields only: the reap keeps its resume position in a field of the same hash.
-    const lockoutFields = async () => lockoutFieldCount(identityId);
-
-    await write();
-    const afterOne = await lockoutFields();
-
-    // Bounded: one write must not have walked the whole hash, or the cost is caller-controlled.
-    expect(afterOne).toBeGreaterThan(1);
-
-    // ...and it must not stall. Scanning from a fixed start drains one segment and then returns the
-    // same live fields forever, leaving everything else resident until the key's TTL.
-    let remaining = afterOne;
-    for (let i = 0; i < 200 && remaining > REAP_THRESHOLD; i += 1) {
-      // eslint-disable-next-line no-await-in-loop
-      await write();
-      // eslint-disable-next-line no-await-in-loop
-      remaining = await lockoutFields();
-    }
-
-    // Down to within the threshold below which the reap deliberately stops walking. What matters is
-    // that the plateau is that constant and not whatever size the caller managed to grow the hash
-    // to -- a fixed scan start plateaus at the latter.
-    expect(remaining).toBeLessThanOrEqual(REAP_THRESHOLD);
   });
 
   test("no lockout path issues a SCAN, whatever the keyspace holds", async () => {
-    // The incident: one SCAN MATCH walk of the whole keyspace per identity on every list row.
-    // MATCH is a post-filter, so the cost tracked the keyspace, not the number of lockouts.
+    // The incident: one SCAN MATCH walk of the whole keyspace per identity on every list row. MATCH
+    // is a post-filter, so the cost tracked the keyspace, not the number of lockouts.
     const decoys: string[] = [];
     const pipeline = testRedis.pipeline();
     for (let i = 0; i < 2_000; i += 1) {
@@ -210,33 +176,27 @@ describe("identity lockout keystore", () => {
     }
     await pipeline.exec();
 
-    await persistIdentityLockoutState(
-      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a", expiryInSeconds: 300 },
-      { lockedOut: true, failedAttempts: 3 },
-      testKeyStore
-    );
+    await lockout(identityId, "alice", 300, true);
 
     const scanBefore = await commandCalls("scan");
-    const hgetallBefore = await commandCalls("hgetall");
+    const rangeBefore = await commandCalls("zrangebyscore");
 
-    // Every read shape the list, detail and admin paths use.
     const LIST_READS = 10;
     for (let i = 0; i < LIST_READS; i += 1) {
       // eslint-disable-next-line no-await-in-loop
       await getIdentityActiveLockoutAuthMethods(identityId, testKeyStore);
     }
     await getIdentityLockoutState(
-      { identityId, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a" },
+      { identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice" },
       testKeyStore
     );
-    await clearIdentityLockoutsForAuthMethod(identityId, IdentityAuthMethod.UNIVERSAL_AUTH, testKeyStore);
+    await clearIdentityLockoutsForAuthMethod(identityId, IdentityAuthMethod.LDAP_AUTH, testKeyStore);
 
-    // Proves the counter is actually being read before the SCAN assertion leans on it: a broken
-    // parser reports zero for every command, which would make that assertion pass having measured
-    // nothing. It also pins the cost itself -- one keyed read per list row, plus the clear path's.
-    expect(await commandCalls("hgetall")).toBe(hgetallBefore + LIST_READS + 1);
+    // Proves the counter is being read at all before the SCAN assertion leans on it: a broken parser
+    // reports zero for every command, which would make that assertion pass having measured nothing.
+    // It also pins the cost -- one keyed range read per list row, and no more.
+    expect(await commandCalls("zrangebyscore")).toBe(rangeBefore + LIST_READS);
     expect(await commandCalls("scan")).toBe(scanBefore);
-    await expect(getIdentityActiveLockoutAuthMethods(identityId, testKeyStore)).resolves.toEqual([]);
 
     await testRedis.del(...decoys);
   });

--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -111,6 +111,29 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     hashGet: async (key, field) => {
       return hashStore[key]?.[field] ?? null;
     },
+    hashGetAll: async (key) => {
+      return { ...(hashStore[key] ?? {}) };
+    },
+    hashGetAllPrimary: async (key) => {
+      return { ...(hashStore[key] ?? {}) };
+    },
+    hashSetFieldWithMinExpiry: async (key, field, value) => {
+      if (!hashStore[key]) hashStore[key] = {};
+      hashStore[key][field] = value;
+    },
+    hashDeleteFields: async (key, fields) => {
+      const hash = hashStore[key];
+      if (!hash) return 0;
+
+      let deleted = 0;
+      fields.forEach((field) => {
+        if (field in hash) {
+          delete hash[field];
+          deleted += 1;
+        }
+      });
+      return deleted;
+    },
     pgIncrementBy: async () => {
       return 1;
     },

--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -112,12 +112,6 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     hashGet: async (key, field) => {
       return hashStore[key]?.[field] ?? null;
     },
-    hashGetAll: async (key) => {
-      return { ...(hashStore[key] ?? {}) };
-    },
-    hashGetAllPrimary: async (key) => {
-      return { ...(hashStore[key] ?? {}) };
-    },
     setIndexedItemWithExpiry: async ({ indexKey, member, itemKey, value, expiryInSeconds, indexed }) => {
       store[itemKey] = value;
       if (!sortedSetStore[indexKey]) sortedSetStore[indexKey] = {};

--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -8,6 +8,7 @@ import { Lock } from "@app/lib/red-lock";
 export const mockKeyStore = (): TKeyStoreFactory => {
   const store: Record<string, string | number | Buffer> = {};
   const hashStore: Record<string, Record<string, string>> = {};
+  const sortedSetStore: Record<string, Record<string, number>> = {};
 
   const getRegex = (pattern: string) =>
     new RE2(`^${pattern.replace(/[-[\]/{}()+?.\\^$|]/g, "\\$&").replace(/\*/g, ".*")}$`);
@@ -117,22 +118,31 @@ export const mockKeyStore = (): TKeyStoreFactory => {
     hashGetAllPrimary: async (key) => {
       return { ...(hashStore[key] ?? {}) };
     },
-    hashSetFieldWithMinExpiry: async (key, field, value) => {
-      if (!hashStore[key]) hashStore[key] = {};
-      hashStore[key][field] = value;
+    setIndexedItemWithExpiry: async ({ indexKey, member, itemKey, value, expiryInSeconds, indexed }) => {
+      store[itemKey] = value;
+      if (!sortedSetStore[indexKey]) sortedSetStore[indexKey] = {};
+      if (indexed) {
+        sortedSetStore[indexKey][member] = Date.now() + expiryInSeconds * 1000;
+      } else {
+        delete sortedSetStore[indexKey][member];
+      }
     },
-    hashDeleteFields: async (key, fields) => {
-      const hash = hashStore[key];
-      if (!hash) return 0;
-
-      let deleted = 0;
-      fields.forEach((field) => {
-        if (field in hash) {
-          delete hash[field];
-          deleted += 1;
-        }
-      });
-      return deleted;
+    deleteIndexedItems: async ({ indexKey, members, itemKeys }) => {
+      itemKeys.forEach((key) => delete store[key]);
+      members.forEach((member) => delete sortedSetStore[indexKey]?.[member]);
+    },
+    sortedSetRangeByScore: async (key, min, max) => {
+      const lower = min === "-inf" ? -Infinity : Number(min);
+      const upper = max === "+inf" ? Infinity : Number(max);
+      return Object.entries(sortedSetStore[key] ?? {})
+        .filter(([, score]) => score >= lower && score <= upper)
+        .sort(([, a], [, b]) => a - b)
+        .map(([member]) => member);
+    },
+    sortedSetMembersPrimary: async (key) => {
+      return Object.entries(sortedSetStore[key] ?? {})
+        .sort(([, a], [, b]) => a - b)
+        .map(([member]) => member);
     },
     pgIncrementBy: async () => {
       return 1;

--- a/backend/e2e-test/vitest-environment-knex.ts
+++ b/backend/e2e-test/vitest-environment-knex.ts
@@ -104,6 +104,8 @@ export default {
       // @ts-expect-error type
       globalThis.testRedis = redis;
       // @ts-expect-error type
+      globalThis.testKeyStore = keyStore;
+      // @ts-expect-error type
       globalThis.testQueue = queue;
       // @ts-expect-error type
       globalThis.testSuperAdminDAL = superAdminDAL;
@@ -142,6 +144,8 @@ export default {
         delete globalThis.testServer;
         // @ts-expect-error type
         delete globalThis.testRedis;
+        // @ts-expect-error type
+        delete globalThis.testKeyStore;
         // @ts-expect-error type
         delete globalThis.testSuperAdminDAL;
         // @ts-expect-error type

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -163,8 +163,11 @@ export const KeyStorePrefixes = {
   LicenseUsageReconcileMarker: (orgId: string) => `license-usage-reconcile-${orgId}` as const,
   LicenseUsageLastReported: (orgId: string, featureKey: string) =>
     `license-usage-last-reported-${orgId}-${featureKey}` as const,
-  IdentityLockoutStateHash: (identityId: string) => `lockout:identity:${identityId}` as const,
-  IdentityLockoutStateField: (authMethod: string, slug: string) => `${authMethod}:${slug}` as const,
+  IdentityLockoutState: (identityId: string, authMethod: string, slug: string) =>
+    `lockout:identity:${identityId}:${authMethod}:${slug}` as const,
+  // Sorted set of the identity's *locked* auth methods, scored by when each lockout ends.
+  IdentityLockoutIndex: (identityId: string) => `lockout:identity:${identityId}` as const,
+  IdentityLockoutMember: (authMethod: string, slug: string) => `${authMethod}:${slug}` as const,
 
   TelemetryAggregatedEventStream: (event: string, bucketId: string) =>
     `telemetry-agg-stream:${event}:${bucketId}` as const,
@@ -305,8 +308,19 @@ export type TKeyStoreFactory = {
   hashGet: (key: string, field: string) => Promise<string | null>;
   hashGetAll: (key: string) => Promise<Record<string, string>>;
   hashGetAllPrimary: (key: string) => Promise<Record<string, string>>;
-  hashSetFieldWithMinExpiry: (key: string, field: string, value: string, expiryInSeconds: number) => Promise<void>;
-  hashDeleteFields: (key: string, fields: string[]) => Promise<number>;
+  // sorted-set indexed items: item key gets native TTL; optional index member is scored by the same
+  // deadline and pruned on write.
+  setIndexedItemWithExpiry: (arg: {
+    indexKey: string;
+    member: string;
+    itemKey: string;
+    value: string;
+    expiryInSeconds: number;
+    indexed: boolean;
+  }) => Promise<void>;
+  deleteIndexedItems: (arg: { indexKey: string; members: string[]; itemKeys: string[] }) => Promise<void>;
+  sortedSetRangeByScore: (key: string, min: string | number, max: string | number) => Promise<string[]>;
+  sortedSetMembersPrimary: (key: string) => Promise<string[]>;
   // pg
   pgIncrementBy: (key: string, dto: { incr?: number; expiry?: string; tx?: Knex }) => Promise<number>;
   pgGetIntItem: (key: string, prefix?: string) => Promise<number | undefined>;
@@ -537,100 +551,78 @@ export const keyStoreFactory = (
 
   const hashGetAllPrimary = async (key: string) => primaryRedis.hgetall(key);
 
-  // A hash carries one TTL for the whole key, so the expiry can only ever grow: shortening it would
-  // drop sibling fields that are still live. Callers stamp each field with its own deadline instead.
-  // HSET and EXPIRE go in one script so a crash between them cannot strand the hash without a TTL.
-  //
-  // Redis cannot expire an individual field, so a hash keyed by caller-supplied slugs would grow
-  // until the whole key expires. Fields past their own deadline are reaped here, but only once the
-  // hash is big enough to be worth walking, so the common one-or-two-field case pays nothing.
-  //
-  // The reap walks one bounded HSCAN slice, never the whole hash.
-  const HASH_SET_FIELD_WITH_MIN_EXPIRY = `
-    redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+  // KEYS[1] indexKey (ZSET), KEYS[2] itemKey (payload string).
+  // ARGV[1] member, ARGV[2] value, ARGV[3] expiryInSeconds, ARGV[4] expiresAt score (ms),
+  // ARGV[5] indexed ('1' | '0'), ARGV[6] now (ms, stale-index prune cutoff).
+  const INDEXED_ITEM_UPSERT = `
+    redis.call('SET', KEYS[2], ARGV[2], 'EX', ARGV[3])
 
-    local current = redis.call('TTL', KEYS[1])
-    local wanted = tonumber(ARGV[3])
-    if current < 0 or current < wanted then
-      redis.call('EXPIRE', KEYS[1], wanted)
+    if ARGV[5] == '1' then
+      redis.call('ZADD', KEYS[1], ARGV[4], ARGV[1])
+    else
+      redis.call('ZREM', KEYS[1], ARGV[1])
     end
 
-    if redis.call('HLEN', KEYS[1]) > tonumber(ARGV[5]) then
-      local now = tonumber(ARGV[4])
-      local batch = tonumber(ARGV[6])
-      -- Resume where the last reap stopped. A fixed start rescans one segment forever: it drains
-      -- that segment and then returns the same live fields on every write, leaving everything
-      -- outside it resident until the key's TTL. The cursor lives in the hash it describes so it
-      -- shares that TTL and needs no separate key; it carries no ':' so every reader of these
-      -- fields already skips it.
-      local cursorField = '__reap_cursor'
-      local position = tonumber(redis.call('HGET', KEYS[1], cursorField) or '0') or 0
+    redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[6])
 
-      local scanned = redis.call('HSCAN', KEYS[1], position, 'COUNT', batch)
-      local entries = scanned[2]
-      local total = #entries / 2
-
-      if total > 0 then
-        local take = math.min(total, batch)
-        local offset = 0
-        local nextPosition = tonumber(scanned[1])
-
-        local listpack = total > batch
-        if listpack then
-          -- A listpack-encoded hash ignores both the cursor and COUNT and returns every field, so
-          -- HSCAN cannot advance on its own and the window has to be tracked by hand.
-          offset = position % total
-        end
-
-        local kept = 0
-        for n = 0, take - 1 do
-          local i = math.floor((offset + n) % total) * 2 + 1
-          local name = entries[i]
-          local reaped = false
-
-          if name ~= ARGV[1] and name ~= cursorField then
-            local ok, parsed = pcall(cjson.decode, entries[i + 1])
-            if ok and type(parsed) == 'table' and type(parsed.expiresAt) == 'number' and parsed.expiresAt <= now then
-              redis.call('HDEL', KEYS[1], name)
-              reaped = true
-            end
-          end
-
-          if not reaped then kept = kept + 1 end
-        end
-
-        if listpack then
-          nextPosition = position + kept
-        end
-
-        redis.call('HSET', KEYS[1], cursorField, nextPosition)
+    if redis.call('ZCARD', KEYS[1]) == 0 then
+      redis.call('DEL', KEYS[1])
+    else
+      local current = redis.call('TTL', KEYS[1])
+      local wanted = tonumber(ARGV[3])
+      if current < 0 or current < wanted then
+        redis.call('EXPIRE', KEYS[1], wanted)
       end
     end
 
     return 1
   `;
 
-  const HASH_FIELD_REAP_THRESHOLD = 50;
-  const HASH_FIELD_REAP_BATCH = 64;
-
-  const hashSetFieldWithMinExpiry = async (key: string, field: string, value: string, expiryInSeconds: number) => {
+  const setIndexedItemWithExpiry: TKeyStoreFactory["setIndexedItemWithExpiry"] = async ({
+    indexKey,
+    member,
+    itemKey,
+    value,
+    expiryInSeconds,
+    indexed
+  }) => {
+    const now = Date.now();
     await primaryRedis.eval(
-      HASH_SET_FIELD_WITH_MIN_EXPIRY,
-      1,
-      key,
-      field,
+      INDEXED_ITEM_UPSERT,
+      2,
+      indexKey,
+      itemKey,
+      member,
       value,
       String(expiryInSeconds),
-      String(Date.now()),
-      String(HASH_FIELD_REAP_THRESHOLD),
-      String(HASH_FIELD_REAP_BATCH)
+      String(now + expiryInSeconds * 1000),
+      indexed ? "1" : "0",
+      String(now)
     );
   };
 
-  const hashDeleteFields = async (key: string, fields: string[]) => {
-    if (!fields.length) return 0;
-    return primaryRedis.hdel(key, ...fields);
+  const DELETE_INDEXED_ITEMS = `
+    for i = 1, #ARGV do
+      redis.call('ZREM', KEYS[1], ARGV[i])
+    end
+    for i = 2, #KEYS do
+      redis.call('DEL', KEYS[i])
+    end
+    if redis.call('ZCARD', KEYS[1]) == 0 then
+      redis.call('DEL', KEYS[1])
+    end
+    return 1
+  `;
+
+  const deleteIndexedItems: TKeyStoreFactory["deleteIndexedItems"] = async ({ indexKey, members, itemKeys }) => {
+    if (!members.length && !itemKeys.length) return;
+    await primaryRedis.eval(DELETE_INDEXED_ITEMS, itemKeys.length + 1, indexKey, ...itemKeys, ...members);
   };
+
+  const sortedSetRangeByScore = async (key: string, min: string | number, max: string | number) =>
+    pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas).zrangebyscore(key, min, max);
+
+  const sortedSetMembersPrimary = async (key: string) => primaryRedis.zrange(key, 0, -1);
 
   // List operations
   const listPush = async (key: string, value: string) => primaryRedis.rpush(key, value);
@@ -760,8 +752,10 @@ export const keyStoreFactory = (
     hashGet,
     hashGetAll,
     hashGetAllPrimary,
-    hashSetFieldWithMinExpiry,
-    hashDeleteFields,
+    setIndexedItemWithExpiry,
+    deleteIndexedItems,
+    sortedSetRangeByScore,
+    sortedSetMembersPrimary,
     listPush,
     listRange,
     listRemove,

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -544,6 +544,8 @@ export const keyStoreFactory = (
   // Redis cannot expire an individual field, so a hash keyed by caller-supplied slugs would grow
   // until the whole key expires. Fields past their own deadline are reaped here, but only once the
   // hash is big enough to be worth walking, so the common one-or-two-field case pays nothing.
+  //
+  // The reap walks one bounded HSCAN slice, never the whole hash.
   const HASH_SET_FIELD_WITH_MIN_EXPIRY = `
     redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
 
@@ -555,8 +557,13 @@ export const keyStoreFactory = (
 
     if redis.call('HLEN', KEYS[1]) > tonumber(ARGV[5]) then
       local now = tonumber(ARGV[4])
-      local entries = redis.call('HGETALL', KEYS[1])
-      for i = 1, #entries, 2 do
+      local batch = tonumber(ARGV[6])
+      local scanned = redis.call('HSCAN', KEYS[1], '0', 'COUNT', batch)
+      local entries = scanned[2]
+      -- COUNT is only a hint, and a listpack-encoded hash ignores it and returns every field, so the
+      -- loop is what actually bounds the decoding.
+      local limit = math.min(#entries, batch * 2)
+      for i = 1, limit, 2 do
         if entries[i] ~= ARGV[1] then
           local ok, parsed = pcall(cjson.decode, entries[i + 1])
           if ok and type(parsed) == 'table' and type(parsed.expiresAt) == 'number' and parsed.expiresAt <= now then
@@ -570,6 +577,7 @@ export const keyStoreFactory = (
   `;
 
   const HASH_FIELD_REAP_THRESHOLD = 50;
+  const HASH_FIELD_REAP_BATCH = 64;
 
   const hashSetFieldWithMinExpiry = async (key: string, field: string, value: string, expiryInSeconds: number) => {
     await primaryRedis.eval(
@@ -580,7 +588,8 @@ export const keyStoreFactory = (
       value,
       String(expiryInSeconds),
       String(Date.now()),
-      String(HASH_FIELD_REAP_THRESHOLD)
+      String(HASH_FIELD_REAP_THRESHOLD),
+      String(HASH_FIELD_REAP_BATCH)
     );
   };
 

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -558,18 +558,52 @@ export const keyStoreFactory = (
     if redis.call('HLEN', KEYS[1]) > tonumber(ARGV[5]) then
       local now = tonumber(ARGV[4])
       local batch = tonumber(ARGV[6])
-      local scanned = redis.call('HSCAN', KEYS[1], '0', 'COUNT', batch)
+      -- Resume where the last reap stopped. A fixed start rescans one segment forever: it drains
+      -- that segment and then returns the same live fields on every write, leaving everything
+      -- outside it resident until the key's TTL. The cursor lives in the hash it describes so it
+      -- shares that TTL and needs no separate key; it carries no ':' so every reader of these
+      -- fields already skips it.
+      local cursorField = '__reap_cursor'
+      local position = tonumber(redis.call('HGET', KEYS[1], cursorField) or '0') or 0
+
+      local scanned = redis.call('HSCAN', KEYS[1], position, 'COUNT', batch)
       local entries = scanned[2]
-      -- COUNT is only a hint, and a listpack-encoded hash ignores it and returns every field, so the
-      -- loop is what actually bounds the decoding.
-      local limit = math.min(#entries, batch * 2)
-      for i = 1, limit, 2 do
-        if entries[i] ~= ARGV[1] then
-          local ok, parsed = pcall(cjson.decode, entries[i + 1])
-          if ok and type(parsed) == 'table' and type(parsed.expiresAt) == 'number' and parsed.expiresAt <= now then
-            redis.call('HDEL', KEYS[1], entries[i])
-          end
+      local total = #entries / 2
+
+      if total > 0 then
+        local take = math.min(total, batch)
+        local offset = 0
+        local nextPosition = tonumber(scanned[1])
+
+        local listpack = total > batch
+        if listpack then
+          -- A listpack-encoded hash ignores both the cursor and COUNT and returns every field, so
+          -- HSCAN cannot advance on its own and the window has to be tracked by hand.
+          offset = position % total
         end
+
+        local kept = 0
+        for n = 0, take - 1 do
+          local i = math.floor((offset + n) % total) * 2 + 1
+          local name = entries[i]
+          local reaped = false
+
+          if name ~= ARGV[1] and name ~= cursorField then
+            local ok, parsed = pcall(cjson.decode, entries[i + 1])
+            if ok and type(parsed) == 'table' and type(parsed.expiresAt) == 'number' and parsed.expiresAt <= now then
+              redis.call('HDEL', KEYS[1], name)
+              reaped = true
+            end
+          end
+
+          if not reaped then kept = kept + 1 end
+        end
+
+        if listpack then
+          nextPosition = position + kept
+        end
+
+        redis.call('HSET', KEYS[1], cursorField, nextPosition)
       end
     end
 

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -163,11 +163,8 @@ export const KeyStorePrefixes = {
   LicenseUsageReconcileMarker: (orgId: string) => `license-usage-reconcile-${orgId}` as const,
   LicenseUsageLastReported: (orgId: string, featureKey: string) =>
     `license-usage-last-reported-${orgId}-${featureKey}` as const,
-  IdentityLockoutState: (identityId: string, authMethod: string, slug: string) =>
-    `lockout:identity:${identityId}:${authMethod}:${slug}` as const,
-  IdentityLockoutStateByMethodPattern: (identityId: string, authMethod: string) =>
-    `lockout:identity:${identityId}:${authMethod}:*` as const,
-  IdentityLockoutStatePattern: (identityId: string) => `lockout:identity:${identityId}:*` as const,
+  IdentityLockoutStateHash: (identityId: string) => `lockout:identity:${identityId}` as const,
+  IdentityLockoutStateField: (authMethod: string, slug: string) => `${authMethod}:${slug}` as const,
 
   TelemetryAggregatedEventStream: (event: string, bucketId: string) =>
     `telemetry-agg-stream:${event}:${bucketId}` as const,
@@ -306,6 +303,10 @@ export type TKeyStoreFactory = {
   // hash operations
   hashSet: (key: string, field: string, value: string) => Promise<number>;
   hashGet: (key: string, field: string) => Promise<string | null>;
+  hashGetAll: (key: string) => Promise<Record<string, string>>;
+  hashGetAllPrimary: (key: string) => Promise<Record<string, string>>;
+  hashSetFieldWithMinExpiry: (key: string, field: string, value: string, expiryInSeconds: number) => Promise<void>;
+  hashDeleteFields: (key: string, fields: string[]) => Promise<number>;
   // pg
   pgIncrementBy: (key: string, dto: { incr?: number; expiry?: string; tx?: Knex }) => Promise<number>;
   pgGetIntItem: (key: string, prefix?: string) => Promise<number | undefined>;
@@ -532,6 +533,62 @@ export const keyStoreFactory = (
 
   const hashGet = async (key: string, field: string) => primaryRedis.hget(key, field);
 
+  const hashGetAll = async (key: string) => pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas).hgetall(key);
+
+  const hashGetAllPrimary = async (key: string) => primaryRedis.hgetall(key);
+
+  // A hash carries one TTL for the whole key, so the expiry can only ever grow: shortening it would
+  // drop sibling fields that are still live. Callers stamp each field with its own deadline instead.
+  // HSET and EXPIRE go in one script so a crash between them cannot strand the hash without a TTL.
+  //
+  // Redis cannot expire an individual field, so a hash keyed by caller-supplied slugs would grow
+  // until the whole key expires. Fields past their own deadline are reaped here, but only once the
+  // hash is big enough to be worth walking, so the common one-or-two-field case pays nothing.
+  const HASH_SET_FIELD_WITH_MIN_EXPIRY = `
+    redis.call('HSET', KEYS[1], ARGV[1], ARGV[2])
+
+    local current = redis.call('TTL', KEYS[1])
+    local wanted = tonumber(ARGV[3])
+    if current < 0 or current < wanted then
+      redis.call('EXPIRE', KEYS[1], wanted)
+    end
+
+    if redis.call('HLEN', KEYS[1]) > tonumber(ARGV[5]) then
+      local now = tonumber(ARGV[4])
+      local entries = redis.call('HGETALL', KEYS[1])
+      for i = 1, #entries, 2 do
+        if entries[i] ~= ARGV[1] then
+          local ok, parsed = pcall(cjson.decode, entries[i + 1])
+          if ok and type(parsed) == 'table' and type(parsed.expiresAt) == 'number' and parsed.expiresAt <= now then
+            redis.call('HDEL', KEYS[1], entries[i])
+          end
+        end
+      end
+    end
+
+    return 1
+  `;
+
+  const HASH_FIELD_REAP_THRESHOLD = 50;
+
+  const hashSetFieldWithMinExpiry = async (key: string, field: string, value: string, expiryInSeconds: number) => {
+    await primaryRedis.eval(
+      HASH_SET_FIELD_WITH_MIN_EXPIRY,
+      1,
+      key,
+      field,
+      value,
+      String(expiryInSeconds),
+      String(Date.now()),
+      String(HASH_FIELD_REAP_THRESHOLD)
+    );
+  };
+
+  const hashDeleteFields = async (key: string, fields: string[]) => {
+    if (!fields.length) return 0;
+    return primaryRedis.hdel(key, ...fields);
+  };
+
   // List operations
   const listPush = async (key: string, value: string) => primaryRedis.rpush(key, value);
 
@@ -658,6 +715,10 @@ export const keyStoreFactory = (
     pgIncrementBy,
     hashSet,
     hashGet,
+    hashGetAll,
+    hashGetAllPrimary,
+    hashSetFieldWithMinExpiry,
+    hashDeleteFields,
     listPush,
     listRange,
     listRemove,

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -164,9 +164,9 @@ export const KeyStorePrefixes = {
   LicenseUsageLastReported: (orgId: string, featureKey: string) =>
     `license-usage-last-reported-${orgId}-${featureKey}` as const,
   IdentityLockoutState: (identityId: string, authMethod: string, slug: string) =>
-    `lockout:identity:${identityId}:${authMethod}:${slug}` as const,
+    `lockout:identity:{${identityId}}:${authMethod}:${slug}` as const,
   // Sorted set of the identity's *locked* auth methods, scored by when each lockout ends.
-  IdentityLockoutIndex: (identityId: string) => `lockout:identity:${identityId}` as const,
+  IdentityLockoutIndex: (identityId: string) => `lockout:identity:{${identityId}}` as const,
   IdentityLockoutMember: (authMethod: string, slug: string) => `${authMethod}:${slug}` as const,
 
   TelemetryAggregatedEventStream: (event: string, bucketId: string) =>
@@ -306,8 +306,6 @@ export type TKeyStoreFactory = {
   // hash operations
   hashSet: (key: string, field: string, value: string) => Promise<number>;
   hashGet: (key: string, field: string) => Promise<string | null>;
-  hashGetAll: (key: string) => Promise<Record<string, string>>;
-  hashGetAllPrimary: (key: string) => Promise<Record<string, string>>;
   // sorted-set indexed items: item key gets native TTL; optional index member is scored by the same
   // deadline and pruned on write.
   setIndexedItemWithExpiry: (arg: {
@@ -547,10 +545,6 @@ export const keyStoreFactory = (
 
   const hashGet = async (key: string, field: string) => primaryRedis.hget(key, field);
 
-  const hashGetAll = async (key: string) => pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas).hgetall(key);
-
-  const hashGetAllPrimary = async (key: string) => primaryRedis.hgetall(key);
-
   // KEYS[1] indexKey (ZSET), KEYS[2] itemKey (payload string).
   // ARGV[1] member, ARGV[2] value, ARGV[3] expiryInSeconds, ARGV[4] expiresAt score (ms),
   // ARGV[5] indexed ('1' | '0'), ARGV[6] now (ms, stale-index prune cutoff).
@@ -750,8 +744,6 @@ export const keyStoreFactory = (
     pgIncrementBy,
     hashSet,
     hashGet,
-    hashGetAll,
-    hashGetAllPrimary,
     setIndexedItemWithExpiry,
     deleteIndexedItems,
     sortedSetRangeByScore,

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -84,12 +84,6 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     hashGet: async (key, field) => {
       return hashStore[key]?.[field] ?? null;
     },
-    hashGetAll: async (key) => {
-      return { ...(hashStore[key] ?? {}) };
-    },
-    hashGetAllPrimary: async (key) => {
-      return { ...(hashStore[key] ?? {}) };
-    },
     setIndexedItemWithExpiry: async ({ indexKey, member, itemKey, value, expiryInSeconds, indexed }) => {
       store[itemKey] = value;
       if (!sortedSetStore[indexKey]) sortedSetStore[indexKey] = {};

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -83,6 +83,29 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     hashGet: async (key, field) => {
       return hashStore[key]?.[field] ?? null;
     },
+    hashGetAll: async (key) => {
+      return { ...(hashStore[key] ?? {}) };
+    },
+    hashGetAllPrimary: async (key) => {
+      return { ...(hashStore[key] ?? {}) };
+    },
+    hashSetFieldWithMinExpiry: async (key, field, value) => {
+      if (!hashStore[key]) hashStore[key] = {};
+      hashStore[key][field] = value;
+    },
+    hashDeleteFields: async (key, fields) => {
+      const hash = hashStore[key];
+      if (!hash) return 0;
+
+      let deleted = 0;
+      fields.forEach((field) => {
+        if (field in hash) {
+          delete hash[field];
+          deleted += 1;
+        }
+      });
+      return deleted;
+    },
     pgIncrementBy: async () => {
       return 1;
     },

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -10,6 +10,7 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
   const store: Record<string, string | number | Buffer> = {};
   const listStore: Record<string, string[]> = {};
   const hashStore: Record<string, Record<string, string>> = {};
+  const sortedSetStore: Record<string, Record<string, number>> = {};
   const getRegex = (pattern: string) =>
     new RE2(`^${pattern.replace(/[-[\]/{}()+?.\\^$|]/g, "\\$&").replace(/\*/g, ".*")}$`);
 
@@ -89,22 +90,31 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
     hashGetAllPrimary: async (key) => {
       return { ...(hashStore[key] ?? {}) };
     },
-    hashSetFieldWithMinExpiry: async (key, field, value) => {
-      if (!hashStore[key]) hashStore[key] = {};
-      hashStore[key][field] = value;
+    setIndexedItemWithExpiry: async ({ indexKey, member, itemKey, value, expiryInSeconds, indexed }) => {
+      store[itemKey] = value;
+      if (!sortedSetStore[indexKey]) sortedSetStore[indexKey] = {};
+      if (indexed) {
+        sortedSetStore[indexKey][member] = Date.now() + expiryInSeconds * 1000;
+      } else {
+        delete sortedSetStore[indexKey][member];
+      }
     },
-    hashDeleteFields: async (key, fields) => {
-      const hash = hashStore[key];
-      if (!hash) return 0;
-
-      let deleted = 0;
-      fields.forEach((field) => {
-        if (field in hash) {
-          delete hash[field];
-          deleted += 1;
-        }
-      });
-      return deleted;
+    deleteIndexedItems: async ({ indexKey, members, itemKeys }) => {
+      itemKeys.forEach((key) => delete store[key]);
+      members.forEach((member) => delete sortedSetStore[indexKey]?.[member]);
+    },
+    sortedSetRangeByScore: async (key, min, max) => {
+      const lower = min === "-inf" ? -Infinity : Number(min);
+      const upper = max === "+inf" ? Infinity : Number(max);
+      return Object.entries(sortedSetStore[key] ?? {})
+        .filter(([, score]) => score >= lower && score <= upper)
+        .sort(([, a], [, b]) => a - b)
+        .map(([member]) => member);
+    },
+    sortedSetMembersPrimary: async (key) => {
+      return Object.entries(sortedSetStore[key] ?? {})
+        .sort(([, a], [, b]) => a - b)
+        .map(([member]) => member);
     },
     pgIncrementBy: async () => {
       return 1;

--- a/backend/src/server/routes/v1/identity-ldap-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-ldap-auth-router.ts
@@ -155,8 +155,18 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
       description: "Login with LDAP Auth for machine identity",
       body: z.object({
         identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.LOGIN.identityId),
-        username: z.string().trim().nonempty("Username is required").describe(LDAP_AUTH.LOGIN.username),
-        password: z.string().trim().nonempty("Password is required").describe(LDAP_AUTH.LOGIN.password),
+        username: z
+          .string()
+          .trim()
+          .nonempty("Username is required")
+          .max(255, "Username cannot be longer than 255 characters")
+          .describe(LDAP_AUTH.LOGIN.username),
+        password: z
+          .string()
+          .trim()
+          .nonempty("Password is required")
+          .max(1024, "Password cannot be longer than 1024 characters")
+          .describe(LDAP_AUTH.LOGIN.password),
         organizationSlug: slugSchema().optional().describe(LDAP_AUTH.LOGIN.organizationSlug)
       }),
       response: {

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -85,10 +85,10 @@ type TIdentityLdapAuthServiceFactoryDep = {
   keyStore: Pick<
     TKeyStoreFactory,
     | "setItemWithExpiryNX"
-    | "hashGet"
-    | "hashGetAllPrimary"
-    | "hashSetFieldWithMinExpiry"
-    | "hashDeleteFields"
+    | "getItem"
+    | "setIndexedItemWithExpiry"
+    | "deleteIndexedItems"
+    | "sortedSetMembersPrimary"
     | "acquireLock"
   >;
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -85,7 +85,7 @@ type TIdentityLdapAuthServiceFactoryDep = {
   keyStore: Pick<
     TKeyStoreFactory,
     | "setItemWithExpiryNX"
-    | "getItem"
+    | "getItemPrimary"
     | "setIndexedItemWithExpiry"
     | "deleteIndexedItems"
     | "sortedSetMembersPrimary"

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -18,7 +18,7 @@ import {
 } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionIdentityActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
-import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
+import { TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
 import {
   BadRequestError,
@@ -43,6 +43,13 @@ import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 
 import { ActorType } from "../auth/auth-type";
 import { TIdentityDALFactory } from "../identity/identity-dal";
+import {
+  clearIdentityLockoutsForAuthMethod,
+  clearIdentityLockoutState,
+  getIdentityLockoutState,
+  identityLockoutLockKey,
+  persistIdentityLockoutState
+} from "../identity/identity-fns";
 import { TIdentityAccessTokenDALFactory } from "../identity-access-token/identity-access-token-dal";
 import { TIdentityAccessTokenServiceFactory } from "../identity-access-token/identity-access-token-service";
 import { TKmsServiceFactory } from "../kms/kms-service";
@@ -77,12 +84,11 @@ type TIdentityLdapAuthServiceFactoryDep = {
   identityAuthTemplateDAL: TIdentityAuthTemplateDALFactory;
   keyStore: Pick<
     TKeyStoreFactory,
-    | "setItemWithExpiry"
     | "setItemWithExpiryNX"
-    | "getItem"
-    | "deleteItem"
-    | "getKeysByPattern"
-    | "deleteItems"
+    | "hashGet"
+    | "hashGetAllPrimary"
+    | "hashSetFieldWithMinExpiry"
+    | "hashDeleteFields"
     | "acquireLock"
   >;
   orgDAL: Pick<TOrgDALFactory, "findById" | "findOne" | "findEffectiveOrgMembership">;
@@ -93,11 +99,6 @@ type TIdentityLdapAuthServiceFactoryDep = {
 };
 
 export type TIdentityLdapAuthServiceFactory = ReturnType<typeof identityLdapAuthServiceFactory>;
-
-type LockoutObject = {
-  lockedOut: boolean;
-  failedAttempts: number;
-};
 
 export const identityLdapAuthServiceFactory = ({
   identityAccessTokenDAL,
@@ -909,14 +910,9 @@ export const identityLdapAuthServiceFactory = ({
     );
     const orgId = identity?.orgId ?? null;
 
-    const lockoutKey = KeyStorePrefixes.IdentityLockoutState(identityId, IdentityAuthMethod.LDAP_AUTH, usernameSlug);
+    const lockoutSelector = { identityId, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: usernameSlug };
 
-    const lockoutRaw = await keyStore.getItem(lockoutKey);
-
-    let lockout: LockoutObject | undefined;
-    if (lockoutRaw) {
-      lockout = JSON.parse(lockoutRaw) as LockoutObject;
-    }
+    let lockout = await getIdentityLockoutState(lockoutSelector, keyStore);
 
     const identityLdapAuth = await identityLdapAuthDAL.findOne({ identityId });
     if (!identityLdapAuth) {
@@ -938,7 +934,7 @@ export const identityLdapAuthServiceFactory = ({
 
       // If auth succeeds, clear any existing lockout
       if (lockout) {
-        await keyStore.deleteItem(lockoutKey);
+        await clearIdentityLockoutState(lockoutSelector, keyStore);
       }
 
       return result;
@@ -948,22 +944,21 @@ export const identityLdapAuthServiceFactory = ({
         if (identityLdapAuth.lockoutEnabled) {
           let lock: Awaited<ReturnType<typeof keyStore.acquireLock>> | undefined;
           try {
-            lock = await keyStore.acquireLock([KeyStorePrefixes.IdentityLockoutLock(lockoutKey)], 500, {
-              retryCount: 10,
-              retryDelay: 300,
-              retryJitter: 100
-            });
+            lock = await keyStore.acquireLock(
+              [identityLockoutLockKey(identityId, IdentityAuthMethod.LDAP_AUTH, usernameSlug)],
+              500,
+              {
+                retryCount: 10,
+                retryDelay: 300,
+                retryJitter: 100
+              }
+            );
 
             // Re-fetch the latest lockout data while holding the lock
-            const lockoutRawNew = await keyStore.getItem(lockoutKey);
-            if (lockoutRawNew) {
-              lockout = JSON.parse(lockoutRawNew) as LockoutObject;
-            } else {
-              lockout = {
-                lockedOut: false,
-                failedAttempts: 0
-              };
-            }
+            lockout = (await getIdentityLockoutState(lockoutSelector, keyStore)) ?? {
+              lockedOut: false,
+              failedAttempts: 0
+            };
 
             if (lockout.lockedOut) {
               throw new UnauthorizedError({
@@ -977,10 +972,15 @@ export const identityLdapAuthServiceFactory = ({
               lockout.lockedOut = true;
             }
 
-            await keyStore.setItemWithExpiry(
-              lockoutKey,
-              lockout.lockedOut ? identityLdapAuth.lockoutDurationSeconds : identityLdapAuth.lockoutCounterResetSeconds,
-              JSON.stringify(lockout)
+            await persistIdentityLockoutState(
+              {
+                ...lockoutSelector,
+                expiryInSeconds: lockout.lockedOut
+                  ? identityLdapAuth.lockoutDurationSeconds
+                  : identityLdapAuth.lockoutCounterResetSeconds
+              },
+              lockout,
+              keyStore
             );
           } catch (e) {
             if (lock === undefined) {
@@ -1058,9 +1058,7 @@ export const identityLdapAuthServiceFactory = ({
       ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
     }
 
-    const deleted = await keyStore.deleteItems({
-      pattern: KeyStorePrefixes.IdentityLockoutStateByMethodPattern(identityId, IdentityAuthMethod.LDAP_AUTH)
-    });
+    const deleted = await clearIdentityLockoutsForAuthMethod(identityId, IdentityAuthMethod.LDAP_AUTH, keyStore);
 
     return { deleted, identityId, orgId: identityMembershipOrg.scopeOrgId };
   };

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -35,6 +35,13 @@ import {
 
 import { ActorType } from "../auth/auth-type";
 import { TIdentityDALFactory } from "../identity/identity-dal";
+import {
+  clearIdentityLockoutsForAuthMethod,
+  clearIdentityLockoutState,
+  getIdentityLockoutState,
+  identityLockoutLockKey,
+  persistIdentityLockoutState
+} from "../identity/identity-fns";
 import { TIdentityAccessTokenServiceFactory } from "../identity-access-token/identity-access-token-service";
 import { TMembershipIdentityDALFactory } from "../membership-identity/membership-identity-dal";
 import { recordIdentityLastLogin, shouldRecordIdentityLastLogin } from "../membership-identity/membership-identity-fns";
@@ -72,22 +79,16 @@ type TIdentityUaServiceFactoryDep = {
   >;
   keyStore: Pick<
     TKeyStoreFactory,
-    | "setItemWithExpiry"
     | "setItemWithExpiryNX"
-    | "getItem"
-    | "deleteItem"
-    | "getKeysByPattern"
-    | "deleteItems"
+    | "hashGet"
+    | "hashGetAllPrimary"
+    | "hashSetFieldWithMinExpiry"
+    | "hashDeleteFields"
     | "acquireLock"
   >;
 };
 
 export type TIdentityUaServiceFactory = ReturnType<typeof identityUaServiceFactory>;
-
-type LockoutObject = {
-  lockedOut: boolean;
-  failedAttempts: number;
-};
 
 // debounce per-secret usage writes so login bursts on one unlimited secret don't pile up on its row lock
 const UA_CLIENT_SECRET_USAGE_DEBOUNCE_SECONDS = 10;
@@ -131,18 +132,13 @@ export const identityUaServiceFactory = ({
         trustedIps: identityUa.clientSecretTrustedIps as TIp[]
       });
 
-      const lockoutKey = KeyStorePrefixes.IdentityLockoutState(
-        identityUa.identityId,
-        IdentityAuthMethod.UNIVERSAL_AUTH,
-        clientId
-      );
+      const lockoutSelector = {
+        identityId: identityUa.identityId,
+        authMethod: IdentityAuthMethod.UNIVERSAL_AUTH,
+        slug: clientId
+      };
 
-      const lockoutRaw = await keyStore.getItem(lockoutKey);
-
-      let lockout: LockoutObject | undefined;
-      if (lockoutRaw) {
-        lockout = JSON.parse(lockoutRaw) as LockoutObject;
-      }
+      let lockout = await getIdentityLockoutState(lockoutSelector, keyStore);
 
       if (lockout && lockout.lockedOut && identityUa.lockoutEnabled) {
         throw new UnauthorizedError({
@@ -177,22 +173,21 @@ export const identityUaServiceFactory = ({
         if (identityUa.lockoutEnabled) {
           let lock: Awaited<ReturnType<typeof keyStore.acquireLock>> | undefined;
           try {
-            lock = await keyStore.acquireLock([KeyStorePrefixes.IdentityLockoutLock(lockoutKey)], 300, {
-              retryCount: 3,
-              retryDelay: 300,
-              retryJitter: 100
-            });
+            lock = await keyStore.acquireLock(
+              [identityLockoutLockKey(identityUa.identityId, IdentityAuthMethod.UNIVERSAL_AUTH, clientId)],
+              300,
+              {
+                retryCount: 3,
+                retryDelay: 300,
+                retryJitter: 100
+              }
+            );
 
             // Re-fetch the latest lockout data while holding the lock
-            const lockoutRawNew = await keyStore.getItem(lockoutKey);
-            if (lockoutRawNew) {
-              lockout = JSON.parse(lockoutRawNew) as LockoutObject;
-            } else {
-              lockout = {
-                lockedOut: false,
-                failedAttempts: 0
-              };
-            }
+            lockout = (await getIdentityLockoutState(lockoutSelector, keyStore)) ?? {
+              lockedOut: false,
+              failedAttempts: 0
+            };
 
             if (lockout.lockedOut) {
               throw new UnauthorizedError({
@@ -211,10 +206,15 @@ export const identityUaServiceFactory = ({
               lockout.lockedOut = true;
             }
 
-            await keyStore.setItemWithExpiry(
-              lockoutKey,
-              lockout.lockedOut ? identityUa.lockoutDurationSeconds : identityUa.lockoutCounterResetSeconds,
-              JSON.stringify(lockout)
+            await persistIdentityLockoutState(
+              {
+                ...lockoutSelector,
+                expiryInSeconds: lockout.lockedOut
+                  ? identityUa.lockoutDurationSeconds
+                  : identityUa.lockoutCounterResetSeconds
+              },
+              lockout,
+              keyStore
             );
           } catch (e) {
             if (lock === undefined) {
@@ -242,7 +242,7 @@ export const identityUaServiceFactory = ({
         });
       } else if (lockout) {
         // If credentials are valid, clear any existing lockout record
-        await keyStore.deleteItem(lockoutKey);
+        await clearIdentityLockoutState(lockoutSelector, keyStore);
       }
 
       const { clientSecretTTL, clientSecretNumUses, clientSecretNumUsesLimit } = validClientSecretInfo;
@@ -1300,9 +1300,7 @@ export const identityUaServiceFactory = ({
 
     await validateIdentityUpdateForSuperAdminPrivileges(identityId, isActorSuperAdmin);
 
-    const deleted = await keyStore.deleteItems({
-      pattern: KeyStorePrefixes.IdentityLockoutStateByMethodPattern(identityId, IdentityAuthMethod.UNIVERSAL_AUTH)
-    });
+    const deleted = await clearIdentityLockoutsForAuthMethod(identityId, IdentityAuthMethod.UNIVERSAL_AUTH, keyStore);
 
     return { deleted, identityId, orgId: identityMembershipOrg.scopeOrgId };
   };

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -80,10 +80,10 @@ type TIdentityUaServiceFactoryDep = {
   keyStore: Pick<
     TKeyStoreFactory,
     | "setItemWithExpiryNX"
-    | "hashGet"
-    | "hashGetAllPrimary"
-    | "hashSetFieldWithMinExpiry"
-    | "hashDeleteFields"
+    | "getItem"
+    | "setIndexedItemWithExpiry"
+    | "deleteIndexedItems"
+    | "sortedSetMembersPrimary"
     | "acquireLock"
   >;
 };

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -80,7 +80,7 @@ type TIdentityUaServiceFactoryDep = {
   keyStore: Pick<
     TKeyStoreFactory,
     | "setItemWithExpiryNX"
-    | "getItem"
+    | "getItemPrimary"
     | "setIndexedItemWithExpiry"
     | "deleteIndexedItems"
     | "sortedSetMembersPrimary"

--- a/backend/src/services/identity-v2/identity-service.test.ts
+++ b/backend/src/services/identity-v2/identity-service.test.ts
@@ -70,7 +70,7 @@ const createService = ({
       insertIdentityWideRevocationMarker: vi.fn().mockResolvedValue(undefined),
       bumpIdentityRevocationVersion: vi.fn().mockResolvedValue(undefined)
     } as never,
-    keyStore: { hashGetAll: vi.fn().mockResolvedValue({}) } as never,
+    keyStore: { sortedSetRangeByScore: vi.fn().mockResolvedValue([]) } as never,
     projectDAL: {
       findActorAccessibleProjectIds: vi.fn(),
       findOrgProjectIds: vi.fn(),

--- a/backend/src/services/identity-v2/identity-service.test.ts
+++ b/backend/src/services/identity-v2/identity-service.test.ts
@@ -70,7 +70,7 @@ const createService = ({
       insertIdentityWideRevocationMarker: vi.fn().mockResolvedValue(undefined),
       bumpIdentityRevocationVersion: vi.fn().mockResolvedValue(undefined)
     } as never,
-    keyStore: { getKeysByPattern: vi.fn(), getItem: vi.fn() } as never,
+    keyStore: { hashGetAll: vi.fn().mockResolvedValue({}) } as never,
     projectDAL: {
       findActorAccessibleProjectIds: vi.fn(),
       findOrgProjectIds: vi.fn(),

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -74,7 +74,7 @@ type TScopedIdentityV2ServiceFactoryDep = {
     TIdentityAccessTokenServiceFactory,
     "insertIdentityWideRevocationMarker" | "bumpIdentityRevocationVersion"
   >;
-  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "hashGetAll">;
   projectDAL: Pick<TProjectDALFactory, "findActorAccessibleProjectIds" | "findOrgProjectIds" | "findById">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   roleDAL: Pick<TRoleDALFactory, "find">;

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -74,7 +74,7 @@ type TScopedIdentityV2ServiceFactoryDep = {
     TIdentityAccessTokenServiceFactory,
     "insertIdentityWideRevocationMarker" | "bumpIdentityRevocationVersion"
   >;
-  keyStore: Pick<TKeyStoreFactory, "hashGetAll">;
+  keyStore: Pick<TKeyStoreFactory, "sortedSetRangeByScore">;
   projectDAL: Pick<TProjectDALFactory, "findActorAccessibleProjectIds" | "findOrgProjectIds" | "findById">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   roleDAL: Pick<TRoleDALFactory, "find">;

--- a/backend/src/services/identity/identity-fns.test.ts
+++ b/backend/src/services/identity/identity-fns.test.ts
@@ -10,123 +10,107 @@ import {
 } from "./identity-fns";
 
 const IDENTITY_ID = "6f7c1b6a-6e6f-4c0e-9f1a-2c2f5b8d9e01";
-const HASH_KEY = KeyStorePrefixes.IdentityLockoutStateHash(IDENTITY_ID);
+const INDEX_KEY = KeyStorePrefixes.IdentityLockoutIndex(IDENTITY_ID);
+const itemKey = (authMethod: string, slug: string) =>
+  KeyStorePrefixes.IdentityLockoutState(IDENTITY_ID, authMethod, slug);
 
-const lockedOut = (expiresAt?: number) => JSON.stringify({ lockedOut: true, failedAttempts: 5, expiresAt });
-const notLockedOut = () => JSON.stringify({ lockedOut: false, failedAttempts: 1 });
-
-const makeKeyStore = (hash: Record<string, string>) => ({
-  hashGetAll: vi.fn().mockResolvedValue(hash),
-  hashGetAllPrimary: vi.fn().mockResolvedValue(hash),
-  hashGet: vi.fn().mockResolvedValue(null),
-  hashDeleteFields: vi.fn().mockResolvedValue(0),
-  hashSetFieldWithMinExpiry: vi.fn().mockResolvedValue(undefined),
-  setItemWithExpiry: vi.fn().mockResolvedValue(undefined),
-  deleteItem: vi.fn().mockResolvedValue(1),
-  deleteItemsByKeyIn: vi.fn().mockResolvedValue(0),
+const makeKeyStore = () => ({
+  getItem: vi.fn().mockResolvedValue(null),
+  setIndexedItemWithExpiry: vi.fn().mockResolvedValue(undefined),
+  deleteIndexedItems: vi.fn().mockResolvedValue(undefined),
+  sortedSetRangeByScore: vi.fn().mockResolvedValue([]),
+  sortedSetMembersPrimary: vi.fn().mockResolvedValue([]),
   getKeysByPattern: vi.fn(),
-  getItem: vi.fn()
-});
-
-describe("getIdentityActiveLockoutAuthMethods", () => {
-  test("returns only the auth methods whose state is locked out", async () => {
-    const keyStore = makeKeyStore({
-      [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut(),
-      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: notLockedOut()
-    });
-
-    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
-      IdentityAuthMethod.UNIVERSAL_AUTH
-    ]);
-    expect(keyStore.hashGetAll).toHaveBeenCalledWith(HASH_KEY);
-  });
-
-  test("never scans the keyspace", async () => {
-    const keyStore = makeKeyStore({ [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut() });
-
-    await getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore);
-
-    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
-    expect(keyStore.getItem).not.toHaveBeenCalled();
-    expect(keyStore.hashGetAll).toHaveBeenCalledTimes(1);
-  });
-
-  test("de-duplicates an auth method locked out under several slugs", async () => {
-    const keyStore = makeKeyStore({
-      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut(),
-      [`${IdentityAuthMethod.LDAP_AUTH}:bob`]: lockedOut()
-    });
-
-    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
-      IdentityAuthMethod.LDAP_AUTH
-    ]);
-  });
-
-  test("returns an empty list for an empty hash and for a missing key", async () => {
-    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, makeKeyStore({}))).resolves.toEqual([]);
-
-    const missing = { ...makeKeyStore({}), hashGetAll: vi.fn().mockResolvedValue(null) };
-    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, missing)).resolves.toEqual([]);
-  });
-
-  test("drops a field whose own deadline has passed", async () => {
-    const keyStore = makeKeyStore({
-      [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut(Date.now() - 1_000),
-      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut(Date.now() + 60_000)
-    });
-
-    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
-      IdentityAuthMethod.LDAP_AUTH
-    ]);
-  });
-
-  test("skips unparseable and malformed fields instead of throwing", async () => {
-    const keyStore = makeKeyStore({
-      "not-a-field": lockedOut(),
-      [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: "{{{",
-      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut()
-    });
-
-    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
-      IdentityAuthMethod.LDAP_AUTH
-    ]);
-  });
+  deleteItems: vi.fn()
 });
 
 describe("getIdentityLockoutState", () => {
   const selector = { identityId: IDENTITY_ID, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a" };
 
-  test("reads the one field it needs, never the whole hash or a string key", async () => {
-    const keyStore = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue(lockedOut()) };
+  test("reads the one key it already knows, and never the index", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.getItem.mockResolvedValue(JSON.stringify({ lockedOut: true, failedAttempts: 3 }));
 
-    await expect(getIdentityLockoutState(selector, keyStore)).resolves.toMatchObject({ lockedOut: true });
-    expect(keyStore.hashGet).toHaveBeenCalledWith(HASH_KEY, `${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`);
-    expect(keyStore.getItem).not.toHaveBeenCalled();
-    expect(keyStore.hashGetAll).not.toHaveBeenCalled();
+    await expect(getIdentityLockoutState(selector, keyStore)).resolves.toEqual({
+      lockedOut: true,
+      failedAttempts: 3
+    });
+    expect(keyStore.getItem).toHaveBeenCalledWith(itemKey(IdentityAuthMethod.UNIVERSAL_AUTH, "client-a"));
+    expect(keyStore.sortedSetRangeByScore).not.toHaveBeenCalled();
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
   });
 
-  test("treats a field past its own deadline as absent", async () => {
-    const keyStore = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue(lockedOut(Date.now() - 1_000)) };
+  test("treats a missing key as no lockout, since the key's TTL is the expiry", async () => {
+    await expect(getIdentityLockoutState(selector, makeKeyStore())).resolves.toBeUndefined();
+  });
+
+  test("treats an unreadable value as no lockout rather than failing the login", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.getItem.mockResolvedValue("{{{");
+
     await expect(getIdentityLockoutState(selector, keyStore)).resolves.toBeUndefined();
   });
+});
 
-  test("keeps a field whose deadline is still ahead", async () => {
-    const keyStore = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue(lockedOut(Date.now() + 60_000)) };
-    await expect(getIdentityLockoutState(selector, keyStore)).resolves.toMatchObject({ lockedOut: true });
+describe("getIdentityActiveLockoutAuthMethods", () => {
+  test("ranges the index by score and reports the methods it names", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.sortedSetRangeByScore.mockResolvedValue([
+      `${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`,
+      `${IdentityAuthMethod.LDAP_AUTH}:alice`
+    ]);
+
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
+      IdentityAuthMethod.UNIVERSAL_AUTH,
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
+
+    const [key, min, max] = keyStore.sortedSetRangeByScore.mock.calls[0] as [string, number, string];
+    expect(key).toBe(INDEX_KEY);
+    expect(max).toBe("+inf");
+    // Filtering by score is what makes a member that outlived its key harmless.
+    expect(min).toBeGreaterThan(0);
   });
 
-  test("returns undefined for a missing or unreadable field", async () => {
-    const missing = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue(null) };
-    await expect(getIdentityLockoutState(selector, missing)).resolves.toBeUndefined();
+  test("reads no item keys at all", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.sortedSetRangeByScore.mockResolvedValue([`${IdentityAuthMethod.LDAP_AUTH}:alice`]);
 
-    const corrupt = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue("{{{") };
-    await expect(getIdentityLockoutState(selector, corrupt)).resolves.toBeUndefined();
+    await getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore);
+
+    expect(keyStore.getItem).not.toHaveBeenCalled();
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+  });
+
+  test("reports a method locked under several slugs once", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.sortedSetRangeByScore.mockResolvedValue([
+      `${IdentityAuthMethod.LDAP_AUTH}:alice`,
+      `${IdentityAuthMethod.LDAP_AUTH}:bob`
+    ]);
+
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
+  });
+
+  test("returns an empty list for an identity with no index", async () => {
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, makeKeyStore())).resolves.toEqual([]);
+  });
+
+  test("ignores a member with no method separator", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.sortedSetRangeByScore.mockResolvedValue(["malformed", `${IdentityAuthMethod.LDAP_AUTH}:alice`]);
+
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
   });
 });
 
 describe("persistIdentityLockoutState", () => {
-  test("writes the hash field only, stamped with its own deadline", async () => {
-    const keyStore = makeKeyStore({});
+  test("indexes a lockout so the list endpoints can see it", async () => {
+    const keyStore = makeKeyStore();
 
     await persistIdentityLockoutState(
       {
@@ -139,79 +123,96 @@ describe("persistIdentityLockoutState", () => {
       keyStore
     );
 
-    const [hashKey, field, payload, hashTtl] = keyStore.hashSetFieldWithMinExpiry.mock.calls[0] as [
-      string,
-      string,
-      string,
-      number
-    ];
+    expect(keyStore.setIndexedItemWithExpiry).toHaveBeenCalledWith({
+      indexKey: INDEX_KEY,
+      member: `${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`,
+      itemKey: itemKey(IdentityAuthMethod.UNIVERSAL_AUTH, "client-a"),
+      value: JSON.stringify({ lockedOut: true, failedAttempts: 3 }),
+      expiryInSeconds: 300,
+      indexed: true
+    });
+  });
 
-    expect(hashKey).toBe(HASH_KEY);
-    expect(field).toBe(`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`);
-    expect(hashTtl).toBe(300);
-    expect(keyStore.setItemWithExpiry).not.toHaveBeenCalled();
+  test("does not index a failure counter", async () => {
+    // The list endpoints have no use for counters, and on LDAP their slug is caller-supplied. Keeping
+    // them out of the index is what stops a username spray from enlarging that read.
+    const keyStore = makeKeyStore();
 
-    const parsed = JSON.parse(payload) as { lockedOut: boolean; failedAttempts: number; expiresAt: number };
-    expect(parsed.lockedOut).toBe(true);
-    expect(parsed.failedAttempts).toBe(3);
-    expect(parsed.expiresAt).toBeGreaterThan(Date.now());
+    await persistIdentityLockoutState(
+      { identityId: IDENTITY_ID, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice", expiryInSeconds: 30 },
+      { lockedOut: false, failedAttempts: 1 },
+      keyStore
+    );
+
+    expect(keyStore.setIndexedItemWithExpiry).toHaveBeenCalledWith(expect.objectContaining({ indexed: false }));
   });
 });
 
 describe("clearIdentityLockoutState", () => {
-  test("removes the hash field and touches no string key", async () => {
-    const keyStore = makeKeyStore({});
+  test("removes the item and its index member together", async () => {
+    const keyStore = makeKeyStore();
 
     await clearIdentityLockoutState(
       { identityId: IDENTITY_ID, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice" },
       keyStore
     );
 
-    expect(keyStore.hashDeleteFields).toHaveBeenCalledWith(HASH_KEY, [`${IdentityAuthMethod.LDAP_AUTH}:alice`]);
-    expect(keyStore.deleteItem).not.toHaveBeenCalled();
+    // Dropping only the item would leave the index reporting a lockout that no longer exists.
+    expect(keyStore.deleteIndexedItems).toHaveBeenCalledWith({
+      indexKey: INDEX_KEY,
+      members: [`${IdentityAuthMethod.LDAP_AUTH}:alice`],
+      itemKeys: [itemKey(IdentityAuthMethod.LDAP_AUTH, "alice")]
+    });
   });
 });
 
 describe("clearIdentityLockoutsForAuthMethod", () => {
-  test("clears only the requested method's fields", async () => {
-    const keyStore = makeKeyStore({
-      [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut(),
-      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut(),
-      [`${IdentityAuthMethod.LDAP_AUTH}:bob`]: notLockedOut()
-    });
-    keyStore.hashDeleteFields.mockResolvedValue(2);
+  test("clears every locked slug for that method and no others", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.sortedSetMembersPrimary.mockResolvedValue([
+      `${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`,
+      `${IdentityAuthMethod.LDAP_AUTH}:alice`,
+      `${IdentityAuthMethod.LDAP_AUTH}:bob`
+    ]);
 
     await expect(clearIdentityLockoutsForAuthMethod(IDENTITY_ID, IdentityAuthMethod.LDAP_AUTH, keyStore)).resolves.toBe(
       2
     );
 
-    expect(keyStore.hashDeleteFields).toHaveBeenCalledWith(HASH_KEY, [
-      `${IdentityAuthMethod.LDAP_AUTH}:alice`,
-      `${IdentityAuthMethod.LDAP_AUTH}:bob`
-    ]);
-    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
-    expect(keyStore.deleteItemsByKeyIn).not.toHaveBeenCalled();
+    expect(keyStore.deleteIndexedItems).toHaveBeenCalledWith({
+      indexKey: INDEX_KEY,
+      members: [`${IdentityAuthMethod.LDAP_AUTH}:alice`, `${IdentityAuthMethod.LDAP_AUTH}:bob`],
+      itemKeys: [itemKey(IdentityAuthMethod.LDAP_AUTH, "alice"), itemKey(IdentityAuthMethod.LDAP_AUTH, "bob")]
+    });
   });
 
   test("decides what to delete from the primary, never a read replica", async () => {
-    // A replica read can lag behind a lockout the primary already holds, and the delete driven off
-    // it would leave that lockout in place after the admin asked to clear it.
-    const keyStore = makeKeyStore({ [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut() });
+    const keyStore = makeKeyStore();
+    keyStore.sortedSetMembersPrimary.mockResolvedValue([`${IdentityAuthMethod.LDAP_AUTH}:alice`]);
 
     await clearIdentityLockoutsForAuthMethod(IDENTITY_ID, IdentityAuthMethod.LDAP_AUTH, keyStore);
 
-    expect(keyStore.hashGetAllPrimary).toHaveBeenCalledWith(HASH_KEY);
-    expect(keyStore.hashGetAll).not.toHaveBeenCalled();
+    expect(keyStore.sortedSetMembersPrimary).toHaveBeenCalledWith(INDEX_KEY);
+    expect(keyStore.sortedSetRangeByScore).not.toHaveBeenCalled();
   });
 
-  test("is a no-op when the identity has no lockouts for that method", async () => {
-    const keyStore = makeKeyStore({ [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut() });
+  test("never scans the keyspace", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.sortedSetMembersPrimary.mockResolvedValue([`${IdentityAuthMethod.LDAP_AUTH}:alice`]);
+
+    await clearIdentityLockoutsForAuthMethod(IDENTITY_ID, IdentityAuthMethod.LDAP_AUTH, keyStore);
+
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+    expect(keyStore.deleteItems).not.toHaveBeenCalled();
+  });
+
+  test("is a no-op when the identity has no lockout for that method", async () => {
+    const keyStore = makeKeyStore();
+    keyStore.sortedSetMembersPrimary.mockResolvedValue([`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]);
 
     await expect(clearIdentityLockoutsForAuthMethod(IDENTITY_ID, IdentityAuthMethod.LDAP_AUTH, keyStore)).resolves.toBe(
       0
     );
-
-    expect(keyStore.deleteItemsByKeyIn).not.toHaveBeenCalled();
-    expect(keyStore.hashDeleteFields).not.toHaveBeenCalled();
+    expect(keyStore.deleteIndexedItems).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/identity/identity-fns.test.ts
+++ b/backend/src/services/identity/identity-fns.test.ts
@@ -1,0 +1,217 @@
+import { IdentityAuthMethod } from "@app/db/schemas";
+import { KeyStorePrefixes } from "@app/keystore/keystore";
+
+import {
+  clearIdentityLockoutsForAuthMethod,
+  clearIdentityLockoutState,
+  getIdentityActiveLockoutAuthMethods,
+  getIdentityLockoutState,
+  persistIdentityLockoutState
+} from "./identity-fns";
+
+const IDENTITY_ID = "6f7c1b6a-6e6f-4c0e-9f1a-2c2f5b8d9e01";
+const HASH_KEY = KeyStorePrefixes.IdentityLockoutStateHash(IDENTITY_ID);
+
+const lockedOut = (expiresAt?: number) => JSON.stringify({ lockedOut: true, failedAttempts: 5, expiresAt });
+const notLockedOut = () => JSON.stringify({ lockedOut: false, failedAttempts: 1 });
+
+const makeKeyStore = (hash: Record<string, string>) => ({
+  hashGetAll: vi.fn().mockResolvedValue(hash),
+  hashGetAllPrimary: vi.fn().mockResolvedValue(hash),
+  hashGet: vi.fn().mockResolvedValue(null),
+  hashDeleteFields: vi.fn().mockResolvedValue(0),
+  hashSetFieldWithMinExpiry: vi.fn().mockResolvedValue(undefined),
+  setItemWithExpiry: vi.fn().mockResolvedValue(undefined),
+  deleteItem: vi.fn().mockResolvedValue(1),
+  deleteItemsByKeyIn: vi.fn().mockResolvedValue(0),
+  getKeysByPattern: vi.fn(),
+  getItem: vi.fn()
+});
+
+describe("getIdentityActiveLockoutAuthMethods", () => {
+  test("returns only the auth methods whose state is locked out", async () => {
+    const keyStore = makeKeyStore({
+      [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut(),
+      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: notLockedOut()
+    });
+
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
+      IdentityAuthMethod.UNIVERSAL_AUTH
+    ]);
+    expect(keyStore.hashGetAll).toHaveBeenCalledWith(HASH_KEY);
+  });
+
+  test("never scans the keyspace", async () => {
+    const keyStore = makeKeyStore({ [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut() });
+
+    await getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore);
+
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+    expect(keyStore.getItem).not.toHaveBeenCalled();
+    expect(keyStore.hashGetAll).toHaveBeenCalledTimes(1);
+  });
+
+  test("de-duplicates an auth method locked out under several slugs", async () => {
+    const keyStore = makeKeyStore({
+      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut(),
+      [`${IdentityAuthMethod.LDAP_AUTH}:bob`]: lockedOut()
+    });
+
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
+  });
+
+  test("returns an empty list for an empty hash and for a missing key", async () => {
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, makeKeyStore({}))).resolves.toEqual([]);
+
+    const missing = { ...makeKeyStore({}), hashGetAll: vi.fn().mockResolvedValue(null) };
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, missing)).resolves.toEqual([]);
+  });
+
+  test("drops a field whose own deadline has passed", async () => {
+    const keyStore = makeKeyStore({
+      [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut(Date.now() - 1_000),
+      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut(Date.now() + 60_000)
+    });
+
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
+  });
+
+  test("skips unparseable and malformed fields instead of throwing", async () => {
+    const keyStore = makeKeyStore({
+      "not-a-field": lockedOut(),
+      [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: "{{{",
+      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut()
+    });
+
+    await expect(getIdentityActiveLockoutAuthMethods(IDENTITY_ID, keyStore)).resolves.toEqual([
+      IdentityAuthMethod.LDAP_AUTH
+    ]);
+  });
+});
+
+describe("getIdentityLockoutState", () => {
+  const selector = { identityId: IDENTITY_ID, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a" };
+
+  test("reads the one field it needs, never the whole hash or a string key", async () => {
+    const keyStore = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue(lockedOut()) };
+
+    await expect(getIdentityLockoutState(selector, keyStore)).resolves.toMatchObject({ lockedOut: true });
+    expect(keyStore.hashGet).toHaveBeenCalledWith(HASH_KEY, `${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`);
+    expect(keyStore.getItem).not.toHaveBeenCalled();
+    expect(keyStore.hashGetAll).not.toHaveBeenCalled();
+  });
+
+  test("treats a field past its own deadline as absent", async () => {
+    const keyStore = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue(lockedOut(Date.now() - 1_000)) };
+    await expect(getIdentityLockoutState(selector, keyStore)).resolves.toBeUndefined();
+  });
+
+  test("keeps a field whose deadline is still ahead", async () => {
+    const keyStore = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue(lockedOut(Date.now() + 60_000)) };
+    await expect(getIdentityLockoutState(selector, keyStore)).resolves.toMatchObject({ lockedOut: true });
+  });
+
+  test("returns undefined for a missing or unreadable field", async () => {
+    const missing = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue(null) };
+    await expect(getIdentityLockoutState(selector, missing)).resolves.toBeUndefined();
+
+    const corrupt = { ...makeKeyStore({}), hashGet: vi.fn().mockResolvedValue("{{{") };
+    await expect(getIdentityLockoutState(selector, corrupt)).resolves.toBeUndefined();
+  });
+});
+
+describe("persistIdentityLockoutState", () => {
+  test("writes the hash field only, stamped with its own deadline", async () => {
+    const keyStore = makeKeyStore({});
+
+    await persistIdentityLockoutState(
+      {
+        identityId: IDENTITY_ID,
+        authMethod: IdentityAuthMethod.UNIVERSAL_AUTH,
+        slug: "client-a",
+        expiryInSeconds: 300
+      },
+      { lockedOut: true, failedAttempts: 3 },
+      keyStore
+    );
+
+    const [hashKey, field, payload, hashTtl] = keyStore.hashSetFieldWithMinExpiry.mock.calls[0] as [
+      string,
+      string,
+      string,
+      number
+    ];
+
+    expect(hashKey).toBe(HASH_KEY);
+    expect(field).toBe(`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`);
+    expect(hashTtl).toBe(300);
+    expect(keyStore.setItemWithExpiry).not.toHaveBeenCalled();
+
+    const parsed = JSON.parse(payload) as { lockedOut: boolean; failedAttempts: number; expiresAt: number };
+    expect(parsed.lockedOut).toBe(true);
+    expect(parsed.failedAttempts).toBe(3);
+    expect(parsed.expiresAt).toBeGreaterThan(Date.now());
+  });
+});
+
+describe("clearIdentityLockoutState", () => {
+  test("removes the hash field and touches no string key", async () => {
+    const keyStore = makeKeyStore({});
+
+    await clearIdentityLockoutState(
+      { identityId: IDENTITY_ID, authMethod: IdentityAuthMethod.LDAP_AUTH, slug: "alice" },
+      keyStore
+    );
+
+    expect(keyStore.hashDeleteFields).toHaveBeenCalledWith(HASH_KEY, [`${IdentityAuthMethod.LDAP_AUTH}:alice`]);
+    expect(keyStore.deleteItem).not.toHaveBeenCalled();
+  });
+});
+
+describe("clearIdentityLockoutsForAuthMethod", () => {
+  test("clears only the requested method's fields", async () => {
+    const keyStore = makeKeyStore({
+      [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut(),
+      [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut(),
+      [`${IdentityAuthMethod.LDAP_AUTH}:bob`]: notLockedOut()
+    });
+    keyStore.hashDeleteFields.mockResolvedValue(2);
+
+    await expect(clearIdentityLockoutsForAuthMethod(IDENTITY_ID, IdentityAuthMethod.LDAP_AUTH, keyStore)).resolves.toBe(
+      2
+    );
+
+    expect(keyStore.hashDeleteFields).toHaveBeenCalledWith(HASH_KEY, [
+      `${IdentityAuthMethod.LDAP_AUTH}:alice`,
+      `${IdentityAuthMethod.LDAP_AUTH}:bob`
+    ]);
+    expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+    expect(keyStore.deleteItemsByKeyIn).not.toHaveBeenCalled();
+  });
+
+  test("decides what to delete from the primary, never a read replica", async () => {
+    // A replica read can lag behind a lockout the primary already holds, and the delete driven off
+    // it would leave that lockout in place after the admin asked to clear it.
+    const keyStore = makeKeyStore({ [`${IdentityAuthMethod.LDAP_AUTH}:alice`]: lockedOut() });
+
+    await clearIdentityLockoutsForAuthMethod(IDENTITY_ID, IdentityAuthMethod.LDAP_AUTH, keyStore);
+
+    expect(keyStore.hashGetAllPrimary).toHaveBeenCalledWith(HASH_KEY);
+    expect(keyStore.hashGetAll).not.toHaveBeenCalled();
+  });
+
+  test("is a no-op when the identity has no lockouts for that method", async () => {
+    const keyStore = makeKeyStore({ [`${IdentityAuthMethod.UNIVERSAL_AUTH}:client-a`]: lockedOut() });
+
+    await expect(clearIdentityLockoutsForAuthMethod(IDENTITY_ID, IdentityAuthMethod.LDAP_AUTH, keyStore)).resolves.toBe(
+      0
+    );
+
+    expect(keyStore.deleteItemsByKeyIn).not.toHaveBeenCalled();
+    expect(keyStore.hashDeleteFields).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/services/identity/identity-fns.test.ts
+++ b/backend/src/services/identity/identity-fns.test.ts
@@ -15,7 +15,8 @@ const itemKey = (authMethod: string, slug: string) =>
   KeyStorePrefixes.IdentityLockoutState(IDENTITY_ID, authMethod, slug);
 
 const makeKeyStore = () => ({
-  getItem: vi.fn().mockResolvedValue(null),
+  getItemPrimary: vi.fn().mockResolvedValue(null),
+  getItem: vi.fn(),
   setIndexedItemWithExpiry: vi.fn().mockResolvedValue(undefined),
   deleteIndexedItems: vi.fn().mockResolvedValue(undefined),
   sortedSetRangeByScore: vi.fn().mockResolvedValue([]),
@@ -27,17 +28,19 @@ const makeKeyStore = () => ({
 describe("getIdentityLockoutState", () => {
   const selector = { identityId: IDENTITY_ID, authMethod: IdentityAuthMethod.UNIVERSAL_AUTH, slug: "client-a" };
 
-  test("reads the one key it already knows, and never the index", async () => {
+  test("reads the one key it already knows, from the primary, and never the index", async () => {
     const keyStore = makeKeyStore();
-    keyStore.getItem.mockResolvedValue(JSON.stringify({ lockedOut: true, failedAttempts: 3 }));
+    keyStore.getItemPrimary.mockResolvedValue(JSON.stringify({ lockedOut: true, failedAttempts: 3 }));
 
     await expect(getIdentityLockoutState(selector, keyStore)).resolves.toEqual({
       lockedOut: true,
       failedAttempts: 3
     });
-    expect(keyStore.getItem).toHaveBeenCalledWith(itemKey(IdentityAuthMethod.UNIVERSAL_AUTH, "client-a"));
+    expect(keyStore.getItemPrimary).toHaveBeenCalledWith(itemKey(IdentityAuthMethod.UNIVERSAL_AUTH, "client-a"));
     expect(keyStore.sortedSetRangeByScore).not.toHaveBeenCalled();
     expect(keyStore.getKeysByPattern).not.toHaveBeenCalled();
+    // A replica can lag behind the failure this read is about to increment.
+    expect(keyStore.getItem).not.toHaveBeenCalled();
   });
 
   test("treats a missing key as no lockout, since the key's TTL is the expiry", async () => {
@@ -46,7 +49,7 @@ describe("getIdentityLockoutState", () => {
 
   test("treats an unreadable value as no lockout rather than failing the login", async () => {
     const keyStore = makeKeyStore();
-    keyStore.getItem.mockResolvedValue("{{{");
+    keyStore.getItemPrimary.mockResolvedValue("{{{");
 
     await expect(getIdentityLockoutState(selector, keyStore)).resolves.toBeUndefined();
   });

--- a/backend/src/services/identity/identity-fns.ts
+++ b/backend/src/services/identity/identity-fns.ts
@@ -16,9 +16,9 @@ export const identityLockoutLockKey = (identityId: string, authMethod: string, s
 
 export const getIdentityLockoutState = async (
   { identityId, authMethod, slug }: { identityId: string; authMethod: string; slug: string },
-  keyStore: Pick<TKeyStoreFactory, "getItem">
+  keyStore: Pick<TKeyStoreFactory, "getItemPrimary">
 ): Promise<TIdentityLockoutState | undefined> => {
-  const raw = await keyStore.getItem(lockoutItemKey(identityId, authMethod, slug));
+  const raw = await keyStore.getItemPrimary(lockoutItemKey(identityId, authMethod, slug));
   if (!raw) return undefined;
 
   try {

--- a/backend/src/services/identity/identity-fns.ts
+++ b/backend/src/services/identity/identity-fns.ts
@@ -1,27 +1,111 @@
 import { IdentityAuthMethod } from "@app/db/schemas";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 
+export type TIdentityLockoutState = {
+  lockedOut: boolean;
+  failedAttempts: number;
+  // Redis cannot expire an individual hash field. The key's TTL only garbage-collects the whole
+  // hash once its longest-lived field is gone, so this deadline is what makes a read correct.
+  expiresAt?: number;
+};
+
+const parseLockoutState = (raw: string): TIdentityLockoutState | null => {
+  try {
+    return JSON.parse(raw) as TIdentityLockoutState;
+  } catch {
+    // A single unreadable field must not fail the whole list page it was read for.
+    return null;
+  }
+};
+
+const isLive = (state: TIdentityLockoutState, now: number) => !state.expiresAt || state.expiresAt > now;
+
+const lockoutHashKey = (identityId: string) => KeyStorePrefixes.IdentityLockoutStateHash(identityId);
+const lockoutField = (authMethod: string, slug: string) => KeyStorePrefixes.IdentityLockoutStateField(authMethod, slug);
+
+// Named after the hash key and field so the login paths serialise per lockout rather than per identity.
+export const identityLockoutLockKey = (identityId: string, authMethod: string, slug: string) =>
+  KeyStorePrefixes.IdentityLockoutLock(`${lockoutHashKey(identityId)}:${lockoutField(authMethod, slug)}`);
+
+export const getIdentityLockoutState = async (
+  { identityId, authMethod, slug }: { identityId: string; authMethod: string; slug: string },
+  keyStore: Pick<TKeyStoreFactory, "hashGet">
+): Promise<TIdentityLockoutState | undefined> => {
+  const raw = await keyStore.hashGet(lockoutHashKey(identityId), lockoutField(authMethod, slug));
+  if (!raw) return undefined;
+
+  const state = parseLockoutState(raw);
+  if (!state || !isLive(state, Date.now())) return undefined;
+
+  return state;
+};
+
 export const getIdentityActiveLockoutAuthMethods = async (
   identityId: string,
-  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">
+  keyStore: Pick<TKeyStoreFactory, "hashGetAll">
 ) => {
-  const activeLockouts = await keyStore.getKeysByPattern(KeyStorePrefixes.IdentityLockoutStatePattern(identityId));
+  const lockoutStates = await keyStore.hashGetAll(lockoutHashKey(identityId));
 
+  const now = Date.now();
   const activeLockoutAuthMethods = new Set<string>();
-  for await (const key of activeLockouts) {
-    const parts = key.split(":");
-    if (parts.length > 3) {
-      const lockoutRaw = await keyStore.getItem(key);
-      if (lockoutRaw) {
-        const lockout = JSON.parse(lockoutRaw) as { lockedOut: boolean };
-        if (lockout.lockedOut) {
-          activeLockoutAuthMethods.add(parts[3]);
-        }
-      }
-    }
-  }
+
+  Object.entries(lockoutStates ?? {}).forEach(([field, raw]) => {
+    const separatorIndex = field.indexOf(":");
+    if (separatorIndex <= 0) return;
+
+    const state = parseLockoutState(raw);
+    if (!state?.lockedOut || !isLive(state, now)) return;
+
+    activeLockoutAuthMethods.add(field.slice(0, separatorIndex));
+  });
 
   return Array.from(activeLockoutAuthMethods);
+};
+
+// The key TTL never shortens, so it always outlives the longest-lived field; expiresAt is what
+// retires this one.
+export const persistIdentityLockoutState = async (
+  {
+    identityId,
+    authMethod,
+    slug,
+    expiryInSeconds
+  }: { identityId: string; authMethod: string; slug: string; expiryInSeconds: number },
+  lockout: { lockedOut: boolean; failedAttempts: number },
+  keyStore: Pick<TKeyStoreFactory, "hashSetFieldWithMinExpiry">
+) => {
+  await keyStore.hashSetFieldWithMinExpiry(
+    lockoutHashKey(identityId),
+    lockoutField(authMethod, slug),
+    JSON.stringify({ ...lockout, expiresAt: Date.now() + expiryInSeconds * 1000 }),
+    expiryInSeconds
+  );
+};
+
+export const clearIdentityLockoutState = async (
+  { identityId, authMethod, slug }: { identityId: string; authMethod: string; slug: string },
+  keyStore: Pick<TKeyStoreFactory, "hashDeleteFields">
+) => {
+  await keyStore.hashDeleteFields(lockoutHashKey(identityId), [lockoutField(authMethod, slug)]);
+};
+
+// The field names carry the slugs, so the whole set for one method is addressable without the
+// pattern delete (a full keyspace SCAN) this replaced.
+export const clearIdentityLockoutsForAuthMethod = async (
+  identityId: string,
+  authMethod: string,
+  keyStore: Pick<TKeyStoreFactory, "hashGetAllPrimary" | "hashDeleteFields">
+) => {
+  const hashKey = lockoutHashKey(identityId);
+  const fieldPrefix = `${authMethod}:`;
+
+  // Primary, not a replica: this read decides what gets deleted, and a lagging replica would hide
+  // a lockout the admin just asked to clear.
+  const lockoutStates = await keyStore.hashGetAllPrimary(hashKey);
+  const fields = Object.keys(lockoutStates ?? {}).filter((field) => field.startsWith(fieldPrefix));
+  if (!fields.length) return 0;
+
+  return keyStore.hashDeleteFields(hashKey, fields);
 };
 
 export const buildAuthMethods = ({

--- a/backend/src/services/identity/identity-fns.ts
+++ b/backend/src/services/identity/identity-fns.ts
@@ -4,66 +4,49 @@ import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 export type TIdentityLockoutState = {
   lockedOut: boolean;
   failedAttempts: number;
-  // Redis cannot expire an individual hash field. The key's TTL only garbage-collects the whole
-  // hash once its longest-lived field is gone, so this deadline is what makes a read correct.
-  expiresAt?: number;
 };
 
-const parseLockoutState = (raw: string): TIdentityLockoutState | null => {
-  try {
-    return JSON.parse(raw) as TIdentityLockoutState;
-  } catch {
-    // A single unreadable field must not fail the whole list page it was read for.
-    return null;
-  }
-};
+const lockoutIndexKey = (identityId: string) => KeyStorePrefixes.IdentityLockoutIndex(identityId);
+const lockoutMember = (authMethod: string, slug: string) => KeyStorePrefixes.IdentityLockoutMember(authMethod, slug);
+const lockoutItemKey = (identityId: string, authMethod: string, slug: string) =>
+  KeyStorePrefixes.IdentityLockoutState(identityId, authMethod, slug);
 
-const isLive = (state: TIdentityLockoutState, now: number) => !state.expiresAt || state.expiresAt > now;
-
-const lockoutHashKey = (identityId: string) => KeyStorePrefixes.IdentityLockoutStateHash(identityId);
-const lockoutField = (authMethod: string, slug: string) => KeyStorePrefixes.IdentityLockoutStateField(authMethod, slug);
-
-// Named after the hash key and field so the login paths serialise per lockout rather than per identity.
 export const identityLockoutLockKey = (identityId: string, authMethod: string, slug: string) =>
-  KeyStorePrefixes.IdentityLockoutLock(`${lockoutHashKey(identityId)}:${lockoutField(authMethod, slug)}`);
+  KeyStorePrefixes.IdentityLockoutLock(lockoutItemKey(identityId, authMethod, slug));
 
 export const getIdentityLockoutState = async (
   { identityId, authMethod, slug }: { identityId: string; authMethod: string; slug: string },
-  keyStore: Pick<TKeyStoreFactory, "hashGet">
+  keyStore: Pick<TKeyStoreFactory, "getItem">
 ): Promise<TIdentityLockoutState | undefined> => {
-  const raw = await keyStore.hashGet(lockoutHashKey(identityId), lockoutField(authMethod, slug));
+  const raw = await keyStore.getItem(lockoutItemKey(identityId, authMethod, slug));
   if (!raw) return undefined;
 
-  const state = parseLockoutState(raw);
-  if (!state || !isLive(state, Date.now())) return undefined;
-
-  return state;
+  try {
+    return JSON.parse(raw) as TIdentityLockoutState;
+  } catch {
+    // An unreadable value must not fail the login it was read for.
+    return undefined;
+  }
 };
 
+// Runs once per row on the list endpoints. Only locked methods are indexed, so this costs one range
+// read bounded by how many of an identity's methods are locked right now
 export const getIdentityActiveLockoutAuthMethods = async (
   identityId: string,
-  keyStore: Pick<TKeyStoreFactory, "hashGetAll">
+  keyStore: Pick<TKeyStoreFactory, "sortedSetRangeByScore">
 ) => {
-  const lockoutStates = await keyStore.hashGetAll(lockoutHashKey(identityId));
+  const members = await keyStore.sortedSetRangeByScore(lockoutIndexKey(identityId), Date.now(), "+inf");
 
-  const now = Date.now();
   const activeLockoutAuthMethods = new Set<string>();
-
-  Object.entries(lockoutStates ?? {}).forEach(([field, raw]) => {
-    const separatorIndex = field.indexOf(":");
-    if (separatorIndex <= 0) return;
-
-    const state = parseLockoutState(raw);
-    if (!state?.lockedOut || !isLive(state, now)) return;
-
-    activeLockoutAuthMethods.add(field.slice(0, separatorIndex));
+  members.forEach((member) => {
+    const separatorIndex = member.indexOf(":");
+    if (separatorIndex > 0) activeLockoutAuthMethods.add(member.slice(0, separatorIndex));
   });
 
   return Array.from(activeLockoutAuthMethods);
 };
 
-// The key TTL never shortens, so it always outlives the longest-lived field; expiresAt is what
-// retires this one.
+// The counter and the lockout share one key and one TTL.
 export const persistIdentityLockoutState = async (
   {
     identityId,
@@ -71,41 +54,50 @@ export const persistIdentityLockoutState = async (
     slug,
     expiryInSeconds
   }: { identityId: string; authMethod: string; slug: string; expiryInSeconds: number },
-  lockout: { lockedOut: boolean; failedAttempts: number },
-  keyStore: Pick<TKeyStoreFactory, "hashSetFieldWithMinExpiry">
+  lockout: TIdentityLockoutState,
+  keyStore: Pick<TKeyStoreFactory, "setIndexedItemWithExpiry">
 ) => {
-  await keyStore.hashSetFieldWithMinExpiry(
-    lockoutHashKey(identityId),
-    lockoutField(authMethod, slug),
-    JSON.stringify({ ...lockout, expiresAt: Date.now() + expiryInSeconds * 1000 }),
-    expiryInSeconds
-  );
+  await keyStore.setIndexedItemWithExpiry({
+    indexKey: lockoutIndexKey(identityId),
+    member: lockoutMember(authMethod, slug),
+    itemKey: lockoutItemKey(identityId, authMethod, slug),
+    value: JSON.stringify(lockout),
+    expiryInSeconds,
+    indexed: lockout.lockedOut
+  });
 };
 
+// Both halves, or the index keeps reporting a lockout whose key is already gone.
 export const clearIdentityLockoutState = async (
   { identityId, authMethod, slug }: { identityId: string; authMethod: string; slug: string },
-  keyStore: Pick<TKeyStoreFactory, "hashDeleteFields">
+  keyStore: Pick<TKeyStoreFactory, "deleteIndexedItems">
 ) => {
-  await keyStore.hashDeleteFields(lockoutHashKey(identityId), [lockoutField(authMethod, slug)]);
+  await keyStore.deleteIndexedItems({
+    indexKey: lockoutIndexKey(identityId),
+    members: [lockoutMember(authMethod, slug)],
+    itemKeys: [lockoutItemKey(identityId, authMethod, slug)]
+  });
 };
 
-// The field names carry the slugs, so the whole set for one method is addressable without the
-// pattern delete (a full keyspace SCAN) this replaced.
 export const clearIdentityLockoutsForAuthMethod = async (
   identityId: string,
   authMethod: string,
-  keyStore: Pick<TKeyStoreFactory, "hashGetAllPrimary" | "hashDeleteFields">
+  keyStore: Pick<TKeyStoreFactory, "sortedSetMembersPrimary" | "deleteIndexedItems">
 ) => {
-  const hashKey = lockoutHashKey(identityId);
-  const fieldPrefix = `${authMethod}:`;
+  const indexKey = lockoutIndexKey(identityId);
+  const memberPrefix = `${authMethod}:`;
 
-  // Primary, not a replica: this read decides what gets deleted, and a lagging replica would hide
-  // a lockout the admin just asked to clear.
-  const lockoutStates = await keyStore.hashGetAllPrimary(hashKey);
-  const fields = Object.keys(lockoutStates ?? {}).filter((field) => field.startsWith(fieldPrefix));
-  if (!fields.length) return 0;
+  const members = await keyStore.sortedSetMembersPrimary(indexKey);
+  const matching = members.filter((member) => member.startsWith(memberPrefix));
+  if (!matching.length) return 0;
 
-  return keyStore.hashDeleteFields(hashKey, fields);
+  await keyStore.deleteIndexedItems({
+    indexKey,
+    members: matching,
+    itemKeys: matching.map((member) => lockoutItemKey(identityId, authMethod, member.slice(memberPrefix.length)))
+  });
+
+  return matching.length;
 };
 
 export const buildAuthMethods = ({

--- a/backend/src/services/identity/identity-service.test.ts
+++ b/backend/src/services/identity/identity-service.test.ts
@@ -76,7 +76,7 @@ const createService = ({
       getOrgPermissionByRoles: vi.fn()
     } as never,
     licenseService: { getPlan: vi.fn(), getOrgSeatUsage: vi.fn(), updateSubscriptionOrgMemberCount: vi.fn() } as never,
-    keyStore: { getKeysByPattern: vi.fn(), getItem: vi.fn() } as never,
+    keyStore: { hashGetAll: vi.fn().mockResolvedValue({}) } as never,
     orgDAL: { findById: vi.fn(), findEffectiveOrgMembership: vi.fn() } as never,
     additionalPrivilegeDAL: { delete: vi.fn().mockResolvedValue(undefined) } as never,
     usageMeteringService: { emit: vi.fn() } as never,

--- a/backend/src/services/identity/identity-service.test.ts
+++ b/backend/src/services/identity/identity-service.test.ts
@@ -76,7 +76,7 @@ const createService = ({
       getOrgPermissionByRoles: vi.fn()
     } as never,
     licenseService: { getPlan: vi.fn(), getOrgSeatUsage: vi.fn(), updateSubscriptionOrgMemberCount: vi.fn() } as never,
-    keyStore: { hashGetAll: vi.fn().mockResolvedValue({}) } as never,
+    keyStore: { sortedSetRangeByScore: vi.fn().mockResolvedValue([]) } as never,
     orgDAL: { findById: vi.fn(), findEffectiveOrgMembership: vi.fn() } as never,
     additionalPrivilegeDAL: { delete: vi.fn().mockResolvedValue(undefined) } as never,
     usageMeteringService: { emit: vi.fn() } as never,

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -49,7 +49,7 @@ type TIdentityServiceFactoryDep = {
   identityProjectDAL: Pick<TIdentityProjectDALFactory, "findByIdentityId">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission" | "getOrgPermissionByRoles">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan" | "getOrgSeatUsage" | "updateSubscriptionOrgMemberCount">;
-  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "hashGetAll">;
   orgDAL: Pick<TOrgDALFactory, "findById" | "findEffectiveOrgMembership">;
   additionalPrivilegeDAL: Pick<TAdditionalPrivilegeDALFactory, "delete">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -49,7 +49,7 @@ type TIdentityServiceFactoryDep = {
   identityProjectDAL: Pick<TIdentityProjectDALFactory, "findByIdentityId">;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission" | "getOrgPermissionByRoles">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan" | "getOrgSeatUsage" | "updateSubscriptionOrgMemberCount">;
-  keyStore: Pick<TKeyStoreFactory, "hashGetAll">;
+  keyStore: Pick<TKeyStoreFactory, "sortedSetRangeByScore">;
   orgDAL: Pick<TOrgDALFactory, "findById" | "findEffectiveOrgMembership">;
   additionalPrivilegeDAL: Pick<TAdditionalPrivilegeDALFactory, "delete">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -81,7 +81,7 @@ const createService = ({
     licenseService: { getPlan: vi.fn() } as never,
     applicationMembershipCleanupService: { cleanupActorApplicationMemberships: vi.fn() } as never,
     projectDAL: { findById: vi.fn() } as never,
-    keyStore: { hashGetAll: vi.fn().mockResolvedValue({}) } as never,
+    keyStore: { sortedSetRangeByScore: vi.fn().mockResolvedValue([]) } as never,
     usageMeteringService: { emit: vi.fn(), emitForProject: vi.fn() } as never,
     alertService: { deleteAlertsForResource } as never,
     identityAccessTokenService: {

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -81,7 +81,7 @@ const createService = ({
     licenseService: { getPlan: vi.fn() } as never,
     applicationMembershipCleanupService: { cleanupActorApplicationMemberships: vi.fn() } as never,
     projectDAL: { findById: vi.fn() } as never,
-    keyStore: { getKeysByPattern: vi.fn(), getItem: vi.fn() } as never,
+    keyStore: { hashGetAll: vi.fn().mockResolvedValue({}) } as never,
     usageMeteringService: { emit: vi.fn(), emitForProject: vi.fn() } as never,
     alertService: { deleteAlertsForResource } as never,
     identityAccessTokenService: {

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -52,7 +52,7 @@ type TMembershipIdentityServiceFactoryDep = {
     "cleanupActorApplicationMemberships"
   >;
   projectDAL: Pick<TProjectDALFactory, "findById">;
-  keyStore: Pick<TKeyStoreFactory, "getKeysByPattern" | "getItem">;
+  keyStore: Pick<TKeyStoreFactory, "hashGetAll">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit" | "emitForProject">;
   alertService: Pick<TAlertServiceFactory, "deleteAlertsForResource">;
   identityAccessTokenService: Pick<

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -52,7 +52,7 @@ type TMembershipIdentityServiceFactoryDep = {
     "cleanupActorApplicationMemberships"
   >;
   projectDAL: Pick<TProjectDALFactory, "findById">;
-  keyStore: Pick<TKeyStoreFactory, "hashGetAll">;
+  keyStore: Pick<TKeyStoreFactory, "sortedSetRangeByScore">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit" | "emitForProject">;
   alertService: Pick<TAlertServiceFactory, "deleteAlertsForResource">;
   identityAccessTokenService: Pick<


### PR DESCRIPTION
## Context

Project membership and identity list endpoints call `getIdentityActiveLockoutAuthMethods` once per row to populate `activeLockoutAuthMethods`. The old layout stored one Redis string key per auth method/slug and discovered them with `getKeysByPattern` (SCAN). A `limit=1000` memberships list walked the entire keyspace up to 1000 times.

Lockout state now uses a **sorted-set index + per-slug item keys**:

- **Item key** (unchanged): `lockout:identity:{identityId}:{authMethod}:{slug}` — JSON `{ lockedOut, failedAttempts }` with native Redis TTL
- **Index key** (new): `lockout:identity:{identityId}` — ZSET of *locked* slugs only, scored by lockout deadline (`{authMethod}:{slug}` members)

List reads do one `ZRANGEBYSCORE` per identity (score ≥ now), bounded by active lockouts. Login reads/writes the known item key directly. Admin clears enumerate the index on the **primary** (`sortedSetMembersPrimary`) so replica lag cannot hide a lockout being removed.

Only `lockedOut: true` states are indexed; failure counters stay off the index so LDAP username sprays cannot inflate list reads. Writes atomically upsert item + index via a Lua script (`setIndexedItemWithExpiry`), prune expired index members, and extend (never shorten) the index TTL. LDAP login now validates username (max 255) and password (max 1024).

## Steps to verify the change

1. After triggering a lockout, confirm Redis layout:
   ```bash
   redis-cli GET "lockout:identity:<identityId>:ldap-auth:<slug>"
   redis-cli ZRANGEBYSCORE "lockout:identity:<identityId>" $(date +%s)000 +inf WITHSCORES
   ```
2. List project identity memberships (`GET /api/v1/projects/{projectId}/memberships/identities?limit=1000`) and confirm `activeLockoutAuthMethods` is correct. Monitor Redis — no `SCAN` on lockout paths; one `ZRANGEBYSCORE` per identity row.
3. Spray failed LDAP logins with varied usernames and confirm the index stays empty (`ZCARD lockout:identity:<identityId>` = 0) until a real lockout occurs.
4. Admin-clear lockouts for an auth method and confirm both item keys and index members are removed; Universal Auth lockouts on the same identity are left intact.
5. Confirm successful login clears the item key and index member together.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)