### PR TITLE
fix(webhook): allow self hosted users to increase timeout and change job behavior

### DIFF
--- a/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
+++ b/backend/src/ee/services/secret-rotation-v2/secret-rotation-v2-service.ts
@@ -1265,7 +1265,11 @@ export const secretRotationV2ServiceFactory = ({
         }
       },
       {
-        jobId: `secret-rotation-webhook-${secretRotation.id}-${Date.now()}`,
+        deduplication: {
+          id: `secret-rotation-webhook-${secretRotation.id}`,
+          keepLastIfActive: true,
+          replace: true
+        },
         removeOnFail: { count: 5 },
         removeOnComplete: true,
         delay: 1000,

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -483,6 +483,18 @@ const envSchema = z
     PAM_AWS_SECRET_ACCESS_KEY: zpStr(z.string().optional()),
     /* ----------------------------------------------------------------------------- */
 
+    /* Webhooks ----------------------------------------------------------------------------- */
+    WEBHOOK_TRIGGER_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .min(1000)
+      .max(40 * 1000)
+      .default(15 * 1000)
+      .describe(
+        "Wall-clock ceiling for a single outbound webhook delivery before it is aborted. Capped at 40s because the webhook test endpoint delivers inline in the request path."
+      ),
+    /* ----------------------------------------------------------------------------- */
+
     /* App Connections ----------------------------------------------------------------------------- */
     ALLOW_INTERNAL_IP_CONNECTIONS: zodStrBool.default("false"),
 
@@ -1068,6 +1080,16 @@ export const overwriteSchema: {
         key: "DISABLE_PUBLIC_SECRET_SHARING",
         description:
           "Disable creation of unauthenticated public secret shares (the /share-secret page). Set to 'true' to block public sharing."
+      }
+    ]
+  },
+  webhooks: {
+    name: "Webhooks",
+    fields: [
+      {
+        key: "WEBHOOK_TRIGGER_TIMEOUT_MS",
+        description:
+          "How long, in milliseconds, to wait for a webhook receiver to respond before the delivery is aborted. Defaults to 15000. Must be between 1000 and 40000."
       }
     ]
   }

