### PR TITLE
docs(style): fix padding at bottom of pages

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -3,7 +3,7 @@
 }
 
 .chat-assistant-floating-input {
-  display: none !important;
+  visibility: hidden !important;
 }
 
 #sidebar li > a.text-primary {


### PR DESCRIPTION
## Context

Fixes padding at the bottom of docs pages.

## Screenshots

Before:

<img width="775" height="167" alt="Screenshot 2026-08-25 at 12 32 28 PM" src="https://github.com/user-attachments/assets/020d2c5f-26c4-4e19-9438-34a7901a8381" />

After:

<img width="836" height="268" alt="Screenshot 2026-08-25 at 12 30 42 PM" src="https://github.com/user-attachments/assets/6260d169-21ad-4a42-a903-3be4e30dddfd" />

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)