### PR TITLE
fix: make approvals check for validation rules

### DIFF
--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1840,6 +1840,8 @@ export const secretApprovalRequestServiceFactory = ({
       project.secretDetectionIgnoreValues || []
     );
 
+    const secretsToValidate: { key: string; value?: string; secretId?: string }[] = [];
+
     // for created secret approval change
     const createdSecrets = data[SecretOperations.Create];
     if (createdSecrets && createdSecrets?.length) {
@@ -1853,13 +1855,7 @@ export const secretApprovalRequestServiceFactory = ({
       if (secrets.length)
         throw new BadRequestError({ message: `Secret already exists: ${secrets.map((el) => el.key).join(",")}` });
 
-      await secretValidationRuleService.validateSecrets({
-        projectId,
-        environment,
-        envId: folder.envId,
-        secretPath,
-        secrets: createdSecrets.map((s) => ({ key: s.secretKey, value: s.secretValue }))
-      });
+      secretsToValidate.push(...createdSecrets.map((s) => ({ key: s.secretKey, value: s.secretValue })));
 
       commits.push(
         ...createdSecrets.map((createdSecret) => ({
@@ -1924,15 +1920,7 @@ export const secretApprovalRequestServiceFactory = ({
             ).values()
           ];
 
-          if (upsertSecrets.length) {
-            await secretValidationRuleService.validateSecrets({
-              projectId,
-              environment,
-              envId: folder.envId,
-              secretPath,
-              secrets: upsertSecrets.map((s) => ({ key: s.secretKey, value: s.secretValue }))
-            });
-          }
+          secretsToValidate.push(...upsertSecrets.map((s) => ({ key: s.secretKey, value: s.secretValue })));
 
           commits.push(
             ...upsertSecrets.map((secret) => ({
@@ -2002,23 +1990,15 @@ export const secretApprovalRequestServiceFactory = ({
 
       const updatingSecretsGroupByKey = groupBy(secretsToUpdateStoredInDB, (el) => el.key);
 
-      const updateSecretsToValidate = actualSecretsToUpdate
-        .filter((s) => s.secretValue !== undefined || s.newSecretName)
-        .map((s) => ({
-          key: s.newSecretName || s.secretKey,
-          value: s.secretValue,
-          secretId: updatingSecretsGroupByKey[s.secretKey]?.[0]?.id
-        }));
-
-      if (updateSecretsToValidate.length) {
-        await secretValidationRuleService.validateSecrets({
-          projectId,
-          environment,
-          envId: folder.envId,
-          secretPath,
-          secrets: updateSecretsToValidate
-        });
-      }
+      secretsToValidate.push(
+        ...actualSecretsToUpdate
+          .filter((s) => s.secretValue !== undefined || s.newSecretName)
+          .map((s) => ({
+            key: s.newSecretName || s.secretKey,
+            value: s.secretValue,
+            secretId: updatingSecretsGroupByKey[s.secretKey]?.[0]?.id
+          }))
+      );
 
       const latestSecretVersions = await secretVersionV2BridgeDAL.findLatestVersionMany(
         folderId,
@@ -2148,6 +2128,16 @@ export const secretApprovalRequestServiceFactory = ({
     }
 
     if (!commits.length) throw new BadRequestError({ message: "Empty commits" });
+
+    if (secretsToValidate.length) {
+      await secretValidationRuleService.validateSecrets({
+        projectId,
+        environment,
+        envId: folder.envId,
+        secretPath,
+        secrets: secretsToValidate
+      });
+    }
 
     const tagIds = unique(Object.values(commitTagIds).flat());
     const tags = tagIds.length ? await secretTagDAL.findManyTagsById(projectId, tagIds) : [];

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -67,6 +67,7 @@ import {
 import { SecretUpdateMode } from "@app/services/secret-v2-bridge/secret-v2-bridge-types";
 import { TSecretVersionV2DALFactory } from "@app/services/secret-v2-bridge/secret-version-dal";
 import { TSecretVersionV2TagDALFactory } from "@app/services/secret-v2-bridge/secret-version-tag-dal";
+import { TSecretValidationRuleServiceFactory } from "@app/services/secret-validation-rule/secret-validation-rule-service";
 import { TProjectSlackConfigDALFactory } from "@app/services/slack/project-slack-config-dal";
 import { SmtpTemplates, TSmtpService } from "@app/services/smtp/smtp-service";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
@@ -162,6 +163,7 @@ type TSecretApprovalRequestServiceFactoryDep = {
   folderCommitService: Pick<TFolderCommitServiceFactory, "createCommit">;
   notificationService: Pick<TNotificationServiceFactory, "createUserNotifications">;
   telemetryService: Pick<TTelemetryServiceFactory, "sendPostHogEvents">;
+  secretValidationRuleService: Pick<TSecretValidationRuleServiceFactory, "validateSecrets">;
 };
 
 export type TSecretApprovalRequestServiceFactory = ReturnType<typeof secretApprovalRequestServiceFactory>;
@@ -195,7 +197,8 @@ export const secretApprovalRequestServiceFactory = ({
   microsoftTeamsService,
   folderCommitService,
   notificationService,
-  telemetryService
+  telemetryService,
+  secretValidationRuleService
 }: TSecretApprovalRequestServiceFactoryDep) => {
   const requestCount = async ({
     projectId,
@@ -1836,6 +1839,23 @@ export const secretApprovalRequestServiceFactory = ({
       })),
       project.secretDetectionIgnoreValues || []
     );
+
+    const secretsToValidate: { key: string; value?: string }[] = [
+      ...(data[SecretOperations.Create] || []).map((s) => ({ key: s.secretKey, value: s.secretValue })),
+      ...(data[SecretOperations.Update] || [])
+        .filter((s) => s.secretValue)
+        .map((s) => ({ key: s.secretKey, value: s.secretValue }))
+    ];
+
+    if (secretsToValidate.length) {
+      await secretValidationRuleService.validateSecrets({
+        projectId,
+        environment,
+        envId: folder.envId,
+        secretPath,
+        secrets: secretsToValidate
+      });
+    }
 
     // for created secret approval change
     const createdSecrets = data[SecretOperations.Create];

--- a/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
+++ b/backend/src/ee/services/secret-approval-request/secret-approval-request-service.ts
@@ -1840,23 +1840,6 @@ export const secretApprovalRequestServiceFactory = ({
       project.secretDetectionIgnoreValues || []
     );
 
-    const secretsToValidate: { key: string; value?: string }[] = [
-      ...(data[SecretOperations.Create] || []).map((s) => ({ key: s.secretKey, value: s.secretValue })),
-      ...(data[SecretOperations.Update] || [])
-        .filter((s) => s.secretValue)
-        .map((s) => ({ key: s.secretKey, value: s.secretValue }))
-    ];
-
-    if (secretsToValidate.length) {
-      await secretValidationRuleService.validateSecrets({
-        projectId,
-        environment,
-        envId: folder.envId,
-        secretPath,
-        secrets: secretsToValidate
-      });
-    }
-
     // for created secret approval change
     const createdSecrets = data[SecretOperations.Create];
     if (createdSecrets && createdSecrets?.length) {
@@ -1869,6 +1852,14 @@ export const secretApprovalRequestServiceFactory = ({
       );
       if (secrets.length)
         throw new BadRequestError({ message: `Secret already exists: ${secrets.map((el) => el.key).join(",")}` });
+
+      await secretValidationRuleService.validateSecrets({
+        projectId,
+        environment,
+        envId: folder.envId,
+        secretPath,
+        secrets: createdSecrets.map((s) => ({ key: s.secretKey, value: s.secretValue }))
+      });
 
       commits.push(
         ...createdSecrets.map((createdSecret) => ({
@@ -1932,6 +1923,16 @@ export const secretApprovalRequestServiceFactory = ({
               missingSecrets.filter((s) => !createdKeys.has(s.secretKey)).map((s) => [s.secretKey, s] as const)
             ).values()
           ];
+
+          if (upsertSecrets.length) {
+            await secretValidationRuleService.validateSecrets({
+              projectId,
+              environment,
+              envId: folder.envId,
+              secretPath,
+              secrets: upsertSecrets.map((s) => ({ key: s.secretKey, value: s.secretValue }))
+            });
+          }
 
           commits.push(
             ...upsertSecrets.map((secret) => ({
@@ -2000,6 +2001,25 @@ export const secretApprovalRequestServiceFactory = ({
       }
 
       const updatingSecretsGroupByKey = groupBy(secretsToUpdateStoredInDB, (el) => el.key);
+
+      const updateSecretsToValidate = actualSecretsToUpdate
+        .filter((s) => s.secretValue !== undefined || s.newSecretName)
+        .map((s) => ({
+          key: s.newSecretName || s.secretKey,
+          value: s.secretValue,
+          secretId: updatingSecretsGroupByKey[s.secretKey]?.[0]?.id
+        }));
+
+      if (updateSecretsToValidate.length) {
+        await secretValidationRuleService.validateSecrets({
+          projectId,
+          environment,
+          envId: folder.envId,
+          secretPath,
+          secrets: updateSecretsToValidate
+        });
+      }
+
       const latestSecretVersions = await secretVersionV2BridgeDAL.findLatestVersionMany(
         folderId,
         secretsToUpdateStoredInDB.map(({ id }) => id)

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2297,7 +2297,8 @@ export const registerRoutes = async (
     microsoftTeamsService,
     folderCommitService,
     notificationService,
-    telemetryService
+    telemetryService,
+    secretValidationRuleService
   });
 
   const secretService = secretServiceFactory({


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Until now, if a change policy is in place and a new approval is created, validation rules would be ignored. So invalid secrets could be added to the project. This enforces the validation rules on change request creations.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)