### PR TITLE
docs(secrets-mgmt): clarify dual-phase rotation

### DIFF
--- a/docs/documentation/platform/secret-rotation/mongodb-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/mongodb-credentials.mdx
@@ -5,12 +5,6 @@ description: "Learn how to automatically rotate MongoDB credentials."
 
 import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
 
-<Note>
-  **Rotation Type: Dual-Phase**
-
-  This rotation maintains two active credential sets with overlapping validity, ensuring zero-downtime during rotation cycles.
-</Note>
-
 ## Prerequisites
 
 1. Create a [MongoDB Connection](/integrations/app-connections/mongodb) with the required **Secret Rotation** permissions
@@ -184,4 +178,3 @@ import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/tw
         ```
     </Tab>
 </Tabs>
-

--- a/docs/documentation/platform/secret-rotation/mongodb-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/mongodb-credentials.mdx
@@ -3,6 +3,8 @@ title: "MongoDB credentials rotation"
 description: "Learn how to automatically rotate MongoDB credentials."
 ---
 
+import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
+
 <Note>
   **Rotation Type: Dual-Phase**
 
@@ -13,6 +15,8 @@ description: "Learn how to automatically rotate MongoDB credentials."
 
 1. Create a [MongoDB Connection](/integrations/app-connections/mongodb) with the required **Secret Rotation** permissions
 2. Create two designated database users for Infisical to rotate the credentials for. Be sure to grant each user login permissions for the desired database with the necessary privileges their use case will require.
+
+    <TwoUserRotation />
 
     An example creation statement might look like:
     ```bash

--- a/docs/documentation/platform/secret-rotation/mssql-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/mssql-credentials.mdx
@@ -3,6 +3,8 @@ title: "Microsoft SQL Server credentials rotation"
 description: "Learn how to automatically rotate Microsoft SQL Server credentials."
 ---
 
+import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
+
 <Note>
   **Rotation Type: Dual-Phase**
 
@@ -13,6 +15,8 @@ description: "Learn how to automatically rotate Microsoft SQL Server credentials
 
 1. Create a [Microsoft SQL Server Connection](/integrations/app-connections/mssql) with the required **Secret Rotation** permissions
 2. Create two designated database users for Infisical to rotate the credentials for. Be sure to grant each user login permissions for the desired database with the necessary privileges their use case will require.
+
+<TwoUserRotation />
 
 An example creation statement might look like:
     ```SQL
@@ -65,7 +69,7 @@ An example creation statement might look like:
         ![Rotation Advance Parameters](/images/secret-rotations-v2/mssql-credentials/mssql-credentials-advance-parameters.png)
 
         - **Rotation Statement** - the template string query to generate password for the rotated user.
-        - **Password Requirements** - the requirements for the password of the Microsoft SQL Server users that will be created for the rotation.
+        - **Password Requirements** - the requirements for the passwords Infisical generates for the two Microsoft SQL Server users.
 
         5. Specify the secret names that the active credentials should be mapped to. Then click **Next**.
         ![Rotation Secrets Mapping](/images/secret-rotations-v2/mssql-credentials/mssql-credentials-secrets-mapping.png)

--- a/docs/documentation/platform/secret-rotation/mssql-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/mssql-credentials.mdx
@@ -5,12 +5,6 @@ description: "Learn how to automatically rotate Microsoft SQL Server credentials
 
 import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
 
-<Note>
-  **Rotation Type: Dual-Phase**
-
-  This rotation maintains two active credential sets with overlapping validity, ensuring zero-downtime during rotation cycles.
-</Note>
-
 ## Prerequisites
 
 1. Create a [Microsoft SQL Server Connection](/integrations/app-connections/mssql) with the required **Secret Rotation** permissions

--- a/docs/documentation/platform/secret-rotation/mysql-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/mysql-credentials.mdx
@@ -5,12 +5,6 @@ description: "Learn how to automatically rotate MySQL credentials."
 
 import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
 
-<Note>
-  **Rotation Type: Dual-Phase**
-
-  This rotation maintains two active credential sets with overlapping validity, ensuring zero-downtime during rotation cycles.
-</Note>
-
 ## Prerequisites
 
 1. Create a [MySQL Connection](/integrations/app-connections/mysql) with the required **Secret Rotation** permissions

--- a/docs/documentation/platform/secret-rotation/mysql-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/mysql-credentials.mdx
@@ -3,6 +3,8 @@ title: "MySQL credentials rotation"
 description: "Learn how to automatically rotate MySQL credentials."
 ---
 
+import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
+
 <Note>
   **Rotation Type: Dual-Phase**
 
@@ -13,6 +15,8 @@ description: "Learn how to automatically rotate MySQL credentials."
 
 1. Create a [MySQL Connection](/integrations/app-connections/mysql) with the required **Secret Rotation** permissions
 2. Create two designated database users for Infisical to rotate the credentials for. Be sure to grant each user login permissions for the desired database with the necessary privileges their use case will require.
+
+    <TwoUserRotation />
 
     An example creation statement might look like:
     ```SQL
