### PR TITLE
fix(identity-ldap-auth): stop returning bind password on GET

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -226,9 +226,8 @@ judgment. Two adjustments to that rule, both small enough to enumerate:
   body: `POST /v1/identities/search`, `POST /v2/identities/search`, `POST /v2/identities/search/count`,
   and the two `memberships/details` routes. All five check a CASL read ability.
 - **A read that hands back credential material loses it**, because the point of closing administration is
-  that a third-party application should not end up holding the org's secrets. Six routes:
+  that a third-party application should not end up holding the org's secrets. Five routes:
   `GET /v1/sso/oidc/config` (`clientSecret`), `GET /v1/ldap/config` (`bindPass`),
-  `GET /v1/auth/ldap-auth/identities/:identityId` (`bindPass`),
   `GET /v1/workspace/:projectId/kms/backup` (the project's KMS backup blob), and Slack
   `GET /install` / `GET /reinstall`, which gate on `OrgPermissionActions.Create` and exist only to start
   an install. Everything else reads through a sanitized schema — `sanitizedClientSecretSchema` returns a

--- a/backend/src/server/routes/v1/identity-ldap-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-ldap-auth-router.ts
@@ -296,7 +296,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
         }
       ],
       params: z.object({
-        identityId: z.string().trim().describe(LDAP_AUTH.ATTACH.identityId)
+        identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.ATTACH.identityId)
       }),
       body: z.union([
         // Template-based configuration
@@ -503,7 +503,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
         }
       ],
       params: z.object({
-        identityId: z.string().trim().describe(LDAP_AUTH.UPDATE.identityId)
+        identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.UPDATE.identityId)
       }),
       body: z
         .object({
@@ -641,7 +641,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
         }
       ],
       params: z.object({
-        identityId: z.string().trim().describe(LDAP_AUTH.RETRIEVE.identityId)
+        identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.RETRIEVE.identityId)
       }),
       response: {
         200: z.object({
@@ -651,7 +651,6 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
             encryptedLdapCaCertificate: true
           }).extend({
             bindDN: z.string(),
-            bindPass: z.string(),
             ldapCaCertificate: z.string().optional(),
             templateId: z.string().optional().nullable()
           })
@@ -700,7 +699,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
         }
       ],
       params: z.object({
-        identityId: z.string().trim().describe(LDAP_AUTH.REVOKE.identityId)
+        identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.REVOKE.identityId)
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/identity-ldap-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-ldap-auth-router.ts
@@ -296,7 +296,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
         }
       ],
       params: z.object({
-        identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.ATTACH.identityId)
+        identityId: z.string().trim().describe(LDAP_AUTH.ATTACH.identityId)
       }),
       body: z.union([
         // Template-based configuration
@@ -503,7 +503,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
         }
       ],
       params: z.object({
-        identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.UPDATE.identityId)
+        identityId: z.string().trim().describe(LDAP_AUTH.UPDATE.identityId)
       }),
       body: z
         .object({
@@ -641,7 +641,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
         }
       ],
       params: z.object({
-        identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.RETRIEVE.identityId)
+        identityId: z.string().trim().describe(LDAP_AUTH.RETRIEVE.identityId)
       }),
       response: {
         200: z.object({
@@ -699,7 +699,7 @@ export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider)
         }
       ],
       params: z.object({
-        identityId: z.string().trim().uuid("Identity ID must be a valid UUID").describe(LDAP_AUTH.REVOKE.identityId)
+        identityId: z.string().trim().describe(LDAP_AUTH.REVOKE.identityId)
       }),
       response: {
         200: z.object({

--- a/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
+++ b/backend/src/services/identity-ldap-auth/identity-ldap-auth-service.ts
@@ -786,12 +786,11 @@ export const identityLdapAuthServiceFactory = ({
     });
 
     const bindDN = decryptor({ cipherTextBlob: ldapIdentityAuth.encryptedBindDN }).toString();
-    const bindPass = decryptor({ cipherTextBlob: ldapIdentityAuth.encryptedBindPass }).toString();
     const ldapCaCertificate = ldapIdentityAuth.encryptedLdapCaCertificate
       ? decryptor({ cipherTextBlob: ldapIdentityAuth.encryptedLdapCaCertificate }).toString()
       : undefined;
 
-    return { ...ldapIdentityAuth, orgId: identityMembershipOrg.scopeOrgId, bindDN, bindPass, ldapCaCertificate };
+    return { ...ldapIdentityAuth, orgId: identityMembershipOrg.scopeOrgId, bindDN, ldapCaCertificate };
   };
 
   const revokeIdentityLdapAuth = async ({

--- a/frontend/src/hooks/api/identities/types.ts
+++ b/frontend/src/hooks/api/identities/types.ts
@@ -728,7 +728,6 @@ export type IdentityLdapAuth = {
   url?: string;
   bindDN?: string;
   templateId?: string;
-  bindPass?: string;
   searchBase?: string;
   searchFilter: string;
   ldapCaCertificate?: string;

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityLdapAuthForm.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgIdentityTab/components/IdentitySection/IdentityLdapAuthForm.tsx
@@ -72,7 +72,7 @@ import { AccessTokenTtlFields } from "./shared/AccessTokenTtlFields";
 import { TrustedIpsField } from "./shared/TrustedIpsField";
 import { IDENTITY_AUTH_FORM_ID, IdentityFormTab } from "./types";
 
-const buildSchema = (maxAccessTokenTTL: number) =>
+const buildSchema = (maxAccessTokenTTL: number, isUpdate: boolean) =>
   z
     .object({
       scope: z.enum(["template", "custom"]),
@@ -177,7 +177,7 @@ const buildSchema = (maxAccessTokenTTL: number) =>
             path: ["bindDN"]
           });
         }
-        if (!data.bindPass) {
+        if (!isUpdate && !data.bindPass) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             message: "Bind Pass is required when using custom scope",
@@ -250,7 +250,10 @@ export const IdentityLdapAuthForm = ({
     enabled: isUpdate
   });
 
-  const resolver = useMemo(() => zodResolver(buildSchema(maxAccessTokenTTL)), [maxAccessTokenTTL]);
+  const resolver = useMemo(
+    () => zodResolver(buildSchema(maxAccessTokenTTL, Boolean(isUpdate))),
+    [maxAccessTokenTTL, isUpdate]
+  );
 
   const {
     control,
@@ -342,7 +345,7 @@ export const IdentityLdapAuthForm = ({
         templateId: data.templateId || "",
         url: data.url || "",
         bindDN: data.bindDN || "",
-        bindPass: data.bindPass || "",
+        bindPass: "",
         searchBase: data.searchBase || "",
         searchFilter: data.searchFilter,
         ldapCaCertificate: data.ldapCaCertificate || undefined,
@@ -454,7 +457,7 @@ export const IdentityLdapAuthForm = ({
             ...basePayload,
             url: submissionUrl,
             bindDN: submissionBindDN,
-            bindPass: submissionBindPass,
+            ...(submissionBindPass ? { bindPass: submissionBindPass } : {}),
             searchBase: submissionSearchBase
           };
 
@@ -552,7 +555,7 @@ export const IdentityLdapAuthForm = ({
                           clearErrors("templateId");
                           setValue("url", data?.url || "");
                           setValue("bindDN", data?.bindDN || "");
-                          setValue("bindPass", data?.bindPass || "");
+                          setValue("bindPass", "");
                           setValue("searchBase", data?.searchBase || "");
                           setValue("ldapCaCertificate", data?.ldapCaCertificate || "");
                           return;
@@ -656,6 +659,11 @@ export const IdentityLdapAuthForm = ({
                     disabled={scope === "template"}
                     isError={Boolean(error)}
                   />
+                  {isUpdate && scope !== "template" && (
+                    <FieldDescription>
+                      Leave blank to keep the current password. Type a new value to rotate it.
+                    </FieldDescription>
+                  )}
                   <FieldError>{error?.message}</FieldError>
                 </Field>
               )}

--- a/frontend/src/views/IdentityAuthMethods/content/IdentityLdapAuthContent.tsx
+++ b/frontend/src/views/IdentityAuthMethods/content/IdentityLdapAuthContent.tsx
@@ -55,19 +55,6 @@ export const IdentityLdapAuthContent = ({
       />
       <IdentityAuthFieldDisplay label="LDAP URL">{data.url}</IdentityAuthFieldDisplay>
       <IdentityAuthFieldDisplay label="Bind DN">{data.bindDN}</IdentityAuthFieldDisplay>
-      <IdentityAuthFieldDisplay label="Bind Pass">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Badge variant="neutral">
-              <EyeIcon />
-              Reveal
-            </Badge>
-          </TooltipTrigger>
-          <TooltipContent side="right" className="max-w-xl p-2">
-            <p className="rounded-sm bg-container p-2 break-words">{data.bindPass}</p>
-          </TooltipContent>
-        </Tooltip>
-      </IdentityAuthFieldDisplay>
       <IdentityAuthFieldDisplay label="Search Base / DN">
         {data.searchBase}
       </IdentityAuthFieldDisplay>


### PR DESCRIPTION
## Context

The retrieve path no longer decrypts or serializes `bindPass`. Bind DN, URL, search base, and CA cert are unchanged. Attach still requires a password; update omits `bindPass` to keep the stored value. The identity LDAP auth form no longer hydrates the password field from the GET, and the auth-method details view no longer has a Reveal control. `identityId` path params on attach/update/get/revoke are validated as UUIDs.

## Steps to verify the change

1. Attach LDAP auth on a machine identity with a custom bind DN/password. Confirm attach still requires Bind Pass.
2. `GET /api/v1/auth/ldap-auth/identities/<identityId>` — response includes `bindDN` and has no `bindPass` (and no `encryptedBindPass`).
3. Open the identity LDAP auth details view: Bind Pass / Reveal is gone.
4. Edit the config, leave Bind Pass blank, save. LDAP login with the original bind credentials still works.
5. Edit again, set a new Bind Pass, save. LDAP login with the old password fails; the new one succeeds.
6. `GET /api/v1/auth/ldap-auth/identities/not-a-uuid` returns 400 (`Identity ID must be a valid UUID`).

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [x] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)