### PR TITLE
fix: harden TRUSTED_PROXY_CIDRS validation for self-hosted reverse proxies

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6737,9 +6737,6 @@
         "win32"
       ]
     },
-    "node_modules/@infisical/quic/node_modules/@infisical/quic-linux-arm": {
-      "optional": true
-    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -9,6 +9,7 @@ import { TSuperAdminDALFactory } from "@app/services/super-admin/super-admin-dal
 
 import { BadRequestError } from "../errors";
 import { removeTrailingSlash } from "../fn";
+import { parseTrustedProxyCidrs } from "../ip";
 import { CustomLogger } from "../logger/logger";
 import { ms } from "../ms";
 import { zpStr } from "../zod";
@@ -580,8 +581,23 @@ const envSchema = z
     // proxy-addr aliases ("loopback", "linklocal", "uniquelocal"). When set, requests whose
     // socket remote address is NOT in this set will have forwarded-IP headers ignored; the
     // socket address is used as the real IP. When unset, legacy first-header-wins behavior
-    // is preserved for backwards compatibility.
-    TRUSTED_PROXY_CIDRS: zpStr(z.string().optional()),
+    // is preserved for backwards compatibility. Entries are trimmed and validated at boot.
+    TRUSTED_PROXY_CIDRS: zpStr(
+      z
+        .string()
+        .optional()
+        .transform((val, ctx) => {
+          try {
+            return parseTrustedProxyCidrs(val);
+          } catch (err) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: err instanceof Error ? err.message : "Invalid TRUSTED_PROXY_CIDRS value"
+            });
+            return z.NEVER;
+          }
+        })
+    ),
 
     /* OracleDB ----------------------------------------------------------------------------- */
     TNS_ADMIN: zpStr(z.string().optional()),

