### PR TITLE
feat: adds Ed25519, Ed25519ph algorithms for sign/verify operation

### DIFF
--- a/.github/workflows/publish-fips-toolchain.yml
+++ b/.github/workflows/publish-fips-toolchain.yml
@@ -3,7 +3,7 @@ name: "Publish FIPS test toolchain image"
 # Builds backend/Dockerfile.fips-toolchain and publishes it to GHCR so that
 # run-backend-tests.yml does not have to compile two OpenSSL trees on every PR.
 #
-# Tagged with the content hash of the toolchain Dockerfile: run-backend-tests.yml
+# Tagged with the content hash of the toolchain Dockerfile and OpenSSL helper sources: run-backend-tests.yml
 # computes the same hash and pulls that exact tag, falling back to building from
 # source when a PR changes the toolchain and the new tag isn't published yet.
 #
@@ -17,6 +17,7 @@ on:
       - main
     paths:
       - "backend/Dockerfile.fips-toolchain"
+      - "backend/src/lib/openssl-ext/**"
       - ".github/workflows/publish-fips-toolchain.yml"
   workflow_dispatch:
 
@@ -60,7 +61,7 @@ jobs:
           set -euo pipefail
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           echo "image=ghcr.io/${OWNER}/backend-fips-toolchain" >> "$GITHUB_OUTPUT"
-          echo "tag=${{ hashFiles('backend/Dockerfile.fips-toolchain') }}" >> "$GITHUB_OUTPUT"
+          echo "tag=${{ hashFiles('backend/Dockerfile.fips-toolchain', 'backend/src/lib/openssl-ext/**') }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push ${{ matrix.arch }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
@@ -98,7 +99,7 @@ jobs:
           set -euo pipefail
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           IMAGE="ghcr.io/${OWNER}/backend-fips-toolchain"
-          TAG="${{ hashFiles('backend/Dockerfile.fips-toolchain') }}"
+          TAG="${{ hashFiles('backend/Dockerfile.fips-toolchain', 'backend/src/lib/openssl-ext/**') }}"
           for target in "$TAG" main; do
             docker buildx imagetools create \
               -t "${IMAGE}:${target}" \

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -76,12 +76,12 @@ jobs:
           # Lowercased: GHCR rejects uppercase repository names and the owner is "Infisical".
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           IMAGE="ghcr.io/${OWNER}/backend-fips-toolchain"
-          TAG="${{ hashFiles('backend/Dockerfile.fips-toolchain') }}"
+          TAG="${{ hashFiles('backend/Dockerfile.fips-toolchain', 'backend/src/lib/openssl-ext/**') }}"
           if docker pull --quiet "$IMAGE:$TAG"; then
             echo "Using published toolchain $IMAGE:$TAG"
             TOOLCHAIN="$IMAGE:$TAG"
           else
-            echo "::notice::No published toolchain for $TAG (this PR changes backend/Dockerfile.fips-toolchain); building from source."
+            echo "::notice::No published toolchain for $TAG (this PR changes the FIPS toolchain inputs); building from source."
             TOOLCHAIN="backend-fips-toolchain:$TAG"
             docker build \
               -f backend/Dockerfile.fips-toolchain \

--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -212,6 +212,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
 RUN printf "[FreeTDS]\nDescription = FreeTDS Driver\nDriver = /usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so\nSetup = /usr/lib/x86_64-linux-gnu/odbc/libtdsS.so\nFileUsage = 1\n" > /etc/odbcinst.ini
 
 WORKDIR /openssl-build
+# TODO: Evaluate upgrading the FIPS OpenSSL/provider to 3.5+ when a validated
+# provider supports Ed25519ph. OpenSSL 3.5+ exposes Ed25519ph in its general
+# provider, but that alone does not make the operation FIPS validated.
 RUN wget https://www.openssl.org/source/openssl-3.1.2.tar.gz \
     && tar -xf openssl-3.1.2.tar.gz \
     && cd openssl-3.1.2 \
@@ -259,6 +262,17 @@ WORKDIR /
 COPY --from=backend-runner /app /backend
 COPY --from=frontend-runner /app ./backend/frontend-build
 COPY --from=go-builder /go-sidecar /backend/go-sidecar
+
+RUN ${CC:-cc} -O2 -Wall -Wextra -Werror \
+        -I/opt/openssl-pqc/include \
+        -I/backend/src/lib/openssl-ext \
+        /backend/src/lib/openssl-ext/main.c \
+        /backend/src/lib/openssl-ext/ed25519ph.c \
+        -L/opt/openssl-pqc/lib64 -L/opt/openssl-pqc/lib \
+        -Wl,--enable-new-dtags,-rpath,/opt/openssl-pqc/lib64:/opt/openssl-pqc/lib \
+        -lcrypto \
+        -o /opt/openssl-ext \
+    && test -x /opt/openssl-ext
 
 # Make export-assets script executable for CDN asset extraction
 RUN chmod +x /backend/scripts/export-assets.sh

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -255,6 +255,17 @@ COPY --from=backend-runner /app /backend
 COPY --from=frontend-runner /app ./backend/frontend-build
 COPY --from=go-builder /go-sidecar /backend/go-sidecar
 
+RUN ${CC:-cc} -O2 -Wall -Wextra -Werror \
+        -I/opt/openssl-pqc/include \
+        -I/backend/src/lib/openssl-ext \
+        /backend/src/lib/openssl-ext/main.c \
+        /backend/src/lib/openssl-ext/ed25519ph.c \
+        -L/opt/openssl-pqc/lib64 -L/opt/openssl-pqc/lib \
+        -Wl,--enable-new-dtags,-rpath,/opt/openssl-pqc/lib64:/opt/openssl-pqc/lib \
+        -lcrypto \
+        -o /opt/openssl-ext \
+    && test -x /opt/openssl-ext
+
 # Make export-assets script executable for CDN asset extraction
 RUN chmod +x /backend/scripts/export-assets.sh
 

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -102,6 +102,17 @@ RUN npm install
 
 COPY . .
 
+RUN ${CC:-cc} -O2 -Wall -Wextra -Werror \
+        -I/opt/openssl-pqc/include \
+        -Isrc/lib/openssl-ext \
+        src/lib/openssl-ext/main.c \
+        src/lib/openssl-ext/ed25519ph.c \
+        -L/opt/openssl-pqc/lib64 -L/opt/openssl-pqc/lib \
+        -Wl,--enable-new-dtags,-rpath,/opt/openssl-pqc/lib64:/opt/openssl-pqc/lib \
+        -lcrypto \
+        -o /opt/openssl-ext \
+    && test -x /opt/openssl-ext
+
 ENV HOST=0.0.0.0
 
 ENTRYPOINT ["/app/dev-entrypoint.sh"]

--- a/backend/Dockerfile.fips-toolchain
+++ b/backend/Dockerfile.fips-toolchain
@@ -92,6 +92,9 @@ RUN mkdir -p /opt/oracle && \
     ldconfig
 
 WORKDIR /openssl-build
+# TODO: Evaluate upgrading the FIPS OpenSSL/provider to 3.5+ when a validated
+# provider supports Ed25519ph. OpenSSL 3.5+ exposes Ed25519ph in its general
+# provider, but that alone does not make the operation FIPS validated.
 RUN wget https://www.openssl.org/source/openssl-3.1.2.tar.gz \
     && echo "a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539  openssl-3.1.2.tar.gz" | sha256sum -c - \
     && tar -xf openssl-3.1.2.tar.gz \
@@ -106,6 +109,7 @@ RUN wget https://www.openssl.org/source/openssl-3.1.2.tar.gz \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 WORKDIR /tmp/openssl-pqc-build
+COPY src/lib/openssl-ext /tmp/openssl-ext
 RUN wget -q https://github.com/openssl/openssl/releases/download/openssl-3.5.6/openssl-3.5.6.tar.gz \
     && echo "deae7c80cba99c4b4f940ecadb3c3338b13cb77418409238e57d7f31f2a3b736  openssl-3.5.6.tar.gz" | sha256sum -c - \
     && tar -xf openssl-3.5.6.tar.gz \
@@ -113,8 +117,18 @@ RUN wget -q https://github.com/openssl/openssl/releases/download/openssl-3.5.6/o
     && ./Configure --prefix=/opt/openssl-pqc --openssldir=/opt/openssl-pqc/ssl no-docs \
     && make -j"$(nproc)" \
     && make install_sw \
+    && ${CC:-cc} -O2 -Wall -Wextra -Werror \
+        -I/opt/openssl-pqc/include \
+        -I/tmp/openssl-ext \
+        /tmp/openssl-ext/main.c \
+        /tmp/openssl-ext/ed25519ph.c \
+        -L/opt/openssl-pqc/lib64 -L/opt/openssl-pqc/lib \
+        -Wl,--enable-new-dtags,-rpath,/opt/openssl-pqc/lib64:/opt/openssl-pqc/lib \
+        -lcrypto \
+        -o /opt/openssl-ext \
+    && test -x /opt/openssl-ext \
     && cd / \
