### PR TITLE
fix(app-connections): standardize add sheet discard handling

### DIFF
--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AddAppConnectionModal.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AddAppConnectionModal.tsx
@@ -1,22 +1,15 @@
-import { useEffect, useState } from "react";
-import { AlertTriangleIcon, ArrowLeftIcon } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowLeftIcon } from "lucide-react";
 
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogMedia,
-  AlertDialogTitle,
+  DiscardChangesAlertDialog,
   Sheet,
   SheetContent,
   SheetDescription,
   SheetHeader,
   SheetTitle
 } from "@app/components/v3";
+import { useDiscardChangesGuard } from "@app/hooks";
 import { TAppConnection } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 import { ProjectType } from "@app/hooks/api/projects/types";
@@ -45,19 +38,40 @@ export const AddAppConnectionModal = ({
   // When `app` is preset (inline create from another flow, or an OAuth reopen) we skip the provider
   // select screen and go straight to that app's form. Otherwise the user picks a provider first.
   const [selectedApp, setSelectedApp] = useState<AppConnection | null>(app ?? null);
-  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const discardActionRef = useRef<VoidFunction>(() => {});
 
   // Reset to the starting step whenever the sheet (re)opens: a preset `app` goes straight to its
   // form, otherwise the provider picker. Keyed on `isOpen` so reopening with an unchanged preset
   // `app` (inline create flows keep the modal mounted) still restores the form instead of falling
   // back to the picker.
   useEffect(() => {
-    if (isOpen) setSelectedApp(app ?? null);
+    if (isOpen) {
+      setSelectedApp(app ?? null);
+      setIsDirty(false);
+    }
   }, [isOpen, app]);
 
-  const closeSheet = () => {
+  const closeSheet = useCallback(() => {
+    setIsDirty(false);
     setSelectedApp(null);
     onOpenChange(false);
+  }, [onOpenChange]);
+
+  const returnToAppSelect = useCallback(() => {
+    setIsDirty(false);
+    setSelectedApp(null);
+  }, []);
+
+  const { confirmDiscard, isDiscardDialogOpen, requestDiscard, setIsDiscardDialogOpen } =
+    useDiscardChangesGuard({
+      isDirty,
+      onDiscard: () => discardActionRef.current()
+    });
+
+  const requestDiscardAction = (action: VoidFunction) => {
+    discardActionRef.current = action;
+    requestDiscard();
   };
 
   const handleComplete = (appConnection: TAppConnection) => {
@@ -66,13 +80,11 @@ export const AddAppConnectionModal = ({
   };
 
   const handleSheetOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen && selectedApp) {
-      // User has started configuring a connection — confirm before discarding.
-      setConfirmDiscardOpen(true);
+    if (!nextOpen) {
+      requestDiscardAction(closeSheet);
       return;
     }
-    if (!nextOpen) setSelectedApp(null);
-    onOpenChange(nextOpen);
+    onOpenChange(true);
   };
 
   // Only offer "back to select" when the user navigated here from the select screen (no preset app).
@@ -88,7 +100,7 @@ export const AddAppConnectionModal = ({
                 {showBack && (
                   <button
                     type="button"
-                    onClick={() => setSelectedApp(null)}
+                    onClick={() => requestDiscardAction(returnToAppSelect)}
                     className="mb-1 flex w-fit cursor-pointer items-center gap-1 text-xs text-muted transition-colors hover:text-foreground hover:underline"
                   >
                     <ArrowLeftIcon className="size-3" />
@@ -112,39 +124,31 @@ export const AddAppConnectionModal = ({
                 app={selectedApp}
                 projectId={projectId}
                 onComplete={handleComplete}
-                // Explicit Cancel is a deliberate abandon, so it closes immediately. Ambiguous
-                // dismissals (X / Escape / outside click) route through handleSheetOpenChange,
-                // which shows the discard confirmation.
-                onCancel={closeSheet}
+                onCancel={() => requestDiscardAction(closeSheet)}
+                onDirtyChange={setIsDirty}
               />
             </div>
           ) : (
             <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
-              <AppConnectionsSelect onSelect={setSelectedApp} projectType={projectType} />
+              <AppConnectionsSelect
+                onSelect={(nextApp) => {
+                  setIsDirty(false);
+                  setSelectedApp(nextApp);
+                }}
+                projectType={projectType}
+              />
             </div>
           )}
         </SheetContent>
       </Sheet>
 
-      <AlertDialog open={confirmDiscardOpen} onOpenChange={setConfirmDiscardOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogMedia>
-              <AlertTriangleIcon />
-            </AlertDialogMedia>
-            <AlertDialogTitle>Discard connection setup?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Your progress configuring this connection will be lost.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Keep Editing</AlertDialogCancel>
-            <AlertDialogAction variant="danger" onClick={closeSheet}>
-              Discard
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DiscardChangesAlertDialog
+        open={isDiscardDialogOpen}
+        onOpenChange={setIsDiscardDialogOpen}
+        onDiscard={confirmDiscard}
+        title="Discard Connection Setup?"
+        description="Your progress configuring this connection will be lost."
+      />
     </>
   );
 };

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionForm.tsx
@@ -678,15 +678,19 @@ const UpdateForm = ({ appConnection, onComplete }: UpdateFormProps) => {
   );
 };
 
-type Props = { onCancel: () => void; projectId?: string } & Pick<FormProps, "onComplete"> &
+type Props = {
+  onCancel: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
+  projectId?: string;
+} & Pick<FormProps, "onComplete"> &
   (
     | { app: AppConnection; appConnection?: undefined }
     | { app?: undefined; appConnection: TAppConnection }
   );
-export const AppConnectionForm = ({ onCancel, projectId, ...props }: Props) => {
+export const AppConnectionForm = ({ onCancel, onDirtyChange, projectId, ...props }: Props) => {
   const { app, appConnection } = props;
 
-  const contextValue = useMemo(() => ({ onCancel }), [onCancel]);
+  const contextValue = useMemo(() => ({ onCancel, onDirtyChange }), [onCancel, onDirtyChange]);
 
   return (
     <AppConnectionFormProvider value={contextValue}>

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionFormContext.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionFormContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, useContext, useEffect } from "react";
 
 type AppConnectionFormContextValue = {
   /**
@@ -6,6 +6,7 @@ type AppConnectionFormContextValue = {
    * have to thread a prop through every form and the ~130 render sites in AppConnectionForm.
    */
   onCancel: () => void;
+  onDirtyChange?: (isDirty: boolean) => void;
 };
 
 const AppConnectionFormContext = createContext<AppConnectionFormContextValue>({
@@ -15,3 +16,11 @@ const AppConnectionFormContext = createContext<AppConnectionFormContextValue>({
 export const AppConnectionFormProvider = AppConnectionFormContext.Provider;
 
 export const useAppConnectionForm = () => useContext(AppConnectionFormContext);
+
+export const useAppConnectionFormDirtyState = (isDirty: boolean) => {
+  const { onDirtyChange } = useAppConnectionForm();
+
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+};

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionFormFooter.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AppConnectionFormFooter.tsx
@@ -3,7 +3,7 @@ import { useFormContext } from "react-hook-form";
 import { Button, SheetFooter } from "@app/components/v3";
 import { useScopeVariant } from "@app/hooks";
 
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 
 type Props = {
   submitLabel: string;
@@ -26,6 +26,8 @@ export const AppConnectionFormFooter = ({
     formState: { isSubmitting, isDirty }
   } = useFormContext();
   const scopeVariant = useScopeVariant();
+
+  useAppConnectionFormDirtyState(isDirty);
 
   return (
     <SheetFooter className="sticky bottom-0 -mx-4 items-center border-t bg-popover">

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureAppConfigurationConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureAppConfigurationConnectionForm.tsx
@@ -38,7 +38,7 @@ import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { AzureAppConfigurationFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
 import { CredentialRotationForm } from "./shared/CredentialRotationForm";
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -162,6 +162,8 @@ export const AzureAppConfigurationConnectionForm = ({
     setValue,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const scopeVariant = useScopeVariant();
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureClientSecretsConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureClientSecretsConnectionForm.tsx
@@ -40,7 +40,7 @@ import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { AzureClientSecretsFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
 import { CredentialRotationForm } from "./shared/CredentialRotationForm";
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -191,6 +191,8 @@ export const AzureClientSecretsConnectionForm = ({ appConnection, onSubmit, proj
     setValue,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const scopeVariant = useScopeVariant();
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDevOpsConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureDevOpsConnectionForm.tsx
@@ -39,7 +39,7 @@ import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { AzureDevOpsFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
 import { CredentialRotationForm } from "./shared/CredentialRotationForm";
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -194,6 +194,8 @@ export const AzureDevOpsConnectionForm = ({ appConnection, onSubmit, projectId }
     formState: { isSubmitting, isDirty },
     setValue
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const scopeVariant = useScopeVariant();
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureEntraIdConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureEntraIdConnectionForm.tsx
@@ -28,7 +28,7 @@ import {
 } from "@app/hooks/api/appConnections/types/azure-entra-id-connection";
 
 import { CredentialRotationForm } from "./shared/CredentialRotationForm";
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -98,6 +98,8 @@ export const AzureEntraIdConnectionForm = ({ appConnection, onSubmit }: Props) =
     control,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const scopeVariant = useScopeVariant();
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureKeyVaultConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/AzureKeyVaultConnectionForm.tsx
@@ -46,7 +46,7 @@ import {
 
 import { AzureKeyVaultFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
 import { CredentialRotationForm } from "./shared/CredentialRotationForm";
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -201,6 +201,8 @@ export const AzureKeyVaultConnectionForm = ({ appConnection, onSubmit, projectId
     watch,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const scopeVariant = useScopeVariant();
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
@@ -174,8 +174,6 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
     formState: { isSubmitting, isDirty }
   } = form;
 
-  useAppConnectionFormDirtyState(isDirty);
-
   const { subscription } = useSubscription();
 
   const selectedMethod = watch("method");
@@ -213,6 +211,8 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
   // The form is restored (not edited) after resuming, so `isDirty` stays false — track this to keep
   // the Connect button enabled.
   const [isResumed, setIsResumed] = useState(false);
+
+  useAppConnectionFormDirtyState(isDirty || isResumed);
 
   // When we come back from creating a new GitHub App, restore the in-progress form and remember the
   // new app so we can select it. The connection itself is created later when the user hits Connect.

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubConnectionForm.tsx
@@ -59,7 +59,7 @@ import { gatewaysQueryKeys } from "@app/hooks/api/gateways/queries";
 import { TGitHubApp, useListGitHubApps } from "@app/hooks/api/gitHubApps";
 
 import { GitHubFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -173,6 +173,8 @@ export const GitHubConnectionForm = ({ appConnection, projectId, onSubmit }: Pro
     setValue,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const { subscription } = useSubscription();
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubRadarConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitHubRadarConnectionForm.tsx
@@ -36,7 +36,7 @@ import {
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
 import { GitHubRadarFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -81,6 +81,8 @@ export const GitHubRadarConnectionForm = ({ appConnection, projectId }: Props) =
     watch,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const selectedMethod = watch("method");
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitLabConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/GitLabConnectionForm.tsx
@@ -41,7 +41,7 @@ import {
 } from "@app/hooks/api/appConnections/types/gitlab-connection";
 
 import { GitLabFormData } from "../../../OauthCallbackPage/OauthCallbackPage.types";
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -126,6 +126,8 @@ export const GitLabConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
     setValue,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const selectedMethod = watch("method");
   const gitLabURL = watch("credentials.instanceUrl");

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HerokuAppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/HerokuAppConnectionForm.tsx
@@ -38,7 +38,7 @@ import {
   THerokuConnection
 } from "@app/hooks/api/appConnections/types/heroku-connection";
 
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -104,6 +104,8 @@ export const HerokuConnectionForm = ({ appConnection, onSubmit: formSubmit, proj
     setValue,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const selectedMethod = watch("method");
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/MicrosoftIntuneConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/MicrosoftIntuneConnectionForm.tsx
@@ -27,7 +27,7 @@ import {
   TMicrosoftIntuneConnection
 } from "@app/hooks/api/appConnections/types/microsoft-intune-connection";
 
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -84,6 +84,8 @@ export const MicrosoftIntuneConnectionForm = ({ appConnection, onSubmit }: Props
     control,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const scopeVariant = useScopeVariant();
 

--- a/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/VenafiTppConnectionForm.tsx
+++ b/frontend/src/pages/organization/AppConnections/AppConnectionsPage/components/AppConnectionForm/VenafiTppConnectionForm.tsx
@@ -32,7 +32,7 @@ import { useScopeVariant } from "@app/hooks";
 import { TVenafiTppConnection, VenafiTppConnectionMethod } from "@app/hooks/api/appConnections";
 import { AppConnection } from "@app/hooks/api/appConnections/enums";
 
-import { useAppConnectionForm } from "./AppConnectionFormContext";
+import { useAppConnectionForm, useAppConnectionFormDirtyState } from "./AppConnectionFormContext";
 import {
   genericAppConnectionFieldsSchema,
   GenericAppConnectionsFields
@@ -95,6 +95,8 @@ export const VenafiTppConnectionForm = ({ appConnection, onSubmit }: Props) => {
     watch,
     formState: { isSubmitting, isDirty }
   } = form;
+
+  useAppConnectionFormDirtyState(isDirty);
 
   const gatewayId = watch("gatewayId");
   const gatewayPoolId = watch("gatewayPoolId");


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

The Add App Connection sheet previously handled dismissal differently across providers and could discard entered credentials without warning. It also could not reliably distinguish a pristine provider form from one with user edits.

This change centralizes discard handling in `AddAppConnectionModal` and propagates React Hook Form dirty state through the shared app-connection form context. The sheet now:

- closes immediately while the selected provider form is pristine;
- prompts before closing, navigating back, or cancelling after form values change;
- preserves entered values when the user keeps editing;
- bypasses the warning after a successful connection is created;
- applies the same behavior to custom credential and OAuth provider forms, including app connections created inline from Secret Sync flows.

Related ticket: [PLATFOR-754](https://linear.app/infisical/issue/PLATFOR-754/standardize-app-connection-sheet-discard-handling)

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Run `make reviewable-ui`.
2. Run `git diff --check main...HEAD`.
3. Open **Organization Settings → App Connections**, click **Add Connection**, select a provider, and dismiss the pristine form. Confirm it closes without a warning.
4. Reopen the sheet, select a provider, change a field, and try the close button, Escape key, outside click, **Back**, and **Cancel**. Confirm each action opens the discard dialog.
5. Choose **Keep Editing** and confirm the entered values remain. Reopen the dialog, choose **Discard**, and confirm the original close or back action completes.
6. Create a connection successfully and confirm the sheet closes without showing the discard dialog.
7. Repeat the dirty-form checks for an OAuth provider, a project-scoped app connection, and an app connection created inline from a Secret Sync flow.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
