### PR TITLE
improvement(secret-sharing): overhaul sharing UX across surfaces

### DIFF
--- a/frontend/src/pages/organization/SecretSharingPage/SecretSharingPage.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/SecretSharingPage.tsx
@@ -1,7 +1,7 @@
 import { Helmet } from "react-helmet";
 import { useTranslation } from "react-i18next";
 
-import { PageHeader } from "@app/components/v2";
+import { PageHeader } from "@app/components/v3";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
 import { ShareSecretSection } from "./ShareSecretSection";
@@ -11,18 +11,21 @@ export const SecretSharingPage = () => {
   return (
     <>
       <Helmet>
-        <title>{t("common.head-title", { title: t("approval.title") })}</title>
+        <title>{t("common.head-title", { title: "Secret Sharing" })}</title>
         <link rel="icon" href="/infisical.ico" />
         <meta property="og:image" content="/images/message.png" />
-        <meta property="og:title" content={String(t("approval.og-title"))} />
-        <meta name="og:description" content={String(t("approval.og-description"))} />
+        <meta property="og:title" content="Secret Sharing" />
+        <meta
+          name="og:description"
+          content="Share sensitive information through secure, expiring links."
+        />
       </Helmet>
       <div className="h-full">
         <div className="mx-auto h-full w-full max-w-8xl text-white">
           <PageHeader
             scope={ProjectType.SecretManager}
             title="Secret Sharing"
-            description="Share secrets securely using a shareable link"
+            description="Send and request sensitive information through secure, expiring links."
           />
           <ShareSecretSection />
         </div>

--- a/frontend/src/pages/organization/SecretSharingPage/ShareSecretSection.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/ShareSecretSection.tsx
@@ -1,7 +1,6 @@
-import { Helmet } from "react-helmet";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 
-import { Tab, TabList, TabPanel, Tabs } from "@app/components/v2";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useOrganization } from "@app/context";
 
@@ -53,27 +52,19 @@ export const ShareSecretSection = () => {
   };
 
   return (
-    <div>
-      <Helmet>
-        <title>Secret Sharing</title>
-        <link rel="icon" href="/infisical.ico" />
-        <meta property="og:image" content="/images/message.png" />
-      </Helmet>
-
-      <Tabs value={activeTab} onValueChange={updateSelectedTab}>
-        <TabList>
-          {tabs.map(({ key, label }) => (
-            <Tab variant="project" value={key} key={`tab-${key}`}>
-              {label}
-            </Tab>
-          ))}
-        </TabList>
-        {tabs.map(({ key, component: Component }) => (
-          <TabPanel value={key} key={`tab-panel-${key}`}>
-            <Component />
-          </TabPanel>
+    <Tabs value={activeTab} onValueChange={updateSelectedTab}>
+      <TabsList variant="project" aria-label="Secret sharing sections">
+        {tabs.map(({ key, label }) => (
+          <TabsTrigger value={key} key={`tab-${key}`}>
+            {label}
+          </TabsTrigger>
         ))}
-      </Tabs>
-    </div>
+      </TabsList>
+      {tabs.map(({ key, component: Component }) => (
+        <TabsContent value={key} key={`tab-panel-${key}`}>
+          <Component />
+        </TabsContent>
+      ))}
+    </Tabs>
   );
 };

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/AddSecretRequestModal.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/AddSecretRequestModal.tsx
@@ -29,7 +29,8 @@ export const AddSecretRequestModal = ({ popUp, handlePopUpToggle }: Props) => {
         <DialogHeader>
           <DialogTitle>Request a Secret</DialogTitle>
           <DialogDescription>
-            Securely request one off secrets from your team or people outside your organization.
+            Create a link that lets someone send you a secret without exposing it over chat or
+            email.
           </DialogDescription>
         </DialogHeader>
         <RequestSecretForm />

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestSecretForm.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestSecretForm.tsx
@@ -2,17 +2,19 @@ import { useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSearch } from "@tanstack/react-router";
-import { Check, Copy, Info, ReplyIcon } from "lucide-react";
+import { format } from "date-fns";
+import { CheckCircle2, Info, ReplyIcon } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
   Button,
+  CopyButton,
   Field,
   FieldDescription,
   FieldError,
+  FieldGroup,
   FieldLabel,
-  IconButton,
   Input,
   Select,
   SelectContent,
@@ -23,8 +25,8 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
-import { useTimedReset } from "@app/hooks";
 import { SecretSharingAccessType, useCreateSecretRequest } from "@app/hooks/api/secretSharing";
+import { ms } from "@app/lib/fn/time";
 
 const schema = z.object({
   name: z.string().optional(),
@@ -36,8 +38,8 @@ const schema = z.object({
 });
 
 const expiresInOptions = [
-  { label: "5 min", value: "5m" },
-  { label: "30 min", value: "30m" },
+  { label: "5 minutes", value: "5m" },
+  { label: "30 minutes", value: "30m" },
   { label: "1 hour", value: "1h" },
   { label: "1 day", value: "1d" },
   { label: "7 days", value: "7d" },
@@ -45,13 +47,19 @@ const expiresInOptions = [
   { label: "30 days", value: "30d" }
 ];
 
+const formatExpiry = (expiresIn: string) => {
+  try {
+    return format(new Date(Date.now() + ms(expiresIn)), "MMM d, yyyy 'at' h:mm a");
+  } catch {
+    return null;
+  }
+};
+
 export type FormData = z.infer<typeof schema>;
 
 export const RequestSecretForm = () => {
   const [secretLink, setSecretLink] = useState("");
-  const [, isCopyingSecret, setCopyTextSecret] = useTimedReset<string>({
-    initialState: "Copy to clipboard"
-  });
+  const [linkExpiresAt, setLinkExpiresAt] = useState<string | null>(null);
   const subOrganization = useSearch({
     strict: false,
     select: (el) => el?.subOrganization
@@ -63,13 +71,16 @@ export const RequestSecretForm = () => {
     control,
     reset,
     handleSubmit,
-    formState: { isSubmitting }
+    formState: { isSubmitting },
+    watch
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: {
       expiresIn: "7d"
     }
   });
+
+  const resolvedExpiry = formatExpiry(watch("expiresIn"));
 
   const onFormSubmit = async ({ name, accessType, expiresIn }: FormData) => {
     const { id } = await createSecretRequest({
@@ -84,126 +95,161 @@ export const RequestSecretForm = () => {
     }
 
     setSecretLink(link.toString());
+    setLinkExpiresAt(formatExpiry(expiresIn));
     reset();
 
-    navigator.clipboard.writeText(link.toString());
+    await navigator.clipboard.writeText(link.toString());
 
     createNotification({
-      text: "Shared secret link copied to clipboard.",
+      text: "Secret request link copied to clipboard.",
       type: "success"
     });
   };
 
-  const hasSecretLink = Boolean(secretLink);
+  if (secretLink) {
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-2.5">
+          <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-success" />
+          <div>
+            <p className="text-sm font-medium text-foreground">Request Link Created</p>
+            <p className="mt-0.5 text-xs text-accent">
+              Send this link to whoever holds the secret. The value they submit is encrypted and
+              only visible to your organization.
+            </p>
+          </div>
+        </div>
 
-  return !hasSecretLink ? (
-    <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
-      <Controller
-        control={control}
-        name="name"
-        render={({ field, fieldState: { error } }) => (
-          <Field>
-            <FieldLabel>
-              Name <span className="text-xs text-muted italic">- Optional</span>
-            </FieldLabel>
-            <Input {...field} placeholder="API Key" type="text" isError={Boolean(error)} />
-            {error && <FieldError>{error.message}</FieldError>}
-          </Field>
-        )}
-      />
+        <div className="rounded-md border border-border bg-container">
+          <div className="flex items-start justify-between gap-2 p-3">
+            <p className="min-w-0 font-mono text-xs break-all text-label">{secretLink}</p>
+            <CopyButton value={secretLink} ariaLabel="Copy request link" size="sm" />
+          </div>
+          {linkExpiresAt && (
+            <div className="border-t border-border px-3 py-2 text-2xs text-muted">
+              Accepts a secret until {linkExpiresAt}
+            </div>
+          )}
+        </div>
 
-      <Controller
-        control={control}
-        name="expiresIn"
-        render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-          <Field>
-            <FieldLabel>
-              Expires In
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Info className="size-3 cursor-help text-muted" />
-                </TooltipTrigger>
-                <TooltipContent className="max-w-xs">
-                  Select for how long someone is able to input the secret. If a secret is shared
-                  with you in time, it will remain available to you, even after the expiration.
-                </TooltipContent>
-              </Tooltip>
-            </FieldLabel>
-            <Select value={field.value} onValueChange={(e) => onChange(e)}>
-              <SelectTrigger className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {expiresInOptions.map(({ label, value: expiresInValue }) => (
-                  <SelectItem value={String(expiresInValue || "")} key={label}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {error && <FieldError>{error.message}</FieldError>}
-          </Field>
-        )}
-      />
-
-      <Controller
-        control={control}
-        name="accessType"
-        defaultValue={SecretSharingAccessType.Organization}
-        render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-          <Field>
-            <FieldLabel>
-              General Access
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Info className="size-3 cursor-help text-muted" />
-                </TooltipTrigger>
-                <TooltipContent>Select who is able to input the secret</TooltipContent>
-              </Tooltip>
-            </FieldLabel>
-            <Select value={field.value} onValueChange={(e) => onChange(e)}>
-              <SelectTrigger className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={SecretSharingAccessType.Anyone}>Anyone</SelectItem>
-                <SelectItem value={SecretSharingAccessType.Organization}>
-                  People within your organization
-                </SelectItem>
-              </SelectContent>
-            </Select>
-            <FieldDescription>Controls who can provide the requested secret</FieldDescription>
-            {error && <FieldError>{error.message}</FieldError>}
-          </Field>
-        )}
-      />
-      <div className="flex w-full justify-end">
-        <Button variant="project" type="submit" isPending={isSubmitting} isDisabled={isSubmitting}>
-          Create Request Link
-        </Button>
-      </div>
-    </form>
-  ) : (
-    <>
-      <div className="relative flex items-center justify-between rounded-md border border-border bg-container p-2 pr-5 pl-3 text-base text-label">
-        <p className="mr-4 break-all">{secretLink}</p>
-        <IconButton
-          aria-label="copy icon"
-          variant="ghost-muted"
-          size="sm"
-          className="absolute top-1 right-1"
+        <Button
+          variant="project"
+          size="lg"
+          isFullWidth
           onClick={() => {
-            navigator.clipboard.writeText(secretLink);
-            setCopyTextSecret("Copied");
+            setSecretLink("");
+            setLinkExpiresAt(null);
           }}
         >
-          {isCopyingSecret ? <Check className="size-4" /> : <Copy className="size-4" />}
-        </IconButton>
+          Request Another Secret
+          <ReplyIcon />
+        </Button>
       </div>
-      <Button className="w-full" variant="project" size="lg" onClick={() => setSecretLink("")}>
-        Request Another Secret
-        <ReplyIcon />
-      </Button>
-    </>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onFormSubmit)}>
+      <FieldGroup>
+        <Controller
+          control={control}
+          name="name"
+          render={({ field, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel htmlFor="request-secret-name">
+                Name <span className="text-xs text-muted italic">- Optional</span>
+              </FieldLabel>
+              <Input
+                {...field}
+                id="request-secret-name"
+                placeholder="API Key"
+                type="text"
+                isError={Boolean(error)}
+              />
+              <FieldDescription>
+                Only visible to your organization, never to the sender.
+              </FieldDescription>
+              {error && <FieldError>{error.message}</FieldError>}
+            </Field>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="expiresIn"
+          render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel htmlFor="request-secret-expires-in">
+                Expires In
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Info className="size-3 cursor-help text-muted" />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-xs">
+                    Once the link expires no one can submit a secret through it. A secret submitted
+                    before then stays available to you.
+                  </TooltipContent>
+                </Tooltip>
+              </FieldLabel>
+              <Select value={field.value} onValueChange={(e) => onChange(e)}>
+                <SelectTrigger className="w-full" id="request-secret-expires-in">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {expiresInOptions.map(({ label, value: expiresInValue }) => (
+                    <SelectItem value={String(expiresInValue || "")} key={label}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {resolvedExpiry && (
+                <FieldDescription>
+                  The link stops accepting a secret on {resolvedExpiry}.
+                </FieldDescription>
+              )}
+              {error && <FieldError>{error.message}</FieldError>}
+            </Field>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="accessType"
+          defaultValue={SecretSharingAccessType.Organization}
+          render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+            <Field>
+              <FieldLabel htmlFor="request-secret-access-type">Who Can Respond</FieldLabel>
+              <Select value={field.value} onValueChange={(e) => onChange(e)}>
+                <SelectTrigger className="w-full" id="request-secret-access-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={SecretSharingAccessType.Anyone}>Anyone</SelectItem>
+                  <SelectItem value={SecretSharingAccessType.Organization}>
+                    People within your organization
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <FieldDescription>
+                Restricting to your organization requires the sender to sign in to Infisical.
+              </FieldDescription>
+              {error && <FieldError>{error.message}</FieldError>}
+            </Field>
+          )}
+        />
+
+        <div className="flex w-full justify-end">
+          <Button
+            variant="project"
+            type="submit"
+            isPending={isSubmitting}
+            isDisabled={isSubmitting}
+          >
+            Create Request Link
+          </Button>
+        </div>
+      </FieldGroup>
+    </form>
   );
 };

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestSecretForm.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestSecretForm.tsx
@@ -98,12 +98,18 @@ export const RequestSecretForm = () => {
     setLinkExpiresAt(formatExpiry(expiresIn));
     reset();
 
-    await navigator.clipboard.writeText(link.toString());
-
-    createNotification({
-      text: "Secret request link copied to clipboard.",
-      type: "success"
-    });
+    try {
+      await navigator.clipboard.writeText(link.toString());
+      createNotification({
+        text: "Secret request link copied to clipboard.",
+        type: "success"
+      });
+    } catch {
+      createNotification({
+        text: "Request link created. Copy it below, your browser blocked clipboard access.",
+        type: "info"
+      });
+    }
   };
 
   if (secretLink) {

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestSecretTab.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestSecretTab.tsx
@@ -55,7 +55,7 @@ export const RequestSecretTab = () => {
           Secret Requests
           <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/secret-sharing" />
         </CardTitle>
-        <CardDescription>Request and manage secrets from your team</CardDescription>
+        <CardDescription>Manage links that let others send you a secret.</CardDescription>
         <CardAction>
           <Button
             variant="project"
@@ -88,7 +88,9 @@ export const RequestSecretTab = () => {
             </AlertDialogMedia>
             <AlertDialogTitle>Delete secret request?</AlertDialogTitle>
             <AlertDialogDescription>
-              This action cannot be undone. The secret request link will no longer be accessible.
+              This action cannot be undone. The link for
+              {` ${popUp.deleteSecretRequestConfirmation.data?.name || "this request"} `}
+              will no longer accept a secret.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsRow.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsRow.tsx
@@ -125,21 +125,23 @@ export const RequestedSecretsRow = ({
               </IconButton>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                isDisabled={Boolean(row.encryptedSecret) || isExpired}
-                onClick={() => {
-                  navigator.clipboard.writeText(
-                    `${window.location.origin}/secret-request/secret/${row.id}`
-                  );
-                  createNotification({
-                    text: "Secret request link copied to clipboard.",
-                    type: "success"
-                  });
-                }}
-              >
-                <Copy />
-                Copy Link
-              </DropdownMenuItem>
+              {!row.encryptedSecret && (
+                <DropdownMenuItem
+                  isDisabled={isExpired}
+                  onClick={() => {
+                    navigator.clipboard.writeText(
+                      `${window.location.origin}/secret-request/secret/${row.id}`
+                    );
+                    createNotification({
+                      text: "Secret request link copied to clipboard.",
+                      type: "success"
+                    });
+                  }}
+                >
+                  <Copy />
+                  Copy Link
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 variant="danger"
                 onClick={() =>

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsRow.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsRow.tsx
@@ -52,7 +52,9 @@ export const RequestedSecretsRow = ({
 
   return (
     <TableRow key={row.id}>
-      <TableCell isTruncatable>{row.name || <span className="text-muted">&mdash;</span>}</TableCell>
+      <TableCell isTruncatable>
+        {row.name || <span className="text-muted">Unnamed request</span>}
+      </TableCell>
       <TableCell>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -77,7 +79,7 @@ export const RequestedSecretsRow = ({
         {row.expiresAt ? (
           format(new Date(row.expiresAt), "MMM d, yyyy h:mm a")
         ) : (
-          <span className="text-muted">&mdash;</span>
+          <span className="text-muted">Never</span>
         )}
       </TableCell>
       <TableCell>
@@ -113,7 +115,12 @@ export const RequestedSecretsRow = ({
           )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <IconButton className="ml-auto" variant="ghost" size="xs" aria-label="actions">
+              <IconButton
+                className="ml-auto"
+                variant="ghost"
+                size="xs"
+                aria-label={`Actions for ${row.name || "secret request"}`}
+              >
                 <Ellipsis className="size-4" />
               </IconButton>
             </DropdownMenuTrigger>
@@ -125,7 +132,7 @@ export const RequestedSecretsRow = ({
                     `${window.location.origin}/secret-request/secret/${row.id}`
                   );
                   createNotification({
-                    text: "Shared secret link copied to clipboard.",
+                    text: "Secret request link copied to clipboard.",
                     type: "success"
                   });
                 }}
@@ -137,7 +144,7 @@ export const RequestedSecretsRow = ({
                 variant="danger"
                 onClick={() =>
                   handlePopUpOpen("deleteSecretRequestConfirmation", {
-                    name: "delete",
+                    name: row.name || "this request",
                     id: row.id
                   })
                 }

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsTable.tsx
@@ -44,8 +44,8 @@ export const RequestedSecretsTable = ({ handlePopUpOpen }: Props) => {
             <TableRow>
               <TableHead className="w-1/4">Name</TableHead>
               <TableHead>Access Type</TableHead>
-              <TableHead>Created</TableHead>
-              <TableHead>Expires</TableHead>
+              <TableHead>Created At</TableHead>
+              <TableHead>Expires At</TableHead>
               <TableHead>Status</TableHead>
               <TableHead aria-label="button" className="w-5" />
             </TableRow>
@@ -76,14 +76,19 @@ export const RequestedSecretsTable = ({ handlePopUpOpen }: Props) => {
           page={page}
           perPage={perPage}
           onChangePage={(newPage) => setPage(newPage)}
-          onChangePerPage={(newPerPage) => setPerPage(newPerPage)}
+          onChangePerPage={(newPerPage) => {
+            setPerPage(newPerPage);
+            setPage(1);
+          }}
         />
       )}
       {!isPending && !data?.secrets?.length && (
         <Empty className="border">
           <EmptyHeader>
-            <EmptyTitle>No secrets requested yet</EmptyTitle>
-            <EmptyDescription>Request a secret to get started</EmptyDescription>
+            <EmptyTitle>No Secret Requests</EmptyTitle>
+            <EmptyDescription>
+              Create a link that lets someone send you a secret securely.
+            </EmptyDescription>
           </EmptyHeader>
         </Empty>
       )}

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RequestedSecretsTable.tsx
@@ -29,7 +29,7 @@ type Props = {
 export const RequestedSecretsTable = ({ handlePopUpOpen }: Props) => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
-  const { isPending, data } = useGetSecretRequests({
+  const { isPending, isError, data } = useGetSecretRequests({
     offset: (page - 1) * perPage,
     limit: perPage
   });
@@ -38,7 +38,7 @@ export const RequestedSecretsTable = ({ handlePopUpOpen }: Props) => {
 
   return (
     <div>
-      {(isPending || hasSecrets) && (
+      {(isPending || hasSecrets) && !isError && (
         <Table>
           <TableHeader>
             <TableRow>
@@ -70,7 +70,7 @@ export const RequestedSecretsTable = ({ handlePopUpOpen }: Props) => {
           </TableBody>
         </Table>
       )}
-      {hasSecrets && data.totalCount >= perPage && data.totalCount !== undefined && (
+      {hasSecrets && data.totalCount > perPage && (
         <Pagination
           count={data.totalCount}
           page={page}
@@ -82,7 +82,15 @@ export const RequestedSecretsTable = ({ handlePopUpOpen }: Props) => {
           }}
         />
       )}
-      {!isPending && !data?.secrets?.length && (
+      {!isPending && isError && (
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyTitle>Could Not Load Secret Requests</EmptyTitle>
+            <EmptyDescription>Refresh the page to try again.</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      )}
+      {!isPending && !isError && !data?.secrets?.length && (
         <Empty className="border">
           <EmptyHeader>
             <EmptyTitle>No Secret Requests</EmptyTitle>

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RevealSecretValueModal.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RevealSecretValueModal.tsx
@@ -1,4 +1,4 @@
-import { ClipboardCheckIcon, Copy } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 
 import {
   Button,
@@ -7,13 +7,9 @@ import {
   DialogDescription,
   DialogFooter,
   DialogHeader,
-  DialogTitle,
-  IconButton,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger
+  DialogTitle
 } from "@app/components/v3";
-import { useToggle } from "@app/hooks";
+import { useTimedReset } from "@app/hooks";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 type Props = {
@@ -28,40 +24,31 @@ type ContentProps = {
 };
 
 const Content = ({ secretValue, onClose }: ContentProps) => {
-  const [isSecretValueCopied, setIsSecretValueCopied] = useToggle(false);
+  const [, isSecretValueCopied, setCopyText] = useTimedReset<string>({
+    initialState: "Copy to clipboard"
+  });
 
   return (
     <>
-      <div className="relative flex items-start justify-between rounded-md border border-border bg-container p-2 pr-5 pl-3 text-base text-label">
-        <p className="mr-4 max-h-128 thin-scrollbar min-w-0 overflow-y-auto break-all">
+      <div className="rounded-md border border-border bg-container p-3 text-base text-label">
+        <p className="max-h-128 thin-scrollbar min-w-0 overflow-y-auto font-mono break-all whitespace-pre-wrap">
           {secretValue}
         </p>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <IconButton
-              aria-label="copy icon"
-              variant="ghost"
-              size="sm"
-              className="absolute top-1 right-1"
-              onClick={() => {
-                navigator.clipboard.writeText(secretValue);
-                setIsSecretValueCopied.on();
-              }}
-            >
-              {isSecretValueCopied ? (
-                <ClipboardCheckIcon className="size-4" />
-              ) : (
-                <Copy className="size-4" />
-              )}
-            </IconButton>
-          </TooltipTrigger>
-          <TooltipContent>Click to copy</TooltipContent>
-        </Tooltip>
       </div>
 
       <DialogFooter>
-        <Button variant="outline" onClick={onClose}>
+        <Button variant="ghost" onClick={onClose}>
           Close
+        </Button>
+        <Button
+          variant="project"
+          onClick={async () => {
+            await navigator.clipboard.writeText(secretValue);
+            setCopyText("Copied");
+          }}
+        >
+          {isSecretValueCopied ? <Check /> : <Copy />}
+          {isSecretValueCopied ? "Copied" : "Copy Value"}
         </Button>
       </DialogFooter>
     </>
@@ -77,12 +64,12 @@ export const RevealSecretValueModal = ({ isOpen, onOpenChange, popUp }: Props) =
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-xl">
         <DialogHeader>
-          <DialogTitle>Shared secret value</DialogTitle>
-          {data?.secretRequestName && (
-            <DialogDescription>
-              Shared secret value for secret request {data.secretRequestName}
-            </DialogDescription>
-          )}
+          <DialogTitle>Requested Secret Value</DialogTitle>
+          <DialogDescription>
+            {data?.secretRequestName
+              ? `Submitted for ${data.secretRequestName}.`
+              : "Submitted through your secret request."}
+          </DialogDescription>
         </DialogHeader>
         <Content secretValue={data?.secretValue} onClose={() => onOpenChange?.(false)} />
       </DialogContent>

--- a/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RevealSecretValueModal.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/RequestSecret/RevealSecretValueModal.tsx
@@ -1,5 +1,6 @@
 import { Check, Copy } from "lucide-react";
 
+import { createNotification } from "@app/components/notifications";
 import {
   Button,
   Dialog,
@@ -43,8 +44,15 @@ const Content = ({ secretValue, onClose }: ContentProps) => {
         <Button
           variant="project"
           onClick={async () => {
-            await navigator.clipboard.writeText(secretValue);
-            setCopyText("Copied");
+            try {
+              await navigator.clipboard.writeText(secretValue);
+              setCopyText("Copied");
+            } catch {
+              createNotification({
+                text: "Could not copy the value. Your browser blocked clipboard access.",
+                type: "error"
+              });
+            }
           }}
         >
           {isSecretValueCopied ? <Check /> : <Copy />}

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/AddShareSecretModal.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/AddShareSecretModal.tsx
@@ -1,11 +1,4 @@
-import {
-  Dialog,
-  DialogBody,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle
-} from "@app/components/v3";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@app/components/v3";
 import { useOrganization } from "@app/context";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 import { ShareSecretForm } from "@app/pages/public/ShareSecretPage/components";
@@ -21,18 +14,20 @@ type Props = {
 export const AddShareSecretModal = ({ popUp, handlePopUpToggle }: Props) => {
   const { currentOrg } = useOrganization();
   return (
-    <Dialog
+    <Sheet
       open={popUp?.createSharedSecret?.isOpen}
       onOpenChange={(isOpen) => {
         handlePopUpToggle("createSharedSecret", isOpen);
       }}
     >
-      <DialogContent className="max-w-xl">
-        <DialogHeader>
-          <DialogTitle>Share a Secret</DialogTitle>
-          <DialogDescription>Securely share one off secrets with your team.</DialogDescription>
-        </DialogHeader>
-        <DialogBody>
+      <SheetContent className="w-full sm:max-w-xl">
+        <SheetHeader>
+          <SheetTitle>Share a Secret</SheetTitle>
+          <SheetDescription>
+            Create an encrypted link with controls for access, expiration, and delivery.
+          </SheetDescription>
+        </SheetHeader>
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
           <ShareSecretForm
             isPublic={false}
             value={(popUp.createSharedSecret.data as { value?: string })?.value}
@@ -42,8 +37,8 @@ export const AddShareSecretModal = ({ popUp, handlePopUpToggle }: Props) => {
             maxSharedSecretLifetime={currentOrg?.maxSharedSecretLifetime}
             maxSharedSecretViewLimit={currentOrg?.maxSharedSecretViewLimit}
           />
-        </DialogBody>
-      </DialogContent>
-    </Dialog>
+        </div>
+      </SheetContent>
+    </Sheet>
   );
 };

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretTab.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretTab.tsx
@@ -37,7 +37,7 @@ export const ShareSecretTab = () => {
   const deleteSecretShare = useDeleteSharedSecret();
 
   const onDeleteApproved = async () => {
-    deleteSecretShare.mutateAsync({
+    await deleteSecretShare.mutateAsync({
       sharedSecretId: (popUp?.deleteSharedSecretConfirmation?.data as DeleteModalData)?.id
     });
     createNotification({
@@ -55,7 +55,7 @@ export const ShareSecretTab = () => {
           Shared Secrets
           <DocumentationLinkBadge href="https://infisical.com/docs/documentation/platform/secret-sharing" />
         </CardTitle>
-        <CardDescription>Manage and view your shared secrets</CardDescription>
+        <CardDescription>Manage active links, access limits, and expiration.</CardDescription>
         <CardAction>
           <Button
             variant="project"
@@ -83,12 +83,18 @@ export const ShareSecretTab = () => {
             </AlertDialogMedia>
             <AlertDialogTitle>Delete shared secret?</AlertDialogTitle>
             <AlertDialogDescription>
-              This action cannot be undone. The shared secret link will no longer be accessible.
+              This action cannot be undone. The link for
+              {` ${(popUp.deleteSharedSecretConfirmation.data as DeleteModalData)?.name || "this secret"} `}
+              will no longer be accessible.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction variant="danger" onClick={onDeleteApproved}>
+            <AlertDialogAction
+              variant="danger"
+              onClick={onDeleteApproved}
+              isPending={deleteSecretShare.isPending}
+            >
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
@@ -1,6 +1,7 @@
 import { format } from "date-fns";
-import { ClockAlertIcon, ClockIcon, Ellipsis, Mail, MailOpen, Trash2 } from "lucide-react";
+import { ClockAlertIcon, ClockIcon, Copy, Ellipsis, Mail, MailOpen, Trash2 } from "lucide-react";
 
+import { createNotification } from "@app/components/notifications";
 import {
   Badge,
   DropdownMenu,
@@ -62,7 +63,7 @@ export const ShareSecretsRow = ({
           </TooltipContent>
         </Tooltip>
       </TableCell>
-      <TableCell>{row.name || <span className="text-muted">&mdash;</span>}</TableCell>
+      <TableCell>{row.name || <span className="text-muted">Unnamed secret</span>}</TableCell>
 
       <TableCell>{format(new Date(row.createdAt), "MMM d, yyyy h:mm a")}</TableCell>
       <TableCell>{format(new Date(row.expiresAt), "MMM d, yyyy h:mm a")}</TableCell>
@@ -70,7 +71,7 @@ export const ShareSecretsRow = ({
         {row.expiresAfterViews !== null ? (
           row.expiresAfterViews
         ) : (
-          <span className="text-muted">&mdash;</span>
+          <span className="text-muted">Unlimited</span>
         )}
       </TableCell>
       <TableCell>
@@ -82,16 +83,36 @@ export const ShareSecretsRow = ({
       <TableCell>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <IconButton variant="ghost" size="xs" aria-label="actions">
+            <IconButton
+              variant="ghost"
+              size="xs"
+              aria-label={`Actions for ${row.name || "shared secret"}`}
+            >
               <Ellipsis className="size-4" />
             </IconButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            {!isExpired && (
+              <DropdownMenuItem
+                onClick={async () => {
+                  await navigator.clipboard.writeText(
+                    `${window.location.origin}/shared/secret/${row.id}`
+                  );
+                  createNotification({
+                    text: "Shared secret link copied to clipboard.",
+                    type: "success"
+                  });
+                }}
+              >
+                <Copy />
+                Copy Link
+              </DropdownMenuItem>
+            )}
             <DropdownMenuItem
               variant="danger"
               onClick={() =>
                 handlePopUpOpen("deleteSharedSecretConfirmation", {
-                  name: "delete",
+                  name: row.name || "this secret",
                   id: row.id
                 })
               }

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
@@ -18,6 +18,18 @@ import {
 import { TSharedSecret } from "@app/hooks/api/secretSharing";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
+const getStatusLabel = ({
+  isTimeExpired,
+  isViewsExhausted
+}: {
+  isTimeExpired: boolean;
+  isViewsExhausted: boolean;
+}) => {
+  if (isViewsExhausted) return "Views Used";
+  if (isTimeExpired) return "Expired";
+  return "Active";
+};
+
 export const ShareSecretsRow = ({
   row,
   handlePopUpOpen
@@ -38,14 +50,9 @@ export const ShareSecretsRow = ({
     ? format(new Date(row.lastViewedAt), "MMM d, yyyy h:mm a")
     : undefined;
 
-  let isExpired = false;
-  if (row.expiresAfterViews !== null && row.expiresAfterViews <= 0) {
-    isExpired = true;
-  }
-
-  if (row.expiresAt !== null && new Date(row.expiresAt) < new Date()) {
-    isExpired = true;
-  }
+  const isViewsExhausted = row.expiresAfterViews !== null && row.expiresAfterViews <= 0;
+  const isTimeExpired = row.expiresAt !== null && new Date(row.expiresAt) < new Date();
+  const isExpired = isViewsExhausted || isTimeExpired;
 
   return (
     <TableRow key={row.id}>
@@ -77,7 +84,7 @@ export const ShareSecretsRow = ({
       <TableCell>
         <Badge variant={isExpired ? "danger" : "success"}>
           {isExpired ? <ClockAlertIcon /> : <ClockIcon />}
-          {isExpired ? "Expired" : "Active"}
+          {getStatusLabel({ isTimeExpired, isViewsExhausted })}
         </Badge>
       </TableCell>
       <TableCell>
@@ -95,13 +102,20 @@ export const ShareSecretsRow = ({
             {!isExpired && (
               <DropdownMenuItem
                 onClick={async () => {
-                  await navigator.clipboard.writeText(
-                    `${window.location.origin}/shared/secret/${row.id}`
-                  );
-                  createNotification({
-                    text: "Shared secret link copied to clipboard.",
-                    type: "success"
-                  });
+                  try {
+                    await navigator.clipboard.writeText(
+                      `${window.location.origin}/shared/secret/${row.id}`
+                    );
+                    createNotification({
+                      text: "Shared secret link copied to clipboard.",
+                      type: "success"
+                    });
+                  } catch {
+                    createNotification({
+                      text: "Could not copy the link. Your browser blocked clipboard access.",
+                      type: "error"
+                    });
+                  }
                 }}
               >
                 <Copy />

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
@@ -60,9 +60,13 @@ export const ShareSecretsRow = ({
         <Tooltip>
           <TooltipTrigger asChild>
             {lastViewedAt ? (
-              <MailOpen className="size-4 text-accent" />
+              <span className="flex size-7 items-center justify-center rounded-md border border-info/10 bg-info/10">
+                <MailOpen className="size-4 text-info" />
+              </span>
             ) : (
-              <Mail className="size-4 text-accent" />
+              <span className="flex size-7 items-center justify-center rounded-md border border-border bg-container">
+                <Mail className="size-4 text-muted opacity-70" />
+              </span>
             )}
           </TooltipTrigger>
           <TooltipContent>

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
@@ -35,7 +35,7 @@ type Props = {
 export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
-  const { isPending, data } = useGetSharedSecrets({
+  const { isPending, isError, data } = useGetSharedSecrets({
     offset: (page - 1) * perPage,
     limit: perPage
   });
@@ -43,7 +43,7 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
 
   return (
     <div>
-      {(isPending || hasSecrets) && (
+      {(isPending || hasSecrets) && !isError && (
         <Table>
           <TableHeader>
             <TableRow>
@@ -76,7 +76,7 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
           </TableBody>
         </Table>
       )}
-      {hasSecrets && data.totalCount >= perPage && data.totalCount !== undefined && (
+      {hasSecrets && data.totalCount > perPage && (
         <Pagination
           count={data.totalCount}
           page={page}
@@ -88,7 +88,15 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
           }}
         />
       )}
-      {!isPending && !data?.secrets?.length && (
+      {!isPending && isError && (
+        <Empty className="border">
+          <EmptyHeader>
+            <EmptyTitle>Could Not Load Shared Secrets</EmptyTitle>
+            <EmptyDescription>Refresh the page to try again.</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      )}
+      {!isPending && !isError && !data?.secrets?.length && (
         <Empty className="border">
           <EmptyHeader>
             <EmptyTitle>No Shared Secrets</EmptyTitle>

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
@@ -49,9 +49,9 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
             <TableRow>
               <TableHead className="w-5" />
               <TableHead className="w-1/4">Name</TableHead>
-              <TableHead>Created</TableHead>
-              <TableHead>Expires</TableHead>
-              <TableHead>Views Left</TableHead>
+              <TableHead>Created At</TableHead>
+              <TableHead>Expires At</TableHead>
+              <TableHead>Views Remaining</TableHead>
               <TableHead>Status</TableHead>
               <TableHead aria-label="button" className="w-5" />
             </TableRow>
@@ -82,14 +82,19 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
           page={page}
           perPage={perPage}
           onChangePage={(newPage) => setPage(newPage)}
-          onChangePerPage={(newPerPage) => setPerPage(newPerPage)}
+          onChangePerPage={(newPerPage) => {
+            setPerPage(newPerPage);
+            setPage(1);
+          }}
         />
       )}
       {!isPending && !data?.secrets?.length && (
         <Empty className="border">
           <EmptyHeader>
-            <EmptyTitle>No secrets shared yet</EmptyTitle>
-            <EmptyDescription>Share a secret to get started</EmptyDescription>
+            <EmptyTitle>No Shared Secrets</EmptyTitle>
+            <EmptyDescription>
+              Create a secure link to share sensitive information.
+            </EmptyDescription>
           </EmptyHeader>
         </Empty>
       )}

--- a/frontend/src/pages/public/ShareSecretPage/ShareSecretPage.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/ShareSecretPage.tsx
@@ -1,28 +1,38 @@
 import { Helmet } from "react-helmet";
+import { LockKeyhole } from "lucide-react";
 
 import { AuthPageBackground } from "@app/components/auth/AuthPageBackground";
 import { AuthPageFooter } from "@app/components/auth/AuthPageFooter";
 import { AuthPageHeader } from "@app/components/auth/AuthPageHeader";
-import { Card, CardContent, CardHeader, CardTitle } from "@app/components/v3";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@app/components/v3";
 
 import { ShareSecretForm } from "./components";
 
 export const ShareSecretPage = () => {
   return (
-    <div className="relative flex max-h-screen min-h-screen flex-col overflow-y-auto bg-linear-to-tr from-card via-bunker-900 to-card px-4">
+    <div className="relative flex max-h-screen min-h-screen flex-col overflow-y-auto bg-bunker-800 px-4 text-foreground scheme-dark">
       <AuthPageBackground />
       <Helmet>
         <title>Securely Share Secrets | Infisical</title>
         <link rel="icon" href="/infisical.ico" />
         <meta property="og:image" content="/images/message.png" />
-        <meta property="og:title" content="" />
-        <meta name="og:description" content="" />
+        <meta property="og:title" content="Securely Share Secrets" />
+        <meta
+          name="og:description"
+          content="Create an encrypted, expiring link for sensitive information."
+        />
       </Helmet>
       <AuthPageHeader />
 
       <Card className="z-50 m-auto w-full max-w-xl">
         <CardHeader>
-          <CardTitle>Share a Secret</CardTitle>
+          <CardTitle>
+            <LockKeyhole className="size-4 text-project" />
+            Share a Secret
+          </CardTitle>
+          <CardDescription>
+            Create an encrypted link that expires on your terms. The secret stays masked by default.
+          </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-y-4">
           <ShareSecretForm isPublic />

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -250,12 +250,18 @@ export const ShareSecretForm = ({
         views: shouldLimitView ? viewLimit : "Unlimited"
       });
 
-      await navigator.clipboard.writeText(link.toString());
-
-      createNotification({
-        text: "Shared secret link copied to clipboard.",
-        type: "success"
-      });
+      try {
+        await navigator.clipboard.writeText(link.toString());
+        createNotification({
+          text: "Shared secret link copied to clipboard.",
+          type: "success"
+        });
+      } catch {
+        createNotification({
+          text: "Secret link created. Copy it below, your browser blocked clipboard access.",
+          type: "info"
+        });
+      }
     }
 
     reset();

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -1,24 +1,25 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSearch } from "@tanstack/react-router";
-import { Check, ClipboardCheck, Copy, ForwardIcon, Info, Lock } from "lucide-react";
+import { format } from "date-fns";
+import { CheckCircle2, ForwardIcon, Info, Lock, MailCheck } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
   Badge,
   Button,
+  CopyButton,
   Field,
   FieldDescription,
   FieldError,
+  FieldGroup,
   FieldLabel,
-  IconButton,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
   Input,
   Select,
   SelectContent,
@@ -31,15 +32,13 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
-import { useTimedReset } from "@app/hooks";
 import { useCreatePublicSharedSecret, useCreateSharedSecret } from "@app/hooks/api";
 import { SecretSharingAccessType } from "@app/hooks/api/secretSharing";
 import { ms } from "@app/lib/fn/time";
 
-// values in ms
 const expiresInOptions = [
-  { label: "5 min", value: "5m" },
-  { label: "30 min", value: "30m" },
+  { label: "5 minutes", value: "5m" },
+  { label: "30 minutes", value: "30m" },
   { label: "1 hour", value: "1h" },
   { label: "1 day", value: "1d" },
   { label: "7 days", value: "7d" },
@@ -47,15 +46,21 @@ const expiresInOptions = [
   { label: "30 days", value: "30d" }
 ];
 
-const viewLimitOptions = [
-  { label: "Unlimited", value: false },
-  { label: "Limited", value: true }
-];
+const MAX_RECIPIENTS = 100;
+const ABSOLUTE_VIEW_CEILING = 1000;
 
-const schema = z.object({
+const parseRecipients = (emails?: string) =>
+  emails
+    ? emails
+        .split(",")
+        .map((email) => email.trim())
+        .filter(Boolean)
+    : [];
+
+const baseSchema = z.object({
   name: z.string().optional(),
   password: z.string().optional(),
-  secret: z.string().min(1),
+  secret: z.string().min(1, "Enter the value you want to share."),
   expiresIn: z.string(),
   viewLimit: z.string(),
   shouldLimitView: z.boolean(),
@@ -65,22 +70,74 @@ const schema = z.object({
     .optional()
     .refine(
       (val) => {
-        if (!val) return true;
-        const emails = val
-          .split(",")
-          .map((email) => email.trim())
-          .filter((email) => email !== "");
-        if (emails.length > 100) return false;
-        return emails.every((email) => z.string().email().safeParse(email).success);
+        const recipients = parseRecipients(val);
+        if (recipients.length > MAX_RECIPIENTS) return false;
+        return recipients.every((email) => z.string().email().safeParse(email).success);
       },
       {
-        message: "Must be a comma-separated list of valid emails (max 100) or empty."
+        message: `Enter up to ${MAX_RECIPIENTS} valid emails, separated by commas.`
       }
     ),
   allowExternalEmails: z.boolean().optional()
 });
 
-export type FormData = z.infer<typeof schema>;
+export type FormData = z.infer<typeof baseSchema>;
+
+const buildSchema = (maxSharedSecretViewLimit?: number | null) =>
+  baseSchema.superRefine((data, ctx) => {
+    if (data.shouldLimitView) {
+      const views = Number(data.viewLimit);
+      const ceiling = maxSharedSecretViewLimit ?? ABSOLUTE_VIEW_CEILING;
+
+      if (!Number.isInteger(views) || views < 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["viewLimit"],
+          message: "Enter a whole number of views, 1 or greater."
+        });
+      } else if (views > ceiling) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["viewLimit"],
+          message: `Enter at most ${ceiling} view${ceiling === 1 ? "" : "s"}.`
+        });
+      }
+    }
+
+    if (data.allowExternalEmails && parseRecipients(data.emails).length > 0 && !data.password) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["password"],
+        message: "External recipients need a password to open the secret."
+      });
+    }
+  });
+
+type ShareResult =
+  | { kind: "link"; url: string; expiresAt: string; views: string }
+  | { kind: "email"; recipientCount: number; requiresAccount: boolean };
+
+const describeResult = (result: ShareResult) => {
+  if (result.kind === "link") {
+    return "The link is copied to your clipboard. It cannot be recovered from the secret value again.";
+  }
+
+  const plural = result.recipientCount === 1 ? "" : "s";
+
+  if (result.requiresAccount) {
+    return `Sent to ${result.recipientCount} recipient${plural}. Only those with an Infisical account will receive a link.`;
+  }
+
+  return `Sent to ${result.recipientCount} recipient${plural}. Each one receives a unique link.`;
+};
+
+const formatExpiry = (expiresIn: string) => {
+  try {
+    return format(new Date(Date.now() + ms(expiresIn)), "MMM d, yyyy 'at' h:mm a");
+  } catch {
+    return null;
+  }
+};
 
 type Props = {
   isPublic: boolean; // whether or not this is a public (non-authenticated) secret sharing form
@@ -97,10 +154,7 @@ export const ShareSecretForm = ({
   maxSharedSecretLifetime,
   maxSharedSecretViewLimit
 }: Props) => {
-  const [secretLink, setSecretLink] = useState<string | null>(null);
-  const [, isCopyingSecret, setCopyTextSecret] = useTimedReset<string>({
-    initialState: "Copy to clipboard"
-  });
+  const [result, setResult] = useState<ShareResult | null>(null);
   const subOrganization = useSearch({
     strict: false,
     select: (el) => el?.subOrganization
@@ -115,6 +169,11 @@ export const ShareSecretForm = ({
     ? expiresInOptions.filter((v) => ms(v.value) / 1000 <= maxSharedSecretLifetime)
     : expiresInOptions;
 
+  const isLifetimeCapped = expiresInOptions.length !== filteredExpiresInOptions.length;
+  const isViewLimitEnforced = Boolean(maxSharedSecretViewLimit);
+
+  const schema = useMemo(() => buildSchema(maxSharedSecretViewLimit), [maxSharedSecretViewLimit]);
+
   const {
     control,
     reset,
@@ -126,7 +185,8 @@ export const ShareSecretForm = ({
     defaultValues: {
       secret: value || "",
       viewLimit: maxSharedSecretViewLimit?.toString() ?? "1",
-      shouldLimitView: Boolean(maxSharedSecretViewLimit),
+      shouldLimitView: isViewLimitEnforced,
+      accessType: isPublic ? undefined : SecretSharingAccessType.Organization,
       expiresIn:
         filteredExpiresInOptions[Math.min(filteredExpiresInOptions.length - 1, 2)].value.toString()
     }
@@ -135,9 +195,12 @@ export const ShareSecretForm = ({
   const isLimitingView = watch("shouldLimitView");
   const isAllowingExternalEmails = watch("allowExternalEmails");
   const accessType = watch("accessType");
+  const selectedExpiresIn = watch("expiresIn");
 
   const isOrgAccess =
     accessType === SecretSharingAccessType.Organization || !allowSecretSharingOutsideOrganization;
+
+  const resolvedExpiry = formatExpiry(selectedExpiresIn);
 
   const onFormSubmit = async ({
     name,
@@ -150,7 +213,7 @@ export const ShareSecretForm = ({
     shouldLimitView,
     allowExternalEmails
   }: FormData) => {
-    const processedEmails = emails ? emails.split(",").map((e) => e.trim()) : undefined;
+    const recipients = parseRecipients(emails);
 
     const { id } = await createSharedSecret.mutateAsync({
       name,
@@ -159,19 +222,19 @@ export const ShareSecretForm = ({
       expiresIn,
       maxViews: shouldLimitView ? Number(viewLimit) : undefined,
       accessType: formAccessType,
-      authorizedEmails: processedEmails,
+      authorizedEmails: recipients.length ? recipients : undefined,
       allowExternalEmails
     });
 
-    if (processedEmails && processedEmails.length > 0) {
-      setSecretLink("");
+    if (recipients.length > 0) {
+      const requiresAccount = !allowExternalEmails && !isOrgAccess;
 
-      const showAccountRequiredMessage = !allowExternalEmails && !isOrgAccess;
+      setResult({ kind: "email", recipientCount: recipients.length, requiresAccount });
 
       createNotification({
-        text: showAccountRequiredMessage
-          ? `If the provided ${processedEmails.length > 1 ? "emails are" : "email is"} associated with an Infisical account they will receive a link`
-          : `Secret link has been sent to the provided ${processedEmails.length > 1 ? "emails" : "email"}`,
+        text: requiresAccount
+          ? `If the provided ${recipients.length > 1 ? "emails are" : "email is"} associated with an Infisical account they will receive a link`
+          : `Secret link has been sent to the provided ${recipients.length > 1 ? "emails" : "email"}`,
         type: "success"
       });
     } else {
@@ -180,9 +243,14 @@ export const ShareSecretForm = ({
         link.searchParams.set("subOrganization", subOrganization);
       }
 
-      setSecretLink(link.toString());
+      setResult({
+        kind: "link",
+        url: link.toString(),
+        expiresAt: formatExpiry(expiresIn) ?? "",
+        views: shouldLimitView ? viewLimit : "Unlimited"
+      });
 
-      navigator.clipboard.writeText(link.toString());
+      await navigator.clipboard.writeText(link.toString());
 
       createNotification({
         text: "Shared secret link copied to clipboard.",
@@ -193,301 +261,348 @@ export const ShareSecretForm = ({
     reset();
   };
 
-  if (secretLink === null)
+  if (result !== null) {
     return (
-      <form onSubmit={handleSubmit(onFormSubmit)} className="flex flex-col gap-4">
-        {!isPublic && (
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-2.5">
+          {result.kind === "link" ? (
+            <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-success" />
+          ) : (
+            <MailCheck className="mt-0.5 size-4 shrink-0 text-success" />
+          )}
+          <div>
+            <p className="text-sm font-medium text-foreground">
+              {result.kind === "link" ? "Secret Link Created" : "Secret Link Sent"}
+            </p>
+            <p className="mt-0.5 text-xs text-accent">{describeResult(result)}</p>
+          </div>
+        </div>
+
+        {result.kind === "link" && (
+          <div className="rounded-md border border-border bg-container">
+            <div className="flex items-start justify-between gap-2 p-3">
+              <p className="min-w-0 font-mono text-xs break-all text-label">{result.url}</p>
+              <CopyButton value={result.url} ariaLabel="Copy secret link" size="sm" />
+            </div>
+            {(result.expiresAt || result.views) && (
+              <div className="flex flex-wrap gap-x-4 gap-y-1 border-t border-border px-3 py-2 text-2xs text-muted">
+                {result.expiresAt && <span>Expires {result.expiresAt}</span>}
+                <span>
+                  {result.views === "Unlimited"
+                    ? "Unlimited views"
+                    : `${result.views} view${result.views === "1" ? "" : "s"}`}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+
+        <Button variant="project" size="lg" isFullWidth onClick={() => setResult(null)}>
+          Share Another Secret
+          <ForwardIcon />
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onFormSubmit)}>
+      <FieldGroup>
+        <FieldSet>
+          {!isPublic && (
+            <Controller
+              control={control}
+              name="name"
+              render={({ field, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="share-secret-name">
+                    Name <span className="text-xs text-muted italic">- Optional</span>
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    id="share-secret-name"
+                    placeholder="API Key"
+                    type="text"
+                    autoComplete="off"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    isError={Boolean(error)}
+                  />
+                  <FieldDescription>
+                    Only visible to your organization, never to the recipient.
+                  </FieldDescription>
+                  {error && <FieldError>{error.message}</FieldError>}
+                </Field>
+              )}
+            />
+          )}
           <Controller
             control={control}
-            name="name"
+            name="secret"
             render={({ field, fieldState: { error } }) => (
               <Field>
-                <FieldLabel>
-                  Name <span className="text-xs text-muted italic">- Optional</span>
-                </FieldLabel>
-                <Input
+                <FieldLabel htmlFor="share-secret-value">Secret Value</FieldLabel>
+                <TextArea
+                  placeholder="Enter sensitive data to share via an encrypted link"
                   {...field}
-                  placeholder="API Key"
-                  type="text"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  spellCheck={false}
-                  isError={Boolean(error)}
+                  id="share-secret-value"
+                  className={twMerge("min-h-[70px] resize-y", isPublic ? "h-40" : "h-24")}
+                  disabled={value !== undefined}
+                  aria-invalid={Boolean(error)}
                 />
                 {error && <FieldError>{error.message}</FieldError>}
               </Field>
             )}
           />
-        )}
-        <Controller
-          control={control}
-          name="secret"
-          render={({ field, fieldState: { error } }) => (
-            <Field>
-              <FieldLabel>Your Secret</FieldLabel>
-              <TextArea
-                placeholder="Enter sensitive data to share via an encrypted link"
-                {...field}
-                className={twMerge("min-h-[70px] resize-y", isPublic ? "h-40" : "h-14")}
-                disabled={value !== undefined}
-                aria-invalid={Boolean(error)}
-              />
-              {error && <FieldError>{error.message}</FieldError>}
-            </Field>
-          )}
-        />
-        <Controller
-          control={control}
-          name="expiresIn"
-          render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-            <Field>
-              <FieldLabel>Expires In</FieldLabel>
-              <Select value={field.value} onValueChange={(e) => onChange(e)}>
-                <SelectTrigger className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {expiresInOptions.map(({ label, value: expiresInValue }) => (
-                    <SelectItem
-                      value={String(expiresInValue || "")}
-                      key={label}
-                      disabled={!filteredExpiresInOptions.some((v) => v.label === label)}
-                    >
-                      {label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {expiresInOptions.length !== filteredExpiresInOptions.length && (
-                <FieldDescription className="text-info">
-                  Limited to {filteredExpiresInOptions[filteredExpiresInOptions.length - 1].label}{" "}
-                  by organization
-                </FieldDescription>
-              )}
-              {error && <FieldError>{error.message}</FieldError>}
-            </Field>
-          )}
-        />
-        <Controller
-          control={control}
-          name="password"
-          render={({ field, fieldState: { error } }) => (
-            <Field>
-              <FieldLabel>
-                Password <span className="text-xs text-muted italic">- Optional</span>
-              </FieldLabel>
-              <Input
-                {...field}
-                placeholder="Password"
-                type="password"
-                autoComplete="new-password"
-                autoCorrect="off"
-                spellCheck={false}
-                aria-autocomplete="none"
-                data-form-type="other"
-                isError={Boolean(error)}
-              />
-              {error && <FieldError>{error.message}</FieldError>}
-            </Field>
-          )}
-        />
+        </FieldSet>
 
-        {!isPublic && (
+        <FieldSeparator />
+
+        <FieldSet>
+          <FieldLegend variant="label">Access</FieldLegend>
           <Controller
             control={control}
-            name="accessType"
-            defaultValue={SecretSharingAccessType.Organization}
+            name="expiresIn"
             render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-              <Field orientation="horizontal">
-                <Switch
-                  variant="project"
-                  checked={
-                    field.value === SecretSharingAccessType.Organization ||
-                    !allowSecretSharingOutsideOrganization
-                  }
-                  disabled={!allowSecretSharingOutsideOrganization}
-                  onCheckedChange={(v) =>
-                    onChange(
-                      v ? SecretSharingAccessType.Organization : SecretSharingAccessType.Anyone
-                    )
-                  }
-                />
-                <FieldLabel className="flex-auto">
-                  <span className="flex items-center">
-                    Limit access to people within organization
-                    {!allowSecretSharingOutsideOrganization && (
+              <Field>
+                <FieldLabel htmlFor="share-secret-expires-in">Expires In</FieldLabel>
+                <Select value={field.value} onValueChange={(e) => onChange(e)}>
+                  <SelectTrigger className="w-full" id="share-secret-expires-in">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {expiresInOptions.map(({ label, value: expiresInValue }) => {
+                      const isAvailable = filteredExpiresInOptions.some((v) => v.label === label);
+
+                      return (
+                        <SelectItem
+                          value={String(expiresInValue || "")}
+                          key={label}
+                          disabled={!isAvailable}
+                        >
+                          {label}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+                <FieldDescription>
+                  {resolvedExpiry ? `The link stops working on ${resolvedExpiry}.` : null}
+                  {isLifetimeCapped && (
+                    <span className="mt-0.5 block text-info">
+                      Your organization caps links at{" "}
+                      {filteredExpiresInOptions[filteredExpiresInOptions.length - 1].label}.
+                    </span>
+                  )}
+                </FieldDescription>
+                {error && <FieldError>{error.message}</FieldError>}
+              </Field>
+            )}
+          />
+
+          {!isPublic && !isViewLimitEnforced && (
+            <Controller
+              control={control}
+              name="shouldLimitView"
+              render={({ field: { onChange, value: isChecked, ...field } }) => (
+                <Field orientation="horizontal">
+                  <Switch
+                    {...field}
+                    variant="project"
+                    id="share-secret-limit-views"
+                    checked={isChecked}
+                    onCheckedChange={onChange}
+                  />
+                  <FieldLabel htmlFor="share-secret-limit-views" className="flex-auto">
+                    Limit how many times it can be viewed
+                  </FieldLabel>
+                </Field>
+              )}
+            />
+          )}
+
+          {!isPublic && isLimitingView && (
+            <Controller
+              control={control}
+              name="viewLimit"
+              render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="share-secret-view-limit">
+                    Maximum Views
+                    {isViewLimitEnforced && (
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <Lock className="ml-2 size-3 text-muted" />
+                          <Lock className="size-3 text-muted" />
                         </TooltipTrigger>
                         <TooltipContent>Enforced by your organization</TooltipContent>
                       </Tooltip>
                     )}
-                  </span>
+                  </FieldLabel>
+                  <Input
+                    onChange={onChange}
+                    {...field}
+                    id="share-secret-view-limit"
+                    min={1}
+                    max={maxSharedSecretViewLimit ?? ABSOLUTE_VIEW_CEILING}
+                    type="number"
+                    isError={Boolean(error)}
+                  />
+                  {isViewLimitEnforced && (
+                    <FieldDescription className="text-info">
+                      Your organization caps links at {maxSharedSecretViewLimit} view
+                      {maxSharedSecretViewLimit === 1 ? "" : "s"}.
+                    </FieldDescription>
+                  )}
+                  {error && <FieldError>{error.message}</FieldError>}
+                </Field>
+              )}
+            />
+          )}
+
+          <Controller
+            control={control}
+            name="password"
+            render={({ field, fieldState: { error } }) => (
+              <Field>
+                <FieldLabel htmlFor="share-secret-password">
+                  Password <span className="text-xs text-muted italic">- Optional</span>
                 </FieldLabel>
+                <Input
+                  {...field}
+                  id="share-secret-password"
+                  placeholder="Password"
+                  type="password"
+                  autoComplete="new-password"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  aria-autocomplete="none"
+                  data-form-type="other"
+                  isError={Boolean(error)}
+                />
+                <FieldDescription>
+                  Recipients must enter this password before the secret is revealed.
+                </FieldDescription>
                 {error && <FieldError>{error.message}</FieldError>}
               </Field>
             )}
           />
+        </FieldSet>
+
+        {!isPublic && (
+          <>
+            <FieldSeparator />
+
+            <FieldSet>
+              <FieldLegend variant="label">Delivery</FieldLegend>
+              <Controller
+                control={control}
+                name="accessType"
+                render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+                  <Field orientation="horizontal">
+                    <Switch
+                      variant="project"
+                      id="share-secret-org-only"
+                      checked={
+                        field.value === SecretSharingAccessType.Organization ||
+                        !allowSecretSharingOutsideOrganization
+                      }
+                      disabled={!allowSecretSharingOutsideOrganization}
+                      onCheckedChange={(v) =>
+                        onChange(
+                          v ? SecretSharingAccessType.Organization : SecretSharingAccessType.Anyone
+                        )
+                      }
+                    />
+                    <FieldLabel htmlFor="share-secret-org-only" className="flex-auto">
+                      Limit access to people within organization
+                      {!allowSecretSharingOutsideOrganization && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Lock className="size-3 text-muted" />
+                          </TooltipTrigger>
+                          <TooltipContent>Enforced by your organization</TooltipContent>
+                        </Tooltip>
+                      )}
+                    </FieldLabel>
+                    {error && <FieldError>{error.message}</FieldError>}
+                  </Field>
+                )}
+              />
+
+              <Controller
+                control={control}
+                name="allowExternalEmails"
+                render={({
+                  field: { onChange, value: isChecked, ...field },
+                  fieldState: { error }
+                }) => (
+                  <Field orientation="horizontal">
+                    <Switch
+                      {...field}
+                      variant="project"
+                      id="share-secret-allow-external"
+                      checked={isOrgAccess ? false : (isChecked ?? false)}
+                      onCheckedChange={onChange}
+                      disabled={isOrgAccess}
+                    />
+                    <FieldLabel htmlFor="share-secret-allow-external" className="flex-auto">
+                      Allow recipients without an Infisical account
+                      {!allowSecretSharingOutsideOrganization && (
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Lock className="size-3 text-muted" />
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            External sharing is disabled by your organization
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </FieldLabel>
+                    {error && <FieldError>{error.message}</FieldError>}
+                  </Field>
+                )}
+              />
+
+              <Controller
+                control={control}
+                name="emails"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="share-secret-emails">
+                      Email Recipients <span className="text-xs text-muted italic">- Optional</span>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Info className="size-3 cursor-help text-muted" />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-sm">
+                          Each recipient gets their own link. Leave this empty to get one link you
+                          can share yourself.
+                        </TooltipContent>
+                      </Tooltip>
+                    </FieldLabel>
+                    <Input
+                      {...field}
+                      id="share-secret-emails"
+                      placeholder="user1@example.com, user2@example.com"
+                      autoComplete="off"
+                      isError={Boolean(error)}
+                    />
+                    <FieldDescription>
+                      {isAllowingExternalEmails
+                        ? "Recipients do not need an Infisical account, but they do need the password above."
+                        : "Recipients must sign in to Infisical so their identity can be verified."}
+                    </FieldDescription>
+                    {error && <FieldError>{error.message}</FieldError>}
+                  </Field>
+                )}
+              />
+            </FieldSet>
+          </>
         )}
 
-        {(!isPublic || maxSharedSecretViewLimit === null || isLimitingView) && (
-          <Accordion type="single" collapsible variant="ghost">
-            <AccordionItem value="advance-settings">
-              <AccordionTrigger>Advanced Settings</AccordionTrigger>
-              <AccordionContent className="flex flex-col gap-y-4">
-                <div className="flex w-full items-end gap-2 overflow-visible">
-                  {maxSharedSecretViewLimit === null && (
-                    <Controller
-                      control={control}
-                      name="shouldLimitView"
-                      render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                        <Field className="flex-1">
-                          <FieldLabel>Max Views</FieldLabel>
-                          <Select
-                            value={field.value.toString()}
-                            onValueChange={(e) => onChange(e === "true")}
-                          >
-                            <SelectTrigger className="w-full">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {viewLimitOptions.map(({ label, value: viewLimitValue }) => (
-                                <SelectItem
-                                  value={viewLimitValue.toString()}
-                                  key={viewLimitValue.toString()}
-                                >
-                                  {label}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                          {error && <FieldError>{error.message}</FieldError>}
-                        </Field>
-                      )}
-                    />
-                  )}
-                  {isLimitingView && (
-                    <Controller
-                      control={control}
-                      name="viewLimit"
-                      render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                        <Field className="flex-1">
-                          {maxSharedSecretViewLimit && <FieldLabel>Max Views</FieldLabel>}
-                          <Input
-                            onChange={onChange}
-                            {...field}
-                            min={1}
-                            max={maxSharedSecretViewLimit ?? 1000}
-                            type="number"
-                            isError={Boolean(error)}
-                          />
-                          {maxSharedSecretViewLimit && (
-                            <FieldDescription className="text-info">
-                              Limited to {maxSharedSecretViewLimit} view
-                              {maxSharedSecretViewLimit === 1 ? "" : "s"} by organization
-                            </FieldDescription>
-                          )}
-                          {error && <FieldError>{error.message}</FieldError>}
-                        </Field>
-                      )}
-                    />
-                  )}
-                </div>
-                {!isPublic && (
-                  <>
-                    <Controller
-                      control={control}
-                      name="emails"
-                      render={({ field, fieldState: { error } }) => (
-                        <Field>
-                          <FieldLabel>
-                            Emails <span className="text-xs text-muted italic">- Optional</span>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Info className="size-3 cursor-help text-muted" />
-                              </TooltipTrigger>
-                              <TooltipContent className="max-w-sm">
-                                <p>
-                                  Unique secret links will be emailed to each individual. The secret
-                                  will only be accessible to those links.
-                                </p>
-                                <p className="mt-2">
-                                  {isAllowingExternalEmails
-                                    ? "External recipients (user without an Infisical account) will need the password to view the secret. Authorized recipients will also need a password if the secret is password-protected."
-                                    : "Recipients must have an Infisical account to verify their identity."}
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </FieldLabel>
-                          <Input
-                            {...field}
-                            placeholder="user1@example.com, user2@example.com"
-                            autoComplete="off"
-                            isError={Boolean(error)}
-                          />
-                          <FieldDescription>
-                            {isAllowingExternalEmails
-                              ? "All recipients will receive a link and need the password to access the secret. They don't need an Infisical account, but a password is mandatory in this case."
-                              : "Recipients must have an Infisical account to verify identity"}
-                          </FieldDescription>
-                          {error && <FieldError>{error.message}</FieldError>}
-                        </Field>
-                      )}
-                    />
-                    <Controller
-                      control={control}
-                      name="allowExternalEmails"
-                      render={({
-                        field: { onChange, value: isChecked, ...field },
-                        fieldState: { error }
-                      }) => (
-                        <Field orientation="horizontal">
-                          <Switch
-                            variant="project"
-                            checked={isOrgAccess ? false : (isChecked ?? false)}
-                            onCheckedChange={onChange}
-                            disabled={isOrgAccess}
-                            id="allow-external-emails"
-                            {...field}
-                          />
-                          <FieldLabel className="flex-auto">
-                            <span className="flex items-center">
-                              Allow external recipients
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Info className="ml-2 size-3 cursor-help text-muted" />
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                  When enabled, the defined emails will receive the secret link via
-                                  email but will need the password to access the secret.
-                                </TooltipContent>
-                              </Tooltip>
-                              {!allowSecretSharingOutsideOrganization && (
-                                <Tooltip>
-                                  <TooltipTrigger asChild>
-                                    <Lock className="ml-2 size-3 text-muted" />
-                                  </TooltipTrigger>
-                                  <TooltipContent>
-                                    External sharing is disabled by your organization
-                                  </TooltipContent>
-                                </Tooltip>
-                              )}
-                            </span>
-                          </FieldLabel>
-                          {error && <FieldError>{error.message}</FieldError>}
-                        </Field>
-                      )}
-                    />
-                  </>
-                )}
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
-        )}
-        <div className="flex w-full justify-end">
+        <div className="flex w-full items-center justify-end gap-2">
           {isPublic && (
-            <Badge variant="ghost" className="mt-auto mr-auto">
+            <Badge variant="ghost" className="mr-auto">
               <img
                 src="/images/logotransparent_trimmed.png"
                 alt="Infisical"
@@ -506,44 +621,7 @@ export const ShareSecretForm = ({
             Create Secret Link
           </Button>
         </div>
-      </form>
-    );
-
-  if (secretLink === "")
-    return (
-      <>
-        <div className="relative flex items-center justify-center rounded-lg border border-border bg-container p-4 pr-6 text-foreground/85">
-          <Check className="mr-2 size-4 text-success" />
-          <span>Shared secret link has been emailed to select users.</span>
-        </div>
-        <Button className="w-full" variant="project" size="lg" onClick={() => setSecretLink(null)}>
-          Share Another Secret
-          <ForwardIcon />
-        </Button>
-      </>
-    );
-
-  return (
-    <>
-      <div className="relative flex items-center justify-between rounded-md border border-border bg-container p-2 pr-5 pl-3 text-base text-label">
-        <p className="mr-4 break-all">{secretLink}</p>
-        <IconButton
-          aria-label="copy icon"
-          variant="ghost-muted"
-          size="sm"
-          className="absolute top-1 right-1"
-          onClick={() => {
-            navigator.clipboard.writeText(secretLink || "");
-            setCopyTextSecret("Copied");
-          }}
-        >
-          {isCopyingSecret ? <ClipboardCheck className="size-4" /> : <Copy className="size-4" />}
-        </IconButton>
-      </div>
-      <Button className="w-full" variant="project" size="lg" onClick={() => setSecretLink(null)}>
-        Share Another Secret
-        <ForwardIcon />
-      </Button>
-    </>
+      </FieldGroup>
+    </form>
   );
 };

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -3,7 +3,7 @@ import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSearch } from "@tanstack/react-router";
 import { format } from "date-fns";
-import { CheckCircle2, ForwardIcon, Info, Lock, MailCheck } from "lucide-react";
+import { CheckCircle2, Eye, EyeOff, ForwardIcon, Info, Lock, MailCheck } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
@@ -21,6 +21,10 @@ import {
   FieldSeparator,
   FieldSet,
   Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
   Select,
   SelectContent,
   SelectItem,
@@ -32,6 +36,7 @@ import {
   TooltipContent,
   TooltipTrigger
 } from "@app/components/v3";
+import { useToggle } from "@app/hooks";
 import { useCreatePublicSharedSecret, useCreateSharedSecret } from "@app/hooks/api";
 import { SecretSharingAccessType } from "@app/hooks/api/secretSharing";
 import { ms } from "@app/lib/fn/time";
@@ -155,6 +160,7 @@ export const ShareSecretForm = ({
   maxSharedSecretViewLimit
 }: Props) => {
   const [result, setResult] = useState<ShareResult | null>(null);
+  const [isPasswordVisible, setIsPasswordVisible] = useToggle(false);
   const subOrganization = useSearch({
     strict: false,
     select: (el) => el?.subOrganization
@@ -473,18 +479,28 @@ export const ShareSecretForm = ({
                 <FieldLabel htmlFor="share-secret-password">
                   Password <span className="text-xs text-muted italic">- Optional</span>
                 </FieldLabel>
-                <Input
-                  {...field}
-                  id="share-secret-password"
-                  placeholder="Password"
-                  type="password"
-                  autoComplete="new-password"
-                  autoCorrect="off"
-                  spellCheck={false}
-                  aria-autocomplete="none"
-                  data-form-type="other"
-                  isError={Boolean(error)}
-                />
+                <InputGroup>
+                  <InputGroupInput
+                    {...field}
+                    id="share-secret-password"
+                    placeholder="Password"
+                    type={isPasswordVisible ? "text" : "password"}
+                    autoComplete="new-password"
+                    autoCorrect="off"
+                    spellCheck={false}
+                    aria-autocomplete="none"
+                    data-form-type="other"
+                    aria-invalid={Boolean(error)}
+                  />
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupButton
+                      onClick={() => setIsPasswordVisible.toggle()}
+                      aria-label={isPasswordVisible ? "Hide password" : "Show password"}
+                    >
+                      {isPasswordVisible ? <EyeOff /> : <Eye />}
+                    </InputGroupButton>
+                  </InputGroupAddon>
+                </InputGroup>
                 <FieldDescription>
                   Recipients must enter this password before the secret is revealed.
                 </FieldDescription>

--- a/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
+++ b/frontend/src/pages/public/ShareSecretPage/components/ShareSecretForm.tsx
@@ -3,12 +3,26 @@ import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useSearch } from "@tanstack/react-router";
 import { format } from "date-fns";
-import { CheckCircle2, Eye, EyeOff, ForwardIcon, Info, Lock, MailCheck } from "lucide-react";
+import {
+  CalendarClock,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  ForwardIcon,
+  Info,
+  Lock,
+  MailCheck,
+  SlidersHorizontal
+} from "lucide-react";
 import { twMerge } from "tailwind-merge";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Badge,
   Button,
   CopyButton,
@@ -18,7 +32,6 @@ import {
   FieldGroup,
   FieldLabel,
   FieldLegend,
-  FieldSeparator,
   FieldSet,
   Input,
   InputGroup,
@@ -275,31 +288,37 @@ export const ShareSecretForm = ({
 
   if (result !== null) {
     return (
-      <div className="flex flex-col gap-4">
-        <div className="flex items-start gap-2.5">
-          {result.kind === "link" ? (
-            <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-success" />
-          ) : (
-            <MailCheck className="mt-0.5 size-4 shrink-0 text-success" />
-          )}
-          <div>
-            <p className="text-sm font-medium text-foreground">
+      <div className="flex flex-col gap-5 py-2">
+        <div className="flex flex-col items-center px-4 text-center">
+          <div className="mb-3 flex size-11 items-center justify-center rounded-full border border-success/20 bg-success/10">
+            {result.kind === "link" ? (
+              <CheckCircle2 className="size-5 text-success" />
+            ) : (
+              <MailCheck className="size-5 text-success" />
+            )}
+          </div>
+          <div className="max-w-sm">
+            <p className="text-lg font-semibold text-foreground">
               {result.kind === "link" ? "Secret Link Created" : "Secret Link Sent"}
             </p>
-            <p className="mt-0.5 text-xs text-accent">{describeResult(result)}</p>
+            <p className="mt-1.5 text-sm leading-relaxed text-accent">{describeResult(result)}</p>
           </div>
         </div>
 
         {result.kind === "link" && (
           <div className="rounded-md border border-border bg-container">
-            <div className="flex items-start justify-between gap-2 p-3">
-              <p className="min-w-0 font-mono text-xs break-all text-label">{result.url}</p>
+            <div className="flex items-center justify-between gap-3 p-3">
+              <p className="min-w-0 font-mono text-xs break-all text-foreground">{result.url}</p>
               <CopyButton value={result.url} ariaLabel="Copy secret link" size="sm" />
             </div>
             {(result.expiresAt || result.views) && (
               <div className="flex flex-wrap gap-x-4 gap-y-1 border-t border-border px-3 py-2 text-2xs text-muted">
-                {result.expiresAt && <span>Expires {result.expiresAt}</span>}
-                <span>
+                {result.expiresAt && (
+                  <span className="inline-flex items-center gap-1.5">
+                    <CalendarClock className="size-3" /> Expires {result.expiresAt}
+                  </span>
+                )}
+                <span className="inline-flex items-center gap-1.5">
                   {result.views === "Unlimited"
                     ? "Unlimited views"
                     : `${result.views} view${result.views === "1" ? "" : "s"}`}
@@ -368,10 +387,8 @@ export const ShareSecretForm = ({
           />
         </FieldSet>
 
-        <FieldSeparator />
-
         <FieldSet>
-          <FieldLegend variant="label">Access</FieldLegend>
+          <FieldLegend variant="label">Expiration</FieldLegend>
           <Controller
             control={control}
             name="expiresIn"
@@ -411,216 +428,231 @@ export const ShareSecretForm = ({
               </Field>
             )}
           />
-
-          {!isPublic && !isViewLimitEnforced && (
-            <Controller
-              control={control}
-              name="shouldLimitView"
-              render={({ field: { onChange, value: isChecked, ...field } }) => (
-                <Field orientation="horizontal">
-                  <Switch
-                    {...field}
-                    variant="project"
-                    id="share-secret-limit-views"
-                    checked={isChecked}
-                    onCheckedChange={onChange}
-                  />
-                  <FieldLabel htmlFor="share-secret-limit-views" className="flex-auto">
-                    Limit how many times it can be viewed
-                  </FieldLabel>
-                </Field>
-              )}
-            />
-          )}
-
-          {!isPublic && isLimitingView && (
-            <Controller
-              control={control}
-              name="viewLimit"
-              render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                <Field>
-                  <FieldLabel htmlFor="share-secret-view-limit">
-                    Maximum Views
-                    {isViewLimitEnforced && (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Lock className="size-3 text-muted" />
-                        </TooltipTrigger>
-                        <TooltipContent>Enforced by your organization</TooltipContent>
-                      </Tooltip>
-                    )}
-                  </FieldLabel>
-                  <Input
-                    onChange={onChange}
-                    {...field}
-                    id="share-secret-view-limit"
-                    min={1}
-                    max={maxSharedSecretViewLimit ?? ABSOLUTE_VIEW_CEILING}
-                    type="number"
-                    isError={Boolean(error)}
-                  />
-                  {isViewLimitEnforced && (
-                    <FieldDescription className="text-info">
-                      Your organization caps links at {maxSharedSecretViewLimit} view
-                      {maxSharedSecretViewLimit === 1 ? "" : "s"}.
-                    </FieldDescription>
-                  )}
-                  {error && <FieldError>{error.message}</FieldError>}
-                </Field>
-              )}
-            />
-          )}
-
-          <Controller
-            control={control}
-            name="password"
-            render={({ field, fieldState: { error } }) => (
-              <Field>
-                <FieldLabel htmlFor="share-secret-password">
-                  Password <span className="text-xs text-muted italic">- Optional</span>
-                </FieldLabel>
-                <InputGroup>
-                  <InputGroupInput
-                    {...field}
-                    id="share-secret-password"
-                    placeholder="Password"
-                    type={isPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    autoCorrect="off"
-                    spellCheck={false}
-                    aria-autocomplete="none"
-                    data-form-type="other"
-                    aria-invalid={Boolean(error)}
-                  />
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      onClick={() => setIsPasswordVisible.toggle()}
-                      aria-label={isPasswordVisible ? "Hide password" : "Show password"}
-                    >
-                      {isPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-                <FieldDescription>
-                  Recipients must enter this password before the secret is revealed.
-                </FieldDescription>
-                {error && <FieldError>{error.message}</FieldError>}
-              </Field>
-            )}
-          />
         </FieldSet>
 
-        {!isPublic && (
-          <>
-            <FieldSeparator />
+        <Accordion type="single" collapsible>
+          <AccordionItem value="options">
+            <AccordionTrigger>
+              <span className="flex flex-1 items-center justify-between gap-3">
+                <span className="inline-flex items-center gap-2">
+                  <SlidersHorizontal className="size-4 text-accent" />
+                  More Options
+                </span>
+                <span className="text-xs font-normal text-muted">Password, views, delivery</span>
+              </span>
+            </AccordionTrigger>
+            <AccordionContent className="space-y-6 p-5">
+              <FieldSet className="gap-4">
+                <FieldLegend variant="label">Access</FieldLegend>
 
-            <FieldSet>
-              <FieldLegend variant="label">Delivery</FieldLegend>
-              <Controller
-                control={control}
-                name="accessType"
-                render={({ field: { onChange, ...field }, fieldState: { error } }) => (
-                  <Field orientation="horizontal">
-                    <Switch
-                      variant="project"
-                      id="share-secret-org-only"
-                      checked={
-                        field.value === SecretSharingAccessType.Organization ||
-                        !allowSecretSharingOutsideOrganization
-                      }
-                      disabled={!allowSecretSharingOutsideOrganization}
-                      onCheckedChange={(v) =>
-                        onChange(
-                          v ? SecretSharingAccessType.Organization : SecretSharingAccessType.Anyone
-                        )
-                      }
-                    />
-                    <FieldLabel htmlFor="share-secret-org-only" className="flex-auto">
-                      Limit access to people within organization
-                      {!allowSecretSharingOutsideOrganization && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Lock className="size-3 text-muted" />
-                          </TooltipTrigger>
-                          <TooltipContent>Enforced by your organization</TooltipContent>
-                        </Tooltip>
-                      )}
-                    </FieldLabel>
-                    {error && <FieldError>{error.message}</FieldError>}
-                  </Field>
+                {!isPublic && !isViewLimitEnforced && (
+                  <Controller
+                    control={control}
+                    name="shouldLimitView"
+                    render={({ field: { onChange, value: isChecked, ...field } }) => (
+                      <Field orientation="horizontal">
+                        <Switch
+                          {...field}
+                          variant="project"
+                          id="share-secret-limit-views"
+                          checked={isChecked}
+                          onCheckedChange={onChange}
+                        />
+                        <FieldLabel htmlFor="share-secret-limit-views" className="flex-auto">
+                          Limit how many times it can be viewed
+                        </FieldLabel>
+                      </Field>
+                    )}
+                  />
                 )}
-              />
 
-              <Controller
-                control={control}
-                name="allowExternalEmails"
-                render={({
-                  field: { onChange, value: isChecked, ...field },
-                  fieldState: { error }
-                }) => (
-                  <Field orientation="horizontal">
-                    <Switch
-                      {...field}
-                      variant="project"
-                      id="share-secret-allow-external"
-                      checked={isOrgAccess ? false : (isChecked ?? false)}
-                      onCheckedChange={onChange}
-                      disabled={isOrgAccess}
-                    />
-                    <FieldLabel htmlFor="share-secret-allow-external" className="flex-auto">
-                      Allow recipients without an Infisical account
-                      {!allowSecretSharingOutsideOrganization && (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Lock className="size-3 text-muted" />
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            External sharing is disabled by your organization
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </FieldLabel>
-                    {error && <FieldError>{error.message}</FieldError>}
-                  </Field>
+                {!isPublic && isLimitingView && (
+                  <Controller
+                    control={control}
+                    name="viewLimit"
+                    render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+                      <Field>
+                        <FieldLabel htmlFor="share-secret-view-limit">
+                          Maximum Views
+                          {isViewLimitEnforced && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Lock className="size-3 text-muted" />
+                              </TooltipTrigger>
+                              <TooltipContent>Enforced by your organization</TooltipContent>
+                            </Tooltip>
+                          )}
+                        </FieldLabel>
+                        <Input
+                          onChange={onChange}
+                          {...field}
+                          id="share-secret-view-limit"
+                          min={1}
+                          max={maxSharedSecretViewLimit ?? ABSOLUTE_VIEW_CEILING}
+                          type="number"
+                          isError={Boolean(error)}
+                        />
+                        {isViewLimitEnforced && (
+                          <FieldDescription className="text-info">
+                            Your organization caps links at {maxSharedSecretViewLimit} view
+                            {maxSharedSecretViewLimit === 1 ? "" : "s"}.
+                          </FieldDescription>
+                        )}
+                        {error && <FieldError>{error.message}</FieldError>}
+                      </Field>
+                    )}
+                  />
                 )}
-              />
 
-              <Controller
-                control={control}
-                name="emails"
-                render={({ field, fieldState: { error } }) => (
-                  <Field>
-                    <FieldLabel htmlFor="share-secret-emails">
-                      Email Recipients <span className="text-xs text-muted italic">- Optional</span>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Info className="size-3 cursor-help text-muted" />
-                        </TooltipTrigger>
-                        <TooltipContent className="max-w-sm">
-                          Each recipient gets their own link. Leave this empty to get one link you
-                          can share yourself.
-                        </TooltipContent>
-                      </Tooltip>
-                    </FieldLabel>
-                    <Input
-                      {...field}
-                      id="share-secret-emails"
-                      placeholder="user1@example.com, user2@example.com"
-                      autoComplete="off"
-                      isError={Boolean(error)}
-                    />
-                    <FieldDescription>
-                      {isAllowingExternalEmails
-                        ? "Recipients do not need an Infisical account, but they do need the password above."
-                        : "Recipients must sign in to Infisical so their identity can be verified."}
-                    </FieldDescription>
-                    {error && <FieldError>{error.message}</FieldError>}
-                  </Field>
-                )}
-              />
-            </FieldSet>
-          </>
-        )}
+                <Controller
+                  control={control}
+                  name="password"
+                  render={({ field, fieldState: { error } }) => (
+                    <Field>
+                      <FieldLabel htmlFor="share-secret-password">
+                        Password <span className="text-xs text-muted italic">- Optional</span>
+                      </FieldLabel>
+                      <InputGroup>
+                        <InputGroupInput
+                          {...field}
+                          id="share-secret-password"
+                          placeholder="Password"
+                          type={isPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          autoCorrect="off"
+                          spellCheck={false}
+                          aria-autocomplete="none"
+                          data-form-type="other"
+                          aria-invalid={Boolean(error)}
+                        />
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            onClick={setIsPasswordVisible.toggle}
+                            aria-label={isPasswordVisible ? "Hide password" : "Show password"}
+                          >
+                            {isPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
+                      {error && <FieldError>{error.message}</FieldError>}
+                    </Field>
+                  )}
+                />
+              </FieldSet>
+
+              {!isPublic && (
+                <FieldSet className="gap-4 border-t border-border pt-6">
+                  <FieldLegend variant="label">Delivery</FieldLegend>
+                  <Controller
+                    control={control}
+                    name="accessType"
+                    render={({ field: { onChange, ...field }, fieldState: { error } }) => (
+                      <Field orientation="horizontal">
+                        <Switch
+                          variant="project"
+                          id="share-secret-org-only"
+                          checked={
+                            field.value === SecretSharingAccessType.Organization ||
+                            !allowSecretSharingOutsideOrganization
+                          }
+                          disabled={!allowSecretSharingOutsideOrganization}
+                          onCheckedChange={(v) =>
+                            onChange(
+                              v
+                                ? SecretSharingAccessType.Organization
+                                : SecretSharingAccessType.Anyone
+                            )
+                          }
+                        />
+                        <FieldLabel htmlFor="share-secret-org-only" className="flex-auto">
+                          Limit access to people within organization
+                          {!allowSecretSharingOutsideOrganization && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Lock className="size-3 text-muted" />
+                              </TooltipTrigger>
+                              <TooltipContent>Enforced by your organization</TooltipContent>
+                            </Tooltip>
+                          )}
+                        </FieldLabel>
+                        {error && <FieldError>{error.message}</FieldError>}
+                      </Field>
+                    )}
+                  />
+
+                  <Controller
+                    control={control}
+                    name="allowExternalEmails"
+                    render={({
+                      field: { onChange, value: isChecked, ...field },
+                      fieldState: { error }
+                    }) => (
+                      <Field orientation="horizontal">
+                        <Switch
+                          {...field}
+                          variant="project"
+                          id="share-secret-allow-external"
+                          checked={isOrgAccess ? false : (isChecked ?? false)}
+                          onCheckedChange={onChange}
+                          disabled={isOrgAccess}
+                        />
+                        <FieldLabel htmlFor="share-secret-allow-external" className="flex-auto">
+                          Allow recipients without an Infisical account
+                          {!allowSecretSharingOutsideOrganization && (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <Lock className="size-3 text-muted" />
+                              </TooltipTrigger>
+                              <TooltipContent>
+                                External sharing is disabled by your organization
+                              </TooltipContent>
+                            </Tooltip>
+                          )}
+                        </FieldLabel>
+                        {error && <FieldError>{error.message}</FieldError>}
+                      </Field>
+                    )}
+                  />
+
+                  <Controller
+                    control={control}
+                    name="emails"
+                    render={({ field, fieldState: { error } }) => (
+                      <Field>
+                        <FieldLabel htmlFor="share-secret-emails">
+                          Email Recipients{" "}
+                          <span className="text-xs text-muted italic">- Optional</span>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Info className="size-3 cursor-help text-muted" />
+                            </TooltipTrigger>
+                            <TooltipContent className="max-w-sm">
+                              Each recipient gets their own link. Leave this empty to get one link
+                              you can share yourself.
+                            </TooltipContent>
+                          </Tooltip>
+                        </FieldLabel>
+                        <Input
+                          {...field}
+                          id="share-secret-emails"
+                          placeholder="user1@example.com, user2@example.com"
+                          autoComplete="off"
+                          isError={Boolean(error)}
+                        />
+                        <FieldDescription>
+                          {isAllowingExternalEmails
+                            ? "Recipients do not need an Infisical account, but they do need the password above."
+                            : "Recipients must sign in to Infisical so their identity can be verified."}
+                        </FieldDescription>
+                        {error && <FieldError>{error.message}</FieldError>}
+                      </Field>
+                    )}
+                  />
+                </FieldSet>
+              )}
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
 
         <div className="flex w-full items-center justify-end gap-2">
           {isPublic && (

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/ViewSharedSecretByIDPage.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/ViewSharedSecretByIDPage.tsx
@@ -259,7 +259,7 @@ export const ViewSharedSecretByIDPage = () => {
             }}
           >
             <h1 className="mb-5 text-lg font-semibold" style={{ color: brandingTheme?.textColor }}>
-              View shared secret
+              View Shared Secret
             </h1>
             {secretContent}
           </div>
@@ -280,7 +280,7 @@ export const ViewSharedSecretByIDPage = () => {
       <div className="relative z-10 my-auto flex flex-col items-center py-10">
         <Card className="w-full max-w-xl">
           <CardHeader>
-            <CardTitle>View shared secret</CardTitle>
+            <CardTitle>View Shared Secret</CardTitle>
           </CardHeader>
           <CardContent>{secretContent}</CardContent>
         </Card>

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/ViewSharedSecretByIDPage.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/ViewSharedSecretByIDPage.tsx
@@ -284,6 +284,14 @@ export const ViewSharedSecretByIDPage = () => {
           </CardHeader>
           <CardContent>{secretContent}</CardContent>
         </Card>
+        <a
+          href="/share-secret"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-4 text-xs text-muted underline-offset-4 transition-colors hover:text-foreground hover:underline"
+        >
+          Share your own secret
+        </a>
       </div>
       <AuthPageFooter />
     </div>

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -55,9 +55,9 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
         }`}
         style={secretDisplayStyle}
       >
-        <p className="max-h-64 thin-scrollbar overflow-y-auto pr-9 font-mono text-sm leading-relaxed break-all whitespace-pre-wrap">
+        <pre className="max-h-80 min-h-20 thin-scrollbar overflow-x-auto overflow-y-auto pr-9 font-mono text-sm leading-relaxed wrap-break-word whitespace-pre-wrap">
           {isVisible ? secret.secretValue : HIDDEN_SECRET}
-        </p>
+        </pre>
         <IconButton
           variant="ghost"
           size="sm"

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -1,6 +1,6 @@
-import { ClipboardCheckIcon, Copy, Eye, EyeOff, ForwardIcon, ShieldCheck } from "lucide-react";
+import { Check, Copy, Eye, EyeOff, ShieldCheck } from "lucide-react";
 
-import { Button, IconButton } from "@app/components/v3";
+import { Button } from "@app/components/v3";
 import { useTimedReset, useToggle } from "@app/hooks";
 import { TAccessSharedSecretResponse } from "@app/hooks/api/secretSharing";
 
@@ -12,13 +12,13 @@ type Props = {
   brandingTheme?: BrandingTheme;
 };
 
+const HIDDEN_SECRET = "••••••••••••••••";
+
 export const SecretContainer = ({ secret, brandingTheme }: Props) => {
   const [isVisible, setIsVisible] = useToggle(false);
   const [, isCopyingSecret, setCopyTextSecret] = useTimedReset<string>({
     initialState: "Copy to clipboard"
   });
-
-  const hiddenSecret = "••••••••••••••••";
 
   const panelStyle = brandingTheme
     ? {
@@ -35,67 +35,85 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
       }
     : undefined;
 
-  const iconButtonStyle = brandingTheme
+  const primaryButtonStyle = brandingTheme
     ? {
-        backgroundColor: brandingTheme.buttonBg,
+        backgroundColor: brandingTheme.inputBg,
+        borderColor: brandingTheme.panelBorder,
         color: brandingTheme.textColor
+      }
+    : undefined;
+
+  const secondaryButtonStyle = brandingTheme
+    ? {
+        backgroundColor: "transparent",
+        borderColor: brandingTheme.panelBorder,
+        color: brandingTheme.textMutedColor
       }
     : undefined;
 
   return (
     <div style={panelStyle}>
-      <div className="mb-2 flex items-center gap-2 text-sm font-medium">
-        <ShieldCheck className="size-4 text-success" />
+      <div
+        className="mb-2 flex items-center gap-2 text-sm font-medium"
+        style={brandingTheme ? { color: brandingTheme.textColor } : undefined}
+      >
+        <ShieldCheck
+          className={`size-4 ${brandingTheme ? "" : "text-success"}`}
+          style={brandingTheme ? { color: brandingTheme.textMutedColor } : undefined}
+        />
         Shared Secret
       </div>
+
       <div
-        className={`flex min-h-24 items-start justify-between rounded-md border p-3 text-base ${
+        className={`min-h-24 rounded-md border p-3 text-base ${
           brandingTheme ? "" : "border-border bg-container text-label"
         }`}
         style={secretDisplayStyle}
       >
-        <p className="min-w-0 pt-1 font-mono break-all whitespace-pre-wrap">
-          {isVisible ? secret.secretValue : hiddenSecret}
+        <p className="min-w-0 font-mono break-all whitespace-pre-wrap">
+          {isVisible ? secret.secretValue : HIDDEN_SECRET}
         </p>
-        <div className="ml-2 flex shrink-0 items-start gap-1 self-start">
-          <IconButton
-            aria-label={isCopyingSecret ? "Secret copied" : "Copy secret"}
-            variant="ghost"
-            size="sm"
-            onClick={async () => {
-              await navigator.clipboard.writeText(secret.secretValue);
-              setCopyTextSecret("Copied");
-            }}
-            style={iconButtonStyle}
-          >
-            {isCopyingSecret ? (
-              <ClipboardCheckIcon className="size-4 text-success" />
-            ) : (
-              <Copy className="size-4" />
-            )}
-          </IconButton>
-          <IconButton
-            aria-label={isVisible ? "Hide secret" : "Reveal secret"}
-            variant="ghost"
-            size="sm"
-            onClick={() => setIsVisible.toggle()}
-            style={iconButtonStyle}
-          >
-            {isVisible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-          </IconButton>
-        </div>
       </div>
-      <SecretShareInfo secret={secret} brandingTheme={brandingTheme} />
-      {!brandingTheme && (
+
+      <div className="mt-3 flex flex-col gap-2">
         <Button
-          className="mt-4 w-full"
-          variant="project"
+          variant="outline"
           size="lg"
-          onClick={() => window.open("/share-secret", "_blank", "noopener")}
+          isFullWidth
+          onClick={() => setIsVisible.toggle()}
+          style={secondaryButtonStyle}
         >
-          Share Your Own Secret
-          <ForwardIcon />
+          {isVisible ? <EyeOff /> : <Eye />}
+          {isVisible ? "Hide Value" : "Reveal Value"}
         </Button>
+        <Button
+          variant={brandingTheme ? "outline" : "project"}
+          size="lg"
+          isFullWidth
+          onClick={async () => {
+            await navigator.clipboard.writeText(secret.secretValue);
+            setCopyTextSecret("Copied");
+          }}
+          style={primaryButtonStyle}
+        >
+          {isCopyingSecret ? <Check /> : <Copy />}
+          {isCopyingSecret ? "Copied" : "Copy Value"}
+        </Button>
+      </div>
+
+      <SecretShareInfo secret={secret} brandingTheme={brandingTheme} />
+
+      {!brandingTheme && (
+        <div className="mt-4 text-center">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-accent"
+            onClick={() => window.open("/share-secret", "_blank", "noopener")}
+          >
+            Share Your Own Secret
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -1,6 +1,6 @@
-import { Check, Copy, Eye, EyeOff, ShieldCheck } from "lucide-react";
+import { Check, Copy, Eye, EyeOff } from "lucide-react";
 
-import { Button } from "@app/components/v3";
+import { Button, IconButton } from "@app/components/v3";
 import { useTimedReset, useToggle } from "@app/hooks";
 import { TAccessSharedSecretResponse } from "@app/hooks/api/secretSharing";
 
@@ -12,6 +12,7 @@ type Props = {
   brandingTheme?: BrandingTheme;
 };
 
+// Fixed length so the mask never discloses how long the value is.
 const HIDDEN_SECRET = "••••••••••••••••";
 
 export const SecretContainer = ({ secret, brandingTheme }: Props) => {
@@ -44,67 +45,49 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
       }
     : undefined;
 
-  const secondaryButtonStyle = brandingTheme
-    ? {
-        backgroundColor: "transparent",
-        borderColor: brandingTheme.panelBorder,
-        color: brandingTheme.textMutedColor
-      }
-    : undefined;
+  const iconButtonStyle = brandingTheme ? { color: brandingTheme.textMutedColor } : undefined;
 
   return (
     <div style={panelStyle}>
       <div
-        className="mb-2 flex items-center gap-2 text-sm font-medium"
-        style={brandingTheme ? { color: brandingTheme.textColor } : undefined}
-      >
-        <ShieldCheck
-          className={`size-4 ${brandingTheme ? "" : "text-success"}`}
-          style={brandingTheme ? { color: brandingTheme.textMutedColor } : undefined}
-        />
-        Shared Secret
-      </div>
-
-      <div
-        className={`min-h-24 rounded-md border p-3 text-base ${
+        className={`relative rounded-md border p-3 ${
           brandingTheme ? "" : "border-border bg-container text-label"
         }`}
         style={secretDisplayStyle}
       >
-        <p className="min-w-0 font-mono break-all whitespace-pre-wrap">
+        <p className="max-h-64 thin-scrollbar overflow-y-auto pr-9 font-mono text-sm leading-relaxed break-all whitespace-pre-wrap">
           {isVisible ? secret.secretValue : HIDDEN_SECRET}
         </p>
+        <IconButton
+          variant="ghost"
+          size="sm"
+          className="absolute top-1.5 right-1.5"
+          aria-label={isVisible ? "Hide value" : "Reveal value"}
+          onClick={() => setIsVisible.toggle()}
+          style={iconButtonStyle}
+        >
+          {isVisible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </IconButton>
       </div>
 
-      <div className="mt-3 flex flex-col gap-2">
-        <Button
-          variant="outline"
-          size="lg"
-          isFullWidth
-          onClick={() => setIsVisible.toggle()}
-          style={secondaryButtonStyle}
-        >
-          {isVisible ? <EyeOff /> : <Eye />}
-          {isVisible ? "Hide Value" : "Reveal Value"}
-        </Button>
-        <Button
-          variant={brandingTheme ? "outline" : "project"}
-          size="lg"
-          isFullWidth
-          onClick={async () => {
-            try {
-              await navigator.clipboard.writeText(secret.secretValue);
-              setCopyTextSecret("Copied");
-            } catch {
-              setHasCopyFailed.on();
-            }
-          }}
-          style={primaryButtonStyle}
-        >
-          {isCopyingSecret ? <Check /> : <Copy />}
-          {isCopyingSecret ? "Copied" : "Copy Value"}
-        </Button>
-      </div>
+      <Button
+        className="mt-3"
+        variant={brandingTheme ? "outline" : "project"}
+        size="lg"
+        isFullWidth
+        onClick={async () => {
+          try {
+            await navigator.clipboard.writeText(secret.secretValue);
+            setCopyTextSecret("Copied");
+          } catch {
+            setHasCopyFailed.on();
+          }
+        }}
+        style={primaryButtonStyle}
+      >
+        {isCopyingSecret ? <Check /> : <Copy />}
+        {isCopyingSecret ? "Copied" : "Copy Value"}
+      </Button>
 
       {hasCopyFailed && (
         <p className="mt-2 text-2xs text-danger">
@@ -115,15 +98,15 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
       <SecretShareInfo secret={secret} brandingTheme={brandingTheme} />
 
       {!brandingTheme && (
-        <div className="mt-4 text-center">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-accent"
-            onClick={() => window.open("/share-secret", "_blank", "noopener")}
+        <div className="mt-5 border-t border-border pt-4 text-center">
+          <a
+            href="/share-secret"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-muted underline-offset-4 transition-colors hover:text-accent hover:underline"
           >
-            Share Your Own Secret
-          </Button>
+            Share your own secret
+          </a>
         </div>
       )}
     </div>

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -1,4 +1,4 @@
-import { ClipboardCheckIcon, Copy, Eye, EyeOff, ForwardIcon } from "lucide-react";
+import { ClipboardCheckIcon, Copy, Eye, EyeOff, ForwardIcon, ShieldCheck } from "lucide-react";
 
 import { Button, IconButton } from "@app/components/v3";
 import { useTimedReset, useToggle } from "@app/hooks";
@@ -18,7 +18,7 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
     initialState: "Copy to clipboard"
   });
 
-  const hiddenSecret = "*".repeat(secret.secretValue.length);
+  const hiddenSecret = "••••••••••••••••";
 
   const panelStyle = brandingTheme
     ? {
@@ -44,34 +44,38 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
 
   return (
     <div style={panelStyle}>
+      <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+        <ShieldCheck className="size-4 text-success" />
+        Shared Secret
+      </div>
       <div
-        className={`flex items-start justify-between rounded-md border p-2 pl-3 text-base ${
+        className={`flex min-h-24 items-start justify-between rounded-md border p-3 text-base ${
           brandingTheme ? "" : "border-border bg-container text-label"
         }`}
         style={secretDisplayStyle}
       >
-        <p className="min-w-0 break-all whitespace-pre-wrap">
+        <p className="min-w-0 pt-1 font-mono break-all whitespace-pre-wrap">
           {isVisible ? secret.secretValue : hiddenSecret}
         </p>
-        <div className="ml-1 flex shrink-0 items-start gap-2 self-start">
+        <div className="ml-2 flex shrink-0 items-start gap-1 self-start">
           <IconButton
-            aria-label="copy icon"
+            aria-label={isCopyingSecret ? "Secret copied" : "Copy secret"}
             variant="ghost"
             size="sm"
-            onClick={() => {
-              navigator.clipboard.writeText(secret.secretValue);
+            onClick={async () => {
+              await navigator.clipboard.writeText(secret.secretValue);
               setCopyTextSecret("Copied");
             }}
             style={iconButtonStyle}
           >
             {isCopyingSecret ? (
-              <ClipboardCheckIcon className="size-4" />
+              <ClipboardCheckIcon className="size-4 text-success" />
             ) : (
               <Copy className="size-4" />
             )}
           </IconButton>
           <IconButton
-            aria-label="toggle visibility"
+            aria-label={isVisible ? "Hide secret" : "Reveal secret"}
             variant="ghost"
             size="sm"
             onClick={() => setIsVisible.toggle()}

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -96,19 +96,6 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
       )}
 
       <SecretShareInfo secret={secret} brandingTheme={brandingTheme} />
-
-      {!brandingTheme && (
-        <div className="mt-5 border-t border-border pt-4 text-center">
-          <a
-            href="/share-secret"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-muted underline-offset-4 transition-colors hover:text-accent hover:underline"
-          >
-            Share your own secret
-          </a>
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretContainer.tsx
@@ -16,6 +16,7 @@ const HIDDEN_SECRET = "••••••••••••••••";
 
 export const SecretContainer = ({ secret, brandingTheme }: Props) => {
   const [isVisible, setIsVisible] = useToggle(false);
+  const [hasCopyFailed, setHasCopyFailed] = useToggle(false);
   const [, isCopyingSecret, setCopyTextSecret] = useTimedReset<string>({
     initialState: "Copy to clipboard"
   });
@@ -91,8 +92,12 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
           size="lg"
           isFullWidth
           onClick={async () => {
-            await navigator.clipboard.writeText(secret.secretValue);
-            setCopyTextSecret("Copied");
+            try {
+              await navigator.clipboard.writeText(secret.secretValue);
+              setCopyTextSecret("Copied");
+            } catch {
+              setHasCopyFailed.on();
+            }
           }}
           style={primaryButtonStyle}
         >
@@ -100,6 +105,12 @@ export const SecretContainer = ({ secret, brandingTheme }: Props) => {
           {isCopyingSecret ? "Copied" : "Copy Value"}
         </Button>
       </div>
+
+      {hasCopyFailed && (
+        <p className="mt-2 text-2xs text-danger">
+          Your browser blocked clipboard access. Reveal the value and copy it manually.
+        </p>
+      )}
 
       <SecretShareInfo secret={secret} brandingTheme={brandingTheme} />
 

--- a/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretShareInfo.tsx
+++ b/frontend/src/pages/public/ViewSharedSecretByIDPage/components/SecretShareInfo.tsx
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { Clock, Eye } from "lucide-react";
+import { CalendarClock, Eye } from "lucide-react";
 
 import { TAccessSharedSecretResponse } from "@app/hooks/api/secretSharing";
 
@@ -33,7 +33,6 @@ export const SecretShareInfo = ({ secret, brandingTheme }: Props) => {
 
   const infoStyle = brandingTheme
     ? {
-        backgroundColor: brandingTheme.inputBg,
         borderColor: brandingTheme.panelBorder,
         color: brandingTheme.textMutedColor
       }
@@ -43,25 +42,29 @@ export const SecretShareInfo = ({ secret, brandingTheme }: Props) => {
 
   return (
     <div
-      className={`mt-4 flex flex-col gap-2 rounded-md border p-3 text-sm ${
-        brandingTheme ? "" : "border-border bg-container text-label"
+      className={`mt-4 grid gap-3 border-t pt-4 text-sm sm:grid-cols-2 ${
+        brandingTheme ? "" : "border-border text-label"
       }`}
       style={infoStyle}
     >
       {timeRemaining && (
-        <div className="flex items-center gap-2">
-          <Clock className="size-3.5 shrink-0" style={iconStyle} />
-          <span>Expires on {timeRemaining}</span>
+        <div className="flex items-start gap-2">
+          <CalendarClock className="mt-0.5 size-3.5 shrink-0" style={iconStyle} />
+          <div>
+            <p className="text-xs font-medium">Expires</p>
+            <p className="mt-0.5 text-xs opacity-80">{timeRemaining}</p>
+          </div>
         </div>
       )}
       {viewsRemaining !== null && (
-        <div className="flex items-center gap-2">
-          <Eye className="size-3.5 shrink-0" style={iconStyle} />
-          <span>
-            {viewsRemaining === 0
-              ? "This is the last time you can view this secret"
-              : `${viewsRemaining} more view${viewsRemaining === 1 ? "" : "s"} remaining`}
-          </span>
+        <div className="flex items-start gap-2">
+          <Eye className="mt-0.5 size-3.5 shrink-0" style={iconStyle} />
+          <div>
+            <p className="text-xs font-medium">Views Remaining</p>
+            <p className="mt-0.5 text-xs opacity-80">
+              {viewsRemaining === 0 ? "Last available view" : viewsRemaining}
+            </p>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Context

Improves the secret sharing and secret request experience across organization and public surfaces. The update clarifies information hierarchy and primary actions, improves table and modal states, makes copying and password visibility more explicit, reports copy/load failures, and groups advanced sharing controls while preserving organization policy enforcement.

## Screenshots

Not included yet. This is a draft PR for early visibility; screenshots or videos will be added before review.

## Steps to verify the change

1. Open Organization Settings > Secret Sharing and review the Share Secret and Request Secret tabs at desktop and mobile widths.
2. Create a shared secret with and without email recipients, a password, expiration, and a view limit.
3. Confirm advanced options expand correctly and organization-enforced access/view policies remain disabled or capped as expected.
4. Open a generated public share link, reveal and copy the secret, and verify multiline/long values remain readable.
5. Submit a requested secret and verify the organization-side reveal and copy flows.
6. Trigger copy or shared-secret loading failures and confirm an error notification is shown.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)