### PR TITLE
chore(backend): dependency updates

### DIFF
--- a/backend-go/go.mod
+++ b/backend-go/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/infisical/gocasl v0.0.7
-	github.com/jackc/pgx/v5 v5.8.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/stretchr/testify v1.11.1

--- a/backend-go/go.sum
+++ b/backend-go/go.sum
@@ -158,8 +158,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
-github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=

--- a/backend/e2e-test/routes/v1/scim.spec.ts
+++ b/backend/e2e-test/routes/v1/scim.spec.ts
@@ -567,4 +567,105 @@ describe("SCIM v1 Router", () => {
       expect(authScheme.primary).toBe(true);
     });
   });
+
+  describe("PATCH /Users/:orgMembershipId", () => {
+    const seedScimUser = async (db: Knex, label: string) => {
+      const [user] = await db(TableName.Users)
+        .insert({
+          email: `scim-patch-${label}@${TEST_DOMAIN}`,
+          username: `scim-patch-${label}@${TEST_DOMAIN}`,
+          isGhost: false,
+          isEmailVerified: true,
+          authMethods: ["email"]
+        })
+        .returning("*");
+      createdUserIds.push(user.id);
+
+      const [membership] = await db(TableName.Membership)
+        .insert({
+          actorUserId: user.id,
+          scopeOrgId: ORG_ID,
+          scope: AccessScope.Organization,
+          isActive: true
+        })
+        .returning("*");
+      createdMembershipIds.push(membership.id);
+
+      await db(TableName.MembershipRole).insert({ membershipId: membership.id, role: "member" });
+
+      // updateScimUser resolves the user through its SSO alias and 404s without one.
+      await db(TableName.UserAliases).insert({
+        userId: user.id,
+        orgId: ORG_ID,
+        aliasType: "saml",
+        externalId: `scim-patch-ext-${label}`
+      });
+
+      return { user, membership };
+    };
+
+    // Body is sent as a raw string so the exact wire bytes reach the parser. Building
+    // __proto__ from an object literal would set the prototype instead of emitting the key.
+    const patch = (membershipId: string, body: string, contentType: string) =>
+      testServer.inject({
+        method: "PATCH",
+        url: `/api/v1/scim/Users/${membershipId}`,
+        headers: {
+          authorization: `Bearer ${scimToken}`,
+          "content-type": contentType
+        },
+        payload: body
+      });
+
+    test("should apply a replace operation and deactivate the membership", async () => {
+      const db = getDb();
+      const { membership } = await seedScimUser(db, `active-${crypto.randomUUID().slice(0, 8)}`);
+
+      const res = await patch(
+        membership.id,
+        JSON.stringify({
+          schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+          Operations: [{ op: "replace", path: "active", value: false }]
+        }),
+        "application/scim+json"
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload).active).toBe(false);
+
+      const [row] = await db(TableName.Membership).where({ id: membership.id }).select("isActive");
+      expect(row.isActive).toBe(false);
+    });
+
+    // CVE-2026-48170: scim-patch below 0.9.1 walks into Object.prototype when a patch
+    // path or value carries __proto__, constructor or prototype. Both content types are
+    // covered because only application/json goes through the proto-rejecting parser;
+    // application/scim+json is parsed with JSON.parse, so scim-patch is the sole guard.
+    test.each(["application/scim+json", "application/json"])(
+      "should not pollute Object.prototype via %s",
+      async (contentType) => {
+        const db = getDb();
+        const { membership } = await seedScimUser(db, `proto-${crypto.randomUUID().slice(0, 8)}`);
+        const canary = `scimCanary${crypto.randomUUID().replace(/-/g, "").slice(0, 12)}`;
+
+        const vectors = [
+          `{"Operations":[{"op":"add","path":"__proto__.${canary}","value":"polluted"}]}`,
+          `{"Operations":[{"op":"add","value":{"__proto__":{"${canary}":"polluted"}}}]}`,
+          `{"Operations":[{"op":"add","path":"constructor.prototype.${canary}","value":"polluted"}]}`,
+          `{"Operations":[{"op":"replace","path":"__proto__.${canary}","value":"polluted"}]}`
+        ];
+
+        try {
+          for (const body of vectors) {
+            await patch(membership.id, body, contentType);
+            expect(Object.prototype).not.toHaveProperty(canary);
+          }
+
+          expect(({} as Record<string, unknown>)[canary]).toBeUndefined();
+        } finally {
+          delete (Object.prototype as unknown as Record<string, unknown>)[canary];
+        }
+      }
+    );
+  });
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -152,7 +152,7 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "safe-regex": "^2.1.1",
-        "scim-patch": "^0.8.3",
+        "scim-patch": "^0.9.1",
         "scim2-parse-filter": "^0.2.10",
         "segfault-handler": "^1.3.0",
         "sjcl": "^1.0.9",
@@ -24745,14 +24745,30 @@
       "license": "MIT"
     },
     "node_modules/scim-patch": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/scim-patch/-/scim-patch-0.8.3.tgz",
