### PR TITLE
docs(vale): fix config and errors

### DIFF
--- a/docs/.vale/styles/Infisical/Terminology.yml
+++ b/docs/.vale/styles/Infisical/Terminology.yml
@@ -9,25 +9,20 @@ vocab: false
 # Boundaries are written out per swap so they compose with the lookarounds
 # below instead of being wrapped a second time.
 nonword: true
-# A retired name is allowed when the text is explicitly saying it is retired.
-exceptions:
-  - formerly Azure AD
-  - formerly known as Azure AD
-  - previously Azure AD
-  - formerly Azure Active Directory
-  - formerly known as Azure Active Directory
-  - Azure Active Directory is now
-  # UI labels quoted verbatim. The product capitalizes this one.
-  - New Sub-Organization
-  - Create Sub-Organization
+# Contextual allowances are lookarounds on the swap keys, not `exceptions:`
+# entries. An exception that only *contains* the match ("formerly known as
+# Azure AD" around "Azure AD") is honored from Vale 3.15 onwards; the Mintlify
+# CI runner is older, so the whole block was inert there while passing locally.
+# Do not convert these back until that runner is known to be 3.15 or newer.
 swap:
   # --- Product naming ---
   # Secret Manager / Secrets Management live in SecretsManager.yml, which GCP
   # pages switch off.
-  # Microsoft renamed this. "Azure AD CS" is Certificate Services, not the
-  # identity product, so it is excluded.
-  '\bAzure Active Directory\b': Entra ID
-  '\bAzure AD\b(?! CS)': Entra ID
+  # Microsoft renamed this. A retired name stands where the text is explicitly
+  # saying it is retired. "Azure AD CS" is Certificate Services, not the
+  # identity product, so it is excluded under both of its spellings.
+  '(?<!formerly |known as |previously )\bAzure Active Directory\b(?! is now)': Entra ID
+  '(?<!formerly |known as |previously )\bAzure AD\b(?! CS| Certificate Services)': Entra ID
   '\bEntra Id\b': Entra ID
   '\bPostgres\b': PostgreSQL
   # Only the mixed-case form. The binary, package, and config file are
@@ -37,7 +32,9 @@ swap:
   '\bMongo DB\b': MongoDB
   '\bDigital Ocean\b': DigitalOcean
   '\bSDK''s\b': SDKs
-  '\bSub-Organization\b': Sub-organization
+  # "+ New Sub-Organization" and "Create Sub-Organization" are UI labels quoted
+  # verbatim; the product capitalizes those.
+  '(?<!\+ New |Create )\bSub-Organization\b': Sub-organization
   '\bSub-Organizations\b': Sub-organizations
 
   # --- Vendor casing ---

--- a/docs/.vale/styles/config/vocabularies/Infisical/any-case/accept.txt
+++ b/docs/.vale/styles/config/vocabularies/Infisical/any-case/accept.txt
@@ -4,7 +4,7 @@
 # legitimately appear in more than one case, so pinning a single canonical form
 # would produce false positives. Comments need a hash AND a space.
 #
-# Terms whose casing IS enforced live in ../enforced/accept.txt.
+# Terms whose casing IS enforced live in ../canonical/accept.txt.
 
 # Product nouns that are Title Case as UI labels and lowercase as common nouns.
 [Gg]ateway
@@ -387,3 +387,7 @@ I
 # Case-insensitive because a canonical entry makes the converter capitalize the
 # common noun "node".
 (?i)Node
+
+# Ordinary technical vocabulary the en_US dictionary does not carry.
+(?i)prefilled
+(?i)unscoped

--- a/docs/.vale/styles/config/vocabularies/Infisical/canonical/accept.txt
+++ b/docs/.vale/styles/config/vocabularies/Infisical/canonical/accept.txt
@@ -9,7 +9,7 @@
 # -- `#Foo` is loaded as a regex, not ignored.
 #
 # A term that legitimately appears in more than one case belongs in
-# ../accepted/accept.txt instead, or it will produce false positives.
+# ../any-case/accept.txt instead, or it will produce false positives.
 
 # --- Infisical ---
 Infisical
@@ -615,3 +615,7 @@ dcr
 als
 ua
 iss
+
+# --- Surfaced by the code-signing pages ---
+# Vale strips a trailing `'s`, so the possessive needs no separate entry.
+MSBuild

--- a/docs/documentation/platform/pam/accounts/postgresql.mdx
+++ b/docs/documentation/platform/pam/accounts/postgresql.mdx
@@ -58,7 +58,7 @@ PostgreSQL accounts let you manage access to your PostgreSQL databases. Users co
   </Step>
 </Steps>
 
-## AWS IAM Authentication
+## AWS IAM authentication
 
 RDS and Aurora instances that require IAM database authentication use the **AWS IAM** auth method. No password is stored: Infisical generates a short-lived authentication token for each connection.
 

--- a/docs/documentation/platform/pki/applications/certificate-renewal.mdx
+++ b/docs/documentation/platform/pki/applications/certificate-renewal.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Renewing Certificates"
+title: "Renewing certificates"
 sidebarTitle: "Renewal"
 description: "Manually renew a certificate, and change its subject, names, validity, or key pair as part of the renewal."
 ---

--- a/docs/documentation/platform/pki/applications/certificates.mdx
+++ b/docs/documentation/platform/pki/applications/certificates.mdx
@@ -54,7 +54,7 @@ For automated issuance, configure an [enrollment method](/documentation/platform
 - [EST](/documentation/platform/pki/applications/enrollment-methods/est) — RFC 7030 enrollment
 - [SCEP](/documentation/platform/pki/applications/enrollment-methods/scep) — Mobile device management (Jamf, Intune)
 
-## Importing Certificates
+## Importing certificates
 
 Click **Import** on the Certificates tab to bring in a certificate you already hold, either as PEM files or as a `.p12` / `.pfx` keystore with its password.
 


### PR DESCRIPTION
## Context

Fixes Vale errors that made it through to main and updates the Vale config to resolve the discrepancy between local and CI runs of Vale.

This discrepancy comes from the fact that Mintlify's CI and our local version of Vale are on different versions and apply rules differently. We might want to write our own CI for this instead of relying on Mintlify's so we can pin a version and stay consistent.

## Steps to verify the change

1. Clone the repo
2. Run `make lint-docs` and check that it exists with 0

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)