### PR TITLE
improvement(secrets): migrate Vault import dialogs to v3

### DIFF
--- a/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sqlDatabase.tsx
+++ b/frontend/src/components/dynamic-secrets/DynamicSecretProviderForm/providerDefinitions/sqlDatabase.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Controller, useFieldArray, useFormContext } from "react-hook-form";
 import { InfoIcon, PlusIcon, Trash2Icon } from "lucide-react";
 
+import { VaultSqlDatabaseImportModal } from "@app/components/external-migrations";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import { ValidationRuleOverrideNotice } from "@app/components/secret-validation/ValidationRuleOverrideNotice";
@@ -40,7 +41,6 @@ import {
   DynamicSecretRuleProvider,
   SecretValidationRuleType
 } from "@app/hooks/api/secretValidationRules";
-import { VaultSqlDatabaseImportModal } from "@app/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/VaultSqlDatabaseImportModal";
 
 import { DynamicSecretProviderFields } from "../DynamicSecretProviderFields";
 import { DynamicSecretProviderGroup } from "../DynamicSecretProviderGroup";

--- a/frontend/src/components/external-migrations/VaultConnectionAndNamespaceFields.tsx
+++ b/frontend/src/components/external-migrations/VaultConnectionAndNamespaceFields.tsx
@@ -116,7 +116,7 @@ export const VaultConnectionAndNamespaceFields = ({
             )}
           />
           <FieldDescription>
-            Project-scoped HashiCorp Vault app connections available to you
+            HashiCorp Vault app connections available to you in this project.
           </FieldDescription>
         </Field>
       )}

