### PR TITLE
feat: conditionally handlebar compilation and secret cache as binary

### DIFF
--- a/backend/e2e-test/mocks/keystore.ts
+++ b/backend/e2e-test/mocks/keystore.ts
@@ -62,6 +62,13 @@ export const mockKeyStore = (): TKeyStoreFactory => {
       }
       return null;
     },
+    // Redis stores values as bytes, so a string written by setItem reads back as its utf8 bytes here.
+    getItemBuffer: async (key) => {
+      const value = store[key];
+      if (Buffer.isBuffer(value)) return value;
+      if (typeof value === "string") return Buffer.from(value, "utf8");
+      return null;
+    },
     getItemPrimary: async (key) => {
       const value = store[key];
       if (typeof value === "string") {

--- a/backend/src/ee/services/permission/permission-fns.test.ts
+++ b/backend/src/ee/services/permission/permission-fns.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test } from "vitest";
 
 import { conditionsMatcher } from "@app/lib/casl";
 
-import { expandLegacyForbidActions, throwIfMissingSecretReadValueOrDescribePermission } from "./permission-fns";
+import {
+  expandLegacyForbidActions,
+  interpolatePermissionRules,
+  throwIfMissingSecretReadValueOrDescribePermission
+} from "./permission-fns";
 import {
   ProjectPermissionActions,
   ProjectPermissionGroupActions,
@@ -249,5 +253,39 @@ describe("throwIfMissingSecretReadValueOrDescribePermission", () => {
         secretPath: "/"
       })
     ).toThrow();
+  });
+});
+
+describe("interpolatePermissionRules", () => {
+  const templatedRule = (value: string): Rule =>
+    ({
+      action: [ProjectPermissionSecretActions.DescribeSecret],
+      subject: ProjectPermissionSub.Secrets,
+      conditions: { environment: value }
+    }) as Rule;
+
+  test("interpolates identity context when the rules carry a template", () => {
+    const [rule] = interpolatePermissionRules([templatedRule("{{ identity.metadata.env }}")], {
+      identity: { metadata: { env: "prod" } }
+    });
+
+    expect(rule.conditions).toEqual({ environment: "prod" });
+  });
+
+  // Untemplated rules are returned as-is rather than copied, so callers share the module-level built-in
+  // rule sets. This is what makes mutating a rule in place unsafe.
+  test("returns untemplated rules as-is, without copying", () => {
+    const rules = [templatedRule("prod"), templatedRule("staging")];
+
+    expect(interpolatePermissionRules(rules, { identity: { metadata: {} } })).toBe(rules);
+  });
+
+  test("still templates block helpers and comments, which are not bare expressions", () => {
+    const [rule] = interpolatePermissionRules(
+      [templatedRule("{{#if identity.metadata.env}}{{ identity.metadata.env }}{{else}}dev{{/if}}")],
+      { identity: { metadata: {} } }
+    );
+
+    expect(rule.conditions).toEqual({ environment: "dev" });
   });
 });

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -438,6 +438,20 @@ const handlebarsClient = (() => {
   return hbs;
 })();
 
