### PR TITLE
chore(docker): drop the source tree and recommended packages from the image

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -151,7 +151,7 @@ RUN apt-get update && apt-get install -y \
 RUN printf "[FreeTDS]\nDescription = FreeTDS Driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so\nFileUsage = 1\n" > /etc/odbcinst.ini
 
 COPY --from=backend-build /app .
-RUN rm -rf ./node_modules ./bdd ./e2e-test
+RUN rm -rf ./node_modules ./bdd ./e2e-test ./src
 RUN npm ci --omit=dev
 
 RUN mkdir frontend-build
@@ -160,7 +160,7 @@ RUN mkdir frontend-build
 FROM base AS production
 
 # Install all required runtime packages
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     autoconf \
     automake \

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -166,7 +166,7 @@ RUN apt-get update && apt-get install -y \
 RUN printf "[FreeTDS]\nDescription = FreeTDS Driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so\nFileUsage = 1\n" > /etc/odbcinst.ini
 
 COPY --from=backend-build /app .
-RUN rm -rf ./node_modules ./bdd ./e2e-test
+RUN rm -rf ./node_modules ./bdd ./e2e-test ./src
 COPY --from=backend-prod-deps /app/node_modules ./node_modules
 
 RUN mkdir frontend-build
@@ -199,7 +199,7 @@ FROM base AS production
 
 # Runtime dependencies only. The PQC OpenSSL toolchain lives in
 # openssl-pqc-builder; nothing here compiles.
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     bash \
     curl \


### PR DESCRIPTION
## Context

Two trims to the standalone runtime image, both from going through a customer container scan.

**The backend source tree was shipping.** `backend-runner` copies the whole build directory and then removes only `node_modules`, `bdd` and `e2e-test`, so `src/` rode along even though the entrypoint runs `dist/main.mjs`. Removing it costs nothing: the source maps embed `sourcesContent`, so stack traces still resolve without the files on disk.

**Recommended packages are not dependencies.** Adding `--no-install-recommends` to the runtime install drops 46 packages, including the whole `python3.13` stack, which nothing in the image uses.

Together they cut about 160 MB, from 2.98 GB to 2.82 GB.

## Steps to verify the change

```bash
docker build -t infisical-standalone:test -f Dockerfile.standalone-infisical .

# src gone, python stack gone, git and perl still there
docker run --rm --entrypoint sh infisical-standalone:test -c '
  [ -d /backend/src ] && echo "src present" || echo "src removed"
  for p in python3.13 libpython3.13 perl git; do
    printf "%-16s %s\n" "$p" "$(dpkg-query -W -f="\${Version}" $p 2>/dev/null || echo NOT INSTALLED)"
  done'
```

Confirm source maps still carry their sources, which is what makes removing `src/` safe:

```bash
docker run --rm --entrypoint node infisical-standalone:test -e '
  const m=require("/backend/dist/lib/crypto/pqc/index.mjs.map");
  console.log("sourcesContent:", Array.isArray(m.sourcesContent) && !!m.sourcesContent[0]);'
```

Boot it against a throwaway database:

```bash
docker compose -f docker-compose.dev.yml --profile test up -d db-test redis
docker run --rm --network infisical_default -p 8093:8080 \
  -e DB_CONNECTION_URI="postgres://infisical:infisical@db-test:5432/infisical-test?sslmode=disable" \
  -e REDIS_URL="redis://redis:6379" \
  -e AUTH_SECRET="smoke" \
  -e ENCRYPTION_KEY="$(openssl rand -hex 16)" \
  -e SITE_URL="http://localhost:8093" \
  infisical-standalone:test
curl -s http://localhost:8093/api/status
```

Use `db-test` rather than `db`. The boot runs migrations and `db` holds local dev data.

### Verified locally

- Image builds; `src/` absent, `python3.13` stack absent, `git` and `perl` still present since git depends on perl
- `dist`, `node_modules`, `go-sidecar` and `frontend-build` all intact
- Boots as uid 1001, runs migrations, detects PQC OpenSSL
- Smoke test: bootstrap, project create, secret write and read back returning identical plaintext
- `GET /` and `GET /api/docs` both 200; only error logged was an unconfigured SMTP connection
- 3640 source map files still present, with `sourcesContent` embedded

Not verified: the FIPS image, which shares the `backend-runner` stage but installs its own runtime package set, so the `--no-install-recommends` half does not apply there.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
