### PR TITLE
fix: collapse signer approvals into a single setup card until a policy exists

### DIFF
--- a/frontend/src/pages/cert-manager/SignerDetailPage/SignerDetailPage.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/SignerDetailPage.tsx
@@ -74,9 +74,8 @@ import {
 import { PkiDocsUrls } from "../pki-docs-urls";
 import { EditSignerModal } from "./components/EditSignerModal";
 import { ExportSignerCertModal } from "./components/ExportSignerCertModal";
-import { SignerApprovalPolicyTab } from "./components/SignerApprovalPolicyTab";
+import { SignerApprovalsSection } from "./components/SignerApprovalsSection";
 import { SignerMembersTab } from "./components/SignerMembersTab";
-import { SignerRequestsTab } from "./components/SignerRequestsTab";
 import { SigningOperationsTable } from "./components/SigningOperationsTable";
 
 type Tab = "activity" | "approvals" | "members";
@@ -299,21 +298,15 @@ export const SignerDetailPage = () => {
                 />
               </TabsContent>
               <TabsContent value="approvals" className="pt-2">
-                <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,5fr)]">
-                  <SignerApprovalPolicyTab signerId={signerId} />
-                  <SignerRequestsTab
-                    signerId={signerId}
-                    canPreApprove={Boolean(
-                      permission.can(SignerPermissionActions.PreApprove, SignerPermissionSub.Signer)
-                    )}
-                    canRequestSign={Boolean(
-                      permission.can(
-                        SignerPermissionActions.RequestSign,
-                        SignerPermissionSub.Signer
-                      )
-                    )}
-                  />
-                </div>
+                <SignerApprovalsSection
+                  signerId={signerId}
+                  canPreApprove={Boolean(
+                    permission.can(SignerPermissionActions.PreApprove, SignerPermissionSub.Signer)
+                  )}
+                  canRequestSign={Boolean(
+                    permission.can(SignerPermissionActions.RequestSign, SignerPermissionSub.Signer)
+                  )}
+                />
               </TabsContent>
               <TabsContent value="members" className="pt-2">
                 <SignerMembersTab signerId={signerId} />

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/SignerApprovalPolicyTab.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/SignerApprovalPolicyTab.tsx
@@ -1,10 +1,15 @@
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
-import { PencilIcon, UsersIcon } from "lucide-react";
+import { PencilIcon, PlusIcon, UsersIcon } from "lucide-react";
 
 import {
+  Button,
   Card,
   CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
   Empty,
+  EmptyContent,
   EmptyDescription,
   EmptyHeader,
   EmptyTitle,
@@ -25,6 +30,7 @@ import { EditSignerPolicyModal } from "./EditSignerPolicyModal";
 
 type Props = {
   signerId: string;
+  isStandalone?: boolean;
 };
 
 type ApproverDisplay = {
@@ -113,7 +119,7 @@ const ApproverStack = ({ approvers }: { approvers: ApproverDisplay[] }) => {
   );
 };
 
-export const SignerApprovalPolicyTab = ({ signerId }: Props) => {
+export const SignerApprovalPolicyTab = ({ signerId, isStandalone = false }: Props) => {
   const { data: policy, isLoading } = useGetSignerPolicy(signerId);
   const { permission } = useSignerPermission();
   const canManagePolicy = permission.can(
@@ -162,34 +168,37 @@ export const SignerApprovalPolicyTab = ({ signerId }: Props) => {
 
   const stepsCount = policy?.steps.length ?? 0;
 
+  const addPolicyButton = (
+    <Button variant="project" onClick={() => setIsEditOpen(true)} isDisabled={!canManagePolicy}>
+      <PlusIcon />
+      Add Policy
+    </Button>
+  );
+
   return (
     <>
       <Card>
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
-            <div className="text-lg leading-none font-semibold text-foreground">
-              Approval Policy
-            </div>
-            <p className="mt-1 text-sm text-accent">
-              {hasSteps
-                ? "Control when approval is required before signing."
-                : "Approval is not configured. Members can sign directly."}
-            </p>
-          </div>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <IconButton
-                aria-label="Edit policy"
-                variant="ghost"
-                onClick={() => setIsEditOpen(true)}
-                isDisabled={!canManagePolicy}
-              >
-                <PencilIcon />
-              </IconButton>
-            </TooltipTrigger>
-            <TooltipContent>Edit policy</TooltipContent>
-          </Tooltip>
-        </div>
+        <CardHeader className={isStandalone ? "border-b" : undefined}>
+          <CardTitle className="justify-between">
+            {isStandalone ? "Approvals" : "Approval Policy"}
+            {hasSteps && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <IconButton
+                    aria-label="Edit policy"
+                    variant="ghost"
+                    onClick={() => setIsEditOpen(true)}
+                    isDisabled={!canManagePolicy}
+                  >
+                    <PencilIcon />
+                  </IconButton>
+                </TooltipTrigger>
+                <TooltipContent>Edit policy</TooltipContent>
+              </Tooltip>
+            )}
+          </CardTitle>
+          <CardDescription>Control when approval is required before signing.</CardDescription>
+        </CardHeader>
         <CardContent>
           {hasSteps ? (
             <>
@@ -257,13 +266,27 @@ export const SignerApprovalPolicyTab = ({ signerId }: Props) => {
               </div>
             </>
           ) : (
-            <Empty className="border border-solid">
+            <Empty className="border">
               <EmptyHeader>
-                <EmptyTitle>No approval steps</EmptyTitle>
+                <EmptyTitle>No approval policy</EmptyTitle>
                 <EmptyDescription>
-                  Add approvers in the editor to require approval before signing.
+                  Any member can sign directly until you add approvers.
                 </EmptyDescription>
               </EmptyHeader>
+              <EmptyContent>
+                {canManagePolicy ? (
+                  addPolicyButton
+                ) : (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span>{addPolicyButton}</span>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      Requires the Manage Policy permission on this signer.
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </EmptyContent>
             </Empty>
           )}
         </CardContent>

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/SignerApprovalsSection.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/SignerApprovalsSection.tsx
@@ -1,0 +1,41 @@
+import { PageLoader } from "@app/components/v3";
+import {
+  SIGNER_TABLE_PAGE_SIZE,
+  useGetSignerPolicy,
+  useListSignerRequests
+} from "@app/hooks/api/signers";
+
+import { SignerApprovalPolicyTab } from "./SignerApprovalPolicyTab";
+import { SignerRequestsTab } from "./SignerRequestsTab";
+
+type Props = {
+  signerId: string;
+  canPreApprove: boolean;
+  canRequestSign: boolean;
+};
+
+export const SignerApprovalsSection = ({ signerId, canPreApprove, canRequestSign }: Props) => {
+  const { data: policy, isLoading: isPolicyLoading } = useGetSignerPolicy(signerId);
+  const { data: requests, isLoading: areRequestsLoading } = useListSignerRequests({
+    signerId,
+    offset: 0,
+    limit: SIGNER_TABLE_PAGE_SIZE
+  });
+
+  if (isPolicyLoading || areRequestsLoading) return <PageLoader />;
+
+  if (!policy?.hasSteps && requests?.totalCount === 0) {
+    return <SignerApprovalPolicyTab signerId={signerId} isStandalone />;
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,2fr)_minmax(0,5fr)]">
+      <SignerApprovalPolicyTab signerId={signerId} />
+      <SignerRequestsTab
+        signerId={signerId}
+        canPreApprove={canPreApprove}
+        canRequestSign={canRequestSign}
+      />
+    </div>
+  );
+};


### PR DESCRIPTION
## Context

When a signer has no approval policy and no requests, the Approvals tab now shows one card with an "Add Policy" button instead of two cards whose only affordance was an edit pencil. Once a policy or any request exists, the usual two-card split returns unchanged.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

Open a signer with no policy, go to Approvals, click "Add Policy", add a step and save. Both cards appear.

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)