### PR TITLE
feature(helm): require config.siteUrl in infisical-nkp chart

### DIFF
--- a/.github/workflows/helm-release-infisical-nkp.yml
+++ b/.github/workflows/helm-release-infisical-nkp.yml
@@ -21,7 +21,7 @@ jobs:
         run: helm lint helm-charts/infisical-nkp
 
       - name: Run helm template
-        run: helm template infisical helm-charts/infisical-nkp > /dev/null
+        run: helm template infisical helm-charts/infisical-nkp --set config.siteUrl=https://infisical.example.com > /dev/null
 
   release:
     needs: test-helm

--- a/.github/workflows/helm-release-infisical-nkp.yml
+++ b/.github/workflows/helm-release-infisical-nkp.yml
@@ -18,7 +18,7 @@ jobs:
           version: v3.17.0
 
       - name: Run helm lint
-        run: helm lint helm-charts/infisical-nkp
+        run: helm lint helm-charts/infisical-nkp --set config.siteUrl=https://infisical.example.com
 
       - name: Run helm template
         run: helm template infisical helm-charts/infisical-nkp --set config.siteUrl=https://infisical.example.com > /dev/null

--- a/helm-charts/infisical-nkp/Chart.yaml
+++ b/helm-charts/infisical-nkp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infisical-nkp
 description: Infisical, the open-source secrets management platform, packaged for the Nutanix NKP partner catalog.
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "v0.162.11"
 home: https://infisical.com
 sources:

--- a/helm-charts/infisical-nkp/templates/configmap.yaml
+++ b/helm-charts/infisical-nkp/templates/configmap.yaml
@@ -1,3 +1,13 @@
+{{- /*
+config.siteUrl is mandatory. Infisical uses SITE_URL to lock down CORS and to
+build every absolute URL it emits (invite / password-reset / verification
+links, SSO and OAuth redirect URIs, WebAuthn relying party). Fail the install
+early with a clear message rather than deploying a silently degraded instance.
+*/ -}}
+{{- $siteUrl := required "config.siteUrl is required: set it to the external URL users will reach Infisical at, e.g. https://infisical.example.com" .Values.config.siteUrl -}}
+{{- if not (regexMatch "^https?://[^/]+$" $siteUrl) -}}
+{{- fail (printf "config.siteUrl must be an origin of the form http(s)://<hostname> with no path suffix or trailing slash (Infisical cannot be served under a path prefix); got %q" $siteUrl) -}}
+{{- end -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -5,6 +15,6 @@ metadata:
   labels:
     {{- include "infisical.labels" . | nindent 4 }}
 data:
-  SITE_URL: {{ .Values.config.siteUrl | quote }}
+  SITE_URL: {{ $siteUrl | quote }}
   PORT: {{ .Values.config.port | quote }}
   TELEMETRY_ENABLED: {{ .Values.config.telemetryEnabled | quote }}

--- a/helm-charts/infisical-nkp/templates/configmap.yaml
+++ b/helm-charts/infisical-nkp/templates/configmap.yaml
@@ -5,8 +5,8 @@ links, SSO and OAuth redirect URIs, WebAuthn relying party). Fail the install
 early with a clear message rather than deploying a silently degraded instance.
 */ -}}
 {{- $siteUrl := required "config.siteUrl is required: set it to the external URL users will reach Infisical at, e.g. https://infisical.example.com" .Values.config.siteUrl -}}
-{{- if not (regexMatch "^https?://[^/]+$" $siteUrl) -}}
-{{- fail (printf "config.siteUrl must be an origin of the form http(s)://<hostname> with no path suffix or trailing slash (Infisical cannot be served under a path prefix); got %q" $siteUrl) -}}
+{{- if not (regexMatch "^https?://[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?(\\.[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?)*(:[0-9]{1,5})?$" $siteUrl) -}}
+{{- fail (printf "config.siteUrl must be a bare origin of the form http(s)://<hostname>[:port] with no path, query, fragment or credentials (Infisical cannot be served under a path prefix); got %q" $siteUrl) -}}
 {{- end -}}
 apiVersion: v1
 kind: ConfigMap

--- a/helm-charts/infisical-nkp/values.yaml
+++ b/helm-charts/infisical-nkp/values.yaml
@@ -11,7 +11,11 @@ image:
 
 # Non-secret application configuration (rendered into a ConfigMap).
 config:
-  siteUrl: "https://infisical.example.com"
+  # REQUIRED. External origin users reach Infisical at, e.g. https://infisical.example.com
+  # (scheme + hostname only; Infisical cannot be served under a path prefix).
+  # Used for CORS, invite/reset/verification links, SSO/OAuth redirect URIs and
+  # WebAuthn. The install fails with a clear error if this is left empty.
+  siteUrl: ""
   port: 8080
   telemetryEnabled: false
 


### PR DESCRIPTION
## Context

Chart 0.2.0 → 0.2.1, requested by Nutanix on the NKP partner catalog review (nutanix-cloud-native/nkp-partner-catalog#62).

Nutanix found the dashboard works with an empty `config.siteUrl`, but Infisical silently degrades without `SITE_URL`: CORS falls back to reflecting any origin with credentials, invite/password-reset/verification links point nowhere, SSO/OAuth redirect URIs and the WebAuthn relying party fall back to localhost. Failing fast at install time is the right behavior, and NKP's declarative UI can't express this constraint without dropping support for arbitrary value overrides.

Changes:
- `config.siteUrl` is now **required**: rendering fails with a clear message when it is empty, and also when it is not a bare `http(s)://<hostname>[:port]` origin (path, query, fragment, credentials or trailing slash are rejected), since Infisical cannot be served under a path prefix (#2367).
- The values default for `siteUrl` is now empty so the guard is meaningful. Previously it defaulted to `https://infisical.example.com`, which would have satisfied any check while still being wrong for every real install.
- Release workflow: the `helm lint` and `helm template` smoke checks pass a sample `siteUrl`.

After merge: run the "Release Infisical NKP Helm chart" workflow to publish `infisical-nkp:0.2.1`; the catalog PR will be bumped to reference it.

## Steps to verify the change

```sh
helm lint helm-charts/infisical-nkp --set config.siteUrl=https://infisical.example.com
helm template x helm-charts/infisical-nkp                                                       # fails: required
helm template x helm-charts/infisical-nkp --set config.siteUrl=https://h.example.com/x         # fails: not a bare origin
helm template x helm-charts/infisical-nkp --set config.siteUrl=https://infisical.10.0.0.5.nip.io  # renders
```

Verified locally: empty, path-suffix, trailing-slash, query, fragment, userinfo, whitespace and invalid-label values all fail with the intended messages; valid origins (incl. nip.io hosts, bare IPs, ports and `http://localhost:8080`) render correctly.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description`
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)