--- a/backend/src/lib/ip/index.ts
+++ b/backend/src/lib/ip/index.ts
@@ -129,8 +129,34 @@ export const checkIPAgainstBlocklist = ({ ipAddress, trustedIps }: { ipAddress: 
   const { type } = extractIPDetails(ipAddress);
   const check = blockList.check(ipAddress, type);
 
-  if (!check)
+  if (!check) {
     throw new ForbiddenRequestError({
-      message: "You are not allowed to access this resource from the current IP address"
+      message: `You are not allowed to access this resource from the current IP address (${ipAddress}). Confirm this address is on the identity's Client Secret Trusted IPs or Access Token Trusted IPs list. If you self-host behind a reverse proxy, set TRUSTED_PROXY_CIDRS to your proxy's CIDRs (not your client subnets) so Infisical detects the correct client IP.`
     });
+  }
+};
+
+const PROXY_ADDR_ALIASES = new Set(["loopback", "linklocal", "uniquelocal"]);
+
+/** Normalize and validate TRUSTED_PROXY_CIDRS entries (CIDR, IP, or proxy-addr alias). */
+export const parseTrustedProxyCidrs = (value: string | undefined): string | undefined => {
+  if (!value) return undefined;
+
+  const entries = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+  if (entries.length === 0) return undefined;
+
+  for (const entry of entries) {
+    if (PROXY_ADDR_ALIASES.has(entry)) continue;
+    if (!isValidIpOrCidr(entry)) {
+      throw new Error(
+        `Invalid TRUSTED_PROXY_CIDRS entry '${entry}'. Use IPv4/IPv6 addresses, CIDR ranges (e.g. 10.0.0.0/8), or the aliases loopback, linklocal, uniquelocal.`
+      );
+    }
+  }
+
+  return entries.join(",");
 };

--- a/backend/src/lib/ip/index.ts
+++ b/backend/src/lib/ip/index.ts
@@ -140,14 +140,20 @@ const PROXY_ADDR_ALIASES = new Set(["loopback", "linklocal", "uniquelocal"]);
 
 /** Normalize and validate TRUSTED_PROXY_CIDRS entries (CIDR, IP, or proxy-addr alias). */
 export const parseTrustedProxyCidrs = (value: string | undefined): string | undefined => {
-  if (!value) return undefined;
+  // Genuinely unset/empty env → legacy trust-all. A supplied value that only contains
+  // separators (e.g. ",") must fail closed rather than falling back to trust-all.
+  if (value === undefined || value === "") return undefined;
 
   const entries = value
     .split(",")
     .map((entry) => entry.trim())
     .filter(Boolean);
 
-  if (entries.length === 0) return undefined;
+  if (entries.length === 0) {
+    throw new Error(
+      "TRUSTED_PROXY_CIDRS was set but contained no valid entries. Provide at least one IP, CIDR, or alias (loopback, linklocal, uniquelocal), or unset the variable to keep legacy trust-all behavior."
+    );
+  }
 
   for (const entry of entries) {
     if (PROXY_ADDR_ALIASES.has(entry)) continue;

--- a/backend/src/lib/ip/ip.test.ts
+++ b/backend/src/lib/ip/ip.test.ts
@@ -4,10 +4,14 @@ import { ForbiddenRequestError } from "../errors";
 import { checkIPAgainstBlocklist, IPType, parseTrustedProxyCidrs } from "./index";
 
 describe("parseTrustedProxyCidrs", () => {
-  it("returns undefined for empty input", () => {
+  it("returns undefined for unset or empty input", () => {
     expect(parseTrustedProxyCidrs(undefined)).toBeUndefined();
     expect(parseTrustedProxyCidrs("")).toBeUndefined();
-    expect(parseTrustedProxyCidrs("  ,  ")).toBeUndefined();
+  });
+
+  it("rejects separator-only values instead of falling back to legacy trust-all", () => {
+    expect(() => parseTrustedProxyCidrs(",")).toThrow(/contained no valid entries/);
+    expect(() => parseTrustedProxyCidrs("  ,  ")).toThrow(/contained no valid entries/);
   });
 
   it("trims entries and preserves aliases", () => {

--- a/backend/src/lib/ip/ip.test.ts
+++ b/backend/src/lib/ip/ip.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { ForbiddenRequestError } from "../errors";
+import { checkIPAgainstBlocklist, IPType, parseTrustedProxyCidrs } from "./index";
+
+describe("parseTrustedProxyCidrs", () => {
+  it("returns undefined for empty input", () => {
+    expect(parseTrustedProxyCidrs(undefined)).toBeUndefined();
+    expect(parseTrustedProxyCidrs("")).toBeUndefined();
+    expect(parseTrustedProxyCidrs("  ,  ")).toBeUndefined();
+  });
+
+  it("trims entries and preserves aliases", () => {
+    expect(parseTrustedProxyCidrs(" uniquelocal , loopback ")).toBe("uniquelocal,loopback");
+  });
+
+  it("accepts IPs and CIDRs", () => {
+    expect(parseTrustedProxyCidrs("10.0.0.0/8,172.16.0.5")).toBe("10.0.0.0/8,172.16.0.5");
+  });
+
+  it("rejects invalid entries", () => {
+    expect(() => parseTrustedProxyCidrs("not-a-cidr")).toThrow(/Invalid TRUSTED_PROXY_CIDRS entry 'not-a-cidr'/);
+  });
+});
+
+describe("checkIPAgainstBlocklist", () => {
+  it("allows matching IPs", () => {
+    expect(() =>
+      checkIPAgainstBlocklist({
+        ipAddress: "192.168.100.20",
+        trustedIps: [{ ipAddress: "192.168.100.0", prefix: 24, type: IPType.IPV4 }]
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects non-matching IPs with the detected address and remediation hint", () => {
+    expect(() =>
+      checkIPAgainstBlocklist({
+        ipAddress: "192.168.200.20",
+        trustedIps: [{ ipAddress: "192.168.100.0", prefix: 24, type: IPType.IPV4 }]
+      })
+    ).toThrow(ForbiddenRequestError);
+
+    try {
+      checkIPAgainstBlocklist({
+        ipAddress: "192.168.200.20",
+        trustedIps: [{ ipAddress: "192.168.100.0", prefix: 24, type: IPType.IPV4 }]
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ForbiddenRequestError);
+      expect((err as ForbiddenRequestError).message).toContain("192.168.200.20");
+      expect((err as ForbiddenRequestError).message).toContain("TRUSTED_PROXY_CIDRS");
+      expect((err as ForbiddenRequestError).message).toContain("Client Secret Trusted IPs");
+    }
+  });
+});

--- a/docs/documentation/platform/identities/universal-auth.mdx
+++ b/docs/documentation/platform/identities/universal-auth.mdx
@@ -98,6 +98,10 @@ using the Universal Auth authentication method.
     If you're using Infisical Cloud, then it is available under the Pro Tier. If you're self-hosting Infisical, then you should contact sales@infisical.com to purchase an enterprise license to use it.
     </Warning>
 
+    <Info>
+      On a self-hosted instance behind a reverse proxy, Infisical only sees the real client IP when [`TRUSTED_PROXY_CIDRS`](/self-hosting/configuration/envars#param-trusted-proxy-cidrs) lists that proxy. Set it to the proxy's CIDR (for Docker Compose, often `uniquelocal`), not to the client subnets you want to allow. Put client subnets in the trusted IP fields above.
+    </Info>
+
   </Step>
   <Step title="Creating a Client Secret">
     In order to use the identity, you'll need the non-sensitive **Client ID**

--- a/docs/documentation/platform/identities/universal-auth.mdx
+++ b/docs/documentation/platform/identities/universal-auth.mdx
@@ -99,7 +99,7 @@ using the Universal Auth authentication method.
     </Warning>
 
     <Info>
-      On a self-hosted instance behind a reverse proxy, Infisical only sees the real client IP when [`TRUSTED_PROXY_CIDRS`](/self-hosting/configuration/envars#param-trusted-proxy-cidrs) lists that proxy. Set it to the proxy's CIDR (for Docker Compose, often `uniquelocal`), not to the client subnets you want to allow. Put client subnets in the trusted IP fields above.
+      On a self-hosted instance behind a reverse proxy, Infisical only sees the real client IP when [`TRUSTED_PROXY_CIDRS`](/self-hosting/configuration/envars#param-trusted-proxy-cidrs) lists that proxy. Set it to the proxy's CIDR or Docker network subnet, not to the client subnets you want to allow. Put client subnets in the trusted IP fields above, and don't publish the Infisical backend port directly if you rely on those allowlists.
     </Info>
 
   </Step>

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -149,12 +149,14 @@ Example values:
   List the addresses of the proxies that connect to Infisical (NGINX, Traefik, an AWS ALB, Cloudflare, and similar), not the client machines that call Infisical through those proxies.
 
   ```
-  # Shared Docker network between Infisical and the reverse proxy
-  TRUSTED_PROXY_CIDRS=uniquelocal
+  # Prefer the reverse proxy's address or the Docker network subnet it uses
+  TRUSTED_PROXY_CIDRS=172.18.0.0/16
 
-  # Explicit proxy CIDRs
-  TRUSTED_PROXY_CIDRS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+  # Multiple proxies
+  TRUSTED_PROXY_CIDRS=10.0.0.0/8,172.16.0.0/12
   ```
+
+  For Docker Compose, inspect the shared network and use that subnet (for example `docker network inspect <project>_infisical --format '{{(index .IPAM.Config 0).Subnet}}'`).
 
   When set, only requests arriving from a socket address within this list will have their forwarded-IP headers respected. Requests from any other source fall back to using the raw socket IP. This prevents IP allowlist bypass via spoofed proxy headers.
 
@@ -163,7 +165,9 @@ Example values:
   <Warning>
     If your deployment sits behind a reverse proxy, set this to the CIDR range of that proxy so Infisical can trust `X-Forwarded-For` and related headers. Leaving this unset is only safe when Infisical is not reachable directly from the internet.
 
-    Do not put end-client or CLI host subnets here. Client restrictions belong on identity **Client Secret Trusted IPs** and **Access Token Trusted IPs**. Listing client CIDRs in `TRUSTED_PROXY_CIDRS` breaks client IP detection and can make machine-identity logins fail from other subnets even when the hosts can reach Infisical.
+    Don't put end-client or CLI host subnets here. Client restrictions belong on identity **Client Secret Trusted IPs** and **Access Token Trusted IPs**. Listing client CIDRs in `TRUSTED_PROXY_CIDRS` breaks client IP detection and can make machine-identity logins fail from other subnets even when the hosts can reach Infisical.
+
+    Avoid the `uniquelocal` alias unless Infisical is reachable only through the reverse proxy. That alias trusts every private-network caller, so a peer that can reach the backend port directly can forge `X-Forwarded-For` and bypass identity trusted-IP allowlists.
   </Warning>
 </ParamField>
 

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -142,11 +142,17 @@ Example values:
 </ParamField>
 
 <ParamField query="TRUSTED_PROXY_CIDRS" type="string" optional>
-  Comma-separated list of trusted reverse-proxy CIDRs or named ranges whose forwarded-IP headers (e.g. `X-Forwarded-For`) Infisical will honor.
+  Comma-separated list of trusted reverse-proxy CIDRs or named ranges whose forwarded-IP headers (for example `X-Forwarded-For`) Infisical will honor.
 
-  Accepted values are IPv4/IPv6 CIDR notation or the named aliases `loopback`, `linklocal`, and `uniquelocal`.
+  Accepted values are IPv4/IPv6 addresses, CIDR notation, or the named aliases `loopback`, `linklocal`, and `uniquelocal`.
+
+  List the addresses of the proxies that connect to Infisical (NGINX, Traefik, an AWS ALB, Cloudflare, and similar), not the client machines that call Infisical through those proxies.
 
   ```
+  # Shared Docker network between Infisical and the reverse proxy
+  TRUSTED_PROXY_CIDRS=uniquelocal
+
+  # Explicit proxy CIDRs
   TRUSTED_PROXY_CIDRS=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
   ```
 
@@ -155,7 +161,9 @@ Example values:
   When unset, Infisical trusts all forwarded-IP headers (legacy behavior, preserved for backwards compatibility with existing self-hosted deployments).
 
   <Warning>
-    If your deployment sits behind a reverse proxy (e.g. NGINX, AWS ALB, Cloudflare), you should set this to the CIDR range of your proxy to prevent clients from spoofing their source IP. Leaving this unset is only safe when Infisical is not reachable directly from the internet.
+    If your deployment sits behind a reverse proxy, set this to the CIDR range of that proxy so Infisical can trust `X-Forwarded-For` and related headers. Leaving this unset is only safe when Infisical is not reachable directly from the internet.
+
+    Do not put end-client or CLI host subnets here. Client restrictions belong on identity **Client Secret Trusted IPs** and **Access Token Trusted IPs**. Listing client CIDRs in `TRUSTED_PROXY_CIDRS` breaks client IP detection and can make machine-identity logins fail from other subnets even when the hosts can reach Infisical.
   </Warning>
 </ParamField>
 

--- a/docs/self-hosting/deployment-options/docker-compose.mdx
+++ b/docs/self-hosting/deployment-options/docker-compose.mdx
@@ -460,7 +460,11 @@ docker logs <container_name> --since 1h
     **5. Update `.env`:**
     ```env
     SITE_URL=https://secrets.example.com
+    # Trust X-Forwarded-* headers from the NGINX container on the Docker network
+    TRUSTED_PROXY_CIDRS=uniquelocal
     ```
+
+    Set `TRUSTED_PROXY_CIDRS` to your proxy's CIDR (for Compose, `uniquelocal` is usually enough). Do not list client machine subnets here; those belong on identity trusted IP allowlists. See [`TRUSTED_PROXY_CIDRS`](/self-hosting/configuration/envars#param-trusted-proxy-cidrs).
 
     **6. Restart services:**
     ```bash

--- a/docs/self-hosting/deployment-options/docker-compose.mdx
+++ b/docs/self-hosting/deployment-options/docker-compose.mdx
@@ -457,16 +457,18 @@ docker logs <container_name> --since 1h
     }
     ```
 
-    **5. Update `.env`:**
+    **5. Stop publishing the backend host port.** With NGINX terminating TLS, remove the `ports` mapping from the `backend` service in `docker-compose.prod.yml` so clients can reach Infisical only through NGINX. Leaving `80:8080` on the backend lets private-network callers bypass the proxy and forge `X-Forwarded-For`.
+
+    **6. Update `.env`:**
     ```env
     SITE_URL=https://secrets.example.com
-    # Trust X-Forwarded-* headers from the NGINX container on the Docker network
-    TRUSTED_PROXY_CIDRS=uniquelocal
+    # Trust X-Forwarded-* only from the Compose network NGINX uses (inspect the subnet)
+    TRUSTED_PROXY_CIDRS=172.18.0.0/16
     ```
 
-    Set `TRUSTED_PROXY_CIDRS` to your proxy's CIDR (for Compose, `uniquelocal` is usually enough). Do not list client machine subnets here; those belong on identity trusted IP allowlists. See [`TRUSTED_PROXY_CIDRS`](/self-hosting/configuration/envars#param-trusted-proxy-cidrs).
+    Set `TRUSTED_PROXY_CIDRS` to the Docker network subnet shared with NGINX (for example `docker network inspect <project>_infisical --format '{{(index .IPAM.Config 0).Subnet}}'`). Don't list client machine subnets here; those belong on identity trusted IP allowlists. Don't use `uniquelocal` while any path still reaches the backend without NGINX. See [`TRUSTED_PROXY_CIDRS`](/self-hosting/configuration/envars#param-trusted-proxy-cidrs).
 
-    **6. Restart services:**
+    **7. Restart services:**
     ```bash
     docker compose -f docker-compose.prod.yml down
     docker compose -f docker-compose.prod.yml up -d

--- a/docs/self-hosting/guides/production-hardening.mdx
+++ b/docs/self-hosting/guides/production-hardening.mdx
@@ -77,11 +77,22 @@ Configure network restrictions and firewall rules:
 # Limit CORS to specific domains
 CORS_ALLOWED_ORIGINS=["https://your-app.example.com"]
 
+# Trust forwarded-IP headers only from your reverse proxy (NGINX, Traefik, ALB, and similar).
+# Use the proxy's CIDR, not client or CLI host subnets. For Docker Compose, `uniquelocal`
+# covers the private networks Infisical and the proxy typically share.
+TRUSTED_PROXY_CIDRS=uniquelocal
+
 # Prevent connections to internal/private IP addresses
 # This blocks access to internal services like metadata endpoints,
 # internal APIs, databases, and other sensitive infrastructure
 ALLOW_INTERNAL_IP_CONNECTIONS=false
 ```
+
+Machine identity **Client Secret Trusted IPs** and **Access Token Trusted IPs** use the
+client IP Infisical derives after applying `TRUSTED_PROXY_CIDRS`. If those allowlists
+exclude a subnet, CLI and API logins from that subnet fail even when the host can reach
+your instance. See [Universal Auth](/documentation/platform/identities/universal-auth)
+and [`TRUSTED_PROXY_CIDRS`](/self-hosting/configuration/envars#param-trusted-proxy-cidrs).
 
 #### Server-side request forgery (SSRF) protection
 

--- a/docs/self-hosting/guides/production-hardening.mdx
+++ b/docs/self-hosting/guides/production-hardening.mdx
@@ -78,9 +78,9 @@ Configure network restrictions and firewall rules:
 CORS_ALLOWED_ORIGINS=["https://your-app.example.com"]
 
 # Trust forwarded-IP headers only from your reverse proxy (NGINX, Traefik, ALB, and similar).
-# Use the proxy's CIDR, not client or CLI host subnets. For Docker Compose, `uniquelocal`
-# covers the private networks Infisical and the proxy typically share.
-TRUSTED_PROXY_CIDRS=uniquelocal
+# Use that proxy's CIDR or Docker network subnet, not client or CLI host subnets.
+# Don't use the uniquelocal alias unless the backend is unreachable except through the proxy.
+TRUSTED_PROXY_CIDRS=172.18.0.0/16
 
 # Prevent connections to internal/private IP addresses
 # This blocks access to internal services like metadata endpoints,


### PR DESCRIPTION
# Context

Self-hosted operators behind Traefik/NGINX sometimes set `TRUSTED_PROXY_CIDRS` to client subnets instead of the reverse proxy’s CIDR. That breaks client IP detection, so machine-identity **Client Secret Trusted IPs** / **Access Token Trusted IPs** can reject logins from other subnets even when those hosts can reach Infisical (see #7921 / ENG-5642).

## Before

* Invalid `TRUSTED_PROXY_CIDRS` values were accepted.
* IP allowlist failures only said the current IP was blocked, with no hint about proxy misconfiguration.
* Docs didn’t warn against listing client CIDRs.

## After

* `TRUSTED_PROXY_CIDRS` is trimmed and validated at boot:

  * CIDR
  * IP
  * `loopback`
  * `linklocal`
  * `uniquelocal`
* IP allowlist errors include the detected IP and point operators at identity trusted IPs and correct `TRUSTED_PROXY_CIDRS` setup.
* Docs clarify proxy vs. client CIDRs in:

  * Environment variables
  * Production hardening
  * Docker Compose HTTPS
  * Universal Auth
* Docker Compose documentation recommends `uniquelocal`.

## Steps to Verify the Change

1. Start the backend with a bad value, e.g.:

   ```bash
   TRUSTED_PROXY_CIDRS=not-a-cidr
   ```

   Boot should fail with a clear validation error.

2. Start with:

   ```bash
   TRUSTED_PROXY_CIDRS=uniquelocal
   ```

   or a real proxy CIDR. Boot should succeed.

3. Call an identity auth path from an IP outside the identity’s trusted IP allowlist. The response should:

   * Name the detected IP.
   * Mention `TRUSTED_PROXY_CIDRS`.
   * Point to the trusted IP fields.

4. Confirm the following documentation updates:

   * Environment variables: `TRUSTED_PROXY_CIDRS`
   * Production hardening: network section
   * Docker Compose HTTPS: `.env` example
   * Universal Auth: Advanced tab note

5. Run the unit test:

   ```bash
   cd backend && npm run test:unit -- src/lib/ip/ip.test.ts
   ```

## Type

* [ ] Fix
* [ ] Feature
* [ ] Improvement
* [ ] Breaking
* [ ] Docs
* [ ] Chore

## Checklist

* [ ] Title follows the [[conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary)](https://www.conventionalcommits.org/en/v1.0.0/#summary) format (`type(scope): short description`; scope is optional, e.g. `fix: prevent crash on sync` or `fix(api): handle null response`).
* [ ] Tested locally
* [ ] Updated docs (if needed)
* [ ] Updated `CLAUDE.md` files (if needed)
* [ ] Read the [[contributing guide](https://infisical.com/docs/contributing/getting-started/overview)](https://infisical.com/docs/contributing/getting-started/overview)