### PR TITLE
feat: add helper text for digicert profiles during issuance

### DIFF
--- a/backend/src/server/routes/v1/certificate-profiles-router.ts
+++ b/backend/src/server/routes/v1/certificate-profiles-router.ts
@@ -329,6 +329,7 @@ export const registerCertificateProfilesRouter = async (
                 name: z.string(),
                 isExternal: z.boolean().optional(),
                 externalType: z.string().nullable().optional(),
+                productNameId: z.string().nullable().optional(),
                 keyAlgorithm: z.string().nullable().optional()
               })
               .optional(),
@@ -439,6 +440,7 @@ export const registerCertificateProfilesRouter = async (
                 name: z.string(),
                 isExternal: z.boolean().optional(),
                 externalType: z.string().nullable().optional(),
+                productNameId: z.string().nullable().optional(),
                 keyAlgorithm: z.string().nullable().optional()
               })
               .optional(),

--- a/backend/src/services/certificate-profile/certificate-profile-dal.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-dal.ts
@@ -9,6 +9,7 @@ import {
   type ProcessedPermissionRules
 } from "@app/lib/knex/permission-filter-utils";
 import { CertStatus } from "@app/services/certificate/certificate-types";
+import { CaType } from "@app/services/certificate-authority/certificate-authority-enums";
 
 import {
   EnrollmentType,
@@ -22,6 +23,18 @@ import {
 } from "./certificate-profile-types";
 
 export type TCertificateProfileDALFactory = ReturnType<typeof certificateProfileDALFactory>;
+
+// DigiCert pins one product per CA, and that product constrains what a request may ask for
+// (ssl_wildcard rejects a non-wildcard common name, for instance). Surface it so the request
+// form can show which product it is ordering against.
+const extractProductNameId = (externalCaType: unknown, configuration: unknown): string | undefined => {
+  if (externalCaType !== CaType.DIGICERT || typeof configuration !== "object" || configuration === null) {
+    return undefined;
+  }
+
+  const { productNameId } = configuration as { productNameId?: unknown };
+  return typeof productNameId === "string" ? productNameId : undefined;
+};
 
 export const certificateProfileDALFactory = (db: TDbClient) => {
   const certificateProfileOrm = ormify(db, TableName.PkiCertificateProfile);
@@ -186,6 +199,7 @@ export const certificateProfileDALFactory = (db: TDbClient) => {
           db.ref("name").withSchema(TableName.CertificateAuthority).as("caName"),
           db.ref("id").withSchema(TableName.ExternalCertificateAuthority).as("externalCaId"),
           db.ref("type").withSchema(TableName.ExternalCertificateAuthority).as("externalCaType"),
+          db.ref("configuration").withSchema(TableName.ExternalCertificateAuthority).as("externalCaConfiguration"),
           db.ref("keyAlgorithm").withSchema(TableName.InternalCertificateAuthority).as("internalCaKeyAlgorithm"),
           db.ref("id").withSchema(TableName.PkiCertificatePolicy).as("policyId"),
           db.ref("projectId").withSchema(TableName.PkiCertificatePolicy).as("policyProjectId"),
@@ -284,6 +298,7 @@ export const certificateProfileDALFactory = (db: TDbClient) => {
             name: result.caName,
             isExternal: !!result.externalCaId,
             externalType: result.externalCaType as string | undefined,
+            productNameId: extractProductNameId(result.externalCaType, result.externalCaConfiguration),
             keyAlgorithm: result.internalCaKeyAlgorithm as string | null
           } as TCertificateProfileWithConfigs["certificateAuthority"])
         : undefined;
@@ -443,6 +458,7 @@ export const certificateProfileDALFactory = (db: TDbClient) => {
           db.ref("status").withSchema(TableName.CertificateAuthority).as("caStatus"),
           db.ref("id").withSchema(TableName.ExternalCertificateAuthority).as("externalCaId"),
           db.ref("type").withSchema(TableName.ExternalCertificateAuthority).as("externalCaType"),
+          db.ref("configuration").withSchema(TableName.ExternalCertificateAuthority).as("externalCaConfiguration"),
           db.ref("keyAlgorithm").withSchema(TableName.InternalCertificateAuthority).as("internalCaKeyAlgorithm"),
           db.ref("id").withSchema(TableName.PkiEstEnrollmentConfig).as("estId"),
           db
@@ -539,6 +555,7 @@ export const certificateProfileDALFactory = (db: TDbClient) => {
               status: result.caStatus as string,
               isExternal: !!result.externalCaId,
               externalType: result.externalCaType as string | undefined,
+              productNameId: extractProductNameId(result.externalCaType, result.externalCaConfiguration),
               keyAlgorithm: result.internalCaKeyAlgorithm as string | null
             }
           : undefined;

--- a/backend/src/services/certificate-profile/certificate-profile-types.ts
+++ b/backend/src/services/certificate-profile/certificate-profile-types.ts
@@ -104,6 +104,7 @@ export type TCertificateProfileWithConfigs = TCertificateProfile & {
     name: string;
     isExternal?: boolean;
     externalType?: string;
+    productNameId?: string;
     keyAlgorithm?: string | null;
   };
   certificatePolicy?: {

--- a/docs/documentation/platform/pki/ca/digicert-direct.mdx
+++ b/docs/documentation/platform/pki/ca/digicert-direct.mdx
@@ -10,6 +10,10 @@ Infisical can issue certificates directly from [DigiCert CertCentral](https://ww
 - **SSL/TLS** — issues OV and EV TLS server certificates under an SSL product entitlement on your account (for example `ssl_plus`).
 - **Code Signing** — issues OV (`code_signing`) and EV (`code_signing_ev`) code-signing certificates against a CSR. The signing key must live on an HSM.
 
+<Note>
+  The product is fixed on the CA and applies to every certificate that CA issues. Each product allows a different range of subject values, and DigiCert checks those values when the order is placed, not when you create the request. For example, `ssl_wildcard` takes only a wildcard common name such as `*.example.com`. To issue a different shape of certificate, create a second CA on another product.
+</Note>
+
 ## Prerequisites
 
 - A [DigiCert App Connection](/integrations/app-connections/digicert) with a validated CertCentral API key.

--- a/docs/documentation/platform/pki/ca/digicert-direct.mdx
+++ b/docs/documentation/platform/pki/ca/digicert-direct.mdx
@@ -11,7 +11,7 @@ Infisical can issue certificates directly from [DigiCert CertCentral](https://ww
 - **Code Signing** — issues OV (`code_signing`) and EV (`code_signing_ev`) code-signing certificates against a CSR. The signing key must live on an HSM.
 
 <Note>
-  The product is fixed on the CA and applies to every certificate that CA issues. Each product allows a different range of subject values, and DigiCert checks those values when the order is placed, not when you create the request. For example, `ssl_wildcard` takes only a wildcard common name such as `*.example.com`. To issue a different shape of certificate, create a second CA on another product.
+  The product is fixed on the CA and applies to every certificate that CA issues. Each product allows a different range of subject values, and DigiCert checks those values when the order is placed, not when you create the request. For example, `ssl_wildcard` takes only a wildcard common name such as `*.example.com`.
 </Note>
 
 ## Prerequisites

--- a/frontend/src/hooks/api/certificateProfiles/types.ts
+++ b/frontend/src/hooks/api/certificateProfiles/types.ts
@@ -55,6 +55,7 @@ export type TCertificateProfile = {
     name: string;
     isExternal?: boolean;
     externalType?: string | null;
+    productNameId?: string | null;
     keyAlgorithm?: string | null;
   };
 };
@@ -67,6 +68,7 @@ export type TCertificateProfileWithDetails = TCertificateProfile & {
     name: string;
     isExternal?: boolean;
     externalType?: string | null;
+    productNameId?: string | null;
     keyAlgorithm?: string | null;
   };
   certificatePolicy?: {

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
@@ -2,11 +2,13 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
-import { FileBadge, Plus, Tags, Trash2 } from "lucide-react";
+import { FileBadge, InfoIcon, Plus, Tags, Trash2 } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  Alert,
+  AlertDescription,
   Button,
   Empty,
   EmptyContent,
@@ -364,6 +366,11 @@ export const CertificateIssuanceModal = ({
 
   const isAwsPcaProfile = externalCaType === CaType.AWS_PCA;
   isAwsPcaProfileRef.current = isAwsPcaProfile;
+
+  const digicertProductNameId =
+    externalCaType === CaType.DIGICERT
+      ? actualSelectedProfile?.certificateAuthority?.productNameId
+      : undefined;
 
   const { data: policyData } = useGetCertificatePolicyById({
     policyId: actualSelectedProfile?.certificatePolicyId || "",
@@ -756,6 +763,20 @@ export const CertificateIssuanceModal = ({
                 </Field>
               )}
             />
+          )}
+
+          {currentStepKey === "subject" && digicertProductNameId && (
+            <Alert variant="info" className="mb-4">
+              <InfoIcon />
+              <AlertDescription>
+                <p>
+                  This profile orders through the DigiCert{" "}
+                  <span className="font-mono">{digicertProductNameId}</span> product, set on the
+                  issuing CA. Subject values the product does not accept are rejected when the order
+                  is placed.
+                </p>
+              </AlertDescription>
+            </Alert>
           )}
 
           {currentStepKey === "subject" && constraints.shouldShowSubjectSection && (

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/CertificateIssuanceModal.tsx
@@ -728,6 +728,19 @@ export const CertificateIssuanceModal = ({
             <p className="mb-4 text-xs text-mineshaft-400">{EXTERNAL_CA_TEMPLATE_HINT}</p>
           )}
 
+          {(currentStepKey === "subject" || currentStepKey === "csr") && digicertProductNameId && (
+            <Alert variant="info" className="mb-4">
+              <InfoIcon />
+              <AlertDescription>
+                <p>
+                  This profile orders through the DigiCert{" "}
+                  <span className="font-mono">{digicertProductNameId}</span> product, which rejects
+                  unsupported subject values when the order is placed.
+                </p>
+              </AlertDescription>
+            </Alert>
+          )}
+
           {currentStepKey === "csr" && (
             <Controller
               control={control}
@@ -763,20 +776,6 @@ export const CertificateIssuanceModal = ({
                 </Field>
               )}
             />
-          )}
-
-          {currentStepKey === "subject" && digicertProductNameId && (
-            <Alert variant="info" className="mb-4">
-              <InfoIcon />
-              <AlertDescription>
-                <p>
-                  This profile orders through the DigiCert{" "}
-                  <span className="font-mono">{digicertProductNameId}</span> product, set on the
-                  issuing CA. Subject values the product does not accept are rejected when the order
-                  is placed.
-                </p>
-              </AlertDescription>
-            </Alert>
           )}
 
           {currentStepKey === "subject" && constraints.shouldShowSubjectSection && (


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

This PR makes it so that a helper text is shown when issuing certificates for a profile that's linked to a Digicert CertCentral CA
<img width="1512" height="855" alt="image" src="https://github.com/user-attachments/assets/676f0526-8197-482c-9205-b39dce1d5a05" />

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)