@@ -60,7 +64,7 @@ description: "Learn how to automatically rotate MySQL credentials."
         ![Rotation Advance Parameters](/images/secret-rotations-v2/mysql-credentials/mysql-credentials-advance-parameters.png)
 
             - **Rotation Statement** - the template string query to generate password for the rotated user.
-            - **Password Requirements** - the requirements for the password of the MySQL users that will be created for the rotation.
+            - **Password Requirements** - the requirements for the passwords Infisical generates for the two MySQL users.
 
         5. Specify the secret names that the active credentials should be mapped to. Then click **Next**.
         ![Rotation Secrets Mapping](/images/secret-rotations-v2/mysql-credentials/mysql-credentials-secrets-mapping.png)

--- a/docs/documentation/platform/secret-rotation/oracledb-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/oracledb-credentials.mdx
@@ -5,12 +5,6 @@ description: "Learn how to automatically rotate Oracle Database credentials."
 
 import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
 
-<Note>
-  **Rotation Type: Dual-Phase**
-
-  This rotation maintains two active credential sets with overlapping validity, ensuring zero-downtime during rotation cycles.
-</Note>
-
 <Info>
     When working with SQL in Oracle databases, any values not surrounded by "quotes" will become UPPERCASE. Keep this in mind when creating users.
 </Info>

--- a/docs/documentation/platform/secret-rotation/oracledb-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/oracledb-credentials.mdx
@@ -3,6 +3,8 @@ title: "OracleDB credentials rotation"
 description: "Learn how to automatically rotate Oracle Database credentials."
 ---
 
+import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
+
 <Note>
   **Rotation Type: Dual-Phase**
 
@@ -17,6 +19,8 @@ description: "Learn how to automatically rotate Oracle Database credentials."
 
 1. Create a [OracleDB Connection](/integrations/app-connections/oracledb) with the required **Secret Rotation** permissions
 2. Create two designated database users for Infisical to rotate the credentials for. Be sure to grant each user login permissions for the desired database with the necessary privileges their use case will require.
