### PR TITLE
feat: resolved approval ui showing uuid in list

### DIFF
--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
@@ -388,6 +388,40 @@ const Form = ({
     [memberOptions, groupOptions]
   );
 
+  const memberById = useMemo(
+    () => new Map(members.map((member) => [member.user.id, member] as const)),
+    [members]
+  );
+
+  const groupById = useMemo(
+    () => new Map(groups.map(({ group }) => [group.id, group] as const)),
+    [groups]
+  );
+
+  // policies only return ids for groups (and for change policy approvers), so labels have to be
+  // resolved against the loaded project members and groups
+  const resolveApproverOption = useCallback(
+    (option: ApproverOptionData): ApproverOptionData => {
+      if (!option.id) return option;
+
+      if (option.type === ApproverType.Group) {
+        const group = groupById.get(option.id);
+        return group ? { ...option, name: group.name } : option;
+      }
+
+      const member = memberById.get(option.id);
+      return member
+        ? {
+            ...option,
+            name: getMemberLabel(member),
+            memberEmail: member.user.username,
+            isOrgMembershipActive: member.user.isOrgMembershipActive
+          }
+        : option;
+    },
+    [memberById, groupById]
+  );
+
   const splitSelectedApprovers = (selected: readonly ApproverOptionData[]) => ({
     users: selected
       .filter((option) => option.type === ApproverType.User)
@@ -442,6 +476,7 @@ const Form = ({
         type: BypasserType.User as const,
         id: option.id,
         username: option.username,
+        name: option.name,
         isOrgMembershipActive: option.isOrgMembershipActive
       })),
     groups: selected
@@ -457,7 +492,7 @@ const Form = ({
   const selectedPolicyApprovers: ApproverOptionData[] = [
     ...(formUserApprovers ?? []),
     ...(formGroupApprovers ?? [])
-  ];
+  ].map(resolveApproverOption);
   const updatePolicyApprovers = (newValue: readonly ApproverOptionData[]) => {
     const { users, groups: selectedGroups } = splitSelectedApprovers(newValue);
     setValue("userApprovers", users, { shouldDirty: true, shouldValidate: true });
@@ -470,7 +505,7 @@ const Form = ({
   const selectedPolicyBypassers: ApproverOptionData[] = [
     ...(formUserBypassers ?? []),
     ...(formGroupBypassers ?? [])
-  ];
+  ].map(resolveApproverOption);
   const updatePolicyBypassers = (newValue: readonly ApproverOptionData[]) => {
     const { users, groups: selectedGroups } = splitSelectedBypassers(newValue);
     setValue("userBypassers", users, { shouldDirty: true, shouldValidate: true });
@@ -525,7 +560,7 @@ const Form = ({
     const selectedOptions: ApproverOptionData[] = [
       ...(watch(`sequenceApprovers.${index}.user`) ?? []),
       ...(watch(`sequenceApprovers.${index}.group`) ?? [])
-    ];
+    ].map(resolveApproverOption);
     const updateSelectedOptions = (newValue: readonly ApproverOptionData[]) => {
       const { users, groups: selectedGroups } = splitSelectedApprovers(newValue);
       setValue(`sequenceApprovers.${index}.user`, users, {


### PR DESCRIPTION
## Context

This PR fixes a bug in the policy ui in secret management where the uuid was being shown

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

1. Before this change - create an approval policy in secret management with approvers as a user/group. Then click on edit and you will see that it's UUID
2. After this change, this should be fixed

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)