### PR TITLE
feat(helm): add liveness probes to match readiness probes (#445)

### DIFF
--- a/helm-charts/infisical-nkp/templates/deployment.yaml
+++ b/helm-charts/infisical-nkp/templates/deployment.yaml
@@ -78,11 +78,15 @@ spec:
               port: http
             initialDelaySeconds: 15
             periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /api/status
+          startupProbe:
+            tcpSocket:
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 36
+          livenessProbe:
+            tcpSocket:
+              port: http
             periodSeconds: 20
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm-charts/infisical-nkp/templates/redis.yaml
+++ b/helm-charts/infisical-nkp/templates/redis.yaml
@@ -45,6 +45,11 @@ spec:
               port: redis
             initialDelaySeconds: 5
             periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 15
+            periodSeconds: 20
           resources:
             requests:
               cpu: 50m

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -66,6 +66,12 @@ spec:
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /api/status
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 20
         ports: 
         - containerPort: 8080
         env:

--- a/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
+++ b/helm-charts/infisical-standalone-postgres/templates/infisical.yaml
@@ -66,11 +66,15 @@ spec:
             port: 8080
           initialDelaySeconds: 10
           periodSeconds: 5
-        livenessProbe:
-          httpGet:
-            path: /api/status
+        startupProbe:
+          tcpSocket:
             port: 8080
-          initialDelaySeconds: 30
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          failureThreshold: 36
+        livenessProbe:
+          tcpSocket:
+            port: 8080
           periodSeconds: 20
         ports: 
         - containerPort: 8080


### PR DESCRIPTION
Closes #445

The issue predates the chart restructure, so this applies the same intent to the current charts: workloads that only had a `readinessProbe` now get a `livenessProbe`, so stuck pods get restarted by kubelet instead of just being taken out of rotation.

## Changes

- `helm-charts/infisical-standalone-postgres/templates/infisical.yaml`: add `startupProbe` + `livenessProbe` (both `tcpSocket` on 8080) next to the existing readiness probe — this chart serves the combined front/back workload
- `helm-charts/infisical-nkp/templates/deployment.yaml`: replace the existing `/api/status` httpGet `livenessProbe` with the same `startupProbe` + tcpSocket `livenessProbe` pattern
- `helm-charts/infisical-nkp/templates/redis.yaml`: add `livenessProbe` (tcpSocket on the redis port, initialDelay 15s / period 20s)

### Probe design rationale

- **Liveness is DB-independent**: the probes use `tcpSocket` instead of `httpGet /api/status`, which reads PostgreSQL. A slow or unavailable database no longer makes kubelet restart an otherwise healthy process (avoids CrashLoop when the DB is the actual problem). Readiness still uses `/api/status`, so pods are taken out of rotation until the DB is reachable.
- **Startup covers migrations**: `startupProbe` (10s delay, 10s period, 36 failures ≈ 6 min) keeps kubelet from killing pods while long-running database migrations execute; liveness only takes effect once startup succeeds.

## Verification

- `helm lint` passes on both charts (0 failed)
- `helm dependency build` + `helm template` on `infisical-standalone-postgres` renders the new `startupProbe`/`livenessProbe` blocks correctly
- `helm template` on `infisical-nkp` renders the new redis and backend probes correctly
