### PR TITLE
chore(docker): refresh stale libssl pin and slim the runtime image

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -195,6 +195,7 @@ RUN apt-get update && apt-get install -y \
     libnghttp2-14=1.64.0-1.1+deb13u1 \
     libngtcp2-16=1.11.0-1+deb13u1 \
     libngtcp2-crypto-gnutls8=1.11.0-1+deb13u1 \
+    libsqlite3-0=3.46.1-7+deb13u1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Oracle Instant Client from parallel stage

--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -189,7 +189,7 @@ RUN apt-get update && apt-get install -y \
     libgnutls30t64=3.8.9-3+deb13u4 \
     libc6=2.41-12+deb13u3 \
     libc-bin=2.41-12+deb13u3 \
-    libssl3t64=3.5.6-1~deb13u2 \
+    libssl3t64=3.5.7-1~deb13u2 \
     dpkg=1.22.22 \
     libcap2 \
     libnghttp2-14=1.64.0-1.1+deb13u1 \

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -196,7 +196,7 @@ RUN apt-get update && apt-get install -y \
     libgnutls30t64=3.8.9-3+deb13u4 \
     libc6=2.41-12+deb13u3 \
     libc-bin=2.41-12+deb13u3 \
-    libssl3t64=3.5.6-1~deb13u2 \
+    libssl3t64=3.5.7-1~deb13u2 \
     dpkg=1.22.22 \
     libcap2 \
     libnghttp2-14=1.64.0-1.1+deb13u1 \

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -171,10 +171,34 @@ COPY --from=backend-prod-deps /app/node_modules ./node_modules
 
 RUN mkdir frontend-build
 
+# OpenSSL 3.5.6 supplies the PQC (ML-DSA / SLH-DSA) algorithms the certificate
+# stack needs. It is built here rather than in the production stage so the
+# toolchain it requires does not ship in the runtime image.
+FROM base AS openssl-pqc-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    perl \
+    wget \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /tmp/openssl-build
+RUN wget -q https://github.com/openssl/openssl/releases/download/openssl-3.5.6/openssl-3.5.6.tar.gz \
+    && echo "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736  openssl-3.5.6.tar.gz" | sha256sum -c - \
+    && tar -xf openssl-3.5.6.tar.gz \
+    && cd openssl-3.5.6 \
+    && ./Configure --prefix=/opt/openssl-pqc --openssldir=/opt/openssl-pqc/ssl no-docs \
+    && make -j"$(nproc)" \
+    && make install_sw \
+    && cd / \
+    && rm -rf /tmp/openssl-build
+
 # Production stage
 FROM base AS production
 
-# Runtime dependencies + build tools needed for PQC OpenSSL build
+# Runtime dependencies only. The PQC OpenSSL toolchain lives in
+# openssl-pqc-builder; nothing here compiles.
 RUN apt-get update && apt-get install -y \
     ca-certificates \
     bash \
@@ -182,10 +206,6 @@ RUN apt-get update && apt-get install -y \
     git \
     unixodbc \
     freetds-bin \
-    wget \
-    perl \
-    build-essential \
-    libssl-dev \
     openssh-client \
     libaio1t64 \
     smbclient \
@@ -202,6 +222,7 @@ RUN apt-get update && apt-get install -y \
     libnghttp2-14=1.64.0-1.1+deb13u1 \
     libngtcp2-16=1.11.0-1+deb13u1 \
     libngtcp2-crypto-gnutls8=1.11.0-1+deb13u1 \
+    libsqlite3-0=3.46.1-7+deb13u1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy Oracle Instant Client from parallel stage
@@ -215,18 +236,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
     echo /opt/oracle/instantclient_23_26 > /etc/ld.so.conf.d/oracle-instantclient.conf && \
     ldconfig
 
