### PR TITLE
feat: sync member email and name from the identity provider when the IdP is authoritative

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -421,6 +421,41 @@ audit-log entitlement, so on those deployments only the `logger.info` line survi
 Do not special-case this event past the retention gate; treat the application log as the floor and
 the audit event as the addition for licensed instances.
 
+### Profile Sync From The IdP (SSO-enforced orgs)
+
+An IdP keyed on a stable identifier lets someone change mailbox and display name without changing
+who they are, so our copy of both goes stale: notification mail goes to an address that no longer
+exists, and every audit entry written from then on records it. `syncSsoUserProfile`
+(`src/services/user-alias/user-alias-fns.ts`) carries the asserted email and name onto the account,
+and is called from all three login services right after `ensureSsoAccountVerified`, outside the
+caller's transaction, with its result flowing into the session.
+
+The gate is `organization.authEnforced` **and** a verified alias, and both halves matter. Enforcement
+is the org saying the IdP is authoritative for identity, which is the same claim that already skips
+email verification at signup. The verified alias is the proof that the IdP controls *this* account:
+an unverified alias asserting an unrecognized email is exactly what `isStaleSsoAlias` exists to
+catch, and reading that as a rename would let a stale alias rewrite somebody else's account. One
+consequence to know: a legacy unverified alias whose email changed before its next login is stale,
+so it gets the email-verification fallback (a code sent to the dead mailbox) rather than a sync.
+
+Two invariants:
+
+- **It never fails a login.** A rename that could not be applied leaves stale data, which is what we
+  already had; a throw locks the person out of an org that has no other way in. Every failure path
+  returns the unchanged user.
+- **It never renames onto an occupied address.** `users.username` is globally unique and the row is
+  global rather than org-scoped, so the asserted address may already be a personal signup or an
+  unmerged duplicate. The conflict is recorded (`SSO_USER_PROFILE_SYNC_CONFLICT`) and the email is
+  left alone; the name still syncs. The preceding read is not a lock, so a unique violation lands on
+  the same path.
+
+SCIM is the other half of the same story and moves with it. `updateScimUser` / `replaceScimUser`
+rejected every email change outright, which left the data stale *and* put the provisioning job in a
+permanent error state (Entra quarantines after repeated failures). Both now accept the change under
+the same `authEnforced` gate via `$resolveScimEmailChange`, and answer an occupied address with
+`409 uniqueness` rather than a constraint-shaped 500. Self-service email change
+(`user-service.ts`) is refused for the same orgs, since the next login would overwrite it anyway.
+
 ### Permission System (CASL)
 
 Uses CASL (`@casl/ability`) with MongoDB-style rules. Permission logic lives in `src/ee/services/permission/`:

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -461,7 +461,11 @@ rejected every email change outright, which left the data stale *and* put the pr
 permanent error state (Entra quarantines after repeated failures). Both now accept the change under
 the same `authEnforced` gate via `$resolveScimEmailChange`, and answer an occupied address with
 `409 uniqueness` rather than a constraint-shaped 500. Self-service email change
-(`user-service.ts`) is refused for the same orgs, since the next login would overwrite it anyway.
+(`user-service.ts`) is refused when the next login would overwrite it anyway, which
+`$getManagedEmailReason` narrows to the case that actually would: the account's own address sits on a
+domain one of its SSO-enforced orgs has verified. Membership in an enforced org is not the test, since
+the user row is global and an address outside that org's domains is one `syncSsoUserProfile` will not
+touch. SCIM stays a blanket refusal, because the directory provisions the address either way.
 
 ### Permission System (CASL)
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -443,6 +443,13 @@ Two invariants:
 - **It never fails a login.** A rename that could not be applied leaves stale data, which is what we
   already had; a throw locks the person out of an org that has no other way in. Every failure path
   returns the unchanged user.
+- **It only renames an address the org owns, onto another address the org owns.** Both halves are
+  checked in the helper against the org's verified domains. The user row is global rather than
+  org-scoped, so without the first half an org could rename an account that merely carries one of
+  its aliases and rewrite the identity every other org of that user sees. Every login path
+  establishes both already (`verifyEmailDomainOwnership` is a positive check: the domain must be
+  verified *for this org*, and the alias branch runs it against the existing account's username),
+  so the helper's copy is there to keep the rename from outliving those checks.
 - **It never renames onto an occupied address.** `users.username` is globally unique and the row is
   global rather than org-scoped, so the asserted address may already be a personal signup or an
   unmerged duplicate. The conflict is recorded (`SSO_USER_PROFILE_SYNC_CONFLICT`) and the email is

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -438,7 +438,7 @@ catch, and reading that as a rename would let a stale alias rewrite somebody els
 consequence to know: a legacy unverified alias whose email changed before its next login is stale,
 so it gets the email-verification fallback (a code sent to the dead mailbox) rather than a sync.
 
-Two invariants:
+Three invariants:
 
 - **It never fails a login.** A rename that could not be applied leaves stale data, which is what we
   already had; a throw locks the person out of an org that has no other way in. Every failure path
@@ -449,12 +449,15 @@ Two invariants:
   its aliases and rewrite the identity every other org of that user sees. Every login path
   establishes both already (`verifyEmailDomainOwnership` is a positive check: the domain must be
   verified *for this org*, and the alias branch runs it against the existing account's username),
-  so the helper's copy is there to keep the rename from outliving those checks.
+  so the helper's copy is there to keep the rename from outliving those checks. It is unreachable
+  today, and audits the skip anyway (`SSO_USER_EMAIL_SYNC_SKIPPED` with
+  `reason: "domain-not-owned"`) so a refactor that removes a caller's check leaves a trail rather
+  than a silently stale account.
 - **It never renames onto an occupied address.** `users.username` is globally unique and the row is
   global rather than org-scoped, so the asserted address may already be a personal signup or an
-  unmerged duplicate. The conflict is recorded (`SSO_USER_PROFILE_SYNC_CONFLICT`) and the email is
-  left alone; the name still syncs. The preceding read is not a lock, so a unique violation lands on
-  the same path.
+  unmerged duplicate. The conflict is recorded (`SSO_USER_EMAIL_SYNC_SKIPPED` with
+  `reason: "address-taken"`) and the email is left alone; the name still syncs. The preceding read
+  is not a lock, so a unique violation lands on the same path.
 
 SCIM is the other half of the same story and moves with it. `updateScimUser` / `replaceScimUser`
 rejected every email change outright, which left the data stale *and* put the provisioning job in a

--- a/backend/e2e-test/routes/v1/scim.spec.ts
+++ b/backend/e2e-test/routes/v1/scim.spec.ts
@@ -668,4 +668,145 @@ describe("SCIM v1 Router", () => {
       }
     );
   });
+
+  describe("Provisioned email changes", () => {
+    const seedUser = async (db: Knex, label: string) => {
+      const [user] = await db(TableName.Users)
+        .insert({
+          email: `scim-email-${label}@${TEST_DOMAIN}`,
+          username: `scim-email-${label}@${TEST_DOMAIN}`,
+          isGhost: false,
+          isEmailVerified: true,
+          authMethods: ["email"]
+        })
+        .returning("*");
+      createdUserIds.push(user.id);
+
+      const [membership] = await db(TableName.Membership)
+        .insert({
+          actorUserId: user.id,
+          scopeOrgId: ORG_ID,
+          scope: AccessScope.Organization,
+          isActive: true
+        })
+        .returning("*");
+      createdMembershipIds.push(membership.id);
+
+      await db(TableName.MembershipRole).insert({ membershipId: membership.id, role: "member" });
+
+      const [alias] = await db(TableName.UserAliases)
+        .insert({
+          userId: user.id,
+          orgId: ORG_ID,
+          aliasType: "saml",
+          externalId: `scim-email-ext-${label}`,
+          emails: [user.username]
+        })
+        .returning("*");
+
+      return { user, membership, alias };
+    };
+
+    // Entra addresses the mailbox through a filter path rather than an index.
+    const patchEmail = (membershipId: string, newEmail: string) =>
+      testServer.inject({
+        method: "PATCH",
+        url: `/api/v1/scim/Users/${membershipId}`,
+        headers: { authorization: `Bearer ${scimToken}`, "content-type": "application/scim+json" },
+        payload: JSON.stringify({
+          schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+          Operations: [{ op: "replace", path: 'emails[type eq "work"].value', value: newEmail }]
+        })
+      });
+
+    const putUser = (membershipId: string, externalId: string, newEmail: string) =>
+      testServer.inject({
+        method: "PUT",
+        url: `/api/v1/scim/Users/${membershipId}`,
+        headers: { authorization: `Bearer ${scimToken}`, "content-type": "application/scim+json" },
+        payload: JSON.stringify({
+          schemas: ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          userName: externalId,
+          name: { givenName: "Robert", familyName: "Smith" },
+          emails: [{ primary: true, value: newEmail }],
+          active: true
+        })
+      });
+
+    afterEach(async () => {
+      await getDb()(TableName.Organization).where({ id: ORG_ID }).update({ authEnforced: false });
+    });
+
+    test("should reject an email change when the org does not enforce SSO", async () => {
+      const db = getDb();
+      const label = `norename-${crypto.randomUUID().slice(0, 8)}`;
+      const { user, membership } = await seedUser(db, label);
+
+      const res = await patchEmail(membership.id, `renamed-${label}@${TEST_DOMAIN}`);
+
+      expect(res.statusCode).toBe(400);
+      expect(JSON.parse(res.payload).mutability).toBe("immutable");
+
+      const [row] = await db(TableName.Users).where({ id: user.id }).select("username");
+      expect(row.username).toBe(user.username);
+    });
+
+    test("should apply a PATCH email change when the org enforces SSO", async () => {
+      const db = getDb();
+      const label = `patch-${crypto.randomUUID().slice(0, 8)}`;
+      const { user, membership, alias } = await seedUser(db, label);
+      const newEmail = `renamed-${label}@${TEST_DOMAIN}`;
+
+      await db(TableName.Organization).where({ id: ORG_ID }).update({ authEnforced: true });
+
+      const res = await patchEmail(membership.id, newEmail);
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload).emails[0].value).toBe(newEmail);
+
+      const [row] = await db(TableName.Users).where({ id: user.id }).select("username", "email");
+      expect(row.username).toBe(newEmail);
+      expect(row.email).toBe(newEmail);
+
+      // The old address stays on the alias so a login in flight from before the rename still resolves.
+      const [aliasRow] = await db(TableName.UserAliases).where({ id: alias.id }).select("emails");
+      expect(aliasRow.emails).toEqual([user.username, newEmail]);
+    });
+
+    test("should apply a PUT email change when the org enforces SSO", async () => {
+      const db = getDb();
+      const label = `put-${crypto.randomUUID().slice(0, 8)}`;
+      const { user, membership } = await seedUser(db, label);
+      const newEmail = `renamed-${label}@${TEST_DOMAIN}`;
+
+      await db(TableName.Organization).where({ id: ORG_ID }).update({ authEnforced: true });
+
+      const res = await putUser(membership.id, `scim-email-ext-${label}`, newEmail);
+
+      expect(res.statusCode).toBe(200);
+      expect(JSON.parse(res.payload).emails[0].value).toBe(newEmail);
+
+      const [row] = await db(TableName.Users).where({ id: user.id }).select("username", "email");
+      expect(row.username).toBe(newEmail);
+      expect(row.email).toBe(newEmail);
+    });
+
+    test("should report a conflict when the new address is already another account", async () => {
+      const db = getDb();
+      const label = `conflict-${crypto.randomUUID().slice(0, 8)}`;
+      const { user, membership } = await seedUser(db, label);
+      const { user: occupant } = await seedUser(db, `occupant-${label}`);
+
+      await db(TableName.Organization).where({ id: ORG_ID }).update({ authEnforced: true });
+
+      const res = await patchEmail(membership.id, occupant.username);
+
+      expect(res.statusCode).toBe(409);
+      expect(JSON.parse(res.payload).scimType).toBe("uniqueness");
+
+      const [row] = await db(TableName.Users).where({ id: user.id }).select("username");
+      expect(row.username).toBe(user.username);
+    });
+  });
+
 });

--- a/backend/e2e-test/routes/v1/scim.spec.ts
+++ b/backend/e2e-test/routes/v1/scim.spec.ts
@@ -850,5 +850,41 @@ describe("SCIM v1 Router", () => {
       const [row] = await db(TableName.Users).where({ id: user.id }).select("username");
       expect(row.username).toBe(user.username);
     });
+
+    test("should take the primary address when the assertion carries several", async () => {
+      const db = getDb();
+      const label = `multi-${crypto.randomUUID().slice(0, 8)}`;
+      const { user, membership } = await seedUser(db, label);
+      const primaryEmail = `renamed-${label}@${TEST_DOMAIN}`;
+      const secondaryEmail = `alias-${label}@${TEST_DOMAIN}`;
+
+      await db(TableName.Organization).where({ id: ORG_ID }).update({ authEnforced: true });
+
+      const res = await testServer.inject({
+        method: "PATCH",
+        url: `/api/v1/scim/Users/${membership.id}`,
+        headers: { authorization: `Bearer ${scimToken}`, "content-type": "application/scim+json" },
+        payload: JSON.stringify({
+          schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+          Operations: [
+            {
+              op: "replace",
+              path: "emails",
+              // The mailbox we key on is not first, which is what the PUT handler already accounts for.
+              value: [
+                { primary: false, value: secondaryEmail, type: "home" },
+                { primary: true, value: primaryEmail, type: "work" }
+              ]
+            }
+          ]
+        })
+      });
+
+      expect(res.statusCode).toBe(200);
+
+      const [row] = await db(TableName.Users).where({ id: user.id }).select("username", "email");
+      expect(row.username).toBe(primaryEmail);
+      expect(row.email).toBe(primaryEmail);
+    });
   });
 });

