### PR TITLE
feat: bring back wget in image

### DIFF
--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -206,6 +206,9 @@ RUN apt-get update && apt-get install -y \
     git \
     unixodbc \
     freetds-bin \
+    # the ECS container health check shells out to wget; dropping it fails the
+    # probe with exit 127 even while the server is serving /api/status fine
+    wget \
     openssh-client \
     libaio1t64 \
     smbclient \


### PR DESCRIPTION
## Context

This PR bring back wget in our image because it was removed in docker image sanitization but was used in healthcheck

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)