### PR TITLE
fix: bound membership removal and role changes by the target's privileges for legacy system

### DIFF
--- a/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
+++ b/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
@@ -298,17 +298,18 @@ describe("Privilege boundary on org membership downgrade", () => {
         asIdentity(actor.token)
       );
       expect(res.statusCode).toBe(403);
-      expect(res.json().message).toContain("more privileged org member");
+      expect(res.json().message).toContain("Failed to change the roles or attributes of this org member");
     });
 
-    test("deactivating a more privileged member follows the removal boundary", async () => {
-      // Deactivation keys on member:delete, so it lands where a removal lands rather than where a role
-      // change does. Own target, because it succeeds on one of the two runs.
+    test("deactivating a more privileged member is bounded on the legacy system only", async () => {
+      // Deactivation keys on member:edit, which the route's own permission check already demanded, so
+      // the new system has nothing further to ask. Own target, because it succeeds on one of the two runs.
       const target = await createAdminTarget();
 
       const res = await patchMembership(target.membershipId, { isActive: false }, asIdentity(actor.token));
       expect(res.statusCode).toBe(newSystem ? 200 : 403);
-      if (!newSystem) expect(res.json().message).toContain("more privileged org member");
+      if (!newSystem)
+        expect(res.json().message).toContain("Failed to change the activation status of this org member");
     });
   });
 

--- a/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
+++ b/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
@@ -21,7 +21,7 @@ import crypto from "node:crypto";
 
 import { packRules } from "@casl/ability/extra";
 
-import { AccessScope, ProjectMembershipRole, TableName } from "@app/db/schemas";
+import { AccessScope, OrgMembershipRole, ProjectMembershipRole, TableName } from "@app/db/schemas";
 import { seedData1 } from "@app/db/seed-data";
 
 const adminHeaders = () => ({ authorization: `Bearer ${jwtAuthToken}` });
@@ -208,6 +208,109 @@ describe("Privilege boundary on project membership downgrade", () => {
       headers: adminHeaders(),
       body: { roles: [{ role: ProjectMembershipRole.NoAccess }] }
     });
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe("Privilege boundary on org membership downgrade", () => {
+  // PATCH /api/v2/organizations/:orgId/memberships/:membershipId updates a member through
+  // org-service rather than through the scoped membership factory, and it only bounded the role
+  // being ASSIGNED. Downgrading an Admin to no-access, or deactivating them, assigns nothing the
+  // boundary could reject, so it was a way around both the update guard and the removal boundary:
+  // downgrade first, then remove the now-weaker member.
+  let actor: { identityId: string; token: string };
+  let adminTarget: { userId: string; membershipId: string };
+
+  const roleSlug = `e2e-org-downgrader-${crypto.randomUUID()}`;
+
+  const patchMembership = (membershipId: string, body: Record<string, unknown>, headers: Record<string, string>) =>
+    testServer.inject({
+      method: "PATCH",
+      url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${membershipId}`,
+      headers,
+      body
+    });
+
+  const giveOrgAdminMembership = async (userId: string) => {
+    const [membership] = await testDb(TableName.Membership)
+      .insert({ scope: AccessScope.Organization, scopeOrgId: seedData1.organization.id, actorUserId: userId })
+      .returning("id");
+    const membershipId = (membership as { id: string }).id;
+    await testDb(TableName.MembershipRole).insert({ membershipId, role: OrgMembershipRole.Admin });
+    return membershipId;
+  };
+
+  beforeAll(async () => {
+    // member edit+delete and nothing else: the actor can legitimately reach the route, yet holds
+    // strictly less than the org Admin it is pointed at.
+    const [role] = await testDb(TableName.Role)
+      .insert({
+        name: roleSlug,
+        slug: roleSlug,
+        orgId: seedData1.organization.id,
+        permissions: JSON.stringify(packRules([{ subject: "member", action: ["read", "edit", "delete"] }] as never))
+      })
+      .returning("id");
+
+    actor = await createActorIdentity(`e2e-org-downgrade-actor-${crypto.randomUUID()}`);
+    const actorMembership = await testDb(TableName.Membership)
+      .where({
+        actorIdentityId: actor.identityId,
+        scope: AccessScope.Organization,
+        scopeOrgId: seedData1.organization.id
+      })
+      .first();
+    const actorMembershipId = (actorMembership as { id: string }).id;
+    await testDb(TableName.MembershipRole).where({ membershipId: actorMembershipId }).delete();
+    await testDb(TableName.MembershipRole).insert({
+      membershipId: actorMembershipId,
+      role: OrgMembershipRole.Custom,
+      customRoleId: (role as { id: string }).id
+    });
+
+    const target = await createTargetUser("org-downgrade");
+    adminTarget = { userId: target.userId, membershipId: await giveOrgAdminMembership(target.userId) };
+  });
+
+  afterAll(async () => {
+    await setNewPrivilegeSystem(true);
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/identities/${actor.identityId}`,
+      headers: adminHeaders()
+    });
+    await testDb(TableName.Membership).where({ actorUserId: adminTarget.userId }).delete();
+    await testDb(TableName.Users).where({ id: adminTarget.userId }).delete();
+    await testDb(TableName.Role).where({ slug: roleSlug }).delete();
+  });
+
+  describe.each([
+    { label: "legacy", newSystem: false },
+    { label: "new", newSystem: true }
+  ])("$label privilege system", ({ newSystem }) => {
+    beforeAll(async () => {
+      await setNewPrivilegeSystem(newSystem);
+    });
+
+    test("downgrading a more privileged member to no-access is bounded", async () => {
+      const res = await patchMembership(
+        adminTarget.membershipId,
+        { role: OrgMembershipRole.NoAccess },
+        asIdentity(actor.token)
+      );
+      expect(res.statusCode).toBe(403);
+      expect(res.json().message).toContain("more privileged org member");
+    });
+
+    test("deactivating a more privileged member is bounded", async () => {
+      const res = await patchMembership(adminTarget.membershipId, { isActive: false }, asIdentity(actor.token));
+      expect(res.statusCode).toBe(403);
+      expect(res.json().message).toContain("more privileged org member");
+    });
+  });
+
+  test("regression: an admin can still downgrade an org Admin to no-access", async () => {
+    const res = await patchMembership(adminTarget.membershipId, { role: OrgMembershipRole.NoAccess }, adminHeaders());
     expect(res.statusCode).toBe(200);
   });
 });

--- a/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
+++ b/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * The membership *update* guard has to bound the target's current roles, not just the roles being
+ * assigned.
+ *
+ * The update guards resolve `dto.data.roles` -- the roles being ASSIGNED -- and filter NoAccess out
+ * before resolution. A request of exactly [no-access] therefore resolved to an empty list, the
+ * boundary loop never ran, and nothing was checked on either privilege system. Since setting a
+ * member to no-access revokes their access just as a delete does, that was a way around the
+ * removal boundary rather than a separate concern:
+ *
+ *   DELETE an Admin target        -> 403 (bounded)
+ *   PATCH  that Admin -> viewer   -> 403 (bounded, actor cannot assign viewer)
+ *   PATCH  that Admin -> no-access-> 200 (unbounded)  <-- the gap
+ *
+ * Removing the filter alone does not fix the legacy system: no-access grants nothing, so
+ * dominating it passes trivially. The boundary has to run against the target's CURRENT roles,
+ * which is what the delete guard already does.
+ */
+
+import crypto from "node:crypto";
+
+import { packRules } from "@casl/ability/extra";
+
+import { AccessScope, ProjectMembershipRole, TableName } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+
+const adminHeaders = () => ({ authorization: `Bearer ${jwtAuthToken}` });
+const asIdentity = (token: string) => ({ authorization: `Bearer ${token}` });
+
+const setNewPrivilegeSystem = async (enabled: boolean) => {
+  await testDb(TableName.Organization)
+    .where({ id: seedData1.organization.id })
+    .update({ shouldUseNewPrivilegeSystem: enabled });
+};
+
+const createActorIdentity = async (name: string) => {
+  const createRes = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/identities",
+    headers: adminHeaders(),
+    body: { name, role: "member", organizationId: seedData1.organization.id }
+  });
+  expect(createRes.statusCode).toBe(200);
+  const identityId = createRes.json().identity.id as string;
+
+  const attachRes = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/auth/universal-auth/identities/${identityId}`,
+    headers: adminHeaders(),
+    body: { accessTokenTTL: 2592000, accessTokenMaxTTL: 2592000, accessTokenNumUsesLimit: 0 }
+  });
+  expect(attachRes.statusCode).toBe(200);
+
+  const csRes = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/auth/universal-auth/identities/${identityId}/client-secrets`,
+    headers: adminHeaders(),
+    body: {}
+  });
+  expect(csRes.statusCode).toBe(200);
+
+  const loginRes = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/auth/universal-auth/login",
+    body: { clientId: attachRes.json().identityUniversalAuth.clientId, clientSecret: csRes.json().clientSecret }
+  });
+  expect(loginRes.statusCode).toBe(200);
+  return { identityId, token: loginRes.json().accessToken as string };
+};
+
+const createTargetUser = async (label: string) => {
+  const username = `${label}-${crypto.randomUUID()}@localhost.local`;
+  const [user] = await testDb(TableName.Users)
+    .insert({ username, email: username, firstName: label, isAccepted: true, isGhost: false })
+    .returning("id");
+  return { userId: (user as { id: string }).id, username };
+};
+
+const giveProjectMembership = async (userId: string, projectId: string, role: ProjectMembershipRole) => {
+  const [membership] = await testDb(TableName.Membership)
+    .insert({
+      scope: AccessScope.Project,
+      scopeOrgId: seedData1.organization.id,
+      scopeProjectId: projectId,
+      actorUserId: userId
+    })
+    .returning("id");
+  const membershipId = (membership as { id: string }).id;
+  await testDb(TableName.MembershipRole).insert({ membershipId, role });
+  return membershipId;
+};
+
+describe("Privilege boundary on project membership downgrade", () => {
+  let project: { id: string };
+  let actor: { identityId: string; token: string };
+
+  beforeAll(async () => {
+    const projRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: adminHeaders(),
+      body: { projectName: `e2e-downgrade-probe-${crypto.randomUUID()}` }
+    });
+    expect(projRes.statusCode).toBe(200);
+    project = projRes.json().project;
+
+    actor = await createActorIdentity(`e2e-downgrade-actor-${crypto.randomUUID()}`);
+
+    const addRes = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/projects/${project.id}/memberships/identities/${actor.identityId}`,
+      headers: adminHeaders(),
+      body: { roles: [{ role: ProjectMembershipRole.Member }] }
+    });
+    expect(addRes.statusCode).toBe(200);
+
+    // A custom role holding member edit+delete and nothing else: strictly weaker than a project Admin.
+    const [role] = await testDb(TableName.Role)
+      .insert({
+        name: "e2e-member-manager",
+        slug: `e2e-member-manager-${crypto.randomUUID()}`,
+        projectId: project.id,
+        permissions: JSON.stringify(packRules([{ subject: "member", action: ["read", "edit", "delete"] }] as never))
+      })
+      .returning("id");
+
+    const membership = await testDb(TableName.Membership)
+      .where({ actorIdentityId: actor.identityId, scopeProjectId: project.id, scope: AccessScope.Project })
+      .first();
+    await testDb(TableName.MembershipRole)
+      .where({ membershipId: (membership as { id: string }).id })
+      .delete();
+    await testDb(TableName.MembershipRole).insert({
+      membershipId: (membership as { id: string }).id,
+      role: "custom",
+      customRoleId: (role as { id: string }).id
+    });
+  });
+
+  afterAll(async () => {
+    await setNewPrivilegeSystem(true);
+    await testServer.inject({ method: "DELETE", url: `/api/v1/projects/${project.id}`, headers: adminHeaders() });
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/identities/${actor.identityId}`,
+      headers: adminHeaders()
+    });
+  });
+
+  describe.each([
+    { label: "legacy", newSystem: false },
+    { label: "new", newSystem: true }
+  ])("$label privilege system", ({ newSystem }) => {
+    beforeAll(async () => {
+      await setNewPrivilegeSystem(newSystem);
+    });
+
+    test("baseline: DELETE on an Admin target follows the removal boundary", async () => {
+      const target = await createTargetUser("del");
+      const membershipId = await giveProjectMembership(target.userId, project.id, ProjectMembershipRole.Admin);
+
+      const res = await testServer.inject({
+        method: "DELETE",
+        url: `/api/v1/projects/${project.id}/memberships/${membershipId}`,
+        headers: asIdentity(actor.token)
+      });
+      // Delete uses the privilege-system-aware boundary, so the new system permits it on the
+      // strength of holding member:delete alone. That asymmetry is the documented design.
+      expect(res.statusCode).toBe(newSystem ? 200 : 403);
+    });
+
+    test("setting a more privileged member to no-access is bounded, like removing them", async () => {
+      const target = await createTargetUser("patch");
+      const membershipId = await giveProjectMembership(target.userId, project.id, ProjectMembershipRole.Admin);
+
+      const res = await testServer.inject({
+        method: "PATCH",
+        url: `/api/v1/projects/${project.id}/memberships/${membershipId}`,
+        headers: asIdentity(actor.token),
+        body: { roles: [{ role: ProjectMembershipRole.NoAccess }] }
+      });
+      expect(res.statusCode).toBe(403);
+      expect(res.json().message).toContain("more privileged member");
+    });
+
+    test("regression: downgrading to a real role stays bounded", async () => {
+      const target = await createTargetUser("patchv");
+      const membershipId = await giveProjectMembership(target.userId, project.id, ProjectMembershipRole.Admin);
+
+      const res = await testServer.inject({
+        method: "PATCH",
+        url: `/api/v1/projects/${project.id}/memberships/${membershipId}`,
+        headers: asIdentity(actor.token),
+        body: { roles: [{ role: ProjectMembershipRole.Viewer }] }
+      });
+      expect(res.statusCode).toBe(403);
+    });
+  });
+
+  test("regression: an admin can still downgrade an Admin member to no-access", async () => {
+    await setNewPrivilegeSystem(false);
+    const target = await createTargetUser("admin-downgrade");
+    const membershipId = await giveProjectMembership(target.userId, project.id, ProjectMembershipRole.Admin);
+
+    const res = await testServer.inject({
+      method: "PATCH",
+      url: `/api/v1/projects/${project.id}/memberships/${membershipId}`,
+      headers: adminHeaders(),
+      body: { roles: [{ role: ProjectMembershipRole.NoAccess }] }
+    });
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
+++ b/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
@@ -220,6 +220,7 @@ describe("Privilege boundary on org membership downgrade", () => {
   // downgrade first, then remove the now-weaker member.
   let actor: { identityId: string; token: string };
   let adminTarget: { userId: string; membershipId: string };
+  const targetUserIds: string[] = [];
 
   const roleSlug = `e2e-org-downgrader-${crypto.randomUUID()}`;
 
@@ -231,13 +232,15 @@ describe("Privilege boundary on org membership downgrade", () => {
       body
     });
 
-  const giveOrgAdminMembership = async (userId: string) => {
+  const createAdminTarget = async () => {
+    const { userId } = await createTargetUser("org-downgrade");
     const [membership] = await testDb(TableName.Membership)
       .insert({ scope: AccessScope.Organization, scopeOrgId: seedData1.organization.id, actorUserId: userId })
       .returning("id");
     const membershipId = (membership as { id: string }).id;
     await testDb(TableName.MembershipRole).insert({ membershipId, role: OrgMembershipRole.Admin });
-    return membershipId;
+    targetUserIds.push(userId);
+    return { userId, membershipId };
   };
 
   beforeAll(async () => {
@@ -268,8 +271,7 @@ describe("Privilege boundary on org membership downgrade", () => {
       customRoleId: (role as { id: string }).id
     });
 
-    const target = await createTargetUser("org-downgrade");
-    adminTarget = { userId: target.userId, membershipId: await giveOrgAdminMembership(target.userId) };
+    adminTarget = await createAdminTarget();
   });
 
   afterAll(async () => {
@@ -279,8 +281,8 @@ describe("Privilege boundary on org membership downgrade", () => {
       url: `/api/v1/identities/${actor.identityId}`,
       headers: adminHeaders()
     });
-    await testDb(TableName.Membership).where({ actorUserId: adminTarget.userId }).delete();
-    await testDb(TableName.Users).where({ id: adminTarget.userId }).delete();
+    await testDb(TableName.Membership).whereIn("actorUserId", targetUserIds).delete();
+    await testDb(TableName.Users).whereIn("id", targetUserIds).delete();
     await testDb(TableName.Role).where({ slug: roleSlug }).delete();
   });
 
@@ -302,10 +304,16 @@ describe("Privilege boundary on org membership downgrade", () => {
       expect(res.json().message).toContain("more privileged org member");
     });
 
-    test("deactivating a more privileged member is bounded", async () => {
-      const res = await patchMembership(adminTarget.membershipId, { isActive: false }, asIdentity(actor.token));
-      expect(res.statusCode).toBe(403);
-      expect(res.json().message).toContain("more privileged org member");
+    test("deactivating a more privileged member follows the removal boundary", async () => {
+      // Deactivation keys on member:delete, so it lands where a removal lands rather than where a
+      // role change does: the new system permits it on the strength of holding that action alone,
+      // the legacy system still compares privilege levels. It gets its own target because it
+      // succeeds on one of the two runs.
+      const target = await createAdminTarget();
+
+      const res = await patchMembership(target.membershipId, { isActive: false }, asIdentity(actor.token));
+      expect(res.statusCode).toBe(newSystem ? 200 : 403);
+      if (!newSystem) expect(res.json().message).toContain("more privileged org member");
     });
   });
 

--- a/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
+++ b/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
@@ -2,19 +2,18 @@
  * The membership *update* guard has to bound the target's current roles, not just the roles being
  * assigned.
  *
- * The update guards resolve `dto.data.roles` -- the roles being ASSIGNED -- and filter NoAccess out
- * before resolution. A request of exactly [no-access] therefore resolved to an empty list, the
- * boundary loop never ran, and nothing was checked on either privilege system. Since setting a
- * member to no-access revokes their access just as a delete does, that was a way around the
- * removal boundary rather than a separate concern:
+ * The update guards resolve the roles being ASSIGNED and filter NoAccess out first, so a request of
+ * exactly [no-access] resolved to an empty list and nothing got checked on either privilege system.
+ * Setting a member to no-access revokes their access just like a delete does, so that was a way
+ * around the removal boundary:
  *
- *   DELETE an Admin target        -> 403 (bounded)
- *   PATCH  that Admin -> viewer   -> 403 (bounded, actor cannot assign viewer)
- *   PATCH  that Admin -> no-access-> 200 (unbounded)  <-- the gap
+ *   DELETE an Admin target         -> 403 (bounded)
+ *   PATCH  that Admin -> viewer    -> 403 (bounded, actor cannot assign viewer)
+ *   PATCH  that Admin -> no-access -> 200 (unbounded)  <-- the gap
  *
- * Removing the filter alone does not fix the legacy system: no-access grants nothing, so
- * dominating it passes trivially. The boundary has to run against the target's CURRENT roles,
- * which is what the delete guard already does.
+ * Dropping the filter alone does not fix the legacy system: no-access grants nothing, so dominating
+ * it passes trivially. The boundary has to run against the target's CURRENT roles, like the delete
+ * guard already does.
  */
 
 import crypto from "node:crypto";
@@ -164,8 +163,7 @@ describe("Privilege boundary on project membership downgrade", () => {
         url: `/api/v1/projects/${project.id}/memberships/${membershipId}`,
         headers: asIdentity(actor.token)
       });
-      // Delete uses the privilege-system-aware boundary, so the new system permits it on the
-      // strength of holding member:delete alone. That asymmetry is the documented design.
+      // The new system lets this through on member:delete alone. That asymmetry is by design.
       expect(res.statusCode).toBe(newSystem ? 200 : 403);
     });
 
@@ -213,11 +211,10 @@ describe("Privilege boundary on project membership downgrade", () => {
 });
 
 describe("Privilege boundary on org membership downgrade", () => {
-  // PATCH /api/v2/organizations/:orgId/memberships/:membershipId updates a member through
-  // org-service rather than through the scoped membership factory, and it only bounded the role
-  // being ASSIGNED. Downgrading an Admin to no-access, or deactivating them, assigns nothing the
-  // boundary could reject, so it was a way around both the update guard and the removal boundary:
-  // downgrade first, then remove the now-weaker member.
+  // PATCH /api/v2/organizations/:orgId/memberships/:membershipId goes through org-service instead of
+  // the scoped membership factory, and only bounded the role being ASSIGNED. Downgrading an Admin to
+  // no-access, or deactivating them, assigns nothing the boundary could reject: downgrade first,
+  // then remove the now-weaker member.
   let actor: { identityId: string; token: string };
   let adminTarget: { userId: string; membershipId: string };
   const targetUserIds: string[] = [];
@@ -305,10 +302,8 @@ describe("Privilege boundary on org membership downgrade", () => {
     });
 
     test("deactivating a more privileged member follows the removal boundary", async () => {
-      // Deactivation keys on member:delete, so it lands where a removal lands rather than where a
-      // role change does: the new system permits it on the strength of holding that action alone,
-      // the legacy system still compares privilege levels. It gets its own target because it
-      // succeeds on one of the two runs.
+      // Deactivation keys on member:delete, so it lands where a removal lands rather than where a role
+      // change does. Own target, because it succeeds on one of the two runs.
       const target = await createAdminTarget();
 
       const res = await patchMembership(target.membershipId, { isActive: false }, asIdentity(actor.token));

--- a/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
+++ b/backend/e2e-test/routes/v1/membership-downgrade-boundary.spec.ts
@@ -308,8 +308,7 @@ describe("Privilege boundary on org membership downgrade", () => {
 
       const res = await patchMembership(target.membershipId, { isActive: false }, asIdentity(actor.token));
       expect(res.statusCode).toBe(newSystem ? 200 : 403);
-      if (!newSystem)
-        expect(res.json().message).toContain("Failed to change the activation status of this org member");
+      if (!newSystem) expect(res.json().message).toContain("Failed to change the activation status of this org member");
     });
   });
 

--- a/backend/e2e-test/routes/v1/privilege-boundary-removal.spec.ts
+++ b/backend/e2e-test/routes/v1/privilege-boundary-removal.spec.ts
@@ -362,13 +362,13 @@ describe("Privilege boundary on org membership removal", () => {
     test("a member:delete-only role cannot remove an org Admin", async () => {
       const res = await deleteOrgMembership(adminTarget.membershipId, asIdentity(actor.token));
       expect(res.statusCode).toBe(403);
-      expect(res.json().message).toContain("more privileged member");
+      expect(res.json().message).toContain("Failed to remove this member from the organization");
     });
 
     test("the bulk route is bounded too, so it is not a way around the single-member route", async () => {
       const res = await bulkDeleteOrgMemberships([adminTarget.membershipId], asIdentity(actor.token));
       expect(res.statusCode).toBe(403);
-      expect(res.json().message).toContain("more privileged member");
+      expect(res.json().message).toContain("Failed to remove this member from the organization");
     });
 
     test("an admin can still remove an org Admin", async () => {

--- a/backend/e2e-test/routes/v1/privilege-boundary-removal.spec.ts
+++ b/backend/e2e-test/routes/v1/privilege-boundary-removal.spec.ts
@@ -12,6 +12,10 @@
  * Prerequisites (handled by vitest-environment-knex.ts): testServer, jwtAuthToken, testDb.
  */
 
+import crypto from "node:crypto";
+
+import { packRules } from "@casl/ability/extra";
+
 import { AccessScope, OrgMembershipRole, ProjectMembershipRole, TableName } from "@app/db/schemas";
 import { seedData1 } from "@app/db/seed-data";
 
@@ -234,5 +238,228 @@ describe("Privilege boundary on the deprecated v1 add-user-to-project route", ()
     // is downstream of the boundary, so reaching it proves the boundary let an admin through.
     expect(res.statusCode).toBe(400);
     expect(res.json().message).toContain("already part of project");
+  });
+});
+
+/**
+ * A custom role holding only the removal action. This is the actor shape the boundary is about: a
+ * principal that legitimately holds `member:delete` yet is weaker than the member it is removing.
+ * The built-in org and project Member roles do not hold `member:delete` at all, so they would be
+ * rejected by the plain permission check and never reach the boundary.
+ *
+ * The role is written straight to the table because the e2e license mock reports `rbac: false`, so
+ * the custom-role routes refuse to create one. That gate is not what these tests are about, and the
+ * boundary resolves roles out of these same columns however they were written.
+ */
+const insertMemberRemoverRole = async (slug: string, scope: { orgId: string } | { projectId: string }) => {
+  const [role] = await testDb(TableName.Role)
+    .insert({
+      name: slug,
+      slug,
+      permissions: JSON.stringify(packRules([{ subject: "member", action: ["read", "delete"] }])),
+      ...scope
+    })
+    .returning("id");
+
+  return (role as { id: string }).id;
+};
+
+/** Repoint an existing membership at a custom role, replacing the built-in role it was created with. */
+const useCustomRole = async (membershipId: string, customRoleId: string) => {
+  await testDb(TableName.MembershipRole).where({ membershipId }).delete();
+  await testDb(TableName.MembershipRole).insert({ membershipId, role: "custom", customRoleId });
+};
+
+const findIdentityMembershipId = async (identityId: string, projectId?: string) => {
+  const row = await testDb(TableName.Membership)
+    .where({
+      actorIdentityId: identityId,
+      scopeOrgId: seedData1.organization.id,
+      scope: projectId ? AccessScope.Project : AccessScope.Organization,
+      ...(projectId ? { scopeProjectId: projectId } : {})
+    })
+    .first();
+  expect(row).toBeDefined();
+
+  return (row as { id: string }).id;
+};
+
+/**
+ * The seed carries exactly one user, and every removal path here targets a *user* membership. The
+ * routes only need a non-ghost Users row joined to a Membership, never a login, so the target is
+ * inserted directly rather than driven through the signup and SRP flow.
+ */
+const createTargetUser = async (label: string) => {
+  const username = `${label}-${crypto.randomUUID()}@localhost.local`;
+  const [user] = await testDb(TableName.Users)
+    .insert({ username, email: username, firstName: label, isAccepted: true, isGhost: false })
+    .returning("id");
+
+  return { userId: (user as { id: string }).id, username };
+};
+
+const giveUserMembership = async ({
+  userId,
+  role,
+  projectId
+}: {
+  userId: string;
+  role: OrgMembershipRole | ProjectMembershipRole;
+  projectId?: string;
+}) => {
+  const [membership] = await testDb(TableName.Membership)
+    .insert({
+      scope: projectId ? AccessScope.Project : AccessScope.Organization,
+      scopeOrgId: seedData1.organization.id,
+      scopeProjectId: projectId ?? null,
+      actorUserId: userId
+    })
+    .returning("id");
+
+  const membershipId = (membership as { id: string }).id;
+  await testDb(TableName.MembershipRole).insert({ membershipId, role });
+  return membershipId;
+};
+
+const dropUser = async (userId: string) => {
+  await testDb(TableName.Membership).where({ actorUserId: userId }).delete();
+  await testDb(TableName.Users).where({ id: userId }).delete();
+};
+
+describe("Privilege boundary on org membership removal", () => {
+  // These are the v2 organization routes, which remove a member through org-service rather than
+  // through the scoped membership factory. They carry the same reach as the scoped delete and so
+  // need the same boundary; without it they are a way around it.
+  let actor: { identityId: string; token: string };
+  let adminTarget: { userId: string; membershipId: string };
+
+  const deleteOrgMembership = (membershipId: string, headers: Record<string, string>) =>
+    testServer.inject({
+      method: "DELETE",
+      url: `/api/v2/organizations/${seedData1.organization.id}/memberships/${membershipId}`,
+      headers
+    });
+
+  const bulkDeleteOrgMemberships = (membershipIds: string[], headers: Record<string, string>) =>
+    testServer.inject({
+      method: "DELETE",
+      url: `/api/v2/organizations/${seedData1.organization.id}/memberships`,
+      headers,
+      body: { membershipIds }
+    });
+
+  beforeAll(async () => {
+    const roleId = await insertMemberRemoverRole("e2e-pb-org-member-remover", {
+      orgId: seedData1.organization.id
+    });
+    actor = await createActorIdentity("e2e-pb-org-actor");
+    await useCustomRole(await findIdentityMembershipId(actor.identityId), roleId);
+
+    const target = await createTargetUser("e2e-pb-org-target");
+    adminTarget = {
+      userId: target.userId,
+      membershipId: await giveUserMembership({ userId: target.userId, role: OrgMembershipRole.Admin })
+    };
+  });
+
+  afterAll(async () => {
+    await deleteIdentity(actor.identityId);
+    await dropUser(adminTarget.userId);
+    await testDb(TableName.Role).where({ slug: "e2e-pb-org-member-remover" }).delete();
+  });
+
+  describe("on the legacy privilege system", () => {
+    beforeAll(() => setNewPrivilegeSystem(false));
+    afterAll(() => setNewPrivilegeSystem(true));
+
+    test("a member:delete-only role cannot remove an org Admin", async () => {
+      const res = await deleteOrgMembership(adminTarget.membershipId, asIdentity(actor.token));
+      expect(res.statusCode).toBe(403);
+      expect(res.json().message).toContain("more privileged member");
+    });
+
+    test("the bulk route is bounded too, so it is not a way around the single-member route", async () => {
+      const res = await bulkDeleteOrgMemberships([adminTarget.membershipId], asIdentity(actor.token));
+      expect(res.statusCode).toBe(403);
+      expect(res.json().message).toContain("more privileged member");
+    });
+
+    test("an admin can still remove an org Admin", async () => {
+      const res = await deleteOrgMembership(adminTarget.membershipId, adminHeaders());
+      expect(res.statusCode).toBe(200);
+
+      adminTarget.membershipId = await giveUserMembership({
+        userId: adminTarget.userId,
+        role: OrgMembershipRole.Admin
+      });
+    });
+  });
+});
+
+describe("Privilege boundary on the bulk project member removal route", () => {
+  // DELETE /api/v1/projects/:projectId/memberships removes members by username through
+  // project-membership-service, bypassing the scoped membership factory's delete guard.
+  let project: { id: string };
+  let actor: { identityId: string; token: string };
+  let adminTarget: { userId: string; username: string };
+
+  const removeMembers = (usernames: string[], headers: Record<string, string>) =>
+    testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/projects/${project.id}/memberships`,
+      headers,
+      body: { usernames }
+    });
+
+  beforeAll(async () => {
+    const createProjectRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: adminHeaders(),
+      body: { projectName: "e2e-privilege-boundary-bulk-remove" }
+    });
+    expect(createProjectRes.statusCode).toBe(200);
+    project = createProjectRes.json().project;
+
+    const roleId = await insertMemberRemoverRole("e2e-pb-project-member-remover", { projectId: project.id });
+    actor = await createActorIdentity("e2e-pb-bulk-actor");
+    await addIdentityToProject(project.id, actor.identityId, ProjectMembershipRole.Member);
+    await useCustomRole(await findIdentityMembershipId(actor.identityId, project.id), roleId);
+
+    const target = await createTargetUser("e2e-pb-bulk-target");
+    adminTarget = target;
+    await giveUserMembership({ userId: target.userId, role: OrgMembershipRole.Member });
+    await giveUserMembership({
+      userId: target.userId,
+      role: ProjectMembershipRole.Admin,
+      projectId: project.id
+    });
+  });
+
+  afterAll(async () => {
+    await deleteIdentity(actor.identityId);
+    await dropUser(adminTarget.userId);
+    await testDb(TableName.Role).where({ slug: "e2e-pb-project-member-remover" }).delete();
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/projects/${project.id}`,
+      headers: adminHeaders()
+    });
+  });
+
+  describe("on the legacy privilege system", () => {
+    beforeAll(() => setNewPrivilegeSystem(false));
+    afterAll(() => setNewPrivilegeSystem(true));
+
+    test("a member:delete-only role cannot remove a project Admin", async () => {
+      const res = await removeMembers([adminTarget.username], asIdentity(actor.token));
+      expect(res.statusCode).toBe(403);
+      expect(res.json().message).toContain("more privileged member");
+    });
+
+    test("an admin can still remove a project Admin", async () => {
+      const res = await removeMembers([adminTarget.username], adminHeaders());
+      expect(res.statusCode).toBe(200);
+    });
   });
 });

--- a/backend/e2e-test/routes/v1/privilege-boundary-removal.spec.ts
+++ b/backend/e2e-test/routes/v1/privilege-boundary-removal.spec.ts
@@ -1,15 +1,11 @@
 /**
- * E2E tests for the privilege boundary on membership removal and role assignment.
- *
  * The gap these cover: the create and update guards in every membership scope factory ran a
  * privilege-boundary check, and the delete guards did not. A default project Member holds
- * `identity:delete`, so it could remove an Admin-role identity's membership -- a privilege change
- * on a principal it does not dominate.
+ * `identity:delete`, so it could remove an Admin-role identity's membership, a privilege change on a
+ * principal it does not dominate.
  *
- * Each test drives the reach as a *machine identity* actor rather than the seeded admin user, so
- * the actor's role is exactly what the assertion is about.
- *
- * Prerequisites (handled by vitest-environment-knex.ts): testServer, jwtAuthToken, testDb.
+ * Every test drives the reach as a machine identity rather than the seeded admin user, so the
+ * actor's role is exactly what the assertion is about.
  */
 
 import crypto from "node:crypto";
@@ -22,7 +18,7 @@ import { seedData1 } from "@app/db/seed-data";
 const adminHeaders = () => ({ authorization: `Bearer ${jwtAuthToken}` });
 const asIdentity = (token: string) => ({ authorization: `Bearer ${token}` });
 
-/** Create an org-Member identity with Universal Auth attached, and log it in. */
+/** Org-Member identity with Universal Auth attached, logged in. */
 const createActorIdentity = async (name: string) => {
   const createRes = await testServer.inject({
     method: "POST",
@@ -61,7 +57,7 @@ const createActorIdentity = async (name: string) => {
   return { identityId, token: loginRes.json().accessToken as string };
 };
 
-/** Create a bare org-level identity, with no auth method. Used as a removal target. */
+/** Bare org-level identity with no auth method, for use as a removal target. */
 const createTargetIdentity = async (name: string, role: OrgMembershipRole) => {
   const res = await testServer.inject({
     method: "POST",
@@ -99,9 +95,8 @@ const removeIdentityFromProject = (projectId: string, identityId: string, header
   });
 
 /**
- * organizations.shouldUseNewPrivilegeSystem decides which of the two boundary semantics applies:
- * false => the actor must dominate the target's privileges; true => holding the action suffices.
- * It defaults to true, so both branches have to be exercised explicitly.
+ * Picks the boundary semantics: false => the actor must dominate the target's privileges, true =>
+ * holding the action is enough. Defaults to true, so both branches need exercising explicitly.
  */
 const setNewPrivilegeSystem = async (enabled: boolean) => {
   await testDb(TableName.Organization)
@@ -145,7 +140,7 @@ describe("Privilege boundary on project identity membership removal", () => {
   });
 
   test("the actor does hold identity:delete, so the reach is real", async () => {
-    // Removing an equal-privilege target succeeds. This is what makes the assertions below
+    // Removing an equal-privilege target succeeds, which is what makes the assertions below
     // boundary checks rather than plain missing-permission rejections.
     const res = await removeIdentityFromProject(project.id, memberTarget, asIdentity(actor.token));
     expect(res.statusCode).toBe(200);
@@ -172,12 +167,9 @@ describe("Privilege boundary on project identity membership removal", () => {
   });
 
   describe("on the new privilege system", () => {
-    // Documents the deliberate scope of the fix rather than an oversight. Under the new privilege
-    // system, holding the action IS the authorization -- validatePrivilegeChangeOperation returns
-    // valid as soon as the actor can perform Delete on the subject, ignoring the target's roles.
-    // Narrowing this is done with conditions on the Delete action, not with a privilege comparison.
-    // NOTE: organizations.shouldUseNewPrivilegeSystem defaults to true, so this is the path most
-    // orgs are on, and the removal boundary is inert for them.
+    // Deliberate, not an oversight: under the new system holding the action IS the authorization, so
+    // Delete passes regardless of the target's roles. You narrow it with conditions on the action,
+    // not with a privilege comparison. This is the default, so most orgs get an inert boundary here.
     test("a project Member can remove an Admin-role identity", async () => {
       const res = await removeIdentityFromProject(project.id, adminTarget, asIdentity(actor.token));
       expect(res.statusCode).toBe(200);
@@ -188,10 +180,9 @@ describe("Privilege boundary on project identity membership removal", () => {
 });
 
 describe("Privilege boundary on the deprecated v1 add-user-to-project route", () => {
-  // POST /api/v1/workspace/:projectId/memberships hardcodes the built-in Member role, so the
-  // boundary only bites for an actor holding member:create with LESS than Member's privileges --
-  // i.e. a custom role. What is asserted here is the regression guard: the added boundary must not
-  // break an admin using the route.
+  // POST /api/v1/workspace/:projectId/memberships hardcodes the built-in Member role, so the boundary
+  // only bites for a custom role holding member:create with less than Member's privileges. All this
+  // asserts is the regression guard: the added boundary must not break an admin using the route.
   let project: { id: string };
 
   beforeAll(async () => {
@@ -234,22 +225,20 @@ describe("Privilege boundary on the deprecated v1 add-user-to-project route", ()
       }
     });
 
-    // The project creator is already a member, so the duplicate check is what rejects this -- which
-    // is downstream of the boundary, so reaching it proves the boundary let an admin through.
+    // The project creator is already a member, so the duplicate check rejects this. That check is
+    // downstream of the boundary, so reaching it proves the boundary let an admin through.
     expect(res.statusCode).toBe(400);
     expect(res.json().message).toContain("already part of project");
   });
 });
 
 /**
- * A custom role holding only the removal action. This is the actor shape the boundary is about: a
- * principal that legitimately holds `member:delete` yet is weaker than the member it is removing.
- * The built-in org and project Member roles do not hold `member:delete` at all, so they would be
+ * The actor shape the boundary is about: legitimately holds `member:delete`, yet is weaker than the
+ * member it is removing. The built-in Member roles do not hold `member:delete` at all, so they get
  * rejected by the plain permission check and never reach the boundary.
  *
- * The role is written straight to the table because the e2e license mock reports `rbac: false`, so
- * the custom-role routes refuse to create one. That gate is not what these tests are about, and the
- * boundary resolves roles out of these same columns however they were written.
+ * Written straight to the table because the e2e license mock reports `rbac: false` and the
+ * custom-role routes refuse to create one. The boundary reads these same columns either way.
  */
 const insertMemberRemoverRole = async (slug: string, scope: { orgId: string } | { projectId: string }) => {
   const [role] = await testDb(TableName.Role)
@@ -285,9 +274,8 @@ const findIdentityMembershipId = async (identityId: string, projectId?: string) 
 };
 
 /**
- * The seed carries exactly one user, and every removal path here targets a *user* membership. The
- * routes only need a non-ghost Users row joined to a Membership, never a login, so the target is
- * inserted directly rather than driven through the signup and SRP flow.
+ * The seed carries exactly one user and every removal path here targets a user membership. The routes
+ * only need a non-ghost Users row joined to a Membership, never a login, so skip signup and SRP.
  */
 const createTargetUser = async (label: string) => {
   const username = `${label}-${crypto.randomUUID()}@localhost.local`;
@@ -327,9 +315,8 @@ const dropUser = async (userId: string) => {
 };
 
 describe("Privilege boundary on org membership removal", () => {
-  // These are the v2 organization routes, which remove a member through org-service rather than
-  // through the scoped membership factory. They carry the same reach as the scoped delete and so
-  // need the same boundary; without it they are a way around it.
+  // The v2 org routes remove a member through org-service rather than the scoped membership factory.
+  // Same reach as the scoped delete, so without the same boundary they are a way around it.
   let actor: { identityId: string; token: string };
   let adminTarget: { userId: string; membershipId: string };
 

--- a/backend/e2e-test/routes/v1/privilege-boundary-removal.spec.ts
+++ b/backend/e2e-test/routes/v1/privilege-boundary-removal.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * E2E tests for the privilege boundary on membership removal and role assignment.
+ *
+ * The gap these cover: the create and update guards in every membership scope factory ran a
+ * privilege-boundary check, and the delete guards did not. A default project Member holds
+ * `identity:delete`, so it could remove an Admin-role identity's membership -- a privilege change
+ * on a principal it does not dominate.
+ *
+ * Each test drives the reach as a *machine identity* actor rather than the seeded admin user, so
+ * the actor's role is exactly what the assertion is about.
+ *
+ * Prerequisites (handled by vitest-environment-knex.ts): testServer, jwtAuthToken, testDb.
+ */
+
+import { AccessScope, OrgMembershipRole, ProjectMembershipRole, TableName } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+
+const adminHeaders = () => ({ authorization: `Bearer ${jwtAuthToken}` });
+const asIdentity = (token: string) => ({ authorization: `Bearer ${token}` });
+
+/** Create an org-Member identity with Universal Auth attached, and log it in. */
+const createActorIdentity = async (name: string) => {
+  const createRes = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/identities",
+    headers: adminHeaders(),
+    body: { name, role: OrgMembershipRole.Member, organizationId: seedData1.organization.id }
+  });
+  expect(createRes.statusCode).toBe(200);
+  const identityId = createRes.json().identity.id as string;
+
+  const attachRes = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/auth/universal-auth/identities/${identityId}`,
+    headers: adminHeaders(),
+    body: { accessTokenTTL: 2592000, accessTokenMaxTTL: 2592000, accessTokenNumUsesLimit: 0 }
+  });
+  expect(attachRes.statusCode).toBe(200);
+  const clientId = attachRes.json().identityUniversalAuth.clientId as string;
+
+  const csRes = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/auth/universal-auth/identities/${identityId}/client-secrets`,
+    headers: adminHeaders(),
+    body: {}
+  });
+  expect(csRes.statusCode).toBe(200);
+  const { clientSecret } = csRes.json();
+
+  const loginRes = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/auth/universal-auth/login",
+    body: { clientId, clientSecret }
+  });
+  expect(loginRes.statusCode).toBe(200);
+
+  return { identityId, token: loginRes.json().accessToken as string };
+};
+
+/** Create a bare org-level identity, with no auth method. Used as a removal target. */
+const createTargetIdentity = async (name: string, role: OrgMembershipRole) => {
+  const res = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/identities",
+    headers: adminHeaders(),
+    body: { name, role, organizationId: seedData1.organization.id }
+  });
+  expect(res.statusCode).toBe(200);
+  return res.json().identity.id as string;
+};
+
+const deleteIdentity = async (identityId: string) => {
+  await testServer.inject({
+    method: "DELETE",
+    url: `/api/v1/identities/${identityId}`,
+    headers: adminHeaders()
+  });
+};
+
+const addIdentityToProject = async (projectId: string, identityId: string, role: ProjectMembershipRole) => {
+  const res = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/projects/${projectId}/memberships/identities/${identityId}`,
+    headers: adminHeaders(),
+    body: { roles: [{ role }] }
+  });
+  expect(res.statusCode).toBe(200);
+};
+
+const removeIdentityFromProject = (projectId: string, identityId: string, headers: Record<string, string>) =>
+  testServer.inject({
+    method: "DELETE",
+    url: `/api/v1/projects/${projectId}/memberships/identities/${identityId}`,
+    headers
+  });
+
+/**
+ * organizations.shouldUseNewPrivilegeSystem decides which of the two boundary semantics applies:
+ * false => the actor must dominate the target's privileges; true => holding the action suffices.
+ * It defaults to true, so both branches have to be exercised explicitly.
+ */
+const setNewPrivilegeSystem = async (enabled: boolean) => {
+  await testDb(TableName.Organization)
+    .where({ id: seedData1.organization.id })
+    .update({ shouldUseNewPrivilegeSystem: enabled });
+};
+
+describe("Privilege boundary on project identity membership removal", () => {
+  let project: { id: string };
+  let actor: { identityId: string; token: string };
+  let adminTarget: string;
+  let memberTarget: string;
+
+  beforeAll(async () => {
+    const createProjectRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: adminHeaders(),
+      body: { projectName: "e2e-privilege-boundary-removal" }
+    });
+    expect(createProjectRes.statusCode).toBe(200);
+    project = createProjectRes.json().project;
+
+    actor = await createActorIdentity("e2e-pb-actor");
+    adminTarget = await createTargetIdentity("e2e-pb-admin-target", OrgMembershipRole.Member);
+    memberTarget = await createTargetIdentity("e2e-pb-member-target", OrgMembershipRole.Member);
+
+    // The actor is a plain project Member, which holds identity:delete.
+    await addIdentityToProject(project.id, actor.identityId, ProjectMembershipRole.Member);
+    await addIdentityToProject(project.id, adminTarget, ProjectMembershipRole.Admin);
+    await addIdentityToProject(project.id, memberTarget, ProjectMembershipRole.Member);
+  });
+
+  afterAll(async () => {
+    await Promise.all([deleteIdentity(actor.identityId), deleteIdentity(adminTarget), deleteIdentity(memberTarget)]);
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/projects/${project.id}`,
+      headers: adminHeaders()
+    });
+  });
+
+  test("the actor does hold identity:delete, so the reach is real", async () => {
+    // Removing an equal-privilege target succeeds. This is what makes the assertions below
+    // boundary checks rather than plain missing-permission rejections.
+    const res = await removeIdentityFromProject(project.id, memberTarget, asIdentity(actor.token));
+    expect(res.statusCode).toBe(200);
+
+    await addIdentityToProject(project.id, memberTarget, ProjectMembershipRole.Member);
+  });
+
+  describe("on the legacy privilege system", () => {
+    beforeAll(() => setNewPrivilegeSystem(false));
+    afterAll(() => setNewPrivilegeSystem(true));
+
+    test("a project Member cannot remove an Admin-role identity", async () => {
+      const res = await removeIdentityFromProject(project.id, adminTarget, asIdentity(actor.token));
+      expect(res.statusCode).toBe(403);
+      expect(res.json().message).toContain("more privileged identity");
+    });
+
+    test("an admin can still remove an Admin-role identity", async () => {
+      const res = await removeIdentityFromProject(project.id, adminTarget, adminHeaders());
+      expect(res.statusCode).toBe(200);
+
+      await addIdentityToProject(project.id, adminTarget, ProjectMembershipRole.Admin);
+    });
+  });
+
+  describe("on the new privilege system", () => {
+    // Documents the deliberate scope of the fix rather than an oversight. Under the new privilege
+    // system, holding the action IS the authorization -- validatePrivilegeChangeOperation returns
+    // valid as soon as the actor can perform Delete on the subject, ignoring the target's roles.
+    // Narrowing this is done with conditions on the Delete action, not with a privilege comparison.
+    // NOTE: organizations.shouldUseNewPrivilegeSystem defaults to true, so this is the path most
+    // orgs are on, and the removal boundary is inert for them.
+    test("a project Member can remove an Admin-role identity", async () => {
+      const res = await removeIdentityFromProject(project.id, adminTarget, asIdentity(actor.token));
+      expect(res.statusCode).toBe(200);
+
+      await addIdentityToProject(project.id, adminTarget, ProjectMembershipRole.Admin);
+    });
+  });
+});
+
+describe("Privilege boundary on the deprecated v1 add-user-to-project route", () => {
+  // POST /api/v1/workspace/:projectId/memberships hardcodes the built-in Member role, so the
+  // boundary only bites for an actor holding member:create with LESS than Member's privileges --
+  // i.e. a custom role. What is asserted here is the regression guard: the added boundary must not
+  // break an admin using the route.
+  let project: { id: string };
+
+  beforeAll(async () => {
+    const createProjectRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: adminHeaders(),
+      body: { projectName: "e2e-privilege-boundary-v1-add" }
+    });
+    expect(createProjectRes.statusCode).toBe(200);
+    project = createProjectRes.json().project;
+  });
+
+  afterAll(async () => {
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/projects/${project.id}`,
+      headers: adminHeaders()
+    });
+  });
+
+  test("an admin passes the boundary and is rejected only as a duplicate member", async () => {
+    const orgMembership = await testDb(TableName.Membership)
+      .where({ scope: AccessScope.Organization, scopeOrgId: seedData1.organization.id, actorUserId: seedData1.id })
+      .first();
+    expect(orgMembership).toBeDefined();
+
+    const res = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/workspace/${project.id}/memberships`,
+      headers: adminHeaders(),
+      body: {
+        members: [
+          {
+            orgMembershipId: (orgMembership as { id: string }).id,
+            workspaceEncryptedKey: "encrypted-key",
+            workspaceEncryptedNonce: "nonce"
+          }
+        ]
+      }
+    });
+
+    // The project creator is already a member, so the duplicate check is what rejects this -- which
+    // is downstream of the boundary, so reaching it proves the boundary let an admin through.
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain("already part of project");
+  });
+});

--- a/backend/e2e-test/setup/reset-shared-org-flags.ts
+++ b/backend/e2e-test/setup/reset-shared-org-flags.ts
@@ -6,10 +6,12 @@ import { seedData1 } from "@app/db/seed-data";
 // Several auth specs flip org-wide flags on the *shared* seeded org and undo it
 // in afterAll:
 //
-//   auth-mfa.spec.ts               enforceMfa
-//   auth-signup-sso-enforced.spec  authEnforced
-//   scim.spec.ts                   scimEnabled
-//   auth-idp-attacks.spec.ts       scimEnabled
+//   auth-mfa.spec.ts                        enforceMfa
+//   auth-signup-sso-enforced.spec           authEnforced
+//   scim.spec.ts                            scimEnabled
+//   auth-idp-attacks.spec.ts                scimEnabled
+//   privilege-boundary-removal.spec.ts      shouldUseNewPrivilegeSystem
+//   membership-downgrade-boundary.spec.ts   shouldUseNewPrivilegeSystem
 //
 // Those afterAll hooks don't run when a file dies hard — a worker OOM or a
 // file-level timeout — and a leaked flag then breaks every later spec that logs
@@ -17,17 +19,19 @@ import { seedData1 } from "@app/db/seed-data";
 //
 // Test files run sequentially in a single fork, so resetting the flags at the
 // start of every file makes each one self-healing regardless of how its
-// predecessor ended. All three columns default to false in the schema, so this
-// restores the seeded baseline rather than inventing one.
+// predecessor ended. Each value below is that column's schema default, so this
+// restores the seeded baseline rather than inventing one. Note that
+// shouldUseNewPrivilegeSystem defaults to true, unlike the three auth flags.
 //
 // This runs before any hook the spec itself registers, so a spec that wants a
-// flag on still gets it. If that ordering ever changed, the affected spec would
-// fail outright rather than silently skip its setup.
+// different value still gets it. If that ordering ever changed, the affected
+// spec would fail outright rather than silently skip its setup.
 beforeAll(async () => {
   const db = (globalThis as unknown as { testDb: Knex }).testDb;
   await db(TableName.Organization).where({ id: seedData1.organization.id }).update({
     enforceMfa: false,
     authEnforced: false,
-    scimEnabled: false
+    scimEnabled: false,
+    shouldUseNewPrivilegeSystem: true
   });
 });

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
@@ -269,6 +269,15 @@ describe("verifyRequestedPermissions input hardening", () => {
     expect(() => verifyRequestedPermissions({ permissions })).toThrow();
   });
 
+  test("rejects a padded environment rather than trimming it", () => {
+    // The service persists the request body verbatim and copies it into the granted privilege, so a
+    // value this schema normalized would be validated as "dev" and granted as " dev ": the request
+    // would be approved and the privilege would match no environment at all.
+    const permissions = packRules([makeRule(" dev ", "/apps/*")]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(BadRequestError);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(/is not allowed/);
+  });
+
   test("rejects an over-long secretPath", () => {
     const permissions = packRules([makeRule("dev", `/${"a".repeat(600)}`)]);
     expect(() => verifyRequestedPermissions({ permissions })).toThrow();

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
@@ -271,8 +271,8 @@ describe("verifyRequestedPermissions input hardening", () => {
 
   test("rejects a padded environment rather than trimming it", () => {
     // The service persists the request body verbatim and copies it into the granted privilege, so a
-    // value this schema normalized would be validated as "dev" and granted as " dev ": the request
-    // would be approved and the privilege would match no environment at all.
+    // value normalized here would be validated as "dev" but granted as " dev ": approved, and
+    // matching no environment at all.
     const permissions = packRules([makeRule(" dev ", "/apps/*")]);
     expect(() => verifyRequestedPermissions({ permissions })).toThrow(BadRequestError);
     expect(() => verifyRequestedPermissions({ permissions })).toThrow(/is not allowed/);

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
@@ -1,6 +1,13 @@
 import { packRules } from "@casl/ability/extra";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
+// logger is initialized at app boot and is undefined under unit tests; stub it so
+// validateHandlebarTemplate's reject path surfaces its BadRequestError rather than a logger error.
+vi.mock("@app/lib/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+// eslint-disable-next-line import/first
 import { verifyRequestedPermissions } from "./access-approval-request-fns";
 
 describe("verifyRequestedPermissions", () => {
@@ -224,5 +231,48 @@ describe("verifyRequestedPermissions: requestedPermissions", () => {
       { subject: "secret-folders", actions: ["create"] }
     ]);
     expect(result.accessTypes).toEqual(["Secrets (Read, Edit)", "Secret Folders (Create)"]);
+  });
+});
+
+describe("verifyRequestedPermissions input hardening", () => {
+  const makeRule = (env: string, secretPath: string) => ({
+    action: "read",
+    subject: "secrets",
+    conditions: {
+      environment: env,
+      secretPath: { $glob: secretPath }
+    }
+  });
+
+  test("rejects a handlebars expression in secretPath", () => {
+    // interpolatePermissionRules compiles the granted privilege before evaluating it, so a template
+    // surviving here would widen the grant at read time.
+    const permissions = packRules([makeRule("dev", "/apps/{{identity.auth.kubernetes.namespace}}/*")]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(/Template sanitization failed/);
+  });
+
+  test("rejects a handlebars expression in environment", () => {
+    const permissions = packRules([makeRule("{{identity.name}}", "/apps/*")]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(/Template sanitization failed/);
+  });
+
+  test("rejects an unescaped handlebars expression", () => {
+    const permissions = packRules([makeRule("dev", "/apps/{{{identity.name}}}/*")]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(/Template sanitization failed/);
+  });
+
+  test("rejects a non-slug environment", () => {
+    const permissions = packRules([makeRule("Dev Environment", "/apps/*")]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow();
+  });
+
+  test("rejects an over-long secretPath", () => {
+    const permissions = packRules([makeRule("dev", `/${"a".repeat(600)}`)]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow();
+  });
+
+  test("still accepts an ordinary glob path", () => {
+    const permissions = packRules([makeRule("dev", "/apps/team-a/*")]);
+    expect(verifyRequestedPermissions({ permissions }).secretPath).toBe("/apps/team-a/*");
   });
 });

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.test.ts
@@ -8,6 +8,9 @@ vi.mock("@app/lib/logger", () => ({
 }));
 
 // eslint-disable-next-line import/first
+import { BadRequestError } from "@app/lib/errors";
+
+// eslint-disable-next-line import/first
 import { verifyRequestedPermissions } from "./access-approval-request-fns";
 
 describe("verifyRequestedPermissions", () => {
@@ -269,6 +272,18 @@ describe("verifyRequestedPermissions input hardening", () => {
   test("rejects an over-long secretPath", () => {
     const permissions = packRules([makeRule("dev", `/${"a".repeat(600)}`)]);
     expect(() => verifyRequestedPermissions({ permissions })).toThrow();
+  });
+
+  test("rejects an unterminated expression as a bad request, not a parse crash", () => {
+    // handlebars.parse throws a plain Error here, which would surface as a 500 unless translated.
+    const permissions = packRules([makeRule("dev", "/apps/{{")]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(BadRequestError);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(/malformed template expression/);
+  });
+
+  test("rejects a block expression as a bad request, not a parse crash", () => {
+    const permissions = packRules([makeRule("dev", "/apps/{{#each x}}")]);
+    expect(() => verifyRequestedPermissions({ permissions })).toThrow(BadRequestError);
   });
 
   test("still accepts an ordinary glob path", () => {

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
@@ -148,11 +148,16 @@ const parseAccessApprovalRequestPermissions = (permissions: TUnpackedAccessAppro
   });
 
 export const verifyRequestedPermissions = ({ permissions }: TVerifyPermission) => {
-  validateHandlebarTemplate("Access Request Permissions", JSON.stringify(permissions ?? []), {
-    allowedExpressions: () => false,
-    allowedHelpers: [],
-    rejectUnescaped: true
-  });
+  try {
+    validateHandlebarTemplate("Access Request Permissions", JSON.stringify(permissions ?? []), {
+      allowedExpressions: () => false,
+      allowedHelpers: [],
+      rejectUnescaped: true
+    });
+  } catch (error) {
+    if (error instanceof BadRequestError) throw error;
+    throw new BadRequestError({ message: "Requested permissions contain a malformed template expression" });
+  }
 
   const permission = unpackRules(permissions as PackRule<TUnpackedAccessApprovalRequestRule>[]);
 

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
@@ -43,8 +43,8 @@ type TUnpackedAccessApprovalRequestRule = {
 // { environment: data.environmentSlug, secretPath: { $glob: data.secretPath } }.
 // .strict() at both levels so no other operator ($in/$eq/...) or key
 // (secretName, secretTags, connectionId, metadata, ...) can be smuggled in.
-// The $glob value reuses the same validator as every other permission surface, bounded here rather
-// than on the shared schema so the tightening cannot affect the other permission surfaces.
+// The $glob value reuses the same validator as every other permission surface, with the length cap
+// added here rather than on the shared schema so the tightening stays local.
 const AccessApprovalRequestConditionsSchema = z
   .object({
     environment: slugSchema({ max: 64, field: "Environment slug", trim: false }),

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
@@ -47,7 +47,7 @@ type TUnpackedAccessApprovalRequestRule = {
 // than on the shared schema so the tightening cannot affect the other permission surfaces.
 const AccessApprovalRequestConditionsSchema = z
   .object({
-    environment: slugSchema({ max: 64, field: "Environment slug" }),
+    environment: slugSchema({ max: 64, field: "Environment slug", trim: false }),
     secretPath: z
       .object({
         $glob: z

--- a/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-fns.ts
@@ -3,6 +3,8 @@ import { z } from "zod";
 
 import { PermissionConditionOperators } from "@app/lib/casl";
 import { BadRequestError } from "@app/lib/errors";
+import { validateHandlebarTemplate } from "@app/lib/template/validate-handlebars";
+import { slugSchema } from "@app/server/lib/schemas";
 
 import { CASL_ACTION_SCHEMA_NATIVE_ENUM } from "../permission/permission-schemas";
 import { PermissionConditionSchema } from "../permission/permission-types";
@@ -15,6 +17,8 @@ import {
   ProjectPermissionSub
 } from "../permission/project-permission";
 import { TVerifyPermission } from "./access-approval-request-types";
+
+const ACCESS_REQUEST_SECRET_PATH_MAX_LENGTH = 512;
 
 // Turn a permission slug into a human-readable label, e.g. "dynamic-secrets" -> "Dynamic Secrets"
 // and "read-root-credential" -> "Read Root Credential". Used for review notifications.
@@ -39,11 +43,21 @@ type TUnpackedAccessApprovalRequestRule = {
 // { environment: data.environmentSlug, secretPath: { $glob: data.secretPath } }.
 // .strict() at both levels so no other operator ($in/$eq/...) or key
 // (secretName, secretTags, connectionId, metadata, ...) can be smuggled in.
-// The $glob value reuses the same validator as every other permission surface.
+// The $glob value reuses the same validator as every other permission surface, bounded here rather
+// than on the shared schema so the tightening cannot affect the other permission surfaces.
 const AccessApprovalRequestConditionsSchema = z
   .object({
-    environment: z.string().min(1),
-    secretPath: z.object({ $glob: PermissionConditionSchema[PermissionConditionOperators.$GLOB] }).strict()
+    environment: slugSchema({ max: 64, field: "Environment slug" }),
+    secretPath: z
+      .object({
+        $glob: z
+          .string()
+          .max(ACCESS_REQUEST_SECRET_PATH_MAX_LENGTH, {
+            message: `Secret path must be ${ACCESS_REQUEST_SECRET_PATH_MAX_LENGTH} or fewer characters`
+          })
+          .pipe(PermissionConditionSchema[PermissionConditionOperators.$GLOB])
+      })
+      .strict()
   })
   .strict();
 
@@ -134,6 +148,12 @@ const parseAccessApprovalRequestPermissions = (permissions: TUnpackedAccessAppro
   });
 
 export const verifyRequestedPermissions = ({ permissions }: TVerifyPermission) => {
+  validateHandlebarTemplate("Access Request Permissions", JSON.stringify(permissions ?? []), {
+    allowedExpressions: () => false,
+    allowedHelpers: [],
+    rejectUnescaped: true
+  });
+
   const permission = unpackRules(permissions as PackRule<TUnpackedAccessApprovalRequestRule>[]);
 
   if (!permission || !permission.length) {

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -723,6 +723,25 @@ export const groupServiceFactory = ({
     }
     const { group } = groupMembership;
 
+    const targetRoles = resolveMembershipRoleSlugs(groupMembership.roles);
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
+        ignoreUnresolvedRoles: true
+      });
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
+        orgDAL.findById(actorOrgId)
+      );
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionGroupActions.Delete,
+        opSubject: OrgPermissionSubjects.Groups,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to delete a more privileged group"
+      });
+    }
+
     const isLinkedGroup = group.orgId !== actorOrgId;
 
     if (isLinkedGroup) {

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -291,6 +291,22 @@ export const groupServiceFactory = ({
       );
       const isCustomRole = Boolean(rolePermissionDetails?.role);
 
+      const targetRoles = resolveMembershipRoleSlugs(groupMembership.roles);
+      if (targetRoles.length) {
+        const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
+          ignoreUnresolvedRoles: true
+        });
+
+        assertRoleSetBoundary({
+          shouldUseNewPrivilegeSystem,
+          opActions: OrgPermissionGroupActions.GrantPrivileges,
+          opSubject: OrgPermissionSubjects.Groups,
+          actorPermission: permission,
+          targetPermissions,
+          baseMessage: "Failed to change the roles of a more privileged group"
+        });
+      }
+
       const permissionBoundary = validatePrivilegeChangeOperation(
         shouldUseNewPrivilegeSystem,
         OrgPermissionGroupActions.GrantPrivileges,

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -1025,7 +1025,9 @@ export const groupServiceFactory = ({
     }
 
     const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
-    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
+    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId, {
+      ignoreUnresolvedRoles: true
+    });
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
       orgDAL.findById(actorOrgId)
     );
@@ -1121,7 +1123,9 @@ export const groupServiceFactory = ({
       });
 
     const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
-    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
+    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId, {
+      ignoreUnresolvedRoles: true
+    });
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
       orgDAL.findById(actorOrgId)
     );
@@ -1214,7 +1218,9 @@ export const groupServiceFactory = ({
     }
 
     const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
-    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
+    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId, {
+      ignoreUnresolvedRoles: true
+    });
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
       orgDAL.findById(actorOrgId)
     );
@@ -1289,7 +1295,9 @@ export const groupServiceFactory = ({
       });
 
     const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
-    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
+    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId, {
+      ignoreUnresolvedRoles: true
+    });
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
       orgDAL.findById(actorOrgId)
     );

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -1063,7 +1063,6 @@ export const groupServiceFactory = ({
       orgDAL.findById(actorOrgId)
     );
 
-    // check if user has broader or equal to privileges than every role the group holds
     assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
       opActions: OrgPermissionGroupActions.AddMembers,
@@ -1161,7 +1160,6 @@ export const groupServiceFactory = ({
       orgDAL.findById(actorOrgId)
     );
 
-    // check if user has broader or equal to privileges than every role the group holds
     assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
       opActions: OrgPermissionGroupActions.AddIdentities,
@@ -1256,7 +1254,6 @@ export const groupServiceFactory = ({
       orgDAL.findById(actorOrgId)
     );
 
-    // check if user has broader or equal to privileges than every role the group holds
     assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
       opActions: OrgPermissionGroupActions.RemoveMembers,
@@ -1333,7 +1330,6 @@ export const groupServiceFactory = ({
       orgDAL.findById(actorOrgId)
     );
 
-    // check if user has broader or equal to privileges than every role the group holds
     assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
       opActions: OrgPermissionGroupActions.RemoveIdentities,

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -31,6 +31,7 @@ import { TIdentityAccessTokenServiceFactory } from "@app/services/identity-acces
 import { PamIdentities, SecretIdentities } from "@app/services/license-client";
 import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage";
 import { TMembershipDALFactory } from "@app/services/membership/membership-dal";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
 import { TMembershipGroupDALFactory } from "@app/services/membership-group/membership-group-dal";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
@@ -41,7 +42,11 @@ import { TUserDALFactory } from "@app/services/user/user-dal";
 
 import { TLicenseServiceFactory } from "../license/license-service";
 import { OrgPermissionGroupActions, OrgPermissionSubjects } from "../permission/org-permission";
-import { constructPermissionErrorMessage, validatePrivilegeChangeOperation } from "../permission/permission-fns";
+import {
+  assertRoleSetBoundary,
+  constructPermissionErrorMessage,
+  validatePrivilegeChangeOperation
+} from "../permission/permission-fns";
 import { TPermissionServiceFactory } from "../permission/permission-service-types";
 import { TGroupDALFactory } from "./group-dal";
 import {
@@ -1019,31 +1024,21 @@ export const groupServiceFactory = ({
       });
     }
 
-    const groupRoles = groupMembership.roles.map((el) => el.customRoleSlug || el.role);
-    const [rolePermissionDetails] = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
+    const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
+    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
       orgDAL.findById(actorOrgId)
     );
 
-    // check if user has broader or equal to privileges than group
-    const permissionBoundary = validatePrivilegeChangeOperation(
+    // check if user has broader or equal to privileges than every role the group holds
+    assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
-      OrgPermissionGroupActions.AddMembers,
-      OrgPermissionSubjects.Groups,
-      permission,
-      rolePermissionDetails.permission
-    );
-
-    if (!permissionBoundary.isValid)
-      throw new PermissionBoundaryError({
-        message: constructPermissionErrorMessage(
-          "Failed to add user to more privileged group",
-          shouldUseNewPrivilegeSystem,
-          OrgPermissionGroupActions.AddMembers,
-          OrgPermissionSubjects.Groups
-        ),
-        details: { missingPermissions: permissionBoundary.missingPermissions }
-      });
+      opActions: OrgPermissionGroupActions.AddMembers,
+      opSubject: OrgPermissionSubjects.Groups,
+      actorPermission: permission,
+      targetPermissions: rolePermissionDetails,
+      baseMessage: "Failed to add user to more privileged group"
+    });
 
     const user = await userDAL.findOne({
       username
@@ -1125,31 +1120,21 @@ export const groupServiceFactory = ({
         message: `Failed to find group with ID ${id}`
       });
 
-    const groupRoles = groupMembership.roles.map((el) => el.customRoleSlug || el.role);
-    const [rolePermissionDetails] = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
+    const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
+    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
       orgDAL.findById(actorOrgId)
     );
 
-    // check if user has broader or equal to privileges than group
-    const permissionBoundary = validatePrivilegeChangeOperation(
+    // check if user has broader or equal to privileges than every role the group holds
+    assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
-      OrgPermissionGroupActions.AddIdentities,
-      OrgPermissionSubjects.Groups,
-      permission,
-      rolePermissionDetails.permission
-    );
-
-    if (!permissionBoundary.isValid)
-      throw new PermissionBoundaryError({
-        message: constructPermissionErrorMessage(
-          "Failed to add identity to more privileged group",
-          shouldUseNewPrivilegeSystem,
-          OrgPermissionGroupActions.AddIdentities,
-          OrgPermissionSubjects.Groups
-        ),
-        details: { missingPermissions: permissionBoundary.missingPermissions }
-      });
+      opActions: OrgPermissionGroupActions.AddIdentities,
+      opSubject: OrgPermissionSubjects.Groups,
+      actorPermission: permission,
+      targetPermissions: rolePermissionDetails,
+      baseMessage: "Failed to add identity to more privileged group"
+    });
 
     const identityMembership = await membershipDAL.findOne({
       scope: AccessScope.Organization,
@@ -1228,30 +1213,21 @@ export const groupServiceFactory = ({
       });
     }
 
-    const groupRoles = groupMembership.roles.map((el) => el.customRoleSlug || el.role);
-    const [rolePermissionDetails] = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
+    const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
+    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
       orgDAL.findById(actorOrgId)
     );
 
-    // check if user has broader or equal to privileges than group
-    const permissionBoundary = validatePrivilegeChangeOperation(
+    // check if user has broader or equal to privileges than every role the group holds
+    assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
-      OrgPermissionGroupActions.RemoveMembers,
-      OrgPermissionSubjects.Groups,
-      permission,
-      rolePermissionDetails.permission
-    );
-    if (!permissionBoundary.isValid)
-      throw new PermissionBoundaryError({
-        message: constructPermissionErrorMessage(
-          "Failed to delete user from more privileged group",
-          shouldUseNewPrivilegeSystem,
-          OrgPermissionGroupActions.RemoveMembers,
-          OrgPermissionSubjects.Groups
-        ),
-        details: { missingPermissions: permissionBoundary.missingPermissions }
-      });
+      opActions: OrgPermissionGroupActions.RemoveMembers,
+      opSubject: OrgPermissionSubjects.Groups,
+      actorPermission: permission,
+      targetPermissions: rolePermissionDetails,
+      baseMessage: "Failed to delete user from more privileged group"
+    });
 
     const user = await userDAL.findOne({ username });
     if (!user) throw new NotFoundError({ message: `Failed to find user with username ${username}` });
@@ -1312,30 +1288,21 @@ export const groupServiceFactory = ({
         message: `Failed to find group with ID ${id}`
       });
 
-    const groupRoles = groupMembership.roles.map((el) => el.customRoleSlug || el.role);
-    const [rolePermissionDetails] = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
+    const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
+    const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId);
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
       orgDAL.findById(actorOrgId)
     );
 
-    // check if user has broader or equal to privileges than group
-    const permissionBoundary = validatePrivilegeChangeOperation(
+    // check if user has broader or equal to privileges than every role the group holds
+    assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
-      OrgPermissionGroupActions.RemoveIdentities,
-      OrgPermissionSubjects.Groups,
-      permission,
-      rolePermissionDetails.permission
-    );
-    if (!permissionBoundary.isValid)
-      throw new PermissionBoundaryError({
-        message: constructPermissionErrorMessage(
-          "Failed to remove identity from more privileged group",
-          shouldUseNewPrivilegeSystem,
-          OrgPermissionGroupActions.RemoveIdentities,
-          OrgPermissionSubjects.Groups
-        ),
-        details: { missingPermissions: permissionBoundary.missingPermissions }
-      });
+      opActions: OrgPermissionGroupActions.RemoveIdentities,
+      opSubject: OrgPermissionSubjects.Groups,
+      actorPermission: permission,
+      targetPermissions: rolePermissionDetails,
+      baseMessage: "Failed to remove identity from more privileged group"
+    });
 
     const identityMembership = await membershipDAL.findOne({
       scope: AccessScope.Organization,

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -292,20 +292,18 @@ export const groupServiceFactory = ({
       const isCustomRole = Boolean(rolePermissionDetails?.role);
 
       const targetRoles = resolveMembershipRoleSlugs(groupMembership.roles);
-      if (targetRoles.length) {
-        const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
-          ignoreUnresolvedRoles: true
-        });
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
+        ignoreUnresolvedRoles: true
+      });
 
-        assertRoleSetBoundary({
-          shouldUseNewPrivilegeSystem,
-          opActions: OrgPermissionGroupActions.GrantPrivileges,
-          opSubject: OrgPermissionSubjects.Groups,
-          actorPermission: permission,
-          targetPermissions,
-          baseMessage: "Failed to change the roles of a more privileged group"
-        });
-      }
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionGroupActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Groups,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged group"
+      });
 
       const permissionBoundary = validatePrivilegeChangeOperation(
         shouldUseNewPrivilegeSystem,
@@ -724,23 +722,21 @@ export const groupServiceFactory = ({
     const { group } = groupMembership;
 
     const targetRoles = resolveMembershipRoleSlugs(groupMembership.roles);
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
-        ignoreUnresolvedRoles: true
-      });
-      const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
-        orgDAL.findById(actorOrgId)
-      );
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
+      orgDAL.findById(actorOrgId)
+    );
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: OrgPermissionGroupActions.Delete,
-        opSubject: OrgPermissionSubjects.Groups,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to delete a more privileged group"
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionGroupActions.Delete,
+      opSubject: OrgPermissionSubjects.Groups,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to delete a more privileged group"
+    });
 
     const isLinkedGroup = group.orgId !== actorOrgId;
 

--- a/backend/src/ee/services/group/group-update-boundary.test.ts
+++ b/backend/src/ee/services/group/group-update-boundary.test.ts
@@ -1,0 +1,133 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { vi } from "vitest";
+
+import { OrgMembershipRole } from "@app/db/schemas";
+import {
+  orgAdminPermissions,
+  orgMemberPermissions,
+  orgNoAccessPermissions,
+  OrgPermissionGroupActions,
+  OrgPermissionSubjects
+} from "@app/ee/services/permission/org-permission";
+import { PermissionBoundaryError } from "@app/lib/errors";
+
+import { groupServiceFactory } from "./group-service";
+
+// updateGroup bounds the change against the role coming in, never the role the group already holds.
+// On the legacy system the incoming NoAccess role resolves to an empty rule set, so that comparison
+// is vacuous -- which left `groups:edit` alone enough to strip an Admin group of its access.
+
+const ORG_ID = "org-id";
+const GROUP_ID = "group-id";
+const MEMBERSHIP_ID = "group-membership-id";
+
+const admin = createMongoAbility<MongoAbility>(orgAdminPermissions);
+const member = createMongoAbility<MongoAbility>(orgMemberPermissions);
+const noAccess = createMongoAbility<MongoAbility>(orgNoAccessPermissions);
+
+// Exactly what the guard's throwUnlessCan demands, plus the grant it needs on the new system.
+const groupEditorOnly = createMongoAbility<MongoAbility>([
+  {
+    action: [OrgPermissionGroupActions.Read, OrgPermissionGroupActions.Edit, OrgPermissionGroupActions.GrantPrivileges],
+    subject: OrgPermissionSubjects.Groups
+  }
+]);
+
+const createUpdate = ({
+  actorPermission,
+  shouldUseNewPrivilegeSystem,
+  currentRole = OrgMembershipRole.Admin,
+  incomingRole = OrgMembershipRole.NoAccess
+}: {
+  actorPermission: MongoAbility;
+  shouldUseNewPrivilegeSystem: boolean;
+  currentRole?: string;
+  incomingRole?: string;
+}) => {
+  const abilityByRole: Record<string, MongoAbility> = {
+    [OrgMembershipRole.Admin]: admin,
+    [OrgMembershipRole.Member]: member,
+    [OrgMembershipRole.NoAccess]: noAccess
+  };
+
+  const membershipRoleDAL = { create: vi.fn(), delete: vi.fn() };
+
+  const service = groupServiceFactory({
+    permissionService: {
+      getOrgPermission: vi.fn().mockResolvedValue({ permission: actorPermission }),
+      getOrgPermissionByRoles: vi
+        .fn()
+        .mockImplementation((roles: string[]) => roles.map((role) => ({ permission: abilityByRole[role] })))
+    } as never,
+    licenseService: { getPlan: vi.fn().mockResolvedValue({ groups: true }) } as never,
+    orgDAL: { findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem }) } as never,
+    groupDAL: {
+      transaction: vi.fn().mockImplementation(async (cb: (tx: unknown) => unknown) => cb({}))
+    } as never,
+    membershipGroupDAL: {
+      getGroupById: vi.fn().mockResolvedValue({
+        group: { id: GROUP_ID, orgId: ORG_ID, name: "the-group" },
+        roles: [{ role: currentRole }]
+      }),
+      findOne: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID })
+    } as never,
+    membershipRoleDAL: membershipRoleDAL as never
+  } as never);
+
+  const run = () =>
+    service.updateGroup({
+      id: GROUP_ID,
+      role: incomingRole,
+      actor: "user",
+      actorId: "actor-id",
+      actorAuthMethod: "email",
+      actorOrgId: ORG_ID
+    } as never);
+
+  return { run, membershipRoleDAL };
+};
+
+describe("updateGroup privilege boundary", () => {
+  test("the actor holds groups:edit, so the plain permission check is not what rejects it", () => {
+    expect(groupEditorOnly.can(OrgPermissionGroupActions.Edit, OrgPermissionSubjects.Groups)).toBe(true);
+  });
+
+  test("on the legacy system, a weaker actor cannot strip an Admin group to no-access", async () => {
+    const { run, membershipRoleDAL } = createUpdate({
+      actorPermission: groupEditorOnly,
+      shouldUseNewPrivilegeSystem: false
+    });
+
+    await expect(run()).rejects.toThrow(PermissionBoundaryError);
+    expect(membershipRoleDAL.create).not.toHaveBeenCalled();
+  });
+
+  test("downgrading to a role the actor may grant is still bounded by what the group holds", async () => {
+    const { run } = createUpdate({
+      actorPermission: groupEditorOnly,
+      shouldUseNewPrivilegeSystem: false,
+      incomingRole: OrgMembershipRole.Member
+    });
+
+    await expect(run()).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("an admin can still change an Admin group's role on either system", async () => {
+    await expect(createUpdate({ actorPermission: admin, shouldUseNewPrivilegeSystem: false }).run()).resolves.toEqual(
+      expect.objectContaining({ id: GROUP_ID })
+    );
+    await expect(createUpdate({ actorPermission: admin, shouldUseNewPrivilegeSystem: true }).run()).resolves.toEqual(
+      expect.objectContaining({ id: GROUP_ID })
+    );
+  });
+
+  test("nothing outranks the actor, so an ordinary no-access group is let through", async () => {
+    const { run } = createUpdate({
+      actorPermission: groupEditorOnly,
+      shouldUseNewPrivilegeSystem: false,
+      currentRole: OrgMembershipRole.NoAccess
+    });
+
+    await expect(run()).resolves.toEqual(expect.objectContaining({ id: GROUP_ID }));
+  });
+});

--- a/backend/src/ee/services/group/group-update-boundary.test.ts
+++ b/backend/src/ee/services/group/group-update-boundary.test.ts
@@ -33,6 +33,19 @@ const groupEditorOnly = createMongoAbility<MongoAbility>([
   }
 ]);
 
+// deleteGroup's own throwUnlessCan demands Delete, which the editor ability above deliberately lacks.
+const groupDeleterOnly = createMongoAbility<MongoAbility>([
+  {
+    action: [
+      OrgPermissionGroupActions.Read,
+      OrgPermissionGroupActions.Edit,
+      OrgPermissionGroupActions.Delete,
+      OrgPermissionGroupActions.GrantPrivileges
+    ],
+    subject: OrgPermissionSubjects.Groups
+  }
+]);
+
 const createUpdate = ({
   actorPermission,
   shouldUseNewPrivilegeSystem,
@@ -74,17 +87,20 @@ const createUpdate = ({
     membershipRoleDAL: membershipRoleDAL as never
   } as never);
 
-  const run = () =>
-    service.updateGroup({
-      id: GROUP_ID,
-      role: incomingRole,
-      actor: "user",
-      actorId: "actor-id",
-      actorAuthMethod: "email",
-      actorOrgId: ORG_ID
-    } as never);
+  const actor = { actor: "user", actorId: "actor-id", actorAuthMethod: "email", actorOrgId: ORG_ID };
 
-  return { run, membershipRoleDAL };
+  const run = () => service.updateGroup({ id: GROUP_ID, role: incomingRole, ...actor } as never);
+  const remove = () => service.deleteGroup({ id: GROUP_ID, ...actor } as never);
+
+  return { run, remove, membershipRoleDAL };
+};
+
+// deleteGroup runs on past the boundary into the teardown this harness does not stand up, so the
+// pass-through cases assert only that the boundary is not what stopped them.
+const expectNoBoundaryError = async (fn: () => Promise<unknown>) => {
+  await fn().catch((err: unknown) => {
+    expect(err).not.toBeInstanceOf(PermissionBoundaryError);
+  });
 };
 
 describe("updateGroup privilege boundary", () => {
@@ -119,6 +135,28 @@ describe("updateGroup privilege boundary", () => {
     await expect(createUpdate({ actorPermission: admin, shouldUseNewPrivilegeSystem: true }).run()).resolves.toEqual(
       expect.objectContaining({ id: GROUP_ID })
     );
+  });
+
+  test("on the legacy system, a weaker actor cannot delete an Admin-role group", async () => {
+    const { remove } = createUpdate({ actorPermission: groupDeleterOnly, shouldUseNewPrivilegeSystem: false });
+
+    await expect(remove()).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("deleting a group nothing outranks the actor on clears the boundary", async () => {
+    const { remove } = createUpdate({
+      actorPermission: groupDeleterOnly,
+      shouldUseNewPrivilegeSystem: false,
+      currentRole: OrgMembershipRole.NoAccess
+    });
+
+    await expectNoBoundaryError(remove);
+  });
+
+  test("an admin actor clears the delete boundary", async () => {
+    const { remove } = createUpdate({ actorPermission: admin, shouldUseNewPrivilegeSystem: false });
+
+    await expectNoBoundaryError(remove);
   });
 
   test("nothing outranks the actor, so an ordinary no-access group is let through", async () => {

--- a/backend/src/ee/services/permission/org-permission.ts
+++ b/backend/src/ee/services/permission/org-permission.ts
@@ -101,6 +101,14 @@ export enum OrgPermissionKmipServerActions {
   RevokeKmipServerAccess = "revoke-kmip-server-access"
 }
 
+export enum OrgPermissionMemberActions {
+  Read = "read",
+  Create = "create",
+  Edit = "edit",
+  Delete = "delete",
+  GrantPrivileges = "grant-privileges"
+}
+
 export enum OrgPermissionIdentityActions {
   Read = "read",
   Create = "create",
@@ -204,7 +212,7 @@ export type OrgPermissionSet =
   | [OrgPermissionProjectActions, OrgPermissionSubjects.Project]
   | [OrgPermissionActions, OrgPermissionSubjects.Role]
   | [OrgPermissionSubOrgActions, OrgPermissionSubjects.SubOrganization]
-  | [OrgPermissionActions, OrgPermissionSubjects.Member]
+  | [OrgPermissionMemberActions, OrgPermissionSubjects.Member]
   | [OrgPermissionActions, OrgPermissionSubjects.Settings]
   | [OrgPermissionActions, OrgPermissionSubjects.IncidentAccount]
   | [OrgPermissionSsoActions, OrgPermissionSubjects.Sso]
@@ -278,7 +286,9 @@ export const OrgPermissionSchema = z.discriminatedUnion("subject", [
   }),
   z.object({
     subject: z.literal(OrgPermissionSubjects.Member).describe("The entity this permission pertains to."),
-    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(OrgPermissionActions).describe("Describe what action an entity can take.")
+    action: CASL_ACTION_SCHEMA_NATIVE_ENUM(OrgPermissionMemberActions).describe(
+      "Describe what action an entity can take."
+    )
   }),
   z.object({
     subject: z.literal(OrgPermissionSubjects.Settings).describe("The entity this permission pertains to."),
@@ -455,10 +465,11 @@ const buildAdminPermission = () => {
   can(OrgPermissionActions.Edit, OrgPermissionSubjects.Role);
   can(OrgPermissionActions.Delete, OrgPermissionSubjects.Role);
 
-  can(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
-  can(OrgPermissionActions.Create, OrgPermissionSubjects.Member);
-  can(OrgPermissionActions.Edit, OrgPermissionSubjects.Member);
-  can(OrgPermissionActions.Delete, OrgPermissionSubjects.Member);
+  can(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
+  can(OrgPermissionMemberActions.Create, OrgPermissionSubjects.Member);
+  can(OrgPermissionMemberActions.Edit, OrgPermissionSubjects.Member);
+  can(OrgPermissionMemberActions.Delete, OrgPermissionSubjects.Member);
+  can(OrgPermissionMemberActions.GrantPrivileges, OrgPermissionSubjects.Member);
 
   can(OrgPermissionActions.Read, OrgPermissionSubjects.SecretScanning);
   can(OrgPermissionActions.Create, OrgPermissionSubjects.SecretScanning);
@@ -625,7 +636,7 @@ const buildMemberPermission = () => {
   can(OrgPermissionActions.Create, OrgPermissionSubjects.Workspace);
   can(OrgPermissionProjectActions.Create, OrgPermissionSubjects.Project);
   can(OrgPermissionProjectActions.RequestAccess, OrgPermissionSubjects.Project);
-  can(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
+  can(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
   can(OrgPermissionGroupActions.Read, OrgPermissionSubjects.Groups);
   can(OrgPermissionActions.Read, OrgPermissionSubjects.Role);
   can(OrgPermissionActions.Read, OrgPermissionSubjects.Settings);

--- a/backend/src/ee/services/permission/permission-by-roles.test.ts
+++ b/backend/src/ee/services/permission/permission-by-roles.test.ts
@@ -1,0 +1,126 @@
+import { packRules } from "@casl/ability/extra";
+import { vi } from "vitest";
+
+import { NotFoundError } from "@app/lib/errors";
+
+import { OrgPermissionActions, OrgPermissionSubjects } from "./org-permission";
+import { permissionServiceFactory } from "./permission-service";
+import { ProjectPermissionActions, ProjectPermissionSub } from "./project-permission";
+
+// A membership row can outlive the role slug it points at: a product gets removed and its slugs stop
+// resolving, while the rows that reference them stay. buildProjectPermissionRules already tolerates
+// that (unknown slug -> no rules). These cover the same tolerance on the by-roles lookups, which the
+// privilege-boundary guards use to measure roles a principal already holds -- without it, a member
+// carrying a stale slug could not be removed at all, because the boundary check 404s first.
+
+const CUSTOM_ROLE_SLUG = "release-manager";
+
+const createService = () => {
+  const roleDAL = {
+    find: vi.fn().mockImplementation(({ $in }: { $in: { slug: string[] } }) =>
+      $in.slug.includes(CUSTOM_ROLE_SLUG)
+        ? [
+            {
+              id: "role-id",
+              name: CUSTOM_ROLE_SLUG,
+              slug: CUSTOM_ROLE_SLUG,
+              permissions: packRules([
+                { subject: ProjectPermissionSub.SecretFolders, action: [ProjectPermissionActions.Read] }
+              ])
+            }
+          ]
+        : []
+    )
+  };
+
+  const service = permissionServiceFactory({
+    roleDAL,
+    projectDAL: { findById: vi.fn().mockResolvedValue({ id: "project-id", type: "secret-manager" }) },
+    serviceTokenDAL: {} as never,
+    permissionDAL: {} as never,
+    keyStore: {} as never,
+    userDAL: {} as never,
+    identityDAL: {} as never,
+    additionalPrivilegeDAL: {} as never,
+    groupDAL: {} as never,
+    secretFolderDAL: {} as never
+  } as never);
+
+  return { service, roleDAL };
+};
+
+describe("getOrgPermissionByRoles", () => {
+  test("throws by default so an assignment of a role that does not exist is rejected", async () => {
+    const { service } = createService();
+
+    await expect(service.getOrgPermissionByRoles(["ssh-host-bootstrapper"], "org-id")).rejects.toThrow(NotFoundError);
+  });
+
+  test("drops the unresolved slug when the caller asks for it", async () => {
+    const { service } = createService();
+
+    const result = await service.getOrgPermissionByRoles(["ssh-host-bootstrapper"], "org-id", {
+      ignoreUnresolvedRoles: true
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("keeps the roles that do resolve alongside one that does not", async () => {
+    const { service } = createService();
+
+    const result = await service.getOrgPermissionByRoles(["admin", "ssh-host-bootstrapper"], "org-id", {
+      ignoreUnresolvedRoles: true
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].permission.can(OrgPermissionActions.Delete, OrgPermissionSubjects.Member)).toBe(true);
+  });
+});
+
+describe("getProjectPermissionByRoles", () => {
+  test("throws by default so an assignment of a role that does not exist is rejected", async () => {
+    const { service } = createService();
+
+    await expect(service.getProjectPermissionByRoles(["ssh-host-bootstrapper"], "project-id")).rejects.toThrow(
+      NotFoundError
+    );
+  });
+
+  test("drops the unresolved slug when the caller asks for it", async () => {
+    const { service } = createService();
+
+    const result = await service.getProjectPermissionByRoles(["ssh-host-bootstrapper"], "project-id", {
+      ignoreUnresolvedRoles: true
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  test("still resolves a custom role sitting next to an unresolved slug", async () => {
+    const { service } = createService();
+
+    const result = await service.getProjectPermissionByRoles(
+      [CUSTOM_ROLE_SLUG, "ssh-host-bootstrapper"],
+      "project-id",
+      {
+        ignoreUnresolvedRoles: true
+      }
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].role?.slug).toBe(CUSTOM_ROLE_SLUG);
+    expect(result[0].permission.can(ProjectPermissionActions.Read, ProjectPermissionSub.SecretFolders)).toBe(true);
+  });
+
+  test("a built-in slug resolves without touching the custom-role table", async () => {
+    const { service, roleDAL } = createService();
+
+    const result = await service.getProjectPermissionByRoles(["admin"], "project-id", {
+      ignoreUnresolvedRoles: true
+    });
+
+    expect(result).toHaveLength(1);
+    expect(roleDAL.find).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/ee/services/permission/permission-by-roles.test.ts
+++ b/backend/src/ee/services/permission/permission-by-roles.test.ts
@@ -3,7 +3,7 @@ import { vi } from "vitest";
 
 import { NotFoundError } from "@app/lib/errors";
 
-import { OrgPermissionActions, OrgPermissionSubjects } from "./org-permission";
+import { OrgPermissionMemberActions, OrgPermissionSubjects } from "./org-permission";
 import { permissionServiceFactory } from "./permission-service";
 import { ProjectPermissionActions, ProjectPermissionSub } from "./project-permission";
 
@@ -74,7 +74,7 @@ describe("getOrgPermissionByRoles", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0].permission.can(OrgPermissionActions.Delete, OrgPermissionSubjects.Member)).toBe(true);
+    expect(result[0].permission.can(OrgPermissionMemberActions.Delete, OrgPermissionSubjects.Member)).toBe(true);
   });
 });
 

--- a/backend/src/ee/services/permission/permission-by-roles.test.ts
+++ b/backend/src/ee/services/permission/permission-by-roles.test.ts
@@ -7,11 +7,10 @@ import { OrgPermissionMemberActions, OrgPermissionSubjects } from "./org-permiss
 import { permissionServiceFactory } from "./permission-service";
 import { ProjectPermissionActions, ProjectPermissionSub } from "./project-permission";
 
-// A membership row can outlive the role slug it points at: a product gets removed and its slugs stop
-// resolving, while the rows that reference them stay. buildProjectPermissionRules already tolerates
-// that (unknown slug -> no rules). These cover the same tolerance on the by-roles lookups, which the
-// privilege-boundary guards use to measure roles a principal already holds -- without it, a member
-// carrying a stale slug could not be removed at all, because the boundary check 404s first.
+// A membership row can outlive the role slug it points at, e.g. a product gets removed and its slugs
+// stop resolving. buildProjectPermissionRules already tolerates that (unknown slug -> no rules); the
+// by-roles lookups need the same tolerance, or a member carrying a stale slug can never be removed
+// because the privilege-boundary check 404s first.
 
 const CUSTOM_ROLE_SLUG = "release-manager";
 

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -394,7 +394,7 @@ type TAssertRoleSetBoundaryArg = {
   opActions: (OrgPermissionSet[0] | ProjectPermissionSet[0]) | (OrgPermissionSet[0] | ProjectPermissionSet[0])[];
   opSubject: OrgPermissionSet[1] | ProjectPermissionSet[1];
   actorPermission: MongoAbility;
-  targetPermissions: { permission: MongoAbility }[];
+  targetPermissions: { permission: MongoAbility; role?: { slug: string } }[];
   baseMessage: string;
   subjectFields?: Record<string, string | undefined>;
 };
@@ -414,13 +414,15 @@ const assertRoleSetBoundary = ({
   const targets = targetPermissions.length ? targetPermissions : [{ permission: createMongoAbility([]) }];
 
   for (const target of targets) {
+    const targetSubjectFields = target.role ? { ...subjectFields, assignableRole: target.role.slug } : subjectFields;
+
     const boundary = validatePrivilegeChangeOperation(
       shouldUseNewPrivilegeSystem,
       opActions,
       opSubject,
       actorPermission,
       target.permission,
-      subjectFields
+      targetSubjectFields
     );
 
     if (!boundary.isValid)

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -389,6 +389,46 @@ const assertPermissionBoundary = (actorPermission: MongoAbility, managedPermissi
   }
 };
 
+type TAssertRoleSetBoundaryArg = {
+  shouldUseNewPrivilegeSystem: boolean;
+  opActions: (OrgPermissionSet[0] | ProjectPermissionSet[0]) | (OrgPermissionSet[0] | ProjectPermissionSet[0])[];
+  opSubject: OrgPermissionSet[1] | ProjectPermissionSet[1];
+  actorPermission: MongoAbility;
+  targetPermissions: { permission: MongoAbility }[];
+  baseMessage: string;
+  subjectFields?: Record<string, string | undefined>;
+};
+
+// Bounds a privilege change against every role the target holds, not just the first one.
+const assertRoleSetBoundary = ({
+  shouldUseNewPrivilegeSystem,
+  opActions,
+  opSubject,
+  actorPermission,
+  targetPermissions,
+  baseMessage,
+  subjectFields
+}: TAssertRoleSetBoundaryArg) => {
+  const primaryAction = Array.isArray(opActions) ? opActions[0] : opActions;
+
+  for (const target of targetPermissions) {
+    const boundary = validatePrivilegeChangeOperation(
+      shouldUseNewPrivilegeSystem,
+      opActions,
+      opSubject,
+      actorPermission,
+      target.permission,
+      subjectFields
+    );
+
+    if (!boundary.isValid)
+      throw new PermissionBoundaryError({
+        message: constructPermissionErrorMessage(baseMessage, shouldUseNewPrivilegeSystem, primaryAction, opSubject),
+        details: { missingPermissions: boundary.missingPermissions }
+      });
+  }
+};
+
 // Subjects whose forbid rules on new fine-grained actions must also forbid the
 // legacy umbrella action they replaced. Without this expansion, an admin allow
 // on the legacy action survives a custom-role forbid on the new actions and
@@ -634,6 +674,7 @@ export const interpolatePermissionRules = <T>(rules: T[], identityContext: Recor
 
 export {
   assertPermissionBoundary,
+  assertRoleSetBoundary,
   constructPermissionErrorMessage,
   escapeHandlebarsMissingDict,
   expandLegacyForbidActions,

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-nested-ternary */
-import { ForbiddenError, MongoAbility, PureAbility, RawRuleOf, subject } from "@casl/ability";
+import { createMongoAbility, ForbiddenError, MongoAbility, PureAbility, RawRuleOf, subject } from "@casl/ability";
 import handlebars from "handlebars";
 import picomatch from "picomatch";
 import { z } from "zod";
@@ -411,7 +411,9 @@ const assertRoleSetBoundary = ({
 }: TAssertRoleSetBoundaryArg) => {
   const primaryAction = Array.isArray(opActions) ? opActions[0] : opActions;
 
-  for (const target of targetPermissions) {
+  const targets = targetPermissions.length ? targetPermissions : [{ permission: createMongoAbility([]) }];
+
+  for (const target of targets) {
     const boundary = validatePrivilegeChangeOperation(
       shouldUseNewPrivilegeSystem,
       opActions,

--- a/backend/src/ee/services/permission/permission-fns.ts
+++ b/backend/src/ee/services/permission/permission-fns.ts
@@ -379,16 +379,6 @@ const constructPermissionErrorMessage = (
   }`;
 };
 
-const assertPermissionBoundary = (actorPermission: MongoAbility, managedPermission: MongoAbility, message: string) => {
-  const boundary = validatePermissionBoundary(actorPermission, managedPermission);
-  if (!boundary.isValid) {
-    throw new PermissionBoundaryError({
-      message,
-      details: { missingPermissions: boundary.missingPermissions }
-    });
-  }
-};
-
 type TAssertRoleSetBoundaryArg = {
   shouldUseNewPrivilegeSystem: boolean;
   opActions: (OrgPermissionSet[0] | ProjectPermissionSet[0]) | (OrgPermissionSet[0] | ProjectPermissionSet[0])[];
@@ -677,7 +667,6 @@ export const interpolatePermissionRules = <T>(rules: T[], identityContext: Recor
 };
 
 export {
-  assertPermissionBoundary,
   assertRoleSetBoundary,
   constructPermissionErrorMessage,
   escapeHandlebarsMissingDict,

--- a/backend/src/ee/services/permission/permission-service-types.ts
+++ b/backend/src/ee/services/permission/permission-service-types.ts
@@ -103,6 +103,10 @@ export type TGetOrgPermissionArg = {
   scope: OrganizationActionScope;
 };
 
+export type TResolveRolesOpts = {
+  ignoreUnresolvedRoles?: boolean;
+};
+
 export type TPermissionServiceFactory = {
   getOrgPermission: (arg: TGetOrgPermissionArg) => Promise<{
     permission: MongoAbility<OrgPermissionSet, MongoQuery>;
@@ -159,7 +163,8 @@ export type TPermissionServiceFactory = {
   }>;
   getOrgPermissionByRoles: (
     roles: string[],
-    orgId: string
+    orgId: string,
+    opts?: TResolveRolesOpts
   ) => Promise<
     {
       permission: MongoAbility<OrgPermissionSet, MongoQuery>;
@@ -176,7 +181,8 @@ export type TPermissionServiceFactory = {
   >;
   getProjectPermissionByRoles: (
     roles: string[],
-    projectId: string
+    projectId: string,
+    opts?: TResolveRolesOpts
   ) => Promise<
     {
       permission: MongoAbility<ProjectPermissionSet, MongoQuery>;

--- a/backend/src/ee/services/permission/permission-service.ts
+++ b/backend/src/ee/services/permission/permission-service.ts
@@ -1029,7 +1029,7 @@ export const permissionServiceFactory = ({
 
   // instead of actor type this will fetch by role slug. meaning it can be the pre defined slugs like
   // admin member or user defined ones like biller etc
-  const getOrgPermissionByRoles: TPermissionServiceFactory["getOrgPermissionByRoles"] = async (roles, orgId) => {
+  const getOrgPermissionByRoles: TPermissionServiceFactory["getOrgPermissionByRoles"] = async (roles, orgId, opts) => {
     const formattedRoles = roles.map((role) => ({
       name: role,
       isCustom: !Object.values(OrgMembershipRole).includes(role as OrgMembershipRole)
@@ -1044,24 +1044,25 @@ export const permissionServiceFactory = ({
           }
         })
       : [];
-    if (customRoles.length !== customRoleDetails.length) {
+    if (customRoles.length !== customRoleDetails.length && !opts?.ignoreUnresolvedRoles) {
       const missingRoles = customRoles.filter((role) => !customRoleDetails.find((el) => el.slug === role));
       throw new NotFoundError({
         message: `Specified roles '${missingRoles.join(",")}' was not found in the organization with ID '${orgId}'`
       });
     }
 
-    return formattedRoles.map((el) => {
+    return formattedRoles.flatMap((el) => {
       if (el.isCustom) {
         const roleDetails = customRoleDetails.find((role) => role.slug === el.name);
+        if (!roleDetails) return [];
         return {
           permission: createMongoAbility<OrgPermissionSet>(
-            buildOrgPermissionRules([{ role: OrgMembershipRole.Custom, permissions: roleDetails?.permissions || [] }]),
+            buildOrgPermissionRules([{ role: OrgMembershipRole.Custom, permissions: roleDetails.permissions || [] }]),
             {
               conditionsMatcher
             }
           ),
-          role: roleDetails!
+          role: roleDetails
         };
       }
 
@@ -1078,7 +1079,8 @@ export const permissionServiceFactory = ({
 
   const getProjectPermissionByRoles: TPermissionServiceFactory["getProjectPermissionByRoles"] = async (
     roles,
-    projectId
+    projectId,
+    opts
   ) => {
     const formattedRoles = roles.map((role) => ({
       name: role,
@@ -1101,27 +1103,28 @@ export const permissionServiceFactory = ({
           }
         })
       : [];
-    if (customRoles.length !== customRoleDetails.length) {
+    if (customRoles.length !== customRoleDetails.length && !opts?.ignoreUnresolvedRoles) {
       const missingRoles = customRoles.filter((role) => !customRoleDetails.find((el) => el.slug === role));
       throw new NotFoundError({
         message: `Specified roles '${missingRoles.join(",")}' was not found in the project with ID '${projectId}'`
       });
     }
 
-    return formattedRoles.map((el) => {
+    return formattedRoles.flatMap((el) => {
       if (el.isCustom) {
         const roleDetails = customRoleDetails.find((role) => role.slug === el.name);
+        if (!roleDetails) return [];
         return {
           permission: createMongoAbility<ProjectPermissionSet>(
             buildProjectPermissionRules(
-              [{ role: ProjectMembershipRole.Custom, permissions: roleDetails?.permissions || [] }],
+              [{ role: ProjectMembershipRole.Custom, permissions: roleDetails.permissions || [] }],
               project?.type
             ),
             {
               conditionsMatcher
             }
           ),
-          role: roleDetails!
+          role: roleDetails
         };
       }
 

--- a/backend/src/ee/services/permission/role-set-boundary.test.ts
+++ b/backend/src/ee/services/permission/role-set-boundary.test.ts
@@ -1,0 +1,77 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+
+import { PermissionBoundaryError } from "@app/lib/errors";
+
+import { projectAdminPermissions, projectMemberPermissions } from "./default-roles";
+import { assertRoleSetBoundary } from "./permission-fns";
+import { ProjectPermissionIdentityActions, ProjectPermissionSet, ProjectPermissionSub } from "./project-permission";
+
+// Regression guard for the privilege-boundary fix on membership removal and role assignment.
+// The bug this replaces was `const [first] = await getOrgPermissionByRoles(roles, orgId)`, which
+// measured a multi-role target against only its first role -- so a principal holding
+// [member, admin-ish-custom-role] was bounded as if it only held `member`.
+
+const admin = createMongoAbility<MongoAbility<ProjectPermissionSet>>(projectAdminPermissions);
+const member = createMongoAbility<MongoAbility<ProjectPermissionSet>>(projectMemberPermissions);
+
+const runBoundary = (actorPermission: MongoAbility, targetPermissions: { permission: MongoAbility }[]) =>
+  assertRoleSetBoundary({
+    shouldUseNewPrivilegeSystem: false,
+    opActions: ProjectPermissionIdentityActions.Delete,
+    opSubject: ProjectPermissionSub.Identity,
+    actorPermission,
+    targetPermissions,
+    baseMessage: "Failed to remove a more privileged identity from the project"
+  });
+
+describe("assertRoleSetBoundary", () => {
+  test("an admin actor dominates a member target", () => {
+    expect(() => runBoundary(admin, [{ permission: member }])).not.toThrow();
+  });
+
+  test("a member actor does not dominate an admin target", () => {
+    expect(() => runBoundary(member, [{ permission: admin }])).toThrow(PermissionBoundaryError);
+  });
+
+  test("checks every role, not just the first", () => {
+    // The regression: `member` alone passes, so a [member, admin] target must still be rejected.
+    expect(() => runBoundary(member, [{ permission: member }])).not.toThrow();
+    expect(() => runBoundary(member, [{ permission: member }, { permission: admin }])).toThrow(PermissionBoundaryError);
+  });
+
+  test("an empty target role set runs no comparison", () => {
+    // This is how the NoAccess / expired-temporary-role exemption arrives: the slug list is
+    // filtered before resolution, so the helper is handed nothing to compare against.
+    expect(() => runBoundary(member, [])).not.toThrow();
+  });
+
+  test("the thrown error carries the missing permissions", () => {
+    try {
+      runBoundary(member, [{ permission: admin }]);
+      expect.unreachable("expected a PermissionBoundaryError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(PermissionBoundaryError);
+      const { details } = err as PermissionBoundaryError & { details: { missingPermissions: unknown[] } };
+      expect(details.missingPermissions.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("under the new privilege system the actor's own action grant decides", () => {
+    const assertNewSystem = (actorPermission: MongoAbility) =>
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem: true,
+        opActions: ProjectPermissionIdentityActions.Delete,
+        opSubject: ProjectPermissionSub.Identity,
+        actorPermission,
+        targetPermissions: [{ permission: admin }],
+        baseMessage: "Failed to remove a more privileged identity from the project"
+      });
+
+    // Member holds identity:delete, so it passes despite being weaker than the target.
+    expect(member.can(ProjectPermissionIdentityActions.Delete, ProjectPermissionSub.Identity)).toBe(true);
+    expect(() => assertNewSystem(member)).not.toThrow();
+
+    const noDelete = createMongoAbility<MongoAbility<ProjectPermissionSet>>([]);
+    expect(() => assertNewSystem(noDelete)).toThrow(PermissionBoundaryError);
+  });
+});

--- a/backend/src/ee/services/permission/role-set-boundary.test.ts
+++ b/backend/src/ee/services/permission/role-set-boundary.test.ts
@@ -1,5 +1,6 @@
 import { createMongoAbility, MongoAbility } from "@casl/ability";
 
+import { conditionsMatcher } from "@app/lib/casl";
 import { PermissionBoundaryError } from "@app/lib/errors";
 
 import { projectAdminPermissions, projectMemberPermissions } from "./default-roles";
@@ -61,6 +62,56 @@ describe("assertRoleSetBoundary", () => {
     expect(() => assertNewSystem(createMongoAbility<MongoAbility<ProjectPermissionSet>>([]))).toThrow(
       PermissionBoundaryError
     );
+  });
+
+  describe("an actor whose rule is scoped with an assignableRole condition", () => {
+    const scopedActor = (condition: Record<string, unknown>) =>
+      createMongoAbility<MongoAbility<ProjectPermissionSet>>(
+        [
+          {
+            action: ProjectPermissionIdentityActions.AssignRole,
+            subject: ProjectPermissionSub.Identity,
+            conditions: { assignableRole: condition }
+          }
+        ],
+        { conditionsMatcher }
+      );
+
+    const assignRole = (
+      actorPermission: MongoAbility,
+      targetPermissions: { permission: MongoAbility; role?: { slug: string } }[]
+    ) =>
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem: true,
+        opActions: ProjectPermissionIdentityActions.AssignRole,
+        opSubject: ProjectPermissionSub.Identity,
+        actorPermission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged identity",
+        subjectFields: { identityId: "identity-1" }
+      });
+
+    test("passes for a target holding a role the condition covers", () => {
+      const actor = scopedActor({ $in: ["viewer", "member"] });
+      expect(() => assignRole(actor, [{ permission: member, role: { slug: "member" } }])).not.toThrow();
+    });
+
+    test("still rejects a target holding a role the condition excludes", () => {
+      const actor = scopedActor({ $in: ["viewer", "member"] });
+      expect(() => assignRole(actor, [{ permission: admin, role: { slug: "admin" } }])).toThrow(
+        PermissionBoundaryError
+      );
+    });
+
+    test("a $glob condition matches the target role instead of throwing", () => {
+      // Evaluating $glob against an absent assignableRole threw a raw TypeError out of picomatch,
+      // which surfaced as a 500 rather than a permission error.
+      const actor = scopedActor({ $glob: "team-*" });
+      expect(() => assignRole(actor, [{ permission: member, role: { slug: "team-a" } }])).not.toThrow();
+      expect(() => assignRole(actor, [{ permission: member, role: { slug: "admin" } }])).toThrow(
+        PermissionBoundaryError
+      );
+    });
   });
 
   test("the thrown error carries the missing permissions", () => {

--- a/backend/src/ee/services/permission/role-set-boundary.test.ts
+++ b/backend/src/ee/services/permission/role-set-boundary.test.ts
@@ -5,7 +5,12 @@ import { PermissionBoundaryError } from "@app/lib/errors";
 
 import { projectAdminPermissions, projectMemberPermissions } from "./default-roles";
 import { assertRoleSetBoundary } from "./permission-fns";
-import { ProjectPermissionIdentityActions, ProjectPermissionSet, ProjectPermissionSub } from "./project-permission";
+import {
+  ProjectPermissionIdentityActions,
+  ProjectPermissionMemberActions,
+  ProjectPermissionSet,
+  ProjectPermissionSub
+} from "./project-permission";
 
 // Regression guard for the privilege-boundary fix on membership removal and role assignment.
 // The bug this replaces was `const [first] = await getOrgPermissionByRoles(roles, orgId)`, which
@@ -142,5 +147,58 @@ describe("assertRoleSetBoundary", () => {
 
     const noDelete = createMongoAbility<MongoAbility<ProjectPermissionSet>>([]);
     expect(() => assertNewSystem(noDelete)).toThrow(PermissionBoundaryError);
+  });
+
+  // The removal guards bound `delete` while passing only `assignableRole`, so a rule scoped to the
+  // resource's own identity (userEmail / groupName / identityId) was evaluated against an absent
+  // field: $eq and $in denied a removal the actor was entitled to, and $glob threw a raw TypeError
+  // out of picomatch as a 500. Every guard now passes the resource field it scopes on.
+  describe("a delete rule scoped to the resource's own identity", () => {
+    const scopedDeleter = (conditions: Record<string, unknown>) =>
+      createMongoAbility<MongoAbility<ProjectPermissionSet>>(
+        [
+          {
+            action: ProjectPermissionMemberActions.Delete,
+            subject: ProjectPermissionSub.Member,
+            conditions
+          }
+        ] as never,
+        { conditionsMatcher }
+      );
+
+    const removeMember = (actorPermission: MongoAbility, userEmail: string | undefined) =>
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem: true,
+        opActions: ProjectPermissionMemberActions.Delete,
+        opSubject: ProjectPermissionSub.Member,
+        actorPermission,
+        targetPermissions: [{ permission: member, role: { slug: "member" } }],
+        baseMessage: "Failed to remove a more privileged member from the project",
+        subjectFields: { userEmail }
+      });
+
+    test.each([{ $eq: "contractor@acme.com" }, { $in: ["contractor@acme.com"] }, { $glob: "*@acme.com" }])(
+      "permits removing a member the condition covers (%j)",
+      (condition) => {
+        expect(() => removeMember(scopedDeleter({ userEmail: condition }), "contractor@acme.com")).not.toThrow();
+      }
+    );
+
+    test.each([{ $eq: "contractor@acme.com" }, { $in: ["contractor@acme.com"] }, { $glob: "*@acme.com" }])(
+      "still rejects removing a member the condition excludes (%j)",
+      (condition) => {
+        expect(() => removeMember(scopedDeleter({ userEmail: condition }), "staff@other.com")).toThrow(
+          PermissionBoundaryError
+        );
+      }
+    );
+
+    test("a target with no email is denied rather than throwing a TypeError", () => {
+      // Users.email is nullable, so the guard passes undefined. picomatch rejects a non-string
+      // input, which reached the client as a 500 instead of a permission error.
+      expect(() => removeMember(scopedDeleter({ userEmail: { $glob: "*@acme.com" } }), undefined)).toThrow(
+        PermissionBoundaryError
+      );
+    });
   });
 });

--- a/backend/src/ee/services/permission/role-set-boundary.test.ts
+++ b/backend/src/ee/services/permission/role-set-boundary.test.ts
@@ -45,6 +45,24 @@ describe("assertRoleSetBoundary", () => {
     expect(() => runBoundary(member, [])).not.toThrow();
   });
 
+  test("an empty target role set still requires the action under the new privilege system", () => {
+    // A no-access group resolves to zero roles, but the actor must still hold the action itself.
+    const assertNewSystem = (actorPermission: MongoAbility) =>
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem: true,
+        opActions: ProjectPermissionIdentityActions.Delete,
+        opSubject: ProjectPermissionSub.Identity,
+        actorPermission,
+        targetPermissions: [],
+        baseMessage: "Failed to remove a more privileged identity from the project"
+      });
+
+    expect(() => assertNewSystem(member)).not.toThrow();
+    expect(() => assertNewSystem(createMongoAbility<MongoAbility<ProjectPermissionSet>>([]))).toThrow(
+      PermissionBoundaryError
+    );
+  });
+
   test("the thrown error carries the missing permissions", () => {
     try {
       runBoundary(member, [{ permission: admin }]);

--- a/backend/src/lib/casl/index.ts
+++ b/backend/src/lib/casl/index.ts
@@ -16,6 +16,7 @@ const glob: JsInterpreter<FieldCondition<string>> = (node, object, context) => {
   const secretPath = context.get(object, node.field) as string;
   const permissionSecretGlobPath = node.value;
   if (permissionSecretGlobPath.trim() === "") return false;
+  if (typeof secretPath !== "string") return false;
   return picomatch.isMatch(secretPath, permissionSecretGlobPath, { strictSlashes: false });
 };
 

--- a/backend/src/server/lib/schemas.ts
+++ b/backend/src/server/lib/schemas.ts
@@ -9,12 +9,12 @@ interface SlugSchemaInputs {
   min?: number;
   max?: number;
   field?: string;
+  trim?: boolean;
 }
 
-export const slugSchema = ({ min = 1, max = 64, field = "Slug" }: SlugSchemaInputs = {}) => {
-  return z
-    .string()
-    .trim()
+export const slugSchema = ({ min = 1, max = 64, field = "Slug", trim = true }: SlugSchemaInputs = {}) => {
+  const base = trim ? z.string().trim() : z.string();
+  return base
     .min(min, {
       message: `${field} field must be at least ${min} lowercase character${min === 1 ? "" : "s"}`
     })

--- a/backend/src/services/identity-v2/identity-delete-boundary.test.ts
+++ b/backend/src/services/identity-v2/identity-delete-boundary.test.ts
@@ -1,0 +1,168 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { vi } from "vitest";
+
+import { AccessScope, OrgMembershipRole, ProjectMembershipRole } from "@app/db/schemas";
+import { projectAdminPermissions, projectNoAccessPermissions } from "@app/ee/services/permission/default-roles";
+import {
+  orgAdminPermissions,
+  orgNoAccessPermissions,
+  OrgPermissionIdentityActions,
+  OrgPermissionSubjects
+} from "@app/ee/services/permission/org-permission";
+import { ProjectPermissionIdentityActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import { PermissionBoundaryError } from "@app/lib/errors";
+
+import { newOrgIdentityFactory } from "./org/org-identity-factory";
+import { newProjectIdentityFactory } from "./project/project-identity-factory";
+
+// The v2 delete guards checked identity:delete and nothing else, so an actor holding that action
+// could delete an identity that outranks it. The membership routes bound the same operation, so the
+// v2 surface was the way around them.
+
+const ORG_ID = "org-id";
+const PROJECT_ID = "project-id";
+const IDENTITY_ID = "identity-id";
+
+const orgAbilityByRole: Record<string, MongoAbility> = {
+  [OrgMembershipRole.Admin]: createMongoAbility<MongoAbility>(orgAdminPermissions),
+  [OrgMembershipRole.NoAccess]: createMongoAbility<MongoAbility>(orgNoAccessPermissions)
+};
+
+const projectAbilityByRole: Record<string, MongoAbility> = {
+  [ProjectMembershipRole.Admin]: createMongoAbility<MongoAbility>(projectAdminPermissions),
+  [ProjectMembershipRole.NoAccess]: createMongoAbility<MongoAbility>(projectNoAccessPermissions)
+};
+
+// Exactly the grant each guard's throwUnlessCan demands, and nothing more.
+const orgIdentityDeleter = createMongoAbility<MongoAbility>([
+  {
+    action: [OrgPermissionIdentityActions.Read, OrgPermissionIdentityActions.Delete],
+    subject: OrgPermissionSubjects.Identity
+  }
+]);
+
+const projectIdentityDeleter = createMongoAbility<MongoAbility>([
+  {
+    action: [ProjectPermissionIdentityActions.Read, ProjectPermissionIdentityActions.Delete],
+    subject: ProjectPermissionSub.Identity
+  }
+]);
+
+const createOrgGuard = ({
+  actorPermission,
+  shouldUseNewPrivilegeSystem,
+  targetRole = OrgMembershipRole.Admin
+}: {
+  actorPermission: MongoAbility;
+  shouldUseNewPrivilegeSystem: boolean;
+  targetRole?: string;
+}) => {
+  const factory = newOrgIdentityFactory({
+    permissionService: {
+      getOrgPermission: vi.fn().mockResolvedValue({ permission: actorPermission }),
+      getOrgPermissionByRoles: vi
+        .fn()
+        .mockImplementation((roles: string[]) => roles.map((role) => ({ permission: orgAbilityByRole[role] })))
+    } as never,
+    orgDAL: { findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem }) } as never,
+    membershipIdentityDAL: { getIdentityById: vi.fn().mockResolvedValue({ roles: [{ role: targetRole }] }) } as never
+  });
+
+  return () =>
+    factory.onDeleteIdentityGuard({
+      permission: { type: "user", id: "actor-id", orgId: ORG_ID, authMethod: "email" },
+      scopeData: { scope: AccessScope.Organization, orgId: ORG_ID },
+      selector: { identityId: IDENTITY_ID }
+    } as never);
+};
+
+const createProjectGuard = ({
+  actorPermission,
+  shouldUseNewPrivilegeSystem,
+  targetRole = ProjectMembershipRole.Admin
+}: {
+  actorPermission: MongoAbility;
+  shouldUseNewPrivilegeSystem: boolean;
+  targetRole?: string;
+}) => {
+  const factory = newProjectIdentityFactory({
+    permissionService: {
+      getProjectPermission: vi.fn().mockResolvedValue({ permission: actorPermission }),
+      getProjectPermissionByRoles: vi
+        .fn()
+        .mockImplementation((roles: string[]) => roles.map((role) => ({ permission: projectAbilityByRole[role] })))
+    } as never,
+    orgDAL: { findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem }) } as never,
+    membershipIdentityDAL: { getIdentityById: vi.fn().mockResolvedValue({ roles: [{ role: targetRole }] }) } as never
+  });
+
+  return () =>
+    factory.onDeleteIdentityGuard({
+      permission: { type: "user", id: "actor-id", orgId: ORG_ID, authMethod: "email" },
+      scopeData: { scope: AccessScope.Project, orgId: ORG_ID, projectId: PROJECT_ID },
+      selector: { identityId: IDENTITY_ID }
+    } as never);
+};
+
+describe("identity v2 delete guards privilege boundary", () => {
+  test("the actor holds identity:delete, so the plain permission check is not what rejects it", () => {
+    expect(orgIdentityDeleter.can(OrgPermissionIdentityActions.Delete, OrgPermissionSubjects.Identity)).toBe(true);
+    expect(projectIdentityDeleter.can(ProjectPermissionIdentityActions.Delete, ProjectPermissionSub.Identity)).toBe(
+      true
+    );
+  });
+
+  test("on the legacy system, a weaker actor cannot delete an Admin identity", async () => {
+    await expect(
+      createOrgGuard({ actorPermission: orgIdentityDeleter, shouldUseNewPrivilegeSystem: false })()
+    ).rejects.toThrow(PermissionBoundaryError);
+
+    await expect(
+      createProjectGuard({ actorPermission: projectIdentityDeleter, shouldUseNewPrivilegeSystem: false })()
+    ).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("an admin actor is unaffected", async () => {
+    await expect(
+      createOrgGuard({
+        actorPermission: orgAbilityByRole[OrgMembershipRole.Admin],
+        shouldUseNewPrivilegeSystem: false
+      })()
+    ).resolves.toBeUndefined();
+
+    await expect(
+      createProjectGuard({
+        actorPermission: projectAbilityByRole[ProjectMembershipRole.Admin],
+        shouldUseNewPrivilegeSystem: false
+      })()
+    ).resolves.toBeUndefined();
+  });
+
+  test("the new system keys on the action, so holding identity:delete is enough", async () => {
+    await expect(
+      createOrgGuard({ actorPermission: orgIdentityDeleter, shouldUseNewPrivilegeSystem: true })()
+    ).resolves.toBeUndefined();
+
+    await expect(
+      createProjectGuard({ actorPermission: projectIdentityDeleter, shouldUseNewPrivilegeSystem: true })()
+    ).resolves.toBeUndefined();
+  });
+
+  test("a target holding nothing that outranks the actor is let through on either system", async () => {
+    await expect(
+      createOrgGuard({
+        actorPermission: orgIdentityDeleter,
+        shouldUseNewPrivilegeSystem: false,
+        targetRole: OrgMembershipRole.NoAccess
+      })()
+    ).resolves.toBeUndefined();
+
+    await expect(
+      createProjectGuard({
+        actorPermission: projectIdentityDeleter,
+        shouldUseNewPrivilegeSystem: false,
+        targetRole: ProjectMembershipRole.NoAccess
+      })()
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/services/identity-v2/identity-service.test.ts
+++ b/backend/src/services/identity-v2/identity-service.test.ts
@@ -60,10 +60,13 @@ const createService = ({
         .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) }),
       getProjectPermission: vi
         .fn()
-        .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) })
+        .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) }),
+      getOrgPermissionByRoles: vi.fn().mockResolvedValue([]),
+      getProjectPermissionByRoles: vi.fn().mockResolvedValue([])
     } as never,
     licenseService: { getPlan: vi.fn(), updateSubscriptionOrgMemberCount: vi.fn() } as never,
-    membershipIdentityDAL: {} as never,
+    // The delete guards bound the removal against the roles the target identity holds.
+    membershipIdentityDAL: { getIdentityById: vi.fn().mockResolvedValue({ roles: [] }) } as never,
     membershipRoleDAL: {} as never,
     identityMetadataDAL: { delete: vi.fn(), insertMany: vi.fn() } as never,
     identityAccessTokenService: {
@@ -76,7 +79,7 @@ const createService = ({
       findOrgProjectIds: vi.fn(),
       findById: vi.fn()
     } as never,
-    orgDAL: { findById: vi.fn() } as never,
+    orgDAL: { findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem: true }) } as never,
     roleDAL: { find: vi.fn() } as never,
     usageMeteringService: { emit: vi.fn(), emitForProject: vi.fn() } as never,
     alertService: { deleteAlertsForDeletedResource } as never

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -44,6 +44,7 @@ import { ActorType } from "../auth/auth-type";
 import { getIdentityActiveLockoutAuthMethods } from "../identity/identity-fns";
 import { TIdentityMetadataDALFactory } from "../identity/identity-metadata-dal";
 import { TIdentityAccessTokenServiceFactory } from "../identity-access-token/identity-access-token-service";
+import { filterRolesNeedingPrivilegeBoundary } from "../membership/membership-fns";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipIdentityDALFactory } from "../membership-identity/membership-identity-dal";
 import { TIdentityV2DALFactory } from "./identity-dal";
@@ -171,30 +172,28 @@ export const identityV2ServiceFactory = ({
       );
 
       const permissionRoles = await permissionService.getProjectPermissionByRoles(
-        data.roles.map((el) => el.role),
+        filterRolesNeedingPrivilegeBoundary(data.roles).map((el) => el.role),
         scopeData.projectId
       );
       for (const permissionRole of permissionRoles) {
-        if (permissionRole?.role?.slug !== ProjectMembershipRole.NoAccess) {
-          const permissionBoundary = validatePrivilegeChangeOperation(
-            shouldUseNewPrivilegeSystem,
-            [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
-            ProjectPermissionSub.Identity,
-            actorPermission,
-            permissionRole.permission,
-            { assignableRole: permissionRole.role?.slug }
-          );
-          if (!permissionBoundary.isValid) {
-            throw new PermissionBoundaryError({
-              message: constructPermissionErrorMessage(
-                "Failed to create identity project membership",
-                shouldUseNewPrivilegeSystem,
-                ProjectPermissionIdentityActions.AssignRole,
-                ProjectPermissionSub.Identity
-              ),
-              details: { missingPermissions: permissionBoundary.missingPermissions }
-            });
-          }
+        const permissionBoundary = validatePrivilegeChangeOperation(
+          shouldUseNewPrivilegeSystem,
+          [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
+          ProjectPermissionSub.Identity,
+          actorPermission,
+          permissionRole.permission,
+          { assignableRole: permissionRole.role?.slug }
+        );
+        if (!permissionBoundary.isValid) {
+          throw new PermissionBoundaryError({
+            message: constructPermissionErrorMessage(
+              "Failed to create identity project membership",
+              shouldUseNewPrivilegeSystem,
+              ProjectPermissionIdentityActions.AssignRole,
+              ProjectPermissionSub.Identity
+            ),
+            details: { missingPermissions: permissionBoundary.missingPermissions }
+          });
         }
       }
 

--- a/backend/src/services/identity-v2/identity-service.ts
+++ b/backend/src/services/identity-v2/identity-service.ts
@@ -101,10 +101,14 @@ export const identityV2ServiceFactory = ({
   alertService
 }: TScopedIdentityV2ServiceFactoryDep) => {
   const orgFactory = newOrgIdentityFactory({
-    permissionService
+    permissionService,
+    orgDAL,
+    membershipIdentityDAL
   });
   const projectFactory = newProjectIdentityFactory({
-    permissionService
+    permissionService,
+    orgDAL,
+    membershipIdentityDAL
   });
 
   const scopeFactory = {

--- a/backend/src/services/identity-v2/org/org-identity-factory.ts
+++ b/backend/src/services/identity-v2/org/org-identity-factory.ts
@@ -2,16 +2,28 @@ import { ForbiddenError } from "@casl/ability";
 
 import { AccessScope, OrganizationActionScope } from "@app/db/schemas";
 import { OrgPermissionIdentityActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
+import { assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { InternalServerError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
+import { TMembershipIdentityDALFactory } from "@app/services/membership-identity/membership-identity-dal";
+import { TOrgDALFactory } from "@app/services/org/org-dal";
 
 import { TIdentityV2Factory } from "../identity-types";
 
 type TOrgIdentityFactoryDep = {
-  permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
+  permissionService: Pick<TPermissionServiceFactory, "getOrgPermission" | "getOrgPermissionByRoles">;
+  orgDAL: Pick<TOrgDALFactory, "findById">;
+  membershipIdentityDAL: Pick<TMembershipIdentityDALFactory, "getIdentityById">;
 };
 
-export const newOrgIdentityFactory = ({ permissionService }: TOrgIdentityFactoryDep): TIdentityV2Factory => {
+export const newOrgIdentityFactory = ({
+  permissionService,
+  orgDAL,
+  membershipIdentityDAL
+}: TOrgIdentityFactoryDep): TIdentityV2Factory => {
   const getScopeField: TIdentityV2Factory["getScopeField"] = (scopeData) => {
     if (scopeData.scope === AccessScope.Organization) {
       return { key: "orgId" as const, value: scopeData.orgId };
@@ -53,6 +65,28 @@ export const newOrgIdentityFactory = ({ permissionService }: TOrgIdentityFactory
       scope: OrganizationActionScope.Any
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Delete, OrgPermissionSubjects.Identity);
+
+    const targetMembership = await membershipIdentityDAL.getIdentityById({
+      scopeData: dto.scopeData,
+      identityId: dto.selector.identityId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
+
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionIdentityActions.Delete,
+      opSubject: OrgPermissionSubjects.Identity,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged identity from the organization"
+    });
   };
 
   const onListIdentityGuard: TIdentityV2Factory["onListIdentityGuard"] = async (dto) => {

--- a/backend/src/services/identity-v2/project/project-identity-factory.ts
+++ b/backend/src/services/identity-v2/project/project-identity-factory.ts
@@ -1,17 +1,29 @@
 import { ForbiddenError, subject } from "@casl/ability";
 
 import { AccessScope, ActionProjectType } from "@app/db/schemas";
+import { assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionIdentityActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
 import { InternalServerError } from "@app/lib/errors";
+import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
+import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
+import { TMembershipIdentityDALFactory } from "@app/services/membership-identity/membership-identity-dal";
+import { TOrgDALFactory } from "@app/services/org/org-dal";
 
 import { TIdentityV2Factory } from "../identity-types";
 
 type TProjectIdentityFactoryDep = {
-  permissionService: Pick<TPermissionServiceFactory, "getProjectPermission">;
+  permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getProjectPermissionByRoles">;
+  orgDAL: Pick<TOrgDALFactory, "findById">;
+  membershipIdentityDAL: Pick<TMembershipIdentityDALFactory, "getIdentityById">;
 };
 
-export const newProjectIdentityFactory = ({ permissionService }: TProjectIdentityFactoryDep): TIdentityV2Factory => {
+export const newProjectIdentityFactory = ({
+  permissionService,
+  orgDAL,
+  membershipIdentityDAL
+}: TProjectIdentityFactoryDep): TIdentityV2Factory => {
   const getScopeField: TIdentityV2Factory["getScopeField"] = (scopeData) => {
     if (scopeData.scope === AccessScope.Project) {
       return { key: "projectId" as const, value: scopeData.projectId };
@@ -65,6 +77,29 @@ export const newProjectIdentityFactory = ({ permissionService }: TProjectIdentit
       ProjectPermissionIdentityActions.Delete,
       subject(ProjectPermissionSub.Identity, { identityId: dto.selector.identityId })
     );
+
+    const targetMembership = await membershipIdentityDAL.getIdentityById({
+      scopeData: dto.scopeData,
+      identityId: dto.selector.identityId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
+
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: ProjectPermissionIdentityActions.Delete,
+      opSubject: ProjectPermissionSub.Identity,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged identity from the project",
+      subjectFields: { identityId: dto.selector.identityId }
+    });
   };
 
   const onListIdentityGuard: TIdentityV2Factory["onListIdentityGuard"] = async (dto) => {

--- a/backend/src/services/identity/identity-service.test.ts
+++ b/backend/src/services/identity/identity-service.test.ts
@@ -55,6 +55,8 @@ const createService = ({
   const membershipIdentityDAL = {
     getIdentityById: vi.fn().mockResolvedValue({
       scopeOrgId: ORG_ID,
+      // The real query inner-joins MembershipRole, so a membership always carries at least one role.
+      roles: [{ role: "member" }],
       identity: { id: IDENTITY_ID, orgId: identityOrgId, projectId: null, hasDeleteProtection }
     }),
     transaction: vi.fn(async (cb: (tx: Knex) => Promise<unknown>) => cb(TX)),
@@ -73,11 +75,14 @@ const createService = ({
       getOrgPermission: vi
         .fn()
         .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) }),
-      getOrgPermissionByRoles: vi.fn()
+      getOrgPermissionByRoles: vi.fn().mockResolvedValue([{ permission: createMongoAbility([]) }])
     } as never,
     licenseService: { getPlan: vi.fn(), getOrgSeatUsage: vi.fn(), updateSubscriptionOrgMemberCount: vi.fn() } as never,
     keyStore: { sortedSetRangeByScore: vi.fn().mockResolvedValue([]) } as never,
-    orgDAL: { findById: vi.fn(), findEffectiveOrgMembership: vi.fn() } as never,
+    orgDAL: {
+      findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem: false }),
+      findEffectiveOrgMembership: vi.fn()
+    } as never,
     additionalPrivilegeDAL: { delete: vi.fn().mockResolvedValue(undefined) } as never,
     usageMeteringService: { emit: vi.fn() } as never,
     alertService: { deleteAlertsForResource, deleteAlertsForDeletedResource } as never,

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -5,6 +5,7 @@ import { getEnforcedIdentityLimit } from "@app/ee/services/license/license-fns";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { OrgPermissionIdentityActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import {
+  assertRoleSetBoundary,
   constructPermissionErrorMessage,
   validatePrivilegeChangeOperation
 } from "@app/ee/services/permission/permission-fns";
@@ -22,6 +23,7 @@ import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage
 import { TAdditionalPrivilegeDALFactory } from "../additional-privilege/additional-privilege-dal";
 import { ActorType } from "../auth/auth-type";
 import { TIdentityAccessTokenServiceFactory } from "../identity-access-token/identity-access-token-service";
+import { resolveMembershipRoleSlugs } from "../membership/membership-fns";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipIdentityDALFactory } from "../membership-identity/membership-identity-dal";
 import { TOrgDALFactory } from "../org/org-dal";
@@ -243,6 +245,24 @@ export const identityServiceFactory = ({
               "Failed to assign custom role to identity due to plan RBAC restriction. Upgrade to Infisical Enterprise to assign custom roles."
           });
       }
+      const targetRoles = resolveMembershipRoleSlugs(
+        await membershipRoleDAL.findRolesByMembershipIds([identityOrgMembership.id])
+      );
+      if (targetRoles.length) {
+        const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
+          ignoreUnresolvedRoles: true
+        });
+
+        assertRoleSetBoundary({
+          shouldUseNewPrivilegeSystem,
+          opActions: OrgPermissionIdentityActions.GrantPrivileges,
+          opSubject: OrgPermissionSubjects.Identity,
+          actorPermission: permission,
+          targetPermissions,
+          baseMessage: "Failed to change the roles of a more privileged identity"
+        });
+      }
+
       const appliedRolePermissionBoundary = validatePrivilegeChangeOperation(
         shouldUseNewPrivilegeSystem,
         OrgPermissionIdentityActions.GrantPrivileges,
@@ -373,6 +393,25 @@ export const identityServiceFactory = ({
     });
 
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Delete, OrgPermissionSubjects.Identity);
+
+    const targetRoles = resolveMembershipRoleSlugs(identityOrgMembership.roles);
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
+        ignoreUnresolvedRoles: true
+      });
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
+        orgDAL.findById(actorOrgId)
+      );
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionIdentityActions.Delete,
+        opSubject: OrgPermissionSubjects.Identity,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to remove a more privileged identity from the organization"
+      });
+    }
 
     await validateIdentityUpdateForSuperAdminPrivileges(id, isActorSuperAdmin);
 

--- a/backend/src/services/identity/identity-service.ts
+++ b/backend/src/services/identity/identity-service.ts
@@ -248,20 +248,18 @@ export const identityServiceFactory = ({
       const targetRoles = resolveMembershipRoleSlugs(
         await membershipRoleDAL.findRolesByMembershipIds([identityOrgMembership.id])
       );
-      if (targetRoles.length) {
-        const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
-          ignoreUnresolvedRoles: true
-        });
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
+        ignoreUnresolvedRoles: true
+      });
 
-        assertRoleSetBoundary({
-          shouldUseNewPrivilegeSystem,
-          opActions: OrgPermissionIdentityActions.GrantPrivileges,
-          opSubject: OrgPermissionSubjects.Identity,
-          actorPermission: permission,
-          targetPermissions,
-          baseMessage: "Failed to change the roles of a more privileged identity"
-        });
-      }
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionIdentityActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Identity,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged identity"
+      });
 
       const appliedRolePermissionBoundary = validatePrivilegeChangeOperation(
         shouldUseNewPrivilegeSystem,
@@ -395,23 +393,21 @@ export const identityServiceFactory = ({
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Delete, OrgPermissionSubjects.Identity);
 
     const targetRoles = resolveMembershipRoleSlugs(identityOrgMembership.roles);
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
-        ignoreUnresolvedRoles: true
-      });
-      const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
-        orgDAL.findById(actorOrgId)
-      );
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, actorOrgId, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
+      orgDAL.findById(actorOrgId)
+    );
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: OrgPermissionIdentityActions.Delete,
-        opSubject: OrgPermissionSubjects.Identity,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to remove a more privileged identity from the organization"
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionIdentityActions.Delete,
+      opSubject: OrgPermissionSubjects.Identity,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged identity from the organization"
+    });
 
     await validateIdentityUpdateForSuperAdminPrivileges(id, isActorSuperAdmin);
 

--- a/backend/src/services/identity/identity-update-boundary.test.ts
+++ b/backend/src/services/identity/identity-update-boundary.test.ts
@@ -1,0 +1,151 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { vi } from "vitest";
+
+import { OrgMembershipRole } from "@app/db/schemas";
+import {
+  orgAdminPermissions,
+  orgMemberPermissions,
+  orgNoAccessPermissions,
+  OrgPermissionIdentityActions,
+  OrgPermissionSubjects
+} from "@app/ee/services/permission/org-permission";
+import { PermissionBoundaryError } from "@app/lib/errors";
+
+import { identityServiceFactory } from "./identity-service";
+
+// Reaches for the instance server config, which has nothing to do with the boundary under test.
+vi.mock("../super-admin/super-admin-fns", () => ({
+  validateIdentityUpdateForSuperAdminPrivileges: vi.fn()
+}));
+
+// updateIdentity bounds the change against the role coming in, and deleteIdentity bounded nothing at
+// all. On the legacy system the incoming NoAccess role resolves to an empty rule set, so that first
+// comparison is vacuous -- which left `identity:edit` alone enough to strip an Admin identity.
+
+const ORG_ID = "org-id";
+const IDENTITY_ID = "identity-id";
+const MEMBERSHIP_ID = "identity-membership-id";
+
+const admin = createMongoAbility<MongoAbility>(orgAdminPermissions);
+const member = createMongoAbility<MongoAbility>(orgMemberPermissions);
+const noAccess = createMongoAbility<MongoAbility>(orgNoAccessPermissions);
+
+// Exactly what the guards' throwUnlessCan demands, plus the grant they need on the new system.
+const identityEditorOnly = createMongoAbility<MongoAbility>([
+  {
+    action: [
+      OrgPermissionIdentityActions.Read,
+      OrgPermissionIdentityActions.Edit,
+      OrgPermissionIdentityActions.Delete,
+      OrgPermissionIdentityActions.GrantPrivileges
+    ],
+    subject: OrgPermissionSubjects.Identity
+  }
+]);
+
+const abilityByRole: Record<string, MongoAbility> = {
+  [OrgMembershipRole.Admin]: admin,
+  [OrgMembershipRole.Member]: member,
+  [OrgMembershipRole.NoAccess]: noAccess
+};
+
+const createService = ({
+  actorPermission,
+  shouldUseNewPrivilegeSystem,
+  currentRole = OrgMembershipRole.Admin
+}: {
+  actorPermission: MongoAbility;
+  shouldUseNewPrivilegeSystem: boolean;
+  currentRole?: string;
+}) => {
+  const membershipRoleDAL = {
+    create: vi.fn(),
+    delete: vi.fn(),
+    findRolesByMembershipIds: vi.fn().mockResolvedValue([{ membershipId: MEMBERSHIP_ID, role: currentRole }])
+  };
+  const identityDAL = {
+    findById: vi.fn().mockResolvedValue({ id: IDENTITY_ID, orgId: ORG_ID, projectId: null }),
+    deleteById: vi.fn().mockResolvedValue({ id: IDENTITY_ID, orgId: ORG_ID }),
+    updateById: vi.fn().mockResolvedValue({ id: IDENTITY_ID, orgId: ORG_ID }),
+    transaction: vi.fn().mockImplementation(async (cb: (tx: unknown) => unknown) => cb({}))
+  };
+
+  const service = identityServiceFactory({
+    permissionService: {
+      getOrgPermission: vi.fn().mockResolvedValue({ permission: actorPermission }),
+      getOrgPermissionByRoles: vi
+        .fn()
+        .mockImplementation((roles: string[]) => roles.map((role) => ({ permission: abilityByRole[role] })))
+    } as never,
+    licenseService: { getPlan: vi.fn().mockResolvedValue({ rbac: true }) } as never,
+    orgDAL: {
+      findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem }),
+      findEffectiveOrgMembership: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID, scopeOrgId: ORG_ID })
+    } as never,
+    membershipIdentityDAL: {
+      getIdentityById: vi.fn().mockResolvedValue({
+        id: MEMBERSHIP_ID,
+        scopeOrgId: ORG_ID,
+        roles: [{ role: currentRole }],
+        identity: { id: IDENTITY_ID, orgId: ORG_ID, projectId: null, hasDeleteProtection: false }
+      })
+    } as never,
+    membershipRoleDAL: membershipRoleDAL as never,
+    identityDAL: identityDAL as never
+  } as never);
+
+  const actor = { actor: "user", actorId: "actor-id", actorAuthMethod: "email", actorOrgId: ORG_ID };
+
+  return {
+    update: (role: string) => service.updateIdentity({ id: IDENTITY_ID, role, ...actor } as never),
+    remove: () => service.deleteIdentity({ id: IDENTITY_ID, ...actor } as never),
+    membershipRoleDAL,
+    identityDAL
+  };
+};
+
+describe("identity service privilege boundary", () => {
+  test("the actor holds identity:edit and identity:delete, so the plain permission check is not what rejects it", () => {
+    expect(identityEditorOnly.can(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity)).toBe(true);
+    expect(identityEditorOnly.can(OrgPermissionIdentityActions.Delete, OrgPermissionSubjects.Identity)).toBe(true);
+  });
+
+  test("on the legacy system, a weaker actor cannot strip an Admin identity to no-access", async () => {
+    const { update, membershipRoleDAL } = createService({
+      actorPermission: identityEditorOnly,
+      shouldUseNewPrivilegeSystem: false
+    });
+
+    await expect(update(OrgMembershipRole.NoAccess)).rejects.toThrow(PermissionBoundaryError);
+    expect(membershipRoleDAL.create).not.toHaveBeenCalled();
+  });
+
+  test("assigning a role the actor may grant is still bounded by what the identity holds", async () => {
+    const { update } = createService({
+      actorPermission: identityEditorOnly,
+      shouldUseNewPrivilegeSystem: false
+    });
+
+    await expect(update(OrgMembershipRole.Member)).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("on the legacy system, a weaker actor cannot delete an Admin identity", async () => {
+    const { remove, identityDAL } = createService({
+      actorPermission: identityEditorOnly,
+      shouldUseNewPrivilegeSystem: false
+    });
+
+    await expect(remove()).rejects.toThrow(PermissionBoundaryError);
+    expect(identityDAL.deleteById).not.toHaveBeenCalled();
+  });
+
+  test("nothing outranks the actor, so an ordinary no-access identity is let through", async () => {
+    const { update } = createService({
+      actorPermission: identityEditorOnly,
+      shouldUseNewPrivilegeSystem: false,
+      currentRole: OrgMembershipRole.NoAccess
+    });
+
+    await expect(update(OrgMembershipRole.NoAccess)).resolves.toBeDefined();
+  });
+});

--- a/backend/src/services/membership-group/membership-group-service.ts
+++ b/backend/src/services/membership-group/membership-group-service.ts
@@ -93,7 +93,8 @@ export const membershipGroupServiceFactory = ({
     [AccessScope.Organization]: newOrgMembershipGroupFactory({
       orgDAL,
       permissionService,
-      groupDAL
+      groupDAL,
+      membershipGroupDAL
     }),
     [AccessScope.Project]: newProjectMembershipGroupFactory({
       membershipGroupDAL,

--- a/backend/src/services/membership-group/org/org-membership-group-factory.ts
+++ b/backend/src/services/membership-group/org/org-membership-group-factory.ts
@@ -8,6 +8,7 @@ import {
   OrgPermissionSubOrgActions
 } from "@app/ee/services/permission/org-permission";
 import {
+  assertRoleSetBoundary,
   constructPermissionErrorMessage,
   validatePrivilegeChangeOperation
 } from "@app/ee/services/permission/permission-fns";
@@ -15,21 +16,25 @@ import { TPermissionServiceFactory } from "@app/ee/services/permission/permissio
 import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { isCustomOrgRole } from "@app/services/org/org-role-fns";
 
+import { TMembershipGroupDALFactory } from "../membership-group-dal";
 import { TMembershipGroupScopeFactory } from "../membership-group-types";
 
 type TOrgMembershipGroupScopeFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission" | "getOrgPermissionByRoles">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   groupDAL: Pick<TGroupDALFactory, "findById">;
+  membershipGroupDAL: Pick<TMembershipGroupDALFactory, "getGroupById">;
 };
 
 export const newOrgMembershipGroupFactory = ({
   permissionService,
   orgDAL,
-  groupDAL
+  groupDAL,
+  membershipGroupDAL
 }: TOrgMembershipGroupScopeFactoryDep): TMembershipGroupScopeFactory => {
   const getScopeField: TMembershipGroupScopeFactory["getScopeField"] = (dto) => {
     if (dto.scope === AccessScope.Organization) {
@@ -197,6 +202,28 @@ export const newOrgMembershipGroupFactory = ({
       scope: OrganizationActionScope.ChildOrganization
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionGroupActions.Delete, OrgPermissionSubjects.Groups);
+
+    const targetMembership = await membershipGroupDAL.getGroupById({
+      scopeData: dto.scopeData,
+      groupId: dto.selector.groupId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId);
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+        requestMemoKeys.orgFindById(dto.permission.orgId),
+        () => orgDAL.findById(dto.permission.orgId)
+      );
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionGroupActions.Delete,
+        opSubject: OrgPermissionSubjects.Groups,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to remove a more privileged group from the organization"
+      });
+    }
 
     return { group: { id: group.id, name: group.name } };
   };

--- a/backend/src/services/membership-group/org/org-membership-group-factory.ts
+++ b/backend/src/services/membership-group/org/org-membership-group-factory.ts
@@ -145,6 +145,27 @@ export const newOrgMembershipGroupFactory = ({
       requestMemoKeys.orgFindById(dto.permission.orgId),
       () => orgDAL.findById(dto.permission.orgId)
     );
+
+    const targetMembership = await membershipGroupDAL.getGroupById({
+      scopeData: dto.scopeData,
+      groupId: dto.selector.groupId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+        ignoreUnresolvedRoles: true
+      });
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionGroupActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Groups,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged group"
+      });
+    }
+
     for (const permissionRole of permissionRoles) {
       if (permissionRole?.role?.name !== OrgMembershipRole.NoAccess) {
         const permissionBoundary = validatePrivilegeChangeOperation(
@@ -209,7 +230,9 @@ export const newOrgMembershipGroupFactory = ({
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId);
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+        ignoreUnresolvedRoles: true
+      });
       const { shouldUseNewPrivilegeSystem } = await requestMemoize(
         requestMemoKeys.orgFindById(dto.permission.orgId),
         () => orgDAL.findById(dto.permission.orgId)

--- a/backend/src/services/membership-group/org/org-membership-group-factory.ts
+++ b/backend/src/services/membership-group/org/org-membership-group-factory.ts
@@ -151,20 +151,18 @@ export const newOrgMembershipGroupFactory = ({
       groupId: dto.selector.groupId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
-        ignoreUnresolvedRoles: true
-      });
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+      ignoreUnresolvedRoles: true
+    });
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: OrgPermissionGroupActions.GrantPrivileges,
-        opSubject: OrgPermissionSubjects.Groups,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged group"
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionGroupActions.GrantPrivileges,
+      opSubject: OrgPermissionSubjects.Groups,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to change the roles of a more privileged group"
+    });
 
     for (const permissionRole of permissionRoles) {
       if (permissionRole?.role?.name !== OrgMembershipRole.NoAccess) {
@@ -229,24 +227,22 @@ export const newOrgMembershipGroupFactory = ({
       groupId: dto.selector.groupId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
-        ignoreUnresolvedRoles: true
-      });
-      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
-        requestMemoKeys.orgFindById(dto.permission.orgId),
-        () => orgDAL.findById(dto.permission.orgId)
-      );
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: OrgPermissionGroupActions.Delete,
-        opSubject: OrgPermissionSubjects.Groups,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to remove a more privileged group from the organization"
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionGroupActions.Delete,
+      opSubject: OrgPermissionSubjects.Groups,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged group from the organization"
+    });
 
     return { group: { id: group.id, name: group.name } };
   };

--- a/backend/src/services/membership-group/org/org-membership-group-factory.ts
+++ b/backend/src/services/membership-group/org/org-membership-group-factory.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError } from "@casl/ability";
 
-import { AccessScope, OrganizationActionScope, OrgMembershipRole } from "@app/db/schemas";
+import { AccessScope, OrganizationActionScope } from "@app/db/schemas";
 import { TGroupDALFactory } from "@app/ee/services/group/group-dal";
 import {
   OrgPermissionGroupActions,
@@ -16,7 +16,10 @@ import { TPermissionServiceFactory } from "@app/ee/services/permission/permissio
 import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
-import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
+import {
+  filterRolesNeedingPrivilegeBoundary,
+  resolveMembershipRoleSlugs
+} from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { isCustomOrgRole } from "@app/services/org/org-role-fns";
 
@@ -90,7 +93,7 @@ export const newOrgMembershipGroupFactory = ({
     }
 
     const permissionRoles = await permissionService.getOrgPermissionByRoles(
-      dto.data.roles.map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       dto.permission.orgId
     );
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(
@@ -98,25 +101,23 @@ export const newOrgMembershipGroupFactory = ({
       () => orgDAL.findById(dto.permission.orgId)
     );
     for (const permissionRole of permissionRoles) {
-      if (permissionRole?.role?.name !== OrgMembershipRole.NoAccess) {
-        const permissionBoundary = validatePrivilegeChangeOperation(
-          shouldUseNewPrivilegeSystem,
-          OrgPermissionGroupActions.GrantPrivileges,
-          OrgPermissionSubjects.Groups,
-          permission,
-          permissionRole.permission
-        );
-        if (!permissionBoundary.isValid)
-          throw new PermissionBoundaryError({
-            message: constructPermissionErrorMessage(
-              "Failed to link group to sub-organization",
-              shouldUseNewPrivilegeSystem,
-              OrgPermissionGroupActions.GrantPrivileges,
-              OrgPermissionSubjects.Groups
-            ),
-            details: { missingPermissions: permissionBoundary.missingPermissions }
-          });
-      }
+      const permissionBoundary = validatePrivilegeChangeOperation(
+        shouldUseNewPrivilegeSystem,
+        OrgPermissionGroupActions.GrantPrivileges,
+        OrgPermissionSubjects.Groups,
+        permission,
+        permissionRole.permission
+      );
+      if (!permissionBoundary.isValid)
+        throw new PermissionBoundaryError({
+          message: constructPermissionErrorMessage(
+            "Failed to link group to sub-organization",
+            shouldUseNewPrivilegeSystem,
+            OrgPermissionGroupActions.GrantPrivileges,
+            OrgPermissionSubjects.Groups
+          ),
+          details: { missingPermissions: permissionBoundary.missingPermissions }
+        });
     }
 
     return { group: { id: group.id, name: group.name } };
@@ -137,7 +138,7 @@ export const newOrgMembershipGroupFactory = ({
     if (!groupDetails) throw new BadRequestError({ message: "Group details not found" });
 
     const permissionRoles = await permissionService.getOrgPermissionByRoles(
-      dto.data.roles.map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       dto.permission.orgId
     );
 
@@ -165,25 +166,23 @@ export const newOrgMembershipGroupFactory = ({
     });
 
     for (const permissionRole of permissionRoles) {
-      if (permissionRole?.role?.name !== OrgMembershipRole.NoAccess) {
-        const permissionBoundary = validatePrivilegeChangeOperation(
-          shouldUseNewPrivilegeSystem,
-          OrgPermissionGroupActions.GrantPrivileges,
-          OrgPermissionSubjects.Groups,
-          permission,
-          permissionRole.permission
-        );
-        if (!permissionBoundary.isValid)
-          throw new PermissionBoundaryError({
-            message: constructPermissionErrorMessage(
-              "Failed to create group org membership",
-              shouldUseNewPrivilegeSystem,
-              OrgPermissionGroupActions.GrantPrivileges,
-              OrgPermissionSubjects.Groups
-            ),
-            details: { missingPermissions: permissionBoundary.missingPermissions }
-          });
-      }
+      const permissionBoundary = validatePrivilegeChangeOperation(
+        shouldUseNewPrivilegeSystem,
+        OrgPermissionGroupActions.GrantPrivileges,
+        OrgPermissionSubjects.Groups,
+        permission,
+        permissionRole.permission
+      );
+      if (!permissionBoundary.isValid)
+        throw new PermissionBoundaryError({
+          message: constructPermissionErrorMessage(
+            "Failed to create group org membership",
+            shouldUseNewPrivilegeSystem,
+            OrgPermissionGroupActions.GrantPrivileges,
+            OrgPermissionSubjects.Groups
+          ),
+          details: { missingPermissions: permissionBoundary.missingPermissions }
+        });
     }
 
     return { group: { id: groupDetails.id, name: groupDetails.name } };

--- a/backend/src/services/membership-group/project/project-membership-group-boundary.test.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-boundary.test.ts
@@ -1,0 +1,129 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { vi } from "vitest";
+
+import { AccessScope, ProjectMembershipRole } from "@app/db/schemas";
+import {
+  projectAdminPermissions,
+  projectMemberPermissions,
+  projectNoAccessPermissions
+} from "@app/ee/services/permission/default-roles";
+import { ProjectPermissionGroupActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import { PermissionBoundaryError } from "@app/lib/errors";
+
+import { newProjectMembershipGroupFactory } from "./project-membership-group-factory";
+
+// The loop that bounds the incoming roles skips NoAccess, so without a check against the roles the
+// target already holds, downgrading a privileged group to no-access is the one role change nothing
+// bounds -- and it strips the group's access as completely as removing it would.
+
+const ORG_ID = "org-id";
+const PROJECT_ID = "project-id";
+const GROUP_ID = "group-id";
+
+const admin = createMongoAbility<MongoAbility>(projectAdminPermissions);
+const member = createMongoAbility<MongoAbility>(projectMemberPermissions);
+
+// Exactly the grant the guard's throwUnlessCan demands, and nothing more.
+const groupEditorOnly = createMongoAbility<MongoAbility>([
+  {
+    action: [ProjectPermissionGroupActions.Read, ProjectPermissionGroupActions.Edit],
+    subject: ProjectPermissionSub.Groups
+  }
+]);
+
+// Outranks the Member role, so the loop over the incoming roles has nothing to object to; only the
+// roles the target already holds can reject this actor.
+const memberWithGroupEdit = createMongoAbility<MongoAbility>([
+  ...projectMemberPermissions,
+  {
+    action: [ProjectPermissionGroupActions.Read, ProjectPermissionGroupActions.Edit],
+    subject: ProjectPermissionSub.Groups
+  }
+] as never);
+
+const createGuard = ({
+  actorPermission,
+  shouldUseNewPrivilegeSystem,
+  targetRole = ProjectMembershipRole.Admin,
+  incomingRole = ProjectMembershipRole.NoAccess
+}: {
+  actorPermission: MongoAbility;
+  shouldUseNewPrivilegeSystem: boolean;
+  targetRole?: string;
+  incomingRole?: string;
+}) => {
+  const abilityByRole: Record<string, MongoAbility> = {
+    [ProjectMembershipRole.Admin]: admin,
+    [ProjectMembershipRole.Member]: member,
+    [ProjectMembershipRole.NoAccess]: createMongoAbility<MongoAbility>(projectNoAccessPermissions)
+  };
+
+  const factory = newProjectMembershipGroupFactory({
+    permissionService: {
+      getProjectPermission: vi.fn().mockResolvedValue({ permission: actorPermission }),
+      getProjectPermissionByRoles: vi.fn().mockImplementation((roles: string[]) =>
+        roles.map((role) => ({
+          permission: abilityByRole[role],
+          role: { name: role, slug: role }
+        }))
+      )
+    } as never,
+    orgDAL: { findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem }) } as never,
+    projectDAL: { findById: vi.fn().mockResolvedValue({ id: PROJECT_ID, type: "secret-manager" }) } as never,
+    groupDAL: { findById: vi.fn().mockResolvedValue({ id: GROUP_ID, name: "the-group" }) } as never,
+    membershipGroupDAL: {
+      findOne: vi.fn().mockResolvedValue({ id: "org-membership-id" }),
+      getGroupById: vi.fn().mockResolvedValue({ roles: [{ role: targetRole }] })
+    } as never
+  });
+
+  return () =>
+    factory.onUpdateMembershipGroupGuard({
+      permission: { type: "user", id: "actor-id", orgId: ORG_ID, authMethod: "email" },
+      scopeData: { scope: AccessScope.Project, orgId: ORG_ID, projectId: PROJECT_ID },
+      selector: { groupId: GROUP_ID },
+      data: { roles: [{ role: incomingRole, isTemporary: false }] }
+    } as never);
+};
+
+describe("onUpdateMembershipGroupGuard privilege boundary", () => {
+  test("the actor holds groups:edit, so the plain permission check is not what rejects it", () => {
+    expect(groupEditorOnly.can(ProjectPermissionGroupActions.Edit, ProjectPermissionSub.Groups)).toBe(true);
+  });
+
+  test("on the legacy system, a weaker actor cannot downgrade an Admin group to no-access", async () => {
+    const guard = createGuard({ actorPermission: groupEditorOnly, shouldUseNewPrivilegeSystem: false });
+
+    await expect(guard()).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("downgrading to a role the actor may grant is still bounded by what the target holds", async () => {
+    const guard = createGuard({
+      actorPermission: memberWithGroupEdit,
+      shouldUseNewPrivilegeSystem: false,
+      incomingRole: ProjectMembershipRole.Member
+    });
+
+    await expect(guard()).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("an admin can still downgrade an Admin group on either system", async () => {
+    await expect(createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: false })()).resolves.toMatchObject({
+      group: { id: GROUP_ID }
+    });
+    await expect(createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: true })()).resolves.toMatchObject({
+      group: { id: GROUP_ID }
+    });
+  });
+
+  test("nothing outranks the actor, so an ordinary downgrade is let through", async () => {
+    const guard = createGuard({
+      actorPermission: groupEditorOnly,
+      shouldUseNewPrivilegeSystem: false,
+      targetRole: ProjectMembershipRole.NoAccess,
+      incomingRole: ProjectMembershipRole.NoAccess
+    });
+
+    await expect(guard()).resolves.toMatchObject({ group: { id: GROUP_ID } });
+  });
+});

--- a/backend/src/services/membership-group/project/project-membership-group-boundary.test.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-boundary.test.ts
@@ -8,6 +8,7 @@ import {
   projectNoAccessPermissions
 } from "@app/ee/services/permission/default-roles";
 import { ProjectPermissionGroupActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import { conditionsMatcher } from "@app/lib/casl";
 import { PermissionBoundaryError } from "@app/lib/errors";
 
 import { newProjectMembershipGroupFactory } from "./project-membership-group-factory";
@@ -40,6 +41,23 @@ const memberWithGroupEdit = createMongoAbility<MongoAbility>([
     subject: ProjectPermissionSub.Groups
   }
 ] as never);
+
+// Holds groups:edit outright, but may only assign roles to groups whose name the glob reaches --
+// "the-group" is outside it.
+const contractorScopedEditor = createMongoAbility<MongoAbility>(
+  [
+    {
+      action: [ProjectPermissionGroupActions.Read, ProjectPermissionGroupActions.Edit],
+      subject: ProjectPermissionSub.Groups
+    },
+    {
+      action: ProjectPermissionGroupActions.AssignRole,
+      subject: ProjectPermissionSub.Groups,
+      conditions: { groupName: { $glob: "contractor-*" } }
+    }
+  ] as never,
+  { conditionsMatcher }
+);
 
 const createGuard = ({
   actorPermission,
@@ -114,6 +132,12 @@ describe("onUpdateMembershipGroupGuard privilege boundary", () => {
     await expect(createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: true })()).resolves.toMatchObject({
       group: { id: GROUP_ID }
     });
+  });
+
+  test("a groupName-scoped actor cannot strip an out-of-scope Admin group down to no-access", async () => {
+    const guard = createGuard({ actorPermission: contractorScopedEditor, shouldUseNewPrivilegeSystem: true });
+
+    await expect(guard()).rejects.toThrow(PermissionBoundaryError);
   });
 
   test("nothing outranks the actor, so an ordinary downgrade is let through", async () => {

--- a/backend/src/services/membership-group/project/project-membership-group-factory.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-factory.ts
@@ -167,6 +167,27 @@ export const newProjectMembershipGroupFactory = ({
       requestMemoKeys.orgFindById(dto.permission.orgId),
       () => orgDAL.findById(dto.permission.orgId)
     );
+
+    const targetMembership = await membershipGroupDAL.getGroupById({
+      scopeData: dto.scopeData,
+      groupId: dto.selector.groupId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+        ignoreUnresolvedRoles: true
+      });
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: [ProjectPermissionGroupActions.AssignRole, ProjectPermissionGroupActions.GrantPrivileges],
+        opSubject: ProjectPermissionSub.Groups,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged group"
+      });
+    }
+
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
       dto.data.roles.map((el) => el.role),
       scope.value
@@ -220,7 +241,9 @@ export const newProjectMembershipGroupFactory = ({
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+        ignoreUnresolvedRoles: true
+      });
       const { shouldUseNewPrivilegeSystem } = await requestMemoize(
         requestMemoKeys.orgFindById(dto.permission.orgId),
         () => orgDAL.findById(dto.permission.orgId)

--- a/backend/src/services/membership-group/project/project-membership-group-factory.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-factory.ts
@@ -256,7 +256,8 @@ export const newProjectMembershipGroupFactory = ({
         opSubject: ProjectPermissionSub.Groups,
         actorPermission: permission,
         targetPermissions,
-        baseMessage: "Failed to remove a more privileged group from the project"
+        baseMessage: "Failed to remove a more privileged group from the project",
+        subjectFields: { groupName: groupDetails.name }
       });
     }
 

--- a/backend/src/services/membership-group/project/project-membership-group-factory.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-factory.ts
@@ -3,6 +3,7 @@ import { ForbiddenError } from "@casl/ability";
 import { AccessScope, ActionProjectType, ProjectMembershipRole, ProjectType } from "@app/db/schemas";
 import { TGroupDALFactory } from "@app/ee/services/group/group-dal";
 import {
+  assertRoleSetBoundary,
   constructPermissionErrorMessage,
   validatePrivilegeChangeOperation
 } from "@app/ee/services/permission/permission-fns";
@@ -15,6 +16,7 @@ import {
 import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 
@@ -24,7 +26,7 @@ import { TMembershipGroupScopeFactory } from "../membership-group-types";
 type TProjectMembershipGroupScopeFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getProjectPermissionByRoles">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
-  membershipGroupDAL: Pick<TMembershipGroupDALFactory, "findOne">;
+  membershipGroupDAL: Pick<TMembershipGroupDALFactory, "findOne" | "getGroupById">;
   groupDAL: Pick<TGroupDALFactory, "findById">;
   projectDAL: Pick<TProjectDALFactory, "findById">;
 };
@@ -211,6 +213,28 @@ export const newProjectMembershipGroupFactory = ({
 
     const groupDetails = await groupDAL.findById(dto.selector.groupId);
     if (!groupDetails) throw new BadRequestError({ message: "Group details not found" });
+
+    const targetMembership = await membershipGroupDAL.getGroupById({
+      scopeData: dto.scopeData,
+      groupId: dto.selector.groupId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+        requestMemoKeys.orgFindById(dto.permission.orgId),
+        () => orgDAL.findById(dto.permission.orgId)
+      );
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: ProjectPermissionGroupActions.Delete,
+        opSubject: ProjectPermissionSub.Groups,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to remove a more privileged group from the project"
+      });
+    }
 
     return { group: { id: groupDetails.id, name: groupDetails.name } };
   };

--- a/backend/src/services/membership-group/project/project-membership-group-factory.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-factory.ts
@@ -184,7 +184,8 @@ export const newProjectMembershipGroupFactory = ({
         opSubject: ProjectPermissionSub.Groups,
         actorPermission: permission,
         targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged group"
+        baseMessage: "Failed to change the roles of a more privileged group",
+        subjectFields: { groupName: groupDetails.name }
       });
     }
 

--- a/backend/src/services/membership-group/project/project-membership-group-factory.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-factory.ts
@@ -173,21 +173,19 @@ export const newProjectMembershipGroupFactory = ({
       groupId: dto.selector.groupId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
-        ignoreUnresolvedRoles: true
-      });
+    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+      ignoreUnresolvedRoles: true
+    });
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: [ProjectPermissionGroupActions.AssignRole, ProjectPermissionGroupActions.GrantPrivileges],
-        opSubject: ProjectPermissionSub.Groups,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged group",
-        subjectFields: { groupName: groupDetails.name }
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: [ProjectPermissionGroupActions.AssignRole, ProjectPermissionGroupActions.GrantPrivileges],
+      opSubject: ProjectPermissionSub.Groups,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to change the roles of a more privileged group",
+      subjectFields: { groupName: groupDetails.name }
+    });
 
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
       dto.data.roles.map((el) => el.role),
@@ -241,25 +239,23 @@ export const newProjectMembershipGroupFactory = ({
       groupId: dto.selector.groupId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
-        ignoreUnresolvedRoles: true
-      });
-      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
-        requestMemoKeys.orgFindById(dto.permission.orgId),
-        () => orgDAL.findById(dto.permission.orgId)
-      );
+    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: ProjectPermissionGroupActions.Delete,
-        opSubject: ProjectPermissionSub.Groups,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to remove a more privileged group from the project",
-        subjectFields: { groupName: groupDetails.name }
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: ProjectPermissionGroupActions.Delete,
+      opSubject: ProjectPermissionSub.Groups,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged group from the project",
+      subjectFields: { groupName: groupDetails.name }
+    });
 
     return { group: { id: groupDetails.id, name: groupDetails.name } };
   };

--- a/backend/src/services/membership-group/project/project-membership-group-factory.ts
+++ b/backend/src/services/membership-group/project/project-membership-group-factory.ts
@@ -16,7 +16,10 @@ import {
 import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
-import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
+import {
+  filterRolesNeedingPrivilegeBoundary,
+  resolveMembershipRoleSlugs
+} from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 
@@ -96,31 +99,29 @@ export const newProjectMembershipGroupFactory = ({
       () => orgDAL.findById(dto.permission.orgId)
     );
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
-      dto.data.roles.map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       scope.value
     );
     for (const permissionRole of permissionRoles) {
-      if (permissionRole?.role?.name !== ProjectMembershipRole.NoAccess) {
-        const permissionBoundary = validatePrivilegeChangeOperation(
-          shouldUseNewPrivilegeSystem,
-          [ProjectPermissionGroupActions.AssignRole, ProjectPermissionGroupActions.GrantPrivileges],
-          ProjectPermissionSub.Groups,
-          permission,
-          permissionRole.permission,
-          { groupName: groupDetails.name, assignableRole: permissionRole.role?.slug }
-        );
+      const permissionBoundary = validatePrivilegeChangeOperation(
+        shouldUseNewPrivilegeSystem,
+        [ProjectPermissionGroupActions.AssignRole, ProjectPermissionGroupActions.GrantPrivileges],
+        ProjectPermissionSub.Groups,
+        permission,
+        permissionRole.permission,
+        { groupName: groupDetails.name, assignableRole: permissionRole.role?.slug }
+      );
 
-        if (!permissionBoundary.isValid)
-          throw new PermissionBoundaryError({
-            message: constructPermissionErrorMessage(
-              "Failed to create group project membership",
-              shouldUseNewPrivilegeSystem,
-              ProjectPermissionGroupActions.AssignRole,
-              ProjectPermissionSub.Groups
-            ),
-            details: { missingPermissions: permissionBoundary.missingPermissions }
-          });
-      }
+      if (!permissionBoundary.isValid)
+        throw new PermissionBoundaryError({
+          message: constructPermissionErrorMessage(
+            "Failed to create group project membership",
+            shouldUseNewPrivilegeSystem,
+            ProjectPermissionGroupActions.AssignRole,
+            ProjectPermissionSub.Groups
+          ),
+          details: { missingPermissions: permissionBoundary.missingPermissions }
+        });
     }
 
     return { group: { id: groupDetails.id, name: groupDetails.name } };
@@ -188,31 +189,29 @@ export const newProjectMembershipGroupFactory = ({
     });
 
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
-      dto.data.roles.map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       scope.value
     );
     for (const permissionRole of permissionRoles) {
-      if (permissionRole?.role?.name !== ProjectMembershipRole.NoAccess) {
-        const permissionBoundary = validatePrivilegeChangeOperation(
-          shouldUseNewPrivilegeSystem,
-          [ProjectPermissionGroupActions.AssignRole, ProjectPermissionGroupActions.GrantPrivileges],
-          ProjectPermissionSub.Groups,
-          permission,
-          permissionRole.permission,
-          { groupName: groupDetails.name, assignableRole: permissionRole.role?.slug }
-        );
+      const permissionBoundary = validatePrivilegeChangeOperation(
+        shouldUseNewPrivilegeSystem,
+        [ProjectPermissionGroupActions.AssignRole, ProjectPermissionGroupActions.GrantPrivileges],
+        ProjectPermissionSub.Groups,
+        permission,
+        permissionRole.permission,
+        { groupName: groupDetails.name, assignableRole: permissionRole.role?.slug }
+      );
 
-        if (!permissionBoundary.isValid)
-          throw new PermissionBoundaryError({
-            message: constructPermissionErrorMessage(
-              "Failed to update group project membership",
-              shouldUseNewPrivilegeSystem,
-              ProjectPermissionGroupActions.AssignRole,
-              ProjectPermissionSub.Groups
-            ),
-            details: { missingPermissions: permissionBoundary.missingPermissions }
-          });
-      }
+      if (!permissionBoundary.isValid)
+        throw new PermissionBoundaryError({
+          message: constructPermissionErrorMessage(
+            "Failed to update group project membership",
+            shouldUseNewPrivilegeSystem,
+            ProjectPermissionGroupActions.AssignRole,
+            ProjectPermissionSub.Groups
+          ),
+          details: { missingPermissions: permissionBoundary.missingPermissions }
+        });
     }
 
     return { group: { id: groupDetails.id, name: groupDetails.name } };

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -50,8 +50,8 @@ const createService = ({
   const membershipIdentityDAL = {
     findOne: vi.fn().mockResolvedValue(existingMembership),
     // The delete guards resolve the target's current roles to bound the removal against them.
-    // "no-access" is filtered out before resolution, so these tests exercise the delete path
-    // without engaging the boundary comparison.
+    // "no-access" is filtered out before resolution, so the target resolves to no roles and the
+    // boundary check falls back to an empty ability.
     getIdentityById: vi.fn().mockResolvedValue({ roles: [{ role: "no-access" }] }),
     findByIdForUpdate: vi.fn().mockResolvedValue(existingMembership),
     find: vi.fn().mockResolvedValue([]),
@@ -75,9 +75,18 @@ const createService = ({
       getProjectPermission: vi
         .fn()
         .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) }),
-      // Role name "no-access" skips the privilege-boundary comparison in the guards.
-      getOrgPermissionByRoles: vi.fn().mockResolvedValue([{ role: { name: "no-access" }, permission: null }]),
-      getProjectPermissionByRoles: vi.fn().mockResolvedValue([{ role: { name: "no-access" }, permission: null }])
+      // Role name "no-access" skips the privilege-boundary comparison in the guards. An empty slug
+      // list resolves to no roles, matching the real implementation.
+      getOrgPermissionByRoles: vi
+        .fn()
+        .mockImplementation(async (roles: string[]) =>
+          roles.length ? [{ role: { name: "no-access" }, permission: null }] : []
+        ),
+      getProjectPermissionByRoles: vi
+        .fn()
+        .mockImplementation(async (roles: string[]) =>
+          roles.length ? [{ role: { name: "no-access" }, permission: null }] : []
+        )
     } as never,
     orgDAL: { findById: vi.fn().mockResolvedValue({}), findEffectiveOrgMembership: vi.fn() } as never,
     additionalPrivilegeDAL: { delete: vi.fn().mockResolvedValue(undefined) } as never,

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -75,18 +75,15 @@ const createService = ({
       getProjectPermission: vi
         .fn()
         .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) }),
-      // Role name "no-access" skips the privilege-boundary comparison in the guards. An empty slug
-      // list resolves to no roles, matching the real implementation.
+      // These tests cover revocation markers, not the privilege boundary. Built-in roles come back
+      // without a `role` field, and an empty target ability satisfies the boundary under both
+      // privilege systems given the `manage all` actor above. An empty slug list resolves to no roles.
       getOrgPermissionByRoles: vi
         .fn()
-        .mockImplementation(async (roles: string[]) =>
-          roles.length ? [{ role: { name: "no-access" }, permission: null }] : []
-        ),
+        .mockImplementation(async (roles: string[]) => (roles.length ? [{ permission: createMongoAbility([]) }] : [])),
       getProjectPermissionByRoles: vi
         .fn()
-        .mockImplementation(async (roles: string[]) =>
-          roles.length ? [{ role: { name: "no-access" }, permission: null }] : []
-        )
+        .mockImplementation(async (roles: string[]) => (roles.length ? [{ permission: createMongoAbility([]) }] : []))
     } as never,
     orgDAL: { findById: vi.fn().mockResolvedValue({}), findEffectiveOrgMembership: vi.fn() } as never,
     additionalPrivilegeDAL: { delete: vi.fn().mockResolvedValue(undefined) } as never,

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -49,6 +49,10 @@ const createService = ({
 
   const membershipIdentityDAL = {
     findOne: vi.fn().mockResolvedValue(existingMembership),
+    // The delete guards resolve the target's current roles to bound the removal against them.
+    // "no-access" is filtered out before resolution, so these tests exercise the delete path
+    // without engaging the boundary comparison.
+    getIdentityById: vi.fn().mockResolvedValue({ roles: [{ role: "no-access" }] }),
     findByIdForUpdate: vi.fn().mockResolvedValue(existingMembership),
     find: vi.fn().mockResolvedValue([]),
     create: vi.fn().mockResolvedValue({ id: MEMBERSHIP_ID, actorIdentityId: IDENTITY_ID }),
@@ -72,7 +76,8 @@ const createService = ({
         .fn()
         .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) }),
       // Role name "no-access" skips the privilege-boundary comparison in the guards.
-      getOrgPermissionByRoles: vi.fn().mockResolvedValue([{ role: { name: "no-access" }, permission: null }])
+      getOrgPermissionByRoles: vi.fn().mockResolvedValue([{ role: { name: "no-access" }, permission: null }]),
+      getProjectPermissionByRoles: vi.fn().mockResolvedValue([{ role: { name: "no-access" }, permission: null }])
     } as never,
     orgDAL: { findById: vi.fn().mockResolvedValue({}), findEffectiveOrgMembership: vi.fn() } as never,
     additionalPrivilegeDAL: { delete: vi.fn().mockResolvedValue(undefined) } as never,

--- a/backend/src/services/membership-identity/membership-identity-service.test.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.test.ts
@@ -49,9 +49,8 @@ const createService = ({
 
   const membershipIdentityDAL = {
     findOne: vi.fn().mockResolvedValue(existingMembership),
-    // The delete guards resolve the target's current roles to bound the removal against them.
-    // "no-access" is filtered out before resolution, so the target resolves to no roles and the
-    // boundary check falls back to an empty ability.
+    // The delete guards bound the removal against the target's current roles. "no-access" is filtered
+    // out before resolution, so the target resolves to no roles and the boundary sees an empty ability.
     getIdentityById: vi.fn().mockResolvedValue({ roles: [{ role: "no-access" }] }),
     findByIdForUpdate: vi.fn().mockResolvedValue(existingMembership),
     find: vi.fn().mockResolvedValue([]),
@@ -76,8 +75,7 @@ const createService = ({
         .fn()
         .mockResolvedValue({ permission: createMongoAbility([{ action: "manage", subject: "all" }]) }),
       // These tests cover revocation markers, not the privilege boundary. Built-in roles come back
-      // without a `role` field, and an empty target ability satisfies the boundary under both
-      // privilege systems given the `manage all` actor above. An empty slug list resolves to no roles.
+      // without a `role` field, and an empty target ability clears the boundary for the actor above.
       getOrgPermissionByRoles: vi
         .fn()
         .mockImplementation(async (roles: string[]) => (roles.length ? [{ permission: createMongoAbility([]) }] : [])),

--- a/backend/src/services/membership-identity/membership-identity-service.ts
+++ b/backend/src/services/membership-identity/membership-identity-service.ts
@@ -83,7 +83,8 @@ export const membershipIdentityServiceFactory = ({
     [AccessScope.Organization]: newOrgMembershipIdentityFactory({
       orgDAL,
       permissionService,
-      identityDAL
+      identityDAL,
+      membershipIdentityDAL
     }),
     [AccessScope.Project]: newProjectMembershipIdentityFactory({
       membershipIdentityDAL,

--- a/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
@@ -127,6 +127,27 @@ export const newOrgMembershipIdentityFactory = ({
       requestMemoKeys.orgFindById(dto.permission.orgId),
       () => orgDAL.findById(dto.permission.orgId)
     );
+
+    const targetMembership = await membershipIdentityDAL.getIdentityById({
+      scopeData: dto.scopeData,
+      identityId: dto.selector.identityId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+        ignoreUnresolvedRoles: true
+      });
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionIdentityActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Identity,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged identity"
+      });
+    }
+
     for (const permissionRole of permissionRoles) {
       if (permissionRole?.role?.name !== OrgMembershipRole.NoAccess) {
         const permissionBoundary = validatePrivilegeChangeOperation(
@@ -192,7 +213,9 @@ export const newOrgMembershipIdentityFactory = ({
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId);
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+        ignoreUnresolvedRoles: true
+      });
       const { shouldUseNewPrivilegeSystem } = await requestMemoize(
         requestMemoKeys.orgFindById(dto.permission.orgId),
         () => orgDAL.findById(dto.permission.orgId)

--- a/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
@@ -1,6 +1,6 @@
 import { ForbiddenError } from "@casl/ability";
 
-import { AccessScope, OrganizationActionScope, OrgMembershipRole } from "@app/db/schemas";
+import { AccessScope, OrganizationActionScope } from "@app/db/schemas";
 import { OrgPermissionIdentityActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import {
   assertRoleSetBoundary,
@@ -12,7 +12,10 @@ import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
-import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
+import {
+  filterRolesNeedingPrivilegeBoundary,
+  resolveMembershipRoleSlugs
+} from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { isCustomOrgRole } from "@app/services/org/org-role-fns";
 
@@ -74,7 +77,7 @@ export const newOrgMembershipIdentityFactory = ({
     }
 
     const permissionRoles = await permissionService.getOrgPermissionByRoles(
-      dto.data.roles.map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       dto.permission.orgId
     );
 
@@ -83,25 +86,23 @@ export const newOrgMembershipIdentityFactory = ({
       () => orgDAL.findById(dto.permission.orgId)
     );
     for (const permissionRole of permissionRoles) {
-      if (permissionRole?.role?.name !== OrgMembershipRole.NoAccess) {
-        const permissionBoundary = validatePrivilegeChangeOperation(
-          shouldUseNewPrivilegeSystem,
-          OrgPermissionIdentityActions.GrantPrivileges,
-          OrgPermissionSubjects.Identity,
-          permission,
-          permissionRole.permission
-        );
-        if (!permissionBoundary.isValid)
-          throw new PermissionBoundaryError({
-            message: constructPermissionErrorMessage(
-              "Failed to update identity org membership",
-              shouldUseNewPrivilegeSystem,
-              OrgPermissionIdentityActions.GrantPrivileges,
-              OrgPermissionSubjects.Identity
-            ),
-            details: { missingPermissions: permissionBoundary.missingPermissions }
-          });
-      }
+      const permissionBoundary = validatePrivilegeChangeOperation(
+        shouldUseNewPrivilegeSystem,
+        OrgPermissionIdentityActions.GrantPrivileges,
+        OrgPermissionSubjects.Identity,
+        permission,
+        permissionRole.permission
+      );
+      if (!permissionBoundary.isValid)
+        throw new PermissionBoundaryError({
+          message: constructPermissionErrorMessage(
+            "Failed to update identity org membership",
+            shouldUseNewPrivilegeSystem,
+            OrgPermissionIdentityActions.GrantPrivileges,
+            OrgPermissionSubjects.Identity
+          ),
+          details: { missingPermissions: permissionBoundary.missingPermissions }
+        });
     }
   };
 
@@ -119,7 +120,7 @@ export const newOrgMembershipIdentityFactory = ({
 
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionIdentityActions.Edit, OrgPermissionSubjects.Identity);
     const permissionRoles = await permissionService.getOrgPermissionByRoles(
-      dto.data.roles.map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       dto.permission.orgId
     );
 
@@ -147,25 +148,23 @@ export const newOrgMembershipIdentityFactory = ({
     });
 
     for (const permissionRole of permissionRoles) {
-      if (permissionRole?.role?.name !== OrgMembershipRole.NoAccess) {
-        const permissionBoundary = validatePrivilegeChangeOperation(
-          shouldUseNewPrivilegeSystem,
-          OrgPermissionIdentityActions.GrantPrivileges,
-          OrgPermissionSubjects.Identity,
-          permission,
-          permissionRole.permission
-        );
-        if (!permissionBoundary.isValid)
-          throw new PermissionBoundaryError({
-            message: constructPermissionErrorMessage(
-              "Failed to update identity org membership",
-              shouldUseNewPrivilegeSystem,
-              OrgPermissionIdentityActions.GrantPrivileges,
-              OrgPermissionSubjects.Identity
-            ),
-            details: { missingPermissions: permissionBoundary.missingPermissions }
-          });
-      }
+      const permissionBoundary = validatePrivilegeChangeOperation(
+        shouldUseNewPrivilegeSystem,
+        OrgPermissionIdentityActions.GrantPrivileges,
+        OrgPermissionSubjects.Identity,
+        permission,
+        permissionRole.permission
+      );
+      if (!permissionBoundary.isValid)
+        throw new PermissionBoundaryError({
+          message: constructPermissionErrorMessage(
+            "Failed to update identity org membership",
+            shouldUseNewPrivilegeSystem,
+            OrgPermissionIdentityActions.GrantPrivileges,
+            OrgPermissionSubjects.Identity
+          ),
+          details: { missingPermissions: permissionBoundary.missingPermissions }
+        });
     }
 
     const identityDetails = await requestMemoize(requestMemoKeys.identityFindById(dto.selector.identityId), () =>

--- a/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
@@ -3,6 +3,7 @@ import { ForbiddenError } from "@casl/ability";
 import { AccessScope, OrganizationActionScope, OrgMembershipRole } from "@app/db/schemas";
 import { OrgPermissionIdentityActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import {
+  assertRoleSetBoundary,
   constructPermissionErrorMessage,
   validatePrivilegeChangeOperation
 } from "@app/ee/services/permission/permission-fns";
@@ -11,21 +12,25 @@ import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { isCustomOrgRole } from "@app/services/org/org-role-fns";
 
+import { TMembershipIdentityDALFactory } from "../membership-identity-dal";
 import { TMembershipIdentityScopeFactory } from "../membership-identity-types";
 
 type TOrgMembershipIdentityScopeFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission" | "getOrgPermissionByRoles">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   identityDAL: Pick<TIdentityDALFactory, "findById">;
+  membershipIdentityDAL: Pick<TMembershipIdentityDALFactory, "getIdentityById">;
 };
 
 export const newOrgMembershipIdentityFactory = ({
   permissionService,
   orgDAL,
-  identityDAL
+  identityDAL,
+  membershipIdentityDAL
 }: TOrgMembershipIdentityScopeFactoryDep): TMembershipIdentityScopeFactory => {
   const getScopeField: TMembershipIdentityScopeFactory["getScopeField"] = (dto) => {
     if (dto.scope === AccessScope.Organization) {
@@ -179,6 +184,28 @@ export const newOrgMembershipIdentityFactory = ({
 
     if (identityDetails.projectId) {
       throw new BadRequestError({ message: "Failed to create organization membership for a project scoped identity" });
+    }
+
+    const targetMembership = await membershipIdentityDAL.getIdentityById({
+      scopeData: dto.scopeData,
+      identityId: dto.selector.identityId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId);
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+        requestMemoKeys.orgFindById(dto.permission.orgId),
+        () => orgDAL.findById(dto.permission.orgId)
+      );
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionIdentityActions.Delete,
+        opSubject: OrgPermissionSubjects.Identity,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to remove a more privileged identity from the organization"
+      });
     }
   };
 

--- a/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/org/org-membership-identity-factory.ts
@@ -133,20 +133,18 @@ export const newOrgMembershipIdentityFactory = ({
       identityId: dto.selector.identityId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
-        ignoreUnresolvedRoles: true
-      });
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+      ignoreUnresolvedRoles: true
+    });
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: OrgPermissionIdentityActions.GrantPrivileges,
-        opSubject: OrgPermissionSubjects.Identity,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged identity"
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionIdentityActions.GrantPrivileges,
+      opSubject: OrgPermissionSubjects.Identity,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to change the roles of a more privileged identity"
+    });
 
     for (const permissionRole of permissionRoles) {
       if (permissionRole?.role?.name !== OrgMembershipRole.NoAccess) {
@@ -212,24 +210,22 @@ export const newOrgMembershipIdentityFactory = ({
       identityId: dto.selector.identityId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
-        ignoreUnresolvedRoles: true
-      });
-      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
-        requestMemoKeys.orgFindById(dto.permission.orgId),
-        () => orgDAL.findById(dto.permission.orgId)
-      );
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: OrgPermissionIdentityActions.Delete,
-        opSubject: OrgPermissionSubjects.Identity,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to remove a more privileged identity from the organization"
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionIdentityActions.Delete,
+      opSubject: OrgPermissionSubjects.Identity,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged identity from the organization"
+    });
   };
 
   const onListMembershipIdentityGuard: TMembershipIdentityScopeFactory["onListMembershipIdentityGuard"] = async (

--- a/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
@@ -2,6 +2,7 @@ import { ForbiddenError, subject } from "@casl/ability";
 
 import { AccessScope, ActionProjectType, ProjectMembershipRole, ProjectType } from "@app/db/schemas";
 import {
+  assertRoleSetBoundary,
   constructPermissionErrorMessage,
   validatePrivilegeChangeOperation
 } from "@app/ee/services/permission/permission-fns";
@@ -15,6 +16,7 @@ import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 
@@ -27,7 +29,7 @@ type TProjectMembershipIdentityScopeFactoryDep = {
 
   identityDAL: Pick<TIdentityDALFactory, "findById">;
   orgDAL: Pick<TOrgDALFactory, "findById" | "findEffectiveOrgMembership">;
-  membershipIdentityDAL: Pick<TMembershipIdentityDALFactory, "findOne">;
+  membershipIdentityDAL: Pick<TMembershipIdentityDALFactory, "findOne" | "getIdentityById">;
   projectDAL: Pick<TProjectDALFactory, "findById">;
 };
 
@@ -35,7 +37,8 @@ export const newProjectMembershipIdentityFactory = ({
   permissionService,
   orgDAL,
   identityDAL,
-  projectDAL
+  projectDAL,
+  membershipIdentityDAL
 }: TProjectMembershipIdentityScopeFactoryDep): TMembershipIdentityScopeFactory => {
   const getScopeField: TMembershipIdentityScopeFactory["getScopeField"] = (dto) => {
     if (dto.scope === AccessScope.Project) {
@@ -231,6 +234,29 @@ export const newProjectMembershipIdentityFactory = ({
     );
     if (identityDetails.projectId) {
       throw new BadRequestError({ message: "Failed to delete project membership for a project scoped identity" });
+    }
+
+    const targetMembership = await membershipIdentityDAL.getIdentityById({
+      scopeData: dto.scopeData,
+      identityId: dto.selector.identityId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+        requestMemoKeys.orgFindById(dto.permission.orgId),
+        () => orgDAL.findById(dto.permission.orgId)
+      );
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: ProjectPermissionIdentityActions.Delete,
+        opSubject: ProjectPermissionSub.Identity,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to remove a more privileged identity from the project",
+        subjectFields: { identityId: dto.selector.identityId }
+      });
     }
   };
 

--- a/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
@@ -16,7 +16,10 @@ import { BadRequestError, InternalServerError, PermissionBoundaryError } from "@
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
 import { TIdentityDALFactory } from "@app/services/identity/identity-dal";
-import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
+import {
+  filterRolesNeedingPrivilegeBoundary,
+  resolveMembershipRoleSlugs
+} from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 
@@ -108,34 +111,32 @@ export const newProjectMembershipIdentityFactory = ({
       () => orgDAL.findById(dto.permission.orgId)
     );
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
-      dto.data.roles.map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       scope.value
     );
     for (const permissionRole of permissionRoles) {
-      if (permissionRole?.role?.name !== ProjectMembershipRole.NoAccess) {
-        const permissionBoundary = validatePrivilegeChangeOperation(
-          shouldUseNewPrivilegeSystem,
-          [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
-          ProjectPermissionSub.Identity,
-          permission,
-          permissionRole.permission,
-          {
-            identityId: identityDetails.id,
-            assignableRole: permissionRole.role?.slug
-          }
-        );
+      const permissionBoundary = validatePrivilegeChangeOperation(
+        shouldUseNewPrivilegeSystem,
+        [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
+        ProjectPermissionSub.Identity,
+        permission,
+        permissionRole.permission,
+        {
+          identityId: identityDetails.id,
+          assignableRole: permissionRole.role?.slug
+        }
+      );
 
-        if (!permissionBoundary.isValid)
-          throw new PermissionBoundaryError({
-            message: constructPermissionErrorMessage(
-              "Failed to create identity project membership",
-              shouldUseNewPrivilegeSystem,
-              ProjectPermissionIdentityActions.AssignRole,
-              ProjectPermissionSub.Identity
-            ),
-            details: { missingPermissions: permissionBoundary.missingPermissions }
-          });
-      }
+      if (!permissionBoundary.isValid)
+        throw new PermissionBoundaryError({
+          message: constructPermissionErrorMessage(
+            "Failed to create identity project membership",
+            shouldUseNewPrivilegeSystem,
+            ProjectPermissionIdentityActions.AssignRole,
+            ProjectPermissionSub.Identity
+          ),
+          details: { missingPermissions: permissionBoundary.missingPermissions }
+        });
     }
   };
 
@@ -201,7 +202,7 @@ export const newProjectMembershipIdentityFactory = ({
     });
 
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
-      dto.data.roles.filter((el) => el.role !== ProjectMembershipRole.NoAccess).map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       scope.value
     );
     for (const permissionRole of permissionRoles) {

--- a/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
@@ -188,7 +188,9 @@ export const newProjectMembershipIdentityFactory = ({
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+        ignoreUnresolvedRoles: true
+      });
       assertRoleSetBoundary({
         shouldUseNewPrivilegeSystem,
         opActions: [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
@@ -261,7 +263,9 @@ export const newProjectMembershipIdentityFactory = ({
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+        ignoreUnresolvedRoles: true
+      });
       const { shouldUseNewPrivilegeSystem } = await requestMemoize(
         requestMemoKeys.orgFindById(dto.permission.orgId),
         () => orgDAL.findById(dto.permission.orgId)

--- a/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
@@ -181,6 +181,25 @@ export const newProjectMembershipIdentityFactory = ({
       requestMemoKeys.orgFindById(dto.permission.orgId),
       () => orgDAL.findById(dto.permission.orgId)
     );
+
+    const targetMembership = await membershipIdentityDAL.getIdentityById({
+      scopeData: dto.scopeData,
+      identityId: dto.selector.identityId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
+        opSubject: ProjectPermissionSub.Identity,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged identity",
+        subjectFields: { identityId: dto.selector.identityId }
+      });
+    }
+
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
       dto.data.roles.filter((el) => el.role !== ProjectMembershipRole.NoAccess).map((el) => el.role),
       scope.value

--- a/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
+++ b/backend/src/services/membership-identity/project/project-membership-identity-factory.ts
@@ -187,20 +187,18 @@ export const newProjectMembershipIdentityFactory = ({
       identityId: dto.selector.identityId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
-        ignoreUnresolvedRoles: true
-      });
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
-        opSubject: ProjectPermissionSub.Identity,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged identity",
-        subjectFields: { identityId: dto.selector.identityId }
-      });
-    }
+    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+      ignoreUnresolvedRoles: true
+    });
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: [ProjectPermissionIdentityActions.AssignRole, ProjectPermissionIdentityActions.GrantPrivileges],
+      opSubject: ProjectPermissionSub.Identity,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to change the roles of a more privileged identity",
+      subjectFields: { identityId: dto.selector.identityId }
+    });
 
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
       dto.data.roles.filter((el) => el.role !== ProjectMembershipRole.NoAccess).map((el) => el.role),
@@ -262,25 +260,23 @@ export const newProjectMembershipIdentityFactory = ({
       identityId: dto.selector.identityId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
-        ignoreUnresolvedRoles: true
-      });
-      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
-        requestMemoKeys.orgFindById(dto.permission.orgId),
-        () => orgDAL.findById(dto.permission.orgId)
-      );
+    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: ProjectPermissionIdentityActions.Delete,
-        opSubject: ProjectPermissionSub.Identity,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to remove a more privileged identity from the project",
-        subjectFields: { identityId: dto.selector.identityId }
-      });
-    }
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: ProjectPermissionIdentityActions.Delete,
+      opSubject: ProjectPermissionSub.Identity,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged identity from the project",
+      subjectFields: { identityId: dto.selector.identityId }
+    });
   };
 
   const onListMembershipIdentityGuard: TMembershipIdentityScopeFactory["onListMembershipIdentityGuard"] = async (

--- a/backend/src/services/membership-user/membership-user-types.ts
+++ b/backend/src/services/membership-user/membership-user-types.ts
@@ -12,7 +12,7 @@ export interface TMembershipUserScopeFactory {
   ) => Promise<{ signUpTokens: { email: string; link: string }[] }>;
 
   onUpdateMembershipUserGuard: (arg: TUpdateMembershipUserDTO) => Promise<void>;
-  onDeleteMembershipUserGuard: (arg: TDeleteMembershipUserDTO | TBulkDeleteMembershipByUsernameDTO) => Promise<void>;
+  onDeleteMembershipUserGuard: (arg: TDeleteMembershipUserDTO) => Promise<void>;
 
   onListMembershipUserGuard: (arg: TListMembershipUserDTO) => Promise<void>;
   onGetMembershipUserByUserIdGuard: (arg: TGetMembershipUserByUserIdDTO) => Promise<void>;
@@ -74,14 +74,6 @@ export type TDeleteMembershipUserDTO = {
   scopeData: AccessScopeData;
   selector: {
     userId: string;
-  };
-};
-
-export type TBulkDeleteMembershipByUsernameDTO = {
-  permission: OrgServiceActor;
-  scopeData: AccessScopeData;
-  data: {
-    usernames: string[];
   };
 };
 

--- a/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
@@ -1,0 +1,137 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { vi } from "vitest";
+
+import { AccessScope } from "@app/db/schemas";
+import {
+  orgAdminPermissions,
+  orgMemberPermissions,
+  orgNoAccessPermissions,
+  OrgPermissionActions,
+  OrgPermissionSubjects
+} from "@app/ee/services/permission/org-permission";
+import { PermissionBoundaryError } from "@app/lib/errors";
+
+import { newOrgMembershipUserFactory } from "./org-membership-user-factory";
+
+// The org update guard bounds a role change against the roles the target already holds, because a
+// downgrade strips privileges as effectively as a removal does. Unlike the identity and group
+// surfaces, this boundary applies on both privilege systems: the new system replaces a superset
+// check with a dedicated `grant-privileges` action, and OrgPermissionSubjects.Member has no such
+// action. Routing it through validatePrivilegeChangeOperation would collapse it to the
+// `can(edit, member)` the guard's own throwUnlessCan already required, leaving no check at all.
+
+const ORG_ID = "org-id";
+const TARGET_USER_ID = "target-user-id";
+
+const admin = createMongoAbility<MongoAbility>(orgAdminPermissions);
+const member = createMongoAbility<MongoAbility>(orgMemberPermissions);
+
+// Exactly the grant the guard's throwUnlessCan demands, and nothing more: weaker than the target,
+// so the boundary is the only thing left that can reject it.
+const memberEditorOnly = createMongoAbility<MongoAbility>([
+  { action: [OrgPermissionActions.Read, OrgPermissionActions.Edit], subject: OrgPermissionSubjects.Member }
+]);
+
+const createGuard = ({
+  actorPermission,
+  shouldUseNewPrivilegeSystem,
+  targetRole = "admin",
+  incomingRole = "member"
+}: {
+  actorPermission: MongoAbility;
+  shouldUseNewPrivilegeSystem: boolean;
+  targetRole?: string;
+  incomingRole?: string;
+}) => {
+  const abilityByRole: Record<string, MongoAbility> = {
+    admin,
+    member,
+    "no-access": createMongoAbility<MongoAbility>(orgNoAccessPermissions)
+  };
+
+  const factory = newOrgMembershipUserFactory({
+    permissionService: {
+      getOrgPermission: vi.fn().mockResolvedValue({ permission: actorPermission }),
+      getOrgPermissionByRoles: vi
+        .fn()
+        .mockImplementation((roles: string[]) => roles.map((role) => ({ permission: abilityByRole[role] })))
+    } as never,
+    orgDAL: { findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem }) } as never,
+    membershipUserDAL: { getUserById: vi.fn().mockResolvedValue({ roles: [{ role: targetRole }] }) } as never,
+    tokenService: {} as never,
+    userDAL: {} as never,
+    smtpService: {} as never,
+    userGroupMembershipDAL: {} as never,
+    licenseService: {} as never,
+    emailDomainDAL: {} as never,
+    oidcConfigDAL: {} as never,
+    samlConfigDAL: {} as never
+  });
+
+  return () =>
+    factory.onUpdateMembershipUserGuard({
+      permission: { type: "user", id: "actor-id", orgId: ORG_ID, authMethod: "email" },
+      scopeData: { scope: AccessScope.Organization, orgId: ORG_ID },
+      selector: { userId: TARGET_USER_ID },
+      data: { roles: [{ role: incomingRole, isTemporary: false }] }
+    } as never);
+};
+
+describe("onUpdateMembershipUserGuard privilege boundary", () => {
+  test("the actor holds member:edit, so the plain permission check is not what rejects it", () => {
+    expect(memberEditorOnly.can(OrgPermissionActions.Edit, OrgPermissionSubjects.Member)).toBe(true);
+  });
+
+  test("on the legacy system, a weaker actor cannot downgrade an Admin member", async () => {
+    const guard = createGuard({ actorPermission: memberEditorOnly, shouldUseNewPrivilegeSystem: false });
+
+    await expect(guard()).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("on the new privilege system, the same actor and target are rejected too", async () => {
+    const guard = createGuard({ actorPermission: memberEditorOnly, shouldUseNewPrivilegeSystem: true });
+
+    await expect(guard()).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("granting a role above the actor is rejected on both systems", async () => {
+    await expect(
+      createGuard({
+        actorPermission: memberEditorOnly,
+        shouldUseNewPrivilegeSystem: false,
+        targetRole: "no-access",
+        incomingRole: "admin"
+      })()
+    ).rejects.toThrow(PermissionBoundaryError);
+
+    await expect(
+      createGuard({
+        actorPermission: memberEditorOnly,
+        shouldUseNewPrivilegeSystem: true,
+        targetRole: "no-access",
+        incomingRole: "admin"
+      })()
+    ).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("an admin actor is unaffected on either system", async () => {
+    await expect(
+      createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: false })()
+    ).resolves.toBeUndefined();
+    await expect(createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: true })()).resolves.toBeUndefined();
+  });
+
+  test("it is the target's privileges that reject, not the actor being weak", async () => {
+    // Same weak actor, but nothing on either side outranks it: no-access is filtered out of the
+    // target set entirely, and grants nothing when requested. The guard has to let this through,
+    // or it would block every role change a non-admin can legitimately make.
+    const guard = createGuard({
+      actorPermission: memberEditorOnly,
+      shouldUseNewPrivilegeSystem: false,
+      targetRole: "no-access",
+      incomingRole: "no-access"
+    });
+
+    await expect(guard()).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
@@ -13,11 +13,10 @@ import { PermissionBoundaryError } from "@app/lib/errors";
 
 import { newOrgMembershipUserFactory } from "./org-membership-user-factory";
 
-// The org update guard bounds a role change against the roles the target already holds, because a
-// downgrade strips privileges as effectively as a removal does. Both privilege systems reject, but
-// for different reasons: the legacy system compares privilege levels, while the new system asks for
-// member:grant-privileges, which is deliberately not implied by the member:edit that the guard's own
-// throwUnlessCan requires.
+// The org update guard bounds a role change against the roles the target already holds, since a
+// downgrade strips privileges as effectively as a removal does. Both systems reject, for different
+// reasons: the legacy one compares privilege levels, the new one asks for member:grant-privileges,
+// which is deliberately not implied by the member:edit the guard's own throwUnlessCan requires.
 
 const ORG_ID = "org-id";
 const TARGET_USER_ID = "target-user-id";
@@ -40,15 +39,6 @@ const memberPrivilegeGranter = createMongoAbility<MongoAbility>([
       OrgPermissionMemberActions.Edit,
       OrgPermissionMemberActions.GrantPrivileges
     ],
-    subject: OrgPermissionSubjects.Member
-  }
-]);
-
-// Holds the action that describes changing a member's activation, but not the one for assigning
-// roles. The pair with memberPrivilegeGranter is what pins each operation to its own action.
-const memberDeleter = createMongoAbility<MongoAbility>([
-  {
-    action: [OrgPermissionMemberActions.Read, OrgPermissionMemberActions.Edit, OrgPermissionMemberActions.Delete],
     subject: OrgPermissionSubjects.Member
   }
 ]);
@@ -181,9 +171,8 @@ describe("onUpdateMembershipUserGuard privilege boundary", () => {
   });
 
   test("it is the target's privileges that reject, not the actor being weak", async () => {
-    // Same weak actor, but nothing on either side outranks it: no-access is filtered out of the
-    // target set entirely, and grants nothing when requested. The guard has to let this through,
-    // or it would block every role change a non-admin can legitimately make.
+    // Same weak actor, but nothing on either side outranks it. The guard has to let this through, or
+    // it would block every role change a non-admin can legitimately make.
     const guard = createGuard({
       actorPermission: memberEditorOnly,
       shouldUseNewPrivilegeSystem: false,
@@ -196,12 +185,12 @@ describe("onUpdateMembershipUserGuard privilege boundary", () => {
 
   // The guard ran one boundary keyed on member:grant-privileges for every field on the route, so a
   // deactivation was gated on a role-assignment permission. Each operation now keys on the action
-  // that describes it, which for metadata is still grant-privileges: it feeds ABAC.
+  // that describes it: activation is a member attribute and stays on member:edit, while metadata
+  // needs grant-privileges because it feeds ABAC.
   describe("gating follows the operation being performed", () => {
     test("a metadata-only edit is bounded, because metadata drives ABAC", async () => {
-      // Org member metadata is the {{identity.metadata.*}} attribute source that project policies
-      // interpolate, so rewriting an Admin's metadata rewrites what their roles grant. member:edit
-      // alone must not reach it.
+      // Org member metadata is the {{identity.metadata.*}} source project policies interpolate, so
+      // rewriting an Admin's metadata rewrites what their roles grant. member:edit must not reach it.
       const metadataOnly = { roles: [], metadata: [{ key: "team", value: "platform" }] };
 
       await expect(
@@ -220,47 +209,38 @@ describe("onUpdateMembershipUserGuard privilege boundary", () => {
           data: metadataOnly
         })()
       ).resolves.toBeUndefined();
-
-      // member:delete does not: deactivating a member and rewriting their attributes are different
-      // operations gated on different actions.
-      await expect(
-        createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: metadataOnly })()
-      ).rejects.toThrow(PermissionBoundaryError);
     });
 
-    test("deactivation keys on member:delete, not member:grant-privileges", async () => {
+    test("deactivation keys on member:edit, so the new system asks for nothing further", async () => {
+      // Activation is a member attribute, not a privilege grant, so it stays on the action the
+      // route's own throwUnlessCan already demanded. On the new system that boundary can only pass.
       const deactivate = { roles: [], isActive: false };
 
-      // Holds grant-privileges but not delete: it can assign roles, and that says nothing about
-      // being allowed to cut off an Admin's access.
       await expect(
-        createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: true, data: deactivate })()
-      ).rejects.toThrow(PermissionBoundaryError);
-
-      await expect(
-        createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: deactivate })()
+        createGuard({ actorPermission: memberEditorOnly, shouldUseNewPrivilegeSystem: true, data: deactivate })()
       ).resolves.toBeUndefined();
-    });
 
-    test("reactivating a privileged member is bounded the same way", async () => {
-      // Restoring an Admin's access is as much a privilege change as removing it, so it cannot be
-      // the ungated direction of the same field.
-      const reactivate = { roles: [], isActive: true };
-
+      // Reactivating is the same operation in the other direction, and gated the same way.
       await expect(
-        createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: true, data: reactivate })()
-      ).rejects.toThrow(PermissionBoundaryError);
-
-      await expect(
-        createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: reactivate })()
+        createGuard({
+          actorPermission: memberEditorOnly,
+          shouldUseNewPrivilegeSystem: true,
+          data: { roles: [], isActive: true }
+        })()
       ).resolves.toBeUndefined();
+
+      // The same actor still cannot touch the target's roles.
+      await expect(
+        createGuard({ actorPermission: memberEditorOnly, shouldUseNewPrivilegeSystem: true })()
+      ).rejects.toThrow(PermissionBoundaryError);
     });
 
     test("the legacy system still compares privilege levels, whatever the operation", async () => {
-      // memberDeleter holds the action, which buys it nothing here: it is still weaker than an Admin.
+      // Holding member:edit buys the actor nothing here: it is still weaker than an Admin, so it
+      // cannot cut off that Admin's access.
       await expect(
         createGuard({
-          actorPermission: memberDeleter,
+          actorPermission: memberEditorOnly,
           shouldUseNewPrivilegeSystem: false,
           data: { roles: [], isActive: false }
         })()
@@ -268,59 +248,48 @@ describe("onUpdateMembershipUserGuard privilege boundary", () => {
     });
 
     test("a target holding no roles is still bounded on the new system", async () => {
-      // A membership whose roles have all expired resolves to an empty role set. Skipping the
-      // boundary for it would let member:edit alone deactivate that member, since nothing else in
-      // the guard asks for member:delete.
-      const deactivate = { roles: [], isActive: false };
+      // A membership whose roles have all expired resolves to an empty role set. The boundary still
+      // runs against it, so a role change there asks for grant-privileges like any other.
+      const roleChange = { roles: [{ role: "member", isTemporary: false }] };
 
       await expect(
         createGuard({
           actorPermission: memberEditorOnly,
           shouldUseNewPrivilegeSystem: true,
           targetRoles: [],
-          data: deactivate
+          data: roleChange
         })()
       ).rejects.toThrow(PermissionBoundaryError);
 
       await expect(
         createGuard({
-          actorPermission: memberDeleter,
+          actorPermission: memberPrivilegeGranter,
           shouldUseNewPrivilegeSystem: true,
           targetRoles: [],
-          data: deactivate
-        })()
-      ).resolves.toBeUndefined();
-
-      // The legacy system compares privilege levels, and no target privileges means nothing to
-      // out-rank, so the same weak actor passes there.
-      await expect(
-        createGuard({
-          actorPermission: memberEditorOnly,
-          shouldUseNewPrivilegeSystem: false,
-          targetRoles: [],
-          data: deactivate
+          data: roleChange
         })()
       ).resolves.toBeUndefined();
     });
 
-    test("a role change and a deactivation in one request need both actions", async () => {
+    test("a role change and a deactivation in one request are gated separately", async () => {
       const both = { roles: [{ role: "member", isTemporary: false }], isActive: false };
 
-      // Each holds exactly one of the two actions, so neither can do both at once.
+      // member:edit carries the deactivation but not the role change, so the request is rejected
+      // as a whole rather than partly applied.
       await expect(
-        createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: true, data: both })()
+        createGuard({ actorPermission: memberEditorOnly, shouldUseNewPrivilegeSystem: true, data: both })()
       ).rejects.toThrow(PermissionBoundaryError);
 
       await expect(
-        createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: both })()
-      ).rejects.toThrow(PermissionBoundaryError);
+        createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: true, data: both })()
+      ).resolves.toBeUndefined();
     });
   });
 });
 
-// An invite always carries a role, so create alone never gets the request through — except for
+// An invite always carries a role, so create alone never gets the request through, except for
 // no-access, which confers nothing and so cannot escalate anything. Unlike the update guard, the
-// invite guard has no target to bound against, so the requested roles are the only thing it checks.
+// invite guard has no target to bound against, so the requested roles are all it checks.
 describe("onCreateMembershipUserGuard privilege boundary", () => {
   const createInviteGuard = ({
     actorPermission,
@@ -382,9 +351,8 @@ describe("onCreateMembershipUserGuard privilege boundary", () => {
   });
 
   test("inviting with no-access is exempt on both systems", async () => {
-    // no-access resolves to an empty rule set, so there is no privilege to escalate and nothing for
-    // grant-privileges to be protecting. Requiring it here would block the one invite that is
-    // provably harmless.
+    // no-access resolves to an empty rule set, so there is nothing to escalate and nothing for
+    // grant-privileges to protect. Requiring it would block the one invite that is provably harmless.
     await expect(
       createInviteGuard({
         actorPermission: memberCreatorOnly,

--- a/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
@@ -57,12 +57,14 @@ const createGuard = ({
   actorPermission,
   shouldUseNewPrivilegeSystem,
   targetRole = "admin",
+  targetRoles,
   incomingRole = "member",
   data
 }: {
   actorPermission: MongoAbility;
   shouldUseNewPrivilegeSystem: boolean;
   targetRole?: string;
+  targetRoles?: string[];
   incomingRole?: string;
   data?: Record<string, unknown>;
 }) => {
@@ -80,7 +82,9 @@ const createGuard = ({
         .mockImplementation((roles: string[]) => roles.map((role) => ({ permission: abilityByRole[role] })))
     } as never,
     orgDAL: { findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem }) } as never,
-    membershipUserDAL: { getUserById: vi.fn().mockResolvedValue({ roles: [{ role: targetRole }] }) } as never,
+    membershipUserDAL: {
+      getUserById: vi.fn().mockResolvedValue({ roles: (targetRoles ?? [targetRole]).map((role) => ({ role })) })
+    } as never,
     tokenService: {} as never,
     userDAL: {} as never,
     smtpService: {} as never,
@@ -241,6 +245,42 @@ describe("onUpdateMembershipUserGuard privilege boundary", () => {
           data: { roles: [], isActive: false }
         })()
       ).rejects.toThrow(PermissionBoundaryError);
+    });
+
+    test("a target holding no roles is still bounded on the new system", async () => {
+      // A membership whose roles have all expired resolves to an empty role set. Skipping the
+      // boundary for it would let member:edit alone deactivate that member, since nothing else in
+      // the guard asks for member:delete.
+      const deactivate = { roles: [], isActive: false };
+
+      await expect(
+        createGuard({
+          actorPermission: memberEditorOnly,
+          shouldUseNewPrivilegeSystem: true,
+          targetRoles: [],
+          data: deactivate
+        })()
+      ).rejects.toThrow(PermissionBoundaryError);
+
+      await expect(
+        createGuard({
+          actorPermission: memberDeleter,
+          shouldUseNewPrivilegeSystem: true,
+          targetRoles: [],
+          data: deactivate
+        })()
+      ).resolves.toBeUndefined();
+
+      // The legacy system compares privilege levels, and no target privileges means nothing to
+      // out-rank, so the same weak actor passes there.
+      await expect(
+        createGuard({
+          actorPermission: memberEditorOnly,
+          shouldUseNewPrivilegeSystem: false,
+          targetRoles: [],
+          data: deactivate
+        })()
+      ).resolves.toBeUndefined();
     });
 
     test("a role change and a deactivation in one request need both actions", async () => {

--- a/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
@@ -53,6 +53,26 @@ const memberDeleter = createMongoAbility<MongoAbility>([
   }
 ]);
 
+// Exactly what the invite guard's throwUnlessCan demands, and nothing more.
+const memberCreatorOnly = createMongoAbility<MongoAbility>([
+  {
+    action: [OrgPermissionMemberActions.Read, OrgPermissionMemberActions.Create],
+    subject: OrgPermissionSubjects.Member
+  }
+]);
+
+// The invite equivalent of memberPrivilegeGranter: create plus the action the new system asks for.
+const memberCreatorGranter = createMongoAbility<MongoAbility>([
+  {
+    action: [
+      OrgPermissionMemberActions.Read,
+      OrgPermissionMemberActions.Create,
+      OrgPermissionMemberActions.GrantPrivileges
+    ],
+    subject: OrgPermissionSubjects.Member
+  }
+]);
+
 const createGuard = ({
   actorPermission,
   shouldUseNewPrivilegeSystem,
@@ -295,5 +315,109 @@ describe("onUpdateMembershipUserGuard privilege boundary", () => {
         createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: both })()
       ).rejects.toThrow(PermissionBoundaryError);
     });
+  });
+});
+
+// An invite always carries a role, so create alone never gets the request through — except for
+// no-access, which confers nothing and so cannot escalate anything. Unlike the update guard, the
+// invite guard has no target to bound against, so the requested roles are the only thing it checks.
+describe("onCreateMembershipUserGuard privilege boundary", () => {
+  const createInviteGuard = ({
+    actorPermission,
+    shouldUseNewPrivilegeSystem,
+    incomingRoles = ["member"]
+  }: {
+    actorPermission: MongoAbility;
+    shouldUseNewPrivilegeSystem: boolean;
+    incomingRoles?: string[];
+  }) => {
+    const abilityByRole: Record<string, MongoAbility> = {
+      admin,
+      member,
+      "no-access": createMongoAbility<MongoAbility>(orgNoAccessPermissions)
+    };
+
+    const factory = newOrgMembershipUserFactory({
+      permissionService: {
+        getOrgPermission: vi.fn().mockResolvedValue({ permission: actorPermission }),
+        getOrgPermissionByRoles: vi
+          .fn()
+          .mockImplementation((roles: string[]) => roles.map((role) => ({ permission: abilityByRole[role] })))
+      } as never,
+      orgDAL: {
+        findById: vi
+          .fn()
+          .mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem, authEnforced: false, rootOrgId: null })
+      } as never,
+      licenseService: { getPlan: vi.fn().mockResolvedValue({}), getOrgSeatUsage: vi.fn() } as never,
+      membershipUserDAL: { find: vi.fn(), getUserById: vi.fn() } as never,
+      tokenService: {} as never,
+      userDAL: {} as never,
+      smtpService: {} as never,
+      userGroupMembershipDAL: {} as never,
+      emailDomainDAL: { find: vi.fn().mockResolvedValue([]) } as never,
+      oidcConfigDAL: {} as never,
+      samlConfigDAL: {} as never
+    });
+
+    return () =>
+      factory.onCreateMembershipUserGuard(
+        {
+          permission: { type: "user", id: "actor-id", orgId: ORG_ID, authMethod: "email" },
+          scopeData: { scope: AccessScope.Organization, orgId: ORG_ID },
+          data: { roles: incomingRoles.map((role) => ({ role, isTemporary: false })) }
+        } as never,
+        [{ id: "invitee-id", email: "invitee@example.com" }] as never
+      );
+  };
+
+  test("member:create alone cannot invite with a real role on the new system", async () => {
+    await expect(
+      createInviteGuard({ actorPermission: memberCreatorOnly, shouldUseNewPrivilegeSystem: true })()
+    ).rejects.toThrow(PermissionBoundaryError);
+
+    await expect(
+      createInviteGuard({ actorPermission: memberCreatorGranter, shouldUseNewPrivilegeSystem: true })()
+    ).resolves.toBeUndefined();
+  });
+
+  test("inviting with no-access is exempt on both systems", async () => {
+    // no-access resolves to an empty rule set, so there is no privilege to escalate and nothing for
+    // grant-privileges to be protecting. Requiring it here would block the one invite that is
+    // provably harmless.
+    await expect(
+      createInviteGuard({
+        actorPermission: memberCreatorOnly,
+        shouldUseNewPrivilegeSystem: true,
+        incomingRoles: ["no-access"]
+      })()
+    ).resolves.toBeUndefined();
+
+    await expect(
+      createInviteGuard({
+        actorPermission: memberCreatorOnly,
+        shouldUseNewPrivilegeSystem: false,
+        incomingRoles: ["no-access"]
+      })()
+    ).resolves.toBeUndefined();
+  });
+
+  test("the exemption is per role, not a way past the boundary", async () => {
+    // Pairing no-access with a real role must not launder the real one through.
+    await expect(
+      createInviteGuard({
+        actorPermission: memberCreatorOnly,
+        shouldUseNewPrivilegeSystem: true,
+        incomingRoles: ["no-access", "admin"]
+      })()
+    ).rejects.toThrow(PermissionBoundaryError);
+
+    await expect(
+      createInviteGuard({
+        actorPermission: memberCreatorOnly,
+        shouldUseNewPrivilegeSystem: false,
+        incomingRoles: ["no-access", "admin"]
+      })()
+    ).rejects.toThrow(PermissionBoundaryError);
   });
 });

--- a/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
@@ -6,7 +6,7 @@ import {
   orgAdminPermissions,
   orgMemberPermissions,
   orgNoAccessPermissions,
-  OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects
 } from "@app/ee/services/permission/org-permission";
 import { PermissionBoundaryError } from "@app/lib/errors";
@@ -14,11 +14,10 @@ import { PermissionBoundaryError } from "@app/lib/errors";
 import { newOrgMembershipUserFactory } from "./org-membership-user-factory";
 
 // The org update guard bounds a role change against the roles the target already holds, because a
-// downgrade strips privileges as effectively as a removal does. Unlike the identity and group
-// surfaces, this boundary applies on both privilege systems: the new system replaces a superset
-// check with a dedicated `grant-privileges` action, and OrgPermissionSubjects.Member has no such
-// action. Routing it through validatePrivilegeChangeOperation would collapse it to the
-// `can(edit, member)` the guard's own throwUnlessCan already required, leaving no check at all.
+// downgrade strips privileges as effectively as a removal does. Both privilege systems reject, but
+// for different reasons: the legacy system compares privilege levels, while the new system asks for
+// member:grant-privileges, which is deliberately not implied by the member:edit that the guard's own
+// throwUnlessCan requires.
 
 const ORG_ID = "org-id";
 const TARGET_USER_ID = "target-user-id";
@@ -29,7 +28,20 @@ const member = createMongoAbility<MongoAbility>(orgMemberPermissions);
 // Exactly the grant the guard's throwUnlessCan demands, and nothing more: weaker than the target,
 // so the boundary is the only thing left that can reject it.
 const memberEditorOnly = createMongoAbility<MongoAbility>([
-  { action: [OrgPermissionActions.Read, OrgPermissionActions.Edit], subject: OrgPermissionSubjects.Member }
+  { action: [OrgPermissionMemberActions.Read, OrgPermissionMemberActions.Edit], subject: OrgPermissionSubjects.Member }
+]);
+
+// Still weaker than an Admin target, but now holding the action the new system asks for. This is the
+// pair that separates the two systems: the privilege comparison still rejects it, the action does not.
+const memberPrivilegeGranter = createMongoAbility<MongoAbility>([
+  {
+    action: [
+      OrgPermissionMemberActions.Read,
+      OrgPermissionMemberActions.Edit,
+      OrgPermissionMemberActions.GrantPrivileges
+    ],
+    subject: OrgPermissionSubjects.Member
+  }
 ]);
 
 const createGuard = ({
@@ -79,7 +91,7 @@ const createGuard = ({
 
 describe("onUpdateMembershipUserGuard privilege boundary", () => {
   test("the actor holds member:edit, so the plain permission check is not what rejects it", () => {
-    expect(memberEditorOnly.can(OrgPermissionActions.Edit, OrgPermissionSubjects.Member)).toBe(true);
+    expect(memberEditorOnly.can(OrgPermissionMemberActions.Edit, OrgPermissionSubjects.Member)).toBe(true);
   });
 
   test("on the legacy system, a weaker actor cannot downgrade an Admin member", async () => {
@@ -119,6 +131,18 @@ describe("onUpdateMembershipUserGuard privilege boundary", () => {
       createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: false })()
     ).resolves.toBeUndefined();
     await expect(createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: true })()).resolves.toBeUndefined();
+  });
+
+  test("member:grant-privileges is what the new system keys on, and only the new system", async () => {
+    // Same actor on both runs. The new system accepts it because it holds the action; the legacy
+    // system still rejects it because holding an action says nothing about out-ranking an Admin.
+    await expect(
+      createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: true })()
+    ).resolves.toBeUndefined();
+
+    await expect(
+      createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: false })()
+    ).rejects.toThrow(PermissionBoundaryError);
   });
 
   test("it is the target's privileges that reject, not the actor being weak", async () => {

--- a/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-boundary.test.ts
@@ -44,16 +44,27 @@ const memberPrivilegeGranter = createMongoAbility<MongoAbility>([
   }
 ]);
 
+// Holds the action that describes changing a member's activation, but not the one for assigning
+// roles. The pair with memberPrivilegeGranter is what pins each operation to its own action.
+const memberDeleter = createMongoAbility<MongoAbility>([
+  {
+    action: [OrgPermissionMemberActions.Read, OrgPermissionMemberActions.Edit, OrgPermissionMemberActions.Delete],
+    subject: OrgPermissionSubjects.Member
+  }
+]);
+
 const createGuard = ({
   actorPermission,
   shouldUseNewPrivilegeSystem,
   targetRole = "admin",
-  incomingRole = "member"
+  incomingRole = "member",
+  data
 }: {
   actorPermission: MongoAbility;
   shouldUseNewPrivilegeSystem: boolean;
   targetRole?: string;
   incomingRole?: string;
+  data?: Record<string, unknown>;
 }) => {
   const abilityByRole: Record<string, MongoAbility> = {
     admin,
@@ -85,7 +96,7 @@ const createGuard = ({
       permission: { type: "user", id: "actor-id", orgId: ORG_ID, authMethod: "email" },
       scopeData: { scope: AccessScope.Organization, orgId: ORG_ID },
       selector: { userId: TARGET_USER_ID },
-      data: { roles: [{ role: incomingRole, isTemporary: false }] }
+      data: data ?? { roles: [{ role: incomingRole, isTemporary: false }] }
     } as never);
 };
 
@@ -157,5 +168,92 @@ describe("onUpdateMembershipUserGuard privilege boundary", () => {
     });
 
     await expect(guard()).resolves.toBeUndefined();
+  });
+
+  // The guard ran one boundary keyed on member:grant-privileges for every field on the route, so a
+  // deactivation was gated on a role-assignment permission. Each operation now keys on the action
+  // that describes it, which for metadata is still grant-privileges: it feeds ABAC.
+  describe("gating follows the operation being performed", () => {
+    test("a metadata-only edit is bounded, because metadata drives ABAC", async () => {
+      // Org member metadata is the {{identity.metadata.*}} attribute source that project policies
+      // interpolate, so rewriting an Admin's metadata rewrites what their roles grant. member:edit
+      // alone must not reach it.
+      const metadataOnly = { roles: [], metadata: [{ key: "team", value: "platform" }] };
+
+      await expect(
+        createGuard({ actorPermission: memberEditorOnly, shouldUseNewPrivilegeSystem: false, data: metadataOnly })()
+      ).rejects.toThrow(PermissionBoundaryError);
+
+      await expect(
+        createGuard({ actorPermission: memberEditorOnly, shouldUseNewPrivilegeSystem: true, data: metadataOnly })()
+      ).rejects.toThrow(PermissionBoundaryError);
+
+      // grant-privileges is the action that reaches it, and only on the new system.
+      await expect(
+        createGuard({
+          actorPermission: memberPrivilegeGranter,
+          shouldUseNewPrivilegeSystem: true,
+          data: metadataOnly
+        })()
+      ).resolves.toBeUndefined();
+
+      // member:delete does not: deactivating a member and rewriting their attributes are different
+      // operations gated on different actions.
+      await expect(
+        createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: metadataOnly })()
+      ).rejects.toThrow(PermissionBoundaryError);
+    });
+
+    test("deactivation keys on member:delete, not member:grant-privileges", async () => {
+      const deactivate = { roles: [], isActive: false };
+
+      // Holds grant-privileges but not delete: it can assign roles, and that says nothing about
+      // being allowed to cut off an Admin's access.
+      await expect(
+        createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: true, data: deactivate })()
+      ).rejects.toThrow(PermissionBoundaryError);
+
+      await expect(
+        createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: deactivate })()
+      ).resolves.toBeUndefined();
+    });
+
+    test("reactivating a privileged member is bounded the same way", async () => {
+      // Restoring an Admin's access is as much a privilege change as removing it, so it cannot be
+      // the ungated direction of the same field.
+      const reactivate = { roles: [], isActive: true };
+
+      await expect(
+        createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: true, data: reactivate })()
+      ).rejects.toThrow(PermissionBoundaryError);
+
+      await expect(
+        createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: reactivate })()
+      ).resolves.toBeUndefined();
+    });
+
+    test("the legacy system still compares privilege levels, whatever the operation", async () => {
+      // memberDeleter holds the action, which buys it nothing here: it is still weaker than an Admin.
+      await expect(
+        createGuard({
+          actorPermission: memberDeleter,
+          shouldUseNewPrivilegeSystem: false,
+          data: { roles: [], isActive: false }
+        })()
+      ).rejects.toThrow(PermissionBoundaryError);
+    });
+
+    test("a role change and a deactivation in one request need both actions", async () => {
+      const both = { roles: [{ role: "member", isTemporary: false }], isActive: false };
+
+      // Each holds exactly one of the two actions, so neither can do both at once.
+      await expect(
+        createGuard({ actorPermission: memberPrivilegeGranter, shouldUseNewPrivilegeSystem: true, data: both })()
+      ).rejects.toThrow(PermissionBoundaryError);
+
+      await expect(
+        createGuard({ actorPermission: memberDeleter, shouldUseNewPrivilegeSystem: true, data: both })()
+      ).rejects.toThrow(PermissionBoundaryError);
+    });
   });
 });

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -350,8 +350,6 @@ export const newOrgMembershipUserFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Delete, OrgPermissionSubjects.Member);
 
-    if (!("selector" in dto)) return;
-
     const targetMembership = await membershipUserDAL.getUserById({
       scopeData: dto.scopeData,
       userId: dto.selector.userId

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -330,29 +330,46 @@ export const newOrgMembershipUserFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Edit, OrgPermissionSubjects.Member);
 
-    const targetMembership = await membershipUserDAL.getUserById({
-      scopeData: dto.scopeData,
-      userId: dto.selector.userId
-    });
-    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(
       requestMemoKeys.orgFindById(dto.permission.orgId),
       () => orgDAL.findById(dto.permission.orgId)
     );
 
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
-        ignoreUnresolvedRoles: true
+    const targetOps: { opAction: OrgPermissionMemberActions; baseMessage: string }[] = [];
+    if (dto.data.roles.length || dto.data.metadata !== undefined)
+      targetOps.push({
+        opAction: OrgPermissionMemberActions.GrantPrivileges,
+        baseMessage: "Failed to change the roles or attributes of a more privileged org member"
+      });
+    if (dto.data.isActive !== undefined)
+      targetOps.push({
+        opAction: OrgPermissionMemberActions.Delete,
+        baseMessage: "Failed to change the activation status of a more privileged org member"
       });
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: OrgPermissionMemberActions.GrantPrivileges,
-        opSubject: OrgPermissionSubjects.Member,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged org member"
+    if (targetOps.length) {
+      const targetMembership = await membershipUserDAL.getUserById({
+        scopeData: dto.scopeData,
+        userId: dto.selector.userId
       });
+      const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+
+      if (targetRoles.length) {
+        const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+          ignoreUnresolvedRoles: true
+        });
+
+        for (const { opAction, baseMessage } of targetOps) {
+          assertRoleSetBoundary({
+            shouldUseNewPrivilegeSystem,
+            opActions: opAction,
+            opSubject: OrgPermissionSubjects.Member,
+            actorPermission: permission,
+            targetPermissions,
+            baseMessage
+          });
+        }
+      }
     }
 
     if (dto.data.roles.length) {

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -324,11 +324,31 @@ export const newOrgMembershipUserFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Edit, OrgPermissionSubjects.Member);
 
+    const targetMembership = await membershipUserDAL.getUserById({
+      scopeData: dto.scopeData,
+      userId: dto.selector.userId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+        ignoreUnresolvedRoles: true
+      });
+
+      for (const targetPermission of targetPermissions) {
+        assertPermissionBoundary(
+          permission,
+          targetPermission.permission,
+          "Failed to change the roles of a more privileged org member"
+        );
+      }
+    }
+
     if (dto.data.roles.length) {
       const permissionRoles = await permissionService.getOrgPermissionByRoles(
         dto.data.roles.map((el) => el.role),
         dto.permission.orgId
       );
+
       for (const permissionRole of permissionRoles) {
         assertPermissionBoundary(
           permission,
@@ -357,7 +377,9 @@ export const newOrgMembershipUserFactory = ({
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     if (!targetRoles.length) return;
 
-    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId);
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+      ignoreUnresolvedRoles: true
+    });
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(
       requestMemoKeys.orgFindById(dto.permission.orgId),
       () => orgDAL.findById(dto.permission.orgId)

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -19,7 +19,10 @@ import { matchesAllowedEmailDomain } from "@app/lib/validator";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
 import { TokenType } from "@app/services/auth-token/auth-token-types";
-import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
+import {
+  filterRolesNeedingPrivilegeBoundary,
+  resolveMembershipRoleSlugs
+} from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { isCustomOrgRole } from "@app/services/org/org-role-fns";
 import { SmtpTemplates, TSmtpService } from "@app/services/smtp/smtp-service";
@@ -105,9 +108,10 @@ export const newOrgMembershipUserFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Create, OrgPermissionSubjects.Member);
 
-    if (dto.data.roles.length) {
+    const rolesToBound = filterRolesNeedingPrivilegeBoundary(dto.data.roles);
+    if (rolesToBound.length) {
       const permissionRoles = await permissionService.getOrgPermissionByRoles(
-        dto.data.roles.map((el) => el.role),
+        rolesToBound.map((el) => el.role),
         dto.permission.orgId
       );
       const { shouldUseNewPrivilegeSystem } = await requestMemoize(
@@ -369,9 +373,10 @@ export const newOrgMembershipUserFactory = ({
       }
     }
 
-    if (dto.data.roles.length) {
+    const rolesToBound = filterRolesNeedingPrivilegeBoundary(dto.data.roles);
+    if (rolesToBound.length) {
       const permissionRoles = await permissionService.getOrgPermissionByRoles(
-        dto.data.roles.map((el) => el.role),
+        rolesToBound.map((el) => el.role),
         dto.permission.orgId
       );
 

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -8,7 +8,7 @@ import { getEnforcedIdentityLimit } from "@app/ee/services/license/license-fns";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
 import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
-import { assertPermissionBoundary } from "@app/ee/services/permission/permission-fns";
+import { assertPermissionBoundary, assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { TSamlConfigDALFactory } from "@app/ee/services/saml-config/saml-config-dal";
 import { getConfig } from "@app/lib/config/env";
@@ -19,6 +19,7 @@ import { matchesAllowedEmailDomain } from "@app/lib/validator";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
 import { TokenType } from "@app/services/auth-token/auth-token-types";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { isCustomOrgRole } from "@app/services/org/org-role-fns";
 import { SmtpTemplates, TSmtpService } from "@app/services/smtp/smtp-service";
@@ -37,7 +38,7 @@ type TOrgMembershipUserScopeFactoryDep = {
   orgDAL: Pick<TOrgDALFactory, "findById">;
   userGroupMembershipDAL: Pick<TUserGroupMembershipDALFactory, "delete">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan" | "getOrgSeatUsage">;
-  membershipUserDAL: Pick<TMembershipUserDALFactory, "find">;
+  membershipUserDAL: Pick<TMembershipUserDALFactory, "find" | "getUserById">;
   emailDomainDAL: Pick<TEmailDomainDALFactory, "find">;
   oidcConfigDAL: Pick<TOidcConfigDALFactory, "findOne">;
   samlConfigDAL: Pick<TSamlConfigDALFactory, "findOne">;
@@ -348,6 +349,30 @@ export const newOrgMembershipUserFactory = ({
       scope: OrganizationActionScope.Any
     });
     ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Delete, OrgPermissionSubjects.Member);
+
+    if (!("selector" in dto)) return;
+
+    const targetMembership = await membershipUserDAL.getUserById({
+      scopeData: dto.scopeData,
+      userId: dto.selector.userId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (!targetRoles.length) return;
+
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId);
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
+
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionActions.Delete,
+      opSubject: OrgPermissionSubjects.Member,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged member from the organization"
+    });
   };
 
   const onListMembershipUserGuard: TMembershipUserScopeFactory["onListMembershipUserGuard"] = async (dto) => {

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -353,22 +353,19 @@ export const newOrgMembershipUserFactory = ({
         userId: dto.selector.userId
       });
       const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
+        ignoreUnresolvedRoles: true
+      });
 
-      if (targetRoles.length) {
-        const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
-          ignoreUnresolvedRoles: true
+      for (const { opAction, baseMessage } of targetOps) {
+        assertRoleSetBoundary({
+          shouldUseNewPrivilegeSystem,
+          opActions: opAction,
+          opSubject: OrgPermissionSubjects.Member,
+          actorPermission: permission,
+          targetPermissions,
+          baseMessage
         });
-
-        for (const { opAction, baseMessage } of targetOps) {
-          assertRoleSetBoundary({
-            shouldUseNewPrivilegeSystem,
-            opActions: opAction,
-            opSubject: OrgPermissionSubjects.Member,
-            actorPermission: permission,
-            targetPermissions,
-            baseMessage
-          });
-        }
       }
     }
 
@@ -405,8 +402,6 @@ export const newOrgMembershipUserFactory = ({
       userId: dto.selector.userId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (!targetRoles.length) return;
-
     const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
       ignoreUnresolvedRoles: true
     });

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -347,7 +347,7 @@ export const newOrgMembershipUserFactory = ({
       });
     if (dto.data.isActive !== undefined)
       targetOps.push({
-        opAction: OrgPermissionMemberActions.Delete,
+        opAction: OrgPermissionMemberActions.Edit,
         baseMessage: "Failed to change the activation status of a more privileged org member"
       });
 

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -7,8 +7,8 @@ import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-grou
 import { getEnforcedIdentityLimit } from "@app/ee/services/license/license-fns";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TOidcConfigDALFactory } from "@app/ee/services/oidc/oidc-config-dal";
-import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
-import { assertPermissionBoundary, assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
+import { OrgPermissionMemberActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
+import { assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { TSamlConfigDALFactory } from "@app/ee/services/saml-config/saml-config-dal";
 import { getConfig } from "@app/lib/config/env";
@@ -103,20 +103,26 @@ export const newOrgMembershipUserFactory = ({
       actorOrgId: dto.permission.orgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Create, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Create, OrgPermissionSubjects.Member);
 
     if (dto.data.roles.length) {
       const permissionRoles = await permissionService.getOrgPermissionByRoles(
         dto.data.roles.map((el) => el.role),
         dto.permission.orgId
       );
-      for (const permissionRole of permissionRoles) {
-        assertPermissionBoundary(
-          permission,
-          permissionRole.permission,
-          "Cannot grant a role exceeding your own privileges to a new org member"
-        );
-      }
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+        requestMemoKeys.orgFindById(dto.permission.orgId),
+        () => orgDAL.findById(dto.permission.orgId)
+      );
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionMemberActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Member,
+        actorPermission: permission,
+        targetPermissions: permissionRoles,
+        baseMessage: "Cannot grant a role exceeding your own privileges to a new org member"
+      });
     }
 
     const identityLimit = getEnforcedIdentityLimit(await licenseService.getPlan(dto.permission.orgId));
@@ -322,25 +328,31 @@ export const newOrgMembershipUserFactory = ({
       actorOrgId: dto.permission.orgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Edit, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Edit, OrgPermissionSubjects.Member);
 
     const targetMembership = await membershipUserDAL.getUserById({
       scopeData: dto.scopeData,
       userId: dto.selector.userId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
+
     if (targetRoles.length) {
       const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, dto.permission.orgId, {
         ignoreUnresolvedRoles: true
       });
 
-      for (const targetPermission of targetPermissions) {
-        assertPermissionBoundary(
-          permission,
-          targetPermission.permission,
-          "Failed to change the roles of a more privileged org member"
-        );
-      }
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionMemberActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Member,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged org member"
+      });
     }
 
     if (dto.data.roles.length) {
@@ -349,13 +361,14 @@ export const newOrgMembershipUserFactory = ({
         dto.permission.orgId
       );
 
-      for (const permissionRole of permissionRoles) {
-        assertPermissionBoundary(
-          permission,
-          permissionRole.permission,
-          "Cannot grant a role exceeding your own privileges to an existing org member"
-        );
-      }
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionMemberActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Member,
+        actorPermission: permission,
+        targetPermissions: permissionRoles,
+        baseMessage: "Cannot grant a role exceeding your own privileges to an existing org member"
+      });
     }
   };
 
@@ -368,7 +381,7 @@ export const newOrgMembershipUserFactory = ({
       actorOrgId: dto.permission.orgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Delete, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Delete, OrgPermissionSubjects.Member);
 
     const targetMembership = await membershipUserDAL.getUserById({
       scopeData: dto.scopeData,
@@ -387,7 +400,7 @@ export const newOrgMembershipUserFactory = ({
 
     assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
-      opActions: OrgPermissionActions.Delete,
+      opActions: OrgPermissionMemberActions.Delete,
       opSubject: OrgPermissionSubjects.Member,
       actorPermission: permission,
       targetPermissions,
@@ -404,7 +417,7 @@ export const newOrgMembershipUserFactory = ({
       actorOrgId: dto.permission.orgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
   };
 
   const onGetMembershipUserByUserIdGuard: TMembershipUserScopeFactory["onGetMembershipUserByUserIdGuard"] = async (
@@ -418,7 +431,7 @@ export const newOrgMembershipUserFactory = ({
       actorOrgId: dto.permission.orgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
   };
 
   return {

--- a/backend/src/services/membership-user/org/org-membership-user-factory.ts
+++ b/backend/src/services/membership-user/org/org-membership-user-factory.ts
@@ -125,7 +125,7 @@ export const newOrgMembershipUserFactory = ({
         opSubject: OrgPermissionSubjects.Member,
         actorPermission: permission,
         targetPermissions: permissionRoles,
-        baseMessage: "Cannot grant a role exceeding your own privileges to a new org member"
+        baseMessage: "Failed to assign the requested role to a new org member"
       });
     }
 
@@ -343,12 +343,12 @@ export const newOrgMembershipUserFactory = ({
     if (dto.data.roles.length || dto.data.metadata !== undefined)
       targetOps.push({
         opAction: OrgPermissionMemberActions.GrantPrivileges,
-        baseMessage: "Failed to change the roles or attributes of a more privileged org member"
+        baseMessage: "Failed to change the roles or attributes of this org member"
       });
     if (dto.data.isActive !== undefined)
       targetOps.push({
         opAction: OrgPermissionMemberActions.Edit,
-        baseMessage: "Failed to change the activation status of a more privileged org member"
+        baseMessage: "Failed to change the activation status of this org member"
       });
 
     if (targetOps.length) {
@@ -386,7 +386,7 @@ export const newOrgMembershipUserFactory = ({
         opSubject: OrgPermissionSubjects.Member,
         actorPermission: permission,
         targetPermissions: permissionRoles,
-        baseMessage: "Cannot grant a role exceeding your own privileges to an existing org member"
+        baseMessage: "Failed to assign the requested role to an existing org member"
       });
     }
   };
@@ -421,7 +421,7 @@ export const newOrgMembershipUserFactory = ({
       opSubject: OrgPermissionSubjects.Member,
       actorPermission: permission,
       targetPermissions,
-      baseMessage: "Failed to remove a more privileged member from the organization"
+      baseMessage: "Failed to remove this member from the organization"
     });
   };
 

--- a/backend/src/services/membership-user/project/project-membership-user-boundary.test.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-boundary.test.ts
@@ -1,0 +1,121 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { vi } from "vitest";
+
+import { AccessScope, ProjectMembershipRole } from "@app/db/schemas";
+import {
+  projectAdminPermissions,
+  projectMemberPermissions,
+  projectNoAccessPermissions
+} from "@app/ee/services/permission/default-roles";
+import { ProjectPermissionMemberActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import { conditionsMatcher } from "@app/lib/casl";
+import { PermissionBoundaryError } from "@app/lib/errors";
+
+import { newProjectMembershipUserFactory } from "./project-membership-user-factory";
+
+// The loop that bounds the incoming roles skips NoAccess, so downgrading a privileged member to
+// no-access is the one role change it never sees. The check against the roles the target already
+// holds is what closes that, and it only holds for a condition-scoped actor if it is handed the
+// same subject fields that loop passes.
+
+const ORG_ID = "org-id";
+const PROJECT_ID = "project-id";
+const USER_ID = "user-id";
+const TARGET_EMAIL = "alice@corp.example";
+
+const admin = createMongoAbility<MongoAbility>(projectAdminPermissions);
+const member = createMongoAbility<MongoAbility>(projectMemberPermissions);
+
+// Exactly the grant the guard's throwUnlessCan demands, plus an assign-role rule that reaches only
+// contractors -- alice@corp.example is out of scope for it.
+const contractorScopedEditor = createMongoAbility<MongoAbility>(
+  [
+    {
+      action: [ProjectPermissionMemberActions.Read, ProjectPermissionMemberActions.Edit],
+      subject: ProjectPermissionSub.Member
+    },
+    {
+      action: ProjectPermissionMemberActions.AssignRole,
+      subject: ProjectPermissionSub.Member,
+      conditions: { userEmail: { $glob: "*@contractors.example" } }
+    }
+  ] as never,
+  { conditionsMatcher }
+);
+
+const createGuard = ({
+  actorPermission,
+  shouldUseNewPrivilegeSystem,
+  targetRole = ProjectMembershipRole.Admin,
+  incomingRole = ProjectMembershipRole.NoAccess,
+  targetEmail = TARGET_EMAIL
+}: {
+  actorPermission: MongoAbility;
+  shouldUseNewPrivilegeSystem: boolean;
+  targetRole?: string;
+  incomingRole?: string;
+  targetEmail?: string;
+}) => {
+  const abilityByRole: Record<string, MongoAbility> = {
+    [ProjectMembershipRole.Admin]: admin,
+    [ProjectMembershipRole.Member]: member,
+    [ProjectMembershipRole.NoAccess]: createMongoAbility<MongoAbility>(projectNoAccessPermissions)
+  };
+
+  const factory = newProjectMembershipUserFactory({
+    permissionService: {
+      getProjectPermission: vi.fn().mockResolvedValue({ permission: actorPermission }),
+      getProjectPermissionByRoles: vi.fn().mockImplementation((roles: string[]) =>
+        roles.map((role) => ({
+          permission: abilityByRole[role],
+          role: { name: role, slug: role }
+        }))
+      )
+    } as never,
+    orgDAL: { findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem }) } as never,
+    projectDAL: { findById: vi.fn().mockResolvedValue({ id: PROJECT_ID, type: "secret-manager" }) } as never,
+    userDAL: { findById: vi.fn().mockResolvedValue({ id: USER_ID, email: targetEmail }) } as never,
+    membershipUserDAL: {
+      find: vi.fn().mockResolvedValue([]),
+      getUserById: vi.fn().mockResolvedValue({ roles: [{ role: targetRole }] })
+    } as never,
+    smtpService: { sendMail: vi.fn() } as never,
+    projectAccessRequestDAL: { delete: vi.fn() } as never
+  });
+
+  return () =>
+    factory.onUpdateMembershipUserGuard({
+      permission: { type: "user", id: "actor-id", orgId: ORG_ID, authMethod: "email" },
+      scopeData: { scope: AccessScope.Project, orgId: ORG_ID, projectId: PROJECT_ID },
+      selector: { userId: USER_ID },
+      data: { roles: [{ role: incomingRole, isTemporary: false }] }
+    } as never);
+};
+
+describe("onUpdateMembershipUserGuard privilege boundary", () => {
+  test("the actor holds member:edit, so the plain permission check is not what rejects it", () => {
+    expect(contractorScopedEditor.can(ProjectPermissionMemberActions.Edit, ProjectPermissionSub.Member)).toBe(true);
+  });
+
+  test("a userEmail-scoped actor cannot strip an out-of-scope Admin down to no-access", async () => {
+    const guard = createGuard({ actorPermission: contractorScopedEditor, shouldUseNewPrivilegeSystem: true });
+
+    await expect(guard()).rejects.toThrow(PermissionBoundaryError);
+  });
+
+  test("the same actor can still change a member who is inside its scope", async () => {
+    const guard = createGuard({
+      actorPermission: contractorScopedEditor,
+      shouldUseNewPrivilegeSystem: true,
+      targetRole: ProjectMembershipRole.Member,
+      targetEmail: "bob@contractors.example"
+    });
+
+    await expect(guard()).resolves.not.toThrow();
+  });
+
+  test("an admin can still downgrade an Admin member on either system", async () => {
+    await expect(createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: false })()).resolves.not.toThrow();
+    await expect(createGuard({ actorPermission: admin, shouldUseNewPrivilegeSystem: true })()).resolves.not.toThrow();
+  });
+});

--- a/backend/src/services/membership-user/project/project-membership-user-boundary.test.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-boundary.test.ts
@@ -14,9 +14,8 @@ import { PermissionBoundaryError } from "@app/lib/errors";
 import { newProjectMembershipUserFactory } from "./project-membership-user-factory";
 
 // The loop that bounds the incoming roles skips NoAccess, so downgrading a privileged member to
-// no-access is the one role change it never sees. The check against the roles the target already
-// holds is what closes that, and it only holds for a condition-scoped actor if it is handed the
-// same subject fields that loop passes.
+// no-access is the one role change it never sees. Checking the roles the target already holds closes
+// that, and for a condition-scoped actor only if it gets the same subject fields that loop passes.
 
 const ORG_ID = "org-id";
 const PROJECT_ID = "project-id";

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -8,6 +8,7 @@ import {
   ProjectType
 } from "@app/db/schemas";
 import {
+  assertRoleSetBoundary,
   constructPermissionErrorMessage,
   validatePrivilegeChangeOperation
 } from "@app/ee/services/permission/permission-fns";
@@ -21,6 +22,7 @@ import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, InternalServerError, NotFoundError, PermissionBoundaryError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
+import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectAccessRequestDALFactory } from "@app/services/project/project-access-request-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
@@ -34,7 +36,7 @@ type TProjectMembershipUserScopeFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getProjectPermissionByRoles">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   projectDAL: Pick<TProjectDALFactory, "findById">;
-  membershipUserDAL: Pick<TMembershipUserDALFactory, "find">;
+  membershipUserDAL: Pick<TMembershipUserDALFactory, "find" | "getUserById">;
   smtpService: Pick<TSmtpService, "sendMail">;
   userDAL: Pick<TUserDALFactory, "findById">;
   projectAccessRequestDAL: Pick<TProjectAccessRequestDALFactory, "delete">;
@@ -274,6 +276,30 @@ export const newProjectMembershipUserFactory = ({
       actorOrgId: dto.permission.orgId
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionMemberActions.Delete, ProjectPermissionSub.Member);
+
+    if (!("selector" in dto)) return;
+
+    const targetMembership = await membershipUserDAL.getUserById({
+      scopeData: dto.scopeData,
+      userId: dto.selector.userId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (!targetRoles.length) return;
+
+    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(
+      requestMemoKeys.orgFindById(dto.permission.orgId),
+      () => orgDAL.findById(dto.permission.orgId)
+    );
+
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: ProjectPermissionMemberActions.Delete,
+      opSubject: ProjectPermissionSub.Member,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged member from the project"
+    });
   };
 
   const onListMembershipUserGuard: TMembershipUserScopeFactory["onListMembershipUserGuard"] = async (dto) => {

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -241,7 +241,9 @@ export const newProjectMembershipUserFactory = ({
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+        ignoreUnresolvedRoles: true
+      });
       assertRoleSetBoundary({
         shouldUseNewPrivilegeSystem,
         opActions: [ProjectPermissionMemberActions.AssignRole, ProjectPermissionMemberActions.GrantPrivileges],
@@ -302,7 +304,9 @@ export const newProjectMembershipUserFactory = ({
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
     if (!targetRoles.length) return;
 
-    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+      ignoreUnresolvedRoles: true
+    });
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(
       requestMemoKeys.orgFindById(dto.permission.orgId),
       () => orgDAL.findById(dto.permission.orgId)

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -319,7 +319,8 @@ export const newProjectMembershipUserFactory = ({
       opSubject: ProjectPermissionSub.Member,
       actorPermission: permission,
       targetPermissions,
-      baseMessage: "Failed to remove a more privileged member from the project"
+      baseMessage: "Failed to remove a more privileged member from the project",
+      subjectFields: { userEmail: targetMembership?.user.email || undefined }
     });
   };
 

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -22,7 +22,10 @@ import { getConfig } from "@app/lib/config/env";
 import { BadRequestError, InternalServerError, NotFoundError, PermissionBoundaryError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
-import { resolveMembershipRoleSlugs } from "@app/services/membership/membership-fns";
+import {
+  filterRolesNeedingPrivilegeBoundary,
+  resolveMembershipRoleSlugs
+} from "@app/services/membership/membership-fns";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectAccessRequestDALFactory } from "@app/services/project/project-access-request-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
@@ -116,7 +119,7 @@ export const newProjectMembershipUserFactory = ({
       () => orgDAL.findById(dto.permission.orgId)
     );
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
-      dto.data.roles.filter((el) => el.role !== ProjectMembershipRole.NoAccess).map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       scope.value
     );
 
@@ -254,7 +257,7 @@ export const newProjectMembershipUserFactory = ({
     });
 
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
-      dto.data.roles.filter((el) => el.role !== ProjectMembershipRole.NoAccess).map((el) => el.role),
+      filterRolesNeedingPrivilegeBoundary(dto.data.roles).map((el) => el.role),
       scope.value
     );
 

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -240,20 +240,18 @@ export const newProjectMembershipUserFactory = ({
       userId: dto.selector.userId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
-        ignoreUnresolvedRoles: true
-      });
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: [ProjectPermissionMemberActions.AssignRole, ProjectPermissionMemberActions.GrantPrivileges],
-        opSubject: ProjectPermissionSub.Member,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged member",
-        subjectFields: { userEmail: targetUser.email || undefined }
-      });
-    }
+    const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
+      ignoreUnresolvedRoles: true
+    });
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: [ProjectPermissionMemberActions.AssignRole, ProjectPermissionMemberActions.GrantPrivileges],
+      opSubject: ProjectPermissionSub.Member,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to change the roles of a more privileged member",
+      subjectFields: { userEmail: targetUser.email || undefined }
+    });
 
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
       dto.data.roles.filter((el) => el.role !== ProjectMembershipRole.NoAccess).map((el) => el.role),
@@ -303,8 +301,6 @@ export const newProjectMembershipUserFactory = ({
       userId: dto.selector.userId
     });
     const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
-    if (!targetRoles.length) return;
-
     const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value, {
       ignoreUnresolvedRoles: true
     });

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -234,6 +234,24 @@ export const newProjectMembershipUserFactory = ({
       requestMemoKeys.orgFindById(dto.permission.orgId),
       () => orgDAL.findById(dto.permission.orgId)
     );
+
+    const targetMembership = await membershipUserDAL.getUserById({
+      scopeData: dto.scopeData,
+      userId: dto.selector.userId
+    });
+    const targetRoles = targetMembership ? resolveMembershipRoleSlugs(targetMembership.roles) : [];
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, scope.value);
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: [ProjectPermissionMemberActions.AssignRole, ProjectPermissionMemberActions.GrantPrivileges],
+        opSubject: ProjectPermissionSub.Member,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged member"
+      });
+    }
+
     const permissionRoles = await permissionService.getProjectPermissionByRoles(
       dto.data.roles.filter((el) => el.role !== ProjectMembershipRole.NoAccess).map((el) => el.role),
       scope.value
@@ -276,8 +294,6 @@ export const newProjectMembershipUserFactory = ({
       actorOrgId: dto.permission.orgId
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionMemberActions.Delete, ProjectPermissionSub.Member);
-
-    if (!("selector" in dto)) return;
 
     const targetMembership = await membershipUserDAL.getUserById({
       scopeData: dto.scopeData,

--- a/backend/src/services/membership-user/project/project-membership-user-factory.ts
+++ b/backend/src/services/membership-user/project/project-membership-user-factory.ts
@@ -250,7 +250,8 @@ export const newProjectMembershipUserFactory = ({
         opSubject: ProjectPermissionSub.Member,
         actorPermission: permission,
         targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged member"
+        baseMessage: "Failed to change the roles of a more privileged member",
+        subjectFields: { userEmail: targetUser.email || undefined }
       });
     }
 

--- a/backend/src/services/membership/membership-fns.test.ts
+++ b/backend/src/services/membership/membership-fns.test.ts
@@ -31,6 +31,34 @@ describe("resolveMembershipRoleSlugs", () => {
     ).toEqual(["admin"]);
   });
 
+  test("deduplicates a slug repeated within one membership", () => {
+    // The uniqueness key on membership roles spans isTemporary, so one membership can hold the same
+    // custom role permanently and temporarily. Passing the slug twice makes getOrgPermissionByRoles
+    // report it as missing, because it compares the requested count against the rows it finds.
+    expect(
+      resolveMembershipRoleSlugs([
+        { role: "custom", customRoleSlug: "release-manager" },
+        {
+          role: "custom",
+          customRoleSlug: "release-manager",
+          isTemporary: true,
+          temporaryAccessEndTime: new Date(Date.now() + 60_000)
+        }
+      ])
+    ).toEqual(["release-manager"]);
+  });
+
+  test("deduplicates slugs shared across memberships in a bulk removal", () => {
+    expect(
+      resolveMembershipRoleSlugs([
+        { role: "member" },
+        { role: "member" },
+        { role: "custom", customRoleSlug: "auditor" },
+        { role: "custom", customRoleSlug: "auditor" }
+      ])
+    ).toEqual(["member", "auditor"]);
+  });
+
   test("returns an empty list when every role filters out", () => {
     expect(
       resolveMembershipRoleSlugs([

--- a/backend/src/services/membership/membership-fns.test.ts
+++ b/backend/src/services/membership/membership-fns.test.ts
@@ -1,0 +1,42 @@
+import { resolveMembershipRoleSlugs } from "./membership-fns";
+
+describe("resolveMembershipRoleSlugs", () => {
+  test("prefers the custom role slug over the built-in role column", () => {
+    expect(resolveMembershipRoleSlugs([{ role: "custom", customRoleSlug: "release-manager" }])).toEqual([
+      "release-manager"
+    ]);
+  });
+
+  test("falls back to the role column when there is no custom slug", () => {
+    expect(resolveMembershipRoleSlugs([{ role: "admin" }, { role: "member", customRoleSlug: null }])).toEqual([
+      "admin",
+      "member"
+    ]);
+  });
+
+  test("drops no-access, which confers nothing", () => {
+    expect(resolveMembershipRoleSlugs([{ role: "no-access" }, { role: "admin" }])).toEqual(["admin"]);
+  });
+
+  test("drops expired temporary roles so a boundary check cannot over-block", () => {
+    const expired = { role: "admin", isTemporary: true, temporaryAccessEndTime: new Date(Date.now() - 60_000) };
+    const live = { role: "member", isTemporary: true, temporaryAccessEndTime: new Date(Date.now() + 60_000) };
+
+    expect(resolveMembershipRoleSlugs([expired, live])).toEqual(["member"]);
+  });
+
+  test("keeps permanent roles regardless of temporaryAccessEndTime", () => {
+    expect(
+      resolveMembershipRoleSlugs([{ role: "admin", isTemporary: false, temporaryAccessEndTime: new Date(0) }])
+    ).toEqual(["admin"]);
+  });
+
+  test("returns an empty list when every role filters out", () => {
+    expect(
+      resolveMembershipRoleSlugs([
+        { role: "no-access" },
+        { role: "admin", isTemporary: true, temporaryAccessEndTime: new Date(Date.now() - 1) }
+      ])
+    ).toEqual([]);
+  });
+});

--- a/backend/src/services/membership/membership-fns.ts
+++ b/backend/src/services/membership/membership-fns.ts
@@ -53,9 +53,12 @@ type TMembershipRole = {
   temporaryAccessEndTime?: Date | null;
 };
 
-// Resolves a membership's roles into the slug list that get{Org,Project}PermissionByRoles expects.
-export const resolveMembershipRoleSlugs = (roles: TMembershipRole[]) =>
-  roles
-    .filter(isActiveRole)
-    .map((role) => role.customRoleSlug || role.role)
-    .filter((slug) => slug !== OrgMembershipRole.NoAccess && slug !== ProjectMembershipRole.NoAccess);
+// Resolves membership roles into the slug list that get{Org,Project}PermissionByRoles expects.
+export const resolveMembershipRoleSlugs = (roles: TMembershipRole[]) => [
+  ...new Set(
+    roles
+      .filter(isActiveRole)
+      .map((role) => role.customRoleSlug || role.role)
+      .filter((slug) => slug !== OrgMembershipRole.NoAccess && slug !== ProjectMembershipRole.NoAccess)
+  )
+];

--- a/backend/src/services/membership/membership-fns.ts
+++ b/backend/src/services/membership/membership-fns.ts
@@ -59,7 +59,6 @@ export const roleNeedsPrivilegeBoundary = (role: string) =>
 export const filterRolesNeedingPrivilegeBoundary = <T extends { role: string }>(roles: T[]) =>
   roles.filter((el) => roleNeedsPrivilegeBoundary(el.role));
 
-// Resolves membership roles into the slug list that get{Org,Project}PermissionByRoles expects.
 export const resolveMembershipRoleSlugs = (roles: TMembershipRole[]) => [
   ...new Set(
     roles

--- a/backend/src/services/membership/membership-fns.ts
+++ b/backend/src/services/membership/membership-fns.ts
@@ -53,6 +53,12 @@ type TMembershipRole = {
   temporaryAccessEndTime?: Date | null;
 };
 
+export const roleNeedsPrivilegeBoundary = (role: string) =>
+  role !== OrgMembershipRole.NoAccess && role !== ProjectMembershipRole.NoAccess;
+
+export const filterRolesNeedingPrivilegeBoundary = <T extends { role: string }>(roles: T[]) =>
+  roles.filter((el) => roleNeedsPrivilegeBoundary(el.role));
+
 // Resolves membership roles into the slug list that get{Org,Project}PermissionByRoles expects.
 export const resolveMembershipRoleSlugs = (roles: TMembershipRole[]) => [
   ...new Set(

--- a/backend/src/services/membership/membership-fns.ts
+++ b/backend/src/services/membership/membership-fns.ts
@@ -1,5 +1,6 @@
-import { AccessScope, ProjectType } from "@app/db/schemas";
+import { AccessScope, OrgMembershipRole, ProjectMembershipRole, ProjectType } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { isActiveRole } from "@app/ee/services/permission/permission-fns";
 import { BadRequestError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
 import { requestMemoize } from "@app/lib/request-context/request-memoizer";
@@ -44,3 +45,17 @@ export const assertSecretsTemporaryAccessAllowed = async ({
     });
   }
 };
+
+type TMembershipRole = {
+  role: string;
+  customRoleSlug?: string | null;
+  isTemporary?: boolean;
+  temporaryAccessEndTime?: Date | null;
+};
+
+// Resolves a membership's roles into the slug list that get{Org,Project}PermissionByRoles expects.
+export const resolveMembershipRoleSlugs = (roles: TMembershipRole[]) =>
+  roles
+    .filter(isActiveRole)
+    .map((role) => role.customRoleSlug || role.role)
+    .filter((slug) => slug !== OrgMembershipRole.NoAccess && slug !== ProjectMembershipRole.NoAccess);

--- a/backend/src/services/membership/membership-role-dal.ts
+++ b/backend/src/services/membership/membership-role-dal.ts
@@ -1,10 +1,44 @@
+import { Knex } from "knex";
+
 import { TDbClient } from "@app/db";
 import { TableName } from "@app/db/schemas";
+import { DatabaseError } from "@app/lib/errors";
 import { ormify } from "@app/lib/knex";
 
 export type TMembershipRoleDALFactory = ReturnType<typeof membershipRoleDALFactory>;
 
+type TMembershipRoleSlug = {
+  membershipId: string;
+  role: string;
+  isTemporary: boolean;
+  temporaryAccessEndTime?: Date | null;
+  customRoleSlug?: string | null;
+};
+
 export const membershipRoleDALFactory = (db: TDbClient) => {
   const orm = ormify(db, TableName.MembershipRole);
-  return orm;
+
+  // Role rows for a set of memberships, carrying the custom-role slug rather than its id so the
+  // result feeds resolveMembershipRoleSlugs directly. Batched so a bulk privilege-boundary check
+  // costs one query no matter how many memberships the caller is removing.
+  const findRolesByMembershipIds = async (membershipIds: string[], tx?: Knex): Promise<TMembershipRoleSlug[]> => {
+    if (!membershipIds.length) return [];
+
+    try {
+      return await (tx || db.replicaNode())(TableName.MembershipRole)
+        .whereIn(`${TableName.MembershipRole}.membershipId`, membershipIds)
+        .leftJoin(TableName.Role, `${TableName.MembershipRole}.customRoleId`, `${TableName.Role}.id`)
+        .select(
+          db.ref("membershipId").withSchema(TableName.MembershipRole),
+          db.ref("role").withSchema(TableName.MembershipRole),
+          db.ref("isTemporary").withSchema(TableName.MembershipRole),
+          db.ref("temporaryAccessEndTime").withSchema(TableName.MembershipRole),
+          db.ref("slug").withSchema(TableName.Role).as("customRoleSlug")
+        );
+    } catch (error) {
+      throw new DatabaseError({ error, name: "FindRolesByMembershipIds" });
+    }
+  };
+
+  return { ...orm, findRolesByMembershipIds };
 };

--- a/backend/src/services/membership/membership-role-dal.ts
+++ b/backend/src/services/membership/membership-role-dal.ts
@@ -18,9 +18,9 @@ type TMembershipRoleSlug = {
 export const membershipRoleDALFactory = (db: TDbClient) => {
   const orm = ormify(db, TableName.MembershipRole);
 
-  // Role rows for a set of memberships, carrying the custom-role slug rather than its id so the
-  // result feeds resolveMembershipRoleSlugs directly. Batched so a bulk privilege-boundary check
-  // costs one query no matter how many memberships the caller is removing.
+  // Carries the custom-role slug rather than its id so the result feeds resolveMembershipRoleSlugs
+  // directly. Batched so a bulk privilege-boundary check is one query however many memberships it
+  // covers.
   const findRolesByMembershipIds = async (membershipIds: string[], tx?: Knex): Promise<TMembershipRoleSlug[]> => {
     if (!membershipIds.length) return [];
 

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -885,21 +885,19 @@ export const orgServiceFactory = ({
 
     if (targetOps.length) {
       const targetRoles = resolveMembershipRoleSlugs(await membershipRoleDAL.findRolesByMembershipIds([membershipId]));
-      if (targetRoles.length) {
-        const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId, {
-          ignoreUnresolvedRoles: true
-        });
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId, {
+        ignoreUnresolvedRoles: true
+      });
 
-        for (const { opAction, baseMessage } of targetOps) {
-          assertRoleSetBoundary({
-            shouldUseNewPrivilegeSystem,
-            opActions: opAction,
-            opSubject: OrgPermissionSubjects.Member,
-            actorPermission: permission,
-            targetPermissions,
-            baseMessage
-          });
-        }
+      for (const { opAction, baseMessage } of targetOps) {
+        assertRoleSetBoundary({
+          shouldUseNewPrivilegeSystem,
+          opActions: opAction,
+          opSubject: OrgPermissionSubjects.Member,
+          actorPermission: permission,
+          targetPermissions,
+          baseMessage
+        });
       }
     }
 
@@ -1228,8 +1226,6 @@ export const orgServiceFactory = ({
     permission: MongoAbility;
   }) => {
     const targetRoles = resolveMembershipRoleSlugs(await membershipRoleDAL.findRolesByMembershipIds(membershipIds));
-    if (!targetRoles.length) return;
-
     const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId, {
       ignoreUnresolvedRoles: true
     });

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -875,12 +875,12 @@ export const orgServiceFactory = ({
     if (role !== undefined || metadata !== undefined)
       targetOps.push({
         opAction: OrgPermissionMemberActions.GrantPrivileges,
-        baseMessage: "Failed to change the roles or attributes of a more privileged org member"
+        baseMessage: "Failed to change the roles or attributes of this org member"
       });
     if (isActive !== undefined)
       targetOps.push({
         opAction: OrgPermissionMemberActions.Edit,
-        baseMessage: "Failed to change the activation status of a more privileged org member"
+        baseMessage: "Failed to change the activation status of this org member"
       });
 
     if (targetOps.length) {
@@ -926,7 +926,7 @@ export const orgServiceFactory = ({
         opSubject: OrgPermissionSubjects.Member,
         actorPermission: permission,
         targetPermissions: permissionRoles,
-        baseMessage: "Cannot assign a role exceeding your own privileges to an org member"
+        baseMessage: "Failed to assign the requested role to an org member"
       });
     }
 
@@ -1239,7 +1239,7 @@ export const orgServiceFactory = ({
       opSubject: OrgPermissionSubjects.Member,
       actorPermission: permission,
       targetPermissions,
-      baseMessage: "Failed to remove a more privileged member from the organization"
+      baseMessage: "Failed to remove this member from the organization"
     });
   };
 

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -871,20 +871,36 @@ export const orgServiceFactory = ({
       orgDAL.findById(orgId)
     );
 
-    const targetRoles = resolveMembershipRoleSlugs(await membershipRoleDAL.findRolesByMembershipIds([membershipId]));
-    if (targetRoles.length) {
-      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId, {
-        ignoreUnresolvedRoles: true
+    const targetOps: { opAction: OrgPermissionMemberActions; baseMessage: string }[] = [];
+    if (role !== undefined || metadata !== undefined)
+      targetOps.push({
+        opAction: OrgPermissionMemberActions.GrantPrivileges,
+        baseMessage: "Failed to change the roles or attributes of a more privileged org member"
+      });
+    if (isActive !== undefined)
+      targetOps.push({
+        opAction: OrgPermissionMemberActions.Delete,
+        baseMessage: "Failed to change the activation status of a more privileged org member"
       });
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: OrgPermissionMemberActions.GrantPrivileges,
-        opSubject: OrgPermissionSubjects.Member,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to change the roles of a more privileged org member"
-      });
+    if (targetOps.length) {
+      const targetRoles = resolveMembershipRoleSlugs(await membershipRoleDAL.findRolesByMembershipIds([membershipId]));
+      if (targetRoles.length) {
+        const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId, {
+          ignoreUnresolvedRoles: true
+        });
+
+        for (const { opAction, baseMessage } of targetOps) {
+          assertRoleSetBoundary({
+            shouldUseNewPrivilegeSystem,
+            opActions: opAction,
+            opSubject: OrgPermissionSubjects.Member,
+            actorPermission: permission,
+            targetPermissions,
+            baseMessage
+          });
+        }
+      }
     }
 
     const isCustomRole = !Object.values(OrgMembershipRole).includes(role as OrgMembershipRole);

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -21,11 +21,12 @@ import { bootstrapPamProject } from "@app/ee/services/pam-project/pam-project-bo
 import {
   OrgPermissionActions,
   OrgPermissionGroupActions,
+  OrgPermissionMemberActions,
   OrgPermissionSecretShareAction,
   OrgPermissionSsoActions,
   OrgPermissionSubjects
 } from "@app/ee/services/permission/org-permission";
-import { assertPermissionBoundary, assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
+import { assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { TSamlConfigDALFactory } from "@app/ee/services/saml-config/saml-config-dal";
 import { getConfig } from "@app/lib/config/env";
@@ -259,7 +260,7 @@ export const orgServiceFactory = ({
       scope: OrganizationActionScope.Any
     });
 
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
 
     const members = await orgDAL.findAllOrgMembers(orgId);
     return members;
@@ -295,7 +296,7 @@ export const orgServiceFactory = ({
       actorOrgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
 
     const members = await orgDAL.findOrgMembersByUsername(orgId, emails);
 
@@ -852,7 +853,7 @@ export const orgServiceFactory = ({
       actorOrgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Edit, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Edit, OrgPermissionSubjects.Member);
 
     const foundMembership = await membershipUserDAL.findOne({
       id: membershipId,
@@ -866,19 +867,24 @@ export const orgServiceFactory = ({
     if (actor === ActorType.USER && foundMembership.actorUserId === actorId)
       throw new UnauthorizedError({ message: "Cannot update own organization membership" });
 
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(orgId), () =>
+      orgDAL.findById(orgId)
+    );
+
     const targetRoles = resolveMembershipRoleSlugs(await membershipRoleDAL.findRolesByMembershipIds([membershipId]));
     if (targetRoles.length) {
       const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId, {
         ignoreUnresolvedRoles: true
       });
 
-      for (const targetPermission of targetPermissions) {
-        assertPermissionBoundary(
-          permission,
-          targetPermission.permission,
-          "Failed to change the roles of a more privileged org member"
-        );
-      }
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionMemberActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Member,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to change the roles of a more privileged org member"
+      });
     }
 
     const isCustomRole = !Object.values(OrgMembershipRole).includes(role as OrgMembershipRole);
@@ -899,12 +905,15 @@ export const orgServiceFactory = ({
     }
 
     if (role) {
-      const [permissionRole] = await permissionService.getOrgPermissionByRoles([role], orgId);
-      assertPermissionBoundary(
-        permission,
-        permissionRole.permission,
-        "Cannot assign a role exceeding your own privileges to an org member"
-      );
+      const permissionRoles = await permissionService.getOrgPermissionByRoles([role], orgId);
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: OrgPermissionMemberActions.GrantPrivileges,
+        opSubject: OrgPermissionSubjects.Member,
+        actorPermission: permission,
+        targetPermissions: permissionRoles,
+        baseMessage: "Cannot assign a role exceeding your own privileges to an org member"
+      });
     }
 
     const updatesToActiveAdmin = role === OrgMembershipRole.Admin && isActive !== false;
@@ -997,7 +1006,7 @@ export const orgServiceFactory = ({
       scope: OrganizationActionScope.ParentOrganization
     });
 
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Create, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Create, OrgPermissionSubjects.Member);
 
     const invitingUser = await userDAL.findOne({ id: actorId });
 
@@ -1180,7 +1189,7 @@ export const orgServiceFactory = ({
       actorAuthMethod,
       actorOrgId
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
 
     const membership = await orgMembershipDAL.findOrgMembershipById(membershipId);
     if (!membership) {
@@ -1214,7 +1223,7 @@ export const orgServiceFactory = ({
 
     assertRoleSetBoundary({
       shouldUseNewPrivilegeSystem,
-      opActions: OrgPermissionActions.Delete,
+      opActions: OrgPermissionMemberActions.Delete,
       opSubject: OrgPermissionSubjects.Member,
       actorPermission: permission,
       targetPermissions,
@@ -1238,7 +1247,7 @@ export const orgServiceFactory = ({
       actorOrgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Delete, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Delete, OrgPermissionSubjects.Member);
 
     const membershipToDelete = await membershipUserDAL.findOne({
       id: membershipId,
@@ -1288,7 +1297,7 @@ export const orgServiceFactory = ({
       actorOrgId,
       scope: OrganizationActionScope.Any
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Delete, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Delete, OrgPermissionSubjects.Member);
 
     const membershipsToDelete = await membershipUserDAL.find({
       scope: AccessScope.Organization,
@@ -1343,7 +1352,7 @@ export const orgServiceFactory = ({
       actorAuthMethod,
       actorOrgId
     });
-    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
 
     const membership = await orgMembershipDAL.findOrgMembershipById(orgMembershipId);
     if (!membership) {

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -56,7 +56,7 @@ import { bootstrapCertManagerProject } from "../cert-manager-instance/cert-manag
 import { TCertificatePolicyDALFactory } from "../certificate-policy/certificate-policy-dal";
 import { TIdentityMetadataDALFactory } from "../identity/identity-metadata-dal";
 import { TMembershipDALFactory } from "../membership/membership-dal";
-import { resolveMembershipRoleSlugs } from "../membership/membership-fns";
+import { resolveMembershipRoleSlugs, roleNeedsPrivilegeBoundary } from "../membership/membership-fns";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipUserDALFactory } from "../membership-user/membership-user-dal";
 import { assertWillRetainOrgAdmin } from "../membership-user/membership-user-fns";
@@ -918,7 +918,7 @@ export const orgServiceFactory = ({
       userRoleId = customRole.id;
     }
 
-    if (role) {
+    if (role && roleNeedsPrivilegeBoundary(role)) {
       const permissionRoles = await permissionService.getOrgPermissionByRoles([role], orgId);
       assertRoleSetBoundary({
         shouldUseNewPrivilegeSystem,

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -1190,7 +1190,9 @@ export const orgServiceFactory = ({
     const targetRoles = resolveMembershipRoleSlugs(await membershipRoleDAL.findRolesByMembershipIds(membershipIds));
     if (!targetRoles.length) return;
 
-    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId);
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId, {
+      ignoreUnresolvedRoles: true
+    });
     const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(orgId), () =>
       orgDAL.findById(orgId)
     );

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -879,7 +879,7 @@ export const orgServiceFactory = ({
       });
     if (isActive !== undefined)
       targetOps.push({
-        opAction: OrgPermissionMemberActions.Delete,
+        opAction: OrgPermissionMemberActions.Edit,
         baseMessage: "Failed to change the activation status of a more privileged org member"
       });
 

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -866,6 +866,21 @@ export const orgServiceFactory = ({
     if (actor === ActorType.USER && foundMembership.actorUserId === actorId)
       throw new UnauthorizedError({ message: "Cannot update own organization membership" });
 
+    const targetRoles = resolveMembershipRoleSlugs(await membershipRoleDAL.findRolesByMembershipIds([membershipId]));
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId, {
+        ignoreUnresolvedRoles: true
+      });
+
+      for (const targetPermission of targetPermissions) {
+        assertPermissionBoundary(
+          permission,
+          targetPermission.permission,
+          "Failed to change the roles of a more privileged org member"
+        );
+      }
+    }
+
     const isCustomRole = !Object.values(OrgMembershipRole).includes(role as OrgMembershipRole);
     let userRole = role;
     let userRoleId: string | null = null;

--- a/backend/src/services/org/org-service.ts
+++ b/backend/src/services/org/org-service.ts
@@ -1,4 +1,4 @@
-import { ForbiddenError } from "@casl/ability";
+import { ForbiddenError, MongoAbility } from "@casl/ability";
 import slugify from "@sindresorhus/slugify";
 import { Knex } from "knex";
 
@@ -25,7 +25,7 @@ import {
   OrgPermissionSsoActions,
   OrgPermissionSubjects
 } from "@app/ee/services/permission/org-permission";
-import { assertPermissionBoundary } from "@app/ee/services/permission/permission-fns";
+import { assertPermissionBoundary, assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { TSamlConfigDALFactory } from "@app/ee/services/saml-config/saml-config-dal";
 import { getConfig } from "@app/lib/config/env";
@@ -55,6 +55,7 @@ import { bootstrapCertManagerProject } from "../cert-manager-instance/cert-manag
 import { TCertificatePolicyDALFactory } from "../certificate-policy/certificate-policy-dal";
 import { TIdentityMetadataDALFactory } from "../identity/identity-metadata-dal";
 import { TMembershipDALFactory } from "../membership/membership-dal";
+import { resolveMembershipRoleSlugs } from "../membership/membership-fns";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipUserDALFactory } from "../membership-user/membership-user-dal";
 import { assertWillRetainOrgAdmin } from "../membership-user/membership-user-fns";
@@ -1177,6 +1178,33 @@ export const orgServiceFactory = ({
     return membership;
   };
 
+  const $assertMembershipRemovalBoundary = async ({
+    membershipIds,
+    orgId,
+    permission
+  }: {
+    membershipIds: string[];
+    orgId: string;
+    permission: MongoAbility;
+  }) => {
+    const targetRoles = resolveMembershipRoleSlugs(await membershipRoleDAL.findRolesByMembershipIds(membershipIds));
+    if (!targetRoles.length) return;
+
+    const targetPermissions = await permissionService.getOrgPermissionByRoles(targetRoles, orgId);
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(orgId), () =>
+      orgDAL.findById(orgId)
+    );
+
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: OrgPermissionActions.Delete,
+      opSubject: OrgPermissionSubjects.Member,
+      actorPermission: permission,
+      targetPermissions,
+      baseMessage: "Failed to remove a more privileged member from the organization"
+    });
+  };
+
   const deleteOrgMembership = async ({
     orgId,
     actor,
@@ -1202,6 +1230,8 @@ export const orgServiceFactory = ({
     });
     if (!membershipToDelete?.actorUserId)
       throw new NotFoundError({ message: `Organization membership with ID '${membershipId}' not found` });
+
+    await $assertMembershipRemovalBoundary({ membershipIds: [membershipId], orgId, permission });
 
     const [deletedMembership] = await deleteOrgMembershipsFn({
       orgMembershipIds: [membershipId],
@@ -1255,6 +1285,8 @@ export const orgServiceFactory = ({
       throw new NotFoundError({
         message: `Organization membership with ID '${missingMembershipIds.join("', '")}' not found`
       });
+
+    await $assertMembershipRemovalBoundary({ membershipIds, orgId, permission });
 
     const deletedMemberships = await deleteOrgMembershipsFn({
       orgMembershipIds: membershipIds,

--- a/backend/src/services/project-membership/project-membership-dal.ts
+++ b/backend/src/services/project-membership/project-membership-dal.ts
@@ -235,14 +235,15 @@ export const projectMembershipDALFactory = (db: TDbClient) => {
         .select(
           selectAllTableCols(TableName.Membership),
           db.ref("id").withSchema(TableName.Users).as("userId"),
-          db.ref("username").withSchema(TableName.Users)
+          db.ref("username").withSchema(TableName.Users),
+          db.ref("email").withSchema(TableName.Users)
         )
         .whereIn("username", usernames)
         .where({ isGhost: false });
 
-      return members.map(({ userId, username, ...data }) => ({
+      return members.map(({ userId, username, email, ...data }) => ({
         ...data,
-        user: { id: userId, username }
+        user: { id: userId, username, email }
       }));
     } catch (error) {
       throw new DatabaseError({ error, name: "Find members by email" });

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -4,6 +4,7 @@ import { Knex } from "knex";
 
 import { AccessScope, ActionProjectType, ProjectMembershipRole, ProjectVersion, TableName } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { assertRoleSetBoundary } from "@app/ee/services/permission/permission-fns";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionMemberActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
 import { getConfig } from "@app/lib/config/env";
@@ -269,6 +270,23 @@ export const projectMembershipServiceFactory = ({
       actionProjectType: ActionProjectType.Any
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionMemberActions.Create, ProjectPermissionSub.Member);
+
+    const memberRolePermissions = await permissionService.getProjectPermissionByRoles(
+      [ProjectMembershipRole.Member],
+      projectId
+    );
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
+      orgDAL.findById(actorOrgId)
+    );
+    assertRoleSetBoundary({
+      shouldUseNewPrivilegeSystem,
+      opActions: [ProjectPermissionMemberActions.AssignRole, ProjectPermissionMemberActions.GrantPrivileges],
+      opSubject: ProjectPermissionSub.Member,
+      actorPermission: permission,
+      targetPermissions: memberRolePermissions,
+      baseMessage: "Failed to add a member with a role exceeding your own privileges"
+    });
+
     const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
       projectDAL.findById(projectId)
     );

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -272,22 +272,6 @@ export const projectMembershipServiceFactory = ({
     });
     ForbiddenError.from(permission).throwUnlessCan(ProjectPermissionMemberActions.Create, ProjectPermissionSub.Member);
 
-    const memberRolePermissions = await permissionService.getProjectPermissionByRoles(
-      [ProjectMembershipRole.Member],
-      projectId
-    );
-    const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
-      orgDAL.findById(actorOrgId)
-    );
-    assertRoleSetBoundary({
-      shouldUseNewPrivilegeSystem,
-      opActions: [ProjectPermissionMemberActions.AssignRole, ProjectPermissionMemberActions.GrantPrivileges],
-      opSubject: ProjectPermissionSub.Member,
-      actorPermission: permission,
-      targetPermissions: memberRolePermissions,
-      baseMessage: "Failed to add a member with a role exceeding your own privileges"
-    });
-
     const project = await requestMemoize(requestMemoKeys.projectFindById(projectId), () =>
       projectDAL.findById(projectId)
     );
@@ -313,6 +297,26 @@ export const projectMembershipServiceFactory = ({
         id: orgMembers.filter((el) => Boolean(el.actorUserId)).map((el) => el.actorUserId as string)
       }
     });
+
+    const memberRolePermissions = await permissionService.getProjectPermissionByRoles(
+      [ProjectMembershipRole.Member],
+      projectId
+    );
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
+      orgDAL.findById(actorOrgId)
+    );
+    for (const addedUser of orgMembershipUsernames) {
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: [ProjectPermissionMemberActions.AssignRole, ProjectPermissionMemberActions.GrantPrivileges],
+        opSubject: ProjectPermissionSub.Member,
+        actorPermission: permission,
+        targetPermissions: memberRolePermissions,
+        baseMessage: "Failed to add a member with a role exceeding your own privileges",
+        subjectFields: { userEmail: addedUser.email || undefined }
+      });
+    }
+
     const userIdsToExcludeForProjectKeyAddition = new Set(
       await userGroupMembershipDAL.findUserGroupMembershipsInProject(
         orgMembershipUsernames.map(({ username }) => username),
@@ -408,25 +412,43 @@ export const projectMembershipServiceFactory = ({
       });
     }
 
-    const targetRoles = resolveMembershipRoleSlugs(
-      await membershipRoleDAL.findRolesByMembershipIds(projectMembers.map(({ id }) => id))
-    );
+    const targetRoleRows = await membershipRoleDAL.findRolesByMembershipIds(projectMembers.map(({ id }) => id));
+    const targetRoles = resolveMembershipRoleSlugs(targetRoleRows);
     if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, projectId, {
+      const resolvedRoles = await permissionService.getProjectPermissionByRoles(targetRoles, projectId, {
         ignoreUnresolvedRoles: true
       });
       const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
         orgDAL.findById(actorOrgId)
       );
 
-      assertRoleSetBoundary({
-        shouldUseNewPrivilegeSystem,
-        opActions: ProjectPermissionMemberActions.Delete,
-        opSubject: ProjectPermissionSub.Member,
-        actorPermission: permission,
-        targetPermissions,
-        baseMessage: "Failed to remove a more privileged member from the project"
-      });
+      const resolvedRoleBySlug: Record<string, (typeof resolvedRoles)[number]> = {};
+      const unattributableRoles: typeof resolvedRoles = [];
+      for (const resolved of resolvedRoles) {
+        if (resolved.role) resolvedRoleBySlug[resolved.role.slug] = resolved;
+        else unattributableRoles.push(resolved);
+      }
+      const roleRowsByMembershipId = groupBy(targetRoleRows, (el) => el.membershipId);
+
+      for (const projectMember of projectMembers) {
+        const targetPermissions = [
+          ...resolveMembershipRoleSlugs(roleRowsByMembershipId[projectMember.id] || [])
+            .map((slug) => resolvedRoleBySlug[slug])
+            .filter(Boolean),
+          ...unattributableRoles
+        ];
+        if (targetPermissions.length) {
+          assertRoleSetBoundary({
+            shouldUseNewPrivilegeSystem,
+            opActions: ProjectPermissionMemberActions.Delete,
+            opSubject: ProjectPermissionSub.Member,
+            actorPermission: permission,
+            targetPermissions,
+            baseMessage: "Failed to remove a more privileged member from the project",
+            subjectFields: { userEmail: projectMember.user.email || undefined }
+          });
+        }
+      }
     }
 
     await checkUserApproverPolicies(

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -414,41 +414,37 @@ export const projectMembershipServiceFactory = ({
 
     const targetRoleRows = await membershipRoleDAL.findRolesByMembershipIds(projectMembers.map(({ id }) => id));
     const targetRoles = resolveMembershipRoleSlugs(targetRoleRows);
-    if (targetRoles.length) {
-      const resolvedRoles = await permissionService.getProjectPermissionByRoles(targetRoles, projectId, {
-        ignoreUnresolvedRoles: true
+    const resolvedRoles = await permissionService.getProjectPermissionByRoles(targetRoles, projectId, {
+      ignoreUnresolvedRoles: true
+    });
+    const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
+      orgDAL.findById(actorOrgId)
+    );
+
+    const resolvedRoleBySlug: Record<string, (typeof resolvedRoles)[number]> = {};
+    const unattributableRoles: typeof resolvedRoles = [];
+    for (const resolved of resolvedRoles) {
+      if (resolved.role) resolvedRoleBySlug[resolved.role.slug] = resolved;
+      else unattributableRoles.push(resolved);
+    }
+    const roleRowsByMembershipId = groupBy(targetRoleRows, (el) => el.membershipId);
+
+    for (const projectMember of projectMembers) {
+      const targetPermissions = [
+        ...resolveMembershipRoleSlugs(roleRowsByMembershipId[projectMember.id] || [])
+          .map((slug) => resolvedRoleBySlug[slug])
+          .filter(Boolean),
+        ...unattributableRoles
+      ];
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: ProjectPermissionMemberActions.Delete,
+        opSubject: ProjectPermissionSub.Member,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to remove a more privileged member from the project",
+        subjectFields: { userEmail: projectMember.user.email || undefined }
       });
-      const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
-        orgDAL.findById(actorOrgId)
-      );
-
-      const resolvedRoleBySlug: Record<string, (typeof resolvedRoles)[number]> = {};
-      const unattributableRoles: typeof resolvedRoles = [];
-      for (const resolved of resolvedRoles) {
-        if (resolved.role) resolvedRoleBySlug[resolved.role.slug] = resolved;
-        else unattributableRoles.push(resolved);
-      }
-      const roleRowsByMembershipId = groupBy(targetRoleRows, (el) => el.membershipId);
-
-      for (const projectMember of projectMembers) {
-        const targetPermissions = [
-          ...resolveMembershipRoleSlugs(roleRowsByMembershipId[projectMember.id] || [])
-            .map((slug) => resolvedRoleBySlug[slug])
-            .filter(Boolean),
-          ...unattributableRoles
-        ];
-        if (targetPermissions.length) {
-          assertRoleSetBoundary({
-            shouldUseNewPrivilegeSystem,
-            opActions: ProjectPermissionMemberActions.Delete,
-            opSubject: ProjectPermissionSub.Member,
-            actorPermission: permission,
-            targetPermissions,
-            baseMessage: "Failed to remove a more privileged member from the project",
-            subjectFields: { userEmail: projectMember.user.email || undefined }
-          });
-        }
-      }
     }
 
     await checkUserApproverPolicies(

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -412,7 +412,9 @@ export const projectMembershipServiceFactory = ({
       await membershipRoleDAL.findRolesByMembershipIds(projectMembers.map(({ id }) => id))
     );
     if (targetRoles.length) {
-      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, projectId);
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, projectId, {
+        ignoreUnresolvedRoles: true
+      });
       const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
         orgDAL.findById(actorOrgId)
       );

--- a/backend/src/services/project-membership/project-membership-service.ts
+++ b/backend/src/services/project-membership/project-membership-service.ts
@@ -25,6 +25,7 @@ import { TAlertChannelRecipientDALFactory } from "../alert/alert-channel-recipie
 import { ActorType } from "../auth/auth-type";
 import { TGroupProjectDALFactory } from "../group-project/group-project-dal";
 import { TApplicationMembershipCleanupServiceFactory } from "../membership/application-membership-cleanup-service";
+import { resolveMembershipRoleSlugs } from "../membership/membership-fns";
 import { TMembershipRoleDALFactory } from "../membership/membership-role-dal";
 import { TMembershipUserDALFactory } from "../membership-user/membership-user-dal";
 import { TNotificationServiceFactory } from "../notification/notification-service";
@@ -52,7 +53,7 @@ type TProjectMembershipServiceFactoryDep = {
   smtpService: TSmtpService;
   projectMembershipDAL: TProjectMembershipDALFactory;
   membershipUserDAL: TMembershipUserDALFactory;
-  membershipRoleDAL: Pick<TMembershipRoleDALFactory, "insertMany" | "find" | "delete">;
+  membershipRoleDAL: Pick<TMembershipRoleDALFactory, "insertMany" | "find" | "delete" | "findRolesByMembershipIds">;
   userDAL: Pick<TUserDALFactory, "find">;
   userAliasDAL: Pick<TUserAliasDALFactory, "findBySsoExternalIds">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
@@ -404,6 +405,25 @@ export const projectMembershipServiceFactory = ({
       throw new BadRequestError({
         message: "Cannot remove yourself from project",
         name: "Delete project membership"
+      });
+    }
+
+    const targetRoles = resolveMembershipRoleSlugs(
+      await membershipRoleDAL.findRolesByMembershipIds(projectMembers.map(({ id }) => id))
+    );
+    if (targetRoles.length) {
+      const targetPermissions = await permissionService.getProjectPermissionByRoles(targetRoles, projectId);
+      const { shouldUseNewPrivilegeSystem } = await requestMemoize(requestMemoKeys.orgFindById(actorOrgId), () =>
+        orgDAL.findById(actorOrgId)
+      );
+
+      assertRoleSetBoundary({
+        shouldUseNewPrivilegeSystem,
+        opActions: ProjectPermissionMemberActions.Delete,
+        opSubject: ProjectPermissionSub.Member,
+        actorPermission: permission,
+        targetPermissions,
+        baseMessage: "Failed to remove a more privileged member from the project"
       });
     }
 

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -18,6 +18,7 @@ import {
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import {
   OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionProjectActions,
   OrgPermissionSubjects
 } from "@app/ee/services/permission/org-permission";
@@ -874,7 +875,7 @@ export const projectServiceFactory = ({
       });
 
       // `includeRoles` is specifically used by organization admins when inviting new users to the organizations to avoid looping redundant api calls.
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Create, OrgPermissionSubjects.Member);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Create, OrgPermissionSubjects.Member);
       const customRoles = await roleDAL.find({
         $in: {
           projectId: workspaces.map((workspace) => workspace.id)

--- a/backend/src/services/user-activation/user-activation-service.ts
+++ b/backend/src/services/user-activation/user-activation-service.ts
@@ -1,5 +1,9 @@
 import { OrganizationActionScope } from "@app/db/schemas";
-import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
+import {
+  OrgPermissionActions,
+  OrgPermissionMemberActions,
+  OrgPermissionSubjects
+} from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { getConfig } from "@app/lib/config/env";
 import { ms } from "@app/lib/ms";
@@ -52,7 +56,7 @@ export const userActivationServiceFactory = ({
       actorAuthMethod,
       scope: OrganizationActionScope.Any
     });
-    if (!permission.can(OrgPermissionActions.Create, OrgPermissionSubjects.Member)) return noActivation;
+    if (!permission.can(OrgPermissionMemberActions.Create, OrgPermissionSubjects.Member)) return noActivation;
 
     // 2. The org must be young enough (SECRETS_ACTIVATION_ORG_MAX_AGE_MONTHS) or has less than 5 u
     const org = await orgDAL.findById(actorOrgId);

--- a/backend/src/services/user-activation/user-activation-service.ts
+++ b/backend/src/services/user-activation/user-activation-service.ts
@@ -1,9 +1,5 @@
 import { OrganizationActionScope } from "@app/db/schemas";
-import {
-  OrgPermissionActions,
-  OrgPermissionMemberActions,
-  OrgPermissionSubjects
-} from "@app/ee/services/permission/org-permission";
+import { OrgPermissionMemberActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { getConfig } from "@app/lib/config/env";
 import { ms } from "@app/lib/ms";

--- a/backend/src/services/user/user-service.ts
+++ b/backend/src/services/user/user-service.ts
@@ -4,7 +4,7 @@ import { Knex } from "knex";
 import { AccessScope, OrganizationActionScope, TUsers } from "@app/db/schemas";
 import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
 import { EmailDomainStatus } from "@app/ee/services/email-domain/email-domain-types";
-import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
+import { OrgPermissionMemberActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
@@ -754,7 +754,7 @@ export const userServiceFactory = ({
         actorOrgId,
         scope: OrganizationActionScope.Any
       });
-      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Read, OrgPermissionSubjects.Member);
+      ForbiddenError.from(permission).throwUnlessCan(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member);
     }
 
     const memberships = await groupProjectDAL.findByUserId(user.id, actorOrgId);

--- a/docs/internals/permissions/organization-permissions.mdx
+++ b/docs/internals/permissions/organization-permissions.mdx
@@ -52,12 +52,13 @@ Below is a comprehensive list of all available organization-level subjects and t
 
 #### Subject: `member`
 
-| Action   | Description                          |
-| -------- | ------------------------------------ |
-| `read`   | View organization members            |
-| `create` | Add new members to the organization  |
-| `edit`   | Modify member details                |
-| `delete` | Remove members from the organization |
+| Action             | Description                                      |
+| ------------------ | ------------------------------------------------ |
+| `read`             | View organization members                        |
+| `create`           | Add new members to the organization              |
+| `edit`             | Modify member details                            |
+| `delete`           | Remove members from the organization             |
+| `grant-privileges` | Change the roles held by organization members    |
 
 #### Subject: `groups`
 

--- a/docs/internals/permissions/organization-permissions.mdx
+++ b/docs/internals/permissions/organization-permissions.mdx
@@ -52,13 +52,13 @@ Below is a comprehensive list of all available organization-level subjects and t
 
 #### Subject: `member`
 
-| Action             | Description                                      |
-| ------------------ | ------------------------------------------------ |
-| `read`             | View organization members                        |
-| `create`           | Add new members to the organization              |
-| `edit`             | Modify member details                            |
-| `delete`           | Remove members from the organization             |
-| `grant-privileges` | Change the roles held by organization members    |
+| Action             | Description                                    |
+| ------------------ | ---------------------------------------------- |
+| `read`             | View organization members                      |
+| `create`           | Add new members to the organization            |
+| `edit`             | Modify member attributes and activation status |
+| `delete`           | Remove members from the organization           |
+| `grant-privileges` | Change the roles held by organization members  |
 
 #### Subject: `groups`
 

--- a/frontend/src/context/OrgPermissionContext/index.tsx
+++ b/frontend/src/context/OrgPermissionContext/index.tsx
@@ -8,6 +8,7 @@ export {
   OrgPermissionGroupActions,
   OrgPermissionHoneyTokenActions,
   OrgPermissionIdentityActions,
+  OrgPermissionMemberActions,
   OrgPermissionProjectActions,
   OrgPermissionSsoActions,
   OrgPermissionSubjects

--- a/frontend/src/context/OrgPermissionContext/types.ts
+++ b/frontend/src/context/OrgPermissionContext/types.ts
@@ -154,6 +154,14 @@ export enum OrgPermissionKmipActions {
   Proxy = "proxy"
 }
 
+export enum OrgPermissionMemberActions {
+  Read = "read",
+  Create = "create",
+  Edit = "edit",
+  Delete = "delete",
+  GrantPrivileges = "grant-privileges"
+}
+
 export enum OrgPermissionIdentityActions {
   Read = "read",
   Create = "create",
@@ -194,7 +202,7 @@ export type OrgPermissionSet =
   | [OrgPermissionProjectActions, OrgPermissionSubjects.Project]
   | [OrgPermissionActions.Read, OrgPermissionSubjects.Workspace]
   | [OrgPermissionActions, OrgPermissionSubjects.Role]
-  | [OrgPermissionActions, OrgPermissionSubjects.Member]
+  | [OrgPermissionMemberActions, OrgPermissionSubjects.Member]
   | [OrgPermissionActions, OrgPermissionSubjects.Settings]
   | [OrgPermissionActions, OrgPermissionSubjects.IncidentAccount]
   | [OrgPermissionActions, OrgPermissionSubjects.Scim]

--- a/frontend/src/context/index.tsx
+++ b/frontend/src/context/index.tsx
@@ -8,6 +8,7 @@ export {
   OrgPermissionGroupActions,
   OrgPermissionHoneyTokenActions,
   OrgPermissionIdentityActions,
+  OrgPermissionMemberActions,
   OrgPermissionProjectActions,
   OrgPermissionSsoActions,
   OrgPermissionSubjects,

--- a/frontend/src/hooks/api/reactQuery.tsx
+++ b/frontend/src/hooks/api/reactQuery.tsx
@@ -87,6 +87,53 @@ function ValidationErrorModal({
   );
 }
 
+type TPermissionConditions = Record<
+  string,
+  string | { [K in PermissionConditionOperators]: string | string[] }
+>;
+
+function PermissionConditionsList({
+  conditions,
+  keyPrefix
+}: {
+  conditions?: unknown;
+  keyPrefix: string;
+}) {
+  const fields = Object.keys((conditions as TPermissionConditions) || {});
+  if (!fields.length) return null;
+
+  return (
+    <ul className="mt-2 flex list-disc flex-col gap-1.5 pl-5 marker:text-muted">
+      {fields.flatMap((field, fieldIndex) => {
+        const operators = (conditions as TPermissionConditions)[field];
+        const formattedFieldName = camelCaseToSpaces(field).toLowerCase();
+
+        if (typeof operators === "string") {
+          return (
+            <li key={`${keyPrefix}-${fieldIndex + 1}`}>
+              <span className="font-medium capitalize">{formattedFieldName}</span>{" "}
+              <span className="text-muted">equal to</span>{" "}
+              <Badge variant="neutral">{operators}</Badge>
+            </li>
+          );
+        }
+
+        return Object.keys(operators).map((operator, operatorIndex) => (
+          <li key={`${keyPrefix}-${fieldIndex + 1}-${operatorIndex + 1}`}>
+            <span className="font-medium capitalize">{formattedFieldName}</span>{" "}
+            <span className="text-muted">
+              {formatedConditionsOperatorNames[operator as PermissionConditionOperators]}
+            </span>{" "}
+            <Badge variant="neutral">
+              {operators[operator as PermissionConditionOperators].toString()}
+            </Badge>
+          </li>
+        ));
+      })}
+    </ul>
+  );
+}
+
 export const onRequestError = (
   error: unknown,
   _variables?: unknown,
@@ -191,54 +238,74 @@ export const onRequestError = (
                         <span>{el.subject.toString()}</span>
                         {hasConditions && <span className="text-muted">with conditions:</span>}
                       </div>
-                      {hasConditions && (
-                        <ul className="mt-2 flex list-disc flex-col gap-1.5 pl-5 marker:text-muted">
-                          {Object.keys(el.conditions || {}).flatMap((field, fieldIndex) => {
-                            const operators = (
-                              el.conditions as Record<
-                                string,
-                                string | { [K in PermissionConditionOperators]: string | string[] }
-                              >
-                            )[field];
-
-                            const formattedFieldName = camelCaseToSpaces(field).toLowerCase();
-                            if (typeof operators === "string") {
-                              return (
-                                <li key={`Forbidden-error-details-${index + 1}-${fieldIndex + 1}`}>
-                                  <span className="font-medium capitalize">
-                                    {formattedFieldName}
-                                  </span>{" "}
-                                  <span className="text-muted">equal to</span>{" "}
-                                  <Badge variant="neutral">{operators}</Badge>
-                                </li>
-                              );
-                            }
-
-                            return Object.keys(operators).map((operator, operatorIndex) => (
-                              <li
-                                key={`Forbidden-error-details-${index + 1}-${
-                                  fieldIndex + 1
-                                }-${operatorIndex + 1}`}
-                              >
-                                <span className="font-medium capitalize">{formattedFieldName}</span>{" "}
-                                <span className="text-muted">
-                                  {
-                                    formatedConditionsOperatorNames[
-                                      operator as PermissionConditionOperators
-                                    ]
-                                  }
-                                </span>{" "}
-                                <Badge variant="neutral">
-                                  {operators[operator as PermissionConditionOperators].toString()}
-                                </Badge>
-                              </li>
-                            ));
-                          })}
-                        </ul>
-                      )}
+                      <PermissionConditionsList
+                        conditions={el.conditions}
+                        keyPrefix={`Forbidden-error-details-${index + 1}`}
+                      />
                     </div>
                   );
                 })}
+              </div>
+            </DialogContent>
+          </Dialog>
+        ) : undefined,
+        copyActions: [
+          {
+            value: serverResponse.reqId,
+            name: "Request ID",
+            label: `Request ID: ${serverResponse.reqId}`
+          }
+        ]
+      });
+      return;
+    }
+    if (serverResponse?.error === ApiErrorTypes.PermissionBoundaryError) {
+      const missingPermissions = serverResponse.details?.missingPermissions ?? [];
+      const toastIdRef: { current: string | number | undefined } = { current: undefined };
+      toastIdRef.current = createNotification({
+        title: "Permission Denied",
+        type: "error",
+        text: `${serverResponse.message}${serverResponse.message.endsWith(".") ? "" : "."}`,
+        callToAction: missingPermissions.length ? (
+          <Dialog
+            onOpenChange={(open) => {
+              if (!open && toastIdRef.current !== undefined) {
+                dismissNotification(toastIdRef.current);
+              }
+            }}
+          >
+            <DialogTrigger asChild>
+              <Button variant="outline" size="xs">
+                Show more
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="z-[70] sm:max-w-2xl" overlayClassName="z-[70]">
+              <DialogHeader>
+                <DialogTitle>Missing Permissions</DialogTitle>
+                <DialogDescription>
+                  Your role needs the permissions below to perform this action.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="flex flex-col gap-2">
+                {missingPermissions.map((el, index) => (
+                  <div
+                    key={`Permission-boundary-details-${index + 1}`}
+                    className="rounded-md border border-border bg-card p-4 text-sm"
+                  >
+                    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+                      <span>Can</span>
+                      <Badge variant="danger">{el.action}</Badge>
+                      <span>{el.subject}</span>
+                      {Boolean(Object.keys(el.conditions || {}).length) && (
+                        <span className="text-muted">with conditions:</span>
+                      )}
+                    </div>
+                    <PermissionConditionsList
+                      conditions={el.conditions}
+                      keyPrefix={`Permission-boundary-details-${index + 1}`}
+                    />
+                  </div>
+                ))}
               </div>
             </DialogContent>
           </Dialog>

--- a/frontend/src/hooks/api/roles/types.ts
+++ b/frontend/src/hooks/api/roles/types.ts
@@ -29,7 +29,7 @@ export type TOrgRole = {
   id: string;
   createdAt: string;
   updatedAt: string;
-  description?: string;
+  description?: string | null;
   permissions: TPermission[];
 };
 
@@ -57,7 +57,7 @@ export type TGetUserProjectPermissionDTO = {
 export type TCreateOrgRoleDTO = {
   orgId: string;
   name: string;
-  description?: string;
+  description?: string | null;
   slug: string;
   permissions: TPermission[];
 };

--- a/frontend/src/hooks/useSecretsActivationNudge.tsx
+++ b/frontend/src/hooks/useSecretsActivationNudge.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
-  OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   useOrganization,
   useOrgPermission,
@@ -38,7 +38,7 @@ export const useSecretsActivationNudge = () => {
   );
 
   const canInviteMembers = permission.can(
-    OrgPermissionActions.Create,
+    OrgPermissionMemberActions.Create,
     OrgPermissionSubjects.Member
   );
 

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Navbar.tsx
@@ -58,7 +58,7 @@ import {
 import { SidebarTrigger } from "@app/components/v3/generic/Sidebar";
 import { envConfig } from "@app/config/env";
 import {
-  OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   useOrganization,
   useServerConfig,
@@ -607,7 +607,7 @@ export const Navbar = () => {
         </Button>
       )}
       {!location.pathname.startsWith("/admin") && !user.superAdmin && (
-        <OrgPermissionCan I={OrgPermissionActions.Create} a={OrgPermissionSubjects.Member}>
+        <OrgPermissionCan I={OrgPermissionMemberActions.Create} a={OrgPermissionSubjects.Member}>
           {(isAllowed) =>
             isAllowed ? (
               <Button variant="outline" size="sm" className="mr-2" asChild>
@@ -709,7 +709,10 @@ export const Navbar = () => {
                 Personal Settings
               </Link>
             </DropdownMenuItem>
-            <OrgPermissionCan I={OrgPermissionActions.Create} a={OrgPermissionSubjects.Member}>
+            <OrgPermissionCan
+              I={OrgPermissionMemberActions.Create}
+              a={OrgPermissionSubjects.Member}
+            >
               {(isAllowed) =>
                 isAllowed ? (
                   <DropdownMenuItem asChild>

--- a/frontend/src/pages/organization/AccessManagementPage/AccessManagementPage.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/AccessManagementPage.tsx
@@ -19,6 +19,7 @@ import {
   OrgPermissionActions,
   OrgPermissionGroupActions,
   OrgPermissionIdentityActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   useOrganization,
   useOrgPermission
@@ -54,9 +55,9 @@ export const AccessManagementPage = () => {
     {
       key: OrgAccessControlTabSections.Member,
       label: "Users",
-      isHidden: permission.cannot(OrgPermissionActions.Read, OrgPermissionSubjects.Member),
+      isHidden: permission.cannot(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member),
       requirement: {
-        action: OrgPermissionActions.Read,
+        action: OrgPermissionMemberActions.Read,
         subject: OrgPermissionSubjects.Member
       },
       component: OrgMembersTab

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddOrgMemberModal.tsx
@@ -37,7 +37,7 @@ const addMemberFormSchema = projectAssignmentSchema.extend({
   organizationRole: z.object({
     name: z.string(),
     slug: z.string(),
-    description: z.string().optional()
+    description: z.string().nullish()
   })
 });
 

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddSubOrgMemberModal.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/AddSubOrgMemberModal.tsx
@@ -36,7 +36,7 @@ const addMemberFormSchema = projectAssignmentSchema.extend({
   organizationRole: z.object({
     name: z.string(),
     slug: z.string(),
-    description: z.string().optional()
+    description: z.string().nullish()
   })
 });
 

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersSection.tsx
@@ -21,7 +21,7 @@ import {
 } from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import {
-  OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   useOrganization,
   useUser
@@ -137,7 +137,7 @@ export const OrgMembersSection = () => {
         onClearSelection={() => setSelectedMemberIds([])}
       >
         <OrgPermissionCan
-          I={OrgPermissionActions.Delete}
+          I={OrgPermissionMemberActions.Delete}
           a={OrgPermissionSubjects.Member}
           renderTooltip
         >
@@ -172,7 +172,10 @@ export const OrgMembersSection = () => {
             Invite and manage {isSubOrganization ? "sub-" : ""}organization users
           </CardDescription>
           <CardAction>
-            <OrgPermissionCan I={OrgPermissionActions.Create} a={OrgPermissionSubjects.Member}>
+            <OrgPermissionCan
+              I={OrgPermissionMemberActions.Create}
+              a={OrgPermissionSubjects.Member}
+            >
               {(isAllowed) => (
                 <Button
                   variant={isSubOrganization ? "sub-org" : "org"}

--- a/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersTable.tsx
+++ b/frontend/src/pages/organization/AccessManagementPage/components/OrgMembersTab/components/OrgMembersSection/OrgMembersTable.tsx
@@ -53,7 +53,7 @@ import {
   TooltipTrigger
 } from "@app/components/v3";
 import {
-  OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   useOrganization,
   useSubscription,
@@ -543,7 +543,7 @@ export const OrgMembersTable = ({
                         </TableCell>
                         <TableCell>
                           <OrgPermissionCan
-                            I={OrgPermissionActions.Edit}
+                            I={OrgPermissionMemberActions.Edit}
                             a={OrgPermissionSubjects.Member}
                           >
                             {(isAllowed) => (
@@ -584,7 +584,7 @@ export const OrgMembersTable = ({
                               !isSubOrganization &&
                               serverDetails?.emailConfigured && (
                                 <OrgPermissionCan
-                                  I={OrgPermissionActions.Edit}
+                                  I={OrgPermissionMemberActions.Create}
                                   a={OrgPermissionSubjects.Member}
                                 >
                                   {(isAllowed) => (
@@ -614,7 +614,7 @@ export const OrgMembersTable = ({
                               </DropdownMenuTrigger>
                               <DropdownMenuContent sideOffset={2} align="end">
                                 <OrgPermissionCan
-                                  I={OrgPermissionActions.Edit}
+                                  I={OrgPermissionMemberActions.Edit}
                                   a={OrgPermissionSubjects.Member}
                                 >
                                   {(isAllowed) => (
@@ -637,7 +637,7 @@ export const OrgMembersTable = ({
                                   )}
                                 </OrgPermissionCan>
                                 <OrgPermissionCan
-                                  I={OrgPermissionActions.Delete}
+                                  I={OrgPermissionMemberActions.Edit}
                                   a={OrgPermissionSubjects.Member}
                                 >
                                   {(isAllowed) => (
@@ -670,7 +670,7 @@ export const OrgMembersTable = ({
                                   )}
                                 </OrgPermissionCan>
                                 <OrgPermissionCan
-                                  I={OrgPermissionActions.Delete}
+                                  I={OrgPermissionMemberActions.Delete}
                                   a={OrgPermissionSubjects.Member}
                                 >
                                   {(isAllowed) => (

--- a/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
+++ b/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
@@ -241,7 +241,7 @@ const ssoPermissionSchema = z
 
 export const formSchema = z.object({
   name: z.string().trim(),
-  description: z.string().trim().optional(),
+  description: z.string().trim().nullish(),
   slug: z
     .string()
     .trim()

--- a/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
+++ b/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
@@ -17,6 +17,7 @@ import {
   OrgPermissionIdentityActions,
   OrgPermissionKmipActions,
   OrgPermissionMachineIdentityAuthTemplateActions,
+  OrgPermissionMemberActions,
   OrgPermissionProjectActions,
   OrgPermissionSecretShareAction,
   OrgPermissionSecretsManagementInsightsActions,
@@ -76,6 +77,18 @@ const appConnectionsPermissionSchema = z
 
 const kmipPermissionSchema = z
   .array(z.object({ [OrgPermissionKmipActions.Proxy]: z.boolean().optional() }))
+  .optional();
+
+const memberPermissionSchema = z
+  .array(
+    z.object({
+      [OrgPermissionMemberActions.Read]: z.boolean().optional(),
+      [OrgPermissionMemberActions.Create]: z.boolean().optional(),
+      [OrgPermissionMemberActions.Edit]: z.boolean().optional(),
+      [OrgPermissionMemberActions.Delete]: z.boolean().optional(),
+      [OrgPermissionMemberActions.GrantPrivileges]: z.boolean().optional()
+    })
+  )
   .optional();
 
 const identityPermissionSchema = z
@@ -237,7 +250,7 @@ export const formSchema = z.object({
     .object({
       project: projectPermissionSchema,
       "audit-logs": auditLogsPermissionSchema,
-      member: generalPermissionSchema,
+      member: memberPermissionSchema,
       groups: groupPermissionSchema,
       role: generalPermissionSchema,
       settings: generalPermissionSchema,
@@ -327,24 +340,29 @@ export const ORG_PERMISSION_OBJECT: Record<string, TOrgPermissionConfig> = {
     description: "Manage organization member access and role assignments",
     actions: [
       {
-        value: OrgPermissionActions.Read,
+        value: OrgPermissionMemberActions.Read,
         label: "View all members",
         description: "View organization members and their roles"
       },
       {
-        value: OrgPermissionActions.Create,
+        value: OrgPermissionMemberActions.Create,
         label: "Invite members",
         description: "Invite new users to join the organization"
       },
       {
-        value: OrgPermissionActions.Edit,
+        value: OrgPermissionMemberActions.Edit,
         label: "Edit members",
         description: "Modify member roles and access settings"
       },
       {
-        value: OrgPermissionActions.Delete,
+        value: OrgPermissionMemberActions.Delete,
         label: "Remove members",
         description: "Remove members from the organization"
+      },
+      {
+        value: OrgPermissionMemberActions.GrantPrivileges,
+        label: "Grant privileges",
+        description: "Assign and change the roles held by organization members"
       }
     ]
   },

--- a/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
+++ b/frontend/src/pages/organization/RoleByIDPage/components/OrgRoleModifySection.utils.ts
@@ -352,7 +352,7 @@ export const ORG_PERMISSION_OBJECT: Record<string, TOrgPermissionConfig> = {
       {
         value: OrgPermissionMemberActions.Edit,
         label: "Edit members",
-        description: "Modify member roles and access settings"
+        description: "Update member attributes and activation status"
       },
       {
         value: OrgPermissionMemberActions.Delete,

--- a/frontend/src/pages/organization/RoleByIDPage/components/RoleModal.tsx
+++ b/frontend/src/pages/organization/RoleByIDPage/components/RoleModal.tsx
@@ -77,7 +77,7 @@ export const RoleModal = ({ popUp, handlePopUpToggle }: Props) => {
     if (role) {
       reset({
         name: role.name,
-        description: role.description,
+        description: role.description ?? "",
         slug: role.slug
       });
     } else {

--- a/frontend/src/pages/organization/RoleByIDPage/components/RolePermissionsSection/RolePermissionsSection.tsx
+++ b/frontend/src/pages/organization/RoleByIDPage/components/RolePermissionsSection/RolePermissionsSection.tsx
@@ -83,6 +83,13 @@ export const RolePermissionsSection = ({ roleId }: Props) => {
         return Array.from(next);
       });
     }
+
+    const fieldError = Object.entries(formErrors).find(
+      ([field, error]) => field !== "permissions" && error?.message
+    );
+    if (fieldError) {
+      createNotification({ type: "error", text: `${fieldError[0]}: ${fieldError[1]?.message}` });
+    }
   });
 
   const isCustomRole = !["admin", "member", "no-access"].includes(role?.slug ?? "");

--- a/frontend/src/pages/organization/UserDetailsByIDPage/UserDetailsByIDPage.tsx
+++ b/frontend/src/pages/organization/UserDetailsByIDPage/UserDetailsByIDPage.tsx
@@ -17,6 +17,7 @@ import {
 import { ROUTE_PATHS } from "@app/const/routes";
 import {
   OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   useOrganization,
   useUser
@@ -268,7 +269,7 @@ const Page = withPermission(
     );
   },
   {
-    action: OrgPermissionActions.Read,
+    action: OrgPermissionMemberActions.Read,
     subject: OrgPermissionSubjects.Member,
     accessRestrictedMode: "dialog"
   }

--- a/frontend/src/pages/organization/UserDetailsByIDPage/UserDetailsByIDPage.tsx
+++ b/frontend/src/pages/organization/UserDetailsByIDPage/UserDetailsByIDPage.tsx
@@ -16,7 +16,6 @@ import {
 } from "@app/components/v3";
 import { ROUTE_PATHS } from "@app/const/routes";
 import {
-  OrgPermissionActions,
   OrgPermissionMemberActions,
   OrgPermissionSubjects,
   useOrganization,
@@ -144,7 +143,7 @@ const Page = withPermission(
                       Copy User ID
                     </DropdownMenuItem>
                     <OrgPermissionCan
-                      I={OrgPermissionActions.Edit}
+                      I={OrgPermissionMemberActions.Edit}
                       a={OrgPermissionSubjects.Member}
                     >
                       {(isAllowed) => (
@@ -164,7 +163,7 @@ const Page = withPermission(
                       )}
                     </OrgPermissionCan>
                     <OrgPermissionCan
-                      I={OrgPermissionActions.Delete}
+                      I={OrgPermissionMemberActions.Edit}
                       a={OrgPermissionSubjects.Member}
                     >
                       {(isAllowed) => (
@@ -194,7 +193,7 @@ const Page = withPermission(
                       )}
                     </OrgPermissionCan>
                     <OrgPermissionCan
-                      I={OrgPermissionActions.Delete}
+                      I={OrgPermissionMemberActions.Delete}
                       a={OrgPermissionSubjects.Member}
                     >
                       {(isAllowed) => (

--- a/frontend/src/pages/organization/UserDetailsByIDPage/components/UserDetailsSection.tsx
+++ b/frontend/src/pages/organization/UserDetailsByIDPage/components/UserDetailsSection.tsx
@@ -29,7 +29,7 @@ import {
   IconButton
 } from "@app/components/v3";
 import {
-  OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   useOrganization,
   useUser
@@ -108,7 +108,7 @@ export const UserDetailsSection = ({ membershipId, handlePopUpOpen }: Props) => 
         <CardDescription>User membership details</CardDescription>
         {userId !== membership.user.id && (
           <CardAction>
-            <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Member}>
+            <OrgPermissionCan I={OrgPermissionMemberActions.Edit} a={OrgPermissionSubjects.Member}>
               {(isAllowed) => (
                 <IconButton
                   isDisabled={!isAllowed}
@@ -259,7 +259,10 @@ export const UserDetailsSection = ({ membershipId, handlePopUpOpen }: Props) => 
           (membership.status === "invited" || membership.status === "verified") &&
           membership.user.email &&
           serverDetails?.emailConfigured && (
-            <OrgPermissionCan I={OrgPermissionActions.Edit} a={OrgPermissionSubjects.Member}>
+            <OrgPermissionCan
+              I={OrgPermissionMemberActions.Create}
+              a={OrgPermissionSubjects.Member}
+            >
               {(isAllowed) => (
                 <Button
                   isDisabled={!isAllowed}

--- a/frontend/src/pages/organization/UserDetailsByIDPage/components/UserProjectsSection/UserAuditLogsSection.tsx
+++ b/frontend/src/pages/organization/UserDetailsByIDPage/components/UserProjectsSection/UserAuditLogsSection.tsx
@@ -1,4 +1,4 @@
-import { OrgPermissionActions, OrgPermissionSubjects, useSubscription } from "@app/context";
+import { OrgPermissionMemberActions, OrgPermissionSubjects, useSubscription } from "@app/context";
 import { withPermission } from "@app/hoc";
 import { OrgUser } from "@app/hooks/api/types";
 import { LogsSection } from "@app/pages/organization/AuditLogsPage/components";
@@ -27,5 +27,5 @@ export const UserAuditLogsSection = withPermission(
       )
     );
   },
-  { action: OrgPermissionActions.Read, subject: OrgPermissionSubjects.Member }
+  { action: OrgPermissionMemberActions.Read, subject: OrgPermissionSubjects.Member }
 );

--- a/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/AddMemberModal.tsx
+++ b/frontend/src/pages/project/AccessControlPage/components/MembersTab/components/AddMemberModal.tsx
@@ -27,7 +27,7 @@ import {
   FilterableSelect
 } from "@app/components/v3";
 import {
-  OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   ProjectPermissionMemberActions,
   ProjectPermissionSub,
@@ -109,7 +109,7 @@ export const AddMemberModal = ({ popUp, handlePopUpToggle }: Props) => {
     ProjectPermissionSub.Member
   );
   const canInviteNewMembers = orgPermission.can(
-    OrgPermissionActions.Create,
+    OrgPermissionMemberActions.Create,
     OrgPermissionSubjects.Member
   );
   const isReferenceDataLoading = isMembersLoading || isOrgUsersLoading || isRolesLoading;

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
@@ -136,6 +136,7 @@ const ActionsMultiSelect = ({
 
         // Hide legacy "grant-privileges" actions unless already selected
         if (
+          subjectScope === PermissionScope.Project &&
           subject === ProjectPermissionSub.Member &&
           value === ProjectPermissionMemberActions.GrantPrivileges
         ) {

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretAccessInsights.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretAccessInsights.tsx
@@ -62,7 +62,7 @@ import {
   TooltipTrigger
 } from "@app/components/v3";
 import {
-  OrgPermissionActions,
+  OrgPermissionMemberActions,
   OrgPermissionSubjects,
   ProjectPermissionIdentityActions,
   ProjectPermissionMemberActions,
@@ -175,7 +175,7 @@ function AddMemberPopover({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const canGrantAccess =
-    orgPermission.can(OrgPermissionActions.Read, OrgPermissionSubjects.Member) &&
+    orgPermission.can(OrgPermissionMemberActions.Read, OrgPermissionSubjects.Member) &&
     permission.can(ProjectPermissionMemberActions.Create, ProjectPermissionSub.Member) &&
     permission.can(
       ProjectPermissionMemberActions.AssignAdditionalPrivileges,
@@ -185,7 +185,7 @@ function AddMemberPopover({
 
   const canAddParentOrgUsers =
     isSubOrganization &&
-    orgPermission.can(OrgPermissionActions.Create, OrgPermissionSubjects.Member);
+    orgPermission.can(OrgPermissionMemberActions.Create, OrgPermissionSubjects.Member);
 
   const { data: orgUsers } = useGetOrgUsers(currentOrg.id);
   const { data: parentOrgAvailableUsers } = useGetAvailableOrgUsers(canAddParentOrgUsers);


### PR DESCRIPTION
## Context

You could remove people who outranked you. If your role let you delete members,
identities, or groups, nothing checked whether the person you were removing had more
privileges than you did. So a custom role scoped to "manage members" was enough to
remove an org admin.

Role changes had a related gap. Downgrading someone to no-access was skipped by the
boundary check even though it strips their access just as completely as removing them.

There was also a bug in how the boundary was measured: when a user, identity, or group
held several roles, only the first one was checked. Holding [member, some-admin-ish-role]
got you measured as if you were just a member.

## Steps to verify the change

Removal and downgrade checks only kick in for orgs on the legacy privilege system, so
flip your test org over first:

```update organizations set "shouldUseNewPrivilegeSystem" = false where id = '<org-id>'```

Then set up a weak actor: make a custom org role that can read and delete members and
nothing else, and assign it to a second user. Log in as them.

Should now get rejected (all of these used to go through):

1. Remove an org admin, both from the members list and from a bulk selection.
2. Do the same in a project with a custom project role that can only remove members.
3. Set a group that holds the Admin role down to no-access.
4. Give a test user two roles, member plus a custom role with broad permissions, then try
   to remove them. Used to pass because only the first role was looked at.

Should still work:

5. An org or project admin doing every one of the above.
6. Removing or downgrading someone who does not outrank you.

Works on either privilege system, so no flag flip needed:

7. As a non-admin who can invite members, try inviting someone as admin, and try promoting
   an existing member to admin. Both should be rejected.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [x] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)