+
+    <TwoUserRotation />
 
     An example creation statement might look like:
     ```SQL
@@ -70,7 +74,7 @@ description: "Learn how to automatically rotate Oracle Database credentials."
         ![Rotation Advance Parameters](/images/secret-rotations-v2/oracledb-credentials/oracledb-credentials-advance-parameters.png)
             
             - **Rotation Statement** - the template string query to generate password for the rotated user.
-            - **Password Requirements** - the requirements for the password of the Oracle Database users that will be created for the rotation.
+            - **Password Requirements** - the requirements for the passwords Infisical generates for the two Oracle Database users.
 
         5. Specify the secret names that the active credentials should be mapped to. Then click **Next**.
         ![Rotation Secrets Mapping](/images/secret-rotations-v2/oracledb-credentials/oracledb-credentials-secrets-mapping.png)

--- a/docs/documentation/platform/secret-rotation/overview.mdx
+++ b/docs/documentation/platform/secret-rotation/overview.mdx
@@ -123,7 +123,7 @@ Infisical supports two rotation models: **Dual-Phase** (used by most providers) 
 
 ## Database credential rotations
 
-Providers differ in whether Infisical can create credentials for you. For most, including Redis and API key providers such as AWS and Cloudflare, Infisical issues a new credential on each rotation and removes the old one once it has been replaced. The connection is the only thing you set up in advance.
+For most providers, including Redis and API key providers such as AWS and Cloudflare, Infisical issues a new credential on each rotation and removes the old one once it has been replaced.
 
 Database rotations work differently. Infisical never creates or drops users in [PostgreSQL](/documentation/platform/secret-rotation/postgres-credentials), [MySQL](/documentation/platform/secret-rotation/mysql-credentials), [Microsoft SQL Server](/documentation/platform/secret-rotation/mssql-credentials), [Oracle Database](/documentation/platform/secret-rotation/oracledb-credentials), or [MongoDB](/documentation/platform/secret-rotation/mongodb-credentials). Doing so would require broader privileges than rotation needs, and a new user would not inherit the grants your applications depend on. Instead, you create two users up front and name them in the rotation.
 

--- a/docs/documentation/platform/secret-rotation/overview.mdx
+++ b/docs/documentation/platform/secret-rotation/overview.mdx
@@ -121,3 +121,26 @@ Infisical supports two rotation models: **Dual-Phase** (used by most providers) 
     </Tab>
 </Tabs>
 
+## Database credential rotations
+
+Providers differ in whether Infisical can create credentials for you. For most, including Redis and API key providers such as AWS and Cloudflare, Infisical issues a new credential on each rotation and removes the old one once it has been replaced. The connection is the only thing you set up in advance.
+
+Database rotations work differently. Infisical never creates or drops users in [PostgreSQL](/documentation/platform/secret-rotation/postgres-credentials), [MySQL](/documentation/platform/secret-rotation/mysql-credentials), [Microsoft SQL Server](/documentation/platform/secret-rotation/mssql-credentials), [Oracle Database](/documentation/platform/secret-rotation/oracledb-credentials), or [MongoDB](/documentation/platform/secret-rotation/mongodb-credentials). Doing so would require broader privileges than rotation needs, and a new user would not inherit the grants your applications depend on. Instead, you create two users up front and name them in the rotation.
+
+### Why two users?
+
+Each cycle, Infisical generates a new password for whichever of the two users is not currently active and maps it to your secrets. The other user's password stays valid as a grace-period credential until the following cycle replaces it, which is what gives the rotation its overlap.
+
+Infisical changes passwords in place, so with a single user it would overwrite the credential currently in use and lock out every client still holding the old password. The cycle never needs more than two users, which is why the configuration form has fixed **Database Username 1** and **Database Username 2** fields.
+
+### Who connects as the two users?
+
+Your applications do. The pair backs one rotating credential: Infisical maps the active username and password to the secrets you choose, and your application connects as whichever user is currently active by reading those secrets.
+
+Grant both users the same privileges, since either one may be the active credential at any time, and let Infisical be the only thing that sets their passwords. The one user you cannot name is the one your [app connection](/integrations/app-connections/overview) authenticates with, because rotating its password would break the connection that performs the rotation.
+
+### Rotating several credentials
+
+Create a separate rotation for each credential you need, each with its own pair of users. A rotation produces a single active credential, so a database serving three applications that need independent credentials needs three rotations and six users. Two rotations must not share a pair of users, as each would overwrite the other's passwords.
+
+If you want credentials issued per identity and revoked after a short lease, rather than one shared credential that changes on a schedule, use a [dynamic secret](/documentation/platform/dynamic-secrets/overview) instead.

--- a/docs/documentation/platform/secret-rotation/postgres-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/postgres-credentials.mdx
@@ -5,12 +5,6 @@ description: "Learn how to automatically rotate PostgreSQL credentials."
 
 import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
 
-<Note>
-  **Rotation Type: Dual-Phase**
-
-  This rotation maintains two active credential sets with overlapping validity, ensuring zero-downtime during rotation cycles.
-</Note>
-
 ## Prerequisites
 
 1. Create a [PostgreSQL Connection](/integrations/app-connections/postgres) with the required **Secret Rotation** permissions

--- a/docs/documentation/platform/secret-rotation/postgres-credentials.mdx
+++ b/docs/documentation/platform/secret-rotation/postgres-credentials.mdx
@@ -3,6 +3,8 @@ title: "PostgreSQL credentials rotation"
 description: "Learn how to automatically rotate PostgreSQL credentials."
 ---
 
+import TwoUserRotation from "/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx";
+
 <Note>
   **Rotation Type: Dual-Phase**
 
@@ -13,6 +15,8 @@ description: "Learn how to automatically rotate PostgreSQL credentials."
 
 1. Create a [PostgreSQL Connection](/integrations/app-connections/postgres) with the required **Secret Rotation** permissions
 2. Create two designated database users for Infisical to rotate the credentials for. Be sure to grant each user login permissions for the desired database with the necessary privileges their use case will require.
+
+    <TwoUserRotation />
 
     An example creation statement might look like:
     ```SQL
