### PR TITLE
fix: cert dashboard and signer approval policy improvements

### DIFF
--- a/frontend/src/pages/cert-manager/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/DashboardPage.tsx
@@ -81,7 +81,7 @@ export const DashboardPage = () => {
               ) : (
                 <div className="flex flex-col gap-6">
                   <KpiCards stats={stats} onNavigate={navigateToInventory} />
-                  <div className="flex flex-wrap gap-4">
+                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
                     <DistributionCharts stats={stats} onNavigate={navigateToInventory} />
                     <ExpirationTimeline
                       buckets={stats.expirationBuckets}

--- a/frontend/src/pages/cert-manager/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/DashboardPage.tsx
@@ -81,7 +81,7 @@ export const DashboardPage = () => {
               ) : (
                 <div className="flex flex-col gap-6">
                   <KpiCards stats={stats} onNavigate={navigateToInventory} />
-                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+                  <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
                     <DistributionCharts stats={stats} onNavigate={navigateToInventory} />
                     <ExpirationTimeline
                       buckets={stats.expirationBuckets}

--- a/frontend/src/pages/cert-manager/DashboardPage/components/DistributionCharts.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/DistributionCharts.tsx
@@ -1,4 +1,5 @@
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip as RechartsTooltip } from "recharts";
+import { twMerge } from "tailwind-merge";
 
 import {
   Card,
@@ -16,7 +17,12 @@ import {
 import type { TDashboardDistribution, TDashboardStats } from "@app/hooks/api/certificates";
 import { certKeyAlgorithmToNameMap } from "@app/hooks/api/certificates/constants";
 
-import { CHART_COLORS, CHART_COLORS_HEX } from "./chart-theme";
+import {
+  CHART_COLORS_HEX,
+  CHART_OTHER_COLOR_HEX,
+  formatShare,
+  MAX_DONUT_SEGMENTS
+} from "./chart-theme";
 
 type Props = {
   stats: TDashboardStats;
@@ -24,6 +30,27 @@ type Props = {
 };
 
 type ChartKey = "enrollmentMethod" | "algorithm" | "ca";
+
+type Segment = TDashboardDistribution & { groupedCount?: number };
+
+const foldTail = (data: TDashboardDistribution[]): Segment[] => {
+  const sorted = data.filter((d) => d.count > 0).sort((a, b) => b.count - a.count);
+  if (sorted.length <= MAX_DONUT_SEGMENTS) return sorted;
+
+  const head = sorted.slice(0, MAX_DONUT_SEGMENTS - 1);
+  const tail = sorted.slice(MAX_DONUT_SEGMENTS - 1);
+  return [
+    ...head,
+    {
+      label: "Other",
+      count: tail.reduce((sum, d) => sum + d.count, 0),
+      groupedCount: tail.length
+    }
+  ];
+};
+
+const colorAt = (segment: Segment, idx: number) =>
+  segment.groupedCount ? CHART_OTHER_COLOR_HEX : CHART_COLORS_HEX[idx % CHART_COLORS_HEX.length];
 
 const DonutChart = ({
   title,
@@ -38,7 +65,7 @@ const DonutChart = ({
   chartKey: ChartKey;
   onSegmentClick?: (entry: TDashboardDistribution) => void;
 }) => {
-  const nonZeroData = data.filter((d) => d.count > 0);
+  const nonZeroData = foldTail(data);
   const total = data.reduce((sum, d) => sum + d.count, 0);
   const chartId = title.replace(/\s+/g, "-").toLowerCase();
   const formatLabel = (label: string) => {
@@ -52,7 +79,7 @@ const DonutChart = ({
   };
 
   return (
-    <Card className="flex h-auto min-w-[250px] flex-1 flex-col">
+    <Card className="flex h-auto min-w-0 flex-col">
       <CardHeader className="pb-0">
         <CardTitle className="text-base font-semibold">{title}</CardTitle>
         {subtitle && <CardDescription className="text-xs">{subtitle}</CardDescription>}
@@ -71,7 +98,7 @@ const DonutChart = ({
                 <PieChart>
                   <defs>
                     {nonZeroData.map((entry, idx) => {
-                      const hex = CHART_COLORS_HEX[idx % CHART_COLORS_HEX.length];
+                      const hex = colorAt(entry, idx);
                       return (
                         <linearGradient
                           key={`grad-${entry.label}`}
@@ -98,7 +125,10 @@ const DonutChart = ({
                     paddingAngle={2}
                     cursor="pointer"
                     stroke="none"
-                    onClick={(_entry, idx) => onSegmentClick?.(nonZeroData[idx])}
+                    onClick={(_entry, idx) => {
+                      const segment = nonZeroData[idx];
+                      if (!segment.groupedCount) onSegmentClick?.(segment);
+                    }}
                   >
                     {nonZeroData.map((entry, idx) => (
                       <Cell key={entry.label} fill={`url(#grad-${chartId}-${idx})`} />
@@ -118,17 +148,23 @@ const DonutChart = ({
             <div className="min-w-0 flex-1">
               <div className="space-y-1.5">
                 {nonZeroData.map((entry, idx) => {
-                  const pct = total > 0 ? Math.round((entry.count / total) * 100) : 0;
+                  const pct = formatShare(entry.count, total);
+                  const isOther = Boolean(entry.groupedCount);
                   return (
                     <button
                       key={entry.label}
                       type="button"
-                      className="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-xs transition-colors hover:bg-foreground/5"
-                      onClick={() => onSegmentClick?.(entry)}
+                      className={twMerge(
+                        "flex w-full items-center gap-2 rounded px-1 py-0.5 text-xs transition-colors",
+                        isOther ? "cursor-default" : "cursor-pointer hover:bg-foreground/5"
+                      )}
+                      onClick={() => {
+                        if (!isOther) onSegmentClick?.(entry);
+                      }}
                     >
                       <span
                         className="h-2.5 w-2.5 shrink-0 rounded-full"
-                        style={{ backgroundColor: CHART_COLORS[idx % CHART_COLORS.length] }}
+                        style={{ backgroundColor: colorAt(entry, idx) }}
                       />
                       <Tooltip>
                         <TooltipTrigger asChild>
@@ -136,9 +172,11 @@ const DonutChart = ({
                             {formatLabel(entry.label)}
                           </span>
                         </TooltipTrigger>
-                        <TooltipContent side="top">{formatLabel(entry.label)}</TooltipContent>
+                        <TooltipContent side="top">
+                          {isOther ? `${entry.groupedCount} more` : formatLabel(entry.label)}
+                        </TooltipContent>
                       </Tooltip>
-                      <span className="shrink-0 text-right text-muted">{pct}%</span>
+                      <span className="shrink-0 text-right text-muted">{pct}</span>
                       <span className="shrink-0 text-right font-medium text-foreground">
                         {entry.count}
                       </span>

--- a/frontend/src/pages/cert-manager/DashboardPage/components/DistributionCharts.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/DistributionCharts.tsx
@@ -19,7 +19,7 @@ import { certKeyAlgorithmToNameMap } from "@app/hooks/api/certificates/constants
 
 import {
   CHART_COLORS_HEX,
-  CHART_OTHER_COLOR_HEX,
+  CHART_OTHER_COLOR,
   formatShare,
   MAX_DONUT_SEGMENTS
 } from "./chart-theme";
@@ -49,8 +49,12 @@ const foldTail = (data: TDashboardDistribution[]): Segment[] => {
   ];
 };
 
+const OTHER_KEY = "__other__";
+
+const segmentKey = (segment: Segment) => (segment.groupedCount ? OTHER_KEY : segment.label);
+
 const colorAt = (segment: Segment, idx: number) =>
-  segment.groupedCount ? CHART_OTHER_COLOR_HEX : CHART_COLORS_HEX[idx % CHART_COLORS_HEX.length];
+  segment.groupedCount ? CHART_OTHER_COLOR : CHART_COLORS_HEX[idx % CHART_COLORS_HEX.length];
 
 const DonutChart = ({
   title,
@@ -101,7 +105,7 @@ const DonutChart = ({
                       const hex = colorAt(entry, idx);
                       return (
                         <linearGradient
-                          key={`grad-${entry.label}`}
+                          key={`grad-${segmentKey(entry)}`}
                           id={`grad-${chartId}-${idx}`}
                           x1="0"
                           y1="0"
@@ -131,7 +135,7 @@ const DonutChart = ({
                     }}
                   >
                     {nonZeroData.map((entry, idx) => (
-                      <Cell key={entry.label} fill={`url(#grad-${chartId}-${idx})`} />
+                      <Cell key={segmentKey(entry)} fill={`url(#grad-${chartId}-${idx})`} />
                     ))}
                   </Pie>
                   <RechartsTooltip
@@ -152,7 +156,7 @@ const DonutChart = ({
                   const isOther = Boolean(entry.groupedCount);
                   return (
                     <button
-                      key={entry.label}
+                      key={segmentKey(entry)}
                       type="button"
                       className={twMerge(
                         "flex w-full items-center gap-2 rounded px-1 py-0.5 text-xs transition-colors",

--- a/frontend/src/pages/cert-manager/DashboardPage/components/ExpirationTimeline.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/ExpirationTimeline.tsx
@@ -16,7 +16,7 @@ import {
 } from "@app/components/v3";
 import type { TExpirationBucket } from "@app/hooks/api/certificates";
 
-import { CHART_COLORS, CHART_COLORS_HEX, formatShare } from "./chart-theme";
+import { CHART_COLORS_HEX, formatShare } from "./chart-theme";
 
 type Props = {
   buckets: TExpirationBucket[];
@@ -53,7 +53,6 @@ export const ExpirationTimeline = ({ buckets, onNavigate }: Props) => {
       DONUT_SEGMENTS.map((seg, idx) => ({
         label: seg.label,
         count: seg.sourceBuckets.reduce((sum, key) => sum + (bucketMap.get(key) || 0), 0),
-        color: CHART_COLORS[idx % CHART_COLORS.length],
         segIdx: idx,
         filter: seg.filter
       })),
@@ -132,7 +131,7 @@ export const ExpirationTimeline = ({ buckets, onNavigate }: Props) => {
             </div>
             <div className="min-w-0 flex-1">
               <div className="space-y-1.5">
-                {chartData.map((item, idx) => {
+                {chartData.map((item) => {
                   const pct = formatShare(item.count, total);
                   return (
                     <button
@@ -145,7 +144,9 @@ export const ExpirationTimeline = ({ buckets, onNavigate }: Props) => {
                     >
                       <span
                         className="h-2.5 w-2.5 shrink-0 rounded-full"
-                        style={{ backgroundColor: CHART_COLORS[idx % CHART_COLORS.length] }}
+                        style={{
+                          backgroundColor: CHART_COLORS_HEX[item.segIdx % CHART_COLORS_HEX.length]
+                        }}
                       />
                       <Tooltip>
                         <TooltipTrigger asChild>

--- a/frontend/src/pages/cert-manager/DashboardPage/components/ExpirationTimeline.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/ExpirationTimeline.tsx
@@ -16,7 +16,7 @@ import {
 } from "@app/components/v3";
 import type { TExpirationBucket } from "@app/hooks/api/certificates";
 
-import { CHART_COLORS, CHART_COLORS_HEX } from "./chart-theme";
+import { CHART_COLORS, CHART_COLORS_HEX, formatShare } from "./chart-theme";
 
 type Props = {
   buckets: TExpirationBucket[];
@@ -64,7 +64,7 @@ export const ExpirationTimeline = ({ buckets, onNavigate }: Props) => {
   const total = chartData.reduce((sum, d) => sum + d.count, 0);
 
   return (
-    <Card className="flex h-auto min-w-[250px] flex-1 flex-col">
+    <Card className="flex h-auto min-w-0 flex-col">
       <CardHeader className="pb-0">
         <CardTitle className="text-base font-semibold">Expiration Timeline</CardTitle>
         <CardDescription className="text-xs">Certificates by time to expiry</CardDescription>
@@ -133,7 +133,7 @@ export const ExpirationTimeline = ({ buckets, onNavigate }: Props) => {
             <div className="min-w-0 flex-1">
               <div className="space-y-1.5">
                 {chartData.map((item, idx) => {
-                  const pct = total > 0 ? Math.round((item.count / total) * 100) : 0;
+                  const pct = formatShare(item.count, total);
                   return (
                     <button
                       key={item.label}
@@ -155,7 +155,7 @@ export const ExpirationTimeline = ({ buckets, onNavigate }: Props) => {
                         </TooltipTrigger>
                         <TooltipContent side="top">{item.label}</TooltipContent>
                       </Tooltip>
-                      <span className="shrink-0 text-right text-muted">{pct}%</span>
+                      <span className="shrink-0 text-right text-muted">{pct}</span>
                       <span className="shrink-0 text-right font-medium text-foreground">
                         {item.count}
                       </span>

--- a/frontend/src/pages/cert-manager/DashboardPage/components/KpiCards.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/KpiCards.tsx
@@ -3,6 +3,8 @@ import { AlertTriangle, FileCheck, FileClock, FileKey, FileX } from "lucide-reac
 import { Badge, Card, CardContent } from "@app/components/v3";
 import type { TDashboardStats } from "@app/hooks/api/certificates";
 
+import { formatShare } from "./chart-theme";
+
 type Props = {
   stats: TDashboardStats;
   onNavigate: (filters: Record<string, string | undefined>) => void;
@@ -60,10 +62,9 @@ const getBadge = (key: string, stats: TDashboardStats) => {
   const { total, active } = stats.totals;
 
   if (key === "total" && total > 0) {
-    const pct = Math.round((active / total) * 100);
     return {
       variant: "org" as const,
-      label: `${pct}% active`
+      label: `${formatShare(active, total)} active`
     };
   }
   if (key === "active" && total > 0) {

--- a/frontend/src/pages/cert-manager/DashboardPage/components/PqcReadinessChart.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/PqcReadinessChart.tsx
@@ -13,7 +13,7 @@ import {
 import type { TDashboardStats } from "@app/hooks/api/certificates";
 import { isPqcAlgorithm } from "@app/hooks/api/certificates/constants";
 
-import { CHART_COLORS, CHART_COLORS_HEX } from "./chart-theme";
+import { CHART_COLORS_HEX, formatShare } from "./chart-theme";
 
 type Props = {
   stats: TDashboardStats;
@@ -111,7 +111,7 @@ export const PqcReadinessChart = ({ stats, onNavigate }: Props) => {
             <div className="min-w-0 flex-1">
               <div className="space-y-1.5">
                 {nonZeroData.map((entry, idx) => {
-                  const pct = total > 0 ? Math.round((entry.count / total) * 100) : 0;
+                  const pct = formatShare(entry.count, total);
                   return (
                     <button
                       key={entry.label}
@@ -121,12 +121,12 @@ export const PqcReadinessChart = ({ stats, onNavigate }: Props) => {
                     >
                       <span
                         className="h-2.5 w-2.5 shrink-0 rounded-full"
-                        style={{ backgroundColor: CHART_COLORS[idx % CHART_COLORS.length] }}
+                        style={{ backgroundColor: CHART_COLORS_HEX[idx % CHART_COLORS_HEX.length] }}
                       />
                       <span className="min-w-0 flex-1 truncate text-left text-foreground">
                         {entry.label}
                       </span>
-                      <span className="shrink-0 text-right text-muted">{pct}%</span>
+                      <span className="shrink-0 text-right text-muted">{pct}</span>
                       <span className="shrink-0 text-right font-medium text-foreground">
                         {entry.count}
                       </span>

--- a/frontend/src/pages/cert-manager/DashboardPage/components/ValidityReadinessSection.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/ValidityReadinessSection.tsx
@@ -23,7 +23,7 @@ import {
 } from "@app/components/v3";
 import type { TDashboardStats } from "@app/hooks/api/certificates";
 
-import { CHART_COLORS, CHART_COLORS_HEX } from "./chart-theme";
+import { CHART_COLORS, CHART_COLORS_HEX, formatShare } from "./chart-theme";
 
 type Props = {
   stats: TDashboardStats;
@@ -292,7 +292,7 @@ const ValidityDistribution = ({ buckets }: { buckets: TDashboardStats["validityB
           <div className="min-w-0 flex-1">
             <div className="space-y-1.5">
               {chartData.map((item) => {
-                const pct = total > 0 ? Math.round((item.count / total) * 100) : 0;
+                const pct = formatShare(item.count, total);
                 return (
                   <div
                     key={item.bucket}
@@ -310,7 +310,7 @@ const ValidityDistribution = ({ buckets }: { buckets: TDashboardStats["validityB
                       </TooltipTrigger>
                       <TooltipContent side="top">{item.compliance}</TooltipContent>
                     </Tooltip>
-                    <span className="shrink-0 text-right text-muted">{pct}%</span>
+                    <span className="shrink-0 text-right text-muted">{pct}</span>
                     <span className="shrink-0 text-right font-medium text-foreground">
                       {item.count}
                     </span>

--- a/frontend/src/pages/cert-manager/DashboardPage/components/chart-theme.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/chart-theme.tsx
@@ -27,7 +27,7 @@ export const CHART_COLORS_HEX = [
 
 export const MAX_DONUT_SEGMENTS = 6;
 
-export const CHART_OTHER_COLOR_HEX = "#8c8f96";
+export const CHART_OTHER_COLOR = "var(--color-muted)";
 
 export const formatShare = (count: number, total: number) => {
   if (total <= 0) return "0%";

--- a/frontend/src/pages/cert-manager/DashboardPage/components/chart-theme.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/chart-theme.tsx
@@ -33,6 +33,7 @@ export const formatShare = (count: number, total: number) => {
   if (total <= 0) return "0%";
   const share = (count / total) * 100;
   if (share > 0 && share < 1) return "<1%";
+  if (share > 99 && share < 100) return ">99%";
   return `${Math.round(share)}%`;
 };
 

--- a/frontend/src/pages/cert-manager/DashboardPage/components/chart-theme.tsx
+++ b/frontend/src/pages/cert-manager/DashboardPage/components/chart-theme.tsx
@@ -25,6 +25,17 @@ export const CHART_COLORS_HEX = [
   "#b8a060" // olive gold
 ];
 
+export const MAX_DONUT_SEGMENTS = 6;
+
+export const CHART_OTHER_COLOR_HEX = "#8c8f96";
+
+export const formatShare = (count: number, total: number) => {
+  if (total <= 0) return "0%";
+  const share = (count / total) * 100;
+  if (share > 0 && share < 1) return "<1%";
+  return `${Math.round(share)}%`;
+};
+
 export const TREND_COLORS = {
   issued: "var(--color-org)",
   expired: "var(--color-danger)",

--- a/frontend/src/pages/cert-manager/RequestsPage/RequestsPage.tsx
+++ b/frontend/src/pages/cert-manager/RequestsPage/RequestsPage.tsx
@@ -161,6 +161,20 @@ export const RequestsPage = () => {
     })
   );
 
+  const pendingApplicationCount = useMemo(
+    () =>
+      (requests as TApprovalRequest[]).filter((r) => r.status === ApprovalRequestStatus.Pending)
+        .length,
+    [requests]
+  );
+  const pendingSigningCount = useMemo(
+    () =>
+      (signingRequests as TApprovalRequest[]).filter(
+        (r) => r.status === ApprovalRequestStatus.Pending
+      ).length,
+    [signingRequests]
+  );
+
   // resolve names only for the applications actually referenced by the visible
   // requests, rather than loading the project's entire application list
   const referencedAppIds = useMemo(() => {
@@ -247,11 +261,21 @@ export const RequestsPage = () => {
               }
             >
               <TabList>
-                <Tab variant="project" value="application-requests">
+                <Tab variant="project" value="application-requests" className="gap-2">
                   Application Requests
+                  {Boolean(pendingApplicationCount) && (
+                    <Badge variant="warning" isSquare>
+                      {pendingApplicationCount}
+                    </Badge>
+                  )}
                 </Tab>
-                <Tab variant="project" value="signing-requests">
+                <Tab variant="project" value="signing-requests" className="gap-2">
                   Signing Requests
+                  {Boolean(pendingSigningCount) && (
+                    <Badge variant="warning" isSquare>
+                      {pendingSigningCount}
+                    </Badge>
+                  )}
                 </Tab>
               </TabList>
 

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/EditSignerPolicyModal/EditSignerPolicyModal.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/EditSignerPolicyModal/EditSignerPolicyModal.tsx
@@ -223,6 +223,7 @@ export const EditSignerPolicyModal = ({
 
   const isLast = safeStep === WIZARD_STEPS.length - 1;
   const showLimitsTab = safeStep === 1;
+  const isCreating = !existingPolicy?.hasSteps;
 
   return (
     <Sheet open={isOpen} onOpenChange={handleClose}>
@@ -235,7 +236,7 @@ export const EditSignerPolicyModal = ({
               </div>
               <div>
                 <div className="flex items-center gap-x-2 text-mineshaft-300">
-                  Edit approval policy
+                  {isCreating ? "Add approval policy" : "Edit approval policy"}
                   <DocumentationLinkBadge href={PkiDocsUrls.codeSigning.approvals.policy} />
                 </div>
                 <p className="text-sm leading-4 text-mineshaft-400">

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/SignerApprovalPolicyTab.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/SignerApprovalPolicyTab.tsx
@@ -169,10 +169,38 @@ export const SignerApprovalPolicyTab = ({ signerId, isStandalone = false }: Prop
   const stepsCount = policy?.steps.length ?? 0;
 
   const addPolicyButton = (
-    <Button variant="project" onClick={() => setIsEditOpen(true)} isDisabled={!canManagePolicy}>
+    <Button
+      variant="project"
+      isFullWidth={!isStandalone}
+      onClick={() => setIsEditOpen(true)}
+      isDisabled={!canManagePolicy}
+    >
       <PlusIcon />
       Add Policy
     </Button>
+  );
+
+  const addPolicyAction = canManagePolicy ? (
+    addPolicyButton
+  ) : (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className={isStandalone ? undefined : "block w-full"}>{addPolicyButton}</span>
+      </TooltipTrigger>
+      <TooltipContent>Requires the Manage Policy permission on this signer.</TooltipContent>
+    </Tooltip>
+  );
+
+  const unconfiguredBody = isStandalone ? (
+    <Empty className="border">
+      <EmptyHeader>
+        <EmptyTitle>No approval policy</EmptyTitle>
+        <EmptyDescription>Any member can sign directly until you add approvers.</EmptyDescription>
+      </EmptyHeader>
+      <EmptyContent>{addPolicyAction}</EmptyContent>
+    </Empty>
+  ) : (
+    addPolicyAction
   );
 
   return (
@@ -266,28 +294,7 @@ export const SignerApprovalPolicyTab = ({ signerId, isStandalone = false }: Prop
               </div>
             </>
           ) : (
-            <Empty className="border">
-              <EmptyHeader>
-                <EmptyTitle>No approval policy</EmptyTitle>
-                <EmptyDescription>
-                  Any member can sign directly until you add approvers.
-                </EmptyDescription>
-              </EmptyHeader>
-              <EmptyContent>
-                {canManagePolicy ? (
-                  addPolicyButton
-                ) : (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span>{addPolicyButton}</span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      Requires the Manage Policy permission on this signer.
-                    </TooltipContent>
-                  </Tooltip>
-                )}
-              </EmptyContent>
-            </Empty>
+            unconfiguredBody
           )}
         </CardContent>
       </Card>

--- a/frontend/src/pages/cert-manager/SignerDetailPage/components/SigningOperationsTable.tsx
+++ b/frontend/src/pages/cert-manager/SignerDetailPage/components/SigningOperationsTable.tsx
@@ -132,89 +132,93 @@ export const SigningOperationsTable = ({ signer, signerId, projectId }: Props) =
           </CardAction>
         </CardHeader>
         <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Timestamp</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Algorithm</TableHead>
-                <TableHead>Data Hash</TableHead>
-                <TableHead>Actor</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {isLoading &&
-                Array.from({ length: 5 }).map((_, i) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <TableRow key={`skeleton-${i}`}>
-                    {Array.from({ length: 5 }).map((__, j) => (
-                      // eslint-disable-next-line react/no-array-index-key
-                      <TableCell key={`skeleton-cell-${j}`}>
-                        <div className="h-4 w-full animate-pulse rounded bg-mineshaft-700" />
+          {(isLoading || operations.length > 0) && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Timestamp</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Algorithm</TableHead>
+                  <TableHead>Data Hash</TableHead>
+                  <TableHead>Actor</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isLoading &&
+                  Array.from({ length: 5 }).map((_, i) => (
+                    // eslint-disable-next-line react/no-array-index-key
+                    <TableRow key={`skeleton-${i}`}>
+                      {Array.from({ length: 5 }).map((__, j) => (
+                        // eslint-disable-next-line react/no-array-index-key
+                        <TableCell key={`skeleton-cell-${j}`}>
+                          <div className="h-4 w-full animate-pulse rounded bg-mineshaft-700" />
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                {!isLoading &&
+                  operations.map((op) => (
+                    <TableRow
+                      key={op.id}
+                      className="cursor-pointer transition-colors hover:bg-mineshaft-700 [&>td]:py-3"
+                      onClick={() =>
+                        navigate({
+                          to: "/organizations/$orgId/projects/cert-manager/$projectId/code-signing/$signerId/operations/$operationId",
+                          params: {
+                            orgId: currentOrg.id,
+                            projectId,
+                            signerId,
+                            operationId: op.id
+                          }
+                        })
+                      }
+                    >
+                      <TableCell>
+                        {format(new Date(op.createdAt), "MMM d, yyyy HH:mm:ss")}
                       </TableCell>
-                    ))}
-                  </TableRow>
-                ))}
-              {!isLoading &&
-                operations.map((op) => (
-                  <TableRow
-                    key={op.id}
-                    className="cursor-pointer transition-colors hover:bg-mineshaft-700 [&>td]:py-3"
-                    onClick={() =>
-                      navigate({
-                        to: "/organizations/$orgId/projects/cert-manager/$projectId/code-signing/$signerId/operations/$operationId",
-                        params: {
-                          orgId: currentOrg.id,
-                          projectId,
-                          signerId,
-                          operationId: op.id
-                        }
-                      })
-                    }
-                  >
-                    <TableCell>{format(new Date(op.createdAt), "MMM d, yyyy HH:mm:ss")}</TableCell>
-                    <TableCell>
-                      <Badge variant={getSigningOperationStatusBadgeVariant(op.status)}>
-                        {signingOperationStatusLabels[op.status] ?? op.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-xs">
-                      {signingAlgorithmLabels[op.signingAlgorithm] ?? op.signingAlgorithm}
-                    </TableCell>
-                    <TableCell className="max-w-[120px] truncate font-mono text-xs">
-                      {op.dataHash}
-                    </TableCell>
-                    <TableCell onClick={(e) => e.stopPropagation()}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="flex items-center gap-1.5">
-                            {op.actorType === SigningActorType.User ? (
-                              <UserIcon className="size-3.5 text-muted" />
-                            ) : (
-                              <HardDriveIcon className="size-3.5 text-muted" />
-                            )}
-                            <button
-                              type="button"
-                              onClick={
-                                isActorClickable(op) ? () => handleActorClick(op) : undefined
-                              }
-                              className={
-                                isActorClickable(op)
-                                  ? "cursor-pointer font-medium text-accent underline"
-                                  : "text-muted"
-                              }
-                            >
-                              {getActorDisplayName(op.actorType, op.actorName)}
-                            </button>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent>{op.actorName ?? op.actorId}</TooltipContent>
-                      </Tooltip>
-                    </TableCell>
-                  </TableRow>
-                ))}
-            </TableBody>
-          </Table>
+                      <TableCell>
+                        <Badge variant={getSigningOperationStatusBadgeVariant(op.status)}>
+                          {signingOperationStatusLabels[op.status] ?? op.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-xs">
+                        {signingAlgorithmLabels[op.signingAlgorithm] ?? op.signingAlgorithm}
+                      </TableCell>
+                      <TableCell className="max-w-[120px] truncate font-mono text-xs">
+                        {op.dataHash}
+                      </TableCell>
+                      <TableCell onClick={(e) => e.stopPropagation()}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="flex items-center gap-1.5">
+                              {op.actorType === SigningActorType.User ? (
+                                <UserIcon className="size-3.5 text-muted" />
+                              ) : (
+                                <HardDriveIcon className="size-3.5 text-muted" />
+                              )}
+                              <button
+                                type="button"
+                                onClick={
+                                  isActorClickable(op) ? () => handleActorClick(op) : undefined
+                                }
+                                className={
+                                  isActorClickable(op)
+                                    ? "cursor-pointer font-medium text-accent underline"
+                                    : "text-muted"
+                                }
+                              >
+                                {getActorDisplayName(op.actorType, op.actorName)}
+                              </button>
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>{op.actorName ?? op.actorId}</TooltipContent>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          )}
           {!isLoading && operations.length === 0 && (
             <Empty className="border border-solid">
               <EmptyHeader>


### PR DESCRIPTION
## Context

Fixes a set of small UI issues across cert manager:

- Approval Requests tabs now show a pending count each, so the sidebar badge points at the right tab.
- The approval policy sheet says "Add approval policy" when there is no policy yet, instead of "Edit".
- Signing History hides its table headers when there is no activity.
- When a signer has requests but no policy, the Add Policy button goes full width instead of sitting squished in an empty state.
- Dashboard distribution charts move to a 2x2 grid, cap at 5 categories plus "Other", and no longer truncate labels.
- Slices under one percent read `<1%` instead of `0%`.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)