### PR TITLE
feat(ui): define a select all on the filterable select for vault migration

### DIFF
--- a/frontend/src/components/v2/FilterableSelect/FilterableSelect.tsx
+++ b/frontend/src/components/v2/FilterableSelect/FilterableSelect.tsx
@@ -5,6 +5,7 @@ import {
   ClearIndicator,
   DropdownIndicator,
   Group,
+  MenuList,
   MultiValueRemove,
   Option
 } from "../Select/components";
@@ -21,11 +22,13 @@ export const FilterableSelect = <T,>({
   getGroupHeaderLabel = null,
   options = [],
   menuListClassName,
+  isSelectAll = false,
   ...props
 }: Props<T> & {
   groupBy?: string | null;
   getGroupHeaderLabel?: ((groupValue: any) => string) | null;
   menuListClassName?: string;
+  isSelectAll?: boolean;
 }) => {
   let processedOptions = options;
 
@@ -83,6 +86,7 @@ export const FilterableSelect = <T,>({
         MultiValueRemove,
         Option,
         Group,
+        ...(isSelectAll ? { MenuList } : {}),
         ...props.components
       }}
       classNames={{

--- a/frontend/src/components/v2/Select/components/index.tsx
+++ b/frontend/src/components/v2/Select/components/index.tsx
@@ -2,13 +2,24 @@ import {
   ClearIndicatorProps,
   components,
   DropdownIndicatorProps,
+  GroupBase,
   GroupProps,
+  MenuListProps,
   MultiValueRemoveProps,
   OptionProps
 } from "react-select";
 import { faCheckCircle, faCircleXmark } from "@fortawesome/free-regular-svg-icons";
 import { faChevronDown, faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+const isOptionGroup = <T,>(option: T | GroupBase<T>): option is GroupBase<T> =>
+  option != null &&
+  typeof option === "object" &&
+  "options" in option &&
+  Array.isArray((option as GroupBase<T>).options);
+
+const flattenOptions = <T,>(options: readonly (T | GroupBase<T>)[]): T[] =>
+  options.flatMap((option) => (isOptionGroup(option) ? option.options : [option]));
 
 export const DropdownIndicator = <T,>(props: DropdownIndicatorProps<T>) => {
   return (
@@ -49,4 +60,48 @@ export const Option = <T,>({ isSelected, children, ...props }: OptionProps<T>) =
 
 export const Group = <T,>(props: GroupProps<T>) => {
   return <components.Group {...props} />;
+};
+
+export const MenuList = <T,>(props: MenuListProps<T, boolean>) => {
+  const { children, isMulti, options, getValue, setValue, clearValue, selectProps } = props;
+  const allOptions = flattenOptions((options ?? []) as (T | GroupBase<T>)[]);
+  const selected = getValue();
+  const { getOptionValue } = selectProps;
+  const allSelected =
+    isMulti &&
+    allOptions.length > 0 &&
+    selected.length === allOptions.length &&
+    allOptions.every((option) =>
+      selected.some((value) => getOptionValue(value) === getOptionValue(option))
+    );
+
+  return (
+    <components.MenuList {...props}>
+      {isMulti && allOptions.length > 0 && (
+        <div className="mb-1 border-b border-mineshaft-600">
+          <button
+            type="button"
+            className="flex w-full cursor-pointer flex-row items-center justify-between rounded-sm px-3 py-2 text-left font-inter text-sm font-normal text-mineshaft-200 hover:bg-mineshaft-700"
+            onMouseDown={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+            }}
+            onClick={() => {
+              if (allSelected) {
+                clearValue();
+              } else {
+                setValue(allOptions, "select-option");
+              }
+            }}
+          >
+            <p className="truncate">{allSelected ? "Clear" : "Select All"}</p>
+            {allSelected && (
+              <FontAwesomeIcon className="ml-2 text-primary" icon={faCheckCircle} size="sm" />
+            )}
+          </button>
+        </div>
+      )}
+      {children}
+    </components.MenuList>
+  );
 };

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/VaultSecretImportModal.tsx
@@ -253,6 +253,7 @@ const Content = ({ onClose, environment, secretPath, appConnections, onImport }:
                 : "Select Vault path(s) to import..."
             }
             isClearable
+            isSelectAll
             className="w-full"
           />
           <p className="mt-1 text-xs text-mineshaft-400">


### PR DESCRIPTION
## Context
Add a way to select all values on the filterable select

## Screenshots
https://github.com/user-attachments/assets/432f2f90-30bf-4b30-a3b8-f1a41da7f09e

<img width="760" height="750" alt="image" src="https://github.com/user-attachments/assets/8ffc6cc7-3369-449d-b0b5-4bb60442f4cc" />


## Steps to verify the change
- create an app connection to hashicorp vault. 

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)