### PR TITLE
fix(pam): show orphan sessions to product admins

### DIFF
--- a/backend/src/ee/services/pam-session-recording/pam-recording-chunk-service.ts
+++ b/backend/src/ee/services/pam-session-recording/pam-recording-chunk-service.ts
@@ -12,8 +12,8 @@ import { TAwsConnectionConfig } from "@app/services/app-connection/aws/aws-conne
 import { ActorType } from "@app/services/auth/auth-type";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 
-import { PamSessionStatus } from "../pam/pam-enums";
-import { checkAccountAccess, TActorContext } from "../pam/pam-permission";
+import { PamProductRole, PamSessionStatus } from "../pam/pam-enums";
+import { checkAccountAccess, TActorContext, verifyProductMembership } from "../pam/pam-permission";
 import { TPamAccountDALFactory } from "../pam-account/pam-account-dal";
 import {
   PamRecordingS3ConfigSchema,
@@ -32,7 +32,7 @@ type TPamSessionChunkServiceFactoryDep = {
   pamSessionDAL: TPamSessionDALFactory;
   pamSessionEventChunkDAL: TPamSessionEventChunkDALFactory;
   pamAccountDAL: Pick<TPamAccountDALFactory, "findByIdWithDetails">;
-  permissionService: Pick<TPermissionServiceFactory, "getResourcePermission">;
+  permissionService: Pick<TPermissionServiceFactory, "getResourcePermission" | "getProjectPermission">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById">;
 };
@@ -103,21 +103,27 @@ export const pamSessionChunkServiceFactory = ({
     session: { accountId?: string | null; projectId: string },
     actor: OrgServiceActor
   ) => {
-    if (!session.accountId) {
-      throw new NotFoundError({ message: "Session has no associated account" });
-    }
-
-    const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
-    if (!account) {
-      throw new NotFoundError({ message: "Account not found" });
-    }
-
     const ctx: TActorContext = {
       actorId: actor.id,
       actor: actor.type,
       actorOrgId: actor.orgId,
       actorAuthMethod: actor.authMethod
     };
+
+    if (!session.accountId) {
+      const { hasRole } = await verifyProductMembership(permissionService, session.projectId, ctx);
+      if (!hasRole(PamProductRole.Admin)) {
+        throw new ForbiddenRequestError({
+          message: "Only a project admin can access a session whose account has been deleted"
+        });
+      }
+      return;
+    }
+
+    const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
+    if (!account) {
+      throw new NotFoundError({ message: "Account not found" });
+    }
 
     await checkAccountAccess(
       permissionService,

--- a/backend/src/ee/services/pam-session/pam-session-dal.ts
+++ b/backend/src/ee/services/pam-session/pam-session-dal.ts
@@ -91,6 +91,7 @@ export const pamSessionDALFactory = (db: TDbClient) => {
     {
       viewSessionsFolderIds,
       viewSessionsAccountIds,
+      includeOrphaned = false,
       offset,
       limit,
       search,
@@ -98,6 +99,7 @@ export const pamSessionDALFactory = (db: TDbClient) => {
     }: {
       viewSessionsFolderIds: string[];
       viewSessionsAccountIds: string[];
+      includeOrphaned?: boolean;
       offset?: number;
       limit?: number;
       search?: string;
@@ -107,7 +109,7 @@ export const pamSessionDALFactory = (db: TDbClient) => {
   ) => {
     // Visibility comes solely from ViewSessions scopes; no scopes means no sessions, and skipping
     // this guard would leave the filter block empty and match every session in the project.
-    if (viewSessionsFolderIds.length === 0 && viewSessionsAccountIds.length === 0) {
+    if (viewSessionsFolderIds.length === 0 && viewSessionsAccountIds.length === 0 && !includeOrphaned) {
       return { sessions: [], totalCount: 0 };
     }
 
@@ -120,6 +122,9 @@ export const pamSessionDALFactory = (db: TDbClient) => {
         }
         if (viewSessionsAccountIds.length > 0) {
           void top.orWhereIn(`${TableName.PamSession}.accountId`, viewSessionsAccountIds);
+        }
+        if (includeOrphaned) {
+          void top.orWhereNull(`${TableName.PamSession}.accountId`);
         }
       });
 

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -22,6 +22,7 @@ import {
   PamAccessStatus,
   PamAccountType,
   PamPostgresAuthMethod,
+  PamProductRole,
   PamSessionEndReason,
   PamSessionStatus
 } from "../pam/pam-enums";
@@ -142,6 +143,25 @@ export const pamSessionServiceFactory = ({
     ctx: TActorContext
   ) => checkAccountAccess(permissionService, accountId, folderId, projectId, action, ctx);
 
+  const checkSession = async (
+    session: { accountId?: string | null; projectId: string },
+    action: ResourcePermissionPamResourceActions,
+    ctx: TActorContext
+  ) => {
+    if (session.accountId) {
+      const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
+      await checkAccount(session.accountId, account?.folderId, session.projectId, action, ctx);
+      return;
+    }
+
+    const { hasRole } = await verifyProductMembership(permissionService, session.projectId, ctx);
+    if (!hasRole(PamProductRole.Admin)) {
+      throw new ForbiddenRequestError({
+        message: "Only a project admin can access a session whose account has been deleted"
+      });
+    }
+  };
+
   const enforceRecordingConfig = (account: Parameters<typeof getAccountAccessibilityIssues>[0]) => {
     const issues = getAccountAccessibilityIssues(account);
     if (issues.includes(PamAccountAccessibilityIssue.NoRecordingConfig)) {
@@ -156,7 +176,7 @@ export const pamSessionServiceFactory = ({
     ctx: TActorContext,
     pagination?: { offset?: number; limit?: number; search?: string; status?: string }
   ) => {
-    await verifyProductMembership(permissionService, projectId, ctx);
+    const { hasRole } = await verifyProductMembership(permissionService, projectId, ctx);
 
     const { folderIds, accountIds } = await getResourceIdsWithActions(
       membershipDAL,
@@ -169,22 +189,16 @@ export const pamSessionServiceFactory = ({
     return pamSessionDAL.findAccessibleByProjectId(projectId, {
       viewSessionsFolderIds: folderIds,
       viewSessionsAccountIds: accountIds,
+      includeOrphaned: hasRole(PamProductRole.Admin),
       ...pagination
     });
   };
 
   const getSessionById = async (sessionId: string, ctx: TActorContext) => {
     const session = await pamSessionDAL.findById(sessionId);
-    if (!session || !session.accountId) return null;
+    if (!session) return null;
 
-    const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
-    await checkAccount(
-      session.accountId,
-      account?.folderId,
-      session.projectId,
-      ResourcePermissionPamResourceActions.ViewSessions,
-      ctx
-    );
+    await checkSession(session, ResourcePermissionPamResourceActions.ViewSessions, ctx);
 
     return session;
   };
@@ -753,18 +767,7 @@ export const pamSessionServiceFactory = ({
       throw new BadRequestError({ message: "Session is not active" });
     }
 
-    if (!session.accountId) {
-      throw new BadRequestError({ message: "Session has no linked account" });
-    }
-
-    const account = await pamAccountDAL.findByIdWithDetails(session.accountId);
-    await checkAccount(
-      session.accountId,
-      account?.folderId,
-      session.projectId,
-      ResourcePermissionPamResourceActions.TerminateSessions,
-      ctx
-    );
+    await checkSession(session, ResourcePermissionPamResourceActions.TerminateSessions, ctx);
 
     const updated = await pamSessionDAL.terminateSessionById(sessionId);
     if (!updated) {

--- a/backend/src/ee/services/pam/CLAUDE.md
+++ b/backend/src/ee/services/pam/CLAUDE.md
@@ -157,8 +157,14 @@ are reused from `app-connection/shared/sql`, and rotation is brokered through th
 ## Sessions
 
 `pam-session/` + `pam-web-access/`. Sessions reference accounts via nullable `accountId` (history survives
-account deletion; orphaned sessions are hidden from all queries). Duration is capped at the template max;
-expiration is enforced by a delayed BullMQ job scheduled at session creation.
+account deletion). Duration is capped at the template max; expiration is enforced by a delayed BullMQ job
+scheduled at session creation.
+
+**An orphaned session (null `accountId`) is scoped to product admin.** Every
+resource-scoped predicate is false once the FK is nulled, so `PamProductRole.Admin` stands in on the
+read/terminate paths (the DAL's `includeOrphaned`, `getSessionById`/`terminateSession`, recording
+playback), as it does for scope-less audit-log rows. `getSessionCredentials` still refuses — no account
+means no credentials to mint.
 
 ## Conventions
 

--- a/frontend/src/pages/pam/PamSessionsPage/PamSessionsPage.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/PamSessionsPage.tsx
@@ -73,11 +73,16 @@ const TerminateCell = ({
   session: TPamSession;
   onTerminate: (session: TPamSession, e?: React.MouseEvent) => void;
 }) => {
-  const { data: perm } = usePamAccountPermission(session.accountId ?? "");
-  const canTerminate = perm?.permission.can(
-    PamResourcePermissionActions.TerminateSessions,
-    PamResourcePermissionSub.PamResource
+  const { data: perm } = usePamAccountPermission(
+    session.accountId ?? "",
+    Boolean(session.accountId)
   );
+  const canTerminate =
+    !session.accountId ||
+    perm?.permission.can(
+      PamResourcePermissionActions.TerminateSessions,
+      PamResourcePermissionSub.PamResource
+    );
 
   if (session.status !== PamSessionStatus.Active || !canTerminate) return null;
 

--- a/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamSessionsPage/components/SessionDetailSheet.tsx
@@ -225,11 +225,16 @@ export const SessionDetailSheet = ({ sessionId, isOpen, onOpenChange, onTerminat
   const { data: session, isLoading } = useGetPamSessionById(sessionId ?? "");
   const isActive = session?.status === PamSessionStatus.Active;
 
-  const { data: accountPerm } = usePamAccountPermission(session?.accountId ?? "");
-  const canTerminate = accountPerm?.permission.can(
-    PamResourcePermissionActions.TerminateSessions,
-    PamResourcePermissionSub.PamResource
+  const { data: accountPerm } = usePamAccountPermission(
+    session?.accountId ?? "",
+    Boolean(session?.accountId)
   );
+  const canTerminate =
+    !session?.accountId ||
+    accountPerm?.permission.can(
+      PamResourcePermissionActions.TerminateSessions,
+      PamResourcePermissionSub.PamResource
+    );
 
   const {
     events,


### PR DESCRIPTION
## Context

Allows product admins to see sessions whose accounts were deleted. Previously those got hidden for everyone.

## Steps to verify the change

Delete an account for a session and verify product admins can still see it. Non product admins should not see it.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)