-      "integrity": "sha512-3d0wD4THAt03Zgi08kCQwc+lvPJ2v4wwk41b0xViVa4gLYSgRUCmGkJNBsaE+yoKg0fufTOJCcSrufZaqYn/og==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/scim-patch/-/scim-patch-0.9.2.tgz",
+      "integrity": "sha512-q+YUC1UgkUW70pTota9/QuGU3hrSq43T2W8h8mSVS5PrV++NUcULFR1Rba5nnqg2YJ1MFuVXjBjh5BnqnrL8nA==",
+      "license": "Unlicense",
       "dependencies": {
-        "@types/node": "^22.0.0",
+        "@types/node": "^26.0.0",
         "fast-deep-equal": "3.1.3",
-        "scim2-parse-filter": "0.2.10"
+        "scim2-parse-filter": "0.3.0"
       }
+    },
+    "node_modules/scim-patch/node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/scim-patch/node_modules/scim2-parse-filter": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scim2-parse-filter/-/scim2-parse-filter-0.3.0.tgz",
+      "integrity": "sha512-GMMvQlgnvps689B0tz5trN81NCRCyUVNrOR8dkLa1qAgRa8KylEElHsIl3jUZy9+VFFH0yPLwjFt1rSy8JnqcA==",
+      "license": "Unlicense"
     },
     "node_modules/scim2-parse-filter": {
       "version": "0.2.10",
@@ -25027,9 +25043,10 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -27122,13 +27139,19 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -28092,9 +28115,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -85,14 +85,16 @@
     "flatted": "^3.4.2",
     "@octokit/request-error": "^5.1.1",
     "fast-uri": "^3.1.2",
-    "undici": "^7.24.0",
+    "undici": "^7.29.0",
     "eslint-plugin-import": {
       "minimatch": "^3.1.2"
     },
     "ws": "^8.20.1",
     "fast-xml-parser": "^5.7.0",
     "path-to-regexp": "^8.4.0",
-    "protobufjs": "^7.5.6"
+    "protobufjs": "^7.5.6",
+    "shell-quote": "^1.9.0",
+    "websocket-driver": "^0.7.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.18.10",
@@ -292,7 +294,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "safe-regex": "^2.1.1",
-    "scim-patch": "^0.8.3",
+    "scim-patch": "^0.9.1",
     "scim2-parse-filter": "^0.2.10",
     "segfault-handler": "^1.3.0",
     "sjcl": "^1.0.9",


### PR DESCRIPTION
## Context

Five dependencies in `backend` and `backend-go` have open security advisories. This raises each one to a version at or above every open advisory against it.

| Package | Before | After | Advisories cleared |
|---|---|---|---|
| `github.com/jackc/pgx/v5` | v5.8.0 | v5.9.2 | CVE-2026-33815, CVE-2026-33816, CVE-2026-41889 |
| `scim-patch` | 0.8.3 | 0.9.2 | CVE-2026-48170 |
| `undici` | 7.24.6 | 7.29.0 | CVE-2026-13697 plus 11 further open advisories |
| `shell-quote` | 1.8.2 | 1.10.0 | CVE-2026-9277, CVE-2026-13311 |
| `websocket-driver` | 0.7.4 | 0.7.5 | CVE-2026-54466, CVE-2026-54490 |

`scim-patch` and `pgx` are direct dependencies and move in their manifests. `undici`, `shell-quote` and `websocket-driver` are transitive, so they are pinned through the existing `overrides` block in `backend/package.json` rather than added as dependencies.

Two notes on how the target versions were chosen. Advisory fix floors are per-CVE and inconsistent across advisories on the same package, so each pin is set to the highest version any open advisory requires rather than to the first patched version of the highest-severity one. Following the floors literally would have left `pgx` on 5.9.0 with CVE-2026-41889 unpatched, and `shell-quote` on 1.8.4 with CVE-2026-13311 unpatched.

The lockfile change is confined to the four npm packages plus three nested transitives that follow them (`scim-patch`'s own `@types/node` and `scim2-parse-filter`, and `undici-types`). It removes no entries.

## Steps to verify the change

Go side:

```bash
cd backend-go
go build ./...
make test-unit
make test-integration
```

Node side, with Postgres and Redis running:

```bash
docker compose -f docker-compose.dev.yml --profile test up -d db-test redis
cd backend
npm ci
npm run test:e2e -- e2e-test/routes/v1/scim.spec.ts
```

Use the `db-test` service rather than `db`. The e2e environment runs `DROP SCHEMA public CASCADE` on setup, and `db-test` is the ephemeral instance tuned for it (`max_locks_per_transaction=512`); pointing this at `db` will drop a local dev database.

To confirm the new pollution assertions actually detect the behavior rather than passing vacuously, downgrade the library and re-run. They should fail:

```bash
npm install scim-patch@0.8.3 --ignore-scripts --no-save
npm run test:e2e -- e2e-test/routes/v1/scim.spec.ts
```

Lockfile integrity on the production install path:

```bash
cd backend && npm ci --omit=dev
```

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