-    && rm -rf /tmp/openssl-pqc-build
+    && rm -rf /tmp/openssl-pqc-build /tmp/openssl-ext
 
 WORKDIR /app
 

--- a/backend/Dockerfile.fips-toolchain
+++ b/backend/Dockerfile.fips-toolchain
@@ -4,8 +4,9 @@
 # Instant Client) and changes very rarely, so it is published to GHCR by
 # .github/workflows/publish-fips-toolchain.yml and consumed by Dockerfile.dev.fips.
 #
-# Anything edited here changes the published tag, so CI will rebuild it from source on
-# the PR that changes it and publish the new tag once that PR lands on main.
+# Anything edited here or in src/lib/openssl-ext changes the published tag, so CI will
+# rebuild it from source on the PR that changes it and publish the new tag once that PR
+# lands on main.
 #
 # SCOPE: this is an internal CI build cache, not a supported Infisical artifact. It is
 # published publicly only so CI and local dev can pull it instead of recompiling. It is

--- a/backend/e2e-test/routes/v1/kms-ed25519-signing.spec.ts
+++ b/backend/e2e-test/routes/v1/kms-ed25519-signing.spec.ts
@@ -66,4 +66,29 @@ describe("KMS Ed25519 signing API", () => {
     expect(corrupted.statusCode).toBe(200);
     expect(JSON.parse(corrupted.payload)).toMatchObject({ signatureValid: false, signingAlgorithm });
   });
+
+  test("rejects digested input for raw Ed25519", async () => {
+    const sign = await request(`/api/v1/kms/keys/${keyId}/sign`, {
+      signingAlgorithm: "ED25519_SHA_512",
+      isDigest: true,
+      data: digest
+    });
+    expect(sign.statusCode).toBe(400);
+
+    const rawSign = await request(`/api/v1/kms/keys/${keyId}/sign`, {
+      signingAlgorithm: "ED25519_SHA_512",
+      isDigest: false,
+      data: message.toString("base64")
+    });
+    expect(rawSign.statusCode).toBe(200);
+    const { signature } = JSON.parse(rawSign.payload) as { signature: string };
+
+    const verify = await request(`/api/v1/kms/keys/${keyId}/verify`, {
+      signingAlgorithm: "ED25519_SHA_512",
+      isDigest: true,
+      data: digest,
+      signature
+    });
+    expect(verify.statusCode).toBe(400);
+  });
 });

--- a/backend/e2e-test/routes/v1/kms-ed25519-signing.spec.ts
+++ b/backend/e2e-test/routes/v1/kms-ed25519-signing.spec.ts
@@ -1,0 +1,69 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+type TKmsKey = { id: string };
+
+const authHeaders = { authorization: `Bearer ${jwtAuthToken}` };
+const message = Buffer.from("Infisical KMS Ed25519 API e2e test");
+const digest = createHash("sha512").update(message).digest("base64");
+
+let projectId: string;
+let keyId: string;
+
+const request = (url: string, body: Record<string, unknown>) =>
+  testServer.inject({ method: "POST", url, headers: authHeaders, body });
+
+describe("KMS Ed25519 signing API", () => {
+  beforeEach(async () => {
+    const project = await request("/api/v1/projects", {
+      projectName: `kms-ed25519-${randomUUID()}`,
+      slug: `kms-${randomUUID()}`,
+      type: "kms",
+      shouldCreateDefaultEnvs: false
+    });
+    expect(project.statusCode).toBe(200);
+    projectId = (JSON.parse(project.payload) as { project: { id: string } }).project.id;
+
+    const key = await request("/api/v1/kms/keys", {
+      projectId,
+      name: `ed25519-${randomUUID().slice(0, 16)}`,
+      keyUsage: "sign-verify",
+      algorithm: "ECC_NIST_ED25519",
+      isExportable: true
+    });
+    expect(key.statusCode, key.payload).toBe(200);
+    keyId = (JSON.parse(key.payload) as { key: TKmsKey }).key.id;
+  });
+
+  afterEach(async () => {
+    if (projectId) {
+      await testServer.inject({ method: "DELETE", url: `/api/v1/projects/${projectId}`, headers: authHeaders });
+    }
+  });
+
+  test.each([
+    ["ED25519_SHA_512", false, message.toString("base64")],
+    ["ED25519_PH_SHA_512", true, digest]
+  ])("signs and verifies %s, rejecting a corrupted signature", async (signingAlgorithm, isDigest, data) => {
+    const sign = await request(`/api/v1/kms/keys/${keyId}/sign`, { signingAlgorithm, isDigest, data });
+    expect(sign.statusCode).toBe(200);
+    const { signature } = JSON.parse(sign.payload) as { signature: string };
+
+    const verify = await request(`/api/v1/kms/keys/${keyId}/verify`, { signingAlgorithm, isDigest, data, signature });
+    expect(verify.statusCode).toBe(200);
+    expect(JSON.parse(verify.payload)).toMatchObject({ signatureValid: true, signingAlgorithm });
+
+    const corruptedSignatureBytes = Buffer.from(signature, "base64");
+    corruptedSignatureBytes[0] = (corruptedSignatureBytes[0] + 1) % 256;
+    const corruptedSignature = corruptedSignatureBytes.toString("base64");
+    const corrupted = await request(`/api/v1/kms/keys/${keyId}/verify`, {
+      signingAlgorithm,
+      isDigest,
+      data,
+      signature: corruptedSignature
+    });
+    expect(corrupted.statusCode).toBe(200);
+    expect(JSON.parse(corrupted.payload)).toMatchObject({ signatureValid: false, signingAlgorithm });
+  });
+});

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -4120,6 +4120,7 @@ interface CmekSignEvent {
   metadata: {
     keyId: string;
     signingAlgorithm: SigningAlgorithm;
+    isDigest: boolean;
     signature: string;
   };
 }
