### PR TITLE
fix(frontend): keep empty value out of key when pasting env vars

### DIFF
--- a/frontend/src/helpers/parseEnvVar.test.ts
+++ b/frontend/src/helpers/parseEnvVar.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { getKeyValue } from "./parseEnvVar";
+
+describe("getKeyValue", () => {
+  const delimiters = ["=", ":"];
+
+  it("splits a key and value on the first delimiter", () => {
+    assert.deepEqual(getKeyValue("KEY=value", delimiters), { key: "KEY", value: "value" });
+    assert.deepEqual(getKeyValue("TOKEN: abc", delimiters), { key: "TOKEN", value: "abc" });
+  });
+
+  it("keeps only the first delimiter as the split point", () => {
+    assert.deepEqual(getKeyValue("A=B=C", delimiters), { key: "A", value: "B=C" });
+  });
+
+  it("returns an empty value when the delimiter is at the end", () => {
+    // A trailing delimiter (e.g. an empty-valued env var) must still strip the
+    // delimiter from the key rather than keeping it (previously "KEY=").
+    assert.deepEqual(getKeyValue("KEY=", delimiters), { key: "KEY", value: "" });
+    assert.deepEqual(getKeyValue("TOKEN:", delimiters), { key: "TOKEN", value: "" });
+  });
+
+  it("treats content with no delimiter as the key", () => {
+    assert.deepEqual(getKeyValue("KEY", delimiters), { key: "KEY", value: "" });
+  });
+
+  it("returns empty key and value for empty content", () => {
+    assert.deepEqual(getKeyValue("", delimiters), { key: "", value: "" });
+  });
+});

--- a/frontend/src/helpers/parseEnvVar.ts
+++ b/frontend/src/helpers/parseEnvVar.ts
@@ -15,9 +15,7 @@ export const getKeyValue = (pastedContent: string, delimiters: string[]) => {
     }
   });
 
-  const hasValueAfterDelimiter = pastedContent.length > firstDelimiterIndex + foundDelimiter.length;
-
-  if (firstDelimiterIndex === -1 || !hasValueAfterDelimiter) {
+  if (firstDelimiterIndex === -1) {
     return { key: pastedContent.trim(), value: "" };
   }
 


### PR DESCRIPTION
## Context

When pasting env content into the Create Secret form, `getKeyValue` splits each line into a key and value on the first delimiter. It returned the **whole string as the key** whenever the delimiter was the last character, because `hasValueAfterDelimiter` was false in that case and the function fell back to `{ key: pastedContent.trim(), value: "" }`.

So an empty-valued line — which is common in `.env` files — was mis-parsed:

```
"KEY="    -> { key: "KEY=", value: "" }     (before)   ❌
"TOKEN:"  -> { key: "TOKEN:", value: "" }   (before)   ❌
```

Pasting `KEY=` created a secret literally named `KEY=` (delimiter included) instead of `KEY` with an empty value.

The fix drops the `hasValueAfterDelimiter` fallback: split on the delimiter whenever one is present, and only treat the whole string as the key when there is no delimiter at all. A trailing delimiter then yields an empty value, as expected.

```
"KEY="    -> { key: "KEY", value: "" }       (after)   ✔
"KEY=v"   -> { key: "KEY", value: "v" }       (unchanged)
"A=B=C"   -> { key: "A", value: "B=C" }        (unchanged, first delimiter wins)
"KEY"     -> { key: "KEY", value: "" }         (unchanged, no delimiter)
```

## Steps to verify the change

In the Secrets Overview, open Create Secret and paste a line with an empty value, e.g. `EMPTY=`. The key field is `EMPTY` (not `EMPTY=`) and the value is empty. Added unit tests in `frontend/src/helpers/parseEnvVar.test.ts` covering trailing-delimiter, no-delimiter, multi-delimiter, and empty-input cases.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format.
- [x] Tested locally (ran `getKeyValue` against the cases above; results match the tests).
- [ ] Updated docs (not needed)
- [ ] Updated CLAUDE.md files (not needed)
- [x] Read the contributing guide

_Disclosure: this change was written with a coding agent; I reviewed it and can explain every line._
