### PR TITLE
fix: add multi arch images on dev env

### DIFF
--- a/docker-compose.dev-read-replica.yml
+++ b/docker-compose.dev-read-replica.yml
@@ -58,7 +58,7 @@ services:
 
   redis-commander:
     container_name: infisical-dev-redis-commander
-    image: rediscommander/redis-commander
+    image: ghcr.io/joeferner/redis-commander:0.9.0
     restart: always
     depends_on:
       - redis
@@ -145,7 +145,7 @@ services:
 
   smtp-server:
     container_name: infisical-dev-smtp-server
-    image: lytrax/mailhog:latest # https://github.com/mailhog/MailHog/issues/353#issuecomment-821137362
+    image: jcalonso/mailhog:v1.0.1 # multi-arch fork; upstream mailhog/mailhog is amd64-only
     restart: always
     logging:
       driver: "none" # disable saving logs

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
 
   redis-commander:
     container_name: infisical-dev-redis-commander
-    image: rediscommander/redis-commander
+    image: ghcr.io/joeferner/redis-commander:0.9.0
     restart: always
     depends_on:
       - redis
@@ -222,7 +222,7 @@ services:
 
   smtp-server:
     container_name: infisical-dev-smtp-server
-    image: lytrax/mailhog:latest # https://github.com/mailhog/MailHog/issues/353#issuecomment-821137362
+    image: jcalonso/mailhog:v1.0.1 # multi-arch fork; upstream mailhog/mailhog is amd64-only
     restart: always
     logging:
       driver: "none" # disable saving logs


### PR DESCRIPTION
## Context

- Add multi arch images on dev docker compose builds.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)