### PR TITLE
fix(db): index FK columns on access_approval_requests + reviewers

### DIFF
--- a/backend/src/db/migrations/20260825064925_add-fk-indexes-access-approval-requests.ts
+++ b/backend/src/db/migrations/20260825064925_add-fk-indexes-access-approval-requests.ts
@@ -1,0 +1,121 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+// access_approval_requests and access_approval_requests_reviewers were created without covering
+// indexes for any of their FK columns. Postgres does not auto-index FK columns, so every parent
+// DELETE (a user is removed, a policy is dropped, a privilege is cascaded, an access request is
+// cleaned up) fires a per-row RI trigger that seq-scans these tables — cheap today, but grows
+// linearly with request/reviewer volume.
+//
+// - policyId (CASCADE, notNullable): every row participates → full index.
+// - privilegeId (CASCADE/SET NULL, nullable): populated only after approval creates the actual
+//   privilege → partial WHERE ... IS NOT NULL index.
+// - requestedByUserId (CASCADE/SET NULL, notNullable): every row participates → full index.
+// - approvedByUserId (SET NULL, nullable): populated only after approval → partial index.
+// - revokedByUserId (SET NULL, nullable): populated only after revocation → partial index.
+// - requestId (CASCADE, notNullable): every reviewer row participates → full index.
+// - reviewerUserId (SET NULL, notNullable): every reviewer row participates → full index.
+//
+// Built CONCURRENTLY so the deploy doesn't take a write-blocking lock — mirrors the pattern from
+// 20260721093822_add-fk-indexes-pki-signer-issuance-jobs.ts, including the invalid-index rebuild
+// guard for interrupted concurrent builds.
+const FK_INDEXES = [
+  {
+    table: TableName.AccessApprovalRequest,
+    column: "policyId",
+    name: "access_approval_requests_policy_id_idx",
+    partial: false
+  },
+  {
+    table: TableName.AccessApprovalRequest,
+    column: "privilegeId",
+    name: "access_approval_requests_privilege_id_idx",
+    partial: true
+  },
+  {
+    table: TableName.AccessApprovalRequest,
+    column: "requestedByUserId",
+    name: "access_approval_requests_requested_by_user_id_idx",
+    partial: false
+  },
+  {
+    table: TableName.AccessApprovalRequest,
+    column: "approvedByUserId",
+    name: "access_approval_requests_approved_by_user_id_idx",
+    partial: true
+  },
+  {
+    table: TableName.AccessApprovalRequest,
+    column: "revokedByUserId",
+    name: "access_approval_requests_revoked_by_user_id_idx",
+    partial: true
+  },
+  {
+    table: TableName.AccessApprovalRequestReviewer,
+    column: "requestId",
+    name: "access_approval_requests_reviewers_request_id_idx",
+    partial: false
+  },
+  {
+    table: TableName.AccessApprovalRequestReviewer,
+    column: "reviewerUserId",
+    name: "access_approval_requests_reviewers_reviewer_user_id_idx",
+    partial: false
+  }
+];
+
+const MIGRATION_TIMEOUT = 60 * 60 * 1000; // 60 minutes
+const MIGRATION_LOCK_TIMEOUT = 30 * 1000; // 30 seconds
+
+// An interrupted CREATE INDEX CONCURRENTLY (deploy cancel, statement_timeout, lost connection)
+// leaves the index row in pg_class with indisvalid=false. A rerun with IF NOT EXISTS then no-ops,
+// so the migration "succeeds" without producing a usable index. Drop any such invalid index
+// before recreating.
+const dropIfInvalid = async (knex: Knex, indexName: string): Promise<void> => {
+  const result = await knex.raw(
+    `SELECT 1 FROM pg_class c
+     JOIN pg_index i ON i.indexrelid = c.oid
+     WHERE c.relname = ? AND c.relkind = 'i' AND i.indisvalid = false`,
+    [indexName]
+  );
+  if (result.rows.length > 0) {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "${indexName}"`);
+  }
+};
+
+export async function up(knex: Knex): Promise<void> {
+  const stmtResult = await knex.raw("SHOW statement_timeout");
+  const originalStatementTimeout = stmtResult.rows[0].statement_timeout;
+  const lockResult = await knex.raw("SHOW lock_timeout");
+  const originalLockTimeout = lockResult.rows[0].lock_timeout;
+
+  try {
+    await knex.raw(`SET statement_timeout = ${MIGRATION_TIMEOUT}`);
+    await knex.raw(`SET lock_timeout = ${MIGRATION_LOCK_TIMEOUT}`);
+
+    for await (const idx of FK_INDEXES) {
+      if ((await knex.schema.hasTable(idx.table)) && (await knex.schema.hasColumn(idx.table, idx.column))) {
+        await dropIfInvalid(knex, idx.name);
+        const predicate = idx.partial ? `WHERE "${idx.column}" IS NOT NULL` : "";
+        await knex.raw(`
+          CREATE INDEX CONCURRENTLY IF NOT EXISTS "${idx.name}"
+          ON ${idx.table} ("${idx.column}")
+          ${predicate}
+        `);
+      }
+    }
+  } finally {
+    await knex.raw(`SET statement_timeout = '${originalStatementTimeout}'`);
+    await knex.raw(`SET lock_timeout = '${originalLockTimeout}'`);
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  for await (const idx of FK_INDEXES) {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "${idx.name}"`);
+  }
+}
+
+const config = { transaction: false };
+export { config };

