### PR TITLE
fix(backend): align project slug validation

### DIFF
--- a/backend/src/server/lib/schemas.test.ts
+++ b/backend/src/server/lib/schemas.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { projectSlugSchema, slugSchema } from "./schemas";
+
+describe("projectSlugSchema", () => {
+  it("accepts underscores between project slug words", () => {
+    expect(projectSlugSchema().safeParse("repro_test_proj").success).toBe(true);
+  });
+
+  it.each(["_repro", "repro_", "repro__project", "repro_-project", "Repro_project"])(
+    "rejects an invalid project slug: %s",
+    (slug) => {
+      expect(projectSlugSchema().safeParse(slug).success).toBe(false);
+    }
+  );
+
+  it("does not change the generic slug format", () => {
+    expect(slugSchema().safeParse("repro_test_proj").success).toBe(false);
+  });
+});

--- a/backend/src/server/lib/schemas.ts
+++ b/backend/src/server/lib/schemas.ts
@@ -26,6 +26,29 @@ export const slugSchema = ({ min = 1, max = 64, field = "Slug" }: SlugSchemaInpu
     });
 };
 
+export const projectSlugSchema = ({ min = 1, max = 64, field = "Project slug" }: SlugSchemaInputs = {}) => {
+  return z
+    .string()
+    .trim()
+    .min(min, {
+      message: `${field} field must be at least ${min} lowercase character${min === 1 ? "" : "s"}`
+    })
+    .max(max, {
+      message: `${field} field must be at most ${max} lowercase character${max === 1 ? "" : "s"}`
+    })
+    .refine(
+      (value) => {
+        const normalized = value.replaceAll("_", "-");
+        return slugify(normalized, { lowercase: true }) === normalized;
+      },
+      {
+        message:
+          `${field} can only contain lowercase letters and numbers, with optional single hyphens (-) or ` +
+          "underscores (_) between words. It cannot start or end with a hyphen or underscore"
+      }
+    );
+};
+
 export const GenericResourceNameSchema = z
   .string()
   .trim()

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -19,10 +19,9 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { InfisicalProjectTemplate } from "@app/ee/services/project-template/project-template-types";
 import { ApiDocsTags, PROJECTS } from "@app/lib/api-docs";
 import { CharacterType, characterValidator } from "@app/lib/validator/validate-string";
-import { re2Validator } from "@app/lib/zod";
 import { JobState } from "@app/queue/queue-service";
 import { projectCreationLimit, readLimit, requestAccessLimit, writeLimit } from "@app/server/config/rateLimiter";