--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -140,6 +140,7 @@ export type TGetSecrets = {
 
 const MAX_SYNC_SECRET_DEPTH = 5;
 const SYNC_SECRET_DEBOUNCE_INTERVAL_MS = 3000;
+const WEBHOOK_DEBOUNCE_INTERVAL_MS = 1000;
 
 export const uniqueSecretQueueKey = (environment: string, secretPath: string) =>
   `secret-queue-dedupe-${environment}-${secretPath}`;
@@ -703,10 +704,14 @@ export const secretQueueFactory = ({
         }
       },
       {
-        jobId: `secret-webhook-${environment}-${projectId}-${secretPath}`,
+        deduplication: {
+          id: `secret-webhook-${environment}-${projectId}-${secretPath}`,
+          keepLastIfActive: true,
+          replace: true
+        },
         removeOnFail: { count: 5 },
         removeOnComplete: true,
-        delay: 1000,
+        delay: WEBHOOK_DEBOUNCE_INTERVAL_MS,
         attempts: 5,
         backoff: {
           type: "exponential",
@@ -1599,37 +1604,43 @@ export const secretQueueFactory = ({
     logger.error(err, "Failed to sync integration %s", job?.id);
   });
 
-  queueService.start(QueueName.SecretWebhook, async (job) => {
-    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
-      type: KmsDataKey.SecretManager,
-      projectId: job.data.payload.projectId
-    });
+  queueService.start(
+    QueueName.SecretWebhook,
+    async (job) => {
+      const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
+        type: KmsDataKey.SecretManager,
+        projectId: job.data.payload.projectId
+      });
 
-    // Resolve changedBy from UUID to human-readable display name
-    let webhookEvent = job.data;
-    if (job.data.type === WebhookEvents.SecretModified) {
-      const { changedBy, changedByActorType } = job.data.payload;
-      if (changedBy && changedByActorType) {
-        const resolvedName = await resolveChangedByDisplayName(changedBy, changedByActorType as ActorType);
-        webhookEvent = {
-          ...job.data,
-          payload: { ...job.data.payload, changedBy: resolvedName }
-        };
+      // Resolve changedBy from UUID to human-readable display name
+      let webhookEvent = job.data;
+      if (job.data.type === WebhookEvents.SecretModified) {
+        const { changedBy, changedByActorType } = job.data.payload;
+        if (changedBy && changedByActorType) {
+          const resolvedName = await resolveChangedByDisplayName(changedBy, changedByActorType as ActorType);
+          webhookEvent = {
+            ...job.data,
+            payload: { ...job.data.payload, changedBy: resolvedName }
+          };
+        }
       }
-    }
 
-    await fnTriggerWebhook({
-      projectId: job.data.payload.projectId,
-      environment: job.data.payload.environment,
-      secretPath: job.data.payload.secretPath || "/",
-      projectEnvDAL,
-      projectDAL,
-      webhookDAL,
-      event: webhookEvent,
-      auditLogService,
-      secretManagerDecryptor: (value) => secretManagerDecryptor({ cipherTextBlob: value }).toString()
-    });
-  });
+      await fnTriggerWebhook({
+        projectId: job.data.payload.projectId,
+        environment: job.data.payload.environment,
+        secretPath: job.data.payload.secretPath || "/",
+        projectEnvDAL,
+        projectDAL,
+        webhookDAL,
+        event: webhookEvent,
+        auditLogService,
+        secretManagerDecryptor: (value) => secretManagerDecryptor({ cipherTextBlob: value }).toString()
+      });
+    },
+    // Deduplication keeps at most one active job per project/environment/path, so ordering per
+    // path no longer relies on this worker being single-threaded.
+    { concurrency: 5 }
+  );
 
   return {
     // depth is internal only field thus no need to make it available outside

--- a/backend/src/services/secret/secret-queue.ts
+++ b/backend/src/services/secret/secret-queue.ts
@@ -1604,43 +1604,37 @@ export const secretQueueFactory = ({
     logger.error(err, "Failed to sync integration %s", job?.id);
   });
 
-  queueService.start(
-    QueueName.SecretWebhook,
-    async (job) => {
-      const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
-        type: KmsDataKey.SecretManager,
-        projectId: job.data.payload.projectId
-      });
+  queueService.start(QueueName.SecretWebhook, async (job) => {
+    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
+      type: KmsDataKey.SecretManager,
+      projectId: job.data.payload.projectId
+    });
 
-      // Resolve changedBy from UUID to human-readable display name
-      let webhookEvent = job.data;
-      if (job.data.type === WebhookEvents.SecretModified) {
-        const { changedBy, changedByActorType } = job.data.payload;
-        if (changedBy && changedByActorType) {
-          const resolvedName = await resolveChangedByDisplayName(changedBy, changedByActorType as ActorType);
-          webhookEvent = {
-            ...job.data,
-            payload: { ...job.data.payload, changedBy: resolvedName }
-          };
-        }
+    // Resolve changedBy from UUID to human-readable display name
+    let webhookEvent = job.data;
+    if (job.data.type === WebhookEvents.SecretModified) {
+      const { changedBy, changedByActorType } = job.data.payload;
+      if (changedBy && changedByActorType) {
+        const resolvedName = await resolveChangedByDisplayName(changedBy, changedByActorType as ActorType);
+        webhookEvent = {
+          ...job.data,
+          payload: { ...job.data.payload, changedBy: resolvedName }
+        };
       }
+    }
 
-      await fnTriggerWebhook({
-        projectId: job.data.payload.projectId,
-        environment: job.data.payload.environment,
-        secretPath: job.data.payload.secretPath || "/",
-        projectEnvDAL,
-        projectDAL,
-        webhookDAL,
-        event: webhookEvent,
-        auditLogService,
-        secretManagerDecryptor: (value) => secretManagerDecryptor({ cipherTextBlob: value }).toString()
-      });
-    },
-    // Deduplication keeps at most one active job per project/environment/path, so ordering per
-    // path no longer relies on this worker being single-threaded.
-    { concurrency: 5 }
-  );
+    await fnTriggerWebhook({
+      projectId: job.data.payload.projectId,
+      environment: job.data.payload.environment,
+      secretPath: job.data.payload.secretPath || "/",
+      projectEnvDAL,
+      projectDAL,
+      webhookDAL,
+      event: webhookEvent,
+      auditLogService,
+      secretManagerDecryptor: (value) => secretManagerDecryptor({ cipherTextBlob: value }).toString()
+    });
+  });
 
   return {
     // depth is internal only field thus no need to make it available outside

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -2,6 +2,7 @@ import picomatch from "picomatch";
 
 import { TWebhooks } from "@app/db/schemas";
 import { EventType, TAuditLogServiceFactory, WebhookTriggeredEvent } from "@app/ee/services/audit-log/audit-log-types";
+import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
@@ -14,8 +15,6 @@ import { TProjectDALFactory } from "../project/project-dal";
 import { TProjectEnvDALFactory } from "../project-env/project-env-dal";
 import { TWebhookDALFactory } from "./webhook-dal";
 import { TWebhookPayloads, WebhookEvents, WebhookType } from "./webhook-types";
-
-const WEBHOOK_TRIGGER_TIMEOUT = 15 * 1000;
 
 export const decryptWebhookDetails = (webhook: TWebhooks, decryptor: (value: Buffer) => string) => {
   const { encryptedPassKey, encryptedUrl } = webhook;
@@ -38,6 +37,7 @@ export const triggerWebhookRequest = async (
   decryptor: (value: Buffer) => string,
   data: Record<string, unknown>
 ) => {
+  const appCfg = getConfig();
   const headers: Record<string, string> = {};
   const payload = { ...data, timestamp: Date.now() };
   const { secretKey, url } = decryptWebhookDetails(webhook, decryptor);
@@ -51,8 +51,8 @@ export const triggerWebhookRequest = async (
 
   const req = await safeRequest.post(url, payload, {
     headers,
-    timeout: WEBHOOK_TRIGGER_TIMEOUT,
-    signal: AbortSignal.timeout(WEBHOOK_TRIGGER_TIMEOUT)
+    timeout: appCfg.WEBHOOK_TRIGGER_TIMEOUT_MS,
+    signal: AbortSignal.timeout(appCfg.WEBHOOK_TRIGGER_TIMEOUT_MS)
   });
 
   return req;

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -460,6 +460,7 @@ export const fnTriggerWebhook = async ({
       } as TWebhookPayloads;
       const payload = getWebhookPayload(formattedEvent);
       if (!payload) return;
+      logger.info({ hookId: hook.id }, "Triggering webhook");
       return triggerWebhookRequest(hook, secretManagerDecryptor, payload);
     })
   );

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -130,6 +130,15 @@ Example values:
   </Note>
 </ParamField>
 
+<ParamField query="WEBHOOK_TRIGGER_TIMEOUT_MS" type="number" default="15000" optional>
+  How long, in milliseconds, to wait for a webhook receiver to respond before the
+  delivery is aborted and recorded as failed. Must be between `1000` and `40000`.
+
+  Raise this when your receivers are slow to acknowledge. This value can also be set
+  from the [Server Admin Console](/documentation/platform/admin-panel/server-admin)
+  without redeploying, see [Environment variable overrides](#environment-variable-overrides).
+</ParamField>
+
 <ParamField
   query="KUBERNETES_AUTO_FETCH_SERVICE_ACCOUNT_TOKEN"
   type="bool"

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/AddWebhookForm.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/AddWebhookForm.tsx
@@ -275,7 +275,7 @@ export const AddWebhookForm = ({
                     />
                     <FieldError>{error?.message}</FieldError>
                     <FieldDescription>
-                      Enter `/` to match all secret paths in the selected environment.
+                      Enter `/**` to match all secret paths in the selected environment.
                     </FieldDescription>
                   </Field>
                 )}


### PR DESCRIPTION
## Context
The previous Webhook job was being scheduled and if a new change happened while a previous Webhook was running, this new one would be lost.  Added a `replace:true` so if a change arrives while a previous change was enqueued, we just removes the old one and updates it with the fresh data. Also added `keepLastIfActive:true` so if a change arrive while a job is delivering this is enqueued to run after the job finishes. 

This also allows self hosted users to define the expiration time they want for the webhook

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change
- Create a server that has a high delay (around 14 seconds)
- Create a webhook pointing to this new server
- create secrets (the webhook needs to match the path of these secrets)
- change the secrets several times. Make sure that at the end only 2 requests were made to the server with delay (replace took action, so only the fresh one was sent.  keepLastActive also took action, since the first one was also sent).
- Play around with the admin and change the timeout there. 

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)