### PR TITLE
docs(cli): service-token only supports creating tokens

### DIFF
--- a/docs/cli/commands/service-token.mdx
+++ b/docs/cli/commands/service-token.mdx
@@ -16,8 +16,8 @@ infisical service-token create --scope=dev:/global --scope=dev:/backend --access
 
 ## Description
 
-The Infisical `service-token` command allows you to manage service tokens for a given Infisical project.
-With this command, you can create, view, and delete service tokens.
+The Infisical `service-token` command allows you to create service tokens for a given Infisical project.
+Viewing and revoking existing service tokens is done in the Infisical web interface or via the API.
 
 <Accordion title="service-token create" defaultOpen="true">
   Use this command to create a service token

--- a/docs/cli/commands/service-token.mdx
+++ b/docs/cli/commands/service-token.mdx
@@ -17,7 +17,7 @@ infisical service-token create --scope=dev:/global --scope=dev:/backend --access
 ## Description
 
 The Infisical `service-token` command allows you to create service tokens for a given Infisical project.
-Viewing and revoking existing service tokens is done in the Infisical web interface or via the API.
+Viewing and revoking existing service tokens is done in the [Infisical web interface](/documentation/platform/token) under Access Control > Service Tokens, or via the API.
 
 <Accordion title="service-token create" defaultOpen="true">
   Use this command to create a service token


### PR DESCRIPTION
Fixes #7810

The page said `infisical service-token` can *create, view, and delete* tokens. The CLI actually registers exactly one subcommand, `create` (`packages/cmd/tokens.go` in Infisical/cli), and bare `infisical service-token` prints nothing useful - so `view` and `delete` read like subcommands that went missing, and anyone trying to revoke a token hits a wall.

The intro now matches reality: the command creates tokens, and viewing/revoking happens in the web interface under Access Control > Service Tokens (linked).
