### PR TITLE
improvement(ui): migrate project upgrade gate to v3

### DIFF
--- a/backend/src/db/seeds/3-project.ts
+++ b/backend/src/db/seeds/3-project.ts
@@ -22,6 +22,7 @@ import {
   OrgMembershipStatus,
   ProjectMembershipRole,
   ProjectType,
+  ProjectVersion,
   TableName
 } from "../schemas";
 import { seedData1 } from "../seed-data";
@@ -30,6 +31,24 @@ export const DEFAULT_PROJECT_ENVS = [
   { name: "Development", slug: "dev" },
   { name: "Staging", slug: "staging" },
   { name: "Production", slug: "prod" }
+];
+
+const DEFAULT_V1_PROJECTS = [
+  {
+    id: seedData1.project.id,
+    name: seedData1.project.name,
+    slug: seedData1.project.slug
+  },
+  {
+    id: "c6f7ec57-f7ca-4f2b-8b90-7b7a3f8b6d1a",
+    name: "second project",
+    slug: "second-project"
+  },
+  {
+    id: "d4e4a4d9-8c2e-4f9c-89c4-2dd9f0f2ab5d",
+    name: "third project",
+    slug: "third-project"
+  }
 ];
 
 const createUserWithGhostUser = async (
@@ -211,16 +230,17 @@ export async function seed(knex: Knex): Promise<void> {
 
   await initEnvConfig(hsmService, kmsRootConfigDAL, superAdminDAL, logger);
 
-  const [project] = await knex(TableName.Project)
-    .insert({
-      name: seedData1.project.name,
-      orgId: seedData1.organization.id,
-      slug: "first-project",
-      type: ProjectType.SecretManager,
-      // eslint-disable-next-line
-      // @ts-ignore
-      id: seedData1.project.id
-    })
+  const projects = await knex(TableName.Project)
+    .insert(
+      DEFAULT_V1_PROJECTS.map((project) => ({
+        id: project.id,
+        name: project.name,
+        orgId: seedData1.organization.id,
+        slug: project.slug,
+        type: ProjectType.SecretManager,
+        version: ProjectVersion.V1
+      }))
+    )
     .returning("*");
 
   const userOrgMembership = await knex(TableName.Membership)
@@ -241,31 +261,35 @@ export async function seed(knex: Knex): Promise<void> {
     throw new Error("User public key not found");
   }
 
-  await createUserWithGhostUser(seedData1.organization.id, project.id, seedData1.id, userOrgMembership.id, knex);
+  for (const project of projects) {
+    await createUserWithGhostUser(seedData1.organization.id, project.id, seedData1.id, userOrgMembership.id, knex);
+  }
 
   // create default environments and default folders
-  const envs = await knex(TableName.Environment)
-    .insert(
+  for (const project of projects) {
+    const envs = await knex(TableName.Environment)
+      .insert(
       DEFAULT_PROJECT_ENVS.map(({ name, slug }, index) => ({
         name,
         slug,
         projectId: project.id,
         position: index + 1
       }))
-    )
-    .returning("*");
-  await knex(TableName.SecretFolder).insert(envs.map(({ id }) => ({ name: "root", envId: id, parentId: null })));
+      )
+      .returning("*");
+    await knex(TableName.SecretFolder).insert(envs.map(({ id }) => ({ name: "root", envId: id, parentId: null })));
 
-  // save secret secret blind index
-  const salt = crypto.randomBytes(16).toString("base64");
-  const secretBlindIndex = crypto.encryption().symmetric().encryptWithRootEncryptionKey(salt);
-  // insert secret blind index for project
-  await knex(TableName.SecretBlindIndex).insert({
-    projectId: project.id,
-    encryptedSaltCipherText: secretBlindIndex.ciphertext,
-    saltIV: secretBlindIndex.iv,
-    saltTag: secretBlindIndex.tag,
-    algorithm: secretBlindIndex.algorithm,
-    keyEncoding: secretBlindIndex.encoding
-  });
+    // save secret secret blind index
+    const salt = crypto.randomBytes(16).toString("base64");
+    const secretBlindIndex = crypto.encryption().symmetric().encryptWithRootEncryptionKey(salt);
+    // insert secret blind index for project
+    await knex(TableName.SecretBlindIndex).insert({
+      projectId: project.id,
+      encryptedSaltCipherText: secretBlindIndex.ciphertext,
+      saltIV: secretBlindIndex.iv,
+      saltTag: secretBlindIndex.tag,
+      algorithm: secretBlindIndex.algorithm,
+      keyEncoding: secretBlindIndex.encoding
+    });
+  }
 }

--- a/backend/src/db/seeds/3-project.ts
+++ b/backend/src/db/seeds/3-project.ts
@@ -22,7 +22,6 @@ import {
   OrgMembershipStatus,
   ProjectMembershipRole,
   ProjectType,
-  ProjectVersion,
   TableName
 } from "../schemas";
 import { seedData1 } from "../seed-data";
@@ -31,24 +30,6 @@ export const DEFAULT_PROJECT_ENVS = [
   { name: "Development", slug: "dev" },
   { name: "Staging", slug: "staging" },
   { name: "Production", slug: "prod" }
-];
-
-const DEFAULT_V1_PROJECTS = [
-  {
-    id: seedData1.project.id,
-    name: seedData1.project.name,
-    slug: seedData1.project.slug
-  },
-  {
-    id: "c6f7ec57-f7ca-4f2b-8b90-7b7a3f8b6d1a",
-    name: "second project",
-    slug: "second-project"
-  },
-  {
-    id: "d4e4a4d9-8c2e-4f9c-89c4-2dd9f0f2ab5d",
-    name: "third project",
-    slug: "third-project"
-  }
 ];
 
 const createUserWithGhostUser = async (
@@ -230,17 +211,16 @@ export async function seed(knex: Knex): Promise<void> {
 
   await initEnvConfig(hsmService, kmsRootConfigDAL, superAdminDAL, logger);
 
-  const projects = await knex(TableName.Project)
-    .insert(
-      DEFAULT_V1_PROJECTS.map((project) => ({
-        id: project.id,
-        name: project.name,
-        orgId: seedData1.organization.id,
-        slug: project.slug,
-        type: ProjectType.SecretManager,
-        version: ProjectVersion.V1
-      }))
-    )
+  const [project] = await knex(TableName.Project)
+    .insert({
+      name: seedData1.project.name,
+      orgId: seedData1.organization.id,
+      slug: "first-project",
+      type: ProjectType.SecretManager,
+      // eslint-disable-next-line
+      // @ts-ignore
+      id: seedData1.project.id
+    })
     .returning("*");
 
   const userOrgMembership = await knex(TableName.Membership)
@@ -261,35 +241,31 @@ export async function seed(knex: Knex): Promise<void> {
     throw new Error("User public key not found");
   }
 
-  for (const project of projects) {
-    await createUserWithGhostUser(seedData1.organization.id, project.id, seedData1.id, userOrgMembership.id, knex);
-  }
+  await createUserWithGhostUser(seedData1.organization.id, project.id, seedData1.id, userOrgMembership.id, knex);
 
   // create default environments and default folders
-  for (const project of projects) {
-    const envs = await knex(TableName.Environment)
-      .insert(
+  const envs = await knex(TableName.Environment)
+    .insert(
       DEFAULT_PROJECT_ENVS.map(({ name, slug }, index) => ({
         name,
         slug,
         projectId: project.id,
         position: index + 1
       }))
-      )
-      .returning("*");
-    await knex(TableName.SecretFolder).insert(envs.map(({ id }) => ({ name: "root", envId: id, parentId: null })));
+    )
+    .returning("*");
+  await knex(TableName.SecretFolder).insert(envs.map(({ id }) => ({ name: "root", envId: id, parentId: null })));
 
-    // save secret secret blind index
-    const salt = crypto.randomBytes(16).toString("base64");
-    const secretBlindIndex = crypto.encryption().symmetric().encryptWithRootEncryptionKey(salt);
-    // insert secret blind index for project
-    await knex(TableName.SecretBlindIndex).insert({
-      projectId: project.id,
-      encryptedSaltCipherText: secretBlindIndex.ciphertext,
-      saltIV: secretBlindIndex.iv,
-      saltTag: secretBlindIndex.tag,
-      algorithm: secretBlindIndex.algorithm,
-      keyEncoding: secretBlindIndex.encoding
-    });
-  }
+  // save secret secret blind index
+  const salt = crypto.randomBytes(16).toString("base64");
+  const secretBlindIndex = crypto.encryption().symmetric().encryptWithRootEncryptionKey(salt);
+  // insert secret blind index for project
+  await knex(TableName.SecretBlindIndex).insert({
+    projectId: project.id,
+    encryptedSaltCipherText: secretBlindIndex.ciphertext,
+    saltIV: secretBlindIndex.iv,
+    saltTag: secretBlindIndex.tag,
+    algorithm: secretBlindIndex.algorithm,
+    keyEncoding: secretBlindIndex.encoding
+  });
 }

--- a/frontend/src/components/v3/platform/AccessRestricted/AccessRestrictedDialog.stories.tsx
+++ b/frontend/src/components/v3/platform/AccessRestricted/AccessRestrictedDialog.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TriangleAlertIcon } from "lucide-react";
 
 import { Button } from "../../generic/Button";
 import { AccessRestrictedDialog } from "./AccessRestrictedDialog";
@@ -64,7 +65,7 @@ export const WithAction: Story = {
     docs: {
       description: {
         story:
-          "Surfaces with a self-serve flow (e.g. request access) can append a call to action after the standard navigation buttons."
+          "Surfaces with a self-serve flow (e.g. request access) can append a call to action after the standard navigation buttons. The footer gives it the remaining row width and stacks it when the panel is narrow."
       }
     }
   }
@@ -79,6 +80,32 @@ export const CustomCopy: Story = {
     docs: {
       description: {
         story: "Override the description when the page has a more specific access rule."
+      }
+    }
+  }
+};
+
+export const Prerequisite: Story = {
+  name: "Example: Prerequisite",
+  args: {
+    title: "Upgrade your secrets engine to view your project dashboard.",
+    subtitle: null,
+    description: "Upgrade this project before viewing its secrets in the UI.",
+    badgeIcon: <TriangleAlertIcon />,
+    badgeLabel: "Upgrade Required",
+    docsUrl: null,
+    showGoBack: false,
+    action: (
+      <Button variant="project" isFullWidth>
+        Upgrade Secrets Engine
+      </Button>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Customize the badge, omit the access-control link, and hide history-based navigation when a page is gated by a prerequisite rather than a missing permission."
       }
     }
   }

