### PR TITLE
fix(cert-manager): evaluate application permissions consistently across actor types

### DIFF
--- a/backend/src/services/certificate-v3/certificate-v3-service.ts
+++ b/backend/src/services/certificate-v3/certificate-v3-service.ts
@@ -415,7 +415,6 @@ export const certificateV3ServiceFactory = ({
         actorContext.actor !== ActorType.EST_ACCOUNT &&
         actorContext.actor !== ActorType.SCEP_ACCOUNT &&
         actorContext.actorId &&
-        actorContext.actorAuthMethod &&
         actorContext.actorOrgId
       ) {
         const { permission } = await permissionService.getResourcePermission({
@@ -424,7 +423,7 @@ export const certificateV3ServiceFactory = ({
           projectId: profile.projectId,
           resourceType: ResourceType.CertificateApplication,
           resourceId: explicit,
-          actorAuthMethod: actorContext.actorAuthMethod,
+          actorAuthMethod: actorContext.actorAuthMethod ?? null,
           actorOrgId: actorContext.actorOrgId
         });
         ForbiddenError.from(permission).throwUnlessCan(


### PR DESCRIPTION
## Context

Application-scoped certificate operations resolved permissions differently depending on how the caller authenticated. This puts all callers on a single path and adds parity coverage across actor types. No change for correctly-permissioned callers.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)