--- a/backend/src/db/migrations/20260825064925_add-fk-indexes-access-approval-requests.ts
+++ b/backend/src/db/migrations/20260825064925_add-fk-indexes-access-approval-requests.ts
@@ -14,12 +14,12 @@ import { TableName } from "../schemas";
 // - requestedByUserId (CASCADE/SET NULL, notNullable): every row participates → full index.
 // - approvedByUserId (SET NULL, nullable): populated only after approval → partial index.
 // - revokedByUserId (SET NULL, nullable): populated only after revocation → partial index.
+// - editedByUserId (SET NULL, nullable): populated only when a reviewer edits a request → partial index.
 // - requestId (CASCADE, notNullable): every reviewer row participates → full index.
 // - reviewerUserId (SET NULL, notNullable): every reviewer row participates → full index.
 //
-// Built CONCURRENTLY so the deploy doesn't take a write-blocking lock — mirrors the pattern from
-// 20260721093822_add-fk-indexes-pki-signer-issuance-jobs.ts, including the invalid-index rebuild
-// guard for interrupted concurrent builds.
+// Built CONCURRENTLY so the deploy doesn't take a write-blocking lock, including an invalid-index
+// rebuild guard for interrupted concurrent builds.
 const FK_INDEXES = [
   {
     table: TableName.AccessApprovalRequest,
@@ -49,6 +49,12 @@ const FK_INDEXES = [
     table: TableName.AccessApprovalRequest,
     column: "revokedByUserId",
     name: "access_approval_requests_revoked_by_user_id_idx",
+    partial: true
+  },
+  {
+    table: TableName.AccessApprovalRequest,
+    column: "editedByUserId",
+    name: "access_approval_requests_edited_by_user_id_idx",
     partial: true
   },
   {


### PR DESCRIPTION
## Context

`access_approval_requests` (from `20240507162141_access.ts`, May 2024) and `access_approval_requests_reviewers` were created without covering indexes for any of their FK columns, and none of the follow-up migrations added them either:

**access_approval_requests:**
- `policyId` → `access_approval_policies(id)` `CASCADE` (notNullable)
- `privilegeId` → additional privileges `CASCADE`/`SET NULL` (nullable)
- `requestedByUserId` → `users(id)` `CASCADE`/`SET NULL` (notNullable, renamed from `requestedBy` in `20240724101056`)
- `approvedByUserId` → `users(id)` `SET NULL` (nullable, added in `20260402160741`)
- `revokedByUserId` → `users(id)` `SET NULL` (nullable, added in `20260402160741`)

**access_approval_requests_reviewers:**
- `requestId` → `access_approval_requests(id)` `CASCADE` (notNullable)
- `reviewerUserId` → `users(id)` `SET NULL` (notNullable, replaces `member` since `20240724101056`)

Postgres does not auto-index FK columns. Every parent `DELETE` — a user is removed, a policy is dropped, a privilege is cascaded, an access request is cleaned up — fires a per-row RI trigger that seq-scans these tables. Cheap today, but grows linearly with request/reviewer volume.

## Changes

New migration `20260825064925_add-fk-indexes-access-approval-requests.ts` that adds seven partial/full indexes:

- Full indexes for `notNullable` FKs (every row participates): `policyId`, `requestedByUserId`, `requestId`, `reviewerUserId`.
- Partial `WHERE ... IS NOT NULL` indexes for the mostly-NULL nullable FKs (populated only after approval/revocation): `privilegeId`, `approvedByUserId`, `revokedByUserId` — same shape used across the codebase per `backend/CLAUDE.md`.

Built `CONCURRENTLY` with the invalid-index rebuild guard used in #7357 so an interrupted concurrent build doesn't leave a never-used invalid index behind. Down path uses `DROP INDEX CONCURRENTLY IF EXISTS`.

Same shape as #7294 / #7357, applied to a different table pair.

## Test plan

- [ ] `npm run migration:latest-dev` from `backend/`
- [ ] Verify indexes exist:
  ```sql
  SELECT indexname FROM pg_indexes
  WHERE tablename IN ('access_approval_requests', 'access_approval_requests_reviewers')
    AND indexname LIKE 'access_approval_requests%_idx'
  ORDER BY indexname;
  ```
- [ ] `npm run migration:rollback-dev` — indexes drop cleanly
- [ ] Re-apply — still idempotent (`IF NOT EXISTS` on up, `IF EXISTS` on down)
