### PR TITLE
fix(pam): send cancellation signal to gateway when a session expires

### DIFF
--- a/backend/src/ee/services/pam-session/pam-session-expiration-queue.ts
+++ b/backend/src/ee/services/pam-session/pam-session-expiration-queue.ts
@@ -1,3 +1,4 @@
+import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { getConfig } from "@app/lib/config/env";
 import { logger } from "@app/lib/logger";
 import { QueueJobs, QueueName, TQueueServiceFactory } from "@app/queue";
@@ -6,8 +7,9 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import { PamSessionEndReason } from "../pam/pam-enums";
+import { resolveSessionActor } from "./pam-session-access-fns";
 import { TPamSessionDALFactory } from "./pam-session-dal";
-import { reportPamSessionEnded } from "./pam-session-fns";
+import { reportPamSessionEnded, sendPamSessionCancellationSignal } from "./pam-session-fns";
 
 type TPamSessionExpirationServiceFactoryDep = {
   queueService: TQueueServiceFactory;
@@ -15,6 +17,7 @@ type TPamSessionExpirationServiceFactoryDep = {
   projectDAL: Pick<TProjectDALFactory, "findById">;
   telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
   userDAL: Pick<TUserDALFactory, "findById">;
+  gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPAMConnectionDetails">;
 };
 
 export type TPamSessionExpirationServiceFactory = ReturnType<typeof pamSessionExpirationServiceFactory>;
@@ -24,7 +27,8 @@ export const pamSessionExpirationServiceFactory = ({
   pamSessionDAL,
   projectDAL,
   telemetryService,
-  userDAL
+  userDAL,
+  gatewayV2Service
 }: TPamSessionExpirationServiceFactoryDep) => {
   const appCfg = getConfig();
 
@@ -40,6 +44,21 @@ export const pamSessionExpirationServiceFactory = ({
         const updated = await pamSessionDAL.endSessionById(sessionId);
         if (updated) {
           logger.info({ sessionId }, `${QueueName.PamSessionExpiration}: session expired [sessionId=${sessionId}]`);
+
+          // endSessionById is status-filtered, so reaching here means nothing else has signalled the gateway
+          if (updated.gatewayId) {
+            const sessionActor = resolveSessionActor(updated);
+            sendPamSessionCancellationSignal({
+              sessionId,
+              gatewayId: updated.gatewayId,
+              accountType: updated.accountType,
+              actorId: sessionActor?.id ?? "",
+              actorType: sessionActor?.type,
+              // Machine identity sessions carry no email
+              actorEmail: updated.actorEmail || updated.actorName,
+              gatewayV2Service
+            });
+          }
 
           const project = await projectDAL.findById(updated.projectId);
           if (project?.orgId) {

--- a/backend/src/ee/services/pam-session/pam-session-fns.ts
+++ b/backend/src/ee/services/pam-session/pam-session-fns.ts
@@ -75,12 +75,13 @@ export const reportPamSessionEnded = async ({
 
 // Flipping a session row to terminated does not cut a live tunnel; only this ALPN signal does. Sent
 // best-effort (fire-and-forget) so callers don't block on the gateway round-trip, and shared by every
-// termination path (manual terminate, grant revocation) so they can't drift.
+// termination path (manual terminate, grant revocation, expiry) so they can't drift.
 export const sendPamSessionCancellationSignal = ({
   sessionId,
   gatewayId,
   accountType,
   actorId,
+  actorType = ActorType.USER,
   actorEmail,
   gatewayV2Service
 }: {
@@ -88,6 +89,7 @@ export const sendPamSessionCancellationSignal = ({
   gatewayId: string;
   accountType: string;
   actorId: string;
+  actorType?: ActorType.USER | ActorType.IDENTITY;
   actorEmail: string;
   gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPAMConnectionDetails">;
 }) => {
@@ -100,7 +102,7 @@ export const sendPamSessionCancellationSignal = ({
         accountType: accountType as PamAccountType,
         host: "0.0.0.0",
         port: 0,
-        actorMetadata: { id: actorId, type: ActorType.USER, name: actorEmail }
+        actorMetadata: { id: actorId, type: actorType, name: actorEmail }
       });
       if (!certs) {
         logger.error(

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1894,7 +1894,8 @@ export const registerRoutes = async (
     pamSessionDAL,
     projectDAL,
     telemetryService,
-    userDAL
+    userDAL,
+    gatewayV2Service
   });
 
   const pamAccessRequestService = pamAccessRequestServiceFactory({


### PR DESCRIPTION
## Context

The session expiration job flipped the session row to `Ended` and stopped there. Every other
path that closes a session (manual terminate, grant revocation) also sends the gateway an ALPN
cancellation signal, which is what actually cuts the tunnel. Expiry did not.

Worth noting for reviewers: the gateway already cuts an expired tunnel on its own. It runs a
per-connection watchdog on the client cert's `NotAfter` (`packages/pam/pam-proxy.go`), and that
cert is minted from the same duration that produces `expiresAt`. So this is defense in depth
rather than a live hole. What it closes is the window where the gateway's wall clock and the
platform-issued cert disagree.

## Steps to verify the change

1. Launch a PAM session against a postgres account with `--duration 1m` and connect with psql.
2. Wait out the minute. The gateway should log `infisical-pam-session-cancellation`,
   `Received session termination message`, and `Active proxy session cancelled via registry`
   for that session id, and psql should drop.

To confirm it is this change doing the work rather than the gateway's own watchdog, temporarily
pass a longer `duration` to `getPAMConnectionDetails` so the cert outlives `expiresAt`, and
disable the client-side timer in `packages/pam/local/database-proxy.go`. The tunnel should still
die at `expiresAt`.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)