@@ -73,7 +77,7 @@ description: "Learn how to automatically rotate PostgreSQL credentials."
         ![Rotation Advance Parameters](/images/secret-rotations-v2/postgres-credentials/postgres-credentials-advance-parameters.png)
 
             - **Rotation Statement** - the template string query to generate a password for the rotated user.
-            - **Password Requirements** - the requirements for the password of the PostgreSQL users that will be created for the rotation.
+            - **Password Requirements** - the requirements for the passwords Infisical generates for the two PostgreSQL users.
 
         5. Specify the secret names that the active credentials should be mapped to. Then click **Next**.
         ![Rotation Secrets Mapping](/images/secret-rotations-v2/postgres-credentials/postgres-credentials-secrets-mapping.png)

--- a/docs/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx
+++ b/docs/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx
@@ -1,0 +1,7 @@
+<Accordion title="Why create two users?">
+    Infisical never creates or drops database users, so it rotates the passwords of the two users you name, alternating between them.
+
+    Each cycle, Infisical generates a new password for whichever user is not currently active and maps it to your secrets. The other user's password stays valid as a grace-period credential until the following cycle replaces it, which is what makes the rotation [dual-phase](/documentation/platform/secret-rotation/overview#dual-phase). A single user has nowhere to write a new password except over the one in use, so every client still holding the old password would be locked out immediately.
+
+    The cycle never needs more than two users, which is why the configuration form has fixed **Database Username 1** and **Database Username 2** fields. Both users must be dedicated to Infisical, and neither can be the user your app connection authenticates with.
+</Accordion>

--- a/docs/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx
+++ b/docs/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx
@@ -1,7 +1,7 @@
 <Accordion title="Why create two users?">
     Infisical never creates or drops database users, so it rotates the passwords of the two users you name, alternating between them.
 
-    Each cycle, Infisical generates a new password for whichever user is not currently active and maps it to your secrets. The other user's password stays valid as a grace-period credential until the following cycle replaces it, which is what makes the rotation [dual-phase](/documentation/platform/secret-rotation/overview#dual-phase). A single user has nowhere to write a new password except over the one in use, so every client still holding the old password would be locked out immediately.
+    Each cycle, Infisical generates a new password for whichever user is not currently active and maps it to your secrets. The other user's password stays valid as a grace-period credential until the following cycle replaces it, which is what makes the rotation [dual-phase](/documentation/platform/secret-rotation/overview#dual-phase). Infisical changes passwords in place, so with a single user it would overwrite the credential currently in use and lock out every client still holding the old password.
 
     The cycle never needs more than two users, which is why the configuration form has fixed **Database Username 1** and **Database Username 2** fields. Both users must be dedicated to Infisical, and neither can be the user your app connection authenticates with.
 </Accordion>

--- a/docs/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx
+++ b/docs/snippets/documentation/platform/secret-rotation/two-user-rotation.mdx
@@ -1,7 +1,3 @@
-<Accordion title="Why create two users?">
-    Infisical never creates or drops database users, so it rotates the passwords of the two users you name, alternating between them.
-
-    Each cycle, Infisical generates a new password for whichever user is not currently active and maps it to your secrets. The other user's password stays valid as a grace-period credential until the following cycle replaces it, which is what makes the rotation [dual-phase](/documentation/platform/secret-rotation/overview#dual-phase). Infisical changes passwords in place, so with a single user it would overwrite the credential currently in use and lock out every client still holding the old password.
-
-    The cycle never needs more than two users, which is why the configuration form has fixed **Database Username 1** and **Database Username 2** fields. Both users must be dedicated to Infisical, and neither can be the user your app connection authenticates with.
-</Accordion>
+<Note>
+    Rotation alternates between these two users, changing one password per cycle so that the other stays valid while your applications pick up the new credentials. See [why two users are required](/documentation/platform/secret-rotation/overview#why-two-users).
+</Note>


### PR DESCRIPTION
## Context

Clarifies dual-phase rotation within database Secret Rotation guides.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)