### PR TITLE
feat(kms): add asymmetric key encryption RSA-4096 for encrypt-decrypt usage

### DIFF
--- a/backend/e2e-test/routes/v1/kms.spec.ts
+++ b/backend/e2e-test/routes/v1/kms.spec.ts
@@ -88,6 +88,18 @@ describe("KMS V1 Router", () => {
       keyUsage: "encrypt-decrypt"
     });
 
+    const oversizedEncryptResponse = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/kms/keys/${key.id}/encrypt`,
+      headers: authHeaders,
+      body: { plaintext: Buffer.alloc(447).toString("base64") }
+    });
+
+    expect(oversizedEncryptResponse.statusCode, oversizedEncryptResponse.payload).toBe(400);
+    expect(JSON.parse(oversizedEncryptResponse.payload)).toMatchObject({
+      message: "Plaintext exceeds the 446-byte limit for RSA-4096 OAEP-SHA256 encryption."
+    });
+
     const plaintext = Buffer.from("RSA-4096 KMS plaintext", "utf8");
     const encryptResponse = await testServer.inject({
       method: "POST",

--- a/backend/e2e-test/routes/v1/kms.spec.ts
+++ b/backend/e2e-test/routes/v1/kms.spec.ts
@@ -1,0 +1,285 @@
+import {
+  constants,
+  createCipheriv,
+  createPrivateKey,
+  createPublicKey,
+  generateKeyPairSync,
+  publicEncrypt,
+  randomBytes
+} from "node:crypto";
+
+import {
+  CreateKeyCommand,
+  DecryptCommand,
+  GetParametersForImportCommand,
+  ImportKeyMaterialCommand,
+  KMSClient,
+  ScheduleKeyDeletionCommand
+} from "@aws-sdk/client-kms";
+
+const authHeaders = {
+  authorization: `Bearer ${jwtAuthToken}`
+};
+
+const wrapKeyMaterialForAws = (keyMaterial: Buffer, awsPublicKey: Buffer) => {
+  const aesKek = randomBytes(32);
+  try {
+    const cipher = createCipheriv("id-aes256-wrap-pad", aesKek, Buffer.from("A65959A6", "hex"));
+    const wrappedKeyMaterial = Buffer.concat([cipher.update(keyMaterial), cipher.final()]);
+    const wrappedAesKey = publicEncrypt(
+      {
+        key: createPublicKey({ key: awsPublicKey, format: "der", type: "spki" }),
+        padding: constants.RSA_PKCS1_OAEP_PADDING,
+        oaepHash: "sha256"
+      },
+      aesKek
+    );
+    return Buffer.concat([wrappedAesKey, wrappedKeyMaterial]);
+  } finally {
+    aesKek.fill(0);
+  }
+};
+
+const stripKmsCiphertextVersionForAws = (ciphertext: Buffer) => {
+  const suffix = ciphertext.subarray(-3).toString("utf8");
+  if (suffix === "v01") return ciphertext.subarray(0, -3);
+  if (suffix === "v02") return ciphertext.subarray(0, -7);
+  throw new Error("Expected an Infisical KMS ciphertext version suffix");
+};
+
+const awsKmsTest = process.env.RUN_AWS_KMS_E2E === "true" ? test : test.skip;
+
+describe("KMS V1 Router", () => {
+  test("creates an exportable RSA-4096 encrypt-decrypt key and decrypts ciphertext", async () => {
+    const projectResponse = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: authHeaders,
+      body: {
+        projectName: "RSA KMS E2E",
+        slug: "rsa-kms-e2e",
+        type: "kms"
+      }
+    });
+
+    expect(projectResponse.statusCode).toBe(200);
+    const { project } = JSON.parse(projectResponse.payload) as { project: { id: string } };
+
+    const createKeyResponse = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/kms/keys",
+      headers: authHeaders,
+      body: {
+        projectId: project.id,
+        name: "rsa-4096-encrypt-decrypt",
+        keyUsage: "encrypt-decrypt",
+        algorithm: "RSA_4096",
+        isExportable: true
+      }
+    });
+
+    expect(createKeyResponse.statusCode).toBe(200);
+    const { key } = JSON.parse(createKeyResponse.payload) as {
+      key: { id: string; algorithm: string; isExportable: boolean; keyUsage: string };
+    };
+    expect(key).toMatchObject({
+      algorithm: "RSA_4096",
+      isExportable: true,
+      keyUsage: "encrypt-decrypt"
+    });
+
+    const plaintext = Buffer.from("RSA-4096 KMS plaintext", "utf8");
+    const encryptResponse = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/kms/keys/${key.id}/encrypt`,
+      headers: authHeaders,
+      body: { plaintext: plaintext.toString("base64") }
+    });
+
+    expect(encryptResponse.statusCode, encryptResponse.payload).toBe(200);
+    const { ciphertext } = JSON.parse(encryptResponse.payload) as { ciphertext: string };
+    expect(ciphertext).not.toBe(plaintext.toString("base64"));
+
+    const decryptResponse = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/kms/keys/${key.id}/decrypt`,
+      headers: authHeaders,
+      body: { ciphertext }
+    });
+
+    expect(decryptResponse.statusCode).toBe(200);
+    const { plaintext: decryptedPlaintext } = JSON.parse(decryptResponse.payload) as { plaintext: string };
+    expect(Buffer.from(decryptedPlaintext, "base64")).toEqual(plaintext);
+
+    const rotateResponse = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/kms/keys/${key.id}/rotate`,
+      headers: authHeaders
+    });
+
+    expect(rotateResponse.statusCode).toBe(400);
+  });
+
+  test("bulk imports an exportable RSA-4096 encrypt-decrypt key and decrypts ciphertext", async () => {
+    const projectResponse = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: authHeaders,
+      body: {
+        projectName: "RSA KMS Import E2E",
+        slug: "rsa-kms-import-e2e",
+        type: "kms"
+      }
+    });
+
+    expect(projectResponse.statusCode).toBe(200);
+    const { project } = JSON.parse(projectResponse.payload) as { project: { id: string } };
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 4096,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" }
+    });
+
+    const importResponse = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/kms/keys/bulk-import",
+      headers: authHeaders,
+      body: {
+        projectId: project.id,
+        keys: [
+          {
+            name: "rsa-4096-imported-ed",
+            keyUsage: "encrypt-decrypt",
+            algorithm: "RSA_4096",
+            keyMaterial: Buffer.from(privateKey).toString("base64"),
+            isExportable: true
+          }
+        ]
+      }
+    });
+
+    expect(importResponse.statusCode, importResponse.payload).toBe(200);
+    const imported = JSON.parse(importResponse.payload) as { errors: unknown[]; keys: { id: string; name: string }[] };
+    expect(imported.errors).toEqual([]);
+    expect(imported.keys).toHaveLength(1);
+
+    const plaintext = Buffer.from("Imported RSA-4096 KMS plaintext", "utf8");
+    const keyId = imported.keys[0].id;
+    const encryptResponse = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/kms/keys/${keyId}/encrypt`,
+      headers: authHeaders,
+      body: { plaintext: plaintext.toString("base64") }
+    });
+
+    expect(encryptResponse.statusCode, encryptResponse.payload).toBe(200);
+    const { ciphertext } = JSON.parse(encryptResponse.payload) as { ciphertext: string };
+    const decryptResponse = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/kms/keys/${keyId}/decrypt`,
+      headers: authHeaders,
+      body: { ciphertext }
+    });
+
+    expect(decryptResponse.statusCode, decryptResponse.payload).toBe(200);
+    const { plaintext: decryptedPlaintext } = JSON.parse(decryptResponse.payload) as { plaintext: string };
+    expect(Buffer.from(decryptedPlaintext, "base64")).toEqual(plaintext);
+  });
+
+  awsKmsTest(
+    "AWS KMS decrypts RSA ciphertext after the Infisical KMS version suffix is removed in test code",
+    async () => {
+      const project = JSON.parse(
+        (
+          await testServer.inject({
+            method: "POST",
+            url: "/api/v1/projects",
+            headers: authHeaders,
+            body: { projectName: "AWS RSA KMS E2E", slug: "aws-rsa-kms-e2e", type: "kms" }
+          })
+        ).payload
+      ) as { project: { id: string } };
+      const key = JSON.parse(
+        (
+          await testServer.inject({
+            method: "POST",
+            url: "/api/v1/kms/keys",
+            headers: authHeaders,
+            body: {
+              projectId: project.project.id,
+              name: "aws-rsa-4096-ed",
+              keyUsage: "encrypt-decrypt",
+              algorithm: "RSA_4096",
+              isExportable: true
+            }
+          })
+        ).payload
+      ) as { key: { id: string } };
+      const exported = await testServer.inject({
+        method: "GET",
+        url: `/api/v1/kms/keys/${key.key.id}/private-key`,
+        headers: authHeaders
+      });
+      expect(exported.statusCode, exported.payload).toBe(200);
+      const privateKey = Buffer.from((JSON.parse(exported.payload) as { privateKey: string }).privateKey, "base64");
+      const privateKeyDer = createPrivateKey({ key: privateKey, format: "pem", type: "pkcs8" }).export({
+        format: "der",
+        type: "pkcs8"
+      });
+      const aws = new KMSClient({ region: "ap-south-2" });
+      const created = await aws.send(
+        new CreateKeyCommand({
+          Origin: "EXTERNAL",
+          KeySpec: "RSA_4096",
+          KeyUsage: "ENCRYPT_DECRYPT",
+          Tags: [{ TagKey: "InfisicalTemporaryE2ETest", TagValue: "true" }]
+        })
+      );
+      const keyId = created.KeyMetadata?.KeyId;
+      expect(keyId).toBeDefined();
+      try {
+        const parameters = await aws.send(
+          new GetParametersForImportCommand({
+            KeyId: keyId,
+            WrappingAlgorithm: "RSA_AES_KEY_WRAP_SHA_256",
+            WrappingKeySpec: "RSA_4096"
+          })
+        );
+        await aws.send(
+          new ImportKeyMaterialCommand({
+            KeyId: keyId,
+            ImportToken: parameters.ImportToken,
+            EncryptedKeyMaterial: wrapKeyMaterialForAws(privateKeyDer, Buffer.from(parameters.PublicKey!)),
+            ExpirationModel: "KEY_MATERIAL_EXPIRES",
+            ValidTo: new Date(Date.now() + 24 * 60 * 60 * 1000)
+          })
+        );
+        const plaintext = Buffer.from("Infisical to AWS RSA plaintext");
+        const encrypted = await testServer.inject({
+          method: "POST",
+          url: `/api/v1/kms/keys/${key.key.id}/encrypt`,
+          headers: authHeaders,
+          body: { plaintext: plaintext.toString("base64") }
+        });
+        expect(encrypted.statusCode, encrypted.payload).toBe(200);
+        const infisicalCiphertext = Buffer.from(
+          (JSON.parse(encrypted.payload) as { ciphertext: string }).ciphertext,
+          "base64"
+        );
+        const awsCiphertext = stripKmsCiphertextVersionForAws(infisicalCiphertext);
+        expect(awsCiphertext).toHaveLength(512);
+        const decrypted = await aws.send(
+          new DecryptCommand({
+            KeyId: keyId,
+            CiphertextBlob: awsCiphertext,
+            EncryptionAlgorithm: "RSAES_OAEP_SHA_256"
+          })
+        );
+        expect(Buffer.from(decrypted.Plaintext!)).toEqual(plaintext);
+      } finally {
+        await aws.send(new ScheduleKeyDeletionCommand({ KeyId: keyId, PendingWindowInDays: 7 }));
+      }
+    },
+    120_000
+  );
+});

