### PR TITLE
fix: always show cross-project secret sharing in prod settings

### DIFF
--- a/backend/src/server/routes/v1/admin-router.ts
+++ b/backend/src/server/routes/v1/admin-router.ts
@@ -59,7 +59,6 @@ const SanitizedSuperAdminSchema = z.object({
   kubernetesAutoFetchServiceAccountToken: z.boolean().optional(),
   paramsFolderSecretDetectionEnabled: z.boolean().optional(),
   isOfflineUsageReportsEnabled: z.boolean().optional(),
-  isCrossProjectSecretSharingEnabled: z.boolean().optional(),
   isClickhouseAuditLogEnabled: z.boolean().optional(),
   defaultAuthOrgSlug: z.string().nullable(),
   defaultAuthOrgAuthEnforced: z.boolean().nullish(),
@@ -90,10 +89,8 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
       const hasOfflineLicense = licenseKeyConfig.isValid && licenseKeyConfig.type === LicenseType.Offline;
 
       const isSuperAdminUser = req.auth && isSuperAdmin(req.auth);
-      const orgId = req.auth?.orgId ?? "";
 
       const latestAvailableVersion = await server.services.updateCheck.getAvailableUpdateVersion();
-      const plan = await server.services.license.getPlan(orgId);
 
       const isClickhouseAuditLogEnabled = Boolean(
         serverEnvs.isClickHouseConfigured && serverEnvs.CLICKHOUSE_AUDIT_LOG_ENABLED
@@ -116,7 +113,6 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
             authConsentContent: config.authConsentContent,
             pageFrameContent: config.pageFrameContent,
             isPublicSecretSharingDisabled: serverEnvs.DISABLE_PUBLIC_SECRET_SHARING,
-            isCrossProjectSecretSharingEnabled: plan.crossProjectSecretSharing,
             isClickhouseAuditLogEnabled,
             latestAvailableVersion
           }
@@ -134,7 +130,6 @@ export const registerAdminRouter = async (server: FastifyZodProvider) => {
           kubernetesAutoFetchServiceAccountToken: serverEnvs.KUBERNETES_AUTO_FETCH_SERVICE_ACCOUNT_TOKEN,
           paramsFolderSecretDetectionEnabled: serverEnvs.PARAMS_FOLDER_SECRET_DETECTION_ENABLED,
           isOfflineUsageReportsEnabled: hasOfflineLicense,
-          isCrossProjectSecretSharingEnabled: plan.crossProjectSecretSharing,
           isClickhouseAuditLogEnabled,
           latestAvailableVersion
         }

--- a/frontend/src/hooks/api/admin/types.ts
+++ b/frontend/src/hooks/api/admin/types.ts
@@ -85,7 +85,6 @@ export type TServerConfig = {
   invalidatingCache: boolean;
   envOverrides?: Record<string, string>;
   isPublicSecretSharingDisabled?: boolean;
-  isCrossProjectSecretSharingEnabled?: boolean;
   isClickhouseAuditLogEnabled?: boolean;
   // populated on self-hosted instances when a newer release than the running version exists
   latestAvailableVersion?: string | null;

--- a/frontend/src/hooks/api/subscriptions/types.ts
+++ b/frontend/src/hooks/api/subscriptions/types.ts
@@ -85,4 +85,5 @@ export type SubscriptionPlan = {
   pam?: boolean | null;
   certManager?: boolean | null;
   secretsFolderRbac: boolean;
+  crossProjectSecretSharing: boolean;
 };

--- a/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
+++ b/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
@@ -158,7 +158,7 @@ export const ProductSettingsPage = () => {
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
-        text="Cross-project secret sharing is not available on your current plan. Upgrade to continue using it."
+        text="Cross-project secret sharing is not available on your plan. Upgrade to the Infisical Pro plan to enable this feature."
       />
     </>
   );

--- a/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
+++ b/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
@@ -158,7 +158,7 @@ export const ProductSettingsPage = () => {
       <UpgradePlanModal
         isOpen={popUp.upgradePlan.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
-        text="Cross-project secret sharing is not available on your current plan. Upgrade to enable secret imports and references across projects."
+        text="Cross-project secret sharing is not available on your current plan. Upgrade to continue using it."
       />
     </>
   );

--- a/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
+++ b/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
@@ -2,6 +2,7 @@ import { Helmet } from "react-helmet";
 import { KeyRound } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
+import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
 import { OrgPermissionCan } from "@app/components/permissions";
 import { PageHeader } from "@app/components/v2";
 import {
@@ -21,8 +22,9 @@ import {
   OrgPermissionActions,
   OrgPermissionSubjects,
   useOrganization,
-  useServerConfig
+  useSubscription
 } from "@app/context";
+import { usePopUp } from "@app/hooks";
 import { useUpdateOrg } from "@app/hooks/api/organization/queries";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
@@ -32,7 +34,8 @@ import { ProjectTemplatesSection } from "./project-templates/ProjectTemplatesSec
 export const ProductSettingsPage = () => {
   const { currentOrg } = useOrganization();
   const { mutateAsync: updateOrg, isPending } = useUpdateOrg();
-  const { config } = useServerConfig();
+  const { subscription } = useSubscription();
+  const { popUp, handlePopUpOpen, handlePopUpToggle } = usePopUp(["upgradePlan"] as const);
 
   const handleToggle = async (state: boolean) => {
     if (!currentOrg?.id) return;
@@ -50,6 +53,11 @@ export const ProductSettingsPage = () => {
 
   const handleCrossProjectSharingToggle = async (state: boolean) => {
     if (!currentOrg?.id) return;
+
+    if (state && !subscription?.crossProjectSecretSharing) {
+      handlePopUpOpen("upgradePlan");
+      return;
+    }
 
     await updateOrg({
       orgId: currentOrg.id,
@@ -111,31 +119,29 @@ export const ProductSettingsPage = () => {
                       )}
                     </OrgPermissionCan>
                   </Field>
-                  {config.isCrossProjectSecretSharingEnabled && (
-                    <Field orientation="horizontal">
-                      <FieldContent>
-                        <FieldTitle>Cross-project secret sharing</FieldTitle>
-                        <FieldDescription>
-                          When enabled, allows secret imports and secret references to target
-                          folders and secrets from other projects within the same organization.
-                        </FieldDescription>
-                      </FieldContent>
-                      <OrgPermissionCan
-                        I={OrgPermissionActions.Edit}
-                        a={OrgPermissionSubjects.Settings}
-                      >
-                        {(isAllowed) => (
-                          <Switch
-                            id="allow-cross-project-secret-sharing"
-                            variant="project"
-                            checked={currentOrg?.allowCrossProjectSecretSharing ?? false}
-                            onCheckedChange={(value) => handleCrossProjectSharingToggle(value)}
-                            disabled={!isAllowed || isPending}
-                          />
-                        )}
-                      </OrgPermissionCan>
-                    </Field>
-                  )}
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldTitle>Cross-project secret sharing</FieldTitle>
+                      <FieldDescription>
+                        When enabled, allows secret imports and secret references to target
+                        folders and secrets from other projects within the same organization.
+                      </FieldDescription>
+                    </FieldContent>
+                    <OrgPermissionCan
+                      I={OrgPermissionActions.Edit}
+                      a={OrgPermissionSubjects.Settings}
+                    >
+                      {(isAllowed) => (
+                        <Switch
+                          id="allow-cross-project-secret-sharing"
+                          variant="project"
+                          checked={currentOrg?.allowCrossProjectSecretSharing ?? false}
+                          onCheckedChange={(value) => handleCrossProjectSharingToggle(value)}
+                          disabled={!isAllowed || isPending}
+                        />
+                      )}
+                    </OrgPermissionCan>
+                  </Field>
                 </FieldGroup>
               </CardContent>
             </Card>
@@ -149,6 +155,11 @@ export const ProductSettingsPage = () => {
           </div>
         </div>
       </div>
+      <UpgradePlanModal
+        isOpen={popUp.upgradePlan.isOpen}
+        onOpenChange={(isOpen) => handlePopUpToggle("upgradePlan", isOpen)}
+        text="Cross-project secret sharing is not available on your current plan. Upgrade to enable secret imports and references across projects."
+      />
     </>
   );
 };

--- a/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
+++ b/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
@@ -123,8 +123,8 @@ export const ProductSettingsPage = () => {
                     <FieldContent>
                       <FieldTitle>Cross-project secret sharing</FieldTitle>
                       <FieldDescription>
-                        When enabled, allows secret imports and secret references to target
-                        folders and secrets from other projects within the same organization.
+                        When enabled, allows secret imports and secret references to target folders
+                        and secrets from other projects within the same organization.
                       </FieldDescription>
                     </FieldContent>
                     <OrgPermissionCan

--- a/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
+++ b/frontend/src/pages/organization/ProductSettingsPage/SecretsManagement/ProductSettingsPage.tsx
@@ -1,8 +1,8 @@
 import { Helmet } from "react-helmet";
 import { KeyRound } from "lucide-react";
 
-import { createNotification } from "@app/components/notifications";
 import { UpgradePlanModal } from "@app/components/license/UpgradePlanModal";
+import { createNotification } from "@app/components/notifications";
 import { OrgPermissionCan } from "@app/components/permissions";
 import { PageHeader } from "@app/components/v2";
 import {

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/PolicySelectionModal.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/PolicySelectionModal.tsx
@@ -14,7 +14,6 @@ import {
 } from "@app/components/v3";
 import { cn } from "@app/components/v3/utils";
 import { ProjectPermissionSub } from "@app/context";
-import { useServerConfig } from "@app/context/ServerConfigContext";
 import { useGetWorkspaceIntegrations } from "@app/hooks/api";
 import { ProjectType } from "@app/hooks/api/projects/types";
 
@@ -50,7 +49,6 @@ const Content = ({
     enabled: Boolean(isSecretManagerProject && projectId),
     refetchInterval: false
   });
-  const { config } = useServerConfig();
 
   const hasNativeIntegrations = integrations.length > 0;
 
@@ -63,11 +61,6 @@ const Content = ({
     )
     .filter(([subject]) => !EXCLUDED_PERMISSION_SUBS.includes(subject as ProjectPermissionSub))
     .filter(([subject]) => subject !== ProjectPermissionSub.Integrations || hasNativeIntegrations)
-    .filter(
-      ([subject]) =>
-        subject !== ProjectPermissionSub.ProjectFolderGrant ||
-        config?.isCrossProjectSecretSharingEnabled
-    )
     .filter(
       ([subject]) => !allowedSubjects || allowedSubjects.includes(subject as ProjectPermissionSub)
     )

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/RolePermissionsSection.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/RolePermissionsSection.tsx
@@ -19,7 +19,6 @@ import {
 } from "@app/components/v3";
 import { ProjectPermissionSub, useProject } from "@app/context";
 import { ProjectPermissionSet } from "@app/context/ProjectPermissionContext";
-import { useServerConfig } from "@app/context/ServerConfigContext";
 import { evaluatePermissionsAbility } from "@app/helpers/permissions";
 import { useGetProjectRoleBySlug, useUpdateProjectRole } from "@app/hooks/api";
 import { ProjectType } from "@app/hooks/api/projects/types";
@@ -149,7 +148,6 @@ export const renderConditionalComponents = (
 
 export const RolePermissionsSection = ({ roleSlug, isDisabled }: Props) => {
   const { currentProject, projectId } = useProject();
-  const { config } = useServerConfig();
 
   const isSecretManagerProject = currentProject.type === ProjectType.SecretManager;
 
@@ -193,9 +191,6 @@ export const RolePermissionsSection = ({ roleSlug, isDisabled }: Props) => {
     if (!projectId || !role?.id) return;
 
     const permissionsForm = { ...el.permissions };
-    if (!config?.isCrossProjectSecretSharingEnabled) {
-      permissionsForm[ProjectPermissionSub.ProjectFolderGrant] = [];
-    }
 
     const updatedRole = await updateRole({
       id: role?.id as string,
@@ -286,11 +281,6 @@ export const RolePermissionsSection = ({ roleSlug, isDisabled }: Props) => {
                     .filter((subject) => !EXCLUDED_PERMISSION_SUBS.includes(subject))
                     .filter(
                       (subject) => ProjectTypePermissionSubjects[currentProject.type][subject]
-                    )
-                    .filter(
-                      (subject) =>
-                        subject !== ProjectPermissionSub.ProjectFolderGrant ||
-                        config?.isCrossProjectSecretSharingEnabled
                     )
                     .map((subject) => (
                       <GeneralPermissionPolicies

--- a/frontend/src/pages/secret-manager/SettingsPage/components/PoliciesTab/PoliciesTab.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/PoliciesTab/PoliciesTab.tsx
@@ -14,9 +14,7 @@ export const PoliciesTab = () => {
     <div>
       <PreferencesSection />
       <SecretValidationRulesSection />
-      {config.isCrossProjectSecretSharingEnabled && currentOrg.allowCrossProjectSecretSharing && (
-        <CrossProjectSharingSection />
-      )}
+      {currentOrg.allowCrossProjectSecretSharing && <CrossProjectSharingSection />}
       <PointInTimeVersionLimitSection />
       {config.paramsFolderSecretDetectionEnabled && <SecretDetectionIgnoreValuesSection />}
     </div>


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Today we only show the option if it's enabled in the plan, now we always show it and show an upgrade popup in case the user tries to enable it.

If it's enabled, it can still be disabled even if not in the plan.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

<img width="1528" height="817" alt="CleanShot 2026-09-01 at 17 48 28" src="https://github.com/user-attachments/assets/bee3ce53-767b-412a-96fb-fe10026127ae" />

<img width="1528" height="817" alt="CleanShot 2026-09-01 at 17 51 14" src="https://github.com/user-attachments/assets/e983b835-62ef-417a-a863-64358fcb9202" />



## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)