@@ -4129,6 +4130,7 @@ interface CmekVerifyEvent {
   metadata: {
     keyId: string;
     signingAlgorithm: SigningAlgorithm;
+    isDigest: boolean;
     signature: string;
     signatureValid: boolean;
   };

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 import { THsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
 import { crypto } from "@app/lib/crypto/cryptography";
+import { initializeOpenSSLExtSupport } from "@app/lib/crypto/ed25519/openssl-ext";
 import { initializePqcSupport } from "@app/lib/crypto/pqc";
 import { QueueWorkerProfile } from "@app/lib/types";
 import { TKmsRootConfigDALFactory } from "@app/services/kms/kms-root-config-dal";
@@ -741,6 +742,7 @@ export const initEnvConfig = async (
     const fipsEnabled = await crypto.initialize(superAdminDAL, hsmService, kmsRootConfigDAL);
 
     await initializePqcSupport();
+    await initializeOpenSSLExtSupport();
 
     if (fipsEnabled) {
       const newEnvCfg = {

--- a/backend/src/lib/crypto/ed25519/ed25519.test.ts
+++ b/backend/src/lib/crypto/ed25519/ed25519.test.ts
@@ -1,0 +1,32 @@
+import { createHash } from "crypto";
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { AsymmetricKeyAlgorithm, SigningAlgorithm } from "../sign/types";
+import { signingService } from "../sign/signing";
+
+import { initializeOpenSSLExtSupport, isOpenSSLExtAvailable } from "./openssl-ext";
+
+describe("Ed25519ph signing", () => {
+  beforeAll(async () => {
+    await initializeOpenSSLExtSupport();
+  });
+
+  it("signs and verifies a SHA-512 prehash with a generated key pair", async ({ skip }) => {
+    if (!isOpenSSLExtAvailable()) skip();
+
+    const ed25519 = signingService(AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519);
+    const privateKey = await ed25519.generateAsymmetricPrivateKey();
+    const publicKey = await ed25519.getPublicKeyFromPrivateKey(privateKey);
+    const digest = createHash("sha512").update("Ed25519ph signing test").digest();
+
+    const signature = await ed25519.sign(digest, privateKey, SigningAlgorithm.ED25519_PH_SHA_512, true);
+
+    expect(signature).toBeInstanceOf(Buffer);
+    expect(signature).toHaveLength(64);
+
+    await expect(
+      ed25519.verify(digest, signature, publicKey, SigningAlgorithm.ED25519_PH_SHA_512, true)
+    ).resolves.toBe(true);
+  });
+});

--- a/backend/src/lib/crypto/ed25519/openssl-ext.ts
+++ b/backend/src/lib/crypto/ed25519/openssl-ext.ts
@@ -1,0 +1,48 @@
+import { spawn } from "child_process";
+
+import { logger } from "@app/lib/logger";
+
+const DEFAULT_BIN_PATH = "/opt/openssl-ext";
+
+let resolvedBinPath: string | null = null;
+let available = false;
+
+export const getOpenSSLExtBinPath = (): string => {
+  if (!resolvedBinPath) {
+    resolvedBinPath = process.env.OPENSSL_EXT_BIN_PATH || DEFAULT_BIN_PATH;
+  }
+  return resolvedBinPath;
+};
+
+const execOpenSSLExt = (args: string[]): Promise<{ stderr: string; code: number }> =>
+  new Promise((resolve, reject) => {
+    const proc = spawn(getOpenSSLExtBinPath(), args, { stdio: ["ignore", "ignore", "pipe"] });
+    const stderrChunks: Buffer[] = [];
+
+    proc.stderr.on("data", (chunk: Buffer) => stderrChunks.push(chunk));
+    proc.on("error", (err) => {
+      reject(new Error(`Failed to spawn OpenSSL extension at '${getOpenSSLExtBinPath()}': ${err.message}`));
+    });
+    proc.on("close", (code) => {
+      resolve({ stderr: Buffer.concat(stderrChunks).toString(), code: code ?? 1 });
+    });
+  });
+
+/** Checks the binary and the OpenSSL Ed25519ph provider implementation at startup. */
+export const initializeOpenSSLExtSupport = async (): Promise<void> => {
+  try {
+    const result = await execOpenSSLExt(["-check"]);
+    available = result.code === 0;
+
+    if (available) {
+      logger?.info("OpenSSL extension detected: Ed25519ph signing is available.");
+    } else {
+      logger?.warn("OpenSSL extension is unavailable. Ed25519ph signing will be disabled.");
+    }
+  } catch {
+    available = false;
+    logger?.warn("OpenSSL extension binary is unavailable. Ed25519ph signing will be disabled.");
+  }
+};
+
+export const isOpenSSLExtAvailable = (): boolean => available;

--- a/backend/src/lib/crypto/sign/signing.ts
+++ b/backend/src/lib/crypto/sign/signing.ts
@@ -138,6 +138,7 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
           message: `KMS ${algorithm} key can only be used with ${algorithm} signing algorithm`
         });
       }
+      return true
     }
 
     if (!((isED25519Key && isED25519Algorithm) || (isRsaKey && isRsaAlgorithm) || (isEccKey && isEccAlgorithm))) {

--- a/backend/src/lib/crypto/sign/signing.ts
+++ b/backend/src/lib/crypto/sign/signing.ts
@@ -9,6 +9,7 @@ import { BadRequestError } from "@app/lib/errors";
 import { cleanTemporaryDirectory, createTemporaryDirectory, writeToTemporaryFile } from "@app/lib/files";
 import { logger } from "@app/lib/logger";
 
+import { getOpenSSLExtBinPath, isOpenSSLExtAvailable } from "../ed25519/openssl-ext";
 import { AsymmetricKeyAlgorithm, SigningAlgorithm, TAsymmetricSignVerifyFns } from "./types";
 
 export const isPqcKeyAlgorithm = (algo: string): boolean => algo.startsWith("ML_DSA");
@@ -28,6 +29,7 @@ enum SupportedHashAlgorithm {
 }
 
 const COMMAND_TIMEOUT = 15_000;
+const OPENSSL_EXT_BIN_PATH = getOpenSSLExtBinPath();
 
 const SHA256_DIGEST_LENGTH = 32;
 const SHA384_DIGEST_LENGTH = 48;
@@ -84,13 +86,20 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
           hashAlgorithm: SupportedHashAlgorithm.SHA256,
           padding: crypto.nativeCrypto.constants.RSA_PKCS1_PADDING
         };
-
       // ECDSA
       case SigningAlgorithm.ECDSA_SHA_256:
         return { hashAlgorithm: SupportedHashAlgorithm.SHA256 };
       case SigningAlgorithm.ECDSA_SHA_384:
         return { hashAlgorithm: SupportedHashAlgorithm.SHA384 };
       case SigningAlgorithm.ECDSA_SHA_512:
+        return { hashAlgorithm: SupportedHashAlgorithm.SHA512 };
+
+      case SigningAlgorithm.ED25519_SHA_512:
+        // no-op , algorithm defaults to sha512
+        return { hashAlgorithm: SupportedHashAlgorithm.SHA512 };
+
+      case SigningAlgorithm.ED25519_PH_SHA_512:
+        // no-op , algorithm defaults to sha512
         return { hashAlgorithm: SupportedHashAlgorithm.SHA512 };
 
       default:
@@ -114,20 +123,14 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
 
   const $validateAlgorithmWithKeyType = (signingAlgorithm: SigningAlgorithm) => {
     const isRsaKey = algorithm.startsWith("RSA");
-    const isEccKey = algorithm.startsWith("ECC");
+    const isEccKey = algorithm.startsWith("ECC_NIST_P");
     const isPqcKey = isPqcKeyAlgorithm(algorithm);
+    const isED25519Key = algorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519;
 
     const isRsaAlgorithm = signingAlgorithm.startsWith("RSASSA");
     const isEccAlgorithm = signingAlgorithm.startsWith("ECDSA");
     const isPqcAlgorithm = isPqcKeyAlgorithm(signingAlgorithm);
-
-    if (isRsaKey && !isRsaAlgorithm) {
-      throw new BadRequestError({ message: `KMS RSA key cannot be used with ${signingAlgorithm}` });
-    }
-
-    if (isEccKey && !isEccAlgorithm) {
-      throw new BadRequestError({ message: `KMS ECC key cannot be used with ${signingAlgorithm}` });
-    }
+    const isED25519Algorithm = signingAlgorithm.startsWith("ED25519");
 
     if (isPqcKey) {
       if (!isPqcAlgorithm || (signingAlgorithm as string) !== (algorithm as string)) {
@@ -135,6 +138,74 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
           message: `KMS ${algorithm} key can only be used with ${algorithm} signing algorithm`
         });
       }
+    }
+
+    if (!((isED25519Key && isED25519Algorithm) || (isRsaKey && isRsaAlgorithm) || (isEccKey && isEccAlgorithm))) {
+      throw new BadRequestError({ message: `KMS ${algorithm} key cannot be used with ${signingAlgorithm}` });
+    }
+  };
+
+  const $signED25519Digest = async (
+    digest: Buffer,
+    privateKey: Buffer,
+    _: SupportedHashAlgorithm,
+    signingAlgorithm: SigningAlgorithm
+  ) => {
+    if (!isOpenSSLExtAvailable()) {
+      throw new BadRequestError({
+        message: "ED25519_PH_SHA_512 is unavailable because the OpenSSL extension is not installed or unsupported"
+      });
+    }
+    const tempDir = await createTemporaryDirectory("ed25519-sign");
+    const digestPath = path.join(tempDir, "digest.bin");
+    const keyPath = path.join(tempDir, "key.pem");
+    const sigPath = path.join(tempDir, "signature.bin");
+
+    try {
+      if (digest.length !== SHA512_DIGEST_LENGTH) {
+        throw new BadRequestError({
+          message: `${signingAlgorithm} requires a SHA-512 digest`
+        });
+      }
+
+      await writeToTemporaryFile(digestPath, digest);
+      await writeToTemporaryFile(keyPath, privateKey);
+
+      const { stderr } = await execFileAsync(
+        OPENSSL_EXT_BIN_PATH,
+        ["-sign", "-inkey", keyPath, "-in", digestPath, "-out", sigPath, "-pkeyopt", "digest:Ed25519ph"],
+        {
+          maxBuffer: 10 * 1024 * 1024,
+          timeout: COMMAND_TIMEOUT
+        }
+      );
+
+      if (stderr) {
+        logger.error(stderr, "KMS: Failed to sign Ed25519 digest");
+        throw new BadRequestError({
+          message: "Failed to sign Ed25519 digest due to signing error"
+        });
+      }
+
+      const signature = await fs.readFile(sigPath);
+
+      if (signature.length === 0) {
+        throw new BadRequestError({
+          message: "No signature was created. Ensure that the input is a SHA-512 digest."
+        });
+      }
+
+      return signature;
+    } catch (err) {
+      if (err instanceof BadRequestError) {
+        throw err;
+      }
+      logger.error(err, "KMS: Failed to sign Ed25519ph digest");
+      throw new BadRequestError({
+        message: `Failed to sign Ed25519ph digest with ${signingAlgorithm} due to signing error. Ensure that your digest is hashed with SHA-512.`
+      });
+    } finally {
+      await cleanTemporaryDirectory(tempDir);
     }
   };
 
@@ -261,6 +332,62 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     }
   };
 
