### PR TITLE
docs(sdk): fix typo in Go SDK docs

### DIFF
--- a/docs/sdks/languages/go.mdx
+++ b/docs/sdks/languages/go.mdx
@@ -26,7 +26,7 @@ func main() {
 
 	client := infisical.NewInfisicalClient(context.Background(), infisical.Config{
 		SiteUrl: "https://app.infisical.com", // Optional, default is https://app.infisical.com
-    AutoTokenRefresh: true, // Wether or not to let the SDK handle the access token lifecycle. Defaults to true if not specified.
+    AutoTokenRefresh: true, // Whether or not to let the SDK handle the access token lifecycle. Defaults to true if not specified.
 	})
 
 	_, err := client.Auth().UniversalAuthLogin("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET")


### PR DESCRIPTION
## Context

Closes #7923

## Steps to verify the change

Just a docs fix.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)