### PR TITLE
fix(secret-approval): show name on edit sheet

### DIFF
--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/AccessPolicyModal.tsx
@@ -75,24 +75,12 @@ import {
   isValidMemberEmail,
   TApprovalPolicyFormSchema
 } from "./approvalPolicyFormSchema";
+import { getApproverOptionLabel as resolveApproverOptionLabel } from "./approvalPolicyFormUtils";
 import { groupApproversBySequence } from "./approvalPolicyRowUtils";
 import { ApproverOption, ApproverOptionData } from "./ApproverOption";
 
 const getApproverOptionValue = (option: ApproverOptionData) =>
   `${option.type}-${option.id ?? option.username ?? ""}`;
-
-const getApproverOptionLabel = (option: ApproverOptionData) =>
-  option.name ?? option.username ?? option.id ?? "Unknown approver";
-
-const formatApproverOptionLabel = (
-  option: ApproverOptionData,
-  { context }: FormatOptionLabelMeta<ApproverOptionData>
-) =>
-  context === "menu" ? (
-    <ApproverOption option={option} label={getApproverOptionLabel(option)} />
-  ) : (
-    getApproverOptionLabel(option)
-  );
 
 const filterApproverOption = ({ data }: { data: ApproverOptionData }, input: string) => {
   const search = input.trim().toLowerCase();
@@ -386,6 +374,21 @@ const Form = ({
   const approverOptions = useMemo<ApproverOptionData[]>(
     () => [...memberOptions, ...(groupOptions ?? [])],
     [memberOptions, groupOptions]
+  );
+
+  const getApproverOptionLabel = useCallback(
+    (option: ApproverOptionData) => resolveApproverOptionLabel(option, members, groups),
+    [members, groups]
+  );
+
+  const formatApproverOptionLabel = useCallback(
+    (option: ApproverOptionData, { context }: FormatOptionLabelMeta<ApproverOptionData>) =>
+      context === "menu" ? (
+        <ApproverOption option={option} label={getApproverOptionLabel(option)} />
+      ) : (
+        getApproverOptionLabel(option)
+      ),
+    [getApproverOptionLabel]
   );
 
   const splitSelectedApprovers = (selected: readonly ApproverOptionData[]) => ({

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/approvalPolicyFormUtils.test.ts
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/approvalPolicyFormUtils.test.ts
@@ -1,7 +1,20 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { getEmptyApprovalStepIndexes } from "./approvalPolicyFormUtils";
+import { ApproverType, BypasserType } from "@app/hooks/api/accessApproval/types";
+import { TGroupMembership } from "@app/hooks/api/groups/types";
+import { TWorkspaceUser } from "@app/hooks/api/users/types";
+
+import { getApproverOptionLabel, getEmptyApprovalStepIndexes } from "./approvalPolicyFormUtils";
+
+const member = (id: string, firstName: string, lastName: string): TWorkspaceUser =>
+  ({
+    inviteEmail: "",
+    user: { id, firstName, lastName, username: `${firstName}@infisical.com`, email: "" }
+  }) as TWorkspaceUser;
+
+const group = (id: string, name: string): TGroupMembership =>
+  ({ group: { id, name } }) as TGroupMembership;
 
 describe("approval policy form steps", () => {
   it("identifies every access-policy sequence without an approver", () => {
@@ -13,5 +26,58 @@ describe("approval policy form steps", () => {
     ]);
 
     assert.deepEqual(emptySteps, [1, 3]);
+  });
+});
+
+describe("approval policy option labels", () => {
+  const members = [member("user-1", "Ada", "Lovelace")];
+  const groups = [group("group-1", "Engineering")];
+
+  it("resolves a user id to the member display name", () => {
+    assert.equal(
+      getApproverOptionLabel({ type: ApproverType.User, id: "user-1" }, members, groups),
+      "Ada Lovelace"
+    );
+  });
+
+  it("resolves a group id to the group name", () => {
+    assert.equal(
+      getApproverOptionLabel({ type: ApproverType.Group, id: "group-1" }, members, groups),
+      "Engineering"
+    );
+  });
+
+  it("falls back to name, username, then id when the member is missing", () => {
+    assert.equal(
+      getApproverOptionLabel(
+        { type: ApproverType.User, id: "removed", name: "Former user" },
+        members,
+        groups
+      ),
+      "Former user"
+    );
+    assert.equal(
+      getApproverOptionLabel(
+        { type: ApproverType.User, id: "removed", username: "gone@infisical.com" },
+        members,
+        groups
+      ),
+      "gone@infisical.com"
+    );
+    assert.equal(
+      getApproverOptionLabel({ type: ApproverType.User, id: "removed" }, members, groups),
+      "removed"
+    );
+  });
+
+  it("uses the entered email for members created by username only", () => {
+    assert.equal(
+      getApproverOptionLabel(
+        { type: BypasserType.User, username: "new@infisical.com", name: "new@infisical.com" },
+        members,
+        groups
+      ),
+      "new@infisical.com"
+    );
   });
 });

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/approvalPolicyFormUtils.ts
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/ApprovalPolicyList/components/approvalPolicyFormUtils.ts
@@ -1,6 +1,29 @@
+import { getMemberLabel } from "@app/helpers/members";
+import { ApproverType, BypasserType } from "@app/hooks/api/accessApproval/types";
+import { TGroupMembership } from "@app/hooks/api/groups/types";
+import { TWorkspaceUser } from "@app/hooks/api/users/types";
+
+import { ApproverOptionData } from "./ApproverOption";
+
 type TApprovalStep = {
   user: unknown[];
   group: unknown[];
+};
+
+export const getApproverOptionLabel = (
+  option: ApproverOptionData,
+  members: TWorkspaceUser[] = [],
+  groups: TGroupMembership[] = []
+) => {
+  if (option.type === ApproverType.Group || option.type === BypasserType.Group) {
+    const groupName = groups.find(({ group }) => group.id === option.id)?.group.name;
+    return groupName ?? option.name ?? option.id ?? "Unknown approver";
+  }
+
+  const member = members.find((workspaceUser) => workspaceUser.user.id === option.id);
+  if (member) return getMemberLabel(member);
+
+  return option.name ?? option.username ?? option.id ?? "Unknown approver";
 };
 
 export const getEmptyApprovalStepIndexes = (steps: TApprovalStep[] = []) =>


### PR DESCRIPTION
## Context

The v3 approvals migration changed how selected chips get their label.

The list API for change policies only returns `{ id, type }` — no name. Before, the select still looked that `id` up in the project members/groups lists and showed `getMemberLabel` / the group name. After the migration, the label was just `option.name ?? option.username ?? option.id`. Hydrated edit values had no `name`, so the chip showed the UUID.

The fix is to resolve the label from members and groups again (with the old fallbacks for removed users and email-only entries). That helper is shared by the change-policy, access-policy, and bypasser selects.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)