--- a/frontend/src/components/v3/platform/AccessRestricted/AccessRestrictedDialog.tsx
+++ b/frontend/src/components/v3/platform/AccessRestricted/AccessRestrictedDialog.tsx
@@ -139,10 +139,7 @@ export const AccessRestrictedDialog = ({
               {description}
             </div>
           </div>
-          <CodeBlock
-            label={requirement ? "Access details" : "Restricted route"}
-            value={accessDetails}
-          />
+          <CodeBlock label={requirement ? "Access details" : undefined} value={accessDetails} />
           {docsUrl && (
             <a
               href={docsUrl}

--- a/frontend/src/components/v3/platform/AccessRestricted/AccessRestrictedDialog.tsx
+++ b/frontend/src/components/v3/platform/AccessRestricted/AccessRestrictedDialog.tsx
@@ -4,6 +4,7 @@ import { ArrowLeftIcon, ExternalLinkIcon, HouseIcon, InfoIcon, LockIcon } from "
 
 import { Badge } from "../../generic/Badge";
 import { Button } from "../../generic/Button";
+import { CodeBlock } from "../../generic/CodeBlock";
 import { cn } from "../../utils";
 
 const RBAC_DOCS_URL =
@@ -54,25 +55,31 @@ export const toPermissionRequirement = (
   typeof action === "string" && typeof subject === "string" ? { action, subject } : undefined;
 
 type Props = {
-  // First line of the two-line heading, matching the error-page family.
+  // Primary heading, matching the error-page family. Set subtitle to null for one line.
   title?: string;
-  subtitle?: string;
+  subtitle?: string | null;
   description?: ReactNode;
   // The CASL action/subject the viewer is missing. Shown verbatim so an operator can hand it to
   // whoever edits their role.
   requirement?: TAccessRestrictedRequirement;
-  docsUrl?: string;
+  // Set to null when access is gated by a prerequisite rather than role-based access control.
+  docsUrl?: string | null;
+  // Non-permission prerequisites can replace the default lock badge while reusing the gate.
+  badgeIcon?: ReactNode;
+  badgeLabel?: string;
   // Extra call to action rendered after "Back to Home" — e.g. a request-access flow on the
   // surfaces that have one.
   action?: ReactNode;
+  showGoBack?: boolean;
   className?: string;
 };
 
 /**
- * Page- and tab-level permission gate, styled to the ErrorPage/ForbiddenPage family: a
+ * Page- and tab-level access gate, styled to the ErrorPage/ForbiddenPage family: a
  * dialog-look panel floating over a redacted stand-in for the content. It renders in normal
  * document flow, so the surrounding page chrome (sidebar, sibling tabs) stays usable by both
- * pointer and keyboard.
+ * pointer and keyboard. It defaults to permission-focused copy but can represent another
+ * prerequisite with custom copy and badge content.
  *
  * For a single section inside an otherwise usable page, use AccessRestrictedNotice instead.
  */
@@ -82,17 +89,17 @@ export const AccessRestrictedDialog = ({
   description = "Your role doesn't include the permission this page requires.",
   requirement,
   docsUrl = RBAC_DOCS_URL,
+  badgeIcon = <LockIcon />,
+  badgeLabel = "Access Restricted",
   action,
+  showGoBack = true,
   className
 }: Props) => {
   const titleId = useId();
 
-  const monoRows: [string, string][] = [
-    ...(requirement
-      ? ([["requires", `${requirement.action} on ${requirement.subject}`]] as [string, string][])
-      : []),
-    ["route", window.location.pathname]
-  ];
+  const accessDetails = requirement
+    ? `requires  ${requirement.action} on ${requirement.subject}\nroute     ${window.location.pathname}`
+    : window.location.pathname;
 
   // Deliberately NOT a real <Dialog>: this is a permanent page state with no close affordance,
   // and Radix DialogContent hardcodes a Tab loop (FocusScope loop) plus mount autofocus even
@@ -108,51 +115,62 @@ export const AccessRestrictedDialog = ({
       <div className="relative col-start-1 row-start-1 flex items-center justify-center p-4">
         <section
           aria-labelledby={titleId}
-          className="flex w-full max-w-2xl animate-in flex-col gap-5 rounded-lg border border-border bg-popover p-6 pb-0 text-foreground shadow-lg duration-200 fade-in-0 zoom-in-95"
+          className="@container/access-restricted flex w-full max-w-2xl animate-in flex-col gap-5 rounded-lg border border-border bg-popover p-6 pb-0 text-foreground shadow-lg duration-200 fade-in-0 zoom-in-95"
         >
           <div className="flex flex-col items-start gap-5 text-left">
             <Badge variant="warning" className="h-6 px-2">
-              <LockIcon />
-              Access Restricted
+              {badgeIcon}
+              {badgeLabel}
             </Badge>
             {/* Alliance ships only weight 400, so font-normal rather than a faux-bolded semibold. */}
-            <h2 id={titleId} className="font-alliance text-3xl leading-tight font-normal">
+            <h2
+              id={titleId}
+              className="font-alliance text-3xl leading-tight font-normal text-balance"
+            >
               {title}
-              <br />
-              <span className="text-2xl">{subtitle}</span>
+              {subtitle && (
+                <>
+                  <br />
+                  <span className="text-2xl">{subtitle}</span>
+                </>
+              )}
             </h2>
-            <p className="text-sm leading-relaxed text-accent">{description}</p>
+            <div className="flex flex-col gap-3 text-sm leading-relaxed text-accent">
+              {description}
+            </div>
           </div>
-          <div className="flex flex-col gap-1.5 rounded-md border border-border bg-bunker-800/50 px-4 py-3">
-            {monoRows.map(([key, value]) => (
-              <div key={key} className="flex gap-4 font-mono text-xs">
-                <span className="w-16 shrink-0 text-muted">{key}</span>
-                <span className="break-all text-label">{value}</span>
-              </div>
-            ))}
-          </div>
-          <a
-            href={docsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex w-fit items-center gap-1.5 text-xs text-info transition-colors hover:text-info/75"
-          >
-            <InfoIcon className="size-3.5" />
-            Access control documentation
-            <ExternalLinkIcon className="size-3" />
-          </a>
-          <div className="-mx-6 flex flex-row flex-wrap justify-end gap-2 rounded-b-lg border-t border-border bg-container p-4">
-            <Button variant="outline" onClick={() => window.history.back()}>
-              <ArrowLeftIcon />
-              Go Back
-            </Button>
-            <Button variant="neutral" asChild>
-              <Link to="/">
-                <HouseIcon />
-                Back to Home
-              </Link>
-            </Button>
-            {action}
+          <CodeBlock
+            label={requirement ? "Access details" : "Restricted route"}
+            value={accessDetails}
+          />
+          {docsUrl && (
+            <a
+              href={docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex w-fit items-center gap-1.5 text-xs text-info transition-colors hover:text-info/75"
+            >
+              <InfoIcon className="size-3.5" />
+              Access control documentation
+              <ExternalLinkIcon className="size-3" />
+            </a>
+          )}
+          <div className="-mx-6 flex flex-col gap-2 rounded-b-lg border-t border-border bg-container p-4 @xl/access-restricted:flex-row @xl/access-restricted:items-center">
+            <div className="ml-auto flex flex-row flex-wrap justify-end gap-2">
+              {showGoBack && (
+                <Button variant="outline" onClick={() => window.history.back()}>
+                  <ArrowLeftIcon />
+                  Go Back
+                </Button>
+              )}
+              <Button variant="neutral" asChild>
+                <Link to="/">
+                  <HouseIcon />
+                  Back to Home
+                </Link>
+              </Button>
+            </div>
+            {action && <div className="flex min-w-0 flex-1 justify-end">{action}</div>}
           </div>
         </section>
       </div>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
@@ -63,8 +63,8 @@ export const SecretV2MigrationSection = () => {
     handleSubmit,
     control,
     reset,
-    formState: { isSubmitting }
-  } = useForm({ resolver: zodResolver(formSchema) });
+    formState: { isSubmitting, isValid }
+  } = useForm({ resolver: zodResolver(formSchema), mode: "onChange" });
   useEffect(() => {
     if (!popUp.migrationInfo.isOpen) {
       reset();
@@ -102,7 +102,7 @@ export const SecretV2MigrationSection = () => {
   return (
     <div className="flex w-full flex-col gap-3">
       {isUpgrading && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-page/80">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-page/80 backdrop-blur-sm">
           <Spinner size="lg" label="Upgrading secrets engine" />
           <div className="ml-4 flex flex-col gap-1 text-foreground">
             <div className="text-3xl font-medium">Please wait</div>
@@ -259,7 +259,12 @@ export const SecretV2MigrationSection = () => {
               >
                 Cancel
               </Button>
-              <Button type="submit" variant="project" isPending={isSubmitting}>
+              <Button
+                type="submit"
+                variant="project"
+                isDisabled={!isValid || isSubmitting}
+                isPending={isSubmitting}
+              >
                 Confirm Upgrade
               </Button>
             </DialogFooter>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
@@ -7,9 +7,9 @@ import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
 import {
+  AccessRestrictedDialog,
   Alert,
   AlertDescription,
-  AlertTitle,
   Button,
   Checkbox,
   Dialog,
@@ -100,7 +100,7 @@ export const SecretV2MigrationSection = () => {
 
   const isAdmin = hasProjectRole(ProjectMembershipRole.Admin);
   return (
-    <div className="mt-4 flex w-full max-w-2xl flex-col gap-3">
+    <div className="flex w-full flex-col gap-3">
       {isUpgrading && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-page/80">
           <Spinner size="lg" label="Upgrading secrets engine" />
@@ -110,21 +110,26 @@ export const SecretV2MigrationSection = () => {
           </div>
         </div>
       )}
-      <Alert variant="warning" className="items-start p-5">
-        <TriangleAlertIcon className="mt-0.5" />
-        <AlertTitle className="text-lg">Upgrade secrets engine version</AlertTitle>
-        <AlertDescription className="gap-4 text-foreground/80">
-          <div className="flex flex-col gap-3 leading-relaxed">
+      <AccessRestrictedDialog
+        title="Upgrade your secrets engine to view your project dashboard."
+        subtitle={null}
+        description={
+          <>
             <p>
-              Your existing workflows to fetch secrets will continue to work. However, viewing
-              secrets on the UI requires you to upgrade your project&apos;s secrets engine version.
+              Your existing secret-fetching workflows will continue to work. To view secrets in the
+              UI, upgrade your project’s secrets engine.
             </p>
             <p>
-              Upgrading is free and enables the use of Infisical&apos;s new secrets engine, which is
-              10x faster and allows you to encrypt secrets with your own KMS provider.
+              The upgrade takes 1–2 minutes with no downtime and delivers up to 10× faster
+              performance plus support for your own KMS provider.
             </p>
-            <p>The upgrade takes only 1-2 minutes and will not cause any downtime.</p>
-          </div>
+          </>
+        }
+        badgeIcon={<TriangleAlertIcon />}
+        badgeLabel="Upgrade Required"
+        docsUrl={null}
+        showGoBack={false}
+        action={
           <Button
             variant="project"
             onClick={() => handlePopUpOpen("migrationInfo")}
@@ -134,8 +139,8 @@ export const SecretV2MigrationSection = () => {
           >
             {isAdmin ? "Upgrade Secrets Engine" : "Upgrade requires admin privilege"}
           </Button>
-        </AlertDescription>
-      </Alert>
+        }
+      />
       {didProjectUpgradeFailed && (
         <Alert variant="danger">
           <CircleXIcon />

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
@@ -103,7 +103,7 @@ export const SecretV2MigrationSection = () => {
     <div className="mt-4 flex w-full max-w-2xl flex-col gap-3">
       {isUpgrading && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-page/80">
-          <Spinner size="lg" label="Upgrading secrets engine" className="fill-project" />
+          <Spinner size="lg" label="Upgrading secrets engine" />
           <div className="ml-4 flex flex-col gap-1 text-foreground">
             <div className="text-3xl font-medium">Please wait</div>
             <span>Upgrading secrets engine...</span>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretV2MigrationSection/SecretV2MigrationSection.tsx
@@ -1,13 +1,32 @@
 import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { faTriangleExclamation, faWarning } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQueryClient } from "@tanstack/react-query";
+import { CircleXIcon, TriangleAlertIcon } from "lucide-react";
 import { z } from "zod";
 
 import { createNotification } from "@app/components/notifications";
-import { Button, Checkbox, Modal, ModalContent, Spinner } from "@app/components/v2";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Checkbox,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldContent,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSet,
+  Spinner
+} from "@app/components/v3";
 import { useProject, useProjectPermission } from "@app/context";
 import { usePopUp } from "@app/hooks";
 import { projectKeys, useGetWorkspaceById, useMigrateProjectToV3 } from "@app/hooks/api";
@@ -40,7 +59,12 @@ export const SecretV2MigrationSection = () => {
   );
   const { hasProjectRole } = useProjectPermission();
   const migrateProjectToV3 = useMigrateProjectToV3();
-  const { handleSubmit, control, reset } = useForm({ resolver: zodResolver(formSchema) });
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { isSubmitting }
+  } = useForm({ resolver: zodResolver(formSchema) });
   useEffect(() => {
     if (!popUp.migrationInfo.isOpen) {
       reset();
@@ -76,71 +100,90 @@ export const SecretV2MigrationSection = () => {
 
   const isAdmin = hasProjectRole(ProjectMembershipRole.Admin);
   return (
-    <div className="mt-4 flex max-w-2xl flex-col rounded-lg border border-primary/50 bg-primary/10 px-6 py-5">
+    <div className="mt-4 flex w-full max-w-2xl flex-col gap-3">
       {isUpgrading && (
-        <div className="bg-opacity-80 absolute top-0 left-0 z-50 flex h-screen w-screen items-center justify-center bg-bunker-500">
-          <Spinner size="lg" className="text-primary" />
-          <div className="ml-4 flex flex-col space-y-1">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-page/80">
+          <Spinner size="lg" label="Upgrading secrets engine" className="fill-project" />
+          <div className="ml-4 flex flex-col gap-1 text-foreground">
             <div className="text-3xl font-medium">Please wait</div>
-            <span className="inline-block">Upgrading secrets engine...</span>
+            <span>Upgrading secrets engine...</span>
           </div>
         </div>
       )}
-      <div className="mb-4 flex items-start gap-2">
-        <FontAwesomeIcon icon={faWarning} size="xl" className="mt-1 text-primary" />
-        <p className="text-xl font-medium">Upgrade secrets engine version</p>
-      </div>
-      <p className="mx-1 mb-4 leading-7 text-mineshaft-100">
-        Your existing workflows to fetch secrets will continue to work. However, viewing secrets on
-        the UI requires you to upgrade your project&apos;s secrets engine version.
-      </p>
-      <p className="mx-1 mb-4 leading-7 text-mineshaft-100">
-        Upgrading is free and enables the use of Infisical&apos;s new secrets engine, which is 10x
-        faster and allows you to encrypt secrets with your own KMS provider.
-      </p>
-      <p className="mx-1 mb-6 leading-7 text-mineshaft-100">
-        The upgrade takes only 1-2 minutes and will not cause any downtime.
-      </p>
-      <Button
-        onClick={() => handlePopUpOpen("migrationInfo")}
-        isDisabled={!isAdmin || isUpgrading}
-        isLoading={migrateProjectToV3.isPending}
-        className="w-full"
-      >
-        {isAdmin ? "Upgrade Secrets Engine" : "Upgrade requires admin privilege"}
-      </Button>
+      <Alert variant="warning" className="items-start p-5">
+        <TriangleAlertIcon className="mt-0.5" />
+        <AlertTitle className="text-lg">Upgrade secrets engine version</AlertTitle>
+        <AlertDescription className="gap-4 text-foreground/80">
+          <div className="flex flex-col gap-3 leading-relaxed">
+            <p>
+              Your existing workflows to fetch secrets will continue to work. However, viewing
+              secrets on the UI requires you to upgrade your project&apos;s secrets engine version.
+            </p>
+            <p>
+              Upgrading is free and enables the use of Infisical&apos;s new secrets engine, which is
+              10x faster and allows you to encrypt secrets with your own KMS provider.
+            </p>
+            <p>The upgrade takes only 1-2 minutes and will not cause any downtime.</p>
+          </div>
+          <Button
+            variant="project"
+            onClick={() => handlePopUpOpen("migrationInfo")}
+            isDisabled={!isAdmin || isUpgrading}
+            isPending={migrateProjectToV3.isPending}
+            isFullWidth
+          >
+            {isAdmin ? "Upgrade Secrets Engine" : "Upgrade requires admin privilege"}
+          </Button>
+        </AlertDescription>
+      </Alert>
       {didProjectUpgradeFailed && (
-        <p className="mt-2 text-sm leading-7 text-red-400">
-          <FontAwesomeIcon icon={faTriangleExclamation} className="mr-2" />
-          Secrets engine upgrade unsuccessful. For assistance, please contact the Infisical support
-          team.
-        </p>
+        <Alert variant="danger">
+          <CircleXIcon />
+          <AlertDescription>
+            Secrets engine upgrade unsuccessful. For assistance, please contact the Infisical
+            support team.
+          </AlertDescription>
+        </Alert>
       )}
-      <Modal
-        isOpen={popUp.migrationInfo.isOpen}
-        onOpenChange={(isOpen) => handlePopUpToggle("migrationInfo", isOpen)}
+      <Dialog
+        open={popUp.migrationInfo.isOpen}
+        onOpenChange={(open) => handlePopUpToggle("migrationInfo", open)}
       >
-        <ModalContent
-          title="Upgrade Checklist"
-          subTitle="To ensure smooth transition, please ensure the following requirements are met before upgrading this project."
-        >
-          <div>
-            <form onSubmit={handleSubmit(handleMigrationSecretV2)}>
-              <div className="flex flex-col space-y-4">
+        <DialogContent className="max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Upgrade Checklist</DialogTitle>
+            <DialogDescription>
+              To ensure smooth transition, please ensure the following requirements are met before
+              upgrading this project.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleSubmit(handleMigrationSecretV2)} className="flex flex-col gap-6">
+            <FieldSet>
+              <FieldLegend className="sr-only">Upgrade requirements</FieldLegend>
+              <FieldGroup>
                 <Controller
                   control={control}
                   name="isCLIChecked"
                   defaultValue={false}
                   render={({ field: { onBlur, value, onChange }, fieldState: { error } }) => (
-                    <Checkbox
-                      id="is-cli-checked"
-                      isChecked={value}
-                      onCheckedChange={onChange}
-                      onBlur={onBlur}
-                      isError={Boolean(error?.message)}
-                    >
-                      Infisical CLI version is v0.25.0 or above.
-                    </Checkbox>
+                    <Field orientation="horizontal" data-invalid={Boolean(error)}>
+                      <Checkbox
+                        id="is-cli-checked"
+                        variant="project"
+                        isChecked={value}
+                        onCheckedChange={(checked) => onChange(checked === true)}
+                        onBlur={onBlur}
+                        isError={Boolean(error)}
+                      />
+                      <FieldContent>
+                        <FieldLabel htmlFor="is-cli-checked" className="cursor-pointer" size="sm">
+                          Infisical CLI version is v0.25.0 or above.
+                        </FieldLabel>
+                        <FieldError>
+                          {error && "Confirm this requirement before upgrading."}
+                        </FieldError>
+                      </FieldContent>
+                    </Field>
                   )}
                 />
                 <Controller
@@ -148,15 +191,28 @@ export const SecretV2MigrationSection = () => {
                   name="isOperatorChecked"
                   defaultValue={false}
                   render={({ field: { onBlur, value, onChange }, fieldState: { error } }) => (
-                    <Checkbox
-                      id="is-operator-checked"
-                      isChecked={value}
-                      onCheckedChange={onChange}
-                      onBlur={onBlur}
-                      isError={Boolean(error?.message)}
-                    >
-                      Infisical Kubernetes Operator version is v0.7.0 or above.
-                    </Checkbox>
+                    <Field orientation="horizontal" data-invalid={Boolean(error)}>
+                      <Checkbox
+                        id="is-operator-checked"
+                        variant="project"
+                        isChecked={value}
+                        onCheckedChange={(checked) => onChange(checked === true)}
+                        onBlur={onBlur}
+                        isError={Boolean(error)}
+                      />
+                      <FieldContent>
+                        <FieldLabel
+                          htmlFor="is-operator-checked"
+                          className="cursor-pointer"
+                          size="sm"
+                        >
+                          Infisical Kubernetes Operator version is v0.7.0 or above.
+                        </FieldLabel>
+                        <FieldError>
+                          {error && "Confirm this requirement before upgrading."}
+                        </FieldError>
+                      </FieldContent>
+                    </Field>
                   )}
                 />
                 <Controller
@@ -164,28 +220,47 @@ export const SecretV2MigrationSection = () => {
                   name="shouldCloseOpenApprovals"
                   defaultValue={false}
                   render={({ field: { onBlur, value, onChange }, fieldState: { error } }) => (
-                    <Checkbox
-                      id="is-approvals-checked"
-                      isChecked={value}
-                      onCheckedChange={onChange}
-                      onBlur={onBlur}
-                      isError={Boolean(error?.message)}
-                    >
-                      Close/merge all open approval/access requests.
-                    </Checkbox>
+                    <Field orientation="horizontal" data-invalid={Boolean(error)}>
+                      <Checkbox
+                        id="is-approvals-checked"
+                        variant="project"
+                        isChecked={value}
+                        onCheckedChange={(checked) => onChange(checked === true)}
+                        onBlur={onBlur}
+                        isError={Boolean(error)}
+                      />
+                      <FieldContent>
+                        <FieldLabel
+                          htmlFor="is-approvals-checked"
+                          className="cursor-pointer"
+                          size="sm"
+                        >
+                          Close/merge all open approval/access requests.
+                        </FieldLabel>
+                        <FieldError>
+                          {error && "Confirm this requirement before upgrading."}
+                        </FieldError>
+                      </FieldContent>
+                    </Field>
                   )}
                 />
-              </div>
-              <div className="mt-8 flex space-x-4">
-                <Button type="submit">Confirm Upgrade</Button>
-                <Button variant="outline_bg" onClick={() => handlePopUpToggle("migrationInfo")}>
-                  Cancel
-                </Button>
-              </div>
-            </form>
-          </div>
-        </ModalContent>
-      </Modal>
+              </FieldGroup>
+            </FieldSet>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => handlePopUpToggle("migrationInfo")}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" variant="project" isPending={isSubmitting}>
+                Confirm Upgrade
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## Context

Updates the project upgrade gate and upgrade checklist dialog to use the v3 component system.

Previously, the pre-v3 Secret Manager project overview rendered the upgrade flow with v2 buttons, checkboxes, modal, spinner, Font Awesome icons, and legacy palette styling. The migrated surface now uses v3 alerts, dialog, fields, checkboxes, buttons, spinner, Lucide icons, and semantic warning, danger, and project variants.

The upgrade mutation, polling, project-admin restriction, notifications, checklist requirements, and post-upgrade project invalidation are unchanged. The checklist now also exposes labels and validation errors programmatically and visually.

Linear: https://linear.app/infisical/issue/SECRETS-533/update-project-upgrade-gate-to-v3-components

## Screenshots

Current screenshots were not captured because browser/rendered testing was not authorized for this task.

Outstanding captures:

1. Project upgrade gate
   - Open a Secret Management project that still uses the v2 secrets engine.
   - Navigate to the project overview route.
   - Capture the warning gate as a project admin.
2. Upgrade checklist dialog
   - From the same gate, select **Upgrade Secrets Engine**.
   - Capture the dialog before selecting any requirements.
   - Optionally submit once without selecting the requirements to capture the validation state.

## Steps to verify the change

1. Run the frontend review gate:
   ```sh
   make reviewable-ui
   ```
2. Open a Secret Management project that still uses the v2 secrets engine and navigate to its overview.
3. Confirm the warning gate renders and the upgrade action is enabled for a project admin.
4. Open the checklist dialog and confirm the close button, Escape key, overlay dismissal, and Cancel action return focus predictably.
5. Submit without selecting every requirement and confirm each missing acknowledgement shows an error.
6. Select all three requirements and confirm the upgrade starts, the pending state prevents duplicate submission, and the full-screen upgrade status is announced.
7. Confirm a non-admin sees a disabled upgrade action.
8. Confirm a failed upgrade renders the danger alert and a completed upgrade removes the gate.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)