-import { slugSchema } from "@app/server/lib/schemas";
+import { projectSlugSchema, slugSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
@@ -213,7 +212,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
           .max(1024, { message: "Description must be 1024 or fewer characters" })
           .optional()
           .describe(PROJECTS.CREATE.projectDescription),
-        slug: slugSchema({ min: 5, max: 64 }).optional().describe(PROJECTS.CREATE.slug),
+        slug: projectSlugSchema({ min: 5, max: 64 }).optional().describe(PROJECTS.CREATE.slug),
         kmsKeyId: z.string().optional(),
         template: slugSchema({ field: "Template Name", max: 64 })
           .optional()
@@ -380,7 +379,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         }
       ],
       params: z.object({
-        slug: slugSchema({ max: 64 }).describe("The slug of the project to get.")
+        slug: projectSlugSchema({ max: 64 }).describe("The slug of the project to get.")
       }),
       response: {
         200: projectWithEnv
@@ -500,16 +499,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
           .boolean()
           .optional()
           .describe(PROJECTS.UPDATE.enforceEncryptedSecretManagerSecretMetadata),
-        slug: z
-          .string()
-          .trim()
-          .max(64, { message: "Slug must be 64 characters or fewer" })
-          .refine(re2Validator(/^[a-z0-9]+(?:[_-][a-z0-9]+)*$/), {
-            message:
-              "Project slug can only contain lowercase letters and numbers, with optional single hyphens (-) or underscores (_) between words. Cannot start or end with a hyphen or underscore."
-          })
-          .optional()
-          .describe(PROJECTS.UPDATE.slug),
+        slug: projectSlugSchema({ max: 64 }).optional().describe(PROJECTS.UPDATE.slug),
         secretSharing: z.boolean().optional().describe(PROJECTS.UPDATE.secretSharing),
         showSnapshotsLegacy: z.boolean().optional().describe(PROJECTS.UPDATE.showSnapshotsLegacy),
         secretDetectionIgnoreValues: z

--- a/backend/src/server/routes/v2/deprecated-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-project-router.ts
@@ -11,7 +11,7 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { InfisicalProjectTemplate } from "@app/ee/services/project-template/project-template-types";
 import { ApiDocsTags, PROJECTS } from "@app/lib/api-docs";
 import { projectCreationLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
-import { slugSchema } from "@app/server/lib/schemas";
+import { projectSlugSchema, slugSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
@@ -106,7 +106,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
           .max(1024, { message: "Description must be 1024 or fewer characters" })
           .optional()
           .describe(PROJECTS.CREATE.projectDescription),
-        slug: slugSchema({ min: 5, max: 64 }).optional().describe(PROJECTS.CREATE.slug),
+        slug: projectSlugSchema({ min: 5, max: 64 }).optional().describe(PROJECTS.CREATE.slug),
         kmsKeyId: z.string().optional(),
         template: slugSchema({ field: "Template Name", max: 64 })
           .optional()
@@ -185,7 +185,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         }
       ],
       params: z.object({
-        slug: slugSchema({ min: 5, max: 64 }).describe("The slug of the project to delete.")
+        slug: projectSlugSchema({ min: 5, max: 64 }).describe("The slug of the project to delete.")
       }),
       response: {
         200: SanitizedProjectSchema
@@ -238,7 +238,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         }
       ],
       params: z.object({
-        slug: slugSchema({ max: 64 }).describe("The slug of the project to get.")
+        slug: projectSlugSchema({ max: 64 }).describe("The slug of the project to get.")
       }),
       response: {
         200: projectWithEnv
@@ -271,7 +271,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
     },
     schema: {
       params: z.object({
-        slug: slugSchema({ min: 5, max: 64 }).describe("The slug of the project to update.")
+        slug: projectSlugSchema({ min: 5, max: 64 }).describe("The slug of the project to update.")
       }),
       body: z.object({
         name: z
@@ -337,7 +337,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
       hide: false,
       tags: [ApiDocsTags.PkiCertificateAuthorities],
       params: z.object({
-        slug: slugSchema({ min: 5, max: 64 }).describe(PROJECTS.LIST_CAS.slug)
+        slug: projectSlugSchema({ min: 5, max: 64 }).describe(PROJECTS.LIST_CAS.slug)
       }),
       querystring: z.object({
         status: z.enum([CaStatus.ACTIVE, CaStatus.PENDING_CERTIFICATE]).optional().describe(PROJECTS.LIST_CAS.status),
@@ -382,7 +382,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
       hide: true,
       tags: [ApiDocsTags.PkiCertificates],
       params: z.object({
-        slug: slugSchema({ min: 5, max: 64 }).describe(PROJECTS.LIST_CERTIFICATES.slug)
+        slug: projectSlugSchema({ min: 5, max: 64 }).describe(PROJECTS.LIST_CERTIFICATES.slug)
       }),
       querystring: z.object({
         friendlyName: z.string().optional().describe(PROJECTS.LIST_CERTIFICATES.friendlyName),


### PR DESCRIPTION
## Context

Closes #7888.

Project slug validation used two different formats. The update route allowed underscores between words, while the read route used the generic slug schema and rejected the same saved slug.

This adds a project-specific slug schema and uses it across v1 and registered v2 project creation and slug-addressed routes. The schema accepts single hyphens or underscores between lowercase alphanumeric words while preserving the generic slug format for other resources.

## Steps to verify the change

```sh
cd backend
npm run test:unit -- --run src/server/lib/schemas.test.ts
npm run type:check
npm run lint
```

The focused test covers underscore acceptance, invalid separator placement, uppercase rejection, and unchanged generic slug behavior.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
