### PR TITLE
fix(api): thread tx through DAL reads in createProject to prevent connection-pool deadlock

### DIFF
--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -280,6 +280,21 @@ export const projectServiceFactory = ({
       throw new ForbiddenRequestError({ message: "You don't have permission to create a project" });
     }
 
+    let projectTemplate: Awaited<ReturnType<typeof projectTemplateService.findProjectTemplateByName>> | null = null;
+
+    switch (template) {
+      case InfisicalProjectTemplate.Default:
+        projectTemplate = null;
+        break;
+      default:
+        projectTemplate = await projectTemplateService.findProjectTemplateByName(template, {
+          id: actorId,
+          orgId: organization.id,
+          type: actor,
+          authMethod: actorAuthMethod
+        });
+    }
+
     const results = await (trx || projectDAL).transaction(async (tx) => {
       await tx.raw("SELECT pg_advisory_xact_lock(?)", [PgSqlLock.CreateProject(organization.id)]);
 
@@ -303,21 +318,6 @@ export const projectServiceFactory = ({
             message: "KMS does not belong in the organization"
           });
         }
-      }
-
-      let projectTemplate: Awaited<ReturnType<typeof projectTemplateService.findProjectTemplateByName>> | null = null;
-
-      switch (template) {
-        case InfisicalProjectTemplate.Default:
-          projectTemplate = null;
-          break;
-        default:
-          projectTemplate = await projectTemplateService.findProjectTemplateByName(template, {
-            id: actorId,
-            orgId: organization.id,
-            type: actor,
-            authMethod: actorAuthMethod
-          });
       }
 
       const slug = projectSlug || slugify(`${workspaceName}-${alphaNumericNanoId(4)}`);
@@ -384,9 +384,12 @@ export const projectServiceFactory = ({
 
         if (projectTemplate.users?.length) {
           const templateUsernames = projectTemplate.users.map((u) => u.username.toLowerCase());
-          const users = await userDAL.find({
-            $in: { username: templateUsernames }
-          });
+          const users = await userDAL.find(
+            {
+              $in: { username: templateUsernames }
+            },
+            { tx }
+          );
 
           // If template has an admin, include the creator in template users, otherwise exclude them
           const usersToProcess = templateHasAdmin ? users : users.filter((u) => u.id !== actorId);
@@ -463,10 +466,13 @@ export const projectServiceFactory = ({
         // Add template groups to the project
         if (projectTemplate.groups?.length) {
           const templateGroupSlugs = projectTemplate.groups.map((g) => g.groupSlug.toLowerCase());
-          const groups = await groupDAL.find({
-            orgId: project.orgId,
-            $in: { slug: templateGroupSlugs }
-          });
+          const groups = await groupDAL.find(
+            {
+              orgId: project.orgId,
+              $in: { slug: templateGroupSlugs }
+            },
+            { tx }
+          );
 
           if (groups.length) {
             const groupSlugToRoles = new Map(projectTemplate.groups.map((g) => [g.groupSlug.toLowerCase(), g.roles]));
@@ -521,10 +527,13 @@ export const projectServiceFactory = ({
         // Add template (org owned) identities to the project
         if (projectTemplate.identities?.length) {
           const templateIdentityIds = projectTemplate.identities.map((i) => i.identityId);
-          const orgIdentities = await identityDAL.find({
-            orgId: project.orgId,
-            $in: { id: templateIdentityIds }
-          });
+          const orgIdentities = await identityDAL.find(
+            {
+              orgId: project.orgId,
+              $in: { id: templateIdentityIds }
+            },
+            { tx }
+          );
 
           if (orgIdentities.length) {
             const identityIdToRoles = new Map(projectTemplate.identities.map((i) => [i.identityId, i.roles]));
@@ -655,7 +664,7 @@ export const projectServiceFactory = ({
       // Skip this if the creator was already added via template with their configured roles
       if (actor === ActorType.USER && !creatorAddedViaTemplate) {
         // Find public key of user
-        const user = await userDAL.findUserEncKeyByUserId(actorId);
+        const user = await userDAL.findUserEncKeyByUserId(actorId, tx);
 
         if (!user) {
           throw new Error("User not found");


### PR DESCRIPTION
## Context

`createProject` in `project-service.ts` opens a database transaction (line 283) and, inside it, was making several DAL read calls that never received the `tx` handle. Each stray call checks out a **second connection** from the pool (`ormify` resolves `(tx || db.replicaNode())`, so an omitted `tx` always opens a new one). The transaction itself already holds one, so a single `createProject` request with a template that includes users, groups, and identities could tie up **8+ connections simultaneously**.

`DB_POOL_MAX` defaults to 10. Two concurrent template-based project creations can exhaust all connections — every request is blocked waiting for a connection that no other request can release. The application deadlocks and every API call (not just project creation) hangs until the process is killed.

### What was leaking

**Direct DAL calls missing `tx`:**

| Line | Call | Fix |
|------|------|-----|
| 387 | `userDAL.find({ $in: { username: … } })` | add `{ tx }` options arg |
| 466 | `groupDAL.find({ orgId: …, $in: { slug: … } })` | add `{ tx }` options arg |
| 524 | `identityDAL.find({ orgId: …, $in: { id: … } })` | add `{ tx }` options arg |
| 658 | `userDAL.findUserEncKeyByUserId(actorId)` | add `, tx` second arg |

**Service call performing unthreaded DB reads inside the transaction:**

| Line | Call | Fix |
|------|------|-----|
| 315 | `projectTemplateService.findProjectTemplateByName(...)` | Hoisted before the transaction — it runs `projectTemplateDAL.findOne` + 3 `findByTemplateId` calls internally, all without `tx`. The lookup is read-only and depends only on inputs available before the transaction. |

Beyond pool exhaustion, these reads also ran outside the transaction boundary, so they could return stale data that the subsequent writes depend on — a correctness issue on top of the availability one.

## Screenshots

N/A — backend-only change, no UI impact.

## Steps to verify the change

### Reproduction (before the fix)

1. Set `DB_POOL_MAX=5` in your `.env` to shorten the fuse.
2. Create an org and a project template that includes at least one user, one group, and one identity.
3. Fire 6 concurrent `POST /api/v1/workspace` requests using that template:
   ```bash
   for i in $(seq 1 6); do
     curl -s -X POST http://localhost:8080/api/v1/workspace \
       -H "Authorization: Bearer $TOKEN" \
       -H "Content-Type: application/json" \
       -d "{\"projectName\":\"pool-test-$i\",\"template\":\"your-template\"}" &
   done
   wait
   ```
4. All requests hang. Subsequent `GET` requests to any endpoint also hang. The process must be killed.

### Verification (after the fix)

1. Same setup, same concurrency.
2. All 6 requests complete (or fail cleanly on duplicate slugs).
3. Unrelated API calls continue to respond normally under load.

### Code review

- Confirm the `findProjectTemplateByName` call now sits **above** the `transaction()` call, not inside it.
- Grep the transaction block and confirm every `await` on a DAL method inside it now ends with `tx` or `{ tx }`. No call inside this transaction should resolve against the bare `db` pool.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