+  const $verifyED25519Digest = async (
+    digest: Buffer,
+    signature: Buffer,
+    publicKey: Buffer,
+    hashAlgorithm: SupportedHashAlgorithm
+  ): Promise<boolean> => {
+    if (hashAlgorithm !== SupportedHashAlgorithm.SHA512 || digest.length !== SHA512_DIGEST_LENGTH) {
+      throw new BadRequestError({ message: "ED25519_PH_SHA_512 requires a SHA-512 digest" });
+    }
+
+    if (!isOpenSSLExtAvailable()) {
+      throw new BadRequestError({
+        message: "ED25519_PH_SHA_512 is unavailable because the OpenSSL extension is not installed or unsupported"
+      });
+    }
+
+    const tempDir = await createTemporaryDirectory("ed25519-signature-verification");
+    const publicKeyPath = path.join(tempDir, "public-key.der");
+    const signaturePath = path.join(tempDir, "signature.bin");
+    const digestPath = path.join(tempDir, "digest.bin");
+
+    try {
+      await Promise.all([
+        writeToTemporaryFile(publicKeyPath, publicKey),
+        writeToTemporaryFile(signaturePath, signature),
+        writeToTemporaryFile(digestPath, digest)
+      ]);
+
+      await execFileAsync(
+        OPENSSL_EXT_BIN_PATH,
+        [
+          "-verify",
+          "-inkey",
+          publicKeyPath,
+          "-in",
+          digestPath,
+          "-sigfile",
+          signaturePath,
+          "-pkeyopt",
+          "digest:Ed25519ph"
+        ],
+        { maxBuffer: 10 * 1024 * 1024, timeout: COMMAND_TIMEOUT }
+      );
+
+      return true;
+    } catch (error) {
+      const err = error as { stderr?: string };
+      if (!err.stderr?.toLowerCase().includes("signature verification failure")) {
+        logger.error(error, "KMS: Failed to verify Ed25519ph signature");
+      }
+      return false;
+    } finally {
+      await cleanTemporaryDirectory(tempDir);
+    }
+  };
+
   const $verifyEccDigest = async (
     digest: Buffer,
     signature: Buffer,
@@ -371,7 +498,8 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     [AsymmetricKeyAlgorithm.ECC_NIST_P256]: $verifyEccDigest,
     [AsymmetricKeyAlgorithm.ECC_NIST_P384]: $verifyEccDigest,
     [AsymmetricKeyAlgorithm.ECC_NIST_P521]: $verifyEccDigest,
-    [AsymmetricKeyAlgorithm.RSA_4096]: $verifyRsaDigest
+    [AsymmetricKeyAlgorithm.RSA_4096]: $verifyRsaDigest,
+    [AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519]: $verifyED25519Digest
   };
 
   const signDigestFunctionsMap: Partial<
@@ -388,7 +516,8 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     [AsymmetricKeyAlgorithm.ECC_NIST_P256]: $signEccDigest,
     [AsymmetricKeyAlgorithm.ECC_NIST_P384]: $signEccDigest,
     [AsymmetricKeyAlgorithm.ECC_NIST_P521]: $signEccDigest,
-    [AsymmetricKeyAlgorithm.RSA_4096]: $signRsaDigest
+    [AsymmetricKeyAlgorithm.RSA_4096]: $signRsaDigest,
+    [AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519]: $signED25519Digest
   };
 
   const sign = async (
@@ -408,6 +537,14 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     }
 
     const { hashAlgorithm, padding, saltLength } = $getSigningParams(signingAlgorithm);
+
+    if (signingAlgorithm === SigningAlgorithm.ED25519_PH_SHA_512) {
+      if (!isDigest) {
+        throw new BadRequestError({
+          message: `${signingAlgorithm} requires digested input`
+        });
+      }
+    }
 
     if (isDigest) {
       if (signingAlgorithm.startsWith("RSASSA_PSS")) {
@@ -454,6 +591,10 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
         dsaEncoding: "der"
       });
     }
+    if (signingAlgorithm === SigningAlgorithm.ED25519_SHA_512) {
+      return crypto.nativeCrypto.sign(null, data, privateKeyObject);
+    }
+
     throw new BadRequestError({
       message: `Signing algorithm ${signingAlgorithm} not implemented`
     });
@@ -466,16 +607,23 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     signingAlgorithm: SigningAlgorithm,
     isDigest: boolean
   ): Promise<boolean> => {
-    if (isPqcKeyAlgorithm(algorithm)) {
-      $validateAlgorithmWithKeyType(signingAlgorithm);
-      if (isDigest) {
-        throw new BadRequestError({ message: "ML-DSA does not support digested input" });
-      }
-      return opensslVerify(publicKey, signature, data);
-    }
-
     try {
       $validateAlgorithmWithKeyType(signingAlgorithm);
+
+      if (isPqcKeyAlgorithm(algorithm)) {
+        if (isDigest) {
+          throw new BadRequestError({ message: "ML-DSA does not support digested input" });
+        }
+        return await opensslVerify(publicKey, signature, data);
+      }
+
+      if (signingAlgorithm === SigningAlgorithm.ED25519_PH_SHA_512) {
+        if (!isDigest) {
+          throw new BadRequestError({
+            message: `${signingAlgorithm} requires digested input`
+          });
+        }
+      }
 
       const { hashAlgorithm, padding, saltLength } = $getSigningParams(signingAlgorithm);
 
@@ -531,6 +679,10 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
           signature
         );
       }
+      if (signingAlgorithm === SigningAlgorithm.ED25519_SHA_512) {
+        return crypto.nativeCrypto.verify(null, data, publicKeyObject, signature);
+      }
+
       throw new BadRequestError({
         message: `Verification for algorithm ${signingAlgorithm} not implemented`
       });
@@ -553,42 +705,29 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
     }
 
     const { privateKey } = await new Promise<{ privateKey: string }>((resolve, reject) => {
+      const keyEncoding = {
+        publicKeyEncoding: { type: "spki" as const, format: "pem" as const },
+        privateKeyEncoding: { type: "pkcs8" as const, format: "pem" as const }
+      };
+      const handleKeyPair = (err: Error | null, _: string, privateKeyPem: string) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ privateKey: privateKeyPem });
+        }
+      };
+
       if (algorithm.startsWith("RSA")) {
         crypto.nativeCrypto.generateKeyPair(
           "rsa",
-          {
-            modulusLength: Number(algorithm.split("_")[1]),
-            publicKeyEncoding: { type: "spki", format: "pem" },
-            privateKeyEncoding: { type: "pkcs8", format: "pem" }
-          },
-          (err, _, pk) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve({ privateKey: pk });
-            }
-          }
+          { ...keyEncoding, modulusLength: Number(algorithm.split("_")[1]) },
+          handleKeyPair
         );
+      } else if (algorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519) {
+        crypto.nativeCrypto.generateKeyPair("ed25519", keyEncoding, handleKeyPair);
       } else {
         const { full: namedCurve } = $getEcCurveName(algorithm);
-
-        crypto.nativeCrypto.generateKeyPair(
-          "ec",
-          {
-            namedCurve,
-            publicKeyEncoding: { type: "spki", format: "pem" },
-            privateKeyEncoding: { type: "pkcs8", format: "pem" }
-          },
-          (err, _, pk) => {
-            if (err) {
-              reject(err);
-            } else {
-              resolve({
-                privateKey: pk
-              });
-            }
-          }
-        );
+        crypto.nativeCrypto.generateKeyPair("ec", { ...keyEncoding, namedCurve }, handleKeyPair);
       }
     });
 

--- a/backend/src/lib/crypto/sign/signing.ts
+++ b/backend/src/lib/crypto/sign/signing.ts
@@ -546,6 +546,12 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
       }
     }
 
+    if (signingAlgorithm === SigningAlgorithm.ED25519_SHA_512 && isDigest) {
+      throw new BadRequestError({
+        message: `${signingAlgorithm} does not support digested input; use ${SigningAlgorithm.ED25519_PH_SHA_512}`
+      });
+    }
+
     if (isDigest) {
       if (signingAlgorithm.startsWith("RSASSA_PSS")) {
         throw new BadRequestError({
@@ -623,6 +629,12 @@ export const signingService = (algorithm: AsymmetricKeyAlgorithm): TAsymmetricSi
             message: `${signingAlgorithm} requires digested input`
           });
         }
+      }
+
+      if (signingAlgorithm === SigningAlgorithm.ED25519_SHA_512 && isDigest) {
+        throw new BadRequestError({
+          message: `${signingAlgorithm} does not support digested input; use ${SigningAlgorithm.ED25519_PH_SHA_512}`
+        });
       }
 
       const { hashAlgorithm, padding, saltLength } = $getSigningParams(signingAlgorithm);

