### PR TITLE
feat(pam): improve error code for deleting discovery cred acc

### DIFF
--- a/backend/src/ee/services/pam-account/pam-account-service.ts
+++ b/backend/src/ee/services/pam-account/pam-account-service.ts
@@ -15,6 +15,8 @@ import {
 import { conditionsMatcher } from "@app/lib/casl";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+import { hasPostgresErrorCode } from "@app/lib/errors/postgres";
+import { logger } from "@app/lib/logger";
 import { createSshKeyPair, SshCertKeyAlgorithm } from "@app/lib/ssh";
 import { TAppConnectionDALFactory } from "@app/services/app-connection/app-connection-dal";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -43,6 +45,7 @@ import {
 import { TPamAccessRequestServiceFactory } from "../pam-access-request/pam-access-request-service";
 import { TPamAccountTemplateDALFactory } from "../pam-account-template/pam-account-template-dal";
 import { PamTemplateSettingsSchema } from "../pam-account-template/pam-account-template-schemas";
+import { TPamDiscoverySourceDALFactory } from "../pam-discovery/pam-discovery-source-dal";
 import { TPamFolderDALFactory } from "../pam-folder/pam-folder-dal";
 import { TPamSessionDALFactory } from "../pam-session/pam-session-dal";
 import { terminatePamSessions } from "../pam-session/pam-session-fns";
@@ -76,6 +79,7 @@ type TPamAccountServiceFactoryDep = {
   membershipDAL: Pick<TMembershipDALFactory, "find" | "delete" | "findResourceMembershipsForActor">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "delete" | "find">;
   pamSessionDAL: Pick<TPamSessionDALFactory, "find" | "update">;
+  pamDiscoverySourceDAL: Pick<TPamDiscoverySourceDALFactory, "find">;
   userDAL: Pick<TUserDALFactory, "findById">;
   permissionService: Pick<
     TPermissionServiceFactory,
@@ -151,6 +155,7 @@ export const pamAccountServiceFactory = (deps: TPamAccountServiceFactoryDep) => 
     membershipDAL,
     membershipRoleDAL,
     pamSessionDAL,
+    pamDiscoverySourceDAL,
     userDAL,
     permissionService,
     kmsService,
@@ -840,12 +845,7 @@ export const pamAccountServiceFactory = (deps: TPamAccountServiceFactoryDep) => 
       sendSessionCancellations?.();
       return deleted;
     } catch (err) {
-      // The ON DELETE RESTRICT FK on rotationAccountId is the race-safe guard; on violation, look up the dependents
-      // to name them (rather than paying for that lookup on every delete).
-      if (
-        err instanceof DatabaseError &&
-        (err.error as { code?: string })?.code === DatabaseErrorCode.ForeignKeyViolation
-      ) {
+      if (hasPostgresErrorCode(err, DatabaseErrorCode.ForeignKeyViolation)) {
         const dependents = (await pamAccountDAL.find({ rotationAccountId: accountId })).filter(
           (dependent) => dependent.id !== accountId
         );
@@ -876,9 +876,24 @@ export const pamAccountServiceFactory = (deps: TPamAccountServiceFactoryDep) => 
               : "This account is used as the rotation account for another account. Reassign it before deleting this one."
           });
         }
-        // The other restricting reference is a discovery source using this account as its credential
+        const sources = await pamDiscoverySourceDAL.find({ credentialAccountId: accountId });
+        if (sources.length) {
+          // Discovery is Admin-only, so a non-admin gets the count rather than the source names.
+          const { hasRole } = await verifyMembership(projectId, ctx);
+          const plural = sources.length > 1;
+          const subject = hasRole(PamProductRole.Admin)
+            ? `discovery source${plural ? "s" : ""} ${sources.map((source) => `'${source.name}'`).join(", ")}`
+            : `${sources.length} discovery source${plural ? "s" : ""}`;
+          throw new BadRequestError({
+            message: `This account is the credential for ${subject}. Point ${
+              plural ? "them" : "it"
+            } at another account, or delete ${plural ? "them" : "it"}, before deleting this account.`
+          });
+        }
+
+        logger.error(err, `Unhandled FK violation deleting PAM account [accountId=${accountId}]`);
         throw new BadRequestError({
-          message: "This account is used as the credential for a discovery source. Delete that source first."
+          message: "This account is still referenced by another resource. Remove that reference before deleting it."
         });
       }
       throw err;

--- a/backend/src/lib/errors/postgres.ts
+++ b/backend/src/lib/errors/postgres.ts
@@ -1,3 +1,5 @@
+import { DatabaseErrorCode } from "@app/lib/error-codes";
+
 /**
  * Postgres error codes we translate into client errors instead of letting them surface as a 500.
  * See https://www.postgresql.org/docs/current/errcodes-appendix.html
@@ -15,7 +17,7 @@ const MAX_CAUSE_DEPTH = 5;
  * DALs wrap the driver error in a `DatabaseError` (sometimes more than one layer deep), so the pg
  * error code is never on the outermost error.
  */
-export const hasPostgresErrorCode = (err: unknown, code: PostgresErrorCode): boolean => {
+export const hasPostgresErrorCode = (err: unknown, code: PostgresErrorCode | DatabaseErrorCode): boolean => {
   let current = err;
 
   for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1970,6 +1970,8 @@ export const registerRoutes = async (
     pamAccessRequestService
   });
 
+  const pamDiscoverySourceDAL = pamDiscoverySourceDALFactory(db);
+
   const pamAccountService = pamAccountServiceFactory({
     pamAccountDAL,
     pamFolderDAL,
@@ -1977,6 +1979,7 @@ export const registerRoutes = async (
     membershipDAL,
     membershipRoleDAL,
     pamSessionDAL,
+    pamDiscoverySourceDAL,
     userDAL,
     permissionService,
     kmsService,
@@ -1988,7 +1991,6 @@ export const registerRoutes = async (
     licenseService
   });
 
-  const pamDiscoverySourceDAL = pamDiscoverySourceDALFactory(db);
   const pamDiscoverySourceRunDAL = pamDiscoverySourceRunDALFactory(db);
   const pamDiscoveredAccountDAL = pamDiscoveredAccountDALFactory(db);
   const pamAccountDependencyDAL = pamAccountDependencyDALFactory(db);


### PR DESCRIPTION
## Context

Improves the error code for when you delete an account being used as a credential for a discovery source. Admins see the source that's blocking the deletion, regular users do not.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

Just delete an account being used as credentials for a discovery source

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)