### PR TITLE
docs(secrets-mgmt): revert browser fix

### DIFF
--- a/docs/snippets/DeliverSecretsBrowser.jsx
+++ b/docs/snippets/DeliverSecretsBrowser.jsx
@@ -1,10 +1,6 @@
 export const DeliverSecretsBrowser = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("All");
-  const currentPath =
-    typeof window === "undefined" ? "" : window.location.pathname;
-  const basePath =
-    currentPath === "/docs" || currentPath.startsWith("/docs/") ? "/docs" : "";
 
   const categories = [
   "All",
@@ -272,7 +268,7 @@ export const DeliverSecretsBrowser = () => {
           {filteredEntries.map((entry) => (
             <a
               key={`${entry.category}-${entry.path}`}
-              href={`${basePath}${entry.path}`}
+              href={entry.path}
               className="group block border border-gray-200 bg-white px-4 py-3 transition-colors hover:border-yellow-200 hover:bg-yellow-50/50 focus:outline-none focus:ring-2 focus:ring-yellow-500 dark:border-gray-700 dark:bg-black dark:hover:border-yellow-700 dark:hover:bg-yellow-950/20"
             >
               <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3">


### PR DESCRIPTION
## Context

Reverts the fix in #7782 ; turns out the issue was caused by a previous deployment. The `/docs` prefix is now being correctly applied but is stacking with the manual one added in the previous PR, so the links are still broken.

## Steps to verify the change

Go to https://infisical.com/docs/integrations/all and check that browser links resolve

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)