--- a/backend/src/lib/crypto/sign/types.ts
+++ b/backend/src/lib/crypto/sign/types.ts
@@ -19,6 +19,7 @@ export enum AsymmetricKeyAlgorithm {
   ECC_NIST_P256 = "ECC_NIST_P256",
   ECC_NIST_P384 = "ECC_NIST_P384",
   ECC_NIST_P521 = "ECC_NIST_P521",
+  ECC_NIST_EDWARDS25519 = "ECC_NIST_ED25519",
   ML_DSA_44 = "ML_DSA_44",
   ML_DSA_65 = "ML_DSA_65",
   ML_DSA_87 = "ML_DSA_87"
@@ -51,5 +52,8 @@ export enum SigningAlgorithm {
   // ML-DSA (post-quantum) — signing algorithm equals key algorithm, no hash variant
   ML_DSA_44 = "ML_DSA_44",
   ML_DSA_65 = "ML_DSA_65",
-  ML_DSA_87 = "ML_DSA_87"
+  ML_DSA_87 = "ML_DSA_87",
+
+  ED25519_SHA_512 = "ED25519_SHA_512",
+  ED25519_PH_SHA_512 = "ED25519_PH_SHA_512"
 }

--- a/backend/src/lib/openssl-ext/ed25519ph.c
+++ b/backend/src/lib/openssl-ext/ed25519ph.c
@@ -1,0 +1,88 @@
+#include "ed25519ph.h"
+
+int ed25519ph_is_available(void)
+{
+    EVP_SIGNATURE *algorithm = EVP_SIGNATURE_fetch(NULL, "Ed25519ph", NULL);
+    if (!algorithm) return 0;
+
+    EVP_SIGNATURE_free(algorithm);
+    return 1;
+}
+
+int ed25519ph_sign(
+    EVP_PKEY *key,
+    const unsigned char *input,
+    size_t input_len,
+    unsigned char **signature,
+    size_t *signature_len
+)
+{
+    if (!signature || !signature_len) return 0;
+    *signature = NULL;
+    *signature_len = 0;
+
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
+    if (!ctx) return 0;
+
+    EVP_SIGNATURE *algorithm = EVP_SIGNATURE_fetch(NULL, "Ed25519ph", NULL);
+    if (!algorithm) {
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    if (EVP_PKEY_sign_init_ex2(ctx, algorithm, NULL) <= 0 ||
+        EVP_PKEY_sign(ctx, NULL, signature_len, input, input_len) <= 0) {
+        EVP_SIGNATURE_free(algorithm);
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    EVP_SIGNATURE_free(algorithm);
+
+    *signature = OPENSSL_malloc(*signature_len);
+    if (!*signature) {
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    int ok = EVP_PKEY_sign(ctx, *signature, signature_len, input, input_len);
+    EVP_PKEY_CTX_free(ctx);
+
+    if (ok <= 0) {
+        OPENSSL_free(*signature);
+        *signature = NULL;
+        return 0;
+    }
+
+    return 1;
+}
+
+int ed25519ph_verify(
+    EVP_PKEY *key,
+    const unsigned char *input,
+    size_t input_len,
+    const unsigned char *signature,
+    size_t signature_len
+)
+{
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_from_pkey(NULL, key, NULL);
+    if (!ctx) return -1;
+
+    EVP_SIGNATURE *algorithm = EVP_SIGNATURE_fetch(NULL, "Ed25519ph", NULL);
+    if (!algorithm) {
+        EVP_PKEY_CTX_free(ctx);
+        return -1;
+    }
+
+    if (EVP_PKEY_verify_init_ex2(ctx, algorithm, NULL) <= 0) {
+        EVP_SIGNATURE_free(algorithm);
+        EVP_PKEY_CTX_free(ctx);
+        return -1;
+    }
+
+    EVP_SIGNATURE_free(algorithm);
+
+    int result = EVP_PKEY_verify(ctx, signature, signature_len, input, input_len);
+    EVP_PKEY_CTX_free(ctx);
+    return result;
+}

--- a/backend/src/lib/openssl-ext/ed25519ph.h
+++ b/backend/src/lib/openssl-ext/ed25519ph.h
@@ -1,0 +1,26 @@
+#ifndef OPENSSL_EXT_ED25519PH_H
+#define OPENSSL_EXT_ED25519PH_H
+
+#include <openssl/evp.h>
+
+#include <stddef.h>
+
+int ed25519ph_is_available(void);
+
+int ed25519ph_sign(
+    EVP_PKEY *key,
+    const unsigned char *input,
+    size_t input_len,
+    unsigned char **signature,
+    size_t *signature_len
+);
+
+int ed25519ph_verify(
+    EVP_PKEY *key,
+    const unsigned char *input,
+    size_t input_len,
+    const unsigned char *signature,
+    size_t signature_len
+);
+
+#endif

--- a/backend/src/lib/openssl-ext/main.c
+++ b/backend/src/lib/openssl-ext/main.c
@@ -1,0 +1,137 @@
+#include "ed25519ph.h"
+
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * The CLI accepts only pre-hashed Ed25519ph input. Both operations require:
+ *   -pkeyopt digest:Ed25519ph
+ */
+
+static unsigned char *read_file(const char *path, size_t *len)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+
+    if (fseek(f, 0, SEEK_END) != 0) {
+        fclose(f);
+        return NULL;
+    }
+
+    long size = ftell(f);
+    if (size < 0 || fseek(f, 0, SEEK_SET) != 0) {
+        fclose(f);
+        return NULL;
+    }
+
+    unsigned char *buf = OPENSSL_malloc(size > 0 ? (size_t)size : 1);
+    if (!buf) {
+        fclose(f);
+        return NULL;
+    }
+
+    size_t bytes_read = fread(buf, 1, (size_t)size, f);
+    if (bytes_read != (size_t)size || ferror(f)) {
+        OPENSSL_free(buf);
+        fclose(f);
+        return NULL;
+    }
+
+    *len = bytes_read;
+    fclose(f);
+    return buf;
+}
+
+static int write_file(const char *path, const unsigned char *buf, size_t len)
+{
+    FILE *f = fopen(path, "wb");
+    if (!f) return 0;
+
+    size_t written = fwrite(buf, 1, len, f);
+    int close_result = fclose(f);
+    return written == len && close_result == 0;
+}
+
+static EVP_PKEY *load_key(const char *path, int public_key)
+{
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+
+    EVP_PKEY *key;
+    if (public_key) {
+        key = PEM_read_PUBKEY(f, NULL, NULL, NULL);
+        if (!key) {
+            ERR_clear_error();
+            rewind(f);
+            key = d2i_PUBKEY_fp(f, NULL);
+        }
+    } else {
+        key = PEM_read_PrivateKey(f, NULL, NULL, NULL);
+    }
+    fclose(f);
+    return key;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc == 2 && strcmp(argv[1], "-check") == 0) {
+        return ed25519ph_is_available() ? 0 : 1;
+    }
+
+    if (argc != 10 ||
+        (strcmp(argv[1], "-sign") != 0 && strcmp(argv[1], "-verify") != 0) ||
+        strcmp(argv[2], "-inkey") != 0 || strcmp(argv[4], "-in") != 0 ||
+        (strcmp(argv[1], "-sign") == 0 ? strcmp(argv[6], "-out") : strcmp(argv[6], "-sigfile")) != 0 ||
+        strcmp(argv[8], "-pkeyopt") != 0 || strcmp(argv[9], "digest:Ed25519ph") != 0) {
+        return 1;
+    }
+
+    int signing = strcmp(argv[1], "-sign") == 0;
+    EVP_PKEY *key = load_key(argv[3], !signing);
+    if (!key) {
+        ERR_print_errors_fp(stderr);
+        return 1;
+    }
+
+    size_t input_len = 0;
+    unsigned char *input = read_file(argv[5], &input_len);
+    if (!input) {
+        EVP_PKEY_free(key);
+        return 1;
+    }
+    if (input_len != 64) {
+        OPENSSL_free(input);
+        EVP_PKEY_free(key);
+        return 1;
+    }
+
+    int exit_code = 1;
+    if (signing) {
+        unsigned char *signature = NULL;
+        size_t signature_len = 0;
+        if (ed25519ph_sign(key, input, input_len, &signature, &signature_len)) {
+            exit_code = write_file(argv[7], signature, signature_len) ? 0 : 1;
+        } else {
+            ERR_print_errors_fp(stderr);
+        }
+        OPENSSL_free(signature);
+    } else {
+        size_t signature_len = 0;
+        unsigned char *signature = read_file(argv[7], &signature_len);
+        if (signature && signature_len == 64) {
+            int result = ed25519ph_verify(key, input, input_len, signature, signature_len);
+            printf(result == 1 ? "Signature Verified Successfully\n" : "Signature Verification Failure\n");
+            exit_code = result == 1 ? 0 : 1;
+        }
+        OPENSSL_free(signature);
+    }
+
+    OPENSSL_free(input);
+    EVP_PKEY_free(key);
+    return exit_code;
+}

--- a/backend/src/server/routes/v1/cmek-router.ts
+++ b/backend/src/server/routes/v1/cmek-router.ts
@@ -900,6 +900,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
           metadata: {
             keyId: inputKeyId,
             signingAlgorithm,
+            isDigest,
             signature: result.signature
           }
         }
@@ -959,6 +960,7 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
             keyId,
             signatureValid: result.signatureValid,
             signingAlgorithm,
+            isDigest,
             signature
           }
         }