--- a/backend/e2e-test/routes/v1/scim.spec.ts
+++ b/backend/e2e-test/routes/v1/scim.spec.ts
@@ -670,10 +670,10 @@ describe("SCIM v1 Router", () => {
   });
 
   describe("Provisioned email changes", () => {
-    const seedUser = async (db: Knex, label: string) => {
+    const seedUser = async (db: Knex, label: string, email?: string) => {
       const [user] = await db(TableName.Users)
         .insert({
-          email: `scim-email-${label}@${TEST_DOMAIN}`,
+          email: email ?? `scim-email-${label}@${TEST_DOMAIN}`,
           username: `scim-email-${label}@${TEST_DOMAIN}`,
           isGhost: false,
           isEmailVerified: true,
@@ -791,6 +791,49 @@ describe("SCIM v1 Router", () => {
       expect(row.email).toBe(newEmail);
     });
 
+    test("should apply an unrelated PATCH when the stored email and username have drifted", async () => {
+      const db = getDb();
+      const label = `drift-${crypto.randomUUID().slice(0, 8)}`;
+      const { user, membership } = await seedUser(db, label, `drifted-${label}@${TEST_DOMAIN}`);
+
+      const res = await testServer.inject({
+        method: "PATCH",
+        url: `/api/v1/scim/Users/${membership.id}`,
+        headers: { authorization: `Bearer ${scimToken}`, "content-type": "application/scim+json" },
+        payload: JSON.stringify({
+          schemas: ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
+          Operations: [{ op: "replace", path: "active", value: false }]
+        })
+      });
+
+      // Deprovisioning names no mailbox, so it must not trip the immutable-email refusal.
+      expect(res.statusCode).toBe(200);
+
+      const [row] = await db(TableName.Membership).where({ id: membership.id }).select("isActive");
+      expect(row.isActive).toBe(false);
+
+      const [userRow] = await db(TableName.Users).where({ id: user.id }).select("username");
+      expect(userRow.username).toBe(user.username);
+    });
+
+    test("should reject an address outside the organization's verified domains", async () => {
+      const db = getDb();
+      const label = `unverified-${crypto.randomUUID().slice(0, 8)}`;
+      const { user, membership } = await seedUser(db, label);
+
+      await db(TableName.Organization).where({ id: ORG_ID }).update({ authEnforced: true });
+
+      const res = await patchEmail(membership.id, `renamed-${label}@not-verified.local`);
+
+      expect(res.statusCode).toBe(400);
+      const body = JSON.parse(res.payload);
+      expect(body.scimType).toBe("invalidValue");
+      expect(body.schemas).toContain("urn:ietf:params:scim:api:messages:2.0:Error");
+
+      const [row] = await db(TableName.Users).where({ id: user.id }).select("username");
+      expect(row.username).toBe(user.username);
+    });
+
     test("should report a conflict when the new address is already another account", async () => {
       const db = getDb();
       const label = `conflict-${crypto.randomUUID().slice(0, 8)}`;
@@ -808,5 +851,4 @@ describe("SCIM v1 Router", () => {
       expect(row.username).toBe(user.username);
     });
   });
-
 });

--- a/backend/e2e-test/routes/v1/scim.spec.ts
+++ b/backend/e2e-test/routes/v1/scim.spec.ts
@@ -764,9 +764,12 @@ describe("SCIM v1 Router", () => {
       expect(res.statusCode).toBe(200);
       expect(JSON.parse(res.payload).emails[0].value).toBe(newEmail);
 
-      const [row] = await db(TableName.Users).where({ id: user.id }).select("username", "email");
+      const [row] = await db(TableName.Users).where({ id: user.id }).select("username", "email", "isEmailVerified");
       expect(row.username).toBe(newEmail);
       expect(row.email).toBe(newEmail);
+      // Account recovery gates on this flag, so a directory write must not leave the new mailbox
+      // able to claim a password reset. The next SSO login re-verifies it.
+      expect(row.isEmailVerified).toBe(false);
 
       // The old address stays on the alias so a login in flight from before the rename still resolves.
       const [aliasRow] = await db(TableName.UserAliases).where({ id: alias.id }).select("emails");
@@ -786,9 +789,10 @@ describe("SCIM v1 Router", () => {
       expect(res.statusCode).toBe(200);
       expect(JSON.parse(res.payload).emails[0].value).toBe(newEmail);
 
-      const [row] = await db(TableName.Users).where({ id: user.id }).select("username", "email");
+      const [row] = await db(TableName.Users).where({ id: user.id }).select("username", "email", "isEmailVerified");
       expect(row.username).toBe(newEmail);
       expect(row.email).toBe(newEmail);
+      expect(row.isEmailVerified).toBe(false);
     });
 
     test("should apply an unrelated PATCH when the stored email and username have drifted", async () => {

--- a/backend/e2e-test/routes/v3/auth-idp.spec.ts
+++ b/backend/e2e-test/routes/v3/auth-idp.spec.ts
@@ -472,4 +472,114 @@ describe("Auth IdP Service-Level Tests", () => {
       expect(result2.user.id).toBe(result1.user.id);
     });
   });
+
+  // syncSsoUserProfile is unit-tested in isolation; these cover the wiring, that each provider's
+  // login actually calls it, after the alias has been promoted to verified, with the assertion's
+  // values rather than the stored ones.
+  describe("SSO profile sync", () => {
+    type TIdpLoginArgs = { externalId: string; email: string; firstName: string; lastName: string };
+
+    const idpLogins: { name: string; slug: string; login: (args: TIdpLoginArgs) => Promise<unknown> }[] = [
+      {
+        name: "SAML",
+        slug: "saml",
+        login: (args) =>
+          getServices().saml.samlLogin({
+            ...args,
+            authProvider: "okta-saml",
+            orgId: TEST_ORG_ID,
+            ip: "127.0.0.1",
+            userAgent: "test-agent"
+          })
+      },
+      {
+        name: "LDAP",
+        slug: "ldap",
+        login: (args) =>
+          getServices().ldap.ldapLogin({
+            ...args,
+            username: args.email,
+            ldapConfigId,
+            orgId: TEST_ORG_ID,
+            ip: "127.0.0.1",
+            userAgent: "test-agent"
+          })
+      },
+      {
+        name: "OIDC",
+        slug: "oidc",
+        login: (args) =>
+          getServices().oidc.oidcLogin({
+            ...args,
+            orgId: TEST_ORG_ID,
+            ip: "127.0.0.1",
+            userAgent: "test-agent"
+          })
+      }
+    ];
+
+    const setAuthEnforced = async (authEnforced: boolean) => {
+      await getDb()(TableName.Organization).where({ id: TEST_ORG_ID }).update({ authEnforced });
+    };
+
+    afterEach(async () => {
+      await setAuthEnforced(false);
+    });
+
+    describe.each(idpLogins)("$name Login", ({ slug, login }) => {
+      // Enforcement is on for the first login of both tests so the alias is created verified,
+      // which is what syncSsoUserProfile requires before it will trust the assertion.
+      const seedVerifiedAlias = async (externalId: string, email: string) => {
+        await setAuthEnforced(true);
+        await login({ externalId, email, firstName: "Original", lastName: "Name" });
+
+        const alias = await getDb()(TableName.UserAliases).where({ externalId, orgId: TEST_ORG_ID }).first();
+        if (!alias) throw new Error(`No alias created for external id '${externalId}'`);
+        expect(alias.isEmailVerified).toBe(true);
+        createdUserIds.push(alias.userId);
+
+        return alias;
+      };
+
+      test("Carries a renamed mailbox and name onto the account when the org enforces SSO", async () => {
+        const externalId = `${slug}-sync-${crypto.randomUUID()}`;
+        const email = `${slug}sync-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+        const renamedEmail = `${slug}renamed-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+
+        const alias = await seedVerifiedAlias(externalId, email);
+
+        // Same externalId, new mailbox and surname: the person was renamed at the IdP.
+        await login({ externalId, email: renamedEmail, firstName: "Original", lastName: "Renamed" });
+
+        const db = getDb();
+        const user = await db(TableName.Users).where({ id: alias.userId }).first();
+        expect(user?.username).toBe(renamedEmail);
+        expect(user?.email).toBe(renamedEmail);
+        expect(user?.lastName).toBe("Renamed");
+
+        // The old address stays on the alias so a login in flight from before the rename
+        // does not read as stale.
+        const updatedAlias = await db(TableName.UserAliases).where({ id: alias.id }).first();
+        expect(updatedAlias?.emails).toEqual(expect.arrayContaining([email, renamedEmail]));
+      });
+
+      test("Leaves the account alone when the org does not enforce SSO", async () => {
+        const externalId = `${slug}-nosync-${crypto.randomUUID()}`;
+        const email = `${slug}nosync-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+        const renamedEmail = `${slug}nosyncrenamed-${crypto.randomUUID()}@${TEST_DOMAIN}`;
+
+        const alias = await seedVerifiedAlias(externalId, email);
+
+        // Enforcement dropped, so the IdP is no longer authoritative for identity. The alias
+        // stays verified, which isolates the enforcement gate from the stale-alias guard.
+        await setAuthEnforced(false);
+        await login({ externalId, email: renamedEmail, firstName: "Original", lastName: "Renamed" });
+
+        const user = await getDb()(TableName.Users).where({ id: alias.userId }).first();
+        expect(user?.username).toBe(email);
+        expect(user?.email).toBe(email);
+        expect(user?.lastName).toBe("Name");
+      });
+    });
+  });
 });

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -592,7 +592,7 @@ export enum EventType {
   OIDC_GROUP_MEMBERSHIP_MAPPING_REMOVE_USER = "oidc-group-membership-mapping-remove-user",
   OIDC_PROVISIONED_PLACEHOLDER_ADOPTED = "oidc-provisioned-placeholder-adopted",
   SSO_USER_PROFILE_SYNCED = "sso-user-profile-synced",
-  SSO_USER_PROFILE_SYNC_CONFLICT = "sso-user-profile-sync-conflict",
+  SSO_USER_EMAIL_SYNC_SKIPPED = "sso-user-email-sync-skipped",
   CREATE_KMIP_CLIENT = "create-kmip-client",
   UPDATE_KMIP_CLIENT = "update-kmip-client",
   DELETE_KMIP_CLIENT = "delete-kmip-client",
@@ -4970,14 +4970,17 @@ interface SsoUserProfileSyncedEvent {
   };
 }
 
-interface SsoUserProfileSyncConflictEvent {
-  type: EventType.SSO_USER_PROFILE_SYNC_CONFLICT;
+export type TSsoUserEmailSyncSkipReason = "address-taken" | "domain-not-owned";
+
+interface SsoUserEmailSyncSkippedEvent {
+  type: EventType.SSO_USER_EMAIL_SYNC_SKIPPED;
   metadata: {
     userId: string;
     aliasType: string;
     externalId: string;
     currentEmail: string;
     assertedEmail: string;
+    reason: TSsoUserEmailSyncSkipReason;
     conflictingUserId?: string;
   };
 }
@@ -7660,7 +7663,7 @@ export type Event =
   | OidcGroupMembershipMappingRemoveUserEvent
   | OidcProvisionedPlaceholderAdoptedEvent
   | SsoUserProfileSyncedEvent
-  | SsoUserProfileSyncConflictEvent
+  | SsoUserEmailSyncSkippedEvent
   | CreateKmipClientEvent
   | UpdateKmipClientEvent
   | DeleteKmipClientEvent

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -591,6 +591,8 @@ export enum EventType {
   OIDC_GROUP_MEMBERSHIP_MAPPING_ASSIGN_USER = "oidc-group-membership-mapping-assign-user",
   OIDC_GROUP_MEMBERSHIP_MAPPING_REMOVE_USER = "oidc-group-membership-mapping-remove-user",
   OIDC_PROVISIONED_PLACEHOLDER_ADOPTED = "oidc-provisioned-placeholder-adopted",
+  SSO_USER_PROFILE_SYNCED = "sso-user-profile-synced",
+  SSO_USER_PROFILE_SYNC_CONFLICT = "sso-user-profile-sync-conflict",
   CREATE_KMIP_CLIENT = "create-kmip-client",
   UPDATE_KMIP_CLIENT = "update-kmip-client",
   DELETE_KMIP_CLIENT = "delete-kmip-client",
@@ -4953,6 +4955,33 @@ interface OidcProvisionedPlaceholderAdoptedEvent {
   };
 }
 
+interface SsoUserProfileSyncedEvent {
+  type: EventType.SSO_USER_PROFILE_SYNCED;
+  metadata: {
+    userId: string;
+    aliasType: string;
+    externalId: string;
+    previousEmail?: string;
+    newEmail?: string;
+    previousFirstName?: string | null;
+    newFirstName?: string;
+    previousLastName?: string | null;
+    newLastName?: string;
+  };
+}
+
+interface SsoUserProfileSyncConflictEvent {
+  type: EventType.SSO_USER_PROFILE_SYNC_CONFLICT;
+  metadata: {
+    userId: string;
+    aliasType: string;
+    externalId: string;
+    currentEmail: string;
+    assertedEmail: string;
+    conflictingUserId?: string;
+  };
+}
+
 interface CreateKmipClientEvent {
   type: EventType.CREATE_KMIP_CLIENT;
   metadata: {
@@ -7630,6 +7659,8 @@ export type Event =
   | OidcGroupMembershipMappingAssignUserEvent
   | OidcGroupMembershipMappingRemoveUserEvent
   | OidcProvisionedPlaceholderAdoptedEvent
+  | SsoUserProfileSyncedEvent
+  | SsoUserProfileSyncConflictEvent
   | CreateKmipClientEvent
   | UpdateKmipClientEvent
   | DeleteKmipClientEvent

--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -9,6 +9,7 @@ import {
   TLdapConfigsUpdate,
   TUsers
 } from "@app/db/schemas";
+import { TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
 import { TGroupDALFactory } from "@app/ee/services/group/group-dal";
 import { addUsersToGroupByUserIds, removeUsersFromGroupByUserIds } from "@app/ee/services/group/group-fns";
 import { TUserGroupMembershipDALFactory } from "@app/ee/services/group/user-group-membership-dal";
@@ -51,7 +52,7 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
-import { ensureSsoAccountVerified, isStaleSsoAlias } from "@app/services/user-alias/user-alias-fns";
+import { ensureSsoAccountVerified, isStaleSsoAlias, syncSsoUserProfile } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
@@ -75,6 +76,7 @@ import { TLdapGroupMapDALFactory } from "./ldap-group-map-dal";
 
 type TLdapConfigServiceFactoryDep = {
   ldapConfigDAL: Pick<TLdapConfigDALFactory, "create" | "update" | "findOne" | "transaction">;
+  auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
   ldapGroupMapDAL: Pick<TLdapGroupMapDALFactory, "find" | "create" | "delete" | "findLdapGroupMapsByLdapConfigId">;
   orgDAL: Pick<
     TOrgDALFactory,
@@ -118,6 +120,7 @@ export type TLdapConfigServiceFactory = ReturnType<typeof ldapConfigServiceFacto
 
 export const ldapConfigServiceFactory = ({
   ldapConfigDAL,
+  auditLogService,
   ldapGroupMapDAL,
   orgDAL,
   groupDAL,
@@ -746,6 +749,19 @@ export const ldapConfigServiceFactory = ({
         userAliasDAL
       }));
     }
+
+    user = await syncSsoUserProfile({
+      user,
+      userAlias,
+      assertedEmail: sanitizedEmail,
+      assertedFirstName: firstName,
+      assertedLastName: lastName,
+      orgId,
+      isAuthEnforced: Boolean(organization.authEnforced),
+      userDAL,
+      userAliasDAL,
+      auditLogService
+    });
 
     if (user.email && (!userAlias.isEmailVerified || !user.isAccepted)) {
       const token = await tokenService.createTokenForUser({

--- a/backend/src/ee/services/ldap-config/ldap-config-service.ts
+++ b/backend/src/ee/services/ldap-config/ldap-config-service.ts
@@ -760,6 +760,7 @@ export const ldapConfigServiceFactory = ({
       isAuthEnforced: Boolean(organization.authEnforced),
       userDAL,
       userAliasDAL,
+      emailDomainDAL,
       auditLogService
     });
 

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -554,6 +554,7 @@ export const oidcConfigServiceFactory = ({
       isAuthEnforced: Boolean(organization.authEnforced),
       userDAL,
       userAliasDAL,
+      emailDomainDAL,
       auditLogService
     });
 

--- a/backend/src/ee/services/oidc/oidc-config-service.ts
+++ b/backend/src/ee/services/oidc/oidc-config-service.ts
@@ -61,7 +61,8 @@ import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
 import {
   adoptProvisionedShadowUser,
   ensureSsoAccountVerified,
-  isStaleSsoAlias
+  isStaleSsoAlias,
+  syncSsoUserProfile
 } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
@@ -540,6 +541,21 @@ export const oidcConfigServiceFactory = ({
         userAliasDAL
       }));
     }
+
+    // The IdP is authoritative for identity in an org that enforces SSO, so a mailbox or name
+    // changed there is carried onto the account rather than left to go stale.
+    user = await syncSsoUserProfile({
+      user,
+      userAlias,
+      assertedEmail: sanitizedEmail,
+      assertedFirstName: firstName,
+      assertedLastName: lastName,
+      orgId,
+      isAuthEnforced: Boolean(organization.authEnforced),
+      userDAL,
+      userAliasDAL,
+      auditLogService
+    });
 
     if (user.email && (!userAlias.isEmailVerified || !user.isAccepted)) {
       const token = await tokenService.createTokenForUser({

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -14,6 +14,7 @@ import {
   TSamlConfigsUpdate,
   TUsers
 } from "@app/db/schemas";
+import { TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
 import { getEnforcedIdentityLimit, throwOnPlanSeatLimitReached } from "@app/ee/services/license/license-fns";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
@@ -44,7 +45,7 @@ import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-serv
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 import { TUserDALFactory } from "@app/services/user/user-dal";
 import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
-import { ensureSsoAccountVerified, isStaleSsoAlias } from "@app/services/user-alias/user-alias-fns";
+import { ensureSsoAccountVerified, isStaleSsoAlias, syncSsoUserProfile } from "@app/services/user-alias/user-alias-fns";
 import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TEmailDomainDALFactory } from "../email-domain/email-domain-dal";
@@ -63,6 +64,7 @@ const GROUP_SYNC_SUPPORTED_PROVIDERS = [SamlProviders.GOOGLE_SAML] as SamlProvid
 
 type TSamlConfigServiceFactoryDep = {
   samlConfigDAL: Pick<TSamlConfigDALFactory, "create" | "findOne" | "update" | "findById">;
+  auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
   userDAL: Pick<
     TUserDALFactory,
     | "create"
@@ -105,6 +107,7 @@ type TSamlConfigServiceFactoryDep = {
 
 export const samlConfigServiceFactory = ({
   samlConfigDAL,
+  auditLogService,
   orgDAL,
   userDAL,
   userAliasDAL,
@@ -793,6 +796,21 @@ export const samlConfigServiceFactory = ({
         userAliasDAL
       }));
     }
+
+    // The IdP is authoritative for identity in an org that enforces SSO, so a mailbox or name
+    // changed there is carried onto the account rather than left to go stale.
+    user = await syncSsoUserProfile({
+      user,
+      userAlias,
+      assertedEmail: sanitizedEmail,
+      assertedFirstName: firstName,
+      assertedLastName: lastName,
+      orgId,
+      isAuthEnforced: Boolean(organization.authEnforced),
+      userDAL,
+      userAliasDAL,
+      auditLogService
+    });
 
     if (user.email && (!userAlias.isEmailVerified || !user.isAccepted)) {
       const token = await tokenService.createTokenForUser({

--- a/backend/src/ee/services/saml-config/saml-config-service.ts
+++ b/backend/src/ee/services/saml-config/saml-config-service.ts
@@ -809,6 +809,7 @@ export const samlConfigServiceFactory = ({
       isAuthEnforced: Boolean(organization.authEnforced),
       userDAL,
       userAliasDAL,
+      emailDomainDAL,
       auditLogService
     });
 

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -804,7 +804,7 @@ export const scimServiceFactory = ({
           {
             firstName: scimUser.name.givenName,
             lastName: scimUser.name.familyName,
-            ...(newEmail ? { email: newEmail, username: newEmail } : {})
+            ...(newEmail ? { email: newEmail, username: newEmail, isEmailVerified: false } : {})
           },
           tx
         );
@@ -921,7 +921,7 @@ export const scimServiceFactory = ({
           {
             firstName,
             lastName,
-            ...(newEmail ? { email: newEmail, username: newEmail } : {})
+            ...(newEmail ? { email: newEmail, username: newEmail, isEmailVerified: false } : {})
           },
           tx
         );

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -645,7 +645,7 @@ export const scimServiceFactory = ({
     if (!assertedEmail) return null;
 
     const newEmail = sanitizeEmail(assertedEmail);
-    if (newEmail === user.email && newEmail === user.username) return null;
+    if (newEmail === user.email || newEmail === user.username) return null;
 
     if (!org.authEnforced) {
       throw new ScimRequestError({
@@ -667,7 +667,16 @@ export const scimServiceFactory = ({
       });
     }
 
-    await verifyEmailDomainOwnership({ email: newEmail, orgId: org.id, emailDomainDAL });
+    try {
+      await verifyEmailDomainOwnership({ email: newEmail, orgId: org.id, emailDomainDAL });
+    } catch (err) {
+      throw new ScimRequestError({
+        detail: `'${newEmail}' is not on a verified email domain for this organization. Add and verify the domain in Infisical, then retry.`,
+        status: 400,
+        scimType: "invalidValue",
+        error: err
+      });
+    }
 
     const conflictingUser = await userDAL.findOne({ username: newEmail });
     if (conflictingUser && conflictingUser.id !== user.id) {
@@ -684,9 +693,15 @@ export const scimServiceFactory = ({
   /**
    * The conflict check above is a read, not a lock, so a concurrent login or invite can take the
    * address first. Report that as the conflict it is instead of a 500 carrying a constraint name.
+   * Only where a rename was actually attempted: the transaction writes other rows too, and calling
+   * an unrelated unique violation an email conflict would send the IdP chasing the wrong address.
    */
-  const $toScimEmailConflictError = (err: unknown, newEmail: string) => {
-    if (err instanceof DatabaseError && (err.error as { code?: string })?.code === DatabaseErrorCode.UniqueViolation) {
+  const $toScimEmailConflictError = (err: unknown, newEmail: string | null) => {
+    if (
+      newEmail &&
+      err instanceof DatabaseError &&
+      (err.error as { code?: string })?.code === DatabaseErrorCode.UniqueViolation
+    ) {
       return new ScimRequestError({
         detail: `An Infisical account already exists for '${newEmail}'. Remove or merge that account before changing this user's email.`,
         status: 409,
@@ -820,7 +835,7 @@ export const scimServiceFactory = ({
         );
       });
     } catch (err) {
-      throw $toScimEmailConflictError(err, newEmail ?? "");
+      throw $toScimEmailConflictError(err, newEmail);
     }
 
     return scimUser;
@@ -944,7 +959,7 @@ export const scimServiceFactory = ({
         );
       });
     } catch (err) {
-      throw $toScimEmailConflictError(err, newEmail ?? "");
+      throw $toScimEmailConflictError(err, newEmail);
     }
 
     return buildScimUser({

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -781,7 +781,7 @@ export const scimServiceFactory = ({
     const newEmail = await $resolveScimEmailChange({
       org,
       user,
-      assertedEmail: scimUser.emails?.[0]?.value
+      assertedEmail: (scimUser.emails?.find((email) => email.primary) ?? scimUser.emails?.[0])?.value
     });
 
     await verifyEmailDomainOwnership({

--- a/backend/src/ee/services/scim/scim-service.ts
+++ b/backend/src/ee/services/scim/scim-service.ts
@@ -11,6 +11,7 @@ import {
   TableName,
   TGroups,
   TMemberships,
+  TOrganizations,
   TUsers
 } from "@app/db/schemas";
 import { TGroupDALFactory } from "@app/ee/services/group/group-dal";
@@ -22,7 +23,9 @@ import { TScimDALFactory } from "@app/ee/services/scim/scim-dal";
 import { PgSqlLock } from "@app/keystore/keystore";
 import { getConfig } from "@app/lib/config/env";
 import { crypto } from "@app/lib/crypto";
-import { BadRequestError, NotFoundError, ScimRequestError, UnauthorizedError } from "@app/lib/errors";
+import { DatabaseErrorCode } from "@app/lib/error-codes";
+import { BadRequestError, DatabaseError, NotFoundError, ScimRequestError, UnauthorizedError } from "@app/lib/errors";
+import { unique } from "@app/lib/fn";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
@@ -88,7 +91,7 @@ type TScimServiceFactoryDep = {
     TUserDALFactory,
     "find" | "findOne" | "create" | "transaction" | "findUserEncKeyByUserIdsBatch" | "findById" | "updateById"
   >;
-  userAliasDAL: Pick<TUserAliasDALFactory, "findOne" | "create" | "delete" | "update" | "find">;
+  userAliasDAL: Pick<TUserAliasDALFactory, "findOne" | "create" | "delete" | "update" | "updateById" | "find">;
   orgDAL: Pick<
     TOrgDALFactory,
     | "createMembership"
@@ -621,6 +624,79 @@ export const scimServiceFactory = ({
     });
   };
 
+  /**
+   * SCIM addresses people by the identifier the IdP asserts, but ours is users.username, which is
+   * the mailbox, so someone renamed at the IdP arrives here as a write to a field we treat as
+   * immutable. Refusing it leaves our copy stale and puts the provisioning job into a permanent
+   * error state. Where the org enforces SSO it has already made the IdP authoritative for identity,
+   * so the new address is taken; otherwise the mailbox is still ours and the refusal stands.
+   *
+   * Returns the address to write, or null when there is nothing to change.
+   */
+  const $resolveScimEmailChange = async ({
+    org,
+    user,
+    assertedEmail
+  }: {
+    org: Pick<TOrganizations, "id" | "authEnforced">;
+    user: Pick<TUsers, "id" | "email" | "username">;
+    assertedEmail?: string | null;
+  }): Promise<string | null> => {
+    if (!assertedEmail) return null;
+
+    const newEmail = sanitizeEmail(assertedEmail);
+    if (newEmail === user.email && newEmail === user.username) return null;
+
+    if (!org.authEnforced) {
+      throw new ScimRequestError({
+        detail:
+          "Email cannot be changed. Enable SSO enforcement for this organization to let your identity provider manage member email addresses.",
+        status: 400,
+        mutability: "immutable"
+      });
+    }
+
+    try {
+      validateEmail(newEmail);
+    } catch (err) {
+      throw new ScimRequestError({
+        detail: `'${assertedEmail}' is not a valid email address`,
+        status: 400,
+        scimType: "invalidValue",
+        error: err
+      });
+    }
+
+    await verifyEmailDomainOwnership({ email: newEmail, orgId: org.id, emailDomainDAL });
+
+    const conflictingUser = await userDAL.findOne({ username: newEmail });
+    if (conflictingUser && conflictingUser.id !== user.id) {
+      throw new ScimRequestError({
+        detail: `An Infisical account already exists for '${newEmail}'. Remove or merge that account before changing this user's email.`,
+        status: 409,
+        scimType: "uniqueness"
+      });
+    }
+
+    return newEmail;
+  };
+
+  /**
+   * The conflict check above is a read, not a lock, so a concurrent login or invite can take the
+   * address first. Report that as the conflict it is instead of a 500 carrying a constraint name.
+   */
+  const $toScimEmailConflictError = (err: unknown, newEmail: string) => {
+    if (err instanceof DatabaseError && (err.error as { code?: string })?.code === DatabaseErrorCode.UniqueViolation) {
+      return new ScimRequestError({
+        detail: `An Infisical account already exists for '${newEmail}'. Remove or merge that account before changing this user's email.`,
+        status: 409,
+        scimType: "uniqueness",
+        error: err
+      });
+    }
+    return err;
+  };
+
   // partial
   const updateScimUser: TScimServiceFactory["updateScimUser"] = async ({ orgMembershipId, orgId, operations }) => {
     const org = await requestMemoize(requestMemoKeys.orgFindOrgById(orgId), () => orgDAL.findOrgById(orgId));
@@ -687,51 +763,65 @@ export const scimServiceFactory = ({
     });
     scimPatch(scimUser, operations);
 
-    // email is our identifier - changing that user must delete this user and provision a new one
-    if (scimUser.emails?.[0]?.value !== user?.email) {
-      throw new ScimRequestError({
-        detail: "Email cannot be changed",
-        status: 400,
-        mutability: "immutable"
-      });
-    }
+    const newEmail = await $resolveScimEmailChange({
+      org,
+      user,
+      assertedEmail: scimUser.emails?.[0]?.value
+    });
 
     await verifyEmailDomainOwnership({
       email: user.username,
       orgId,
       emailDomainDAL
     });
-    await userDAL.transaction(async (tx) => {
-      await membershipUserDAL.updateById(
-        membership.id,
-        {
-          isActive: scimUser.active
-        },
-        tx
-      );
-      await userDAL.updateById(
-        membership.actorUserId as string,
-        {
-          firstName: scimUser.name.givenName,
-          lastName: scimUser.name.familyName
-        },
-        tx
-      );
 
-      await scimEventsDAL.create(
-        {
-          orgId,
-          eventType: ScimEvent.UPDATE_USER,
-          event: {
+    try {
+      await userDAL.transaction(async (tx) => {
+        await membershipUserDAL.updateById(
+          membership.id,
+          {
+            isActive: scimUser.active
+          },
+          tx
+        );
+        await userDAL.updateById(
+          membership.actorUserId as string,
+          {
             firstName: scimUser.name.givenName,
-            email: scimUser.userName,
             lastName: scimUser.name.familyName,
-            active: scimUser.active
-          }
-        },
-        tx
-      );
-    });
+            ...(newEmail ? { email: newEmail, username: newEmail } : {})
+          },
+          tx
+        );
+
+        // The old address stays on the alias: it is what past assertions carried, and dropping it
+        // would make a login in flight from before the rename look stale.
+        if (newEmail) {
+          await Promise.all(
+            userAliases.map((alias) =>
+              userAliasDAL.updateById(alias.id, { emails: unique([...(alias.emails ?? []), newEmail]) }, tx)
+            )
+          );
+        }
+
+        await scimEventsDAL.create(
+          {
+            orgId,
+            eventType: ScimEvent.UPDATE_USER,
+            event: {
+              firstName: scimUser.name.givenName,
+              email: scimUser.userName,
+              lastName: scimUser.name.familyName,
+              active: scimUser.active,
+              ...(newEmail ? { previousEmail: user.username, newEmail } : {})
+            }
+          },
+          tx
+        );
+      });
+    } catch (err) {
+      throw $toScimEmailConflictError(err, newEmail ?? "");
+    }
 
     return scimUser;
   };
@@ -794,14 +884,7 @@ export const scimServiceFactory = ({
 
     const user = await userDAL.findOne({ id: membership.actorUserId });
 
-    // email is our identifier - changing that user must delete this user and provision a new one
-    if (email && (user.email !== email || user.username !== email)) {
-      throw new ScimRequestError({
-        detail: "Email cannot be changed",
-        status: 400,
-        mutability: "immutable"
-      });
-    }
+    const newEmail = await $resolveScimEmailChange({ org, user, assertedEmail: email });
 
     await verifyEmailDomainOwnership({
       email: user.username,
@@ -809,46 +892,65 @@ export const scimServiceFactory = ({
       emailDomainDAL
     });
 
-    await userDAL.transaction(async (tx) => {
-      await membershipUserDAL.updateById(
-        membership.id,
-        {
-          isActive: active
-        },
-        tx
-      );
-      await userDAL.updateById(
-        membership.actorUserId!,
-        {
-          firstName,
-          lastName
-        },
-        tx
-      );
-
-      // Update externalId on existing alias if provided and changed
-      await userAliasDAL.update({ orgId, aliasType, userId: membership.actorUserId as string }, { externalId }, tx);
-
-      await scimEventsDAL.create(
-        {
-          orgId,
-          eventType: ScimEvent.REPLACE_USER,
-          event: {
-            username: externalId,
+    try {
+      await userDAL.transaction(async (tx) => {
+        await membershipUserDAL.updateById(
+          membership.id,
+          {
+            isActive: active
+          },
+          tx
+        );
+        await userDAL.updateById(
+          membership.actorUserId!,
+          {
             firstName,
-            email: email?.toLowerCase(),
             lastName,
-            active
-          }
-        },
-        tx
-      );
-    });
+            ...(newEmail ? { email: newEmail, username: newEmail } : {})
+          },
+          tx
+        );
+
+        // Update externalId on existing alias if provided and changed. The old address stays on the
+        // alias: it is what past assertions carried, and dropping it would make a login in flight
+        // from before the rename look stale.
+        await Promise.all(
+          userAliases.map((alias) =>
+            userAliasDAL.updateById(
+              alias.id,
+              {
+                externalId,
+                ...(newEmail ? { emails: unique([...(alias.emails ?? []), newEmail]) } : {})
+              },
+              tx
+            )
+          )
+        );
+
+        await scimEventsDAL.create(
+          {
+            orgId,
+            eventType: ScimEvent.REPLACE_USER,
+            event: {
+              username: externalId,
+              firstName,
+              email: email?.toLowerCase(),
+              lastName,
+              active,
+              ...(newEmail ? { previousEmail: user.username, newEmail } : {})
+            }
+          },
+          tx
+        );
+      });
+    } catch (err) {
+      throw $toScimEmailConflictError(err, newEmail ?? "");
+    }
 
     return buildScimUser({
       orgMembershipId: membership.id,
       username: externalId || user.username,
-      email: user.email,
+      email: newEmail ?? user.email,
       firstName: firstName || user.firstName,
       lastName: lastName || user.lastName,
       active,

--- a/backend/src/lib/errors/index.ts
+++ b/backend/src/lib/errors/index.ts
@@ -190,16 +190,20 @@ export class ScimRequestError extends Error {
 
   mutability?: string;
 
+  scimType?: string;
+
   constructor({
     name,
     error,
     detail,
     status,
-    mutability
+    mutability,
+    scimType
   }: {
     message?: string;
     name?: string;
     mutability?: string;
+    scimType?: string;
     error?: unknown;
     detail: string;
     status: number;
@@ -211,6 +215,7 @@ export class ScimRequestError extends Error {
     this.detail = detail;
     this.status = status;
     this.mutability = mutability;
+    this.scimType = scimType;
   }
 }
 

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -309,7 +309,8 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
         schemas: error.schemas,
         status: error.status,
         detail: error.detail,
-        mutability: error.mutability
+        mutability: error.mutability,
+        scimType: error.scimType
       });
     } else if (error instanceof OidcAuthError) {
       void res.status(HttpStatusCodes.InternalServerError).send({

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1362,6 +1362,7 @@ export const registerRoutes = async (
   });
 
   const samlService = samlConfigServiceFactory({
+    auditLogService,
     identityMetadataDAL,
     additionalPrivilegeDAL,
     permissionService,
@@ -1388,6 +1389,7 @@ export const registerRoutes = async (
   });
 
   const ldapService = ldapConfigServiceFactory({
+    auditLogService,
     additionalPrivilegeDAL,
     ldapConfigDAL,
     ldapGroupMapDAL,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1313,7 +1313,8 @@ export const registerRoutes = async (
     webAuthnCredentialDAL,
     mfaRecoveryCodeService,
     usageMeteringService,
-    alertChannelRecipientDAL
+    alertChannelRecipientDAL,
+    emailDomainDAL
   });
 
   const totpService = totpServiceFactory({

--- a/backend/src/services/user-alias/user-alias-fns.test.ts
+++ b/backend/src/services/user-alias/user-alias-fns.test.ts
@@ -1,11 +1,16 @@
 import { Knex } from "knex";
 import { describe, expect, test, vi } from "vitest";
 
-import { TUsers } from "@app/db/schemas";
+import { TUserAliases, TUsers } from "@app/db/schemas";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { DatabaseError, ForbiddenRequestError } from "@app/lib/errors";
 
-import { adoptProvisionedShadowUser, resolveAliasUserIds } from "./user-alias-fns";
+import { adoptProvisionedShadowUser, resolveAliasUserIds, syncSsoUserProfile } from "./user-alias-fns";
+import { UserAliasType } from "./user-alias-types";
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() }
+}));
 
 const alias = (externalId: string, userId: string) => ({ externalId, userId });
 
@@ -294,5 +299,163 @@ describe("adoptProvisionedShadowUser", () => {
     deps.userDAL.findOne.mockResolvedValueOnce(shadowUser()).mockResolvedValueOnce(null);
 
     await expect(adopt(deps)).rejects.toThrow(DatabaseError);
+  });
+});
+
+const makeUser = (overrides: Partial<TUsers> = {}) =>
+  ({
+    id: "user-1",
+    username: "old@example.com",
+    email: "old@example.com",
+    firstName: "Robert",
+    lastName: "Smith",
+    ...overrides
+  }) as TUsers;
+
+const makeAlias = (overrides: Partial<TUserAliases> = {}) =>
+  ({
+    id: "alias-1",
+    userId: "user-1",
+    orgId: "org-1",
+    aliasType: UserAliasType.OIDC,
+    externalId: "m249913@one.example.com",
+    emails: ["old@example.com"],
+    isEmailVerified: true,
+    ...overrides
+  }) as TUserAliases;
+
+type TAuditLogArg = { orgId: string; event: { type: string; metadata: Record<string, unknown> } };
+
+const makeDeps = ({ conflictingUser = null as TUsers | null, updateError = null as Error | null } = {}) => {
+  const updatedRows: Record<string, unknown>[] = [];
+  const userDAL = {
+    findOne: vi.fn().mockResolvedValue(conflictingUser),
+    updateById: vi.fn().mockImplementation((id: string, update: Record<string, unknown>) => {
+      if (updateError) throw updateError;
+      updatedRows.push(update);
+      return { ...makeUser(), ...update };
+    }),
+    transaction: vi.fn().mockImplementation((cb: (tx: unknown) => unknown) => cb({}))
+  };
+  const userAliasDAL = { updateById: vi.fn().mockResolvedValue(undefined) };
+  const auditLogService = {
+    createAuditLog: vi.fn<(arg: TAuditLogArg) => Promise<void>>().mockResolvedValue(undefined)
+  };
+
+  return { userDAL, userAliasDAL, auditLogService, updatedRows };
+};
+
+const sync = (args: Record<string, unknown>, deps: ReturnType<typeof makeDeps>) =>
+  syncSsoUserProfile({
+    user: makeUser(),
+    userAlias: makeAlias(),
+    assertedEmail: "old@example.com",
+    orgId: "org-1",
+    isAuthEnforced: true,
+    userDAL: deps.userDAL,
+    userAliasDAL: deps.userAliasDAL,
+    auditLogService: deps.auditLogService,
+    ...args
+  } as Parameters<typeof syncSsoUserProfile>[0]);
+
+describe("syncSsoUserProfile", () => {
+  test("does nothing when the org does not enforce SSO", async () => {
+    const deps = makeDeps();
+    const user = await sync({ assertedEmail: "new@example.com", isAuthEnforced: false }, deps);
+
+    expect(user.username).toBe("old@example.com");
+    expect(deps.userDAL.updateById).not.toHaveBeenCalled();
+    expect(deps.auditLogService.createAuditLog).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when the alias is not yet verified", async () => {
+    const deps = makeDeps();
+    const user = await sync(
+      { assertedEmail: "new@example.com", userAlias: makeAlias({ isEmailVerified: false }) },
+      deps
+    );
+
+    expect(user.username).toBe("old@example.com");
+    expect(deps.userDAL.updateById).not.toHaveBeenCalled();
+  });
+
+  test("does not write when nothing differs", async () => {
+    const deps = makeDeps();
+    await sync({ assertedFirstName: "Robert", assertedLastName: "Smith" }, deps);
+
+    expect(deps.userDAL.findOne).not.toHaveBeenCalled();
+    expect(deps.userDAL.updateById).not.toHaveBeenCalled();
+  });
+
+  test("carries a renamed mailbox onto the account and the alias", async () => {
+    const deps = makeDeps();
+    const user = await sync({ assertedEmail: "new@example.com" }, deps);
+
+    expect(user.username).toBe("new@example.com");
+    expect(user.email).toBe("new@example.com");
+    expect(deps.userAliasDAL.updateById).toHaveBeenCalledWith(
+      "alias-1",
+      { emails: ["old@example.com", "new@example.com"] },
+      expect.anything()
+    );
+    const [audited] = deps.auditLogService.createAuditLog.mock.calls[0];
+    expect(audited.event.type).toBe("sso-user-profile-synced");
+    expect(audited.event.metadata.previousEmail).toBe("old@example.com");
+    expect(audited.event.metadata.newEmail).toBe("new@example.com");
+  });
+
+  test("syncs a changed name without touching the email", async () => {
+    const deps = makeDeps();
+    const user = await sync({ assertedFirstName: "Bob", assertedLastName: "Smith" }, deps);
+
+    expect(user.firstName).toBe("Bob");
+    expect(deps.updatedRows[0]).toEqual({ firstName: "Bob" });
+    expect(deps.userAliasDAL.updateById).not.toHaveBeenCalled();
+  });
+
+  test("does not blank out a name the assertion omits", async () => {
+    const deps = makeDeps();
+    await sync({ assertedFirstName: "", assertedLastName: undefined }, deps);
+
+    expect(deps.userDAL.updateById).not.toHaveBeenCalled();
+  });
+
+  test("skips the email but keeps the name when the address belongs to another account", async () => {
+    const deps = makeDeps({ conflictingUser: { ...makeUser(), id: "user-2" } as TUsers });
+    const user = await sync({ assertedEmail: "new@example.com", assertedFirstName: "Bob" }, deps);
+
+    expect(user.username).toBe("old@example.com");
+    expect(user.firstName).toBe("Bob");
+    expect(deps.updatedRows[0]).toEqual({ firstName: "Bob" });
+    const [audited] = deps.auditLogService.createAuditLog.mock.calls[0];
+    expect(audited.event.type).toBe("sso-user-profile-sync-conflict");
+    expect(audited.event.metadata.conflictingUserId).toBe("user-2");
+  });
+
+  test("leaves the account untouched when the conflicting account is the only change", async () => {
+    const deps = makeDeps({ conflictingUser: { ...makeUser(), id: "user-2" } as TUsers });
+    const user = await sync({ assertedEmail: "new@example.com" }, deps);
+
+    expect(user.username).toBe("old@example.com");
+    expect(deps.userDAL.updateById).not.toHaveBeenCalled();
+  });
+
+  test("never fails the login when the address is taken between the check and the write", async () => {
+    const deps = makeDeps({
+      updateError: new DatabaseError({ error: { code: DatabaseErrorCode.UniqueViolation } })
+    });
+    const user = await sync({ assertedEmail: "new@example.com" }, deps);
+
+    expect(user.username).toBe("old@example.com");
+    const [audited] = deps.auditLogService.createAuditLog.mock.calls[0];
+    expect(audited.event.type).toBe("sso-user-profile-sync-conflict");
+  });
+
+  test("never fails the login on an unexpected database error", async () => {
+    const deps = makeDeps({ updateError: new Error("connection reset") });
+    const user = await sync({ assertedEmail: "new@example.com" }, deps);
+
+    expect(user.username).toBe("old@example.com");
+    expect(deps.auditLogService.createAuditLog).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/user-alias/user-alias-fns.test.ts
+++ b/backend/src/services/user-alias/user-alias-fns.test.ts
@@ -329,6 +329,7 @@ type TAuditLogArg = { orgId: string; event: { type: string; metadata: Record<str
 const makeDeps = ({
   conflictingUser = null as TUsers | null,
   updateError = null as Error | null,
+  emailUpdateError = null as Error | null,
   orgVerifiedDomains = ["example.com"] as string[]
 } = {}) => {
   const updatedRows: Record<string, unknown>[] = [];
@@ -336,6 +337,7 @@ const makeDeps = ({
     findOne: vi.fn().mockResolvedValue(conflictingUser),
     updateById: vi.fn().mockImplementation((id: string, update: Record<string, unknown>) => {
       if (updateError) throw updateError;
+      if (emailUpdateError && update.username) throw emailUpdateError;
       updatedRows.push(update);
       return { ...makeUser(), ...update };
     }),
@@ -439,6 +441,7 @@ describe("syncSsoUserProfile", () => {
     expect(user.username).toBe("old@example.com");
     expect(user.firstName).toBe("Bob");
     expect(deps.updatedRows[0]).toEqual({ firstName: "Bob" });
+    expect(deps.userDAL.findOne).toHaveBeenCalledWith({ username: "new@example.com" });
     const [audited] = deps.auditLogService.createAuditLog.mock.calls[0];
     expect(audited.event.type).toBe("sso-user-profile-sync-conflict");
     expect(audited.event.metadata.conflictingUserId).toBe("user-2");
@@ -461,6 +464,24 @@ describe("syncSsoUserProfile", () => {
     expect(user.username).toBe("old@example.com");
     const [audited] = deps.auditLogService.createAuditLog.mock.calls[0];
     expect(audited.event.type).toBe("sso-user-profile-sync-conflict");
+  });
+
+  test("keeps the name when the address is taken between the check and the write", async () => {
+    const deps = makeDeps({
+      emailUpdateError: new DatabaseError({ error: { code: DatabaseErrorCode.UniqueViolation } })
+    });
+    const user = await sync({ assertedEmail: "new@example.com", assertedFirstName: "Bob" }, deps);
+
+    expect(user.username).toBe("old@example.com");
+    expect(user.firstName).toBe("Bob");
+    expect(deps.updatedRows).toEqual([{ firstName: "Bob" }]);
+
+    const [conflict] = deps.auditLogService.createAuditLog.mock.calls[0];
+    expect(conflict.event.type).toBe("sso-user-profile-sync-conflict");
+    const [synced] = deps.auditLogService.createAuditLog.mock.calls[1];
+    expect(synced.event.type).toBe("sso-user-profile-synced");
+    expect(synced.event.metadata.newEmail).toBeUndefined();
+    expect(synced.event.metadata.newFirstName).toBe("Bob");
   });
 
   test("never fails the login on an unexpected database error", async () => {

--- a/backend/src/services/user-alias/user-alias-fns.test.ts
+++ b/backend/src/services/user-alias/user-alias-fns.test.ts
@@ -326,7 +326,11 @@ const makeAlias = (overrides: Partial<TUserAliases> = {}) =>
 
 type TAuditLogArg = { orgId: string; event: { type: string; metadata: Record<string, unknown> } };
 
-const makeDeps = ({ conflictingUser = null as TUsers | null, updateError = null as Error | null } = {}) => {
+const makeDeps = ({
+  conflictingUser = null as TUsers | null,
+  updateError = null as Error | null,
+  orgVerifiedDomains = ["example.com"] as string[]
+} = {}) => {
   const updatedRows: Record<string, unknown>[] = [];
   const userDAL = {
     findOne: vi.fn().mockResolvedValue(conflictingUser),
@@ -338,11 +342,18 @@ const makeDeps = ({ conflictingUser = null as TUsers | null, updateError = null 
     transaction: vi.fn().mockImplementation((cb: (tx: unknown) => unknown) => cb({}))
   };
   const userAliasDAL = { updateById: vi.fn().mockResolvedValue(undefined) };
+  const emailDomainDAL = {
+    findOne: vi
+      .fn()
+      .mockImplementation(({ domain }: { domain: string }) =>
+        orgVerifiedDomains.includes(domain) ? { id: "domain-1", domain } : undefined
+      )
+  };
   const auditLogService = {
     createAuditLog: vi.fn<(arg: TAuditLogArg) => Promise<void>>().mockResolvedValue(undefined)
   };
 
-  return { userDAL, userAliasDAL, auditLogService, updatedRows };
+  return { userDAL, userAliasDAL, emailDomainDAL, auditLogService, updatedRows };
 };
 
 const sync = (args: Record<string, unknown>, deps: ReturnType<typeof makeDeps>) =>
@@ -354,6 +365,7 @@ const sync = (args: Record<string, unknown>, deps: ReturnType<typeof makeDeps>) 
     isAuthEnforced: true,
     userDAL: deps.userDAL,
     userAliasDAL: deps.userAliasDAL,
+    emailDomainDAL: deps.emailDomainDAL,
     auditLogService: deps.auditLogService,
     ...args
   } as Parameters<typeof syncSsoUserProfile>[0]);
@@ -457,5 +469,23 @@ describe("syncSsoUserProfile", () => {
 
     expect(user.username).toBe("old@example.com");
     expect(deps.auditLogService.createAuditLog).not.toHaveBeenCalled();
+  });
+
+  test("skips the email but keeps the name when the org does not own the address being replaced", async () => {
+    const deps = makeDeps({ orgVerifiedDomains: ["new-corp.com"] });
+    const user = await sync({ assertedEmail: "renamed@new-corp.com", assertedFirstName: "Bob" }, deps);
+
+    expect(user.username).toBe("old@example.com");
+    expect(user.firstName).toBe("Bob");
+    expect(deps.updatedRows[0]).toEqual({ firstName: "Bob" });
+  });
+
+  test("skips the email when the org does not own the address being written", async () => {
+    const deps = makeDeps({ orgVerifiedDomains: ["example.com"] });
+    const user = await sync({ assertedEmail: "renamed@elsewhere.com" }, deps);
+
+    expect(user.username).toBe("old@example.com");
+    expect(deps.userDAL.updateById).not.toHaveBeenCalled();
+    expect(deps.userDAL.findOne).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/services/user-alias/user-alias-fns.test.ts
+++ b/backend/src/services/user-alias/user-alias-fns.test.ts
@@ -443,7 +443,8 @@ describe("syncSsoUserProfile", () => {
     expect(deps.updatedRows[0]).toEqual({ firstName: "Bob" });
     expect(deps.userDAL.findOne).toHaveBeenCalledWith({ username: "new@example.com" });
     const [audited] = deps.auditLogService.createAuditLog.mock.calls[0];
-    expect(audited.event.type).toBe("sso-user-profile-sync-conflict");
+    expect(audited.event.type).toBe("sso-user-email-sync-skipped");
+    expect(audited.event.metadata.reason).toBe("address-taken");
     expect(audited.event.metadata.conflictingUserId).toBe("user-2");
   });
 
@@ -463,7 +464,8 @@ describe("syncSsoUserProfile", () => {
 
     expect(user.username).toBe("old@example.com");
     const [audited] = deps.auditLogService.createAuditLog.mock.calls[0];
-    expect(audited.event.type).toBe("sso-user-profile-sync-conflict");
+    expect(audited.event.type).toBe("sso-user-email-sync-skipped");
+    expect(audited.event.metadata.reason).toBe("address-taken");
   });
 
   test("keeps the name when the address is taken between the check and the write", async () => {
@@ -477,7 +479,8 @@ describe("syncSsoUserProfile", () => {
     expect(deps.updatedRows).toEqual([{ firstName: "Bob" }]);
 
     const [conflict] = deps.auditLogService.createAuditLog.mock.calls[0];
-    expect(conflict.event.type).toBe("sso-user-profile-sync-conflict");
+    expect(conflict.event.type).toBe("sso-user-email-sync-skipped");
+    expect(conflict.event.metadata.reason).toBe("address-taken");
     const [synced] = deps.auditLogService.createAuditLog.mock.calls[1];
     expect(synced.event.type).toBe("sso-user-profile-synced");
     expect(synced.event.metadata.newEmail).toBeUndefined();
@@ -499,6 +502,11 @@ describe("syncSsoUserProfile", () => {
     expect(user.username).toBe("old@example.com");
     expect(user.firstName).toBe("Bob");
     expect(deps.updatedRows[0]).toEqual({ firstName: "Bob" });
+
+    const [skipped] = deps.auditLogService.createAuditLog.mock.calls[0];
+    expect(skipped.event.type).toBe("sso-user-email-sync-skipped");
+    expect(skipped.event.metadata.reason).toBe("domain-not-owned");
+    expect(skipped.event.metadata.conflictingUserId).toBeUndefined();
   });
 
   test("skips the email when the org does not own the address being written", async () => {
@@ -508,5 +516,9 @@ describe("syncSsoUserProfile", () => {
     expect(user.username).toBe("old@example.com");
     expect(deps.userDAL.updateById).not.toHaveBeenCalled();
     expect(deps.userDAL.findOne).not.toHaveBeenCalled();
+
+    const [skipped] = deps.auditLogService.createAuditLog.mock.calls[0];
+    expect(skipped.event.type).toBe("sso-user-email-sync-skipped");
+    expect(skipped.event.metadata.reason).toBe("domain-not-owned");
   });
 });

--- a/backend/src/services/user-alias/user-alias-fns.ts
+++ b/backend/src/services/user-alias/user-alias-fns.ts
@@ -212,18 +212,18 @@ export const syncSsoUserProfile = async ({
     }
   }
 
-  try {
-    const updatedUser = await userDAL.transaction(async (tx) => {
+  const writeProfile = (applyEmail: boolean) =>
+    userDAL.transaction(async (tx) => {
       const nextUser = await userDAL.updateById(
         user.id,
         {
           ...nameChanges,
-          ...(isEmailApplied ? { email: assertedUsername, username: assertedUsername } : {})
+          ...(applyEmail ? { email: assertedUsername, username: assertedUsername } : {})
         },
         tx
       );
 
-      if (isEmailApplied) {
+      if (applyEmail) {
         await userAliasDAL.updateById(
           userAlias.id,
           { emails: unique([...(userAlias.emails ?? []), assertedUsername]) },
@@ -234,43 +234,56 @@ export const syncSsoUserProfile = async ({
       return nextUser;
     });
 
-    logger.info(
-      { userId: user.id, orgId, externalId: userAlias.externalId, isEmailApplied },
-      `Synced SSO profile from the identity provider [userId=${user.id}] [orgId=${orgId}]`
-    );
-
-    await auditLogService
-      .createAuditLog({
-        actor: { type: ActorType.PLATFORM, metadata: {} },
-        orgId,
-        event: {
-          type: EventType.SSO_USER_PROFILE_SYNCED,
-          metadata: {
-            userId: user.id,
-            aliasType: userAlias.aliasType,
-            externalId: userAlias.externalId,
-            ...(isEmailApplied ? { previousEmail: user.username, newEmail: assertedUsername } : {}),
-            ...(nameChanges.firstName
-              ? { previousFirstName: user.firstName, newFirstName: nameChanges.firstName }
-              : {}),
-            ...(nameChanges.lastName ? { previousLastName: user.lastName, newLastName: nameChanges.lastName } : {})
-          }
-        }
-      })
-      .catch((err) => {
-        logger.error(err, `Failed to audit SSO profile sync for user ${user.id} in org ${orgId}`);
-      });
-
-    return updatedUser;
+  let updatedUser: TUsers;
+  try {
+    updatedUser = await writeProfile(isEmailApplied);
   } catch (err) {
-    if (err instanceof DatabaseError && (err.error as { code?: string })?.code === DatabaseErrorCode.UniqueViolation) {
-      await logConflict();
+    if (
+      !(err instanceof DatabaseError) ||
+      (err.error as { code?: string })?.code !== DatabaseErrorCode.UniqueViolation
+    ) {
+      logger.error(err, `Failed to sync SSO profile for user ${user.id} in org ${orgId}`);
       return user;
     }
 
-    logger.error(err, `Failed to sync SSO profile for user ${user.id} in org ${orgId}`);
-    return user;
+    await logConflict();
+    isEmailApplied = false;
+    if (!isNameChanged) return user;
+
+    try {
+      updatedUser = await writeProfile(false);
+    } catch (nameErr) {
+      logger.error(nameErr, `Failed to sync SSO profile name for user ${user.id} in org ${orgId}`);
+      return user;
+    }
   }
+
+  logger.info(
+    { userId: user.id, orgId, externalId: userAlias.externalId, isEmailApplied },
+    `Synced SSO profile from the identity provider [userId=${user.id}] [orgId=${orgId}]`
+  );
+
+  await auditLogService
+    .createAuditLog({
+      actor: { type: ActorType.PLATFORM, metadata: {} },
+      orgId,
+      event: {
+        type: EventType.SSO_USER_PROFILE_SYNCED,
+        metadata: {
+          userId: user.id,
+          aliasType: userAlias.aliasType,
+          externalId: userAlias.externalId,
+          ...(isEmailApplied ? { previousEmail: user.username, newEmail: assertedUsername } : {}),
+          ...(nameChanges.firstName ? { previousFirstName: user.firstName, newFirstName: nameChanges.firstName } : {}),
+          ...(nameChanges.lastName ? { previousLastName: user.lastName, newLastName: nameChanges.lastName } : {})
+        }
+      }
+    })
+    .catch((err) => {
+      logger.error(err, `Failed to audit SSO profile sync for user ${user.id} in org ${orgId}`);
+    });
+
+  return updatedUser;
 };
 
 type TResolveAliasUserIdsDTO = {

--- a/backend/src/services/user-alias/user-alias-fns.ts
+++ b/backend/src/services/user-alias/user-alias-fns.ts
@@ -1,7 +1,11 @@
 import { Knex } from "knex";
 
 import { AccessScope, TableName, TUserAliases, TUsers } from "@app/db/schemas";
-import { EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
+import {
+  EventType,
+  TAuditLogServiceFactory,
+  TSsoUserEmailSyncSkipReason
+} from "@app/ee/services/audit-log/audit-log-types";
 import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
 import { verifyEmailDomainOwnership } from "@app/ee/services/email-domain/email-domain-fns";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
@@ -158,29 +162,40 @@ export const syncSsoUserProfile = async ({
 
   if (!isEmailChanged && !isNameChanged) return user;
 
-  const logConflict = async (conflictingUserId?: string) => {
+  const logSkippedEmailSync = async ({
+    reason,
+    conflictingUserId
+  }: {
+    reason: TSsoUserEmailSyncSkipReason;
+    conflictingUserId?: string;
+  }) => {
+    const detail =
+      reason === "domain-not-owned"
+        ? "the organization does not own both addresses"
+        : "the asserted address belongs to another account";
     logger.warn(
       { userId: user.id, orgId, externalId: userAlias.externalId, assertedEmail: assertedUsername, conflictingUserId },
-      `Skipped SSO email sync, the asserted address belongs to another account [userId=${user.id}] [orgId=${orgId}]`
+      `Skipped SSO email sync, ${detail} [userId=${user.id}] [orgId=${orgId}]`
     );
     await auditLogService
       .createAuditLog({
         actor: { type: ActorType.PLATFORM, metadata: {} },
         orgId,
         event: {
-          type: EventType.SSO_USER_PROFILE_SYNC_CONFLICT,
+          type: EventType.SSO_USER_EMAIL_SYNC_SKIPPED,
           metadata: {
             userId: user.id,
             aliasType: userAlias.aliasType,
             externalId: userAlias.externalId,
             currentEmail: user.username,
             assertedEmail: assertedUsername,
+            reason,
             conflictingUserId
           }
         }
       })
       .catch((err) => {
-        logger.error(err, `Failed to audit SSO profile sync conflict for user ${user.id} in org ${orgId}`);
+        logger.error(err, `Failed to audit the skipped SSO email sync for user ${user.id} in org ${orgId}`);
       });
   };
 
@@ -195,10 +210,7 @@ export const syncSsoUserProfile = async ({
 
     if (!isOrgOwnedRename) {
       isEmailApplied = false;
-      logger.warn(
-        { userId: user.id, orgId, externalId: userAlias.externalId },
-        `Skipped SSO email sync, the organization does not own both addresses [userId=${user.id}] [orgId=${orgId}]`
-      );
+      await logSkippedEmailSync({ reason: "domain-not-owned" });
       if (!isNameChanged) return user;
     }
   }
@@ -207,7 +219,7 @@ export const syncSsoUserProfile = async ({
     const conflictingUser = await userDAL.findOne({ username: assertedUsername });
     if (conflictingUser && conflictingUser.id !== user.id) {
       isEmailApplied = false;
-      await logConflict(conflictingUser.id);
+      await logSkippedEmailSync({ reason: "address-taken", conflictingUserId: conflictingUser.id });
       if (!isNameChanged) return user;
     }
   }
@@ -246,7 +258,7 @@ export const syncSsoUserProfile = async ({
       return user;
     }
 
-    await logConflict();
+    await logSkippedEmailSync({ reason: "address-taken" });
     isEmailApplied = false;
     if (!isNameChanged) return user;
 

--- a/backend/src/services/user-alias/user-alias-fns.ts
+++ b/backend/src/services/user-alias/user-alias-fns.ts
@@ -2,6 +2,8 @@ import { Knex } from "knex";
 
 import { AccessScope, TableName, TUserAliases, TUsers } from "@app/db/schemas";
 import { EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
+import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
+import { verifyEmailDomainOwnership } from "@app/ee/services/email-domain/email-domain-fns";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { DatabaseError, ForbiddenRequestError } from "@app/lib/errors";
 import { unique } from "@app/lib/fn";
@@ -107,6 +109,7 @@ type TSyncSsoUserProfileDTO = {
   isAuthEnforced: boolean;
   userDAL: Pick<TUserDALFactory, "findOne" | "updateById" | "transaction">;
   userAliasDAL: Pick<TUserAliasDALFactory, "updateById">;
+  emailDomainDAL: Pick<TEmailDomainDALFactory, "findOne">;
   auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
 };
 
@@ -138,6 +141,7 @@ export const syncSsoUserProfile = async ({
   isAuthEnforced,
   userDAL,
   userAliasDAL,
+  emailDomainDAL,
   auditLogService
 }: TSyncSsoUserProfileDTO): Promise<TUsers> => {
   if (!isAuthEnforced || !userAlias.isEmailVerified) return user;
@@ -182,6 +186,24 @@ export const syncSsoUserProfile = async ({
 
   let isEmailApplied = isEmailChanged;
   if (isEmailChanged) {
+    const isOrgOwnedRename = await Promise.all([
+      verifyEmailDomainOwnership({ email: user.username, orgId, emailDomainDAL }),
+      verifyEmailDomainOwnership({ email: assertedUsername, orgId, emailDomainDAL })
+    ])
+      .then(() => true)
+      .catch(() => false);
+
+    if (!isOrgOwnedRename) {
+      isEmailApplied = false;
+      logger.warn(
+        { userId: user.id, orgId, externalId: userAlias.externalId },
+        `Skipped SSO email sync, the organization does not own both addresses [userId=${user.id}] [orgId=${orgId}]`
+      );
+      if (!isNameChanged) return user;
+    }
+  }
+
+  if (isEmailApplied) {
     const conflictingUser = await userDAL.findOne({ username: assertedUsername });
     if (conflictingUser && conflictingUser.id !== user.id) {
       isEmailApplied = false;

--- a/backend/src/services/user-alias/user-alias-fns.ts
+++ b/backend/src/services/user-alias/user-alias-fns.ts
@@ -1,11 +1,14 @@
 import { Knex } from "knex";
 
 import { AccessScope, TableName, TUserAliases, TUsers } from "@app/db/schemas";
+import { EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
 import { DatabaseError, ForbiddenRequestError } from "@app/lib/errors";
 import { unique } from "@app/lib/fn";
+import { logger } from "@app/lib/logger";
 import { sanitizeEmail } from "@app/lib/validator/validate-email";
 
+import { ActorType } from "../auth/auth-type";
 import { TOrgDALFactory } from "../org/org-dal";
 import { TUserDALFactory } from "../user/user-dal";
 import { TUserAliasDALFactory } from "./user-alias-dal";
@@ -91,6 +94,161 @@ export const ensureSsoAccountVerified = async ({
     user: { ...user, isAccepted: true, isEmailVerified: true },
     userAlias: { ...userAlias, isEmailVerified: true }
   };
+};
+
+type TSyncSsoUserProfileDTO = {
+  user: TUsers;
+  userAlias: TUserAliases;
+  // Caller has already sanitized this and verified its domain against the org.
+  assertedEmail: string;
+  assertedFirstName?: string | null;
+  assertedLastName?: string | null;
+  orgId: string;
+  isAuthEnforced: boolean;
+  userDAL: Pick<TUserDALFactory, "findOne" | "updateById" | "transaction">;
+  userAliasDAL: Pick<TUserAliasDALFactory, "updateById">;
+  auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
+};
+
+/**
+ * An IdP that keys people on a stable identifier (a UPN, say) lets them change mailbox and display
+ * name without changing who they are, so our copy of both goes stale: notification mail is sent to
+ * an address that no longer exists, and every audit entry written from then on records it. Where
+ * the org enforces SSO it has already made the IdP authoritative for identity, so the assertion is
+ * the better source and we take it.
+ *
+ * Requires a verified alias, which is our proof that the IdP controls this account. An unverified
+ * alias asserting an unrecognized email is what isStaleSsoAlias exists to catch, and reading that
+ * as a rename would let a stale alias rewrite somebody else's account.
+ *
+ * Runs on every login, so it writes only on a real difference. Call it outside the caller's
+ * transaction: it owns its own, and the audit entry must not describe a change that later rolls
+ * back.
+ *
+ * Never fails the login. An unsynced profile is stale data, which is what we already had, whereas a
+ * throw here locks someone out of an org that has no other way in.
+ */
+export const syncSsoUserProfile = async ({
+  user,
+  userAlias,
+  assertedEmail,
+  assertedFirstName,
+  assertedLastName,
+  orgId,
+  isAuthEnforced,
+  userDAL,
+  userAliasDAL,
+  auditLogService
+}: TSyncSsoUserProfileDTO): Promise<TUsers> => {
+  if (!isAuthEnforced || !userAlias.isEmailVerified) return user;
+
+  const assertedUsername = sanitizeEmail(assertedEmail);
+  const isEmailChanged = Boolean(assertedUsername) && assertedUsername !== user.username;
+
+  const firstName = assertedFirstName?.trim();
+  const lastName = assertedLastName?.trim();
+  const nameChanges: { firstName?: string; lastName?: string } = {};
+  if (firstName && firstName !== user.firstName) nameChanges.firstName = firstName;
+  if (lastName && lastName !== user.lastName) nameChanges.lastName = lastName;
+  const isNameChanged = Object.keys(nameChanges).length > 0;
+
+  if (!isEmailChanged && !isNameChanged) return user;
+
+  const logConflict = async (conflictingUserId?: string) => {
+    logger.warn(
+      { userId: user.id, orgId, externalId: userAlias.externalId, assertedEmail: assertedUsername, conflictingUserId },
+      `Skipped SSO email sync, the asserted address belongs to another account [userId=${user.id}] [orgId=${orgId}]`
+    );
+    await auditLogService
+      .createAuditLog({
+        actor: { type: ActorType.PLATFORM, metadata: {} },
+        orgId,
+        event: {
+          type: EventType.SSO_USER_PROFILE_SYNC_CONFLICT,
+          metadata: {
+            userId: user.id,
+            aliasType: userAlias.aliasType,
+            externalId: userAlias.externalId,
+            currentEmail: user.username,
+            assertedEmail: assertedUsername,
+            conflictingUserId
+          }
+        }
+      })
+      .catch((err) => {
+        logger.error(err, `Failed to audit SSO profile sync conflict for user ${user.id} in org ${orgId}`);
+      });
+  };
+
+  let isEmailApplied = isEmailChanged;
+  if (isEmailChanged) {
+    const conflictingUser = await userDAL.findOne({ username: assertedUsername });
+    if (conflictingUser && conflictingUser.id !== user.id) {
+      isEmailApplied = false;
+      await logConflict(conflictingUser.id);
+      if (!isNameChanged) return user;
+    }
+  }
+
+  try {
+    const updatedUser = await userDAL.transaction(async (tx) => {
+      const nextUser = await userDAL.updateById(
+        user.id,
+        {
+          ...nameChanges,
+          ...(isEmailApplied ? { email: assertedUsername, username: assertedUsername } : {})
+        },
+        tx
+      );
+
+      if (isEmailApplied) {
+        await userAliasDAL.updateById(
+          userAlias.id,
+          { emails: unique([...(userAlias.emails ?? []), assertedUsername]) },
+          tx
+        );
+      }
+
+      return nextUser;
+    });
+
+    logger.info(
+      { userId: user.id, orgId, externalId: userAlias.externalId, isEmailApplied },
+      `Synced SSO profile from the identity provider [userId=${user.id}] [orgId=${orgId}]`
+    );
+
+    await auditLogService
+      .createAuditLog({
+        actor: { type: ActorType.PLATFORM, metadata: {} },
+        orgId,
+        event: {
+          type: EventType.SSO_USER_PROFILE_SYNCED,
+          metadata: {
+            userId: user.id,
+            aliasType: userAlias.aliasType,
+            externalId: userAlias.externalId,
+            ...(isEmailApplied ? { previousEmail: user.username, newEmail: assertedUsername } : {}),
+            ...(nameChanges.firstName
+              ? { previousFirstName: user.firstName, newFirstName: nameChanges.firstName }
+              : {}),
+            ...(nameChanges.lastName ? { previousLastName: user.lastName, newLastName: nameChanges.lastName } : {})
+          }
+        }
+      })
+      .catch((err) => {
+        logger.error(err, `Failed to audit SSO profile sync for user ${user.id} in org ${orgId}`);
+      });
+
+    return updatedUser;
+  } catch (err) {
+    if (err instanceof DatabaseError && (err.error as { code?: string })?.code === DatabaseErrorCode.UniqueViolation) {
+      await logConflict();
+      return user;
+    }
+
+    logger.error(err, `Failed to sync SSO profile for user ${user.id} in org ${orgId}`);
+    return user;
+  }
 };
 
 type TResolveAliasUserIdsDTO = {

--- a/backend/src/services/user/user-service.test.ts
+++ b/backend/src/services/user/user-service.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { EmailDomainStatus } from "@app/ee/services/email-domain/email-domain-types";
+
+import { userServiceFactory } from "./user-service";
+
+vi.mock("@app/lib/config/env", () => ({
+  getConfig: () => ({ SITE_URL: "https://app.infisical.com", isSmtpConfigured: true })
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}));
+
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const ENFORCED_ORG_ID = "22222222-2222-2222-2222-222222222222";
+
+const user = {
+  id: USER_ID,
+  username: "alice@corp.com",
+  email: "alice@corp.com",
+  authMethods: ["email"]
+};
+
+type Overrides = {
+  organizations?: { id: string; scimEnabled?: boolean; authEnforced?: boolean }[];
+  verifiedDomains?: { orgId: string; domain: string; status: string }[];
+};
+
+const buildService = ({ organizations = [], verifiedDomains = [] }: Overrides) => {
+  const emailDomainDAL = {
+    find: vi.fn(async (filter: Record<string, unknown>) => {
+      const orgIds = (filter.$in as { orgId: string[] })?.orgId ?? [];
+      return verifiedDomains.filter(
+        (row) => row.domain === filter.domain && row.status === filter.status && orgIds.includes(row.orgId)
+      );
+    })
+  };
+
+  const tokenService = { createTokenForUser: vi.fn().mockResolvedValue("123456") };
+  const smtpService = { sendMail: vi.fn().mockResolvedValue(undefined) };
+
+  const service = userServiceFactory({
+    userDAL: {
+      findById: vi.fn().mockResolvedValue(user),
+      // The service threads `tx` through every call; the stubs ignore it.
+      transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({}))
+    },
+    membershipUserDAL: {
+      find: vi.fn().mockResolvedValue(organizations.map((org) => ({ scopeOrgId: org.id })))
+    },
+    orgDAL: { find: vi.fn().mockResolvedValue(organizations) },
+    emailDomainDAL,
+    tokenService,
+    smtpService
+  } as unknown as Parameters<typeof userServiceFactory>[0]);
+
+  return { service, emailDomainDAL, tokenService };
+};
+
+// Settle the call before advancing the clock, so a refusal that rejects while the timers run still
+// has a handler attached. The success path pads its response to a fixed duration to defeat timing
+// enumeration, which is what needs the clock advanced at all.
+const requestChange = async (service: ReturnType<typeof buildService>["service"]) => {
+  const settled = service
+    .requestEmailChangeOTP({ userId: USER_ID, newEmail: "alice@newcorp.com" })
+    .then((value) => ({ value, error: undefined }))
+    .catch((error: Error) => ({ value: undefined, error }));
+
+  await vi.runAllTimersAsync();
+
+  const { value, error } = await settled;
+  if (error) throw error;
+  return value;
+};
+
+describe("requestEmailChangeOTP managed-email gate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("allows the change when the user belongs to no organization", async () => {
+    const { service, tokenService } = buildService({});
+
+    await expect(requestChange(service)).resolves.toMatchObject({ success: true });
+    expect(tokenService.createTokenForUser).toHaveBeenCalledOnce();
+  });
+
+  test("refuses the change when any organization has SCIM enabled", async () => {
+    const { service, emailDomainDAL } = buildService({
+      organizations: [{ id: ENFORCED_ORG_ID, scimEnabled: true }]
+    });
+
+    await expect(requestChange(service)).rejects.toThrow(/SCIM is enabled/);
+    expect(emailDomainDAL.find).not.toHaveBeenCalled();
+  });
+
+  test("refuses the change when the address is on a verified domain of an SSO-enforced org", async () => {
+    const { service } = buildService({
+      organizations: [{ id: ENFORCED_ORG_ID, authEnforced: true }],
+      verifiedDomains: [{ orgId: ENFORCED_ORG_ID, domain: "corp.com", status: EmailDomainStatus.Verified }]
+    });
+
+    await expect(requestChange(service)).rejects.toThrow(/enforces SSO/);
+  });
+
+  test("allows the change when the enforced org has not verified the address's domain", async () => {
+    const { service, tokenService } = buildService({
+      organizations: [{ id: ENFORCED_ORG_ID, authEnforced: true }],
+      verifiedDomains: [{ orgId: ENFORCED_ORG_ID, domain: "other.com", status: EmailDomainStatus.Verified }]
+    });
+
+    await expect(requestChange(service)).resolves.toMatchObject({ success: true });
+    expect(tokenService.createTokenForUser).toHaveBeenCalledOnce();
+  });
+
+  test("allows the change when the domain is verified only by an org that does not enforce SSO", async () => {
+    const { service, tokenService } = buildService({
+      organizations: [{ id: ENFORCED_ORG_ID, authEnforced: true }, { id: "33333333-3333-3333-3333-333333333333" }],
+      verifiedDomains: [
+        { orgId: "33333333-3333-3333-3333-333333333333", domain: "corp.com", status: EmailDomainStatus.Verified }
+      ]
+    });
+
+    await expect(requestChange(service)).resolves.toMatchObject({ success: true });
+    expect(tokenService.createTokenForUser).toHaveBeenCalledOnce();
+  });
+
+  test("allows the change when the domain is only pending verification", async () => {
+    const { service, tokenService } = buildService({
+      organizations: [{ id: ENFORCED_ORG_ID, authEnforced: true }],
+      verifiedDomains: [{ orgId: ENFORCED_ORG_ID, domain: "corp.com", status: EmailDomainStatus.Pending }]
+    });
+
+    await expect(requestChange(service)).resolves.toMatchObject({ success: true });
+    expect(tokenService.createTokenForUser).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/src/services/user/user-service.ts
+++ b/backend/src/services/user/user-service.ts
@@ -1,7 +1,9 @@
 import { ForbiddenError } from "@casl/ability";
 import { Knex } from "knex";
 
-import { AccessScope, OrganizationActionScope } from "@app/db/schemas";
+import { AccessScope, OrganizationActionScope, TUsers } from "@app/db/schemas";
+import { TEmailDomainDALFactory } from "@app/ee/services/email-domain/email-domain-dal";
+import { EmailDomainStatus } from "@app/ee/services/email-domain/email-domain-types";
 import { OrgPermissionActions, OrgPermissionSubjects } from "@app/ee/services/permission/org-permission";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { getConfig } from "@app/lib/config/env";
@@ -75,6 +77,7 @@ type TUserServiceFactoryDep = {
   mfaRecoveryCodeService: Pick<TMfaRecoveryCodeServiceFactory, "rotateRecoveryCodes" | "deleteRecoveryCodes">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
   alertChannelRecipientDAL: Pick<TAlertChannelRecipientDALFactory, "deleteByPrincipals">;
+  emailDomainDAL: Pick<TEmailDomainDALFactory, "find">;
 };
 
 export type TUserServiceFactory = ReturnType<typeof userServiceFactory>;
@@ -92,7 +95,8 @@ export const userServiceFactory = ({
   webAuthnCredentialDAL,
   mfaRecoveryCodeService,
   usageMeteringService,
-  alertChannelRecipientDAL
+  alertChannelRecipientDAL,
+  emailDomainDAL
 }: TUserServiceFactoryDep) => {
   const sendEmailVerificationCode = async (token: string) => {
     const config = getConfig();
@@ -272,11 +276,16 @@ export const userServiceFactory = ({
    * Returns why this account's email is managed elsewhere, or null when the user owns it. SCIM
    * provisions the address from the directory; SSO enforcement makes the IdP authoritative for it
    * and overwrites whatever is set here on the next login, so offering the change would be a lie.
+   *
+   * Enforcement only reaches an address on a domain the enforcing org has verified, since
+   * syncSsoUserProfile refuses to rename anything else. The user row is global, so membership in an
+   * enforced org is not on its own a claim over the address: someone whose mailbox sits outside that
+   * org's domains still owns it and keeps the change.
    */
-  const $getManagedEmailReason = async (userId: string, tx?: Knex) => {
+  const $getManagedEmailReason = async (user: Pick<TUsers, "id" | "username">, tx?: Knex) => {
     const userOrgs = await membershipUserDAL.find(
       {
-        actorUserId: userId,
+        actorUserId: user.id,
         scope: AccessScope.Organization
       },
       { tx }
@@ -293,8 +302,27 @@ export const userServiceFactory = ({
       return "Email changes are disabled because SCIM is enabled for one or more of your organizations";
     }
 
-    if (organizations.some((org) => org.authEnforced)) {
-      return "Email changes are disabled because one or more of your organizations enforce SSO. Your email address is managed by your identity provider.";
+    const authEnforcedOrgIds = organizations.filter((org) => org.authEnforced).map((org) => org.id);
+    if (!authEnforcedOrgIds.length) {
+      return null;
+    }
+
+    const emailDomain = user.username.split("@")[1]?.toLowerCase().trim();
+    if (!emailDomain) {
+      return null;
+    }
+
+    const [managedDomain] = await emailDomainDAL.find(
+      {
+        domain: emailDomain,
+        status: EmailDomainStatus.Verified,
+        $in: { orgId: authEnforcedOrgIds }
+      },
+      { tx, limit: 1 }
+    );
+
+    if (managedDomain) {
+      return "Email changes are disabled because your address is on a domain belonging to an organization that enforces SSO. Your email address is managed by your identity provider.";
     }
 
     return null;
@@ -327,7 +355,7 @@ export const userServiceFactory = ({
         });
       }
 
-      const managedEmailReason = await $getManagedEmailReason(userId, tx);
+      const managedEmailReason = await $getManagedEmailReason(user, tx);
       if (managedEmailReason) {
         throw new BadRequestError({ message: managedEmailReason, name: "RequestEmailChangeOTP" });
       }
@@ -373,7 +401,7 @@ export const userServiceFactory = ({
         throw new BadRequestError({ message: "Cannot update email for LDAP users", name: "VerifyCurrentEmailOTP" });
       }
 
-      const managedEmailReason = await $getManagedEmailReason(userId, tx);
+      const managedEmailReason = await $getManagedEmailReason(user, tx);
       if (managedEmailReason) {
         throw new BadRequestError({ message: managedEmailReason, name: "VerifyCurrentEmailOTP" });
       }
@@ -450,7 +478,7 @@ export const userServiceFactory = ({
         throw new BadRequestError({ message: "Cannot update email for LDAP users", name: "UpdateUserEmail" });
       }
 
-      const managedEmailReason = await $getManagedEmailReason(userId, tx);
+      const managedEmailReason = await $getManagedEmailReason(user, tx);
       if (managedEmailReason) {
         throw new BadRequestError({ message: managedEmailReason, name: "UpdateUserEmail" });
       }

--- a/backend/src/services/user/user-service.ts
+++ b/backend/src/services/user/user-service.ts
@@ -268,7 +268,12 @@ export const userServiceFactory = ({
     return updatedUser;
   };
 
-  const checkUserScimRestriction = async (userId: string, tx?: Knex) => {
+  /**
+   * Returns why this account's email is managed elsewhere, or null when the user owns it. SCIM
+   * provisions the address from the directory; SSO enforcement makes the IdP authoritative for it
+   * and overwrites whatever is set here on the next login, so offering the change would be a lie.
+   */
+  const $getManagedEmailReason = async (userId: string, tx?: Knex) => {
     const userOrgs = await membershipUserDAL.find(
       {
         actorUserId: userId,
@@ -278,13 +283,21 @@ export const userServiceFactory = ({
     );
 
     if (userOrgs.length === 0) {
-      return false;
+      return null;
     }
 
     const orgIds = userOrgs.map((membership) => membership.scopeOrgId);
     const organizations = await orgDAL.find({ $in: { id: orgIds } }, { tx });
 
-    return organizations.some((org) => org.scimEnabled);
+    if (organizations.some((org) => org.scimEnabled)) {
+      return "Email changes are disabled because SCIM is enabled for one or more of your organizations";
+    }
+
+    if (organizations.some((org) => org.authEnforced)) {
+      return "Email changes are disabled because one or more of your organizations enforce SSO. Your email address is managed by your identity provider.";
+    }
+
+    return null;
   };
 
   const requestEmailChangeOTP = async ({ userId, newEmail }: TUpdateUserEmailDTO) => {
@@ -314,12 +327,9 @@ export const userServiceFactory = ({
         });
       }
 
-      const hasScimRestriction = await checkUserScimRestriction(userId, tx);
-      if (hasScimRestriction) {
-        throw new BadRequestError({
-          message: "Email changes are disabled because SCIM is enabled for one or more of your organizations",
-          name: "RequestEmailChangeOTP"
-        });
+      const managedEmailReason = await $getManagedEmailReason(userId, tx);
+      if (managedEmailReason) {
+        throw new BadRequestError({ message: managedEmailReason, name: "RequestEmailChangeOTP" });
       }
 
       // Availability of the requested address is deliberately NOT checked here: step 1
@@ -363,12 +373,9 @@ export const userServiceFactory = ({
         throw new BadRequestError({ message: "Cannot update email for LDAP users", name: "VerifyCurrentEmailOTP" });
       }
 
-      const hasScimRestriction = await checkUserScimRestriction(userId, tx);
-      if (hasScimRestriction) {
-        throw new BadRequestError({
-          message: "Email changes are disabled because SCIM is enabled for one or more of your organizations",
-          name: "VerifyCurrentEmailOTP"
-        });
+      const managedEmailReason = await $getManagedEmailReason(userId, tx);
+      if (managedEmailReason) {
+        throw new BadRequestError({ message: managedEmailReason, name: "VerifyCurrentEmailOTP" });
       }
 
       let tokenData;
@@ -443,12 +450,9 @@ export const userServiceFactory = ({
         throw new BadRequestError({ message: "Cannot update email for LDAP users", name: "UpdateUserEmail" });
       }
 
-      const hasScimRestriction = await checkUserScimRestriction(userId, tx);
-      if (hasScimRestriction) {
-        throw new BadRequestError({
-          message: "You are part of an organization that has SCIM enabled, and email changes are not allowed",
-          name: "UpdateUserEmail"
-        });
+      const managedEmailReason = await $getManagedEmailReason(userId, tx);
+      if (managedEmailReason) {
+        throw new BadRequestError({ message: managedEmailReason, name: "UpdateUserEmail" });
       }
 
       // Validate OTP and get the new email from token aliasId field

--- a/docs/documentation/platform/scim/overview.mdx
+++ b/docs/documentation/platform/scim/overview.mdx
@@ -24,6 +24,12 @@ You can configure your organization in Infisical to have users and user groups b
 - Provisioning: The SCIM provider pushes user information to Infisical. If the user exists in Infisical, Infisical sends an email invitation to add them to the relevant organization in Infisical; if not, Infisical initializes a new user and sends them an email invitation to finish setting up their account in the organization.
 - Deprovisioning: The SCIM provider instructs Infisical to remove user(s) from an organization in Infisical.
 
+## Email address changes
+
+Infisical identifies a member by their email address, so an update that changes the address is rejected unless your organization [enforces SSO](/documentation/platform/sso/overview#sso-enforcement). With enforcement on, the address comes from your identity provider: the update renames the existing Infisical account, and the member keeps their memberships and project access.
+
+The update is rejected with `409 Conflict` when another Infisical account already uses the new address. Remove or merge that account, then retry the provisioning job.
+
 SCIM providers:
 
 - [Okta SCIM](/documentation/platform/scim/okta)

--- a/docs/documentation/platform/sso/overview.mdx
+++ b/docs/documentation/platform/sso/overview.mdx
@@ -46,10 +46,11 @@ If your required identity provider is not shown in the list above, please reach 
 
 ## SSO enforcement
 
-When you enforce SAML or OIDC SSO for your organization, members can only access Infisical by logging in through your identity provider. Enforcement has two additional effects tied to your [verified email domain(s)](/documentation/platform/email-domain):
+When you enforce SAML or OIDC SSO for your organization, members can only access Infisical by logging in through your identity provider. Enforcement has three additional effects tied to your [verified email domain(s)](/documentation/platform/email-domain):
 
 - **Email & password signup is blocked for your verified domain(s).** Once SSO is enforced, new email/password accounts can no longer be created for addresses on your verified domain(s). The verified domain and IdP are authoritative, so allowing a competing password account would reopen an account-takeover vector.
 - **Email verification is skipped for SSO sign-ins.** Because the verified domain and IdP already prove ownership of the email, Infisical skips the additional email-verification step that normally applies to SSO logins (see the FAQ below).
+- **Email addresses and names come from your identity provider.** Each SSO login updates the member's email address and name to match the assertion. Someone renamed in your identity provider keeps their Infisical account and their access, and later notifications and audit log entries carry the new address. Members can't change their own email address while enforcement is on.
 
 <Warning>
   Before enforcing SSO, make sure a break-glass organization admin already has a password and SSO bypass access. After enforcement is enabled, the signup block prevents creating new password accounts for the domain.
@@ -76,6 +77,13 @@ This portal is accessible at `/login/admin` (e.g., https://app.infisical.com/log
         verification step upon their first login.
 
         To skip this step, [enforce SSO](#sso-enforcement) for your organization. Enforcement requires a [verified email domain](/documentation/platform/email-domain), so the domain and your identity provider are already authoritative for that email.
+    </Accordion>
+    <Accordion title="What happens when a member's email address changes in my identity provider?">
+        With SSO enforcement on, the next login updates that member's Infisical email address and name to match the assertion. The account, its memberships, and its access are unchanged, and audit log entries written from then on carry the new address. Entries written earlier keep the address that was current when they were recorded.
+
+        If your organization provisions through [SCIM](/documentation/platform/scim/overview), the change arrives on the provisioning job instead, without waiting for the member to log in.
+
+        When another Infisical account already uses the new address, Infisical leaves the email address as it is and records the conflict in the audit log. Remove or merge the other account, and the change applies on the next login.
     </Accordion>
     <Accordion title="Why do I get redirected to SSO when trying to use the Admin Login Portal?">
         You are likely being redirected because you do not have email authentication mode enabled, or you're not an **Organization Admin**. This portal requires **Organization Admin** status and direct credential login (email and password). **Server Admin** status alone is insufficient.

--- a/docs/documentation/platform/sso/overview.mdx
+++ b/docs/documentation/platform/sso/overview.mdx
@@ -50,7 +50,7 @@ When you enforce SAML or OIDC SSO for your organization, members can only access
 
 - **Email & password signup is blocked for your verified domain(s).** Once SSO is enforced, new email/password accounts can no longer be created for addresses on your verified domain(s). The verified domain and IdP are authoritative, so allowing a competing password account would reopen an account-takeover vector.
 - **Email verification is skipped for SSO sign-ins.** Because the verified domain and IdP already prove ownership of the email, Infisical skips the additional email-verification step that normally applies to SSO logins (see the FAQ below).
-- **Email addresses and names come from your identity provider.** Each SSO login updates the member's email address and name to match the assertion. Someone renamed in your identity provider keeps their Infisical account and their access, and later notifications and audit log entries carry the new address. Members can't change their own email address while enforcement is on.
+- **Email addresses and names come from your identity provider.** Each SSO login updates the member's email address and name to match the assertion. Someone renamed in your identity provider keeps their Infisical account and their access, and later notifications and audit log entries carry the new address. Members on one of your verified domains can't change their own email address while enforcement is on.
 
 <Warning>
   Before enforcing SSO, make sure a break-glass organization admin already has a password and SSO bypass access. After enforcement is enabled, the signup block prevents creating new password accounts for the domain.

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -200,8 +200,7 @@ export const eventToNameMap: { [K in EventType]: string } = {
   [EventType.OIDC_PROVISIONED_PLACEHOLDER_ADOPTED]:
     "OIDC login adopted provisioned placeholder account",
   [EventType.SSO_USER_PROFILE_SYNCED]: "Synced user profile from identity provider",
-  [EventType.SSO_USER_PROFILE_SYNC_CONFLICT]:
-    "Skipped user email sync from identity provider due to conflict",
+  [EventType.SSO_USER_EMAIL_SYNC_SKIPPED]: "Skipped user email sync from identity provider",
   [EventType.SECRET_APPROVAL_REQUEST_REVIEW]: "Review Secret Approval Request",
   [EventType.CREATE_KMIP_CLIENT]: "Create KMIP client",
   [EventType.UPDATE_KMIP_CLIENT]: "Update KMIP client",

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -199,6 +199,9 @@ export const eventToNameMap: { [K in EventType]: string } = {
     "OIDC group membership mapping removed user from groups",
   [EventType.OIDC_PROVISIONED_PLACEHOLDER_ADOPTED]:
     "OIDC login adopted provisioned placeholder account",
+  [EventType.SSO_USER_PROFILE_SYNCED]: "Synced user profile from identity provider",
+  [EventType.SSO_USER_PROFILE_SYNC_CONFLICT]:
+    "Skipped user email sync from identity provider due to conflict",
   [EventType.SECRET_APPROVAL_REQUEST_REVIEW]: "Review Secret Approval Request",
   [EventType.CREATE_KMIP_CLIENT]: "Create KMIP client",
   [EventType.UPDATE_KMIP_CLIENT]: "Update KMIP client",

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -206,6 +206,8 @@ export enum EventType {
   OIDC_GROUP_MEMBERSHIP_MAPPING_ASSIGN_USER = "oidc-group-membership-mapping-assign-user",
   OIDC_GROUP_MEMBERSHIP_MAPPING_REMOVE_USER = "oidc-group-membership-mapping-remove-user",
   OIDC_PROVISIONED_PLACEHOLDER_ADOPTED = "oidc-provisioned-placeholder-adopted",
+  SSO_USER_PROFILE_SYNCED = "sso-user-profile-synced",
+  SSO_USER_PROFILE_SYNC_CONFLICT = "sso-user-profile-sync-conflict",
   CREATE_KMIP_CLIENT = "create-kmip-client",
   UPDATE_KMIP_CLIENT = "update-kmip-client",
   DELETE_KMIP_CLIENT = "delete-kmip-client",

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -207,7 +207,7 @@ export enum EventType {
   OIDC_GROUP_MEMBERSHIP_MAPPING_REMOVE_USER = "oidc-group-membership-mapping-remove-user",
   OIDC_PROVISIONED_PLACEHOLDER_ADOPTED = "oidc-provisioned-placeholder-adopted",
   SSO_USER_PROFILE_SYNCED = "sso-user-profile-synced",
-  SSO_USER_PROFILE_SYNC_CONFLICT = "sso-user-profile-sync-conflict",
+  SSO_USER_EMAIL_SYNC_SKIPPED = "sso-user-email-sync-skipped",
   CREATE_KMIP_CLIENT = "create-kmip-client",
   UPDATE_KMIP_CLIENT = "update-kmip-client",
   DELETE_KMIP_CLIENT = "delete-kmip-client",


### PR DESCRIPTION
## Context

Identity providers identify a person using a stable identifier, so a person can be renamed at the IdP due to a legal name change, domain migration, or mailbox move without ceasing to be the same person. Infisical identifies a member by their email address, so we previously had no way to accommodate this.

As a result, our copy could become stale. Notifications continued to be sent to a mailbox that no longer existed, and audit entries written afterwards continued to record the outdated address. With SCIM, the behavior was more severe: we rejected the update entirely, leaving the provisioning job in a permanent error state. Entra can quarantine a connector after repeated failures, which can also prevent deprovisioning from functioning correctly.

This change makes the IdP authoritative for email and display name in organizations that **enforce SSO**. This is consistent with the existing behavior of SSO enforcement, which blocks password-based signup for verified domains and skips email verification during SSO sign-in.

## What changes for enforced organizations

* **SSO profile sync:** SAML, OIDC, and LDAP logins sync the asserted email and name to the account. Memberships and project access are unchanged.
* **SCIM updates:** `PATCH` and `PUT` now accept email changes, allowing IdP renames to propagate without requiring a login.
* **Self-service changes:** Members whose email is controlled by an enforced SSO organization can no longer change it manually.

Organizations that do not enforce SSO behave as before.

## Safeguards

Because an account can belong to multiple organizations:

* Sync requires SSO enforcement and a verified SSO alias.
* Both the current and new email addresses must use domains verified by the organization.
* An email cannot be changed to one already associated with another account. SCIM returns `409 Conflict`; SSO login records the conflict, preserves the email, and still syncs the name.
* Profile sync never blocks login. Failures leave the account unchanged.
* The previous email remains as an alias so in-flight logins can still resolve.

Two audit events are added: **profile synced** and **sync skipped due to conflict**.

## Steps to verify the change

## Local SSO test harness

The local SSO harness is documented in [`[sso.md](https://chatgpt.com/c/sso.md)`](sso.md). Unlock the EE feature gates first.

### Login-driven sync

Using OIDC with Keycloak:

1. Run `make up-dev-oidc` and `make seed-dev-oidc`, then open `http://localhost:8080`.
2. Sign in as `john@oidc.com` through SSO to create the account and alias.
3. Enable **Organization Settings → SSO → Enforce OIDC SSO** for the `oidc` organization. The `oidc.com` domain is already verified by the seed.
4. In Keycloak, change John's email to another `@oidc.com` address and sign in through SSO again. The email updates, while memberships and project access remain unchanged. The audit log records *Synced user profile from identity provider*.
5. Disable enforcement, change the email again, and sign in. The email remains unchanged.
6. Change the email to an unverified domain. The existing verified-domain check rejects the login.
7. Create another account using the target email, then rename John to that address in Keycloak. The login succeeds, John's email remains unchanged, and the audit log records *Skipped user email sync ... due to conflict*.

Repeat the login-driven tests with LDAP using `make up-dev-ldap` and `make seed-dev-ldap`.

### SCIM provisioning

Using SAML and Authentik:

1. Run `make up-dev-saml` and `make seed-dev-saml`. This uses real outbound SCIM.
2. In Authentik, change `john@saml.com`'s email and run the SCIM provider sync.
3. With SSO enforcement disabled, the sync is rejected by the immutable-email restriction.
4. Enable enforcement for the `saml` organization and sync again. John's email updates and memberships remain intact.
5. Change John's email to Alice's address and sync. Authentik receives `409 Conflict`.
6. Deactivate John in Authentik and sync. Deprovisioning succeeds, covering the case that was previously blocked.

### Self-service email changes

For an enforced organization, a member whose email uses a verified organization domain cannot change it from Personal Settings. The error explains that the identity provider controls the address.

A member whose email is outside the organization's verified domains can still change it.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)