--- a/backend/e2e-test/routes/v1/kms.spec.ts
+++ b/backend/e2e-test/routes/v1/kms.spec.ts
@@ -123,6 +123,18 @@ describe("KMS V1 Router", () => {
     const { plaintext: decryptedPlaintext } = JSON.parse(decryptResponse.payload) as { plaintext: string };
     expect(Buffer.from(decryptedPlaintext, "base64")).toEqual(plaintext);
 
+    const invalidCiphertextResponse = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/kms/keys/${key.id}/decrypt`,
+      headers: authHeaders,
+      body: { ciphertext: Buffer.alloc(512).toString("base64") }
+    });
+
+    expect(invalidCiphertextResponse.statusCode, invalidCiphertextResponse.payload).toBe(400);
+    expect(JSON.parse(invalidCiphertextResponse.payload)).toMatchObject({
+      message: "Ciphertext cannot be decrypted with this KMS key."
+    });
+
     const rotateResponse = await testServer.inject({
       method: "POST",
       url: `/api/v1/kms/keys/${key.id}/rotate`,

--- a/backend/src/lib/crypto/cryptography/crypto.ts
+++ b/backend/src/lib/crypto/cryptography/crypto.ts
@@ -24,8 +24,14 @@ import { logger } from "../../logger";
 import { getLegacyDecryptionCandidates, getLegacyEncryptionSnapshot, TLegacyKeySnapshot } from "../legacy-key";
 import { asymmetricFipsValidated } from "./asymmetric-fips";
 import { hasherFipsValidated } from "./hash-fips";
-import type { TDecryptAsymmetricInput, TDecryptSymmetricInput, TEncryptSymmetricInput } from "./types";
-import { DigestType, SymmetricKeySize } from "./types";
+import type {
+  TDecryptAsymmetricInput,
+  TDecryptHybridInput,
+  TDecryptSymmetricInput,
+  TEncryptHybridInput,
+  TEncryptSymmetricInput
+} from "./types";
+import { DigestType, HybridSigningAlgorithm, SymmetricKeySize } from "./types";
 
 const bytesToBits = (bytes: number) => bytes * 8;
 
@@ -401,7 +407,82 @@ const cryptographyFactory = () => {
       };
     };
 
+    const hybrid = () => {
+      type HashType = "SHA256" | "SHA1";
+
+      // PKCS #1 / RFC 8017 | RSAES_OEAP
+      const $rsaesOaepEncrypt = (data: Buffer, publicKey: string | Buffer, hashType: HashType): Buffer => {
+        const keyObject = Buffer.isBuffer(publicKey)
+          ? crypto.createPublicKey({ key: publicKey, format: "der", type: "spki" })
+          : crypto.createPublicKey(publicKey);
+
+        if (keyObject.asymmetricKeyType !== "rsa") {
+          throw new CryptographyError({ message: "RSA-OAEP encryption requires an RSA public key" });
+        }
+
+        return crypto.publicEncrypt(
+          {
+            key: keyObject,
+            padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: hashType.toLowerCase()
+          },
+          data
+        );
+      };
+
+      // PKCS #1 / RFC 8017 | RSAES_OEAP
+      const $rsaesOaepDecrypt = (data: Buffer, privateKey: crypto.KeyLike, hashType: HashType): Buffer => {
+        return crypto.privateDecrypt(
+          {
+            key: privateKey,
+            padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: hashType.toLowerCase()
+          },
+          data
+        );
+      };
+
+      /**
+       * @param cipherText string hex encoded | Buffer
+       */
+      const decrypt = ({ algorithm, cipherText, privateKey }: TDecryptHybridInput) => {
+        if (algorithm === HybridSigningAlgorithm.RSAES_OEAP_SHA256) {
+          return $rsaesOaepDecrypt(
+            typeof cipherText === "string" ? Buffer.from(cipherText, "hex") : cipherText,
+            privateKey,
+            "SHA256"
+          );
+        }
+        throw new CryptographyError({
+          message: `Unsupported algorithm ${String(algorithm)}`
+        });
+      };
+
+      /**
+       *
+       * @param plainText string utf8 encoded | Buffer
+       */
+      const encrypt = ({ algorithm, plainText, publicKey }: TEncryptHybridInput) => {
+        if (algorithm === HybridSigningAlgorithm.RSAES_OEAP_SHA256) {
+          return $rsaesOaepEncrypt(
+            typeof plainText === "string" ? Buffer.from(plainText, "utf8") : plainText,
+            publicKey,
+            "SHA256"
+          );
+        }
+        throw new CryptographyError({
+          message: `Unsupported algorithm ${String(algorithm)}`
+        });
+      };
+
+      return {
+        encrypt,
+        decrypt
+      };
+    };
+
     return {
+      hybrid,
       asymmetric,
       symmetric
     };

--- a/backend/src/lib/crypto/cryptography/types.ts
+++ b/backend/src/lib/crypto/cryptography/types.ts
@@ -10,6 +10,10 @@ export enum SymmetricKeySize {
   Bits256 = "256-bits"
 }
 
+export enum HybridSigningAlgorithm {
+  RSAES_OEAP_SHA256 = "RSAES_OEAP_SHA256"
+}
+
 export type TDecryptSymmetricInput =
   | {
       ciphertext: string;
@@ -37,6 +41,18 @@ export type TEncryptSymmetricInput =
       key: string | Buffer;
       keySize: SymmetricKeySize.Bits128;
     };
+
+export type TEncryptHybridInput = {
+  plainText: string | Buffer;
+  publicKey: string | Buffer;
+  algorithm: HybridSigningAlgorithm;
+};
+
+export type TDecryptHybridInput = {
+  cipherText: string | Buffer;
+  privateKey: string | Buffer;
+  algorithm: HybridSigningAlgorithm;
+};
 
 export type TDecryptAsymmetricInput = {
   ciphertext: string;

--- a/backend/src/server/routes/v1/cmek-router.ts
+++ b/backend/src/server/routes/v1/cmek-router.ts
@@ -101,13 +101,16 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
           const algorithm = data.algorithm ?? data.encryptionAlgorithm ?? SymmetricKeyAlgorithm.AES_GCM_256;
           if (
             data.keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT &&
-            !Object.values(SymmetricKeyAlgorithm).includes(algorithm as SymmetricKeyAlgorithm)
+            !Object.values(SymmetricKeyAlgorithm).includes(algorithm as SymmetricKeyAlgorithm) &&
+            algorithm !== AsymmetricKeyAlgorithm.RSA_4096
           ) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              message: `algorithm must be a valid symmetric encryption algorithm. Valid options are: ${Object.values(
+              message: `algorithm must be a valid supported encryption algorithm. Valid options are: ${Object.values(
                 SymmetricKeyAlgorithm
-              ).join(", ")}`
+              )
+                .join(", ")
+                .concat(", ", AsymmetricKeyAlgorithm.RSA_4096)}`
             });
           }
           if (
@@ -677,11 +680,12 @@ export const registerCmekRouter = async (server: FastifyZodProvider) => {
                 }
                 if (
                   data.keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT &&
-                  !Object.values(SymmetricKeyAlgorithm).includes(algorithm as SymmetricKeyAlgorithm)
+                  !Object.values(SymmetricKeyAlgorithm).includes(algorithm as SymmetricKeyAlgorithm) &&
+                  algorithm !== AsymmetricKeyAlgorithm.RSA_4096
                 ) {
                   ctx.addIssue({
                     code: z.ZodIssueCode.custom,
-                    message: `algorithm must be a symmetric algorithm for encrypt-decrypt keys`
+                    message: `algorithm must be a supported algorithm for encrypt-decrypt keys`
                   });
                 }
                 if (

--- a/backend/src/services/kms/kms-fns.ts
+++ b/backend/src/services/kms/kms-fns.ts
@@ -86,7 +86,10 @@ export const verifyKeyTypeAndAlgorithm = (
   }
 
   if (keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT) {
-    if (!Object.values(SymmetricKeyAlgorithm).includes(algorithm as SymmetricKeyAlgorithm)) {
+    if (
+      !Object.values(SymmetricKeyAlgorithm).includes(algorithm as SymmetricKeyAlgorithm) &&
+      algorithm !== AsymmetricKeyAlgorithm.RSA_4096
+    ) {
       throw new BadRequestError({
         message: `Unsupported encryption algorithm for encrypt/decrypt key: ${algorithm as string}`
       });

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -114,6 +114,7 @@ type TCachedProjectSmKmsMaterial = {
 // akhilmhdh: Don't edit this value. This is measured for blob concatination in kms
 const KMS_VERSION = "v01";
 const KMS_VERSION_BLOB_LENGTH = 3;
+const RSA_4096_OAEP_SHA256_MAX_PLAINTEXT_BYTES = 446;
 // v02 blobs additionally embed the key material version that encrypted them: [ciphertext][4-byte BE version]["v02"]
 // Written only for keys with version > 1 so never-rotated keys keep producing byte-identical v01 blobs.
 const KMS_VERSION_V2 = "v02";
@@ -963,6 +964,12 @@ export const kmsServiceFactory = ({
       const publicKeyObject = createPublicKey({ key: publicKey, format: "der", type: "spki" });
 
       return ({ plainText }: Pick<TEncryptWithKmsDTO, "plainText">) => {
+        if (plainText.length > RSA_4096_OAEP_SHA256_MAX_PLAINTEXT_BYTES) {
+          throw new BadRequestError({
+            message: `Plaintext exceeds the ${RSA_4096_OAEP_SHA256_MAX_PLAINTEXT_BYTES}-byte limit for RSA-4096 OAEP-SHA256 encryption.`
+          });
+        }
+
         const encryptedPlainTextBlob = publicEncrypt(
           {
             key: publicKeyObject,

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -1,3 +1,5 @@
+import { constants, createPublicKey, publicEncrypt } from "node:crypto";
+
 import slugify from "@sindresorhus/slugify";
 import { Knex } from "knex";
 import { z } from "zod";
@@ -14,11 +16,13 @@ import {
 import { THsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
 import { THsmStatus } from "@app/ee/services/hsm/hsm-types";
 import { KeyStorePrefixes, PgSqlLock, TKeyStoreFactory } from "@app/keystore/keystore";
+import { KMS } from "@app/lib/api-docs";
 import { withCache } from "@app/lib/cache/with-cache";
 import { getOriginalConfig, TEnvConfig } from "@app/lib/config/env";
 import { generateSecretValueBlindIndexFromKmsKey } from "@app/lib/crypto/blind-index";
 import { symmetricCipherService, SymmetricKeyAlgorithm } from "@app/lib/crypto/cipher";
 import { crypto } from "@app/lib/crypto/cryptography";
+import { HybridSigningAlgorithm } from "@app/lib/crypto/cryptography/types";
 import { HmacAlgorithm, hmacService } from "@app/lib/crypto/hmac";
 import { setLegacyKeyMaterial, TLegacyKeyMaterial, TLegacyKeySnapshot } from "@app/lib/crypto/legacy-key";
 import { detectPqcVariantFromDer } from "@app/lib/crypto/pqc/pqc-crypto";
@@ -49,6 +53,7 @@ import { TKmsKeyDALFactory } from "./kms-key-dal";
 import { TKmsLegacyEncryptionKeyDALFactory } from "./kms-legacy-encryption-key-dal";
 import { TKmsRootConfigDALFactory } from "./kms-root-config-dal";
 import {
+  EncryptUsageKeyAlgorithm,
   KmsDataKey,
   KmsKeyUsage,
   KmsType,
@@ -172,11 +177,11 @@ export const kmsServiceFactory = ({
     verifyKeyTypeAndAlgorithm(keyUsage, encryptionAlgorithm);
 
     let kmsKeyMaterial: Buffer | null = null;
-    if (keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT) {
-      kmsKeyMaterial = crypto.randomBytes(
-        getByteLengthForSymmetricEncryptionAlgorithm(encryptionAlgorithm as SymmetricKeyAlgorithm)
-      );
-    } else if (keyUsage === KmsKeyUsage.SIGN_VERIFY) {
+
+    if (
+      keyUsage === KmsKeyUsage.SIGN_VERIFY ||
+      (encryptionAlgorithm === AsymmetricKeyAlgorithm.RSA_4096 && keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT)
+    ) {
       const { generateAsymmetricPrivateKey, getPublicKeyFromPrivateKey } = signingService(
         encryptionAlgorithm as AsymmetricKeyAlgorithm
       );
@@ -184,6 +189,10 @@ export const kmsServiceFactory = ({
 
       // daniel: safety check to ensure we're able to extract the public key from the private key before we proceed to key creation
       await getPublicKeyFromPrivateKey(kmsKeyMaterial);
+    } else if (keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT) {
+      kmsKeyMaterial = crypto.randomBytes(
+        getByteLengthForSymmetricEncryptionAlgorithm(encryptionAlgorithm as SymmetricKeyAlgorithm)
+      );
     } else if (keyUsage === KmsKeyUsage.GENERATE_VERIFY_MAC) {
       kmsKeyMaterial = hmacService(encryptionAlgorithm as HmacAlgorithm).generateKeyMaterial();
     }
@@ -257,10 +266,14 @@ export const kmsServiceFactory = ({
         throw new BadRequestError({ message: "Key is disabled" });
       }
 
-      if ((kmsDoc.keyUsage as KmsKeyUsage) !== KmsKeyUsage.ENCRYPT_DECRYPT) {
+      if (
+        (kmsDoc.keyUsage as KmsKeyUsage) !== KmsKeyUsage.ENCRYPT_DECRYPT ||
+        // asymmetric key with ENCRYP_DECRYPT usage type is disallowed
+        kmsDoc.internalKms?.encryptionAlgorithm === AsymmetricKeyAlgorithm.RSA_4096
+      ) {
         throw new BadRequestError({
           message:
-            "Only encrypt-decrypt keys support rotation. To rotate a sign-verify or MAC key, create a new key and update your applications to use it."
+            "Only symmetric encrypt-decrypt keys support rotation. To rotate a sign-verify or MAC key, create a new key and update your applications to use it."
         });
       }
 
@@ -326,6 +339,8 @@ export const kmsServiceFactory = ({
   /*
    * Simple decryption service function to do all the encryption tasks in infisical
    * This can be even later exposed directly as api for encryption as function
+   * Note : supports only SymmetricKeyAlgorithm as default , AsymmetricKeyAlgorithm with HybridSigningAlgorithm type support
+   * to be added on first demand
    */
   const decryptWithInputKey = async ({ key }: Omit<TDecryptWithKeyDTO, "cipherTextBlob">) => {
     const cipher = symmetricCipherService(SymmetricKeyAlgorithm.AES_GCM_256);
@@ -486,17 +501,32 @@ export const kmsServiceFactory = ({
       };
     }
 
-    const encryptionAlgorithm = kmsDoc.internalKms?.encryptionAlgorithm as SymmetricKeyAlgorithm;
+    const encryptionAlgorithm = kmsDoc.internalKms?.encryptionAlgorithm as EncryptUsageKeyAlgorithm;
     verifyKeyTypeAndAlgorithm(kmsDoc.keyUsage as KmsKeyUsage, encryptionAlgorithm, {
       forceType: KmsKeyUsage.ENCRYPT_DECRYPT
     });
-
+    // tdlr : get assymetric server or related for Assymetric Encrypt algorithm type
     // internal KMS
+
     const keyCipher = symmetricCipherService(SymmetricKeyAlgorithm.AES_GCM_256);
-    const dataCipher = symmetricCipherService(encryptionAlgorithm);
     const internalKmsId = kmsDoc.internalKms?.id as string;
     const currentKeyVersion = kmsDoc.internalKms?.version as number; // NOT NULL, defaults to 1
     const kmsKey = keyCipher.decrypt(kmsDoc.internalKms?.encryptedKey as Buffer, ROOT_ENCRYPTION_KEY);
+
+    // decrypt method based of 'encryptionAlgorithm' , relavant only inside decrptyWithKmsKey
+    const getDecryptWithKeyMaterial = () => {
+      if (encryptionAlgorithm === AsymmetricKeyAlgorithm.RSA_4096) {
+        return (cipherText: Buffer, privateKey: Buffer) =>
+          crypto.encryption().hybrid().decrypt({
+            algorithm: HybridSigningAlgorithm.RSAES_OEAP_SHA256,
+            cipherText,
+            privateKey
+          });
+      }
+      const dataCipher = symmetricCipherService(encryptionAlgorithm as SymmetricKeyAlgorithm);
+      return dataCipher.decrypt;
+    };
+    const decryptWithKeyMaterial = getDecryptWithKeyMaterial();
 
     const keyMaterialByVersion = new Map<number, Buffer>([[currentKeyVersion, kmsKey]]);
     let archivedVersionsLoaded = false;
@@ -520,7 +550,7 @@ export const kmsServiceFactory = ({
       const attempt = (material?: Buffer) => {
         if (!material) return null;
         try {
-          return dataCipher.decrypt(cipherTextBlob, material);
+          return decryptWithKeyMaterial(cipherTextBlob, material);
         } catch {
           return null; // GCM auth failure for this material; try the next candidate
         }
@@ -560,14 +590,14 @@ export const kmsServiceFactory = ({
         const decrypted = await $tryDecryptWithAnyMaterial(cipherTextBlob, embeddedVersion);
         if (decrypted) return decrypted;
 
-        return dataCipher.decrypt(cipherTextBlob, kmsKey);
+        return decryptWithKeyMaterial(cipherTextBlob, kmsKey);
       }
 
       // legacy v01 (or anything not validated as v02): strip the 3-byte suffix and try all available material
       const cipherTextBlob = versionedCipherTextBlob.subarray(0, -KMS_VERSION_BLOB_LENGTH);
       const decrypted = await $tryDecryptWithAnyMaterial(cipherTextBlob, currentKeyVersion);
       if (decrypted) return decrypted;
-      return dataCipher.decrypt(cipherTextBlob, kmsKey);
+      return decryptWithKeyMaterial(cipherTextBlob, kmsKey);
     };
   };
 
@@ -639,16 +669,10 @@ export const kmsServiceFactory = ({
   ) => {
     verifyKeyTypeAndAlgorithm(keyUsage, algorithm);
 
-    if (keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT) {
-      const expectedLength = getByteLengthForSymmetricEncryptionAlgorithm(algorithm as SymmetricKeyAlgorithm);
-      if (key.length !== expectedLength) {
-        throw new BadRequestError({
-          message: `Invalid key material length for ${algorithm}. Expected ${expectedLength} bytes, got ${key.length}.`
-        });
-      }
-    }
-
-    if (keyUsage === KmsKeyUsage.SIGN_VERIFY) {
+    if (
+      keyUsage === KmsKeyUsage.SIGN_VERIFY ||
+      (algorithm === AsymmetricKeyAlgorithm.RSA_4096 && keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT)
+    ) {
       const { getPublicKeyFromPrivateKey } = signingService(algorithm as AsymmetricKeyAlgorithm);
       try {
         await getPublicKeyFromPrivateKey(key);
@@ -689,6 +713,15 @@ export const kmsServiceFactory = ({
             });
           }
         }
+      }
+    }
+
+    if (keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT && algorithm !== AsymmetricKeyAlgorithm.RSA_4096) {
+      const expectedLength = getByteLengthForSymmetricEncryptionAlgorithm(algorithm as SymmetricKeyAlgorithm);
+      if (key.length !== expectedLength) {
+        throw new BadRequestError({
+          message: `Invalid key material length for ${algorithm}. Expected ${expectedLength} bytes, got ${key.length}.`
+        });
       }
     }
 
@@ -743,9 +776,19 @@ export const kmsServiceFactory = ({
 
     const encryptionAlgorithm = kmsDoc.internalKms?.encryptionAlgorithm as AsymmetricKeyAlgorithm;
 
-    verifyKeyTypeAndAlgorithm(kmsDoc.keyUsage as KmsKeyUsage, encryptionAlgorithm, {
-      forceType: KmsKeyUsage.SIGN_VERIFY
-    });
+    if (
+      !(
+        kmsDoc.keyUsage === KmsKeyUsage.SIGN_VERIFY ||
+        (kmsDoc.keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT &&
+          kmsDoc.internalKms?.encryptionAlgorithm === AsymmetricKeyAlgorithm.RSA_4096)
+      )
+    ) {
+      throw new BadRequestError({
+        message: `Unsupported key type, expected asymetric algorithm for key but got ${kmsDoc.internalKms?.encryptionAlgorithm}`
+      });
+    }
+
+    verifyKeyTypeAndAlgorithm(kmsDoc.keyUsage as KmsKeyUsage, encryptionAlgorithm);
 
     const keyCipher = symmetricCipherService(SymmetricKeyAlgorithm.AES_GCM_256);
     const kmsKey = keyCipher.decrypt(kmsDoc.internalKms?.encryptedKey as Buffer, ROOT_ENCRYPTION_KEY);
@@ -906,16 +949,35 @@ export const kmsServiceFactory = ({
       };
     }
 
-    const encryptionAlgorithm = kmsDoc.internalKms?.encryptionAlgorithm as SymmetricKeyAlgorithm;
+    const encryptionAlgorithm = kmsDoc.internalKms?.encryptionAlgorithm as EncryptUsageKeyAlgorithm;
     verifyKeyTypeAndAlgorithm(kmsDoc.keyUsage as KmsKeyUsage, encryptionAlgorithm, {
       forceType: KmsKeyUsage.ENCRYPT_DECRYPT
     });
 
-    // internal KMS
     const keyCipher = symmetricCipherService(SymmetricKeyAlgorithm.AES_GCM_256);
-    const dataCipher = symmetricCipherService(encryptionAlgorithm);
     const currentKeyVersion = kmsDoc.internalKms?.version as number; // NOT NULL, defaults to 1
     const kmsKey = keyCipher.decrypt(kmsDoc.internalKms?.encryptedKey as Buffer, ROOT_ENCRYPTION_KEY);
+
+    if (encryptionAlgorithm === AsymmetricKeyAlgorithm.RSA_4096) {
+      const publicKey = await signingService(encryptionAlgorithm).getPublicKeyFromPrivateKey(kmsKey);
+      const publicKeyObject = createPublicKey({ key: publicKey, format: "der", type: "spki" });
+
+      return ({ plainText }: Pick<TEncryptWithKmsDTO, "plainText">) => {
+        const encryptedPlainTextBlob = publicEncrypt(
+          {
+            key: publicKeyObject,
+            padding: constants.RSA_PKCS1_OAEP_PADDING,
+            oaepHash: "sha256"
+          },
+          plainText
+        );
+
+        const cipherTextBlob = buildKmsCipherTextBlob(encryptedPlainTextBlob, currentKeyVersion);
+        return Promise.resolve({ cipherTextBlob });
+      };
+    }
+
+    const dataCipher = symmetricCipherService(encryptionAlgorithm as SymmetricKeyAlgorithm);
 
     return ({ plainText }: Pick<TEncryptWithKmsDTO, "plainText">) => {
       const encryptedPlainTextBlob = dataCipher.encrypt(plainText, kmsKey);

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -591,14 +591,14 @@ export const kmsServiceFactory = ({
         const decrypted = await $tryDecryptWithAnyMaterial(cipherTextBlob, embeddedVersion);
         if (decrypted) return decrypted;
 
-        return decryptWithKeyMaterial(cipherTextBlob, kmsKey);
+        throw new BadRequestError({ message: "Ciphertext cannot be decrypted with this KMS key." });
       }
 
       // legacy v01 (or anything not validated as v02): strip the 3-byte suffix and try all available material
       const cipherTextBlob = versionedCipherTextBlob.subarray(0, -KMS_VERSION_BLOB_LENGTH);
       const decrypted = await $tryDecryptWithAnyMaterial(cipherTextBlob, currentKeyVersion);
       if (decrypted) return decrypted;
-      return decryptWithKeyMaterial(cipherTextBlob, kmsKey);
+      throw new BadRequestError({ message: "Ciphertext cannot be decrypted with this KMS key." });
     };
   };
 

--- a/backend/src/services/kms/kms-types.ts
+++ b/backend/src/services/kms/kms-types.ts
@@ -4,6 +4,8 @@ import { SymmetricKeyAlgorithm } from "@app/lib/crypto/cipher";
 import { HmacAlgorithm } from "@app/lib/crypto/hmac";
 import { AsymmetricKeyAlgorithm, SigningAlgorithm } from "@app/lib/crypto/sign/types";
 
+export type EncryptUsageKeyAlgorithm = SymmetricKeyAlgorithm | AsymmetricKeyAlgorithm.RSA_4096
+
 export enum KmsDataKey {
   Organization,
   SecretManager

--- a/docs/documentation/platform/kms/overview.mdx
+++ b/docs/documentation/platform/kms/overview.mdx
@@ -21,7 +21,7 @@ If you are on-premise, your KMS root key will be created at random with the `ROO
 
 The typical workflow for using Infisical KMS consists of the following steps:
 
-1. Creating a KMS key. As part of this step, you specify a name for the key and the encryption algorithm meant to be used for it (e.g. `AES-GCM-128`, `AES-GCM-256`).
+1. Creating a KMS key. As part of this step, you specify a name, usage, and algorithm for the key. Encrypt/decrypt keys support `AES-GCM-128`, `AES-GCM-256`, and `RSA-4096`.
 2. Encryption: To encrypt data, you would make a request to the Infisical KMS API endpoint, specifying the base64-encoded plaintext and the intended key to use for encryption; the API would return the base64-encoded ciphertext.
 3. Decryption: To decrypt data, you would make a request to the Infisical KMS API endpoint, specifying the base64-encoded ciphertext and the intended key to use for decryption; the API would return the base64-encoded plaintext.
 
@@ -47,10 +47,14 @@ In the following steps, we explore how to generate a key and use it to encrypt d
 
                 - Name: A slug-friendly name for the key.
                 - Key Usage: The type of key to create (e.g `Encrypt/Decrypt` for encryption, `Sign/Verify` for signing, and `Generate/Verify MAC` for message authentication codes).
-                - Algorithm: The encryption algorithm associated with the key (e.g. `AES-GCM-256`).
+                - Algorithm: The algorithm associated with the key. Encrypt/decrypt keys support `AES-GCM-128`, `AES-GCM-256`, and `RSA-4096`.
                 - Description: An optional description of what the intended usage is for the key.
                 - Allow Export: Whether the raw key material can be exported later. When disabled, the key material can never leave Infisical, regardless of permissions. This cannot be changed after the key is created.
                 - Delete Protection: Whether the key is protected from deletion. While enabled, the key cannot be deleted on its own. You can turn this off at any time by editing the key. Deleting the whole project still removes its keys.
+
+                <Note>
+                  RSA-4096 encrypt/decrypt keys cannot be rotated. Create a replacement key and update your application to use it when you need to rotate an RSA key.
+                </Note>
 
                 ![kms add key modal](/images/platform/kms/infisical-kms/kms-add-key-modal.png)
             </Step>

--- a/docs/sdks/languages/go.mdx
+++ b/docs/sdks/languages/go.mdx
@@ -1225,6 +1225,7 @@ Create a new key in Infisical.
       Valid options for Encryption/Decryption keys are:
       - `aes-256-gcm`
       - `aes-128-gcm`
+      - `RSA_4096`
     </ParamField>
     <ParamField query="ProjectId" type="string" required>
       The ID of the project where the key will be created.

--- a/docs/sdks/languages/node.mdx
+++ b/docs/sdks/languages/node.mdx
@@ -619,7 +619,7 @@ console.log(signingKey);
 - `description` (string, optional): A description of the key's purpose.
 - `keyUsage` (KeyUsage): Either `KeyUsage.ENCRYPTION` for encrypt/decrypt operations or `KeyUsage.SIGNING` for sign/verify operations.
 - `encryptionAlgorithm` (EncryptionAlgorithm): The algorithm to use. Options include:
-  - For encryption: `AES_256_GCM`, `AES_128_GCM`, `RSA_4096`, `ECC_NIST_P256`
+  - For encryption: `AES_256_GCM`, `AES_128_GCM`, `RSA_4096`
   - For signing: `RSA_4096`, `ECC_NIST_P256`
 
 **Returns:**

--- a/frontend/src/pages/kms/OverviewPage/components/CmekModal.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekModal.tsx
@@ -196,6 +196,7 @@ const CmekForm = ({ onComplete, cmek }: FormProps) => {
                       // eslint-disable-next-line @typescript-eslint/no-unused-vars
                       ?.filter(([_, value]) => {
                         if (selectedKeyUsage === KmsKeyUsage.ENCRYPT_DECRYPT) {
+                          if(value === AsymmetricKeyAlgorithm.RSA_4096) return true
                           return Object.values(SymmetricKeyAlgorithm).includes(
                             value as unknown as SymmetricKeyAlgorithm
                           );

--- a/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
+++ b/frontend/src/pages/kms/OverviewPage/components/CmekTable.tsx
@@ -676,7 +676,7 @@ export const CmekTable = () => {
                                   <PencilIcon className="mr-2 size-4" />
                                   Edit Key
                                 </DropdownMenuItem>
-                                {keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT && (
+                                {keyUsage === KmsKeyUsage.ENCRYPT_DECRYPT && algorithm != AsymmetricKeyAlgorithm.RSA_4096 && (
                                   <DropdownMenuItem
                                     onClick={() => handlePopUpOpen("rotateKey", cmek)}
                                     isDisabled={cannotRotateKey || isDisabled}


### PR DESCRIPTION
## Context

Encrypt_decrypt type key usage can only be used with symmetric keys today.

Post change, asymmetric key encryption RSA_4096 is available for encrypt_decrypt RSAES_OEAP_SHA256 as encryption algorithm.
## Approach

* Uitlizes RSAES_OEAP_SHA256 as default encryptionAlgorithm.

* Available options are [RSAES_OEAP_SHA256, RSAES_OEAP_SHA1].

* Rotataions are explicity disabled for Encrypt type KMS key with RSA_4096, being an asymmetric type key.

* RSAES_OEAP_SHA256 follows signing described in PKCS #1 v2.2 / RFC 8017.

## Screenshots
![Created Key](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs-kms-screenshots/docs/images/platform/kms/infisical-kms/rsa-encryption/kms-rsa-4096-key.png)
![Form Create Key](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs-kms-screenshots/docs/images/platform/kms/infisical-kms/rsa-encryption/kms-rsa-4096-key-form.png)
![encrypt with asymmetric key](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs-kms-screenshots/docs/images/platform/kms/infisical-kms/rsa-encryption/kms-rsa-4096-encrypt-data.png)
![decrypt with rsa](https://raw.githubusercontent.com/Shaik-Sirajuddin/infisical/docs-kms-screenshots/docs/images/platform/kms/infisical-kms/rsa-encryption/kms-rsa-4096-decrypted-data.png)

## Steps to verify the change
- Start docker containers
- run test suite backend/e2e-test/routes/v1/kms.spec.ts 
- or use v1/ api endpoints to verify api accepts , RSA_4096 for kms encrypt operations

## Type

* [ ] Fix
* [x] Feature
* [ ] Improvement
* [ ] Breaking
* [ ] Docs
* [ ] Chore

## Checklist

* [x] Title follows the [[conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary)](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
* [x] Tested locally
* [ ] Updated docs (if needed)
* [ ] Updated CLAUDE.md files (if needed)
* [x] Read the [[contributing guide](https://infisical.com/docs/contributing/getting-started/overview)](https://infisical.com/docs/contributing/getting-started/overview)


* [x] Updated frontend

* [x] Inlcuded Test cases

# Note for maintainers
Pr has been handwritten , including all of backend , use of AI was restricted to parts of verifications , some of frontend changes