--- a/backend/src/services/cmek/cmek-service.ts
+++ b/backend/src/services/cmek/cmek-service.ts
@@ -4,6 +4,7 @@ import { ActionProjectType } from "@app/db/schemas";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ProjectPermissionCmekActions, ProjectPermissionSub } from "@app/ee/services/permission/project-permission";
+import { isOpenSSLExtAvailable } from "@app/lib/crypto/ed25519/openssl-ext";
 import { AsymmetricKeyAlgorithm, isPqcKeyAlgorithm, SigningAlgorithm, signingService } from "@app/lib/crypto/sign";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
@@ -298,7 +299,11 @@ export const cmekServiceFactory = ({
 
     if (encryptionAlgorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519) {
       return {
-        signingAlgorithms: Object.values(SigningAlgorithm).filter((a) => a.toLowerCase().startsWith("ed25519")),
+        signingAlgorithms: Object.values(SigningAlgorithm).filter(
+          (signingAlgorithm) =>
+            signingAlgorithm.toLowerCase().startsWith("ed25519") &&
+            (signingAlgorithm !== SigningAlgorithm.ED25519_PH_SHA_512 || isOpenSSLExtAvailable())
+        ),
         projectId: key.projectId
       };
     }

--- a/backend/src/services/cmek/cmek-service.ts
+++ b/backend/src/services/cmek/cmek-service.ts
@@ -296,6 +296,13 @@ export const cmekServiceFactory = ({
       return { signingAlgorithms: [encryptionAlgorithm as unknown as SigningAlgorithm], projectId: key.projectId };
     }
 
+    if (encryptionAlgorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519) {
+      return {
+        signingAlgorithms: Object.values(SigningAlgorithm).filter((a) => a.toLowerCase().startsWith("ed25519")),
+        projectId: key.projectId
+      };
+    }
+
     const algos = [
       {
         keyAlgorithm: "rsa",

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -661,6 +661,12 @@ export const kmsServiceFactory = ({
               message: `Key material does not match the declared algorithm. Expected an EC P-256 key.`
             });
           }
+        } else if (algorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519) {
+          if (keyType !== "ed25519") {
+            throw new BadRequestError({
+              message: `Key material does not match the declared algorithm. Expected an EC ed25519 key.`
+            });
+          }
         }
       }
     }

--- a/backend/src/services/signer/signer-service.ts
+++ b/backend/src/services/signer/signer-service.ts
@@ -203,20 +203,32 @@ const getKeyAlgorithmFamily = (key: KeyObject): AsymmetricKeyAlgorithm => {
         });
     }
   }
