### PR TITLE
fix(docs): route vulnerability reports through the disclosure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ If you are interested in managed Infisical Cloud of self-hosted Enterprise Offer
 
 Please do not file GitHub issues or post on our public forum for security vulnerabilities, as they are public!
 
-Infisical takes security issues very seriously. If you have any concerns about Infisical or believe you have uncovered a vulnerability, please get in touch via the e-mail address security@infisical.com. In the message, try to provide a description of the issue and ideally a way of reproducing it. The security team will get back to you as soon as possible.
+Infisical takes security issues very seriously. If you have any concerns about Infisical or believe you have uncovered a vulnerability, please report it privately through our vulnerability disclosure policy at <https://infisical.com/vulnerability-disclosure>. Scope, safe harbour and disclosure terms are all set out there. See also [SECURITY.md](./SECURITY.md).
 
-Note that this security address should be used only for undisclosed vulnerabilities. Please report any security problems to us before disclosing it publicly.
+Please report any security problems to us before disclosing them publicly. For compliance documentation and security questionnaires, use security@infisical.com instead.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,27 @@
 # Security Policy
 
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for a security problem.**
+
+Report it through our vulnerability disclosure policy at <https://infisical.com/vulnerability-disclosure>.
+
+Please include what you found, where, how to reproduce it, what an attacker could achieve, and how you would like to be credited.
+
+## Scope and safe harbour
+
+The full scope of the program, along with our safe harbour and coordinated disclosure terms, is set out in the policy linked above.
+
+## Rewards
+
+**This is a vulnerability disclosure program, not a bug bounty.** It offers acknowledgement and public credit rather than payment.
+
+Infisical's paid bug bounty is a separate **private, invitation-only program** covering Infisical Cloud. It is not open to public submissions, and reports made through this repository are not eligible for its rewards. Strong reports here are a good route to an invitation.
+
 ## Supported versions
 
-We always recommend using the latest version of Infisical to ensure you get all security updates.
+Security fixes ship in the latest release. We always recommend running the latest version of Infisical. If you self-host, upgrading promptly is the fastest way to stay protected.
 
-## Reporting vulnerabilities
+## General security contact
 
-Please do not file GitHub issues or post on our public forum for security vulnerabilities, as they are public!
-
-Infisical takes security issues very seriously. If you have any concerns about Infisical or believe you have uncovered a vulnerability, please get in touch via the e-mail address security@infisical.com. In the message, try to provide a description of the issue and ideally a way of reproducing it. The security team will get back to you as soon as possible.
-
-Note that this security address should be used only for undisclosed vulnerabilities. Please report any security problems to us before disclosing it publicly.
+For compliance documentation, security questionnaires, penetration-test reports and SOC 2 requests, use [security@infisical.com](mailto:security@infisical.com). That address is not a vulnerability intake channel.

--- a/docs/contributing/getting-started/overview.mdx
+++ b/docs/contributing/getting-started/overview.mdx
@@ -32,8 +32,8 @@ Bug reports help make Infisical a better experience for everyone. When you repor
 Before raising a new issue, please search existing ones to make sure you're not creating a duplicate.
 
 <Info>
-  If the issue is related to security, please email us directly at
-  security@infisical.com.
+  If the issue is related to security, please report it privately through
+  https://infisical.com/vulnerability-disclosure rather than opening an issue.
 </Info>
 
 ## Deciding what to work on

--- a/docs/internals/security.mdx
+++ b/docs/internals/security.mdx
@@ -269,6 +269,12 @@ Most recently, Infisical commissioned cybersecurity firm [Cure53](https://cure53
 
 Please email security@infisical.com to request any reports including a letter of attestation for the conducted penetration test.
 
+## Reporting a vulnerability
+
+Infisical runs a public vulnerability disclosure program. If you have found a security issue in an Infisical product or service, report it privately through [infisical.com/vulnerability-disclosure](https://infisical.com/vulnerability-disclosure), where scope, safe harbour and coordinated disclosure terms are set out.
+
+Please do not open a public GitHub issue for a security problem. Infisical's paid bug bounty is a separate private, invitation-only program and is not open to public submissions.
+
 ## Employee data access
 
 Whether or not Infisical or your employees can access data in the Infisical instance and/or storage backend depends on many factors how you use Infisical:


### PR DESCRIPTION
Reporting instructions across the repo pointed at security@infisical.com. That address handles compliance documentation, security questionnaires and SOC 2 requests, and is not wired to vulnerability triage, so reports following the documented path landed in the wrong queue.

Point them at infisical.com/vulnerability-disclosure instead, which carries the scope, safe harbour and coordinated disclosure terms.

- SECURITY.md rewritten around the policy link
- README security section updated
- Contributing guide no longer directs security issues to email
- Architecture docs gain a reporting section, since the policy page links here and there was no route back

security@infisical.com stays for compliance traffic, now labelled as such. States explicitly that this is a disclosure program and that the paid bug bounty is a separate private, invitation-only program.

## Context

Every reporting instruction in this repo pointed at security@infisical.com. That mailbox handles SOC 2 requests, NDAs and customer security questionnaires. It is not routed to triage.

So a researcher following our own docs reached a compliance inbox. Nothing tracked the report, nothing checked it against our known issues, and no clock started.

All four paths now point at the policy. security@ keeps the two places it belongs, penetration-test report requests and employee data inquiries, and is labelled there as not a vulnerability channel.

`docs/internals/security.mdx` gains a reporting section. The policy page links to it for our architecture, and there was no route back.

Documentation only. No code changes.

## Steps to verify the change

1. Open `SECURITY.md`. The only route given should be https://infisical.com/vulnerability-disclosure, and the link should resolve.
2. Confirm `security@infisical.com` now appears only under "General security contact".
3. Build the docs. "Reporting a vulnerability" should render between "Penetration testing" and "Employee data access".
4. Run `grep -rn "security@infisical.com" . --include="*.md" --include="*.mdx"`. Every remaining hit should be compliance, not reporting.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)