### PR TITLE
feat: add lazy segfault catch for error code 139

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -154,6 +154,7 @@
         "safe-regex": "^2.1.1",
         "scim-patch": "^0.8.3",
         "scim2-parse-filter": "^0.2.10",
+        "segfault-handler": "^1.3.0",
         "sjcl": "^1.0.9",
         "smee-client": "^2.0.0",
         "snowflake-sdk": "^2.0.4",
@@ -6735,6 +6736,9 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@infisical/quic/node_modules/@infisical/quic-linux-arm": {
+      "optional": true
     },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
@@ -13655,6 +13659,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -17263,6 +17276,12 @@
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/filename-reserved-regex": {
       "version": "3.0.0",
@@ -24745,6 +24764,17 @@
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "dev": true
+    },
+    "node_modules/segfault-handler": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/segfault-handler/-/segfault-handler-1.3.0.tgz",
+      "integrity": "sha512-p7kVHo+4uoYkr0jmIiTBthwV5L2qmWtben/KDunDZ834mbos+tY+iO0//HpAJpOFSQZZ+wxKWuRo4DxV02B7Lg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.2.1",
+        "nan": "^2.14.0"
+      }
     },
     "node_modules/selderee": {
       "version": "0.11.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -294,6 +294,7 @@
     "safe-regex": "^2.1.1",
     "scim-patch": "^0.8.3",
     "scim2-parse-filter": "^0.2.10",
+    "segfault-handler": "^1.3.0",
     "sjcl": "^1.0.9",
     "smee-client": "^2.0.0",
     "snowflake-sdk": "^2.0.4",

--- a/backend/src/@types/segfault-handler.d.ts
+++ b/backend/src/@types/segfault-handler.d.ts
@@ -1,0 +1,15 @@
+declare module "segfault-handler" {
+  interface SegfaultHandler {
+    /**
+     * Installs a native handler for SIGSEGV/SIGBUS/SIGILL/SIGFPE that writes a backtrace
+     * to stderr (and to `logPath`, when given) before the process dies.
+     */
+    registerHandler(logPath?: string): void;
+
+    /** Dereferences a null pointer on purpose. Only for verifying the handler is armed. */
+    causeSegfault(): void;
+  }
+
+  const segfaultHandler: SegfaultHandler;
+  export = segfaultHandler;
+}

--- a/backend/src/lib/telemetry/segfault-handler.ts
+++ b/backend/src/lib/telemetry/segfault-handler.ts
@@ -1,0 +1,30 @@
+import { logger } from "@app/lib/logger";
+
+// Read from process.env rather than the parsed env config: a SIGSEGV gives the process no chance to
+// run any JS afterwards, so the handler is only useful if it is armed before the fault. Waiting for
+// initEnvConfig() would leave an unguarded window and couple crash diagnostics to config loading.
+const isSegfaultHandlerEnabled = () => process.env.SEGFAULT_HANDLER_ENABLED === "true";
+
+/**
+ * Arms a native crash handler that prints a backtrace naming the faulting module, which is the only
+ * way to attribute a SIGSEGV: the process is killed by the kernel, so Node writes no log line, flushes
+ * no pino buffer, and emits no diagnostic report (--report-on-fatalerror does not cover signals).
+ *
+ * The addon is imported behind the flag so a deployment that leaves it off never loads the binary.
+ */
+export const registerSegfaultHandler = async () => {
+  if (!isSegfaultHandlerEnabled()) return;
+
+  try {
+    const segfaultHandler = (await import("segfault-handler")).default;
+
+    // No log path: the container filesystem dies with the task, so stderr is the only sink that
+    // survives, and it is already shipped to CloudWatch by the awslogs driver.
+    segfaultHandler.registerHandler();
+
+    logger.info("registerSegfaultHandler: native crash handler armed, backtraces will go to stderr");
+  } catch (err) {
+    // An optional native dependency that is missing or failed to build must never stop the boot.
+    logger.error(err, "registerSegfaultHandler: failed to arm native crash handler");
+  }
+};

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -20,6 +20,7 @@ import { removeTemporaryBaseDirectory } from "./lib/files";
 import { initLogger } from "./lib/logger";
 import { CustomLogger } from "./lib/logger/logger";
 import { registerInfrastructureMetrics } from "./lib/telemetry/metrics";
+import { registerSegfaultHandler } from "./lib/telemetry/segfault-handler";
 import { queueServiceFactory } from "./queue";
 import { main } from "./server/app";
 import { bootstrapCheck } from "./server/boot-strap-check";
@@ -35,6 +36,7 @@ const setupAxiosResponseInterceptor = (logger: CustomLogger) => {
 
 const run = async () => {
   const logger = initLogger();
+  await registerSegfaultHandler();
   await removeTemporaryBaseDirectory();
 
   setupAxiosResponseInterceptor(logger);


### PR DESCRIPTION
## Context

This PR adds the support to catch the seg error that happens and shows it in infisical logs as stack trace. This can be enabled with flag `SEGFAULT_HANDLER_ENABLED`. 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [x] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)