### PR TITLE
chore: comment storybook preview links

### DIFF
--- a/.github/workflows/publish-storybook-chromatic.yml
+++ b/.github/workflows/publish-storybook-chromatic.yml
@@ -11,6 +11,10 @@ on:
       - "frontend/package-lock.json"
       - ".github/workflows/publish-storybook-chromatic.yml"
 
+concurrency:
+  group: storybook-chromatic-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/publish-storybook-chromatic.yml
+++ b/.github/workflows/publish-storybook-chromatic.yml
@@ -11,6 +11,10 @@ on:
       - "frontend/package-lock.json"
       - ".github/workflows/publish-storybook-chromatic.yml"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   chromatic:
     name: Publish
@@ -41,9 +45,53 @@ jobs:
         run: npm ci
         working-directory: frontend
       - name: 🎨 Publish to Chromatic
+        id: chromatic
         uses: chromaui/action@2a0b63f30233c48591844a46d451b9cf68128186 # v18.7.2
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: frontend
           onlyChanged: true
           exitZeroOnChanges: true
+      - name: 💬 Comment Storybook preview
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          STORYBOOK_URL: ${{ steps.chromatic.outputs.storybookUrl }}
+          CHROMATIC_BUILD_URL: ${{ steps.chromatic.outputs.buildUrl }}
+        with:
+          retries: 3
+          script: |
+            const marker = "<!-- chromatic-storybook-preview -->";
+            const head = context.payload.pull_request.head.sha.slice(0, 7);
+            const body = [
+              marker,
+              "## Storybook preview",
+              "",
+              `📚 [Open Storybook](${process.env.STORYBOOK_URL})`,
+              "",
+              `[🔍 View Chromatic build details](${process.env.CHROMATIC_BUILD_URL})`,
+              "",
+              `Updated for \`${head}\`.`
+            ].join("\n");
+
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+            const existing = comments.find(
+              (comment) => comment.user?.login === "github-actions[bot]" && comment.body?.startsWith(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }


### PR DESCRIPTION
## Context

The Storybook Chromatic workflow introduced in #7914 publishes a preview for relevant pull requests, but the preview URL is only exposed through status checks and workflow output.

This change posts a persistent PR comment after a successful Chromatic publish. The comment links to both the hosted Storybook and the Chromatic build details, records the current head commit, and is updated on later pushes instead of creating duplicate comments. PR-scoped concurrency cancels superseded runs so an older build cannot overwrite the latest preview.

## Screenshots

Not applicable — this changes CI workflow behavior only. The behavior is exercised directly on this PR by the live `Storybook preview` comment.

## Steps to verify the change

- Open or synchronize a same-repository PR that matches the Storybook workflow path filters.
- Wait for the `Publish Storybook to Chromatic / Publish` job to complete.
- Confirm the PR receives one `Storybook preview` comment with working Storybook and Chromatic build links.
- Push another commit and confirm the existing comment updates to the new head SHA instead of adding another comment.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g. `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)