### PR TITLE
docs(cli): add note about --recursive

### DIFF
--- a/docs/cli/commands/run.mdx
+++ b/docs/cli/commands/run.mdx
@@ -182,6 +182,21 @@ infisical run -- npm run dev
 
   </Accordion>
 
+  <Accordion title="--recursive">
+    By default, `infisical run` only injects the secrets that sit directly in `--path` (the root of the environment, `/`, unless you set it). Secrets inside folders are left out. Add `--recursive` to also inject the secrets in every subfolder of `--path`.
+
+    ```bash
+    # Example - every secret in the environment
+    infisical run --recursive -- npm run dev
+
+    # Example - every secret under /backend and its subfolders
+    infisical run --path="/backend" --recursive -- npm run dev
+    ```
+
+    Default value: `false`
+
+  </Accordion>
+
 </Accordion>
 
 

--- a/docs/cli/commands/run.mdx
+++ b/docs/cli/commands/run.mdx
@@ -185,13 +185,17 @@ infisical run -- npm run dev
   <Accordion title="--recursive">
     By default, `infisical run` only injects the secrets that sit directly in `--path` (the root of the environment, `/`, unless you set it). Secrets inside folders are left out. Add `--recursive` to also inject the secrets in every subfolder of `--path`.
 
-    ```bash
-    # Example - every secret in the environment
-    infisical run --recursive -- npm run dev
+    If your secrets sit in one folder, `--path` alone is enough. Use `--recursive` when that folder has subfolders you also need.
 
+    ```bash
     # Example - every secret under /backend and its subfolders
     infisical run --path="/backend" --recursive -- npm run dev
+
+    # Example - every secret in the environment, from every folder
+    infisical run --recursive -- npm run dev
     ```
+
+    Since `--recursive` widens what gets injected, scope it with `--path` so your application only receives the secrets it needs.
 
     Default value: `false`
 

--- a/docs/cli/commands/secrets.mdx
+++ b/docs/cli/commands/secrets.mdx
@@ -87,6 +87,17 @@ infisical secrets
     ```
 
   </Accordion>
+  <Accordion title="--recursive">
+    By default, only the secrets sitting directly in `--path` are listed. Add `--recursive` to also list the secrets in every subfolder of `--path`.
+
+    ```bash
+    # Example
+    infisical secrets --path="/" --env=dev --recursive
+    ```
+
+    Default value: `false`
+
+  </Accordion>
   <Accordion title="--plain">
     The `--plain` flag will output all your secret values without formatting, one per line.
 

--- a/docs/snippets/cli/local-development/start-application.mdx
+++ b/docs/snippets/cli/local-development/start-application.mdx
@@ -31,10 +31,15 @@ infisical run --env=dev -- dotnet run
 The CLI fetches the secrets you have access to and passes them to your application as environment variables. Your application reads them the same way it always has, through `process.env` in Node.js or `os.environ` in Python, so you don't need to change any application code.
 
 <Note>
-  **If your secrets live in [folders](/documentation/platform/folder), add `--recursive`.** By default `infisical run` only injects the secrets sitting at the root of the environment, so anything inside a folder is skipped and your application starts without it.
+  By default, `infisical run` only injects the secrets sitting at the root of the environment, so anything inside a folder is skipped. If your secrets live in [folders](/documentation/platform/folder), you can specify a folder to include using `--path`:
 
   ```bash
-  infisical run --env=dev --recursive -- npm run dev
+  infisical run --env=dev --path="/backend" -- npm run dev
+  ```
+
+  If you also need the secrets in that folder's subfolders, add `--recursive`:
+  ```bash
+  infisical run --env=dev --path="/backend" --recursive -- npm run dev
   ```
 </Note>
 

--- a/docs/snippets/cli/local-development/start-application.mdx
+++ b/docs/snippets/cli/local-development/start-application.mdx
@@ -30,6 +30,14 @@ infisical run --env=dev -- dotnet run
 
 The CLI fetches the secrets you have access to and passes them to your application as environment variables. Your application reads them the same way it always has, through `process.env` in Node.js or `os.environ` in Python, so you don't need to change any application code.
 
+<Note>
+  **If your secrets live in [folders](/documentation/platform/folder), add `--recursive`.** By default `infisical run` only injects the secrets sitting at the root of the environment, so anything inside a folder is skipped and your application starts without it.
+
+  ```bash
+  infisical run --env=dev --recursive -- npm run dev
+  ```
+</Note>
+
 <Tip>
   Add `--watch` while you work to restart your application automatically whenever one of its secrets changes in Infisical.
 </Tip>


### PR DESCRIPTION
## Context

Adds a callout to inform CLI users that if they added their secrets to folders, they need to use the `--recursive` flag for those secrets to be imported into their project.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)