### PR TITLE
feat: set project retention limits

### DIFF
--- a/backend/e2e-test/routes/v1/project.spec.ts
+++ b/backend/e2e-test/routes/v1/project.spec.ts
@@ -39,6 +39,17 @@ const getProject = async (projectId: string) => {
   });
 };
 
+const updateProject = async (projectId: string, body: Record<string, unknown>) => {
+  return testServer.inject({
+    method: "PATCH",
+    url: `/api/v1/projects/${projectId}`,
+    headers: {
+      authorization: `Bearer ${jwtAuthToken}`
+    },
+    body
+  });
+};
+
 const listProjects = async (): Promise<TProject[]> => {
   const res = await testServer.inject({
     method: "GET",
@@ -89,5 +100,31 @@ describe("Project deletion (soft-delete + async cleanup)", async () => {
 
     // second delete resolves the project via the soft-delete-filtered read → not found
     expect((await deleteProject(project.id)).statusCode).toBe(404);
+  });
+});
+
+describe("Project update (audit logs retention)", async () => {
+  test("rejects a retention period the plan does not allow", async () => {
+    const project = await createProject("e2e-retention-plan-limit");
+
+    const res = await updateProject(project.id, { auditLogsRetentionDays: 30 });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.payload).message).toContain("audit logs");
+
+    expect(JSON.parse((await getProject(project.id)).payload).project.auditLogsRetentionDays).toBeNull();
+
+    await deleteProject(project.id);
+  });
+
+  test("leaves other fields updatable", async () => {
+    const project = await createProject("e2e-retention-other-fields");
+
+    const res = await updateProject(project.id, { name: "e2e-retention-renamed" });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload).project.name).toBe("e2e-retention-renamed");
+
+    await deleteProject(project.id);
   });
 });

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -1048,7 +1048,9 @@ export const PROJECTS = {
     defaultProduct: "The default product in which the project will open",
     secretDetectionIgnoreValues: "The list of secret values to ignore for secret detection.",
     enforceEncryptedSecretManagerSecretMetadata:
-      "Enable or disable enforcement of encrypted secret metadata for the project."
+      "Enable or disable enforcement of encrypted secret metadata for the project.",
+    auditLogsRetentionDays:
+      "The number of days to retain audit logs for. Can only be set on self-hosted and dedicated instances, and cannot exceed the retention period included in your plan."
   },
   GET_KEY: {
     projectId: "The ID of the project to get the key from."

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -516,7 +516,8 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
           .array(z.string())
           .optional()
           .describe(PROJECTS.UPDATE.secretDetectionIgnoreValues),
-        pitVersionLimit: z.number().min(1).max(100).optional()
+        pitVersionLimit: z.number().min(1).max(100).optional(),
+        auditLogsRetentionDays: z.number().int().min(0).optional().describe(PROJECTS.UPDATE.auditLogsRetentionDays)
       }),
       response: {
         200: z.object({
@@ -541,7 +542,8 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
           showSnapshotsLegacy: req.body.showSnapshotsLegacy,
           secretDetectionIgnoreValues: req.body.secretDetectionIgnoreValues,
           pitVersionLimit: req.body.pitVersionLimit,
-          enforceEncryptedSecretManagerSecretMetadata: req.body.enforceEncryptedSecretManagerSecretMetadata
+          enforceEncryptedSecretManagerSecretMetadata: req.body.enforceEncryptedSecretManagerSecretMetadata,
+          auditLogsRetentionDays: req.body.auditLogsRetentionDays
         },
         actorAuthMethod: req.permission.authMethod,
         actorId: req.permission.id,

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -517,7 +517,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
           .optional()
           .describe(PROJECTS.UPDATE.secretDetectionIgnoreValues),
         pitVersionLimit: z.number().min(1).max(100).optional(),
-        auditLogsRetentionDays: z.number().min(0).max(365).optional().describe(PROJECTS.UPDATE.auditLogsRetentionDays)
+        auditLogsRetentionDays: z.number().min(1).max(365).optional().describe(PROJECTS.UPDATE.auditLogsRetentionDays)
       }),
       response: {
         200: z.object({

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -517,7 +517,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
           .optional()
           .describe(PROJECTS.UPDATE.secretDetectionIgnoreValues),
         pitVersionLimit: z.number().min(1).max(100).optional(),
-        auditLogsRetentionDays: z.number().int().min(0).optional().describe(PROJECTS.UPDATE.auditLogsRetentionDays)
+        auditLogsRetentionDays: z.number().min(0).max(365).optional().describe(PROJECTS.UPDATE.auditLogsRetentionDays)
       }),
       response: {
         200: z.object({

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -920,6 +920,8 @@ export const projectServiceFactory = ({
 
   const updateProject = async ({ actor, actorId, actorOrgId, actorAuthMethod, update, filter }: TUpdateProjectDTO) => {
     const project = await projectDAL.findProjectByFilter(filter);
+    const appCfg = getConfig();
+    const plan = await licenseService.getPlan(project.orgId);
 
     const { permission, hasRole } = await permissionService.getProjectPermission({
       actor,
@@ -943,6 +945,33 @@ export const projectServiceFactory = ({
       });
     }
 
+    if (update.auditLogsRetentionDays !== undefined) {
+      if (!hasRole(ProjectMembershipRole.Admin)) {
+        throw new ForbiddenRequestError({
+          message: "Only project admins can update the audit logs retention period"
+        });
+      }
+
+      if (appCfg.isCloud) {
+        throw new BadRequestError({
+          message: "The audit logs retention period can not be updated on Infisical Cloud instances."
+        });
+      }
+
+      if (!plan.auditLogs) {
+        throw new BadRequestError({
+          message:
+            "Failed to update the audit logs retention period because audit logs are not included in your current plan. Upgrade your plan to configure retention."
+        });
+      }
+
+      if (update.auditLogsRetentionDays > plan.auditLogsRetentionDays) {
+        throw new BadRequestError({
+          message: `Failed to update the audit logs retention period because your current plan allows a maximum of ${plan.auditLogsRetentionDays} days. Upgrade your plan to increase this limit.`
+        });
+      }
+    }
+
     try {
       const updatedProject = await projectDAL.updateById(project.id, {
         name: update.name,
@@ -956,7 +985,8 @@ export const projectServiceFactory = ({
         showSnapshotsLegacy: update.showSnapshotsLegacy,
         secretDetectionIgnoreValues: update.secretDetectionIgnoreValues,
         pitVersionLimit: update.pitVersionLimit,
-        enforceEncryptedSecretManagerSecretMetadata: update.enforceEncryptedSecretManagerSecretMetadata
+        enforceEncryptedSecretManagerSecretMetadata: update.enforceEncryptedSecretManagerSecretMetadata,
+        auditLogsRetentionDays: update.auditLogsRetentionDays
       });
 
       return updatedProject;

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -921,7 +921,6 @@ export const projectServiceFactory = ({
   const updateProject = async ({ actor, actorId, actorOrgId, actorAuthMethod, update, filter }: TUpdateProjectDTO) => {
     const project = await projectDAL.findProjectByFilter(filter);
     const appCfg = getConfig();
-    const plan = await licenseService.getPlan(project.orgId);
 
     const { permission, hasRole } = await permissionService.getProjectPermission({
       actor,
@@ -957,6 +956,8 @@ export const projectServiceFactory = ({
           message: "The audit logs retention period can not be updated on Infisical Cloud instances."
         });
       }
+
+      const plan = await licenseService.getPlan(project.orgId);
 
       if (!plan.auditLogs) {
         throw new BadRequestError({

--- a/backend/src/services/project/project-types.ts
+++ b/backend/src/services/project/project-types.ts
@@ -99,6 +99,7 @@ export type TUpdateProjectDTO = {
     showSnapshotsLegacy?: boolean;
     secretDetectionIgnoreValues?: string[];
     enforceEncryptedSecretManagerSecretMetadata?: boolean;
+    auditLogsRetentionDays?: number;
   };
 } & Omit<TProjectPermission, "projectId">;
 


### PR DESCRIPTION
## Context

Added support for configuring project retention limits in the regular project update endpoint.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)