### PR TITLE
docs(secrets-mgmt): add local dev guide

### DIFF
--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -3,6 +3,8 @@ title: 'Install'
 description: "Infisical's CLI is one of the best ways to manage environments and secrets. Install it here"
 ---
 
+import InstallCli from "/snippets/cli/install-cli.mdx";
+
 <Warning>
   **Action required for Linux users.** The Infisical CLI Linux package repository has moved from Cloudsmith to `artifacts-cli.infisical.com`. The Cloudsmith repository stops serving on **September 16, 2026**. Machines still pointed at the old URL will fail to install or update. See the [migration guide](/cli/cloudsmith-migration) for step-by-step instructions.
 </Warning>
@@ -12,131 +14,33 @@ You can use it across various environments, whether it's local development, CI/C
 
 ## Installation
 
-<Tabs>
-  <Tab title="MacOS">
-  	Use [brew](https://brew.sh/) package manager
+Install the CLI with the package manager for your operating system.
 
-    	```bash
-    	brew install infisical/get-cli/infisical
-    	```
+<InstallCli />
 
-    	### Updates
+<Tip>
+  When you install the CLI in a production environment, pin it to a specific version so that the version stays the same across reinstalls. [View versions](https://github.com/Infisical/cli/releases)
+</Tip>
 
-    	```bash
-    	brew update && brew upgrade infisical
-    	```
-  </Tab>
-  <Tab title="Windows">
+## Update the CLI
 
-	<Accordion title="Scoop package manager">
-		Use [Scoop](https://scoop.sh/) package manager
+<CodeGroup>
 
-		```bash
-		scoop bucket add org https://github.com/Infisical/scoop-infisical.git
-		```
+```bash macOS
+brew update && brew upgrade infisical
+```
 
-			```bash
-			scoop install infisical
-			```
+```bash Windows (Scoop)
+scoop update infisical
+```
 
-		### Updates
+```bash npm
+npm update -g @infisical/cli
+```
 
-		```bash
-		scoop update infisical
-		```
-	</Accordion>
+</CodeGroup>
 
-	<Accordion title="Winget package manager">
-		Use [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/) package manager
-
-		```bash
-		winget install infisical
-		```
-	</Accordion>
-
-  </Tab>
-  <Tab title="NPM">
-      Use [NPM](https://www.npmjs.com/) package manager
-
-    	```bash
-      npm install -g @infisical/cli
-    	```
-
-    	### Updates
-
-    	```bash
-    	npm update -g @infisical/cli
-    	```
-  </Tab>
-	 <Tab title="Alpine">
-	 Install prerequisite
-		```bash
-		apk add --no-cache bash sudo wget
-		```
-
-    	Add Infisical repository
-    	```bash
-    	wget -qO- 'https://artifacts-cli.infisical.com/setup.apk.sh' | sudo sh
-    	```
-
-    	Then install CLI
-    	```bash
-    	apk update && sudo apk add infisical
-    	```
-		###
-		<Tip>
-			If you are installing the CLI in production environments, we highly recommend to set the version of the CLI to a specific version. This will help keep your CLI version consistent across reinstalls. [View versions](https://github.com/Infisical/cli/releases)
-		</Tip>
-   </Tab>
-	 <Tab title="RedHat/CentOs/Amazon">
-	 Add Infisical repository
-		```bash
-		curl -1sLf \
-		'https://artifacts-cli.infisical.com/setup.rpm.sh' \
-		| sudo -E bash
-		```
-
-    	Then install CLI
-    	```bash
-    	sudo yum install infisical
-    	```
-		###
-		<Tip>
-			If you are installing the CLI in production environments, we highly recommend to set the version of the CLI to a specific version. This will help keep your CLI version consistent across reinstalls. [View versions](https://github.com/Infisical/cli/releases)
-		</Tip>
-   </Tab>
-	 <Tab title="Debian/Ubuntu">
-
-	 	Add Infisical repository 
-			
-		```bash
-		curl -1sLf \
-		'https://artifacts-cli.infisical.com/setup.deb.sh' \
-		| sudo -E bash
-		```
-
-    	Then install CLI
-    	```bash
-    	sudo apt-get update && sudo apt-get install -y infisical
-    	```
-	###
-	<Tip>
-		If you are installing the CLI in production environments, we highly recommend to set the version of the CLI to a specific version. This will help keep your CLI version consistent across reinstalls. [View versions](https://github.com/Infisical/cli/releases)
-	</Tip>
-   </Tab>
-	<Tab title="Arch Linux">
-		Use the `yay` package manager to install from the [Arch User Repository](https://aur.archlinux.org/packages/infisical-bin)
-			
-		```bash
-		yay -S infisical-bin
-		```
-
-	###
-	<Tip>
-		If you are installing the CLI in production environments, we highly recommend to set the version of the CLI to a specific version. This will help keep your CLI version consistent across reinstalls. [View versions](https://github.com/Infisical/cli/releases)
-	</Tip>
-   </Tab>
-</Tabs>
+On Linux, update the CLI with the package manager you installed it with.
 
 ## Quick usage guide
 <Card color="#00A300" href="./usage">

--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -3,85 +3,17 @@ title: "Quickstart"
 description: "Manage secrets with Infisical CLI"
 ---
 
+import InjectSecretsLocally from "/snippets/cli/inject-secrets-locally.mdx";
+
 The CLI is designed for a variety of secret management applications ranging from local development to CI/CD and production scenarios.
 
 <Tabs>
   <Tab title="Local development">
-    In the following steps, we explore how to use the Infisical CLI to fetch back environment variables from Infisical
-    and inject them into your local development process.
-    
-    <Note>
-    If you prefer learning by watching, you can follow along our step-by-step video tutorial [here](https://www.youtube.com/watch?v=zYCeELjcgQ4).
-    </Note>
+    The steps below authenticate the CLI with your own account, link a codebase to an Infisical project, and inject the secrets you have access to into your local development process as environment variables.
 
-    <Steps>
-      <Step title="Log in with the CLI">
-        Start by running the `infisical login` command to authenticate with Infisical.
+    <InjectSecretsLocally />
 
-        ```bash
-        infisical login
-        ```
-        <Note>
-          If you are in a containerized environment such as WSL 2 or Codespaces, run `infisical login -i` to avoid browser based login
-        </Note>
-      </Step>
-      <Step title="Initialize Infisical for your project">
-        Next, navigate to your project and initialize Infisical.
-
-        ```bash
-        # navigate to your project
-        cd /path/to/project
-
-        # initialize infisical
-        infisical init
-        ```
-
-        The `infisical init` command creates a `.infisical.json` file, containing [local project settings](./project-config), at the location where the command is executed.
-
-        <Note>
-          The `.infisical.json` file does not contain any sensitive data, so you may commit it to your git repository.
-        </Note>
-      </Step>
-      <Step title="Inject environment variables">
-        Finally, pass environment variables from Infisical into your application.
-
-        <Tabs>
-          <Tab title="Feed secrets to your application">
-            ```bash
-            infisical run --env=dev --path=/apps/firefly -- [your application start command] # e.g. npm run dev
-
-            # example with node (nodemon)
-            infisical run --env=staging --path=/apps/spotify -- nodemon index.js
-
-            # example with flask
-            infisical run --env=prod --path=/apps/backend -- flask run
-
-            # example with spring boot - maven
-            infisical run --env=dev --path=/apps/ -- ./mvnw spring-boot:run --quiet
-            ```
-
-          </Tab>
-          <Tab title="Feed secrets via custom aliases (advanced)">
-            Custom aliases can utilize secrets from Infisical. Suppose there is a custom alias `yd` in `custom.sh` that runs `yarn dev` and needs the secrets provided by Infisical.
-            ```bash
-            #!/bin/sh
-
-            yd() {
-              yarn dev
-            }
-            ```
-
-            To make the secrets available from Infisical to `yd`, you can run the following command:
-
-            ```bash
-            infisical run --env=prod --path=/apps/reddit --command="source custom.sh && yd"
-            ```
-          </Tab>
-        </Tabs>
-
-        View all available options for `run` command [here](./commands/run)
-      </Step>
-    </Steps>
+    For installation instructions, troubleshooting, and related local workflows such as personal overrides and secret scanning, see the [local development guide](/documentation/guides/local-development).
 
   </Tab>
 

--- a/docs/cli/usage.mdx
+++ b/docs/cli/usage.mdx
@@ -3,17 +3,33 @@ title: "Quickstart"
 description: "Manage secrets with Infisical CLI"
 ---
 
-import InjectSecretsLocally from "/snippets/cli/inject-secrets-locally.mdx";
+import LogIn from "/snippets/cli/local-development/log-in.mdx";
+import LinkProject from "/snippets/cli/local-development/link-project.mdx";
+import StartApplication from "/snippets/cli/local-development/start-application.mdx";
 
 The CLI is designed for a variety of secret management applications ranging from local development to CI/CD and production scenarios.
 
 <Tabs>
   <Tab title="Local development">
-    The steps below authenticate the CLI with your own account, link a codebase to an Infisical project, and inject the secrets you have access to into your local development process as environment variables.
+  The steps below authenticate the CLI with your own account, link a codebase to an Infisical project, and inject the secrets you have access to into your local development process as environment variables.
 
-    <InjectSecretsLocally />
+  <Note>
+    If you prefer to learn by watching, follow along with our [step-by-step video tutorial](https://www.youtube.com/watch?v=zYCeELjcgQ4).
+  </Note>
 
-    For installation instructions, troubleshooting, and related local workflows such as personal overrides and secret scanning, see the [local development guide](/documentation/guides/local-development).
+  ## Step 1: Log in to Infisical
+
+  <LogIn />
+
+  ## Step 2: Link your codebase to your project
+
+  <LinkProject />
+
+  ## Step 3: Start your application with secrets injected
+
+  <StartApplication />
+
+  For installation instructions, troubleshooting, and related local workflows such as personal overrides and secret scanning, see the [local development guide](/documentation/guides/local-development).
 
   </Tab>
 

--- a/docs/documentation/guides/local-development.mdx
+++ b/docs/documentation/guides/local-development.mdx
@@ -100,7 +100,7 @@ The hook stops the commit when it finds something that looks like a secret. Chec
     The CLI is pointed at the wrong instance. It uses Infisical Cloud US by default, so an EU or self-hosted account needs the address set through the `INFISICAL_DOMAIN` environment variable, the `--domain` flag, or the `domain` field in [`.infisical.json`](/cli/project-config).
   </Accordion>
   <Accordion title="It works in your terminal but not in your editor">
-    Your editor's run configuration starts the application on its own, outside the `infisical run` process, so the injected variables never reach it. Either start your editor from a terminal, or change the run configuration to call `infisical run --env=dev -- <your-start-command>`.
+    Your editor's run configuration starts your application on its own, outside the `infisical run` process, and the injected variables exist only inside that process and the commands it starts. Change the run configuration to call `infisical run --env=dev -- <your-start-command>`. If your editor doesn't allow that, quit and relaunch it through the CLI with `infisical run --env=dev -- <your-editor-command>`, so that everything it starts inherits the secrets.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/documentation/guides/local-development.mdx
+++ b/docs/documentation/guides/local-development.mdx
@@ -5,7 +5,9 @@ description: "Run your application on your own machine with secrets pulled from 
 ---
 
 import InstallCli from "/snippets/cli/install-cli.mdx";
-import InjectSecretsLocally from "/snippets/cli/inject-secrets-locally.mdx";
+import LogIn from "/snippets/cli/local-development/log-in.mdx";
+import LinkProject from "/snippets/cli/local-development/link-project.mdx";
+import StartApplication from "/snippets/cli/local-development/start-application.mdx";
 
 This guide shows you how to inject secrets from Infisical into your local application without using a `.env` file. You'll install the [Infisical CLI](/cli/overview), link your codebase to your Infisical project, and start your application through `infisical run`.
 
@@ -27,7 +29,21 @@ infisical --version
 
 ## Step 2: Inject secrets into your application
 
-<InjectSecretsLocally />
+<Note>
+  If you prefer to learn by watching, follow along with our [step-by-step video tutorial](https://www.youtube.com/watch?v=zYCeELjcgQ4).
+</Note>
+
+### Log in to Infisical
+
+<LogIn />
+
+### Link your codebase to your project
+
+<LinkProject />
+
+### Start your application with secrets injected
+
+<StartApplication />
 
 ## Confirm secrets are injected
 

--- a/docs/documentation/guides/local-development.mdx
+++ b/docs/documentation/guides/local-development.mdx
@@ -116,7 +116,7 @@ The hook stops the commit when it finds something that looks like a secret. Chec
     The CLI is pointed at the wrong instance. It uses Infisical Cloud US by default, so an EU or self-hosted account needs the address set through the `INFISICAL_DOMAIN` environment variable, the `--domain` flag, or the `domain` field in [`.infisical.json`](/cli/project-config).
   </Accordion>
   <Accordion title="It works in your terminal but not in your editor">
-    Your editor's run configuration starts your application on its own, outside the `infisical run` process, and the injected variables exist only inside that process and the commands it starts. Change the run configuration to call `infisical run --env=dev -- <your-start-command>`. If your editor doesn't allow that, quit and relaunch it through the CLI with `infisical run --env=dev -- <your-editor-command>`, so that everything it starts inherits the secrets.
+    Your editor's run configuration starts your application on its own, outside the `infisical run` process, and the injected variables exist only inside that process and the commands it starts. Change the run configuration to call `infisical run --env=dev -- <your-start-command>`. Avoid launching the editor itself through `infisical run`, because its extensions, language servers, and other child processes would also inherit the secrets.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/documentation/guides/local-development.mdx
+++ b/docs/documentation/guides/local-development.mdx
@@ -1,34 +1,110 @@
 ---
-title: "Secret management in development environments"
+title: "Inject secrets into local development"
 sidebarTitle: "Local development"
-description: "Learn how to manage secrets in local development environments."
+description: "Run your application on your own machine with secrets pulled from Infisical instead of a .env file."
 ---
 
-## Problem at hand
+import InstallCli from "/snippets/cli/install-cli.mdx";
+import InjectSecretsLocally from "/snippets/cli/inject-secrets-locally.mdx";
 
-There are a number of issues that arise with secret management in local development environment: 
-1. **Getting secrets onto local machines**. When new developers join or a new project is created, the process of getting the development set of secrets onto local machines is often unclear. As a result, developers end up spending a lot of time onboarding and risk potentially following insecure practices when sharing secrets from one developer to another.
-2. **Syncing secrets with teammates**. One of the problems with .env files is that they become unsynced when one of the developers updates a secret or configuration. Even if the rest of the team is notified, developers don't make all the right changes immediately, and later on end up spending a lot of time debugging an issue due to missing environment variables. This leads to a lot of inefficiencies and lost time. 
-3. **Accidentally leaking secrets**. When developing locally, it's common for developers to accidentally leak a hardcoded secret as part of a commit. As soon as the secret is part of the git history, it becomes hard to get it removed and create a security vulnerability.
+This guide shows you how to inject secrets from Infisical into your local application without using a `.env` file. You'll install the [Infisical CLI](/cli/overview), link your codebase to your Infisical project, and start your application through `infisical run`.
 
-## Solution
+## Prerequisites
 
-One of the main benefits of Infisical is the facilitation of secret management workflows in local development use cases. In particular, Infisical heavily follows the "Security Shift Left" principle to enable developers to effortlessly follow secure practices when coding.
+- An Infisical project with secrets in its **Development** environment. If you don't have one yet, follow the [quickstart](/documentation/platform/secrets-mgmt/quick-starts/deliver-first-secret) first.
 
-### CLI
+## Step 1: Install the CLI
 
-[Infisical CLI](/cli/overview) is the most frequently used Infisical tool for secret management in local development environments. It makes it easy to inject secrets right into the local application environments based on the permissions given to corresponding developers.
+Install the CLI with the package manager for your operating system.
 
-### Dashboard
+<InstallCli />
 
-On top of that, Infisical provides a great [Web Dashboard](https://app.infisical.com/signup) that can be used to making quick secret updates.
+Check that the installation worked:
 
-![project dashboard](../../images/dashboard.png)
+```bash
+infisical --version
+```
 
-### Personal overrides
+## Step 2: Inject secrets into your application
 
-By default, all the secrets in the Infisical environments are shared among project members who have the permission to access those environment. At the same time, when doing local development, it is often desirable to change the value of a certain secret only for a particular self. For such use cases, Infisical supports the functionality of **Personal Overrides** – which allow developers to override values of any secrets without affecting the workflows of the rest of the team. Personal Overrides can be created both in the dashboard or via [Infisical CLI](/cli/overview). 
+<InjectSecretsLocally />
 
-### Secret scanning
+## Confirm secrets are injected
 
-In addition, Infisical also provides a set of tools to automatically prevent secret leaks to git history. This functionality can be set up on the level of [Infisical CLI using pre-commit hooks](/cli/scanning-overview#automatically-scan-changes-before-you-commit) or through a direct integration with platforms like GitHub.
+If your application starts but behaves as though a value is missing, check what the CLI is injecting before you look at your application code. This prints one secret exactly as your application would receive it:
+
+```bash
+infisical run --env=dev -- printenv <YOUR_SECRET_KEY>
+```
+
+To see every key available in an environment, list the secrets directly:
+
+```bash
+infisical secrets --env=dev --path=/
+```
+
+## Override secrets locally
+
+Everyone working in a project shares the same values for a given environment, which is what keeps a team in sync. When you need a different value on your machine alone, such as pointing a database URL at a database running on your laptop, create a [personal override](/documentation/platform/secrets-mgmt/project#personal-overrides) instead of editing the shared secret:
+
+```bash
+infisical secrets set <YOUR_SECRET_KEY>=<your-local-value> --type=personal
+```
+
+Your next `infisical run` uses the override, and your teammates keep receiving the shared value. You can also create an override from the secret's row in the dashboard.
+
+## Export secrets to a file
+
+Some tools read secrets from a file and offer no way to accept them from the environment. For those cases, write the secrets to a file with [`infisical export`](/cli/commands/export):
+
+```bash
+infisical export --env=dev --format=dotenv --output-file=./.env
+```
+
+<Warning>
+  An exported file is plain text, and it goes out of date as soon as someone changes a value in Infisical. Add it to your `.gitignore`, and regenerate it rather than treating it as the source of truth. We recommend using `infisical run` wherever possible.
+</Warning>
+
+## Scan commits for secrets
+
+Fetching secrets from Infisical keeps them out of your repository, but a credential can still reach a commit by being pasted into a source file. Install the pre-commit hook to scan your staged changes each time you commit:
+
+```bash
+infisical scan install --pre-commit-hook
+```
+
+The hook stops the commit when it finds something that looks like a secret. Check out [Secret Scanning](/documentation/platform/secret-scanning/overview) to learn more.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="infisical: command not found">
+    The CLI isn't on your `PATH`. Run the install command for your platform again, then open a new terminal window so that it picks up the updated `PATH`.
+  </Accordion>
+  <Accordion title="Your application starts, but a secret is missing">
+    The CLI is probably reading from a different environment or folder than the one holding your secret. Run `infisical secrets --env=dev --path=/` to see what it resolves to, confirm the environment slug in your project settings, and add `--path` if the secret lives in a folder rather than at the root.
+  </Accordion>
+  <Accordion title="The CLI can't find your project, or asks you to log in again">
+    The CLI is pointed at the wrong instance. It uses Infisical Cloud US by default, so an EU or self-hosted account needs the address set through the `INFISICAL_DOMAIN` environment variable, the `--domain` flag, or the `domain` field in [`.infisical.json`](/cli/project-config).
+  </Accordion>
+  <Accordion title="It works in your terminal but not in your editor">
+    Your editor's run configuration starts the application on its own, outside the `infisical run` process, so the injected variables never reach it. Either start your editor from a terminal, or change the run configuration to call `infisical run --env=dev -- <your-start-command>`.
+  </Accordion>
+</AccordionGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="CLI reference" icon="terminal" href="/cli/commands/run">
+    All available flags for `run`, `export`, `secrets`, and the rest of the CLI.
+  </Card>
+  <Card title="Docker" icon="docker" href="/integrations/platforms/docker">
+    Inject the same secrets into containers and Docker Compose services.
+  </Card>
+  <Card title="Secrets delivery" icon="truck-fast" href="/documentation/platform/secrets-mgmt/concepts/secrets-delivery">
+    Choose how to deliver secrets to CI/CD, Kubernetes, and production workloads.
+  </Card>
+  <Card title="Language SDKs" icon="code" href="/sdks/overview">
+    Fetch secrets from inside your application code instead of the environment.
+  </Card>
+</CardGroup>

--- a/docs/documentation/guides/local-development.mdx
+++ b/docs/documentation/guides/local-development.mdx
@@ -33,9 +33,21 @@ infisical --version
 
 If your application starts but behaves as though a value is missing, check what the CLI is injecting before you look at your application code. This prints one secret exactly as your application would receive it:
 
-```bash
+<CodeGroup>
+
+```bash macOS/Linux
 infisical run --env=dev -- printenv <YOUR_SECRET_KEY>
 ```
+
+```powershell Windows (PowerShell)
+infisical run --env=dev -- powershell -Command 'echo $env:<YOUR_SECRET_KEY>'
+```
+
+```batch Windows (Command Prompt)
+infisical run --env=dev -- cmd /c echo %<YOUR_SECRET_KEY>%
+```
+
+</CodeGroup>
 
 To see every key available in an environment, list the secrets directly:
 
@@ -78,8 +90,8 @@ The hook stops the commit when it finds something that looks like a secret. Chec
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="infisical: command not found">
-    The CLI isn't on your `PATH`. Run the install command for your platform again, then open a new terminal window so that it picks up the updated `PATH`.
+  <Accordion title="The infisical command isn't found">
+    Your shell reports `infisical: command not found`, or `infisical is not recognized` on Windows. The CLI isn't on your `PATH`. Run the install command for your platform again, then open a new terminal window so that it picks up the updated `PATH`.
   </Accordion>
   <Accordion title="Your application starts, but a secret is missing">
     The CLI is probably reading from a different environment or folder than the one holding your secret. Run `infisical secrets --env=dev --path=/` to see what it resolves to, confirm the environment slug in your project settings, and add `--path` if the secret lives in a folder rather than at the root.

--- a/docs/documentation/platform/secrets-mgmt/concepts/secrets-delivery.mdx
+++ b/docs/documentation/platform/secrets-mgmt/concepts/secrets-delivery.mdx
@@ -32,9 +32,9 @@ From here, you can explore the delivery method that best matches your environmen
 
 For local development, one-off scripts, or basic automation, the [Infisical CLI](/cli/overview) is a quick and flexible option.
 
-Instead of using a `.env` file, you can use [`infisical run`](/cli/commands/run) to inject secrets as environment variables directly into your development process. This provides a cleaner and more secure workflow. You can also use [`infisical secrets`](/cli/commands/secrets#infisical-secrets) to perform CRUD operations on secrets from the command line, which works well for debugging, local tooling, and lightweight scripting.
+Instead of using a `.env` file, you can use [`infisical run`](/cli/commands/run) to inject secrets as environment variables directly into your development process. This provides a cleaner and more secure workflow. Because the CLI reads the current values each time your application starts, a developer joining the team never needs a copy of a teammate's `.env` file, and no one is left running a stale value after a credential changes. You can also use [`infisical secrets`](/cli/commands/secrets#infisical-secrets) to perform CRUD operations on secrets from the command line, which works well for debugging, local tooling, and lightweight scripting.
 
-To learn more, refer to the [CLI quickstart](/cli/usage).
+To set this up on your own machine, see the [local development guide](/documentation/guides/local-development).
 
 ## Applications and services
 

--- a/docs/snippets/cli/inject-secrets-locally.mdx
+++ b/docs/snippets/cli/inject-secrets-locally.mdx
@@ -1,0 +1,94 @@
+<Note>
+  If you prefer to learn by watching, follow along with our [step-by-step video tutorial](https://www.youtube.com/watch?v=zYCeELjcgQ4).
+</Note>
+
+### Log in to Infisical
+
+Authenticate the CLI with your Infisical account.
+
+```bash
+infisical login
+```
+
+The prompt asks which instance you want to use. Select **Infisical Cloud (US)**, **Infisical Cloud (EU)**, or **Self-hosted**, then finish signing in through your browser.
+
+<Note>
+  On a machine with no browser, such as a remote SSH session, WSL 2, or Codespaces, run `infisical login -i` to log in from the terminal instead.
+</Note>
+
+### Link your codebase to your project
+
+Go to the directory of the codebase you are working on and link it to your Infisical project.
+
+```bash
+cd /path/to/your/project
+infisical init
+```
+
+Select your organization and project when prompted. This creates an `.infisical.json` file with your [local project settings](/cli/project-config), so the commands you run next don't need a project ID.
+
+<Note>
+  `.infisical.json` holds no secret values, so you can safely commit it to version control. Everyone who clones the repository is then pointed at the same project.
+</Note>
+
+### Start your application with secrets injected
+
+Run your usual start command through `infisical run`, placing it after the `--` separator.
+
+<CodeGroup>
+
+```bash Node.js
+infisical run --env=dev -- npm run dev
+```
+
+```bash Python
+infisical run --env=dev -- flask run
+```
+
+```bash Go
+infisical run --env=dev -- go run main.go
+```
+
+```bash Ruby
+infisical run --env=dev -- bundle exec rails server
+```
+
+```bash Java
+infisical run --env=dev -- ./mvnw spring-boot:run
+```
+
+```bash .NET
+infisical run --env=dev -- dotnet run
+```
+
+</CodeGroup>
+
+The CLI fetches the secrets you have access to and passes them to your application as environment variables. Your application reads them the same way it always has, through `process.env` in Node.js or `os.environ` in Python, so you don't need to change any application code.
+
+<Tip>
+  Add `--watch` while you work to restart your application automatically whenever one of its secrets changes in Infisical.
+</Tip>
+
+<Accordion title="Injecting secrets into a shell function or alias">
+  A start command that is a shell function or an alias can't be called directly after `--`, because it only exists inside your shell. Use the `--command` flag to run it in a shell instead.
+
+  For example, if `custom.sh` defines a `yd` function that runs `yarn dev`:
+
+  ```bash
+  #!/bin/sh
+
+  yd() {
+    yarn dev
+  }
+  ```
+
+  Source the file and call the function in a single command:
+
+  ```bash
+  infisical run --env=dev --command="source custom.sh && yd"
+  ```
+
+  The `--command` flag is also how you chain commands together, as in `--command="npm run migrate && npm run dev"`.
+</Accordion>
+
+For every available option, see the [`infisical run`](/cli/commands/run) reference.

--- a/docs/snippets/cli/install-cli.mdx
+++ b/docs/snippets/cli/install-cli.mdx
@@ -1,0 +1,40 @@
+<CodeGroup>
+
+```bash macOS
+brew install infisical/get-cli/infisical
+```
+
+```bash Windows (winget)
+winget install infisical
+```
+
+```bash Windows (Scoop)
+scoop bucket add org https://github.com/Infisical/scoop-infisical.git
+scoop install infisical
+```
+
+```bash npm
+npm install -g @infisical/cli
+```
+
+```bash Debian/Ubuntu
+curl -1sLf 'https://artifacts-cli.infisical.com/setup.deb.sh' | sudo -E bash
+sudo apt-get update && sudo apt-get install -y infisical
+```
+
+```bash RedHat/CentOS/Amazon Linux
+curl -1sLf 'https://artifacts-cli.infisical.com/setup.rpm.sh' | sudo -E bash
+sudo yum install infisical
+```
+
+```bash Alpine
+apk add --no-cache bash sudo wget
+wget -qO- 'https://artifacts-cli.infisical.com/setup.apk.sh' | sudo sh
+apk update && sudo apk add infisical
+```
+
+```bash Arch Linux
+yay -S infisical-bin
+```
+
+</CodeGroup>

--- a/docs/snippets/cli/local-development/link-project.mdx
+++ b/docs/snippets/cli/local-development/link-project.mdx
@@ -1,0 +1,12 @@
+Go to the directory of the codebase you are working on and link it to your Infisical project.
+
+```bash
+cd /path/to/your/project
+infisical init
+```
+
+Select your organization and project when prompted. This creates an `.infisical.json` file with your [local project settings](/cli/project-config), so the commands you run next don't need a project ID.
+
+<Note>
+  `.infisical.json` holds no secret values, so you can safely commit it to version control. Everyone who clones the repository is then pointed at the same project.
+</Note>

--- a/docs/snippets/cli/local-development/log-in.mdx
+++ b/docs/snippets/cli/local-development/log-in.mdx
@@ -1,0 +1,11 @@
+Authenticate the CLI with your Infisical account.
+
+```bash
+infisical login
+```
+
+The prompt asks which instance you want to use. Select **Infisical Cloud (US)**, **Infisical Cloud (EU)**, or **Self-hosted**, then finish signing in through your browser.
+
+<Note>
+  On a machine with no browser, such as a remote SSH session, WSL 2, or Codespaces, run `infisical login -i` to log in from the terminal instead.
+</Note>

--- a/docs/snippets/cli/local-development/start-application.mdx
+++ b/docs/snippets/cli/local-development/start-application.mdx
@@ -1,38 +1,3 @@
-<Note>
-  If you prefer to learn by watching, follow along with our [step-by-step video tutorial](https://www.youtube.com/watch?v=zYCeELjcgQ4).
-</Note>
-
-### Log in to Infisical
-
-Authenticate the CLI with your Infisical account.
-
-```bash
-infisical login
-```
-
-The prompt asks which instance you want to use. Select **Infisical Cloud (US)**, **Infisical Cloud (EU)**, or **Self-hosted**, then finish signing in through your browser.
-
-<Note>
-  On a machine with no browser, such as a remote SSH session, WSL 2, or Codespaces, run `infisical login -i` to log in from the terminal instead.
-</Note>
-
-### Link your codebase to your project
-
-Go to the directory of the codebase you are working on and link it to your Infisical project.
-
-```bash
-cd /path/to/your/project
-infisical init
-```
-
-Select your organization and project when prompted. This creates an `.infisical.json` file with your [local project settings](/cli/project-config), so the commands you run next don't need a project ID.
-
-<Note>
-  `.infisical.json` holds no secret values, so you can safely commit it to version control. Everyone who clones the repository is then pointed at the same project.
-</Note>
-
-### Start your application with secrets injected
-
 Run your usual start command through `infisical run`, placing it after the `--` separator.
 
 <CodeGroup>


### PR DESCRIPTION
## Context

Adds a guide to local development, replacing the old contents of the page (which were more conceptual and didn't contain any actual guides or instructions).

Closes DX-110

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)