--- a/frontend/src/components/external-migrations/VaultConnectionAndNamespaceFields.tsx
+++ b/frontend/src/components/external-migrations/VaultConnectionAndNamespaceFields.tsx
@@ -1,5 +1,19 @@
-import { AppConnectionOption } from "@app/components/app-connections";
-import { FilterableSelect, FormControl } from "@app/components/v2";
+import { ReactNode } from "react";
+import { CircleHelpIcon } from "lucide-react";
+
+import {
+  Badge,
+  Combobox,
+  Field,
+  FieldDescription,
+  FieldLabel,
+  OrgIcon,
+  SubOrgIcon,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
+import { useOrganization } from "@app/context";
 import { TAvailableAppConnection } from "@app/hooks/api/appConnections/types";
 import { useGetVaultNamespaces } from "@app/hooks/api/migration/queries";
 
@@ -11,10 +25,41 @@ type Props = {
   onNamespaceChange: (namespace: string) => void;
   namespaceTooltip: string;
   namespaceHelpText: string;
+  idPrefix?: string;
+};
+
+type VaultFieldLabelProps = {
+  children: ReactNode;
+  htmlFor: string;
+  tooltip: string;
+  tooltipLabel: string;
 };
 
 export const defaultVaultConnectionId = (appConnections: TAvailableAppConnection[]) =>
   appConnections.length === 1 ? appConnections[0].id : null;
+
+export const VaultFieldLabel = ({
+  children,
+  htmlFor,
+  tooltip,
+  tooltipLabel
+}: VaultFieldLabelProps) => (
+  <div className="flex items-center gap-1.5">
+    <FieldLabel htmlFor={htmlFor}>{children}</FieldLabel>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label={`${tooltipLabel} information`}
+          className="rounded-sm text-muted outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <CircleHelpIcon className="size-3.5" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  </div>
+);
 
 export const VaultConnectionAndNamespaceFields = ({
   appConnections,
@@ -23,65 +68,86 @@ export const VaultConnectionAndNamespaceFields = ({
   namespace,
   onNamespaceChange,
   namespaceTooltip,
-  namespaceHelpText
+  namespaceHelpText,
+  idPrefix = "vault-import"
 }: Props) => {
+  const { isSubOrganization } = useOrganization();
   const hasAppConnections = appConnections.length > 0;
   const needsConnection = hasAppConnections && !connectionId;
   const activeConnectionId = hasAppConnections ? (connectionId ?? undefined) : undefined;
   const { data: namespaces, isLoading: isLoadingNamespaces } =
     useGetVaultNamespaces(activeConnectionId);
+  const connectionInputId = `${idPrefix}-app-connection`;
+  const namespaceInputId = `${idPrefix}-namespace`;
 
   return (
     <>
       {hasAppConnections && (
-        <FormControl
-          label="App Connection"
-          className="mb-4"
-          tooltipText="Select the HashiCorp Vault app connection to use for this import."
-        >
-          <>
-            <FilterableSelect
-              value={appConnections.find((conn) => conn.id === connectionId) ?? null}
-              onChange={(value) => {
-                if (value && !Array.isArray(value)) {
-                  onConnectionIdChange((value as TAvailableAppConnection).id);
-                }
-              }}
-              options={appConnections}
-              getOptionValue={(option) => option.id}
-              getOptionLabel={(option) => option.name}
-              placeholder="Select app connection..."
-              className="w-full"
-              components={{ Option: AppConnectionOption }}
-            />
-            <p className="mt-1 text-xs text-mineshaft-400">
-              Project-scoped HashiCorp Vault app connections available to you
-            </p>
-          </>
-        </FormControl>
+        <Field>
+          <VaultFieldLabel
+            htmlFor={connectionInputId}
+            tooltip="Select the HashiCorp Vault app connection to use for this import."
+            tooltipLabel="App Connection"
+          >
+            App Connection
+          </VaultFieldLabel>
+          <Combobox
+            id={connectionInputId}
+            value={appConnections.find((connection) => connection.id === connectionId) ?? null}
+            onValueChange={(connection) => onConnectionIdChange(connection.id)}
+            options={appConnections}
+            getOptionValue={(option) => option.id}
+            getOptionLabel={(option) => option.name}
+            placeholder="Select app connection..."
+            searchPlaceholder="Search app connections..."
+            searchAriaLabel="Search app connections"
+            emptyMessage="No app connections found."
+            modal
+            renderOption={(option) => (
+              <div className="flex min-w-0 items-center justify-between gap-2">
+                <span className="truncate">{option.name}</span>
+                {!option.projectId && (
+                  <Badge variant={isSubOrganization ? "sub-org" : "org"}>
+                    {isSubOrganization ? <SubOrgIcon /> : <OrgIcon />}
+                    {isSubOrganization ? "Sub-Organization" : "Organization"}
+                  </Badge>
+                )}
+              </div>
+            )}
+          />
+          <FieldDescription>
+            Project-scoped HashiCorp Vault app connections available to you
+          </FieldDescription>
+        </Field>
       )}
 
-      <FormControl label="Namespace" className="mb-4" tooltipText={namespaceTooltip}>
-        <>
-          <FilterableSelect
-            value={namespaces?.find((ns) => ns.name === namespace) ?? null}
-            onChange={(value) => {
-              if (value && !Array.isArray(value)) {
-                onNamespaceChange((value as { id: string; name: string }).name);
-              }
-            }}
-            options={namespaces || []}
-            getOptionValue={(option) => option.name}
-            getOptionLabel={(option) => (option.name === "/" ? "root" : option.name)}
-            isDisabled={isLoadingNamespaces || needsConnection}
-            placeholder={
-              needsConnection ? "Select an app connection first..." : "Select namespace..."
-            }
-            className="w-full"
-          />
-          <p className="mt-1 text-xs text-mineshaft-400">{namespaceHelpText}</p>
-        </>
-      </FormControl>
+      <Field>
+        <VaultFieldLabel
+          htmlFor={namespaceInputId}
+          tooltip={namespaceTooltip}
+          tooltipLabel="Namespace"
+        >
+          Namespace
+        </VaultFieldLabel>
+        <Combobox
+          id={namespaceInputId}
+          value={namespaces?.find((option) => option.name === namespace) ?? null}
+          onValueChange={(option) => onNamespaceChange(option.name)}
+          options={namespaces ?? []}
+          getOptionValue={(option) => option.name}
+          getOptionLabel={(option) => (option.name === "/" ? "root" : option.name)}
+          isDisabled={isLoadingNamespaces || needsConnection}
+          isLoading={isLoadingNamespaces}
+          placeholder={
+            needsConnection ? "Select an app connection first..." : "Select namespace..."
+          }
+          searchPlaceholder="Search namespaces..."
+          searchAriaLabel="Search Vault namespaces"
+          emptyMessage="No Vault namespaces found."
+          modal
+        />
+        <FieldDescription>{namespaceHelpText}</FieldDescription>
+      </Field>
     </>
   );
 };

--- a/frontend/src/components/external-migrations/VaultRoleImportModal.tsx
+++ b/frontend/src/components/external-migrations/VaultRoleImportModal.tsx
@@ -1,0 +1,317 @@
+import { useReducer } from "react";
+import { InfoIcon } from "lucide-react";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Alert,
+  AlertDescription,
+  Button,
+  Combobox,
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldDescription
+} from "@app/components/v3";
+import { TAvailableAppConnection } from "@app/hooks/api/appConnections/types";
+import {
+  useGetVaultAuthMounts,
+  useGetVaultDatabaseRoles,
+  useGetVaultKubernetesAuthRoles,
+  useGetVaultKubernetesRoles,
+  useGetVaultLdapRoles,
+  useGetVaultMounts
+} from "@app/hooks/api/migration/queries";
+import {
+  VaultDatabaseRole,
+  VaultKubernetesAuthRole,
+  VaultKubernetesRole,
+  VaultLdapRole
+} from "@app/hooks/api/migration/types";
+
+import {
+  VaultConnectionAndNamespaceFields,
+  VaultFieldLabel
+} from "./VaultConnectionAndNamespaceFields";
+import { createVaultImportSelection, vaultImportSelectionReducer } from "./vaultImportSelection";
+import {
+  getVaultRoleImportMounts,
+  getVaultRoleImportRoles,
+  VAULT_ROLE_IMPORT_CONFIG,
+  VaultMount,
+  VaultRoleImportEngine
+} from "./VaultRoleImportModal.utils";
+
+type VaultRole = VaultDatabaseRole | VaultKubernetesAuthRole | VaultKubernetesRole | VaultLdapRole;
+
+type BaseProps<TRole extends VaultRole> = {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  appConnections: TAvailableAppConnection[];
+  onImport: (role: TRole) => void;
+};
+
+type ContentProps<TRole extends VaultRole> = {
+  appConnections: TAvailableAppConnection[];
+  engine: VaultRoleImportEngine;
+  onClose: () => void;
+  onImport: (role: TRole) => void;
+};
+
+const VaultRoleImportContent = <TRole extends VaultRole>({
+  appConnections,
+  engine,
+  onClose,
+  onImport
+}: ContentProps<TRole>) => {
+  const config = VAULT_ROLE_IMPORT_CONFIG[engine];
+  const hasAppConnections = appConnections.length > 0;
+  const [state, dispatch] = useReducer(
+    vaultImportSelectionReducer<TRole>,
+    appConnections.map(({ id }) => id),
+    createVaultImportSelection<TRole>
+  );
+  const { connectionId, mountPath, namespace, selection: selectedRole } = state;
+  const activeConnectionId = hasAppConnections ? (connectionId ?? undefined) : undefined;
+  const shouldFetchMounts = Boolean(namespace && activeConnectionId);
+  const shouldFetchRoles = Boolean(namespace && mountPath && activeConnectionId);
+  const isAuthImport = engine === "kubernetesAuth";
+
+  const vaultMountsQuery = useGetVaultMounts(
+    shouldFetchMounts && !isAuthImport,
+    namespace ?? undefined,
+    activeConnectionId
+  );
+  const authMountsQuery = useGetVaultAuthMounts(
+    shouldFetchMounts && isAuthImport,
+    namespace ?? undefined,
+    "kubernetes",
+    activeConnectionId
+  );
+  const ldapRolesQuery = useGetVaultLdapRoles(
+    shouldFetchRoles && engine === "ldap",
+    namespace ?? undefined,
+    mountPath ?? undefined,
+    activeConnectionId
+  );
+  const databaseRolesQuery = useGetVaultDatabaseRoles(
+    shouldFetchRoles && (engine === "sqlDatabase" || engine === "cassandra"),
+    namespace ?? undefined,
+    mountPath ?? undefined,
+    activeConnectionId
+  );
+  const kubernetesRolesQuery = useGetVaultKubernetesRoles(
+    shouldFetchRoles && engine === "kubernetes",
+    namespace ?? undefined,
+    mountPath ?? undefined,
+    activeConnectionId
+  );
+  const kubernetesAuthRolesQuery = useGetVaultKubernetesAuthRoles(
+    shouldFetchRoles && isAuthImport,
+    namespace ?? undefined,
+    mountPath ?? undefined,
+    activeConnectionId
+  );
+
+  const mountsQuery = isAuthImport ? authMountsQuery : vaultMountsQuery;
+  const mounts = getVaultRoleImportMounts(engine, mountsQuery.data as VaultMount[] | undefined);
+  const rawRoles = (() => {
+    if (engine === "ldap") return ldapRolesQuery.data;
+    if (engine === "kubernetes") return kubernetesRolesQuery.data;
+    if (engine === "kubernetesAuth") return kubernetesAuthRolesQuery.data;
+    return databaseRolesQuery.data;
+  })() as TRole[] | undefined;
+  const roles = getVaultRoleImportRoles(engine, rawRoles) as TRole[];
+  const rolesQuery = (() => {
+    if (engine === "ldap") return ldapRolesQuery;
+    if (engine === "kubernetes") return kubernetesRolesQuery;
+    if (engine === "kubernetesAuth") return kubernetesAuthRolesQuery;
+    return databaseRolesQuery;
+  })();
+  const idPrefix = `vault-${engine}-import`;
+  const mountInputId = `${idPrefix}-mount`;
+  const roleInputId = `${idPrefix}-role`;
+  let { rolePlaceholder } = config;
+  if (!mountPath) {
+    rolePlaceholder = isAuthImport
+      ? "Select an auth engine first..."
+      : "Select a mount path first...";
+  }
+
+  const handleImport = () => {
+    if (!selectedRole) {
+      createNotification({ type: "error", text: config.roleSelectionMessage });
+      return;
+    }
+    if (!namespace) {
+      createNotification({ type: "error", text: "Please select a namespace" });
+      return;
+    }
+    if (hasAppConnections && !connectionId) {
+      createNotification({ type: "error", text: "Please select an app connection" });
+      return;
+    }
+    if (!mounts.length) {
+      createNotification({ type: "error", text: config.noMountsMessage });
+      return;
+    }
+
+    onImport(selectedRole);
+    onClose();
+  };
+
+  return (
+    <>
+      <DialogBody className="space-y-5">
+        {config.infoText && (
+          <Alert variant="project">
+            <InfoIcon />
+            <AlertDescription>{config.infoText}</AlertDescription>
+          </Alert>
+        )}
+
+        <VaultConnectionAndNamespaceFields
+          appConnections={appConnections}
+          connectionId={connectionId}
+          onConnectionIdChange={(value) => dispatch({ type: "connection", value })}
+          namespace={namespace}
+          onNamespaceChange={(value) => dispatch({ type: "namespace", value })}
+          namespaceTooltip={config.namespaceTooltip}
+          namespaceHelpText={config.namespaceHelpText}
+          idPrefix={idPrefix}
+        />
+
+        <Field>
+          <VaultFieldLabel
+            htmlFor={mountInputId}
+            tooltip={config.mountTooltip}
+            tooltipLabel={config.mountLabel}
+          >
+            {config.mountLabel}
+          </VaultFieldLabel>
+          <Combobox
+            id={mountInputId}
+            value={mounts.find((mount) => mount.path.replace(/\/$/, "") === mountPath) ?? null}
+            onValueChange={(mount) =>
+              dispatch({ type: "mount", value: mount.path.replace(/\/$/, "") })
+            }
+            onClear={() => dispatch({ type: "mount", value: null })}
+            options={mounts}
+            getOptionValue={(mount) => mount.path}
+            getOptionLabel={(mount) => mount.path.replace(/\/$/, "")}
+            isDisabled={!namespace || mountsQuery.isLoading || !mounts.length}
+            isLoading={mountsQuery.isLoading}
+            isError={mountsQuery.isError}
+            placeholder={namespace ? config.mountPlaceholder : "Select a namespace first..."}
+            searchPlaceholder={`Search ${config.mountLabel.toLowerCase()}...`}
+            searchAriaLabel={`Search ${config.mountLabel}`}
+            clearAriaLabel={`Clear ${config.mountLabel}`}
+            emptyMessage={`No ${config.mountLabel.toLowerCase()} found.`}
+            modal
+          />
+          <FieldDescription>{config.mountHelpText}</FieldDescription>
+        </Field>
+
+        <Field>
+          <VaultFieldLabel
+            htmlFor={roleInputId}
+            tooltip={config.roleHelpText}
+            tooltipLabel={config.roleLabel}
+          >
+            {config.roleLabel}
+          </VaultFieldLabel>
+          <Combobox
+            id={roleInputId}
+            value={selectedRole}
+            onValueChange={(value) => dispatch({ type: "selection", value })}
+            onClear={() => dispatch({ type: "selection", value: null })}
+            options={roles}
+            getOptionValue={(role) => role.name}
+            getOptionLabel={(role) => role.name}
+            isDisabled={!mountPath || rolesQuery.isLoading || !roles.length}
+            isLoading={rolesQuery.isLoading}
+            isError={rolesQuery.isError}
+            placeholder={rolePlaceholder}
+            searchPlaceholder={`Search ${config.roleLabel.toLowerCase()}...`}
+            searchAriaLabel={`Search ${config.roleLabel}`}
+            clearAriaLabel={`Clear ${config.roleLabel}`}
+            emptyMessage={`No ${config.roleLabel.toLowerCase()} found.`}
+            modal
+          />
+          <FieldDescription>{config.roleHelpText}</FieldDescription>
+        </Field>
+      </DialogBody>
+
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button>Cancel</Button>
+        </DialogClose>
+        <Button
+          variant={config.scope}
+          onClick={handleImport}
+          isDisabled={!selectedRole || mountsQuery.isLoading || rolesQuery.isLoading}
+        >
+          {config.actionLabel}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+};
+
+type VaultRoleImportModalProps<TRole extends VaultRole> = BaseProps<TRole> & {
+  engine: VaultRoleImportEngine;
+};
+
+const VaultRoleImportModal = <TRole extends VaultRole>({
+  isOpen,
+  onOpenChange,
+  appConnections,
+  onImport,
+  engine
+}: VaultRoleImportModalProps<TRole>) => {
+  const config = VAULT_ROLE_IMPORT_CONFIG[engine];
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      {isOpen && (
+        <DialogContent className="max-w-2xl overflow-hidden">
+          <DialogHeader>
+            <DialogTitle>{config.title}</DialogTitle>
+            <DialogDescription>{config.description}</DialogDescription>
+          </DialogHeader>
+          <VaultRoleImportContent
+            appConnections={appConnections}
+            engine={engine}
+            onClose={() => onOpenChange(false)}
+            onImport={onImport}
+          />
+        </DialogContent>
+      )}
+    </Dialog>
+  );
+};
+
+export const VaultLdapImportModal = (props: BaseProps<VaultLdapRole>) => (
+  <VaultRoleImportModal {...props} engine="ldap" />
+);
+
+export const VaultSqlDatabaseImportModal = (props: BaseProps<VaultDatabaseRole>) => (
+  <VaultRoleImportModal {...props} engine="sqlDatabase" />
+);
+
+export const VaultCassandraImportModal = (props: BaseProps<VaultDatabaseRole>) => (
+  <VaultRoleImportModal {...props} engine="cassandra" />
+);
+
+export const VaultKubernetesImportModal = (props: BaseProps<VaultKubernetesRole>) => (
+  <VaultRoleImportModal {...props} engine="kubernetes" />
+);
+
+export const VaultKubernetesAuthImportModal = (props: BaseProps<VaultKubernetesAuthRole>) => (
+  <VaultRoleImportModal {...props} engine="kubernetesAuth" />
+);

--- a/frontend/src/components/external-migrations/VaultRoleImportModal.tsx
+++ b/frontend/src/components/external-migrations/VaultRoleImportModal.tsx
@@ -279,7 +279,7 @@ const VaultRoleImportModal = <TRole extends VaultRole>({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       {isOpen && (
-        <DialogContent className="max-w-2xl overflow-hidden">
+        <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle>{config.title}</DialogTitle>
             <DialogDescription>{config.description}</DialogDescription>

--- a/frontend/src/components/external-migrations/VaultRoleImportModal.tsx
+++ b/frontend/src/components/external-migrations/VaultRoleImportModal.tsx
@@ -279,7 +279,12 @@ const VaultRoleImportModal = <TRole extends VaultRole>({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       {isOpen && (
-        <DialogContent className="max-w-2xl">
+        // Match the legacy parent modal's layer; portal order keeps this dialog and its comboboxes above it.
+        <DialogContent
+          className="z-[60] max-w-2xl"
+          overlayClassName="z-[60]"
+          onOpenAutoFocus={(event) => event.preventDefault()}
+        >
           <DialogHeader>
             <DialogTitle>{config.title}</DialogTitle>
             <DialogDescription>{config.description}</DialogDescription>

--- a/frontend/src/components/external-migrations/VaultRoleImportModal.utils.test.ts
+++ b/frontend/src/components/external-migrations/VaultRoleImportModal.utils.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { VaultDatabaseRole } from "@app/hooks/api/migration/types";
+
+import {
+  getVaultRoleImportMounts,
+  getVaultRoleImportRoles,
+  VAULT_ROLE_IMPORT_CONFIG
+} from "./VaultRoleImportModal.utils";
+
+describe("Vault role import configuration", () => {
+  it("keeps each provider on its supported Vault mount type", () => {
+    const mounts = [
+      { path: "ldap/", type: "ldap" },
+      { path: "database/", type: "database" },
+      { path: "kubernetes/", type: "kubernetes" }
+    ];
+
+    assert.deepEqual(getVaultRoleImportMounts("ldap", mounts), [mounts[0]]);
+    assert.deepEqual(getVaultRoleImportMounts("sqlDatabase", mounts), [mounts[1]]);
+    assert.deepEqual(getVaultRoleImportMounts("cassandra", mounts), [mounts[1]]);
+    assert.deepEqual(getVaultRoleImportMounts("kubernetes", mounts), [mounts[2]]);
+    assert.deepEqual(getVaultRoleImportMounts("kubernetesAuth", mounts), [mounts[2]]);
+  });
+
+  it("limits Cassandra imports to Cassandra database plugins", () => {
+    const roles: VaultDatabaseRole[] = [
+      {
+        name: "cassandra-role",
+        mountPath: "database",
+        db_name: "cassandra",
+        config: {
+          plugin_name: "cassandra-database-plugin",
+          connection_details: {}
+        }
+      },
+      {
+        name: "postgres-role",
+        mountPath: "database",
+        db_name: "postgres",
+        config: {
+          plugin_name: "postgresql-database-plugin",
+          connection_details: {}
+        }
+      }
+    ];
+
+    assert.deepEqual(getVaultRoleImportRoles("cassandra", roles), [roles[0]]);
+    assert.deepEqual(getVaultRoleImportRoles("sqlDatabase", roles), roles);
+  });
+
+  it("keeps organization Kubernetes auth behavior distinct from dynamic secrets", () => {
+    const auth = VAULT_ROLE_IMPORT_CONFIG.kubernetesAuth;
+
+    assert.equal(auth.title, "Load Kubernetes Auth from HashiCorp Vault");
+    assert.equal(auth.mountLabel, "Auth Engine");
+    assert.equal(auth.actionLabel, "Load");
+    assert.equal(auth.scope, "org");
+    assert.equal(auth.infoText, undefined);
+    assert.equal(VAULT_ROLE_IMPORT_CONFIG.kubernetes.actionLabel, "Load Configuration");
+  });
+});

--- a/frontend/src/components/external-migrations/VaultRoleImportModal.utils.ts
+++ b/frontend/src/components/external-migrations/VaultRoleImportModal.utils.ts
@@ -1,0 +1,156 @@
+import type { VaultDatabaseRole } from "@app/hooks/api/migration/types";
+
+export type VaultRoleImportEngine =
+  | "cassandra"
+  | "kubernetes"
+  | "kubernetesAuth"
+  | "ldap"
+  | "sqlDatabase";
+
+export type VaultMount = { path: string; type: string; version?: string | null };
+
+type VaultRoleImportConfig = {
+  actionLabel: string;
+  description: string;
+  infoText?: string;
+  mountHelpText: string;
+  mountLabel: string;
+  mountPlaceholder: string;
+  mountTooltip: string;
+  mountType: string;
+  namespaceHelpText: string;
+  namespaceTooltip: string;
+  noMountsMessage: string;
+  roleHelpText: string;
+  roleLabel: string;
+  rolePlaceholder: string;
+  roleSelectionMessage: string;
+  scope: "org" | "project";
+  title: string;
+};
+
+export const VAULT_ROLE_IMPORT_CONFIG: Record<VaultRoleImportEngine, VaultRoleImportConfig> = {
+  ldap: {
+    title: "Load from HashiCorp Vault",
+    description: "Select an LDAP secrets engine role to load its configuration.",
+    infoText:
+      "Select an LDAP secrets engine role from Vault to pre-fill the form with its configuration including connection details, LDIF statements, TTL settings, etc.",
+    namespaceTooltip: "Select the Vault namespace containing the LDAP secrets engine.",
+    namespaceHelpText: "Select the Vault namespace to fetch available LDAP secrets engines",
+    mountType: "ldap",
+    mountLabel: "LDAP Secrets Engine",
+    mountTooltip: "Select the LDAP secrets engine mount to fetch available roles.",
+    mountHelpText: "Choose an LDAP secrets engine mount to list available roles",
+    mountPlaceholder: "Select LDAP secrets engine...",
+    roleLabel: "LDAP Role",
+    roleHelpText: "Choose an LDAP role from the selected mount to load its configuration",
+    rolePlaceholder: "Select a role to load...",
+    roleSelectionMessage: "Please select a Vault LDAP role to load",
+    noMountsMessage:
+      "No Vault mounts found. Please ensure you have LDAP secrets engine configured.",
+    actionLabel: "Load Configuration",
+    scope: "project"
+  },
+  sqlDatabase: {
+    title: "Load from HashiCorp Vault",
+    description: "Select a database secrets engine role to load its configuration.",
+    infoText:
+      "Select a database secrets engine role from Vault to pre-fill the form with its configuration including connection details, creation/revocation statements, TTL settings, etc.",
+    namespaceTooltip: "Select the Vault namespace containing the database secrets engine.",
+    namespaceHelpText: "Select the Vault namespace to fetch available database secrets engines",
+    mountType: "database",
+    mountLabel: "Database Secrets Engine",
+    mountTooltip: "Select the database secrets engine mount to fetch available roles.",
+    mountHelpText: "Choose a database secrets engine mount to list available roles",
+    mountPlaceholder: "Select database secrets engine...",
+    roleLabel: "Database Role",
+    roleHelpText:
+      "Choose a database dynamic role from the selected mount to load its configuration",
+    rolePlaceholder: "Select a role to load...",
+    roleSelectionMessage: "Please select a Vault database role to load",
+    noMountsMessage:
+      "No Vault mounts found. Please ensure you have database secrets engine configured.",
+    actionLabel: "Load Configuration",
+    scope: "project"
+  },
+  cassandra: {
+    title: "Load from HashiCorp Vault",
+    description: "Select a Cassandra database role to load its configuration.",
+    infoText:
+      "Select a Cassandra database role from Vault to pre-fill the form with its configuration including connection details, creation/revocation statements, TTL settings, etc.",
+    namespaceTooltip: "Select the Vault namespace containing the database secrets engine.",
+    namespaceHelpText: "Select the Vault namespace to fetch available database secrets engines",
+    mountType: "database",
+    mountLabel: "Database Secrets Engine",
+    mountTooltip: "Select the database secrets engine mount to fetch available Cassandra roles.",
+    mountHelpText: "Choose a database secrets engine mount to list available Cassandra roles",
+    mountPlaceholder: "Select database secrets engine...",
+    roleLabel: "Cassandra Role",
+    roleHelpText: "Choose a Cassandra role from the selected mount to load its configuration",
+    rolePlaceholder: "Select a role to load...",
+    roleSelectionMessage: "Please select a Vault Cassandra role to load",
+    noMountsMessage:
+      "No Vault mounts found. Please ensure you have database secrets engine configured.",
+    actionLabel: "Load Configuration",
+    scope: "project"
+  },
+  kubernetes: {
+    title: "Load from HashiCorp Vault",
+    description: "Select a Kubernetes secrets engine role to load its configuration.",
+    infoText:
+      "Select a Kubernetes secrets engine role from Vault to pre-fill the form with its configuration including cluster URL, CA certificate, TTL settings, etc.",
+    namespaceTooltip: "Select the Vault namespace containing the Kubernetes secrets engine.",
+    namespaceHelpText: "Select the Vault namespace to fetch available Kubernetes secrets engines",
+    mountType: "kubernetes",
+    mountLabel: "Kubernetes Secrets Engine",
+    mountTooltip: "Select the Kubernetes secrets engine mount to fetch available roles.",
+    mountHelpText: "Choose a Kubernetes secrets engine mount to list available roles",
+    mountPlaceholder: "Select Kubernetes secrets engine...",
+    roleLabel: "Kubernetes Role",
+    roleHelpText: "Choose a Kubernetes role from the selected mount to load its configuration",
+    rolePlaceholder: "Select a role to load...",
+    roleSelectionMessage: "Please select a Vault Kubernetes role to load",
+    noMountsMessage:
+      "No Vault mounts found. Please ensure you have Kubernetes secrets engine configured.",
+    actionLabel: "Load Configuration",
+    scope: "project"
+  },
+  kubernetesAuth: {
+    title: "Load Kubernetes Auth from HashiCorp Vault",
+    description:
+      "Load Kubernetes authentication configuration from your Vault instance. The auth method and role settings will be automatically translated and prefilled in the form.",
+    namespaceTooltip: "Select the Vault namespace containing the Kubernetes auth configuration.",
+    namespaceHelpText: "Select the Vault namespace to fetch available auth mounts",
+    mountType: "kubernetes",
+    mountLabel: "Auth Engine",
+    mountTooltip: "Select the Kubernetes auth engine to narrow down available roles.",
+    mountHelpText: "Choose a Kubernetes auth engine to filter available roles",
+    mountPlaceholder: "Select auth engine...",
+    roleLabel: "Kubernetes Role",
+    roleHelpText: "Select the Kubernetes role to load configuration from",
+    rolePlaceholder: "Select a Kubernetes role to load...",
+    roleSelectionMessage: "Please select a Kubernetes role to load",
+    noMountsMessage:
+      "No Vault auth mounts found. Please ensure you have Kubernetes authentication configured.",
+    actionLabel: "Load",
+    scope: "org"
+  }
+};
+
+export const getVaultRoleImportMounts = (
+  engine: VaultRoleImportEngine,
+  mounts: VaultMount[] | undefined
+) => mounts?.filter((mount) => mount.type === VAULT_ROLE_IMPORT_CONFIG[engine].mountType) ?? [];
+
+export const getVaultRoleImportRoles = <TRole extends { name: string }>(
+  engine: VaultRoleImportEngine,
+  roles: TRole[] | undefined
+) => {
+  if (engine !== "cassandra") return roles ?? [];
+
+  return (
+    (roles as Array<TRole & VaultDatabaseRole> | undefined)?.filter((role) =>
+      role.config.plugin_name?.toLowerCase().includes("cassandra")
+    ) ?? []
+  );
+};

--- a/frontend/src/components/external-migrations/index.ts
+++ b/frontend/src/components/external-migrations/index.ts
@@ -1,1 +1,3 @@
 export * from "./VaultConnectionAndNamespaceFields";
+export * from "./VaultRoleImportModal";
+export * from "./VaultRoleImportModal.utils";

--- a/frontend/src/components/external-migrations/vaultImportSelection.test.ts
+++ b/frontend/src/components/external-migrations/vaultImportSelection.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { createVaultImportSelection, vaultImportSelectionReducer } from "./vaultImportSelection";
+
+describe("Vault import selection", () => {
+  it("selects the only available app connection by default", () => {
+    assert.deepEqual(createVaultImportSelection<string>(["connection-id"]), {
+      connectionId: "connection-id",
+      namespace: null,
+      mountPath: null,
+      selection: null
+    });
+    assert.equal(createVaultImportSelection<string>(["one", "two"]).connectionId, null);
+  });
+
+  it("clears every dependent selection when the connection changes", () => {
+    const result = vaultImportSelectionReducer(
+      {
+        connectionId: "old-connection",
+        namespace: "admin",
+        mountPath: "database",
+        selection: "role"
+      },
+      { type: "connection", value: "new-connection" }
+    );
+
+    assert.deepEqual(result, {
+      connectionId: "new-connection",
+      namespace: null,
+      mountPath: null,
+      selection: null
+    });
+  });
+
+  it("clears downstream values as namespace and mount selections change", () => {
+    const initial = {
+      connectionId: "connection",
+      namespace: "old-namespace",
+      mountPath: "old-mount",
+      selection: ["old-path"]
+    };
+    const namespaceResult = vaultImportSelectionReducer(initial, {
+      type: "namespace",
+      value: "new-namespace"
+    });
+    const mountResult = vaultImportSelectionReducer(namespaceResult, {
+      type: "mount",
+      value: "new-mount"
+    });
+
+    assert.deepEqual(namespaceResult, {
+      connectionId: "connection",
+      namespace: "new-namespace",
+      mountPath: null,
+      selection: null
+    });
+    assert.deepEqual(mountResult, {
+      connectionId: "connection",
+      namespace: "new-namespace",
+      mountPath: "new-mount",
+      selection: null
+    });
+  });
+});

--- a/frontend/src/components/external-migrations/vaultImportSelection.ts
+++ b/frontend/src/components/external-migrations/vaultImportSelection.ts
@@ -1,0 +1,44 @@
+export type VaultImportSelectionState<TSelection> = {
+  connectionId: string | null;
+  namespace: string | null;
+  mountPath: string | null;
+  selection: TSelection | null;
+};
+
+export type VaultImportSelectionAction<TSelection> =
+  | { type: "connection"; value: string }
+  | { type: "namespace"; value: string }
+  | { type: "mount"; value: string | null }
+  | { type: "selection"; value: TSelection | null };
+
+export const createVaultImportSelection = <TSelection>(
+  connectionIds: string[]
+): VaultImportSelectionState<TSelection> => ({
+  connectionId: connectionIds.length === 1 ? connectionIds[0] : null,
+  namespace: null,
+  mountPath: null,
+  selection: null
+});
+
+export const vaultImportSelectionReducer = <TSelection>(
+  state: VaultImportSelectionState<TSelection>,
+  action: VaultImportSelectionAction<TSelection>
+): VaultImportSelectionState<TSelection> => {
+  switch (action.type) {
+    case "connection":
+      return {
+        connectionId: action.value,
+        namespace: null,
+        mountPath: null,
+        selection: null
+      };
+    case "namespace":
+      return { ...state, namespace: action.value, mountPath: null, selection: null };
+    case "mount":
+      return { ...state, mountPath: action.value, selection: null };
+    case "selection":
+      return { ...state, selection: action.value };
+    default:
+      return state;
+  }
+};

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityKubernetesAuthForm.tsx
@@ -5,6 +5,7 @@ import { useParams } from "@tanstack/react-router";
 import { HelpCircleIcon, InfoIcon } from "lucide-react";
 import { z } from "zod";
 
+import { VaultKubernetesAuthImportModal } from "@app/components/external-migrations";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import {
@@ -62,7 +63,6 @@ import { AccessTokenNumUsesLimitField } from "./shared/AccessTokenNumUsesLimitFi
 import { AccessTokenTtlFields } from "./shared/AccessTokenTtlFields";
 import { TrustedIpsField } from "./shared/TrustedIpsField";
 import { IDENTITY_AUTH_FORM_ID, IdentityFormTab } from "./types";
-import { VaultKubernetesAuthImportModal } from "./VaultKubernetesAuthImportModal";
 
 const buildSchema = (maxAccessTokenTTL: number) =>
   z

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/VaultPolicyImportModal.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/VaultPolicyImportModal.tsx
@@ -278,7 +278,7 @@ const Content = ({ onClose, appConnections }: ContentProps) => {
               )}
             />
             <FieldDescription>
-              Project-scoped HashiCorp Vault app connections available to you.
+              HashiCorp Vault app connections available to you in this project.
             </FieldDescription>
           </Field>
         )}

--- a/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/OverviewPage.tsx
@@ -3892,8 +3892,6 @@ const OverviewPageContent = () => {
       <VaultSecretImportModal
         isOpen={popUp.importFromVault.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("importFromVault", isOpen)}
-        environment={singleEnvSlug}
-        secretPath={secretPath}
         appConnections={vaultAppConnections}
         onImport={handleVaultImport}
       />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/CassandraInputForm.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
 
+import { VaultCassandraImportModal } from "@app/components/external-migrations";
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import {
@@ -33,7 +34,6 @@ import { ProjectEnv } from "@app/hooks/api/types";
 import { slugSchema } from "@app/lib/schemas";
 
 import { LoadFromVaultBanner } from "./components/LoadFromVaultBanner";
-import { VaultCassandraImportModal } from "./VaultCassandraImportModal";
 
 const formSchema = z.object({
   provider: z.object({

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/KubernetesInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/KubernetesInputForm.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
 
+import { VaultKubernetesImportModal } from "@app/components/external-migrations";
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
@@ -38,7 +39,6 @@ import { ProjectEnv } from "@app/hooks/api/types";
 import { slugSchema } from "@app/lib/schemas";
 
 import { LoadFromVaultBanner } from "./components/LoadFromVaultBanner";
-import { VaultKubernetesImportModal } from "./VaultKubernetesImportModal";
 
 enum RoleType {
   ClusterRole = "cluster-role",

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/LdapInputForm.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
 
+import { VaultLdapImportModal } from "@app/components/external-migrations";
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import {
@@ -30,7 +31,6 @@ import { ProjectEnv } from "@app/hooks/api/types";
 import { slugSchema } from "@app/lib/schemas";
 
 import { LoadFromVaultBanner } from "./components/LoadFromVaultBanner";
-import { VaultLdapImportModal } from "./VaultLdapImportModal";
 
 enum CredentialType {
   Dynamic = "dynamic",

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/CreateDynamicSecretForm/SqlDatabaseInputForm.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import ms from "ms";
 import { z } from "zod";
 
+import { VaultSqlDatabaseImportModal } from "@app/components/external-migrations";
 import { TtlFormLabel } from "@app/components/features";
 import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
@@ -47,7 +48,6 @@ import { slugSchema } from "@app/lib/schemas";
 
 import { MetadataForm } from "../../DynamicSecretListView/MetadataForm";
 import { LoadFromVaultBanner } from "./components/LoadFromVaultBanner";
-import { VaultSqlDatabaseImportModal } from "./VaultSqlDatabaseImportModal";
 
 const passwordRequirementsSchema = z
   .object({

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
@@ -331,7 +331,7 @@ export const VaultSecretImportModal = ({
 }: Props) => (
   <Dialog open={isOpen} onOpenChange={onOpenChange}>
     {isOpen && (
-      <DialogContent className="max-w-2xl overflow-hidden">
+      <DialogContent className="max-w-2xl">
         <DialogHeader>
           <DialogTitle>Import from HashiCorp Vault</DialogTitle>
           <DialogDescription>

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
@@ -1,5 +1,5 @@
 import { useReducer, useRef } from "react";
-import { InfoIcon, TriangleAlertIcon } from "lucide-react";
+import { TriangleAlertIcon } from "lucide-react";
 
 import {
   VaultConnectionAndNamespaceFields,
@@ -17,16 +17,15 @@ import {
   Badge,
   Button,
   Combobox,
-  Dialog,
-  DialogBody,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
   Field,
   FieldDescription,
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
   Tooltip,
   TooltipContent,
   TooltipTrigger
@@ -38,16 +37,12 @@ import { useGetVaultMounts, useGetVaultSecretPaths } from "@app/hooks/api/migrat
 type Props = {
   isOpen: boolean;
   onOpenChange: (isOpen: boolean) => void;
-  environment: string;
-  secretPath: string;
   appConnections: TAvailableAppConnection[];
   onImport: (vaultPaths: string[], namespace: string, connectionId: string) => void;
 };
 
 type ContentProps = {
   onClose: () => void;
-  environment: string;
-  secretPath: string;
   appConnections: TAvailableAppConnection[];
   onImport: (vaultPaths: string[], namespace: string, connectionId: string) => void;
 };
@@ -81,7 +76,7 @@ const renderWildcardPath = (path: string) => {
   );
 };
 
-const Content = ({ onClose, environment, secretPath, appConnections, onImport }: ContentProps) => {
+const Content = ({ onClose, appConnections, onImport }: ContentProps) => {
   const hasAppConnections = appConnections.length > 0;
   const [state, dispatch] = useReducer(
     vaultImportSelectionReducer<string[]>,
@@ -153,19 +148,7 @@ const Content = ({ onClose, environment, secretPath, appConnections, onImport }:
 
   return (
     <>
-      <DialogBody className="space-y-5">
-        <Alert variant="project">
-          <InfoIcon />
-          <AlertTitle>Import Secrets from HashiCorp Vault</AlertTitle>
-          <AlertDescription>
-            <p>
-              Select a Vault namespace and one or more secret paths to import secrets into the
-              current Infisical environment (<code className="text-xs">{environment}</code>) at path{" "}
-              <code className="text-xs">{secretPath}</code>.
-            </p>
-          </AlertDescription>
-        </Alert>
-
+      <div className="flex min-h-0 flex-1 flex-col space-y-5 overflow-y-auto p-4">
         <VaultConnectionAndNamespaceFields
           appConnections={appConnections}
           connectionId={connectionId}
@@ -301,12 +284,12 @@ const Content = ({ onClose, environment, secretPath, appConnections, onImport }:
             </AlertDescription>
           </Alert>
         )}
-      </DialogBody>
+      </div>
 
-      <DialogFooter>
-        <DialogClose asChild>
-          <Button>Cancel</Button>
-        </DialogClose>
+      <SheetFooter className="border-t">
+        <SheetClose asChild>
+          <Button variant="ghost">Cancel</Button>
+        </SheetClose>
         <Button
           variant="project"
           onClick={handleImport}
@@ -316,7 +299,7 @@ const Content = ({ onClose, environment, secretPath, appConnections, onImport }:
         >
           Import Secrets
         </Button>
-      </DialogFooter>
+      </SheetFooter>
     </>
   );
 };
@@ -324,29 +307,30 @@ const Content = ({ onClose, environment, secretPath, appConnections, onImport }:
 export const VaultSecretImportModal = ({
   isOpen,
   onOpenChange,
-  environment,
-  secretPath,
   appConnections,
   onImport
 }: Props) => (
-  <Dialog open={isOpen} onOpenChange={onOpenChange}>
+  <Sheet open={isOpen} onOpenChange={onOpenChange}>
     {isOpen && (
-      <DialogContent className="max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Import from HashiCorp Vault</DialogTitle>
-          <DialogDescription>
+      <SheetContent className="sm:max-w-2xl" onOpenAutoFocus={(event) => event.preventDefault()}>
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <div className="flex size-5 items-center justify-center rounded-full bg-foreground/75">
+              <img src="/images/integrations/Vault.png" alt="" className="mt-0.5 size-4" />
+            </div>
+            Import from HashiCorp Vault
+          </SheetTitle>
+          <SheetDescription>
             Select a Vault namespace and one or more secret paths to import secrets into the current
             environment and folder.
-          </DialogDescription>
-        </DialogHeader>
+          </SheetDescription>
+        </SheetHeader>
         <Content
           onClose={() => onOpenChange(false)}
-          environment={environment}
-          secretPath={secretPath}
           appConnections={appConnections}
           onImport={onImport}
         />
-      </DialogContent>
+      </SheetContent>
     )}
-  </Dialog>
+  </Sheet>
 );

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
@@ -1,24 +1,36 @@
-import { useEffect, useRef, useState } from "react";
-import { faInfoCircle } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { TriangleAlertIcon } from "lucide-react";
+import { useReducer, useRef } from "react";
+import { InfoIcon, TriangleAlertIcon } from "lucide-react";
 
 import {
-  defaultVaultConnectionId,
-  VaultConnectionAndNamespaceFields
+  VaultConnectionAndNamespaceFields,
+  VaultFieldLabel
 } from "@app/components/external-migrations";
+import {
+  createVaultImportSelection,
+  vaultImportSelectionReducer
+} from "@app/components/external-migrations/vaultImportSelection";
 import { createNotification } from "@app/components/notifications";
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Badge,
   Button,
-  FilterableSelect,
-  FormControl,
-  Modal,
-  ModalClose,
-  ModalContent,
-  Tooltip
-} from "@app/components/v2";
-import { Badge } from "@app/components/v3";
-import { Alert, AlertDescription, AlertTitle } from "@app/components/v3/generic/Alert";
+  Combobox,
+  Dialog,
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldDescription,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger
+} from "@app/components/v3";
 import { useBadgeOverflow } from "@app/components/v3/generic/DataGrid/hooks/use-badge-overflow";
 import { TAvailableAppConnection } from "@app/hooks/api/appConnections/types";
 import { useGetVaultMounts, useGetVaultSecretPaths } from "@app/hooks/api/migration/queries";
@@ -40,9 +52,6 @@ type ContentProps = {
   onImport: (vaultPaths: string[], namespace: string, connectionId: string) => void;
 };
 
-// Cap the rendered path length so every badge stays a predictable size. Longer
-// paths are truncated from the start with a leading ellipsis so the meaningful
-// tail (including the wildcard `+`) stays visible.
 const MAX_PATH_LENGTH = 30;
 
 const getDisplayPath = (path: string) =>
@@ -51,7 +60,6 @@ const getDisplayPath = (path: string) =>
 const renderWildcardPath = (path: string) => {
   const isTruncated = path.length > MAX_PATH_LENGTH;
   const visiblePath = isTruncated ? path.slice(path.length - MAX_PATH_LENGTH) : path;
-
   let position = 0;
 
   return (
@@ -75,32 +83,34 @@ const renderWildcardPath = (path: string) => {
 
 const Content = ({ onClose, environment, secretPath, appConnections, onImport }: ContentProps) => {
   const hasAppConnections = appConnections.length > 0;
-  const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(
-    defaultVaultConnectionId(appConnections)
+  const [state, dispatch] = useReducer(
+    vaultImportSelectionReducer<string[]>,
+    appConnections.map(({ id }) => id),
+    createVaultImportSelection<string[]>
   );
-  const [selectedNamespace, setSelectedNamespace] = useState<string | null>(null);
-  const [selectedMountPath, setSelectedMountPath] = useState<string | null>(null);
-  const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
-  const [shouldFetchPaths, setShouldFetchPaths] = useState(false);
-  const [shouldFetchMounts, setShouldFetchMounts] = useState(false);
+  const { connectionId, mountPath, namespace } = state;
+  const selectedPaths = state.selection ?? [];
+  const activeConnectionId = hasAppConnections ? (connectionId ?? undefined) : undefined;
+  const shouldFetchMounts = Boolean(namespace && activeConnectionId);
+  const shouldFetchPaths = Boolean(namespace && mountPath && activeConnectionId);
 
-  const activeConnectionId = hasAppConnections ? (selectedConnectionId ?? undefined) : undefined;
-
-  const { data: vaultSecretPaths, isLoading: isLoadingPaths } = useGetVaultSecretPaths(
+  const vaultSecretPathsQuery = useGetVaultSecretPaths(
     shouldFetchPaths,
-    selectedNamespace ?? undefined,
-    selectedMountPath ?? undefined,
+    namespace ?? undefined,
+    mountPath ?? undefined,
     activeConnectionId
   );
-  const secretPaths = vaultSecretPaths?.secretPaths;
-  const skippedWildcardPaths = vaultSecretPaths?.skippedWildcardPaths ?? [];
-  const { data: mounts, isLoading: isLoadingMounts } = useGetVaultMounts(
+  const secretPaths = vaultSecretPathsQuery.data?.secretPaths ?? [];
+  const skippedWildcardPaths = vaultSecretPathsQuery.data?.skippedWildcardPaths ?? [];
+  const mountsQuery = useGetVaultMounts(
     shouldFetchMounts,
-    selectedNamespace ?? undefined,
+    namespace ?? undefined,
     activeConnectionId
   );
-
-  const kvMounts = mounts?.filter((mount) => mount.type === "kv" || mount.type.startsWith("kv"));
+  const kvMounts =
+    mountsQuery.data?.filter((mount) => mount.type === "kv" || mount.type.startsWith("kv")) ?? [];
+  const pathOptions = secretPaths.map((path) => ({ path }));
+  const selectedPathOptions = selectedPaths.map((path) => ({ path }));
 
   const badgeContainerRef = useRef<HTMLDivElement>(null);
   const { visibleItems: visibleSkippedPaths, hiddenCount } = useBadgeOverflow({
@@ -113,35 +123,6 @@ const Content = ({ onClose, environment, secretPath, appConnections, onImport }:
   });
   const hiddenSkippedPaths = skippedWildcardPaths.slice(visibleSkippedPaths.length);
 
-  const handleConnectionChange = (id: string) => {
-    setSelectedConnectionId(id);
-    setSelectedNamespace(null);
-    setSelectedMountPath(null);
-    setSelectedPaths([]);
-    setShouldFetchMounts(false);
-    setShouldFetchPaths(false);
-  };
-
-  const handleNamespaceChange = (ns: string) => {
-    setSelectedNamespace(ns);
-    setSelectedMountPath(null);
-    setSelectedPaths([]);
-  };
-
-  useEffect(() => {
-    if (selectedNamespace) {
-      setShouldFetchMounts(true);
-    }
-  }, [selectedNamespace]);
-
-  useEffect(() => {
-    if (selectedNamespace && selectedMountPath) {
-      setShouldFetchPaths(true);
-    } else {
-      setShouldFetchPaths(false);
-    }
-  }, [selectedNamespace, selectedMountPath]);
-
   const handleImport = () => {
     if (!selectedPaths.length) {
       createNotification({
@@ -150,18 +131,15 @@ const Content = ({ onClose, environment, secretPath, appConnections, onImport }:
       });
       return;
     }
-
-    if (!selectedConnectionId) {
+    if (!connectionId) {
       createNotification({ type: "error", text: "Please select an app connection" });
       return;
     }
-
-    if (!selectedNamespace) {
+    if (!namespace) {
       createNotification({ type: "error", text: "Please select a namespace" });
       return;
     }
-
-    if (!mounts || mounts.length === 0) {
+    if (!kvMounts.length) {
       createNotification({
         type: "error",
         text: "No Vault mounts found. Please ensure you have KV secret engines configured."
@@ -169,160 +147,176 @@ const Content = ({ onClose, environment, secretPath, appConnections, onImport }:
       return;
     }
 
-    onImport(selectedPaths, selectedNamespace, selectedConnectionId);
+    onImport(selectedPaths, namespace, connectionId);
     onClose();
   };
 
   return (
     <>
-      <div className="mb-4 rounded-md bg-primary/10 p-3 text-sm text-mineshaft-200">
-        <div className="flex items-start gap-2">
-          <FontAwesomeIcon icon={faInfoCircle} className="mt-0.5 text-primary" />
-          <div>
-            <div className="mb-2">
-              <strong>Import Secrets from HashiCorp Vault</strong>
-            </div>
-            <div className="space-y-1.5 text-xs leading-relaxed">
-              <p>
-                Select a Vault namespace and one or more secret paths to import secrets into the
-                current Infisical environment (<code className="text-xs">{environment}</code>) at
-                path <code className="text-xs">{secretPath}</code>.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <VaultConnectionAndNamespaceFields
-        appConnections={appConnections}
-        connectionId={selectedConnectionId}
-        onConnectionIdChange={handleConnectionChange}
-        namespace={selectedNamespace}
-        onNamespaceChange={handleNamespaceChange}
-        namespaceTooltip="Select the Vault namespace containing the secrets you want to import."
-        namespaceHelpText="Select the Vault namespace to fetch available mounts"
-      />
-
-      <FormControl
-        label="Secrets Engine"
-        className="mb-4"
-        tooltipText="Select the KV secrets engine to narrow down secret paths."
-      >
-        <>
-          <FilterableSelect
-            value={kvMounts?.find((mount) => mount.path === selectedMountPath)}
-            onChange={(value) => {
-              if (value && !Array.isArray(value)) {
-                const mount = value as { path: string; type: string; version: string | null };
-                setSelectedMountPath(mount.path.replace(/\/$/, "")); // Remove trailing slash
-                setSelectedPaths([]);
-              }
-            }}
-            options={kvMounts || []}
-            getOptionValue={(option) => option.path}
-            getOptionLabel={(option) => option.path.replace(/\/$/, "")}
-            isDisabled={isLoadingMounts || !kvMounts?.length}
-            placeholder="Select secrets engine..."
-            className="w-full"
-          />
-          <p className="mt-1 text-xs text-mineshaft-400">
-            Choose a KV secrets engine to filter available secret paths
-          </p>
-        </>
-      </FormControl>
-
-      <FormControl label="Vault Secret Path" className="mb-6">
-        <>
-          <FilterableSelect
-            isMulti
-            value={selectedPaths.map((path) => ({ path }))}
-            onChange={(value) => {
-              if (!value) {
-                setSelectedPaths([]);
-              } else if (Array.isArray(value)) {
-                setSelectedPaths(value.map((option) => option.path));
-              }
-            }}
-            options={(secretPaths || []).map((path) => ({ path }))}
-            getOptionValue={(option) => option.path}
-            getOptionLabel={(option) => option.path}
-            isDisabled={isLoadingPaths || !secretPaths?.length || !selectedMountPath}
-            placeholder={
-              !selectedMountPath
-                ? "Select a mount path first..."
-                : "Select Vault path(s) to import..."
-            }
-            isClearable
-            className="w-full"
-          />
-          <p className="mt-1 text-xs text-mineshaft-400">
-            Choose one or more secret paths from the selected mount to import into Infisical
-          </p>
-        </>
-      </FormControl>
-
-      {skippedWildcardPaths.length > 0 && (
-        <Alert variant="warning" className="mb-4">
-          <TriangleAlertIcon />
-          <AlertTitle>
-            {skippedWildcardPaths.length} secret path
-            {skippedWildcardPaths.length > 1 ? "s are" : " is"} unavailable
-          </AlertTitle>
+      <DialogBody className="space-y-5">
+        <Alert variant="project">
+          <InfoIcon />
+          <AlertTitle>Import Secrets from HashiCorp Vault</AlertTitle>
           <AlertDescription>
             <p>
-              {skippedWildcardPaths.length} secret path
-              {skippedWildcardPaths.length > 1 ? "s are" : " is"} not available for selection. Vault
-              imports don&apos;t support wildcard (<code className="text-yellow-500/80">+</code>){" "}
-              paths. In Vault, update the policy on the App role or token behind this App Connection
-              to grant access to absolute paths instead.
+              Select a Vault namespace and one or more secret paths to import secrets into the
+              current Infisical environment (<code className="text-xs">{environment}</code>) at path{" "}
+              <code className="text-xs">{secretPath}</code>.
             </p>
-            <div ref={badgeContainerRef} className="mt-2 flex flex-wrap items-start gap-1">
-              {visibleSkippedPaths.map((path) => (
-                <Badge key={path} variant="warning" className="font-mono text-foreground/80">
-                  {renderWildcardPath(path)}
-                </Badge>
-              ))}
-              {hiddenCount > 0 && (
-                <Tooltip
-                  className="max-w-sm p-2"
-                  content={
-                    <div className="flex flex-wrap gap-1">
-                      {hiddenSkippedPaths.map((path) => (
-                        <Badge
-                          isTruncatable
-                          key={path}
-                          variant="warning"
-                          className="font-mono text-foreground/80"
-                        >
-                          {renderWildcardPath(path)}
-                        </Badge>
-                      ))}
-                    </div>
-                  }
-                >
-                  <Badge variant="warning" className="cursor-default font-mono">
-                    +{hiddenCount} more
-                  </Badge>
-                </Tooltip>
-              )}
-            </div>
           </AlertDescription>
         </Alert>
-      )}
 
-      <div className="mt-8 flex space-x-4">
+        <VaultConnectionAndNamespaceFields
+          appConnections={appConnections}
+          connectionId={connectionId}
+          onConnectionIdChange={(value) => dispatch({ type: "connection", value })}
+          namespace={namespace}
+          onNamespaceChange={(value) => dispatch({ type: "namespace", value })}
+          namespaceTooltip="Select the Vault namespace containing the secrets you want to import."
+          namespaceHelpText="Select the Vault namespace to fetch available mounts"
+          idPrefix="vault-secret-import"
+        />
+
+        <Field>
+          <VaultFieldLabel
+            htmlFor="vault-secret-import-mount"
+            tooltip="Select the KV secrets engine to narrow down secret paths."
+            tooltipLabel="Secrets Engine"
+          >
+            Secrets Engine
+          </VaultFieldLabel>
+          <Combobox
+            id="vault-secret-import-mount"
+            value={kvMounts.find((mount) => mount.path.replace(/\/$/, "") === mountPath) ?? null}
+            onValueChange={(mount) =>
+              dispatch({ type: "mount", value: mount.path.replace(/\/$/, "") })
+            }
+            onClear={() => dispatch({ type: "mount", value: null })}
+            options={kvMounts}
+            getOptionValue={(mount) => mount.path}
+            getOptionLabel={(mount) => mount.path.replace(/\/$/, "")}
+            isDisabled={!namespace || mountsQuery.isLoading || !kvMounts.length}
+            isLoading={mountsQuery.isLoading}
+            isError={mountsQuery.isError}
+            placeholder={namespace ? "Select secrets engine..." : "Select a namespace first..."}
+            searchPlaceholder="Search secrets engines..."
+            searchAriaLabel="Search Secrets Engine"
+            clearAriaLabel="Clear Secrets Engine"
+            emptyMessage="No KV secrets engines found."
+            modal
+          />
+          <FieldDescription>
+            Choose a KV secrets engine to filter available secret paths
+          </FieldDescription>
+        </Field>
+
+        <Field>
+          <VaultFieldLabel
+            htmlFor="vault-secret-import-paths"
+            tooltip="Choose one or more secret paths from the selected mount to import into Infisical."
+            tooltipLabel="Vault Secret Path"
+          >
+            Vault Secret Path
+          </VaultFieldLabel>
+          <Combobox
+            id="vault-secret-import-paths"
+            multiple
+            value={selectedPathOptions}
+            onValueChange={(options) =>
+              dispatch({ type: "selection", value: options.map(({ path }) => path) })
+            }
+            onClear={() => dispatch({ type: "selection", value: [] })}
+            options={pathOptions}
+            getOptionValue={(option) => option.path}
+            getOptionLabel={(option) => option.path}
+            isDisabled={!mountPath || vaultSecretPathsQuery.isLoading || !secretPaths.length}
+            isLoading={vaultSecretPathsQuery.isLoading}
+            isError={vaultSecretPathsQuery.isError}
+            placeholder={
+              mountPath ? "Select Vault path(s) to import..." : "Select a mount path first..."
+            }
+            searchPlaceholder="Search Vault secret paths..."
+            searchAriaLabel="Search Vault secret paths"
+            clearAriaLabel="Clear Vault secret paths"
+            emptyMessage="No Vault secret paths found."
+            modal
+          />
+          <FieldDescription>
+            Choose one or more secret paths from the selected mount to import into Infisical
+          </FieldDescription>
+        </Field>
+
+        {skippedWildcardPaths.length > 0 && (
+          <Alert variant="warning">
+            <TriangleAlertIcon />
+            <AlertTitle>
+              {skippedWildcardPaths.length} secret path
+              {skippedWildcardPaths.length > 1 ? "s are" : " is"} unavailable
+            </AlertTitle>
+            <AlertDescription>
+              <p>
+                {skippedWildcardPaths.length} secret path
+                {skippedWildcardPaths.length > 1 ? "s are" : " is"} not available for selection.
+                Vault imports don&apos;t support wildcard (
+                <code className="text-warning/80">+</code>) paths. In Vault, update the policy on
+                the App role or token behind this App Connection to grant access to absolute paths
+                instead.
+              </p>
+              <div ref={badgeContainerRef} className="mt-2 flex flex-wrap items-start gap-1">
+                {visibleSkippedPaths.map((path) => (
+                  <Badge key={path} variant="warning" className="font-mono text-foreground/80">
+                    {renderWildcardPath(path)}
+                  </Badge>
+                ))}
+                {hiddenCount > 0 && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={`Show ${hiddenCount} more unavailable secret paths`}
+                        className="rounded-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      >
+                        <Badge variant="warning" className="cursor-default font-mono">
+                          +{hiddenCount} more
+                        </Badge>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-sm p-2">
+                      <div className="flex flex-wrap gap-1">
+                        {hiddenSkippedPaths.map((path) => (
+                          <Badge
+                            isTruncatable
+                            key={path}
+                            variant="warning"
+                            className="font-mono text-foreground/80"
+                          >
+                            {renderWildcardPath(path)}
+                          </Badge>
+                        ))}
+                      </div>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            </AlertDescription>
+          </Alert>
+        )}
+      </DialogBody>
+
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button>Cancel</Button>
+        </DialogClose>
         <Button
+          variant="project"
           onClick={handleImport}
-          isDisabled={!selectedPaths.length || isLoadingMounts || isLoadingPaths}
+          isDisabled={
+            !selectedPaths.length || mountsQuery.isLoading || vaultSecretPathsQuery.isLoading
+          }
         >
           Import Secrets
         </Button>
-        <ModalClose asChild>
-          <Button colorSchema="secondary" variant="plain">
-            Cancel
-          </Button>
-        </ModalClose>
-      </div>
+      </DialogFooter>
     </>
   );
 };
@@ -334,15 +328,17 @@ export const VaultSecretImportModal = ({
   secretPath,
   appConnections,
   onImport
-}: Props) => {
-  return (
-    <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
-      <ModalContent
-        bodyClassName="overflow-visible"
-        title="Import from HashiCorp Vault"
-        subTitle="Select a Vault namespace and one or more secret paths to import secrets into the current environment and folder."
-        className="max-w-2xl"
-      >
+}: Props) => (
+  <Dialog open={isOpen} onOpenChange={onOpenChange}>
+    {isOpen && (
+      <DialogContent className="max-w-2xl overflow-hidden">
+        <DialogHeader>
+          <DialogTitle>Import from HashiCorp Vault</DialogTitle>
+          <DialogDescription>
+            Select a Vault namespace and one or more secret paths to import secrets into the current
+            environment and folder.
+          </DialogDescription>
+        </DialogHeader>
         <Content
           onClose={() => onOpenChange(false)}
           environment={environment}
@@ -350,7 +346,7 @@ export const VaultSecretImportModal = ({
           appConnections={appConnections}
           onImport={onImport}
         />
-      </ModalContent>
-    </Modal>
-  );
-};
+      </DialogContent>
+    )}
+  </Dialog>
+);


### PR DESCRIPTION
## Context

[SECRETS-385](https://linear.app/infisical/issue/SECRETS-385/move-import-hashicorp-vault-modals-to-v3) moves the shared HashiCorp Vault import dialogs to the v3 component system.

An earlier migration attempt in #6814 was reverted because the App Connection and Namespace controls are shared by project secret imports, dynamic-secret provider imports, and organization Kubernetes authentication. Before this change, those flows still rendered a mixture of legacy modal/form/select components, and migrating only one caller could regress the other shared paths.

This change:

- replaces the shared App Connection and Namespace controls with v3 Field and Combobox components while preserving organization/sub-organization connection context, defaults, helper text, and tooltips;
- adds one shared v3 role-import dialog contract for LDAP, SQL Database, Cassandra, Kubernetes dynamic secrets, and organization Kubernetes authentication;
- migrates the project Vault secret-import dialog to v3 Dialog, Field, Combobox, Alert, Badge, and Tooltip components;
- preserves the Secrets Engine information tooltip, namespace/mount/role semantics, wildcard-path warning, payloads, permissions, sensitive configuration handling, pending/error behavior, and close/reset behavior;
- updates both the route-local dynamic-secret callers and the current SQL provider-registry caller to use the shared implementation;
- leaves policy import and organization-wide direct-credential migration distinct because their workflows and payloads differ.

There are no backend or API changes. Legacy route-local dialog files remain for the separately owned ENG-5522 deletion/audit follow-up.

## Screenshots

<img width="3078" height="2082" alt="CleanShot 2026-08-25 at 15 55 06@2x" src="https://github.com/user-attachments/assets/e9f3ba64-b784-4672-b5ac-ce636fb8165b" />

## Steps to verify the change

1. From `frontend/`, run:

   ```sh
   TSX_TSCONFIG_PATH=tsconfig.app.json node node_modules/tsx/dist/cli.mjs --test \
     src/components/external-migrations/vaultImportSelection.test.ts \
     src/components/external-migrations/VaultRoleImportModal.utils.test.ts \
     src/components/dynamic-secrets/DynamicSecretProviderForm/sql-database-contract.test.ts
   ```

   All 11 focused assertions should pass.

2. Run the frontend review gate:

   ```sh
   make reviewable-ui
   ```

3. Follow the navigation and prerequisites in **Screenshots** and confirm:
   - changing an App Connection clears Namespace, mount, and role/path selections;
   - changing Namespace clears mount and role/path selections;
   - changing the mount clears the role/path selection;
   - Cancel, Escape, close button, and successful import all close and reset the dialog;
   - project secret imports retain the Secrets Engine tooltip and wildcard-path warning;
   - each role import prefills the same provider/authentication values as before.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)