### PR TITLE
fix: honor machine identity auth on org membership endpoints

### DIFF
--- a/backend/e2e-test/routes/v2/org-membership-machine-identity.spec.ts
+++ b/backend/e2e-test/routes/v2/org-membership-machine-identity.spec.ts
@@ -1,0 +1,177 @@
+import crypto from "node:crypto";
+
+import { Knex } from "knex";
+
+import { AccessScope, OrgMembershipRole, OrgMembershipStatus, TableName } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+
+const getDb = () => (globalThis as unknown as { testDb: Knex }).testDb;
+
+const getMachineIdentityToken = async () => {
+  const loginRes = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/auth/universal-auth/login",
+    body: {
+      clientId: seedData1.machineIdentity.clientCredentials.id,
+      clientSecret: seedData1.machineIdentity.clientCredentials.secret
+    }
+  });
+  expect(loginRes.statusCode).toBe(200);
+  return loginRes.json().accessToken as string;
+};
+
+describe("Org membership routes with machine identity auth", () => {
+  const createdUserIds: string[] = [];
+  let identityToken: string;
+
+  beforeAll(async () => {
+    identityToken = await getMachineIdentityToken();
+  });
+
+  afterAll(async () => {
+    const db = getDb();
+    if (createdUserIds.length) {
+      await db(TableName.Membership).whereIn("actorUserId", createdUserIds).del();
+      await db(TableName.Users).whereIn("id", createdUserIds).del();
+    }
+  });
+
+  // A throwaway member in the seeded org. Never an admin, so removing it cannot trip the
+  // last-admin guard.
+  const addMember = async () => {
+    const db = getDb();
+    const suffix = crypto.randomUUID().slice(0, 8);
+    const [user] = await db(TableName.Users)
+      .insert({
+        email: `mi-member-${suffix}@localhost.local`,
+        username: `mi-member-${suffix}`,
+        isGhost: false,
+        isEmailVerified: true,
+        authMethods: ["email"]
+      })
+      .returning("*");
+    createdUserIds.push(user.id);
+
+    const [membership] = await db(TableName.Membership)
+      .insert({
+        actorUserId: user.id,
+        scopeOrgId: seedData1.organization.id,
+        scope: AccessScope.Organization,
+        status: OrgMembershipStatus.Accepted,
+        isActive: true
+      })
+      .returning("*");
+    await db(TableName.MembershipRole).insert({ membershipId: membership.id, role: OrgMembershipRole.Member });
+
+    return membership.id;
+  };
+
+  const membershipExists = async (membershipId: string) => {
+    const row = await getDb()(TableName.Membership).where({ id: membershipId }).first();
+    return Boolean(row);
+  };
+
+  test("DELETE membership removes the member", async () => {
+    const membershipId = await addMember();
+
+    const res = await testServer.inject({
+      method: "DELETE",
+      url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${membershipId}`,
+      headers: { authorization: `Bearer ${identityToken}` }
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().membership.id).toBe(membershipId);
+    await expect(membershipExists(membershipId)).resolves.toBe(false);
+  });
+
+  test("bulk DELETE memberships removes the members", async () => {
+    const membershipIds = [await addMember(), await addMember()];
+
+    const res = await testServer.inject({
+      method: "DELETE",
+      url: `/api/v2/organizations/${seedData1.organization.id}/memberships`,
+      headers: { authorization: `Bearer ${identityToken}` },
+      body: { membershipIds }
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(
+      res
+        .json()
+        .memberships.map((el: { id: string }) => el.id)
+        .sort()
+    ).toEqual([...membershipIds].sort());
+    await expect(membershipExists(membershipIds[0])).resolves.toBe(false);
+    await expect(membershipExists(membershipIds[1])).resolves.toBe(false);
+  });
+
+  test("PATCH membership deactivates the member", async () => {
+    const membershipId = await addMember();
+
+    const res = await testServer.inject({
+      method: "PATCH",
+      url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${membershipId}`,
+      headers: { authorization: `Bearer ${identityToken}` },
+      body: { isActive: false }
+    });
+
+    expect(res.statusCode).toBe(200);
+    const row = await getDb()(TableName.Membership).where({ id: membershipId }).first();
+    expect(row?.isActive).toBe(false);
+  });
+
+  // Identity and group org memberships live in the same table as user memberships, so the user
+  // membership routes have to reject them rather than delete them under a user's audit event.
+  test("DELETE refuses an identity's org membership", async () => {
+    const db = getDb();
+    const suffix = crypto.randomUUID().slice(0, 8);
+    const [identity] = await db(TableName.Identity)
+      .insert({ name: `mi-reject-${suffix}`, orgId: seedData1.organization.id } as never)
+      .returning("*");
+    const [membership] = await db(TableName.Membership)
+      .insert({
+        actorIdentityId: identity.id,
+        scopeOrgId: seedData1.organization.id,
+        scope: AccessScope.Organization
+      })
+      .returning("*");
+
+    try {
+      const res = await testServer.inject({
+        method: "DELETE",
+        url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${membership.id}`,
+        headers: { authorization: `Bearer ${identityToken}` }
+      });
+
+      expect(res.statusCode).toBe(404);
+      await expect(membershipExists(membership.id)).resolves.toBe(true);
+    } finally {
+      await db(TableName.Membership).where({ id: membership.id }).del();
+      await db(TableName.Identity).where({ id: identity.id }).del();
+    }
+  });
+
+  // These asserted 200-with-empty-body before machine identities could reach the handlers, so the
+  // status code is the regression guard: any 2xx here means the request was silently dropped again.
+  test("DELETE reports an unknown membership instead of reporting success", async () => {
+    const res = await testServer.inject({
+      method: "DELETE",
+      url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${crypto.randomUUID()}`,
+      headers: { authorization: `Bearer ${identityToken}` }
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  test("bulk DELETE reports an unknown membership instead of reporting success", async () => {
+    const res = await testServer.inject({
+      method: "DELETE",
+      url: `/api/v2/organizations/${seedData1.organization.id}/memberships`,
+      headers: { authorization: `Bearer ${identityToken}` },
+      body: { membershipIds: [crypto.randomUUID()] }
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/backend/e2e-test/routes/v2/org-membership-machine-identity.spec.ts
+++ b/backend/e2e-test/routes/v2/org-membership-machine-identity.spec.ts
@@ -121,9 +121,9 @@ describe("Org membership routes with machine identity auth", () => {
     expect(row?.isActive).toBe(false);
   });
 
-  // Identity and group org memberships live in the same table as user memberships, so the user
-  // membership routes have to reject them rather than delete them under a user's audit event.
-  test("DELETE refuses an identity's org membership", async () => {
+  // An identity's org membership carries metadata keyed by identityId with a null userId. It exists
+  // here so the PATCH assertion below can prove the route no longer clears every such row in the org.
+  const addIdentityMember = async () => {
     const db = getDb();
     const suffix = crypto.randomUUID().slice(0, 8);
     const [identity] = await db(TableName.Identity)
@@ -136,19 +136,54 @@ describe("Org membership routes with machine identity auth", () => {
         scope: AccessScope.Organization
       })
       .returning("*");
+    const [metadata] = await db(TableName.IdentityMetadata)
+      .insert({ identityId: identity.id, orgId: seedData1.organization.id, key: "team", value: "platform" })
+      .returning("*");
+
+    const cleanup = async () => {
+      await db(TableName.IdentityMetadata).where({ identityId: identity.id }).del();
+      await db(TableName.Membership).where({ id: membership.id }).del();
+      await db(TableName.Identity).where({ id: identity.id }).del();
+    };
+
+    return { membershipId: membership.id, metadataId: metadata.id, cleanup };
+  };
+
+  // Identity and group org memberships live in the same table as user memberships, so the user
+  // membership routes have to reject them rather than act on them under a user's audit event.
+  test("DELETE refuses an identity's org membership", async () => {
+    const { membershipId, cleanup } = await addIdentityMember();
 
     try {
       const res = await testServer.inject({
         method: "DELETE",
-        url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${membership.id}`,
+        url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${membershipId}`,
         headers: { authorization: `Bearer ${identityToken}` }
       });
 
       expect(res.statusCode).toBe(404);
-      await expect(membershipExists(membership.id)).resolves.toBe(true);
+      await expect(membershipExists(membershipId)).resolves.toBe(true);
     } finally {
-      await db(TableName.Membership).where({ id: membership.id }).del();
-      await db(TableName.Identity).where({ id: identity.id }).del();
+      await cleanup();
+    }
+  });
+
+  test("PATCH refuses an identity's org membership without clearing identity metadata", async () => {
+    const { membershipId, metadataId, cleanup } = await addIdentityMember();
+
+    try {
+      const res = await testServer.inject({
+        method: "PATCH",
+        url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${membershipId}`,
+        headers: { authorization: `Bearer ${identityToken}` },
+        body: { metadata: [{ key: "team", value: "overwritten" }] }
+      });
+
+      expect(res.statusCode).toBe(404);
+      const metadata = await getDb()(TableName.IdentityMetadata).where({ id: metadataId }).first();
+      expect(metadata?.value).toBe("platform");
+    } finally {
+      await cleanup();
     }
   });
 

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -213,6 +213,7 @@ export enum EventType {
   UPDATE_IDENTITY = "update-identity",
   DELETE_IDENTITY = "delete-identity",
 
+  UPDATE_USER_ORG_MEMBERSHIP = "update-user-org-membership",
   DELETE_USER_ORG_MEMBERSHIP = "delete-user-org-membership",
 
   CREATE_IDENTITY_ORG_MEMBERSHIP = "create-identity-org-membership",
@@ -2104,6 +2105,17 @@ interface ClearIdentityLdapAuthLockoutsEvent {
   type: EventType.CLEAR_IDENTITY_LDAP_AUTH_LOCKOUTS;
   metadata: {
     identityId: string;
+  };
+}
+
+interface UpdateUserOrgMembershipEvent {
+  type: EventType.UPDATE_USER_ORG_MEMBERSHIP;
+  metadata: {
+    membershipId: string;
+    userId: string;
+    role?: string;
+    isActive?: boolean;
+    metadataKeys?: string[];
   };
 }
 
@@ -7253,6 +7265,7 @@ export type Event =
   | GetIdentityLdapAuthEvent
   | RevokeIdentityLdapAuthEvent
   | ClearIdentityLdapAuthLockoutsEvent
+  | UpdateUserOrgMembershipEvent
   | DeleteUserOrgMembershipEvent
   | CreateIdentityOrgMembershipEvent
   | UpdateIdentityOrgMembershipEvent

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -213,6 +213,8 @@ export enum EventType {
   UPDATE_IDENTITY = "update-identity",
   DELETE_IDENTITY = "delete-identity",
 
+  DELETE_USER_ORG_MEMBERSHIP = "delete-user-org-membership",
+
   CREATE_IDENTITY_ORG_MEMBERSHIP = "create-identity-org-membership",
   UPDATE_IDENTITY_ORG_MEMBERSHIP = "update-identity-org-membership",
   DELETE_IDENTITY_ORG_MEMBERSHIP = "delete-identity-org-membership",
@@ -2102,6 +2104,14 @@ interface ClearIdentityLdapAuthLockoutsEvent {
   type: EventType.CLEAR_IDENTITY_LDAP_AUTH_LOCKOUTS;
   metadata: {
     identityId: string;
+  };
+}
+
+interface DeleteUserOrgMembershipEvent {
+  type: EventType.DELETE_USER_ORG_MEMBERSHIP;
+  metadata: {
+    membershipId: string;
+    userId: string;
   };
 }
 
@@ -7243,6 +7253,7 @@ export type Event =
   | GetIdentityLdapAuthEvent
   | RevokeIdentityLdapAuthEvent
   | ClearIdentityLdapAuthLockoutsEvent
+  | DeleteUserOrgMembershipEvent
   | CreateIdentityOrgMembershipEvent
   | UpdateIdentityOrgMembershipEvent
   | DeleteIdentityOrgMembershipEvent

--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -211,6 +211,21 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
         ...req.body
       });
 
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.params.organizationId,
+        event: {
+          type: EventType.UPDATE_USER_ORG_MEMBERSHIP,
+          metadata: {
+            membershipId: membership.id,
+            userId: membership.actorUserId as string,
+            role: req.body.role,
+            isActive: req.body.isActive,
+            metadataKeys: req.body.metadata?.map(({ key }) => key)
+          }
+        }
+      });
+
       if (req.body.role) {
         void server.services.telemetry.sendPostHogEvents({
           event: PostHogEventTypes.OrgMembershipRoleUpdated,

--- a/backend/src/server/routes/v2/organization-router.ts
+++ b/backend/src/server/routes/v2/organization-router.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { OrgMembershipsSchema, OrgMembershipStatus, ProjectMembershipsSchema, ProjectsSchema } from "@app/db/schemas";
+import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, ORGANIZATIONS } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -200,10 +201,9 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      if (req.auth.actor !== ActorType.USER) return;
-
       const membership = await server.services.org.updateOrgMembership({
-        userId: req.permission.id,
+        actor: req.permission.type,
+        actorId: req.permission.id,
         actorAuthMethod: req.permission.authMethod,
         orgId: req.params.organizationId,
         membershipId: req.params.membershipId,
@@ -262,14 +262,25 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      if (req.auth.actor !== ActorType.USER) return;
-
       const membership = await server.services.org.deleteOrgMembership({
-        userId: req.permission.id,
+        actor: req.permission.type,
+        actorId: req.permission.id,
         actorAuthMethod: req.permission.authMethod,
         orgId: req.params.organizationId,
         membershipId: req.params.membershipId,
         actorOrgId: req.permission.orgId
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.params.organizationId,
+        event: {
+          type: EventType.DELETE_USER_ORG_MEMBERSHIP,
+          metadata: {
+            membershipId: membership.id,
+            userId: membership.actorUserId as string
+          }
+        }
       });
 
       void server.services.telemetry.sendPostHogEvents({
@@ -322,15 +333,29 @@ export const registerOrgRouter = async (server: FastifyZodProvider) => {
     },
     onRequest: verifyAuth([AuthMode.JWT, AuthMode.API_KEY, AuthMode.IDENTITY_ACCESS_TOKEN]),
     handler: async (req) => {
-      if (req.auth.actor !== ActorType.USER) return;
-
       const memberships = await server.services.org.bulkDeleteOrgMemberships({
-        userId: req.permission.id,
+        actor: req.permission.type,
+        actorId: req.permission.id,
         actorAuthMethod: req.permission.authMethod,
         orgId: req.params.organizationId,
         membershipIds: req.body.membershipIds,
         actorOrgId: req.permission.orgId
       });
+
+      for (const membership of memberships) {
+        // eslint-disable-next-line no-await-in-loop
+        await server.services.auditLog.createAuditLog({
+          ...req.auditLogInfo,
+          orgId: req.params.organizationId,
+          event: {
+            type: EventType.DELETE_USER_ORG_MEMBERSHIP,
+            metadata: {
+              membershipId: membership.id,
+              userId: membership.actorUserId as string
+            }
+          }
+        });
+      }
 
       void server.services.telemetry.sendPostHogEvents({
         event: PostHogEventTypes.OrgMembershipDeleted,

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -863,8 +863,8 @@ export const orgServiceFactory = ({
       scope: AccessScope.Organization,
       scopeOrgId: actorOrgId
     });
-    if (!foundMembership)
-      throw new NotFoundError({ message: `Organization membership with ID ${membershipId} not found` });
+    if (!foundMembership?.actorUserId)
+      throw new NotFoundError({ message: `Organization membership with ID '${membershipId}' not found` });
     if (foundMembership.scopeOrgId !== orgId)
       throw new UnauthorizedError({ message: "Updated org member doesn't belong to the organization" });
     if (actor === ActorType.USER && foundMembership.actorUserId === actorId)

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -841,15 +841,16 @@ export const orgServiceFactory = ({
     role,
     isActive,
     orgId,
-    userId,
+    actor,
+    actorId,
     membershipId,
     actorAuthMethod,
     actorOrgId,
     metadata
   }: TUpdateOrgMembershipDTO) => {
     const { permission } = await permissionService.getOrgPermission({
-      actor: ActorType.USER,
-      actorId: userId,
+      actor,
+      actorId,
       orgId,
       actorAuthMethod,
       actorOrgId,
@@ -866,7 +867,7 @@ export const orgServiceFactory = ({
       throw new NotFoundError({ message: `Organization membership with ID ${membershipId} not found` });
     if (foundMembership.scopeOrgId !== orgId)
       throw new UnauthorizedError({ message: "Updated org member doesn't belong to the organization" });
-    if (foundMembership.actorUserId === userId)
+    if (actor === ActorType.USER && foundMembership.actorUserId === actorId)
       throw new UnauthorizedError({ message: "Cannot update own organization membership" });
 
     const isCustomRole = !Object.values(OrgMembershipRole).includes(role as OrgMembershipRole);
@@ -1180,20 +1181,29 @@ export const orgServiceFactory = ({
 
   const deleteOrgMembership = async ({
     orgId,
-    userId,
+    actor,
+    actorId,
     membershipId,
     actorAuthMethod,
     actorOrgId
   }: TDeleteOrgMembershipDTO) => {
     const { permission } = await permissionService.getOrgPermission({
-      actor: ActorType.USER,
-      actorId: userId,
+      actor,
+      actorId,
       orgId,
       actorAuthMethod,
       actorOrgId,
       scope: OrganizationActionScope.Any
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Delete, OrgPermissionSubjects.Member);
+
+    const membershipToDelete = await membershipUserDAL.findOne({
+      id: membershipId,
+      scope: AccessScope.Organization,
+      scopeOrgId: orgId
+    });
+    if (!membershipToDelete?.actorUserId)
+      throw new NotFoundError({ message: `Organization membership with ID '${membershipId}' not found` });
 
     const [deletedMembership] = await deleteOrgMembershipsFn({
       orgMembershipIds: [membershipId],
@@ -1202,7 +1212,7 @@ export const orgServiceFactory = ({
       projectKeyDAL,
       userAliasDAL,
       licenseService,
-      userId,
+      userId: actor === ActorType.USER ? actorId : undefined,
       membershipUserDAL,
       membershipRoleDAL,
       userGroupMembershipDAL,
@@ -1219,14 +1229,15 @@ export const orgServiceFactory = ({
 
   const bulkDeleteOrgMemberships = async ({
     orgId,
-    userId,
+    actor,
+    actorId,
     membershipIds,
     actorAuthMethod,
     actorOrgId
   }: TDeleteOrgMembershipsDTO) => {
     const { permission } = await permissionService.getOrgPermission({
-      actor: ActorType.USER,
-      actorId: userId,
+      actor,
+      actorId,
       orgId,
       actorAuthMethod,
       actorOrgId,
@@ -1234,9 +1245,18 @@ export const orgServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Delete, OrgPermissionSubjects.Member);
 
-    if (membershipIds.includes(userId)) {
-      throw new BadRequestError({ message: "You cannot delete your own organization membership" });
-    }
+    const membershipsToDelete = await membershipUserDAL.find({
+      scope: AccessScope.Organization,
+      scopeOrgId: orgId,
+      $in: { id: membershipIds },
+      $notNull: ["actorUserId"]
+    });
+    const foundMembershipIds = new Set(membershipsToDelete.map((el) => el.id));
+    const missingMembershipIds = membershipIds.filter((id) => !foundMembershipIds.has(id));
+    if (missingMembershipIds.length)
+      throw new NotFoundError({
+        message: `Organization membership with ID '${missingMembershipIds.join("', '")}' not found`
+      });
 
     const deletedMemberships = await deleteOrgMembershipsFn({
       orgMembershipIds: membershipIds,
@@ -1245,7 +1265,7 @@ export const orgServiceFactory = ({
       projectKeyDAL,
       userAliasDAL,
       licenseService,
-      userId,
+      userId: actor === ActorType.USER ? actorId : undefined,
       membershipUserDAL,
       membershipRoleDAL,
       userGroupMembershipDAL,

--- a/backend/src/services/org/org-types.ts
+++ b/backend/src/services/org/org-types.ts
@@ -9,35 +9,23 @@ import { OrgWithSubOrgsSchema } from "./org-schema";
 export type TOrgWithSubOrgs = z.infer<typeof OrgWithSubOrgsSchema>;
 
 export type TUpdateOrgMembershipDTO = {
-  userId: string;
-  orgId: string;
   membershipId: string;
   role?: string;
   isActive?: boolean;
-  actorOrgId: string;
   metadata?: { key: string; value: string }[];
-  actorAuthMethod: ActorAuthMethod;
-};
+} & TOrgPermission;
 
 export type TGetOrgMembershipDTO = {
   membershipId: string;
 } & TOrgPermission;
 
 export type TDeleteOrgMembershipDTO = {
-  userId: string;
-  orgId: string;
   membershipId: string;
-  actorOrgId: string;
-  actorAuthMethod: ActorAuthMethod;
-};
+} & TOrgPermission;
 
 export type TDeleteOrgMembershipsDTO = {
-  userId: string;
-  orgId: string;
   membershipIds: string[];
-  actorOrgId: string;
-  actorAuthMethod: ActorAuthMethod;
-};
+} & TOrgPermission;
 
 export type TInviteUserToOrgDTO = {
   inviteeEmails: string[];

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -316,6 +316,8 @@ export const eventToNameMap: { [K in EventType]: string } = {
   [EventType.CREATE_SUB_ORGANIZATION]: "Create Sub Organization",
   [EventType.UPDATE_SUB_ORGANIZATION]: "Update Sub Organization",
 
+  [EventType.DELETE_USER_ORG_MEMBERSHIP]: "Delete User Org Membership",
+
   [EventType.CREATE_IDENTITY_ORG_MEMBERSHIP]: "Create Identity Org Membership",
   [EventType.UPDATE_IDENTITY_ORG_MEMBERSHIP]: "Update Identity Org Membership",
   [EventType.DELETE_IDENTITY_ORG_MEMBERSHIP]: "Delete Identity Org Membership",

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -316,6 +316,7 @@ export const eventToNameMap: { [K in EventType]: string } = {
   [EventType.CREATE_SUB_ORGANIZATION]: "Create Sub Organization",
   [EventType.UPDATE_SUB_ORGANIZATION]: "Update Sub Organization",
 
+  [EventType.UPDATE_USER_ORG_MEMBERSHIP]: "Update User Org Membership",
   [EventType.DELETE_USER_ORG_MEMBERSHIP]: "Delete User Org Membership",
 
   [EventType.CREATE_IDENTITY_ORG_MEMBERSHIP]: "Create Identity Org Membership",

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -305,6 +305,8 @@ export enum EventType {
   CREATE_SUB_ORGANIZATION = "create-sub-organization",
   UPDATE_SUB_ORGANIZATION = "update-sub-organization",
 
+  DELETE_USER_ORG_MEMBERSHIP = "delete-user-org-membership",
+
   CREATE_IDENTITY_ORG_MEMBERSHIP = "create-identity-org-membership",
   UPDATE_IDENTITY_ORG_MEMBERSHIP = "update-identity-org-membership",
   DELETE_IDENTITY_ORG_MEMBERSHIP = "delete-identity-org-membership",

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -305,6 +305,7 @@ export enum EventType {
   CREATE_SUB_ORGANIZATION = "create-sub-organization",
   UPDATE_SUB_ORGANIZATION = "update-sub-organization",
 
+  UPDATE_USER_ORG_MEMBERSHIP = "update-user-org-membership",
   DELETE_USER_ORG_MEMBERSHIP = "delete-user-org-membership",
 
   CREATE_IDENTITY_ORG_MEMBERSHIP = "create-identity-org-membership",

--- a/frontend/src/hooks/api/users/queries.tsx
+++ b/frontend/src/hooks/api/users/queries.tsx
@@ -275,22 +275,6 @@ export const useDeleteOrgMembershipBatch = () => {
   });
 };
 
-export const useDeactivateOrgMembership = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation<object, object, DeleteOrgMembershipDTO>({
-    mutationFn: ({ membershipId, orgId }) => {
-      return apiRequest.post(
-        `/api/v2/organizations/${orgId}/memberships/${membershipId}/deactivate`
-      );
-    },
-    onSuccess: (_, { orgId, membershipId }) => {
-      queryClient.invalidateQueries({ queryKey: userKeys.getOrgUsers(orgId) });
-      queryClient.invalidateQueries({ queryKey: userKeys.getOrgMembership(orgId, membershipId) });
-    }
-  });
-};
-
 export const useUpdateOrgMembership = () => {
   const queryClient = useQueryClient();
 


### PR DESCRIPTION
## Context

1. Machine identity requests were silently doing nothing. All three routes include IDENTITY_ACCESS_TOKEN in verifyAuth, but each handler started with if (req.auth.actor !== ActorType.USER) return;.

2. Unknown membership IDs returned 500 instead of 404. deleteOrgMembershipsFn returned [], then the route tried to read membership.status from undefined and threw a TypeError. Passing a user ID where a membership ID is expected is an obvious way to hit this.

3. Writes could affect non-user memberships. Identity and group org memberships share the memberships table. The read lookups filter by actorUserId, but the write lookups did not. For example, passing an identity's org membership ID to PATCH with a metadata body triggered identityMetadataDAL.delete({ userId: null, orgId }). Knex renders that as where "userId" is null, which deleted every machine identity's metadata in the org.

4. Adds a `delete-user-org-membership` audit event. There was no audit trail for user org
  membership removal at all, only a PostHog event. Emitted once per removed member, matching
  `REMOVE_PROJECT_MEMBER`.

## Steps to verify the change

1. In the UI, go to **Access Control > Machine Identities > Create**, and select the **Admin** role. Open **Universal Auth**, copy the **Client ID**, and add a **Client Secret**.

2. Get a token:

```bash
curl -s -X POST http://localhost:8080/api/v1/auth/universal-auth/login \
  -H 'Content-Type: application/json' \
  -d '{"clientId":"<id>","clientSecret":"<secret>"}' | jq -r .accessToken
```

3. Invite a throwaway user and get its membership ID from `GET /api/v2/organizations/$ORG/memberships`. Then run:

```bash
BASE=http://localhost:8080/api/v2/organizations/$ORG/memberships
A="Authorization: Bearer $TOKEN"

# 200 + membership body; the row is actually deleted
# (previously returned 200 + an empty body without deleting the row)
curl -i -X DELETE "$BASE/$MEMBERSHIP_ID" -H "$A"

# 404 with the requested ID
# (previously returned 500)
curl -i -X DELETE "$BASE/00000000-0000-4000-8000-000000000000" -H "$A"

# 200; isActive is set to false
curl -i -X PATCH "$BASE/$MEMBERSHIP_ID" -H "$A" \
  -H 'Content-Type: application/json' -d '{"isActive":false}'
```

4. Verify non-user membership rejection. Take an `id` from `GET /api/v2/organizations/$ORG/identity-memberships` (this `id` is the membership row ID) and confirm that both requests return **404**. Also confirm that `identity_metadata` still contains its rows:

```bash
curl -i -X DELETE "$BASE/$IDENTITY_MEMBERSHIP_ID" -H "$A"
curl -i -X PATCH "$BASE/$IDENTITY_MEMBERSHIP_ID" -H "$A" \
  -H 'Content-Type: application/json' -d '{"metadata":[{"key":"x","value":"y"}]}'
```

5. Check the audit log under **Organization > Audit Logs**. There should be one **Delete User Org Membership** entry for each removed member, with `identity` as the actor and metadata containing `membershipId` and a non-null `userId`. The rejected 404 requests should not produce any audit log entries.


## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)