### PR TITLE
fix(webhook): send type-aware payload for webhook test events

### DIFF
--- a/backend/src/services/webhook/webhook-fns.test.ts
+++ b/backend/src/services/webhook/webhook-fns.test.ts
@@ -54,6 +54,53 @@ describe("getWebhookPayload: secrets.modified", () => {
   });
 });
 
+describe("getWebhookPayload: test", () => {
+  test("general payload keeps the documented shape", () => {
+    const result = getWebhookPayload({
+      type: WebhookEvents.TestEvent,
+      payload: { ...projectFields, type: WebhookType.GENERAL }
+    });
+
+    expect(result).toEqual({
+      event: "test",
+      project: {
+        workspaceId: "proj-1",
+        projectId: "proj-1",
+        projectName: "Secrets management",
+        environment: "prod",
+        environmentName: "Production",
+        secretPath: "/api"
+      }
+    });
+  });
+
+  test("slack payload carries a text line so incoming webhooks accept it", () => {
+    const result = getWebhookPayload({
+      type: WebhookEvents.TestEvent,
+      payload: { ...projectFields, type: WebhookType.SLACK }
+    }) as { text: string; attachments: { fields: { title: string }[] }[] };
+
+    expect(result.text).toBe("Infisical webhook test successful.");
+    expect(result.attachments).toHaveLength(1);
+    expect(result.attachments[0].fields.map((f) => f.title)).toEqual([
+      "Project",
+      "Environment",
+      "Environment Name",
+      "Secret Path"
+    ]);
+  });
+
+  test("teams payload is an adaptive card with a fact set", () => {
+    const result = getWebhookPayload({
+      type: WebhookEvents.TestEvent,
+      payload: { ...projectFields, type: WebhookType.MICROSOFT_TEAMS }
+    }) as { type: string; attachments: { content: { body: { type: string }[] } }[] };
+
+    expect(result.type).toBe("message");
+    expect(result.attachments[0].content.body.map((b) => b.type)).toEqual(["TextBlock", "FactSet"]);
+  });
+});
+
 describe("getWebhookPayload: secrets.rotation-failed", () => {
   test("general payload nests rotation detail under project", () => {
     const result = getWebhookPayload({

--- a/backend/src/services/webhook/webhook-fns.ts
+++ b/backend/src/services/webhook/webhook-fns.ts
@@ -578,7 +578,76 @@ export const getWebhookPayload = (event: TWebhookPayloads) => {
   }
 
   if (event.type === WebhookEvents.TestEvent) {
-    const { projectName, projectId, environment, environmentName, secretPath } = event.payload;
+    const { projectName, projectId, environment, environmentName, secretPath, type } = event.payload;
+
+    // Slack incoming webhooks reject bodies without text/blocks/attachments, and
+    // Teams Workflows expect an adaptive card - mirror the real-event payloads so
+    // the test button exercises the same format the consumer will receive.
+    if (type === WebhookType.SLACK) {
+      return {
+        text: "Infisical webhook test successful.",
+        attachments: [
+          {
+            color: "#E7F256",
+            fields: [
+              {
+                title: "Project",
+                value: projectName || "",
+                short: false
+              },
+              {
+                title: "Environment",
+                value: environment,
+                short: false
+              },
+              {
+                title: "Environment Name",
+                value: environmentName || "",
+                short: false
+              },
+              {
+                title: "Secret Path",
+                value: secretPath || "",
+                short: false
+              }
+            ]
+          }
+        ]
+      };
+    }
+
+    if (type === WebhookType.MICROSOFT_TEAMS) {
+      return {
+        type: "message",
+        attachments: [
+          {
+            contentType: "application/vnd.microsoft.card.adaptive",
+            content: {
+              type: "AdaptiveCard",
+              version: "1.2",
+              body: [
+                {
+                  type: "TextBlock",
+                  size: "Medium",
+                  weight: "Bolder",
+                  text: "Infisical webhook test successful."
+                },
+                {
+                  type: "FactSet",
+                  facts: [
+                    { title: "Project", value: projectName || "" },
+                    { title: "Environment", value: environment },
+                    { title: "Environment Name", value: environmentName || "" },
+                    { title: "Secret Path", value: secretPath || "" }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      };
+    }
+
     return {
       event: event.type,
       project: {


### PR DESCRIPTION
Fixes #7881

The Test button on a Slack (or Teams) webhook always failed because `getWebhookPayload`'s TestEvent branch ignored the webhook type and sent the General-shaped body - Slack incoming webhooks require a `text` field and answer `400 no_text`, as the issue describes. Real secret-change events to the same URL work fine, which made this extra confusing for users.

The fix builds the test payload per webhook type, mirroring the real-event formats:

- **Slack**: `text` line plus attachment fields (Project, Environment, Environment Name, Secret Path)
- **Microsoft Teams**: adaptive card with a TextBlock + FactSet, same facts
- **General**: unchanged

Validation: `backend` unit tests pass - `npx vitest run -c vitest.unit.config.mts src/services/webhook/webhook-fns.test.ts`, 37/37 including three new cases covering the test-event payload for General, Slack and Teams.
