### PR TITLE
feat: added better logging around the tunnel closing and changed the tunnel closing order

### DIFF
--- a/backend/src/ee/services/pam-session/pam-session-fns.ts
+++ b/backend/src/ee/services/pam-session/pam-session-fns.ts
@@ -3,7 +3,7 @@ import net from "net";
 
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { GatewayProxyProtocol } from "@app/lib/gateway/types";
-import { createGatewayConnection, createRelayConnection } from "@app/lib/gateway-v2/gateway-v2";
+import { createGatewayConnection, createRelayConnection, destroyGatewayTunnel } from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TTelemetryServiceFactory } from "@app/services/telemetry/telemetry-service";
@@ -104,6 +104,8 @@ export const sendPamSessionCancellationSignal = ({
 }) => {
   void (async () => {
     let relayConn: net.Socket | null = null;
+    let cancelConn: net.Socket | null = null;
+    const tunnelId = sessionId;
     try {
       const certs = await gatewayV2Service.getPAMConnectionDetails({
         gatewayId,
@@ -124,18 +126,22 @@ export const sendPamSessionCancellationSignal = ({
         relayHost: certs.relayHost,
         clientCertificate: certs.relay.clientCertificate,
         clientPrivateKey: certs.relay.clientPrivateKey,
-        serverCertificateChain: certs.relay.serverCertificateChain
+        serverCertificateChain: certs.relay.serverCertificateChain,
+        tunnelId
       });
-      const cancelConn = await createGatewayConnection(
+      cancelConn = await createGatewayConnection(
         relayConn,
         certs.gateway,
-        GatewayProxyProtocol.PamSessionCancellation
+        GatewayProxyProtocol.PamSessionCancellation,
+        tunnelId
       );
       cancelConn.end();
     } catch (err) {
       logger.error({ sessionId, err }, `Session [sessionId=${sessionId}] termination ALPN signal failed (best-effort)`);
     } finally {
-      relayConn?.destroy();
+      // end() leaves the inner TLS session reading the gateway's close_notify through relayConn, so
+      // the transport must not be destroyed first.
+      destroyGatewayTunnel({ relayConn, gatewayConn: cancelConn });
     }
   })();
 };

--- a/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
+++ b/backend/src/ee/services/pam-web-access/pam-web-access-service.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import net from "node:net";
 
 import type WebSocket from "ws";
@@ -12,7 +13,12 @@ import { TPermissionServiceFactory } from "@app/ee/services/permission/permissio
 import { ResourcePermissionPamResourceActions } from "@app/ee/services/permission/resource-permission";
 import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { GatewayProxyProtocol } from "@app/lib/gateway/types";
-import { createGatewayConnection, createRelayConnection, setupRelayServer } from "@app/lib/gateway-v2/gateway-v2";
+import {
+  createGatewayConnection,
+  createRelayConnection,
+  destroyGatewayTunnel,
+  setupRelayServer
+} from "@app/lib/gateway-v2/gateway-v2";
 import { logger } from "@app/lib/logger";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TAuthTokenServiceFactory } from "@app/services/auth-token/auth-token-service";
@@ -392,23 +398,29 @@ export const pamWebAccessServiceFactory = ({
         relayCerts = null;
         void (async () => {
           let relayConn: net.Socket | null = null;
+          let cancelConn: net.Socket | null = null;
+          const tunnelId = crypto.randomBytes(4).toString("hex");
           try {
             relayConn = await createRelayConnection({
               relayHost: certs.relayHost,
               clientCertificate: certs.relay.clientCertificate,
               clientPrivateKey: certs.relay.clientPrivateKey,
-              serverCertificateChain: certs.relay.serverCertificateChain
+              serverCertificateChain: certs.relay.serverCertificateChain,
+              tunnelId
             });
-            const cancelConn = await createGatewayConnection(
+            cancelConn = await createGatewayConnection(
               relayConn,
               certs.gateway,
-              GatewayProxyProtocol.PamSessionCancellation
+              GatewayProxyProtocol.PamSessionCancellation,
+              tunnelId
             );
             cancelConn.end();
           } catch (err) {
             logger.debug(err, "Session cancellation signal failed (best-effort)");
           } finally {
-            relayConn?.destroy();
+            // end() leaves the inner TLS session reading the gateway's close_notify through
+            // relayConn, so the transport must not be destroyed first.
+            destroyGatewayTunnel({ relayConn, gatewayConn: cancelConn });
           }
         })();
       }

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import net from "node:net";
 import tls from "node:tls";
 
@@ -26,18 +27,55 @@ interface IGatewayRelayServer {
 
 const DEFAULT_RELAY_CONNECTION_TIMEOUT_MS = 100000;
 
+/**
+ * A gateway tunnel is TLS inside TLS: `gatewayConn` is a TLSSocket whose transport is `relayConn`,
+ * itself a TLSSocket. Tear the two down innermost-first.
+ */
+export const destroyGatewayTunnel = ({
+  relayConn,
+  gatewayConn,
+  tunnelId,
+  trigger
+}: {
+  relayConn?: net.Socket | null;
+  gatewayConn?: net.Socket | null;
+  /** Correlates the teardown with the tunnel's other lifecycle lines. */
+  tunnelId?: string;
+  /** What asked for the teardown, so a crashing tunnel can be traced to its trigger. */
+  trigger?: string;
+}) => {
+  // Logged either side of the setImmediate on purpose: a process that dies between the two lines
+  // crashed inside the deferred destroy, which is the window this whole helper exists to move away
+  // from OpenSSL's stack.
+  if (tunnelId) {
+    logger.info(
+      `gatewayTunnel: teardown scheduled [tunnelId=${tunnelId}] [trigger=${trigger ?? "unknown"}] [gatewayDestroyed=${Boolean(gatewayConn?.destroyed)}] [relayDestroyed=${Boolean(relayConn?.destroyed)}]`
+    );
+  }
+
+  setImmediate(() => {
+    gatewayConn?.destroy();
+    relayConn?.destroy();
+    if (tunnelId) {
+      logger.info(`gatewayTunnel: teardown complete [tunnelId=${tunnelId}] [trigger=${trigger ?? "unknown"}]`);
+    }
+  });
+};
+
 export const createRelayConnection = async ({
   relayHost,
   clientCertificate,
   clientPrivateKey,
   serverCertificateChain,
-  timeoutMs = DEFAULT_RELAY_CONNECTION_TIMEOUT_MS
+  timeoutMs = DEFAULT_RELAY_CONNECTION_TIMEOUT_MS,
+  tunnelId
 }: {
   relayHost: string;
   clientCertificate: string;
   clientPrivateKey: string;
   serverCertificateChain: string;
   timeoutMs?: number;
+  tunnelId?: string;
 }): Promise<net.Socket> => {
   const [targetHost] = await verifyHostInputValidity({ host: relayHost, isDynamicSecret: false });
   const [, portStr] = relayHost.split(":");
@@ -58,7 +96,7 @@ export const createRelayConnection = async ({
   return new Promise((resolve, reject) => {
     try {
       const socket = tls.connect(tlsOptions, () => {
-        logger.info("Relay TLS connection established successfully");
+        logger.info(`Relay TLS connection established successfully [tunnelId=${tunnelId ?? "n/a"}]`);
         resolve(socket);
       });
 
@@ -88,7 +126,8 @@ export const createRelayConnection = async ({
 export const createGatewayConnection = async (
   relayConn: net.Socket,
   gateway: { clientCertificate: string; clientPrivateKey: string; serverCertificateChain: string },
-  protocol: GatewayProxyProtocol
+  protocol: GatewayProxyProtocol,
+  tunnelId?: string
 ): Promise<net.Socket> => {
   const appCfg = getConfig();
 
@@ -129,11 +168,14 @@ export const createGatewayConnection = async (
           return;
         }
 
-        logger.info("Gateway mTLS connection established successfully");
+        logger.info(`Gateway mTLS connection established successfully [tunnelId=${tunnelId ?? "n/a"}]`);
         resolve(gatewaySocket);
       });
 
       gatewaySocket.on("error", (err: Error) => {
+        // Callers respond to a rejection by destroying relayConn, so the inner socket has to go
+        // first or it is left reading a transport that is about to disappear.
+        gatewaySocket.destroy();
         reject(new Error(`Failed to establish gateway mTLS: ${err.message}`));
       });
 
@@ -177,30 +219,53 @@ export const setupRelayServer = async ({
   const relayErrorMsg: string[] = [];
   let establishedChannel = false;
   const loadTracker = getGatewayLoadTracker();
+  let localPort = 0;
+  const tunnelLog = (tunnelId: string, event: string, extra = "") =>
+    logger.info(
+      `gatewayTunnel: ${event} [tunnelId=${tunnelId}] [gatewayId=${gatewayId}] [protocol=${protocol}] [localPort=${localPort}]${extra}`
+    );
 
   type TUpstream = {
+    tunnelId: string;
     relayConn: net.Socket;
     gatewayConn: net.Socket;
     releaseChannel: () => void;
   };
 
   const openUpstream = async (): Promise<TUpstream> => {
+    const tunnelId = crypto.randomBytes(4).toString("hex");
+
     // Stage 1: Connect to relay with TLS
-    const relayConn = await createRelayConnection({
-      relayHost,
-      clientCertificate: relay.clientCertificate,
-      clientPrivateKey: relay.clientPrivateKey,
-      serverCertificateChain: relay.serverCertificateChain
-    });
+    let relayConn: net.Socket;
+    try {
+      relayConn = await createRelayConnection({
+        relayHost,
+        clientCertificate: relay.clientCertificate,
+        clientPrivateKey: relay.clientPrivateKey,
+        serverCertificateChain: relay.serverCertificateChain,
+        tunnelId
+      });
+    } catch (err) {
+      tunnelLog(tunnelId, "relay connect failed", ` [err=${err instanceof Error ? err.message : String(err)}]`);
+      throw err;
+    }
 
     let gatewayConn: net.Socket;
     try {
       // Stage 2: Establish mTLS connection to gateway through the relay
-      gatewayConn = await createGatewayConnection(relayConn, gateway, protocol);
+      gatewayConn = await createGatewayConnection(relayConn, gateway, protocol, tunnelId);
     } catch (err) {
-      relayConn.destroy();
+      tunnelLog(tunnelId, "gateway mTLS failed", ` [err=${err instanceof Error ? err.message : String(err)}]`);
+      destroyGatewayTunnel({ relayConn, tunnelId, trigger: "gatewayHandshakeFailed" });
       throw err;
     }
+
+    relayConn.on("close", (hadError: boolean) => tunnelLog(tunnelId, "relay socket close", ` [hadError=${hadError}]`));
+    gatewayConn.on("close", (hadError: boolean) =>
+      tunnelLog(tunnelId, "gateway socket close", ` [hadError=${hadError}]`)
+    );
+    relayConn.on("error", (err: Error) => tunnelLog(tunnelId, "relay socket error", ` [err=${err.message}]`));
+    gatewayConn.on("error", (err: Error) => tunnelLog(tunnelId, "gateway socket error", ` [err=${err.message}]`));
 
     // The gateway dials the target the moment it accepts the channel, so from here the attempt is
     // no longer safe to replay even if we abandon this connection.
@@ -246,6 +311,7 @@ export const setupRelayServer = async ({
     let released = false;
 
     return {
+      tunnelId,
       relayConn,
       gatewayConn,
       releaseChannel: () => {
@@ -261,11 +327,10 @@ export const setupRelayServer = async ({
 
   const discardPendingUpstream = () => {
     if (!pendingUpstream) return;
-    const { relayConn, gatewayConn, releaseChannel } = pendingUpstream;
+    const { tunnelId, relayConn, gatewayConn, releaseChannel } = pendingUpstream;
     pendingUpstream = null;
     releaseChannel();
-    relayConn.destroy();
-    gatewayConn.destroy();
+    destroyGatewayTunnel({ relayConn, gatewayConn, tunnelId, trigger: "discardUnclaimed" });
   };
 
   return new Promise((resolve, reject) => {
@@ -279,35 +344,40 @@ export const setupRelayServer = async ({
 
           const claimed = pendingUpstream;
           pendingUpstream = null;
-          const { relayConn, gatewayConn, releaseChannel } = claimed ?? (await openUpstream());
+          const { tunnelId, relayConn, gatewayConn, releaseChannel } = claimed ?? (await openUpstream());
+          tunnelLog(tunnelId, claimed ? "claimed pre-opened tunnel" : "opened tunnel for client");
 
           // Its "close" already fired, so the teardown listeners below would never run and the
           // channel would stay counted for the life of the pod.
           if (clientConn.destroyed) {
             releaseChannel();
-            relayConn.destroy();
-            gatewayConn.destroy();
+            destroyGatewayTunnel({ relayConn, gatewayConn, tunnelId, trigger: "clientAlreadyGone" });
             return;
           }
 
-          const destroyAll = () => {
+          // Only the first trigger is interesting: six listeners point here, and every later one is
+          // a consequence of the teardown the first already started.
+          let tornDown = false;
+          const destroyAll = (trigger: string) => {
+            if (tornDown) return;
+            tornDown = true;
+            tunnelLog(tunnelId, "teardown triggered", ` [trigger=${trigger}]`);
             releaseChannel();
             clientConn.destroy();
-            relayConn.destroy();
-            gatewayConn.destroy();
+            destroyGatewayTunnel({ relayConn, gatewayConn, tunnelId, trigger });
           };
 
-          clientConn.on("error", () => destroyAll());
-          relayConn.on("error", () => destroyAll());
-          gatewayConn.on("error", () => destroyAll());
+          clientConn.on("error", (err: Error) => destroyAll(`clientError:${err.message}`));
+          relayConn.on("error", () => destroyAll("relayError"));
+          gatewayConn.on("error", () => destroyAll("gatewayError"));
 
           // Bidirectional data forwarding
           clientConn.pipe(gatewayConn);
           gatewayConn.pipe(clientConn);
 
-          clientConn.on("close", destroyAll);
-          relayConn.on("close", destroyAll);
-          gatewayConn.on("close", destroyAll);
+          clientConn.on("close", () => destroyAll("clientClose"));
+          relayConn.on("close", () => destroyAll("relayClose"));
+          gatewayConn.on("close", () => destroyAll("gatewayClose"));
         } catch (err) {
           const errorMsg = err instanceof Error ? err.message : String(err);
           relayErrorMsg.push(errorMsg);
@@ -328,6 +398,7 @@ export const setupRelayServer = async ({
         reject(new Error("Failed to get server port"));
         return;
       }
+      localPort = address.port;
 
       const relayServer: IGatewayRelayServer = {
         server,

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -160,10 +160,14 @@ export const createGatewayConnection = async (
 
   return new Promise((resolve, reject) => {
     try {
+      // These listeners outlive the handshake, so each one has to stay correct once the tunnel is
+      // established: destroying is always deferred, and reject() is a no-op on a settled promise.
+      // Callers respond to a rejection by scheduling relayConn's destroy, which lands on the same
+      // queue behind ours, so the inner socket still goes first.
       const gatewaySocket = tls.connect(tlsOptions, () => {
         if (!gatewaySocket.authorized) {
           const error = gatewaySocket.authorizationError;
-          gatewaySocket.destroy();
+          destroyGatewayTunnel({ gatewayConn: gatewaySocket, tunnelId, trigger: "gatewayUnauthorized" });
           reject(new Error(`Gateway TLS authorization failed: ${error?.message}`));
           return;
         }
@@ -173,15 +177,13 @@ export const createGatewayConnection = async (
       });
 
       gatewaySocket.on("error", (err: Error) => {
-        // Callers respond to a rejection by destroying relayConn, so the inner socket has to go
-        // first or it is left reading a transport that is about to disappear.
-        gatewaySocket.destroy();
+        destroyGatewayTunnel({ gatewayConn: gatewaySocket, tunnelId, trigger: `gatewayError:${err.message}` });
         reject(new Error(`Failed to establish gateway mTLS: ${err.message}`));
       });
 
       gatewaySocket.setTimeout(120000);
       gatewaySocket.on("timeout", () => {
-        gatewaySocket.destroy();
+        destroyGatewayTunnel({ gatewayConn: gatewaySocket, tunnelId, trigger: "gatewayTimeout" });
         reject(new Error("Gateway connection timeout"));
       });
     } catch (error: unknown) {

--- a/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
+++ b/backend/src/services/identity-kubernetes-auth/identity-kubernetes-auth-service.ts
@@ -363,6 +363,9 @@ export const identityKubernetesAuthServiceFactory = ({
         caCert = decryptor({ cipherTextBlob: identityKubernetesAuth.encryptedKubernetesCaCertificate }).toString();
       }
 
+      if (appCfg.isCloud) {
+        logger.info(`Processing k8s auth for the identity=${identity.id}`);
+      }
       const tokenReviewCallbackRaw = async ({
         host = identityKubernetesAuth.kubernetesHost,
         port,
@@ -467,13 +470,17 @@ export const identityKubernetesAuthServiceFactory = ({
       };
 
       const tokenReviewCallbackThroughGateway = async (host: string, port?: number) => {
+        // localPort is the correlation key into the gatewayTunnel:* lines, which carry the tunnel id
+        // and outlive this request: the tunnel is torn down after the response is already logged.
+        const gatewayIdForLog =
+          identityKubernetesAuth.gatewayV2Id ??
+          identityKubernetesAuth.gatewayId ??
+          identityKubernetesAuth.gatewayPoolId;
         logger.info(
-          {
-            host,
-            port
-          },
-          "tokenReviewCallbackThroughGateway: Processing kubernetes token review using gateway"
+          { host, port },
+          `tokenReviewCallbackThroughGateway: Processing kubernetes token review using gateway [identityId=${identityKubernetesAuth.identityId}] [gatewayId=${gatewayIdForLog}] [localPort=${port}]`
         );
+        const startedAt = Date.now();
 
         const res = await request
           .post<TCreateTokenReviewResponse>(
@@ -500,7 +507,7 @@ export const identityKubernetesAuthServiceFactory = ({
           .catch((err) => {
             logger.error(
               { error: err as Error, host, port },
-              "tokenReviewCallbackThroughGateway: Kubernetes token review request error"
+              `tokenReviewCallbackThroughGateway: Kubernetes token review request error [identityId=${identityKubernetesAuth.identityId}] [gatewayId=${gatewayIdForLog}] [localPort=${port}] [elapsedMs=${Date.now() - startedAt}]`
             );
 
             if (err instanceof AxiosError) {
@@ -517,6 +524,12 @@ export const identityKubernetesAuthServiceFactory = ({
               error: err
             });
           });
+
+        const reviewStatus = res.data?.status;
+        const authenticated = Boolean(reviewStatus && "authenticated" in reviewStatus && reviewStatus.authenticated);
+        logger.info(
+          `tokenReviewCallbackThroughGateway: Kubernetes token review completed [identityId=${identityKubernetesAuth.identityId}] [gatewayId=${gatewayIdForLog}] [localPort=${port}] [authenticated=${authenticated}] [elapsedMs=${Date.now() - startedAt}]`
+        );
 
         return res.data;
       };


### PR DESCRIPTION
## Context

This PR adds more visibility over the k8s auth process by logging on tunnels and also rearranges the tunnel closing to be more resilient 

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)