-# Build OpenSSL 3.5.6 for PQC (ML-DSA / SLH-DSA) certificate support.
-# Installed to /opt/openssl-pqc so it does not conflict with the system OpenSSL.
-WORKDIR /tmp/openssl-build
-RUN wget -q https://github.com/openssl/openssl/releases/download/openssl-3.5.6/openssl-3.5.6.tar.gz \
-    && echo "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736  openssl-3.5.6.tar.gz" | sha256sum -c - \
-    && tar -xf openssl-3.5.6.tar.gz \
-    && cd openssl-3.5.6 \
-    && ./Configure --prefix=/opt/openssl-pqc --openssldir=/opt/openssl-pqc/ssl no-docs \
-    && make -j"$(nproc)" \
-    && make install_sw \
-    && cd / \
-    && rm -rf /tmp/openssl-build
+# PQC OpenSSL, built in openssl-pqc-builder. Consumed as a self-contained
+# prefix by lib/crypto/pqc (bin/openssl plus lib64:lib on the load path).
+COPY --from=openssl-pqc-builder /opt/openssl-pqc /opt/openssl-pqc
 
 WORKDIR /
 


### PR DESCRIPTION
## Context

**1. Stale `libssl3t64` pin.** The production stage pins `libssl3t64=3.5.6-1~deb13u2`. Debian published 3.5.7 to `trixie-security` on 2026-08-23, so the runtime installs now pull 3.5.7 and the pin resolves as a downgrade.

**2. Compiler in the runtime image.** The production stage installed `build-essential`, `libssl-dev`, `wget` and `perl` only to compile OpenSSL 3.5.6 for post-quantum certificate support in that same stage, leaving the toolchain in the shipped image. This moves the build to an `openssl-pqc-builder` stage and copies only `/opt/openssl-pqc` forward.

Effects:

- Drops `linux-libc-dev`, which carries 17 scan findings. They are kernel CVEs with no fix version, and a container uses the host kernel, so they were never exploitable. Removing the package is the only way to clear them.
- Pins `libsqlite3-0=3.46.1-7+deb13u1`. The base ships 3.46.1-7 and nothing upgrades it. This one patches real code (CVE-2025-7709).
- Image shrinks by about 400 MB.
- `perl` stays. `git` pulls it, and secret scanning shells out to `git` at runtime.

## Steps to verify the change

```bash
docker build --no-cache -t infisical-standalone:test -f Dockerfile.standalone-infisical .

# expect: linux-libc-dev absent, libsqlite3-0 3.46.1-7+deb13u1, libssl3t64 3.5.7-1~deb13u2
docker run --rm --entrypoint sh infisical-standalone:test -c \
  'dpkg-query -W -f="\${Package} \${Version}\n" linux-libc-dev libsqlite3-0 libssl3t64 2>&1'

# toolchain gone, relocated OpenSSL still usable by the runtime user
docker run --rm --user 1001 --entrypoint sh infisical-standalone:test -c '
  command -v gcc || echo "gcc absent"
  LD_LIBRARY_PATH=/opt/openssl-pqc/lib64:/opt/openssl-pqc/lib \
    /opt/openssl-pqc/bin/openssl genpkey -algorithm ML-DSA-44 -out /tmp/k.pem && echo "keygen OK"'
```

Boot it:

```bash
docker compose -f docker-compose.dev.yml --profile test up -d db-test redis
docker run --rm --network infisical_default -p 8099:8080 \
  -e DB_CONNECTION_URI="postgres://infisical:infisical@db-test:5432/infisical-test?sslmode=disable" \
  -e REDIS_URL="redis://redis:6379" \
  -e AUTH_SECRET="boot-test" \
  -e ENCRYPTION_KEY="$(openssl rand -hex 16)" \
  -e SITE_URL="http://localhost:8099" \
  infisical-standalone:test
curl -s http://localhost:8099/api/status
```

Use `db-test`, not `db`. The boot runs migrations and `db` holds local dev data.

### Verified locally

- Standard image builds on linux/amd64 and linux/arm64
- Both arches: `linux-libc-dev` absent, both pins applied, no `gcc`/`cc`/`make`, `perl` present
- Boots on both arches, migrates, serves `/api/status` and the frontend as uid 1001, logs `PQC OpenSSL detected: OpenSSL 3.5.6`
- FIPS image builds on arm64, loads its FIPS provider, detects PQC OpenSSL, completes migrations, then exits at the FIPS license check as expected without a licensed key
- Old 3.5.6 pin reproduces the downgrade failure on amd64 and arm64

### CI coverage

These Dockerfiles build only on a `v0.*.*` tag push, so CI does not exercise this PR. A pull-request trigger would not have caught the pin either, since the change came from Debian rather than the repo. 

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
