### PR TITLE
docs(self-hosting): add copy button for env vars

### DIFF
--- a/docs/field-name-copy.js
+++ b/docs/field-name-copy.js
@@ -1,0 +1,42 @@
+(() => {
+  const fieldSelector = '[data-component-part="field-name"]';
+  const resetTimers = new WeakMap();
+
+  document.addEventListener(
+    "click",
+    async (event) => {
+      if (!(event.target instanceof Element)) return;
+
+      const field = event.target.closest(fieldSelector);
+      if (!(field instanceof HTMLElement)) return;
+
+      const fieldName = field.textContent?.trim();
+      if (!fieldName) return;
+
+      // The separate chain icon keeps the permalink action.
+      event.preventDefault();
+      event.stopPropagation();
+
+      try {
+        await navigator.clipboard.writeText(fieldName);
+        field.dataset.copyState = "copied";
+
+        const existingTimer = resetTimers.get(field);
+        if (existingTimer) {
+          window.clearTimeout(existingTimer);
+        }
+
+        resetTimers.set(
+          field,
+          window.setTimeout(() => {
+            delete field.dataset.copyState;
+            resetTimers.delete(field);
+          }, 1500)
+        );
+      } catch (error) {
+        console.error("Unable to copy field name.", error);
+      }
+    },
+    true
+  );
+})();

--- a/docs/style.css
+++ b/docs/style.css
@@ -571,6 +571,7 @@ a.ifx-steps__label:hover {
 .ifx-card {
   --ifx-ink: #6f6f6f;
   --ifx-accent: #dbf530;
+  position: relative;
   display: flex;
   flex-direction: column;
   padding: 1.5rem;
@@ -667,6 +668,17 @@ a.ifx-card:hover .ifx-card__icon {
 a.ifx-card__title {
   align-self: flex-start;
   text-decoration: none;
+}
+
+div.ifx-card a.ifx-card__title::after {
+  position: absolute;
+  inset: 0;
+  content: "";
+}
+
+div.ifx-card a:not(.ifx-card__title) {
+  position: relative;
+  z-index: 1;
 }
 
 .ifx-card__chevron {
@@ -942,4 +954,35 @@ a.ifx-card__title:hover .ifx-card__chevron {
   .ifx-home__hero-aside {
     align-self: stretch;
   }
+}
+
+[data-component-part="field-name"] {
+  position: relative;
+}
+
+[data-component-part="field-name"]::after {
+  content: "Click to copy";
+  position: absolute;
+  bottom: calc(100% + 0.5rem);
+  left: 50%;
+  z-index: 50;
+  transform: translateX(-50%);
+  visibility: hidden;
+  padding: 0.375rem 0.5rem;
+  border-radius: 0.375rem;
+  background: #18181b;
+  color: #ffffff;
+  font: 500 0.75rem/1 system-ui, sans-serif;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+[data-component-part="field-name"]:hover::after,
+[data-component-part="field-name"]:focus-visible::after {
+  visibility: visible;
+}
+
+[data-component-part="field-name"][data-copy-state="copied"]::after {
+  content: "Copied";
+  visibility: visible;
 }


### PR DESCRIPTION
## Context

There's currently no easy way to copy environment variable names in our docs without accidentally clicking their anchor link. This PR implements Mintlify's proposed solution, which adds a copy button to each environment variable name.

## Steps to verify the change

1. Go to `/self-hosting/configuration/envars#general-platform`.
2. Hover over one of the environment variable links and click to copy.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)