+  if (keyType === "ed25519") {
+    return AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519;
+  }
   throw new BadRequestError({ message: `Unsupported key type: ${keyType}` });
 };
 
 const validateSigningAlgorithmForKey = (signingAlgorithm: SigningAlgorithm, keyAlgorithm: AsymmetricKeyAlgorithm) => {
   const isRsaKey = keyAlgorithm.startsWith("RSA");
+  const isECCKey = keyAlgorithm.startsWith("ECC_NIST_P");
+  const isEd25519Key = keyAlgorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519;
+
   const isRsaAlgorithm = signingAlgorithm.startsWith("RSASSA");
   const isEccAlgorithm = signingAlgorithm.startsWith("ECDSA");
+  const isEd25519Algorithm = signingAlgorithm.startsWith("ED25519");
 
   if (isRsaKey && !isRsaAlgorithm) {
     throw new BadRequestError({
       message: `RSA key cannot be used with signing algorithm ${signingAlgorithm}`
     });
   }
-  if (!isRsaKey && !isEccAlgorithm) {
+  if (isEd25519Key && !isEd25519Algorithm) {
+    throw new BadRequestError({
+      message: `ED25519 key cannot be used with signing algorithm ${signingAlgorithm}`
+    });
+  }
+  if (isECCKey && !isEccAlgorithm) {
     throw new BadRequestError({
       message: `ECC key cannot be used with signing algorithm ${signingAlgorithm}`
     });

--- a/backend/tsup.config.js
+++ b/backend/tsup.config.js
@@ -30,7 +30,7 @@ export default defineConfig({
   external: ["../../../frontend/node_modules/next/dist/server/next-server.js"],
   outDir: "dist",
   tsconfig: "./tsconfig.json",
-  entry: ["./src", "!./src/**/*.dev.ts"],
+  entry: ["./src", "!./src/**/*.dev.ts", "!./src/**/*.c", "!./src/**/*.h"],
   sourceMap: true,
   skipNodeModulesBundle: true,
   // ts-node/register is only needed when running TS files directly (knex CLI in dev).

--- a/docs/documentation/platform/kms/overview.mdx
+++ b/docs/documentation/platform/kms/overview.mdx
@@ -243,6 +243,10 @@ In the following steps, we explore how to generate a key and use it to sign data
                - `ECDSA SHA 384`: Not deterministic, and includes randomness.
                - `ECDSA SHA 256`: Not deterministic, and includes randomness.
 
+               **For Ed25519 keys (`ECC_NIST_ED25519`):**
+               - `ED25519_SHA_512`
+               - `ED25519_PH_SHA_512`: Ed25519ph. Requires `isDigest: true` and a 64-byte SHA-512 digest.
+
                **For ML-DSA keys (post-quantum):**
                - `ML_DSA_44`: The signing algorithm is the same as the key algorithm.
                - `ML_DSA_65`: The signing algorithm is the same as the key algorithm.
@@ -600,6 +604,7 @@ The exported file is a JSON array where each entry is one of the following shape
     **Signing and verification:**
     - `RSA_4096`
     - `ECC_NIST_P256`
+    - `ECC_NIST_ED25519`
     - `ML_DSA_44` (post-quantum)
     - `ML_DSA_65` (post-quantum)
     - `ML_DSA_87` (post-quantum)
@@ -678,7 +683,7 @@ The exported file is a JSON array where each entry is one of the following shape
     ```
 
     <Note>
-      Please note that `RSA PSS` signing algorithms are not supported for digest signing and verification. Please use `RSA PKCS1 V1.5` signing algorithms for digest signing and verification, or `ECDSA` if you're using an ECC key. ML-DSA keys also do not support digest signing and verification, as ML-DSA handles hashing internally.
+      Please note that `RSA PSS` signing algorithms are not supported for digest signing and verification. Please use `RSA PKCS1 V1.5` signing algorithms for digest signing and verification, or `ECDSA` if you're using an ECC key. `ED25519_PH_SHA_512` is supported only for digest signing and verification, and requires a 64-byte SHA-512 digest. ML-DSA keys also do not support digest signing and verification, as ML-DSA handles hashing internally.
     </Note>
   </Accordion>
 </AccordionGroup>

--- a/docs/sdks/languages/go.mdx
+++ b/docs/sdks/languages/go.mdx
@@ -1368,6 +1368,10 @@ res, err := client.Kms().Signing().SignData(infisical.KmsSignDataOptions{
       - `ECDSA_SHA_512`
       - `ECDSA_SHA_384`
       - `ECDSA_SHA_256`
+
+      Valid options for `ECC_NIST_ED25519` keys are:
+      - `ED25519_SHA_512`
+      - `ED25519_PH_SHA_512` (requires `IsDigest: true` and a 64-byte SHA-512 digest)
     </ParamField>
 
   </Expandable>

--- a/docs/sdks/languages/node.mdx
+++ b/docs/sdks/languages/node.mdx
@@ -620,7 +620,7 @@ console.log(signingKey);
 - `keyUsage` (KeyUsage): Either `KeyUsage.ENCRYPTION` for encrypt/decrypt operations or `KeyUsage.SIGNING` for sign/verify operations.
 - `encryptionAlgorithm` (EncryptionAlgorithm): The algorithm to use. Options include:
   - For encryption: `AES_256_GCM`, `AES_128_GCM`, `RSA_4096`, `ECC_NIST_P256`
-  - For signing: `RSA_4096`, `ECC_NIST_P256`
+  - For signing: `RSA_4096`, `ECC_NIST_P256`, `ECC_NIST_ED25519`
 
 **Returns:**
 - `KmsKey`: The created KMS key object.
@@ -725,6 +725,8 @@ console.log(signature);
   - **RSA PSS** (non-deterministic): `RSASSA_PSS_SHA_256`, `RSASSA_PSS_SHA_384`, `RSASSA_PSS_SHA_512`
   - **RSA PKCS#1 v1.5** (deterministic): `RSASSA_PKCS1_V1_5_SHA_256`, `RSASSA_PKCS1_V1_5_SHA_384`, `RSASSA_PKCS1_V1_5_SHA_512`
   - **ECDSA** (non-deterministic): `ECDSA_SHA_256`, `ECDSA_SHA_384`, `ECDSA_SHA_512`
+  - **Ed25519** (`ECC_NIST_ED25519`): `ED25519_SHA_512`, `ED25519_PH_SHA_512`
+- `ED25519_PH_SHA_512` requires `isDigest: true` and a 64-byte SHA-512 digest.
 - `isDigest` (boolean, optional): Whether the data is already a hash digest. Defaults to `false`.
 
 **Returns:**

--- a/frontend/src/helpers/kms.ts
+++ b/frontend/src/helpers/kms.ts
@@ -46,5 +46,8 @@ export const getDefaultSigningAlgorithm = (cmek: TCmek): SigningAlgorithm => {
   if (cmek?.algorithm?.startsWith("RSA")) {
     return SigningAlgorithm.RSASSA_PSS_SHA_512;
   }
+  if (cmek?.algorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519) {
+    return SigningAlgorithm.ED25519_SHA_512;
+  }
   return SigningAlgorithm.ECDSA_SHA_256;
 };

--- a/frontend/src/hooks/api/cmeks/mutations.tsx
+++ b/frontend/src/hooks/api/cmeks/mutations.tsx
@@ -107,11 +107,13 @@ export const useCmekSign = () => {
       keyId,
       data,
       signingAlgorithm,
-      isBase64Encoded
+      isBase64Encoded,
+      isDigest = false,
     }: TCmekSign & { isBase64Encoded: boolean }) => {
       const res = await apiRequest.post<TCmekSignResponse>(`/api/v1/kms/keys/${keyId}/sign`, {
         data: isBase64Encoded ? data : encodeBase64(Buffer.from(data)),
-        signingAlgorithm
+        signingAlgorithm,
+        isDigest,
       });
 
       return res.data;
@@ -126,12 +128,14 @@ export const useCmekVerify = () => {
       data,
       signature,
       signingAlgorithm,
-      isBase64Encoded
+      isBase64Encoded,
+      isDigest,
     }: TCmekVerify & { isBase64Encoded: boolean }) => {
       const res = await apiRequest.post<TCmekVerifyResponse>(`/api/v1/kms/keys/${keyId}/verify`, {
         data: isBase64Encoded ? data : encodeBase64(Buffer.from(data)),
         signature,
-        signingAlgorithm
+        signingAlgorithm,
+        isDigest
       });
 
       return res.data;

--- a/frontend/src/hooks/api/cmeks/types.ts
+++ b/frontend/src/hooks/api/cmeks/types.ts
@@ -39,11 +39,12 @@ export type TRotateCmek = KeyRef & ProjectRef;
 export type TCmekEncrypt = KeyRef & { plaintext: string; isBase64Encoded?: boolean };
 export type TCmekDecrypt = KeyRef & { ciphertext: string };
 
-export type TCmekSign = KeyRef & { data: string; signingAlgorithm: SigningAlgorithm };
+export type TCmekSign = KeyRef & { data: string; signingAlgorithm: SigningAlgorithm , isDigest : boolean};
 export type TCmekVerify = KeyRef & {
   data: string;
   signature: string;
   signingAlgorithm: SigningAlgorithm;
+  isDigest: boolean;
 };
 
 export type TCmekGenerateMac = KeyRef & { data: string };

--- a/frontend/src/hooks/api/cmeks/types.ts
+++ b/frontend/src/hooks/api/cmeks/types.ts
@@ -152,7 +152,12 @@ export enum CmekOrderBy {
 
 export enum AsymmetricKeyAlgorithm {
   RSA_4096 = "RSA_4096",
+
   ECC_NIST_P256 = "ECC_NIST_P256",
+  ECC_NIST_P384 = "ECC_NIST_P384",
+  ECC_NIST_P521 = "ECC_NIST_P521",
+
+  ECC_NIST_EDWARDS25519 = "ECC_NIST_ED25519",
   ML_DSA_44 = "ML_DSA_44",
   ML_DSA_65 = "ML_DSA_65",
   ML_DSA_87 = "ML_DSA_87"
@@ -197,5 +202,8 @@ export enum SigningAlgorithm {
   // ML-DSA (post-quantum) — signing algorithm equals key algorithm
   ML_DSA_44 = "ML_DSA_44",
   ML_DSA_65 = "ML_DSA_65",
-  ML_DSA_87 = "ML_DSA_87"
+  ML_DSA_87 = "ML_DSA_87",
+
+  ED25519_SHA_512 = "ED25519_SHA_512",
+  ED25519_PH_SHA_512 = "ED25519_PH_SHA_512"
 }

--- a/frontend/src/hooks/api/signers/types.ts
+++ b/frontend/src/hooks/api/signers/types.ts
@@ -167,6 +167,8 @@ export const signingAlgorithmLabels: Record<SigningAlgorithm, string> = {
   [SigningAlgorithm.ECDSA_SHA_256]: "ECDSA (SHA-256)",
   [SigningAlgorithm.ECDSA_SHA_384]: "ECDSA (SHA-384)",
   [SigningAlgorithm.ECDSA_SHA_512]: "ECDSA (SHA-512)",
+  [SigningAlgorithm.ED25519_SHA_512]: "Ed25519 (SHA-512)",
+  [SigningAlgorithm.ED25519_PH_SHA_512]: "Ed25519ph (SHA-512)",
   [SigningAlgorithm.ML_DSA_44]: "ML-DSA-44",
   [SigningAlgorithm.ML_DSA_65]: "ML-DSA-65",
   [SigningAlgorithm.ML_DSA_87]: "ML-DSA-87"

--- a/frontend/src/pages/kms/OverviewPage/components/CmekSignModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekSignModal.tsx
@@ -20,6 +20,7 @@ import {
 import { getDefaultSigningAlgorithm } from "@app/helpers/kms";
 import { useTimedReset } from "@app/hooks";
 import { SigningAlgorithm, TCmek, useCmekSign } from "@app/hooks/api/cmeks";
+import { compatibleSigningAlgorithmsForKeyAlgorithm } from "./utils";
 
 const formSchema = z.object({
   data: z.string(),
@@ -72,12 +73,7 @@ const SignForm = ({ cmek }: FormProps) => {
 
     setCopySignature("Copied to Clipboard");
   };
-
-  const allowedSigningAlgorithms = Object.values(SigningAlgorithm).filter((a) => {
-    if (cmek?.algorithm?.startsWith("ML_DSA")) return (a as string) === (cmek.algorithm as string);
-    if (cmek?.algorithm?.startsWith("RSA")) return a.toLowerCase().startsWith("rsa");
-    return a.toLowerCase().startsWith("ecdsa");
-  });
+  const allowedSigningAlgorithms = compatibleSigningAlgorithmsForKeyAlgorithm(cmek?.algorithm);
 
   return (
     <form onSubmit={handleSubmit(handleSignData)}>

--- a/frontend/src/pages/kms/OverviewPage/components/CmekSignModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekSignModal.tsx
@@ -45,12 +45,13 @@ const SignForm = ({ cmek }: FormProps) => {
     handleSubmit,
     register,
     control,
+    setValue,
     formState: { isSubmitting, errors }
   } = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       signingAlgorithm: getDefaultSigningAlgorithm(cmek),
-      isBase64Encoded: false
+      isBase64Encoded: getDefaultSigningAlgorithm(cmek) === SigningAlgorithm.ED25519_PH_SHA_512
     }
   });
 
@@ -59,7 +60,11 @@ const SignForm = ({ cmek }: FormProps) => {
   });
 
   const handleSignData = async (formData: FormData) => {
-    await cmekSign.mutateAsync({ ...formData, keyId: cmek.id });
+    await cmekSign.mutateAsync({
+      ...formData,
+      keyId: cmek.id,
+      isDigest: formData.signingAlgorithm === SigningAlgorithm.ED25519_PH_SHA_512
+    });
     createNotification({
       text: "Successfully signed data",
       type: "success"
@@ -99,17 +104,26 @@ const SignForm = ({ cmek }: FormProps) => {
             <Controller
               control={control}
               name="signingAlgorithm"
-              render={({ field: { onChange, value } }) => (
-                <FormControl label="Signing Algorithm">
-                  <Select onValueChange={onChange} value={value} className="w-full">
-                    {allowedSigningAlgorithms.map((a) => (
-                      <SelectItem key={a} value={a}>
-                        {a.replaceAll("_", " ")}
-                      </SelectItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              )}
+              render={({ field: { onChange, value } }) => {
+                const handleAlgorithmChange = (algorithm: string) => {
+                  onChange(algorithm);
+                  if (algorithm === SigningAlgorithm.ED25519_PH_SHA_512) {
+                    setValue("isBase64Encoded", true);
+                  }
+                };
+
+                return (
+                  <FormControl label="Signing Algorithm">
+                    <Select onValueChange={handleAlgorithmChange} value={value} className="w-full">
+                      {allowedSigningAlgorithms.map((a) => (
+                        <SelectItem key={a} value={a}>
+                          {a.replaceAll("_", " ")}
+                        </SelectItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                );
+              }}
             />
 
             <Controller

--- a/frontend/src/pages/kms/OverviewPage/components/CmekVerifyModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekVerifyModal.tsx
@@ -22,6 +22,7 @@ import { Badge } from "@app/components/v3";
 import { getDefaultSigningAlgorithm } from "@app/helpers/kms";
 import { SigningAlgorithm, TCmek, useCmekVerify } from "@app/hooks/api/cmeks";
 import { isBase64 } from "@app/lib/fn/base64";
+import { compatibleSigningAlgorithmsForKeyAlgorithm } from "./utils";
 
 const formSchema = z.object({
   data: z.string().min(1, { message: "Data cannot be empty" }),
@@ -91,11 +92,7 @@ const VerifyForm = ({ cmek }: FormProps) => {
   const signatureValid = cmekVerify.data?.signatureValid;
   const signingAlgorithm = cmekVerify.data?.signingAlgorithm;
 
-  const allowedSigningAlgorithms = Object.values(SigningAlgorithm).filter((a) => {
-    if (cmek?.algorithm?.startsWith("ML_DSA")) return (a as string) === (cmek.algorithm as string);
-    if (cmek?.algorithm?.startsWith("RSA")) return a.toLowerCase().startsWith("rsa");
-    return a.toLowerCase().startsWith("ecdsa");
-  });
+  const allowedSigningAlgorithms = compatibleSigningAlgorithmsForKeyAlgorithm(cmek?.algorithm);
 
   return (
     <form onSubmit={handleSubmit(handleVerifyData)}>

--- a/frontend/src/pages/kms/OverviewPage/components/CmekVerifyModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekVerifyModal.tsx
@@ -59,17 +59,22 @@ const VerifyForm = ({ cmek }: FormProps) => {
     register,
     watch,
     control,
+    setValue,
     formState: { isSubmitting, errors }
   } = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       signingAlgorithm: getDefaultSigningAlgorithm(cmek),
-      isBase64Encoded: false
+      isBase64Encoded: getDefaultSigningAlgorithm(cmek) === SigningAlgorithm.ED25519_PH_SHA_512
     }
   });
 
   const handleVerifyData = async (formData: FormData) => {
-    const result = await cmekVerify.mutateAsync({ ...formData, keyId: cmek.id });
+    const result = await cmekVerify.mutateAsync({
+      ...formData,
+      keyId: cmek.id,
+      isDigest: formData.signingAlgorithm === SigningAlgorithm.ED25519_PH_SHA_512
+    });
 
     if (result.signatureValid) {
       createNotification({
@@ -125,7 +130,7 @@ const VerifyForm = ({ cmek }: FormProps) => {
           </div>
           <div>
             <span className="text-sm opacity-60">Data:</span>{" "}
-            <div className="rounded-md border border-mineshaft-700 bg-mineshaft-900 p-2 text-sm">
+            <div className="rounded-md border border-mineshaft-700 bg-mineshaft-900 p-2 text-sm break-words">
               {isBase64Encoded ? decodeBase64(data).toString() : data}
             </div>
           </div>
@@ -156,17 +161,26 @@ const VerifyForm = ({ cmek }: FormProps) => {
             <Controller
               control={control}
               name="signingAlgorithm"
-              render={({ field: { onChange, value } }) => (
-                <FormControl label="Signing Algorithm">
-                  <Select onValueChange={onChange} value={value} className="w-full">
-                    {allowedSigningAlgorithms.map((a) => (
-                      <SelectItem key={a} value={a}>
-                        {a.replaceAll("_", " ")}
-                      </SelectItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              )}
+              render={({ field: { onChange, value } }) => {
+                const handleAlgorithmChange = (algorithm: string) => {
+                  onChange(algorithm);
+                  if (algorithm === SigningAlgorithm.ED25519_PH_SHA_512) {
+                    setValue("isBase64Encoded", true);
+                  }
+                };
+
+                return (
+                  <FormControl label="Signing Algorithm">
+                    <Select onValueChange={handleAlgorithmChange} value={value} className="w-full">
+                      {allowedSigningAlgorithms.map((a) => (
+                        <SelectItem key={a} value={a}>
+                          {a.replaceAll("_", " ")}
+                        </SelectItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                );
+              }}
             />
 
             <Controller

--- a/frontend/src/pages/kms/OverviewPage/components/utils.ts
+++ b/frontend/src/pages/kms/OverviewPage/components/utils.ts
@@ -1,0 +1,23 @@
+import {
+  AsymmetricKeyAlgorithm,
+  HmacAlgorithm,
+  SigningAlgorithm,
+  SymmetricKeyAlgorithm
+} from "@app/hooks/api/cmeks";
+
+type KeyAlgorithm = AsymmetricKeyAlgorithm | SymmetricKeyAlgorithm | HmacAlgorithm;
+
+export const compatibleSigningAlgorithmsForKeyAlgorithm = (
+  algorithm: KeyAlgorithm
+): SigningAlgorithm[] => {
+  return Object.values(SigningAlgorithm).filter((a) => {
+    if (algorithm.startsWith("ML_DSA")) return (a as string) === (algorithm as string);
+    if (algorithm?.startsWith("RSA")) return a.toLowerCase().startsWith("rsa");
+    if (algorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519)
+      return a.toLowerCase().startsWith("ed25519");
+    return a.toLowerCase().startsWith("ecdsa");
+  });
+};
+
+// Temporary compatibility for the original misspelled export.
+export const comptableSigningAlgoritmsForKeyAlgorithm = compatibleSigningAlgorithmsForKeyAlgorithm;

--- a/frontend/src/pages/kms/OverviewPage/components/utils.ts
+++ b/frontend/src/pages/kms/OverviewPage/components/utils.ts
@@ -11,7 +11,7 @@ export const compatibleSigningAlgorithmsForKeyAlgorithm = (
   algorithm: KeyAlgorithm
 ): SigningAlgorithm[] => {
   return Object.values(SigningAlgorithm).filter((a) => {
-    if (algorithm.startsWith("ML_DSA")) return (a as string) === (algorithm as string);
+    if (algorithm?.startsWith("ML_DSA")) return (a as string) === (algorithm as string);
     if (algorithm?.startsWith("RSA")) return a.toLowerCase().startsWith("rsa");
     if (algorithm === AsymmetricKeyAlgorithm.ECC_NIST_EDWARDS25519)
       return a.toLowerCase().startsWith("ed25519");


### PR DESCRIPTION
Adds Ed25519, Ed25519ph algorithms for sign/verify operation

# Approach

OpenSSL lacks Ed25519ph support via CLI, available via C interface.
Created a minimal C executable to expose Ed25519ph sign/verify methods.
Patched Docker containers to bundle the binary.



# Followups required
FIPS Docker images use < 3.5 OpenSSL image variants. Ed25519ph variant is FIPS enabled starting in OpenSSL 3.5+.
Bumping it is needed to enable support for FIPS image. API detects and sends `unsupported` response in this case.
Ed25519ph itself is FIPS approved.

## Verification

2 algorithm compliance strategies are used.

Cross interoperability of same key with AWS, sign/verify algorithms:

* Sign at Infisical, verify at AWS work for Ed25519, Ed25519ph.
* AWS does dual hash Ed25519ph, needed a dual hash at client side before verification.
  This is not mandated by standard, Infisical doesn't do dual hash due to same reason.
* Also validated scenarios of Infisical verify, AWS sign, etc.

Cross interoperability with noble/curves Ed25519ph methods:

* Sign, verify with same keys at Infisical API, noble/curves cross-use pass.

Added tests to cover new algorithms, excluding one-time test cases.

![Algorithm selection](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs/ed25519-signature-screenshots/docs/images/kms/ed25519/algorithm-selection.png)

![Signing with Ed25519 SHA-512](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs/ed25519-signature-screenshots/docs/images/kms/ed25519/ed25519-sha512-signing.png)

![Successful Ed25519 SHA-512 signature](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs/ed25519-signature-screenshots/docs/images/kms/ed25519/ed25519-sha512-success.png)

![Signing with Ed25519ph and prehashed input](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs/ed25519-signature-screenshots/docs/images/kms/ed25519/ed25519ph-prehashed-signing.png)

![Verifying an Ed25519ph signature](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs/ed25519-signature-screenshots/docs/images/kms/ed25519/ed25519ph-verification.png)

# Note for maintainers

PR has been handwritten, including all of backend. Use of AI was restricted to parts of verifications, some of frontend changes.