+// Compiling a template is the most expensive step of building an ability, and almost no rule set needs
+// it: built-in roles carry no `{{ }}` at all, only custom roles with identity conditions do. A template
+// with no mustaches renders byte-identical to its input, so serializing once to look for one and
+// returning the rules untouched skips the compile, the render and the reparse.
+export const interpolatePermissionRules = <T>(rules: T[], identityContext: Record<string, unknown>): T[] => {
+  const serializedRules = JSON.stringify(rules);
+
+  if (!serializedRules.includes("{{")) return rules;
+
+  const templatedRules = handlebarsClient.compile(serializedRules, { data: false });
+
+  return JSON.parse(templatedRules(identityContext, { data: false })) as T[];
+};
+
 export {
   assertPermissionBoundary,
   constructPermissionErrorMessage,

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -72,7 +72,7 @@ import { TPermissionDALFactory } from "./permission-dal";
 import {
   escapeHandlebarsMissingDict,
   expandLegacyForbidActions,
-  handlebarsClient,
+  interpolatePermissionRules,
   validateOrgSSO
 } from "./permission-fns";
 import {
@@ -657,7 +657,6 @@ export const permissionServiceFactory = ({
       }
 
       const rules = buildProjectPermissionRules(permissionFromRoles, projectDetails.type);
-      const templatedRules = handlebarsClient.compile(JSON.stringify(rules), { data: false });
       const unescapedMetadata = objectify(
         permissionData?.[0]?.metadata,
         (i) => i.key,
@@ -672,24 +671,18 @@ export const permissionServiceFactory = ({
           ? escapeHandlebarsMissingDict(unescapedIdentityAuthInfo as never, "identity.auth")
           : {};
 
-      const interpolateRules = templatedRules(
-        {
-          identity: {
-            id: actorId,
-            username,
-            metadata: metadataKeyValuePair,
-            auth: identityAuthInfo
-          }
-        },
-        { data: false }
-      );
-
-      const permission = createMongoAbility<ProjectPermissionSet>(
-        JSON.parse(interpolateRules) as RawRuleOf<MongoAbility<ProjectPermissionSet>>[],
-        {
-          conditionsMatcher
+      const interpolatedRules = interpolatePermissionRules(rules, {
+        identity: {
+          id: actorId,
+          username,
+          metadata: metadataKeyValuePair,
+          auth: identityAuthInfo
         }
-      );
+      });
+
+      const permission = createMongoAbility<ProjectPermissionSet>(interpolatedRules, {
+        conditionsMatcher
+      });
 
       const result = {
         permission,
@@ -862,7 +855,6 @@ export const permissionServiceFactory = ({
         })) || [];
 
       const rules = buildProjectPermissionRules(rolePermissions.concat(additionalPrivileges));
-      const templatedRules = handlebarsClient.compile(JSON.stringify(rules), { data: false });
       const metadataKeyValuePair = escapeHandlebarsMissingDict(
         objectify(
           userProjectPermission.metadata,
@@ -871,22 +863,16 @@ export const permissionServiceFactory = ({
         ),
         "identity.metadata"
       );
-      const interpolateRules = templatedRules(
-        {
-          identity: {
-            id: userProjectPermission.userId,
-            username: userProjectPermission.username,
-            metadata: metadataKeyValuePair
-          }
-        },
-        { data: false }
-      );
-      const permission = createMongoAbility<ProjectPermissionSet>(
-        JSON.parse(interpolateRules) as RawRuleOf<MongoAbility<ProjectPermissionSet>>[],
-        {
-          conditionsMatcher
+      const interpolatedRules = interpolatePermissionRules(rules, {
+        identity: {
+          id: userProjectPermission.userId,
+          username: userProjectPermission.username,
+          metadata: metadataKeyValuePair
         }
-      );
+      });
+      const permission = createMongoAbility<ProjectPermissionSet>(interpolatedRules, {
+        conditionsMatcher
+      });
 
       return {
         permission,
@@ -908,7 +894,6 @@ export const permissionServiceFactory = ({
         })) || [];
 
       const rules = buildProjectPermissionRules(rolePermissions.concat(additionalPrivileges));
-      const templatedRules = handlebarsClient.compile(JSON.stringify(rules), { data: false });
       const metadataKeyValuePair = escapeHandlebarsMissingDict(
         objectify(
           identityProjectPermission.metadata,
@@ -917,22 +902,16 @@ export const permissionServiceFactory = ({
         ),
         "identity.metadata"
       );
-      const interpolateRules = templatedRules(
-        {
-          identity: {
-            id: identityProjectPermission.identityId,
-            username: identityProjectPermission.username,
-            metadata: metadataKeyValuePair
-          }
-        },
-        { data: false }
-      );
-      const permission = createMongoAbility<ProjectPermissionSet>(
-        JSON.parse(interpolateRules) as RawRuleOf<MongoAbility<ProjectPermissionSet>>[],
-        {
-          conditionsMatcher
+      const interpolatedRules = interpolatePermissionRules(rules, {
+        identity: {
+          id: identityProjectPermission.identityId,
+          username: identityProjectPermission.username,
+          metadata: metadataKeyValuePair
         }
-      );
+      });
+      const permission = createMongoAbility<ProjectPermissionSet>(interpolatedRules, {
+        conditionsMatcher
+      });
 
       return {
         permission,

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -257,6 +257,7 @@ type TWaitTillReady = {
 export type TKeyStoreFactory = {
   setItem: (key: string, value: string | number | Buffer, prefix?: string) => Promise<"OK">;
   getItem: (key: string, prefix?: string) => Promise<string | null>;
+  getItemBuffer: (key: string, prefix?: string) => Promise<Buffer | null>;
   getItemPrimary: (key: string, prefix?: string) => Promise<string | null>;
   getItems: (keys: string[], prefix?: string) => Promise<(string | null)[]>;
   setExpiry: (key: string, expiryInSeconds: number) => Promise<number>;
@@ -370,6 +371,11 @@ export const keyStoreFactory = (
 
   const getItem = async (key: string, prefix?: string) =>
     pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas).get(prefix ? `${prefix}:${key}` : key);
+
+  // Reads a value written as raw bytes. Callers holding binary blobs (ciphertext) use this instead of
+  // getItem so the payload never round-trips through a base64 string on either side.
+  const getItemBuffer = async (key: string, prefix?: string) =>
+    pickPrimaryOrSecondaryRedis(primaryRedis, redisReadReplicas).getBuffer(prefix ? `${prefix}:${key}` : key);
 
   const getItemPrimary = async (key: string, prefix?: string) => primaryRedis.get(prefix ? `${prefix}:${key}` : key);
 
@@ -721,6 +727,7 @@ export const keyStoreFactory = (
   return {
     setItem,
     getItem,
+    getItemBuffer,
     getItemPrimary,
     setExpiry,
     ttl,

--- a/backend/src/keystore/memory.ts
+++ b/backend/src/keystore/memory.ts
@@ -63,6 +63,13 @@ export const inMemoryKeyStore = (): TKeyStoreFactory => {
       }
       return null;
     },
+    // Redis stores values as bytes, so a string written by setItem reads back as its utf8 bytes here.
+    getItemBuffer: async (key) => {
+      const value = store[key];
+      if (Buffer.isBuffer(value)) return value;
+      if (typeof value === "string") return Buffer.from(value, "utf8");
+      return null;
+    },
     getItemPrimary: async (key) => {
       const value = store[key];
       if (typeof value === "string") {

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -34,7 +34,7 @@ export const SecretServiceCacheKeys = {
     requestParamsHash: string;
   }) => {
     const { projectId, version, actorId, permissionFingerprint, permissionHash, requestParamsHash } = arg;
-    return `${SecretServiceCacheKeys.productKey}:${projectId}:${TableName.SecretV2}-dal:v${version}:get-secrets-service-layer:${actorId}-${permissionFingerprint}-${permissionHash}-${requestParamsHash}`;
+    return `${SecretServiceCacheKeys.productKey}:${projectId}:${TableName.SecretV2}-dal:v${version}:get-secrets-service-layer-bin:${actorId}-${permissionFingerprint}-${permissionHash}-${requestParamsHash}`;
   }
 };
 

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts
@@ -169,7 +169,14 @@ type TSecretV2BridgeServiceFactoryDep = {
   resourceMetadataDAL: Pick<TResourceMetadataDALFactory, "insertMany" | "delete">;
   keyStore: Pick<
     TKeyStoreFactory,
-    "getItem" | "setExpiry" | "setItemWithExpiry" | "deleteItem" | "pgGetIntItem" | "hashGet" | "hashSet"
+    | "getItem"
+    | "getItemBuffer"
+    | "setExpiry"
+    | "setItemWithExpiry"
+    | "deleteItem"
+    | "pgGetIntItem"
+    | "hashGet"
+    | "hashSet"
   >;
   reminderService: Pick<TReminderServiceFactory, "createReminder" | "getReminder" | "batchCreateReminders">;
   reminderDAL: Pick<TReminderDALFactory, "findSecretReminders" | "delete">;
@@ -1359,11 +1366,11 @@ export const secretV2BridgeServiceFactory = ({
         projectId
       });
 
-    const encryptedCachedSecrets = await keyStore.getItem(cacheKey);
+    const encryptedCachedSecrets = await keyStore.getItemBuffer(cacheKey);
     if (encryptedCachedSecrets) {
       try {
         await keyStore.setExpiry(cacheKey, SECRET_DAL_TTL());
-        const cachedSecrets = secretManagerDecryptor({ cipherTextBlob: Buffer.from(encryptedCachedSecrets, "base64") });
+        const cachedSecrets = secretManagerDecryptor({ cipherTextBlob: encryptedCachedSecrets });
         // Decrypted bytes are the exact serialized payload the miss path hashed, so hashing them reproduces
         // the same ETag without re-serializing the object.
         const cachedEtag = `"${generateCacheKeyFromBuffer(cachedSecrets)}"`;
@@ -1643,7 +1650,7 @@ export const secretV2BridgeServiceFactory = ({
       const cacheBytes = encryptedUpdatedCachedSecrets.byteLength;
       const stored = cacheBytes < MAX_SECRET_CACHE_BYTES;
       if (stored) {
-        await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL(), encryptedUpdatedCachedSecrets.toString("base64"));
+        await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL(), encryptedUpdatedCachedSecrets);
       }
       recordSecretCacheWriteMetric({ bytes: cacheBytes, stored });
       recordSecretCacheAccessMetric(SecretCacheAccessResult.MISS, { hasIfNoneMatch, etagMissReason });
@@ -1735,7 +1742,7 @@ export const secretV2BridgeServiceFactory = ({
     const cacheBytes = encryptedUpdatedCachedSecrets.byteLength;
     const stored = cacheBytes < MAX_SECRET_CACHE_BYTES;
     if (stored) {
-      await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL(), encryptedUpdatedCachedSecrets.toString("base64"));
+      await keyStore.setItemWithExpiry(cacheKey, SECRET_DAL_TTL(), encryptedUpdatedCachedSecrets);
     }
     recordSecretCacheWriteMetric({ bytes: cacheBytes, stored });
     recordSecretCacheAccessMetric(SecretCacheAccessResult.MISS, { hasIfNoneMatch, etagMissReason });


### PR DESCRIPTION
## Context

This PR is part of optimization of our node profile
1. The cache currently performs a base64 conversion and then saves the result to Redis. Instead, it directly saves the Redis buffer to minimise intermediate buffers.
2. Handlebar conditional compilation is handled because most of them do not use templated policies.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Use list secret to check cache is working
2. Try templated permission

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)