### PR TITLE
fix(auth): hide initial signup progress

### DIFF
--- a/frontend/src/components/auth/OnboardingPageLayout.tsx
+++ b/frontend/src/components/auth/OnboardingPageLayout.tsx
@@ -11,7 +11,7 @@ type Props = Omit<ComponentProps<typeof AuthPageLayout>, "children" | "headerAct
   totalSteps: number;
 };
 
-const OnboardingProgress = ({
+export const OnboardingProgress = ({
   currentStep,
   totalSteps
 }: Pick<Props, "currentStep" | "totalSteps">) => (

--- a/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
@@ -243,12 +243,13 @@ export const SignUpPage = ({ invite }: SignUpPageProps) => {
     return undefined;
   };
 
-  // Without an email service the invite step is skipped, so the counter tops out at 3.
-  const totalSteps = serverDetails?.emailConfigured ? 4 : 3;
+  // Step one (email entry and code verification) shows no counter, so the indicator numbers only
+  // the steps after it; without an email service the invite step is skipped too.
+  const totalSteps = serverDetails?.emailConfigured ? 3 : 2;
   const stepNumber = STEP_NUMBERS[section];
   const stepIndicator =
     !isInvite && stepNumber && stepNumber > 1 ? (
-      <OnboardingProgress currentStep={stepNumber} totalSteps={totalSteps} />
+      <OnboardingProgress currentStep={stepNumber - 1} totalSteps={totalSteps} />
     ) : undefined;
 
   const completeAsideDescription = (() => {

--- a/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/auth/SignUpPage/SignUpPage.tsx
@@ -7,6 +7,7 @@ import { AuthPageLayout } from "@app/components/auth/AuthPageLayout";
 import { AuthTermsNotice } from "@app/components/auth/AuthTermsNotice";
 import CodeInputStep from "@app/components/auth/CodeInputStep";
 import InitialSignupStep from "@app/components/auth/InitialSignupStep";
+import { OnboardingProgress } from "@app/components/auth/OnboardingPageLayout";
 import ProductSelectionStep from "@app/components/auth/ProductSelectionStep";
 import SignupCompleteStep from "@app/components/auth/SignupCompleteStep";
 import { getSignupProduct, SignupProductType } from "@app/components/auth/signupProducts";
@@ -246,10 +247,8 @@ export const SignUpPage = ({ invite }: SignUpPageProps) => {
   const totalSteps = serverDetails?.emailConfigured ? 4 : 3;
   const stepNumber = STEP_NUMBERS[section];
   const stepIndicator =
-    !isInvite && stepNumber ? (
-      <span className="rounded-sm border border-border bg-container/50 px-2.5 py-0.5 font-jetbrains-mono text-[10px] tracking-widest text-muted uppercase">
-        Step {stepNumber} of {totalSteps}
-      </span>
+    !isInvite && stepNumber && stepNumber > 1 ? (
+      <OnboardingProgress currentStep={stepNumber} totalSteps={totalSteps} />
     ) : undefined;
 
   const completeAsideDescription = (() => {

--- a/frontend/src/pages/organization/SignupOnboardingPage/SignupOnboardingPage.tsx
+++ b/frontend/src/pages/organization/SignupOnboardingPage/SignupOnboardingPage.tsx
@@ -5,6 +5,7 @@ import { useNavigate } from "@tanstack/react-router";
 
 import { AuthPageLayout } from "@app/components/auth/AuthPageLayout";
 import { AuthTermsNotice } from "@app/components/auth/AuthTermsNotice";
+import { OnboardingProgress } from "@app/components/auth/OnboardingPageLayout";
 import OrgNameStep from "@app/components/auth/OrgNameStep";
 import ProductSelectionStep from "@app/components/auth/ProductSelectionStep";
 import SignupCompleteStep from "@app/components/auth/SignupCompleteStep";
@@ -140,9 +141,7 @@ export const SignupOnboardingPage = () => {
   const totalSteps = serverDetails?.emailConfigured ? 3 : 2;
   const stepNumber = STEP_NUMBERS[section];
   const stepIndicator = stepNumber ? (
-    <span className="rounded-sm border border-border bg-container/50 px-2.5 py-0.5 font-jetbrains-mono text-[10px] tracking-widest text-muted uppercase">
-      Step {stepNumber} of {totalSteps}
-    </span>
+    <OnboardingProgress currentStep={stepNumber} totalSteps={totalSteps} />
   ) : undefined;
 
   const completeAsideDescription = (() => {


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

The signup header previously showed a textual `Step 1 of X` indicator during the first signup stage, including email verification. This made the initial screen feel prematurely like an onboarding wizard and used a different progress treatment from the self-hosted setup flow.

This change:

- hides signup progress throughout step 1;
- starts showing progress at step 2;
- reuses the accessible line-style `OnboardingProgress` component from the self-hosted onboarding layout.

The change is visual only and does not alter signup navigation or step counting.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

Current screenshots are still outstanding:

1. Step 1 at `/signup`, showing no progress indicator in the header.
2. Step 2 after email verification, showing the line-style progress indicator.

To capture locally, sign out, open `http://localhost:8080/signup`, submit an email, retrieve the verification code from MailHog at `http://localhost:8025`, and complete verification.

## Steps to verify the change

1. Sign out and open `/signup`.
2. Confirm no progress indicator is visible while entering an email.
3. Submit the email and confirm the verification-code screen still has no progress indicator.
4. Complete email verification.
5. Confirm step 2 displays the line-style progress indicator with the current and remaining steps represented correctly.
6. Continue through the flow and confirm the line progress advances with each step.

Checks performed:

- `git diff --check` passed.
- Local Docker preview frontend and `/api/status` health checks passed.
- The serialized frontend gate was attempted but could not run because this worktree does not have host frontend dependencies installed (`eslint: command not found`).

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)