### PR TITLE
docs(footer): fix forum link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4508,7 +4508,7 @@
           },
           {
             "label": "Forum",
-            "href": "https://infisical-users.slack.com/"
+            "href": "https://infisical.com/slack"
           }
         ]
       },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -4508,7 +4508,7 @@
           },
           {
             "label": "Forum",
-            "href": "https://questions.infisical.com/"
+            "href": "https://infisical-users.slack.com/"
           }
         ]
       },


### PR DESCRIPTION
## Context

Fixes the forum link in the footer of the docs.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)