### PR TITLE
fix(ci): isolate the Oracle download and unbreak the additional-privilege tests

### DIFF
--- a/backend-go/tests/infra/stack.go
+++ b/backend-go/tests/infra/stack.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"testing"
 
 	"github.com/testcontainers/testcontainers-go"
 
@@ -30,6 +31,17 @@ func (s *Stack) Redis() *RedisService       { return s.redis }
 func (s *Stack) NodeJS() *NodeJSService     { return s.nodejs }
 func (s *Stack) Config() *config.Config     { return s.cfg }
 func (s *Stack) DB() pg.DB                  { return s.db }
+
+// EnableLegacyAdditionalPrivileges flips the project flag that additional
+// privileges are gated on. New projects default to false and no route exposes
+// the column, so tests covering the legacy path have to set it directly.
+func (s *Stack) EnableLegacyAdditionalPrivileges(t *testing.T, projectID string) {
+	t.Helper()
+	if _, err := s.db.Primary().Exec(context.Background(),
+		`UPDATE projects SET "isLegacyAdditionalPrivilegesEnabled" = true WHERE id = $1`, projectID); err != nil {
+		t.Fatalf("infra.EnableLegacyAdditionalPrivileges: %v", err)
+	}
+}
 
 // Stop tears down all containers, the network, and closes the DB pool.
 func (s *Stack) Stop() {

--- a/backend-go/tests/infra/stack.go
+++ b/backend-go/tests/infra/stack.go
@@ -4,6 +4,7 @@ package infra
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"testing"
@@ -34,13 +35,41 @@ func (s *Stack) DB() pg.DB                  { return s.db }
 
 // EnableLegacyAdditionalPrivileges flips the project flag that additional
 // privileges are gated on. New projects default to false and no route exposes
-// the column, so tests covering the legacy path have to set it directly.
+// the column, so tests covering the legacy path set it directly. The previous
+// value is restored on cleanup, since some packages share one project fixture.
 func (s *Stack) EnableLegacyAdditionalPrivileges(t *testing.T, projectID string) {
 	t.Helper()
-	if _, err := s.db.Primary().Exec(context.Background(),
-		`UPDATE projects SET "isLegacyAdditionalPrivilegesEnabled" = true WHERE id = $1`, projectID); err != nil {
+	ctx := context.Background()
+
+	var previous bool
+	if err := s.db.Primary().QueryRow(ctx,
+		`SELECT "isLegacyAdditionalPrivilegesEnabled" FROM projects WHERE id = $1`, projectID,
+	).Scan(&previous); err != nil {
+		t.Fatalf("infra.EnableLegacyAdditionalPrivileges: reading project %s: %v", projectID, err)
+	}
+
+	if err := s.setLegacyAdditionalPrivileges(ctx, projectID, true); err != nil {
 		t.Fatalf("infra.EnableLegacyAdditionalPrivileges: %v", err)
 	}
+
+	t.Cleanup(func() {
+		if err := s.setLegacyAdditionalPrivileges(ctx, projectID, previous); err != nil {
+			t.Errorf("infra.EnableLegacyAdditionalPrivileges cleanup: %v", err)
+		}
+	})
+}
+
+func (s *Stack) setLegacyAdditionalPrivileges(ctx context.Context, projectID string, enabled bool) error {
+	tag, err := s.db.Primary().Exec(ctx,
+		`UPDATE projects SET "isLegacyAdditionalPrivilegesEnabled" = $2 WHERE id = $1`, projectID, enabled)
+	if err != nil {
+		return err
+	}
+	// A stale or wrong ID updates nothing and would surface later as a confusing 400.
+	if n := tag.RowsAffected(); n != 1 {
+		return fmt.Errorf("expected 1 row updated for project %s, got %d", projectID, n)
+	}
+	return nil
 }
 
 // Stop tears down all containers, the network, and closes the DB pool.

--- a/backend-go/tests/platform/permission/permission_test.go
+++ b/backend-go/tests/platform/permission/permission_test.go
@@ -525,6 +525,7 @@ func TestGroupViewer_UserInheritsReadOnly(t *testing.T) {
 
 func TestIdentityAdditionalPrivilege_ExtendsRole(t *testing.T) {
 	nodejs := stack.NodeJS()
+	stack.EnableLegacyAdditionalPrivileges(t, proj.ID)
 
 	identity := nodejs.CreateIdentity(t, "addl-priv-identity")
 	nodejs.AddIdentityToProject(t, proj.ID, identity.ID, infra.Role("viewer"))

--- a/backend-go/tests/secretmanager/secrets/list_secrets_permission_integration_test.go
+++ b/backend-go/tests/secretmanager/secrets/list_secrets_permission_integration_test.go
@@ -381,6 +381,7 @@ func TestIdentityAdditionalPrivilege_ExtendsRole(t *testing.T) {
 	nodejs := stack.NodeJS()
 
 	proj := nodejs.CreateProject(t, "addl-priv-test")
+	stack.EnableLegacyAdditionalPrivileges(t, proj.ID)
 
 	nodejs.CreateSecret(t, proj.ID, "dev", "/", "DEV_SECRET", "dev-value", nil)
 	nodejs.CreateSecret(t, proj.ID, "staging", "/", "STAGING_SECRET", "staging-value", nil)
@@ -421,6 +422,7 @@ func TestIdentityMultipleAdditionalPrivileges_Merge(t *testing.T) {
 	nodejs := stack.NodeJS()
 
 	proj := nodejs.CreateProject(t, "multi-addl-priv-test")
+	stack.EnableLegacyAdditionalPrivileges(t, proj.ID)
 
 	nodejs.CreateSecret(t, proj.ID, "dev", "/", "DEV_SECRET", "dev-value", nil)
 	nodejs.CreateSecret(t, proj.ID, "staging", "/", "STAGING_SECRET", "staging-value", nil)
@@ -573,6 +575,7 @@ func TestIdentityTemporaryAdditionalPrivilege_Active(t *testing.T) {
 	nodejs := stack.NodeJS()
 
 	proj := nodejs.CreateProject(t, "temp-addl-active-test")
+	stack.EnableLegacyAdditionalPrivileges(t, proj.ID)
 	nodejs.CreateSecret(t, proj.ID, proj.EnvSlug, "/", "TEMP_ADDL_SECRET", "temp-addl-value", nil)
 
 	identity := nodejs.CreateIdentity(t, "temp-addl-active-identity")
@@ -600,6 +603,7 @@ func TestIdentityTemporaryAdditionalPrivilege_Expired(t *testing.T) {
 	nodejs := stack.NodeJS()
 
 	proj := nodejs.CreateProject(t, "temp-addl-expired-test")
+	stack.EnableLegacyAdditionalPrivileges(t, proj.ID)
 	nodejs.CreateSecret(t, proj.ID, proj.EnvSlug, "/", "EXPIRED_ADDL_SECRET", "expired-value", nil)
 
 	identity := nodejs.CreateIdentity(t, "temp-addl-expired-identity")

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,3 +1,25 @@
+FROM debian:trixie-slim AS oracle
+RUN apt-get update && apt-get install -y unzip wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Own stage so the 127 MB fetch caches independently and runs in parallel. Better
+# still would be mirroring the zip on artifacts-cli.infisical.com, which drops the
+# third-party CDN dependency instead of retrying around it.
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+        ORACLE_ZIP="instantclient-basic-linux.x64-23.26.0.0.0.zip" && \
+        EXPECTED_SHA="d6c79cbcf0ff209363e779855c690d4fc730aed847e9198a2c439bcf34760af5"; \
+    elif [ "$ARCH" = "arm64" ]; then \
+        ORACLE_ZIP="instantclient-basic-linux.arm64-23.26.0.0.0.zip" && \
+        EXPECTED_SHA="9c9a32051e97f087016fb334b7ad5c0aea8511ca8363afd8e0dc6ec4fc515c32"; \
+    fi && \
+    ORACLE_URL="https://download.oracle.com/otn_software/linux/instantclient/2326000/${ORACLE_ZIP}" && \
+    wget -q "$ORACLE_URL" && \
+    echo "$EXPECTED_SHA  $ORACLE_ZIP" | sha256sum -c - && \
+    mkdir -p /opt/oracle && \
+    unzip "$ORACLE_ZIP" -d /opt/oracle && \
+    rm "$ORACLE_ZIP"
+
 FROM node:22.22.0-trixie-slim
 
 # ? Setup a test SoftHSM module. In production a real HSM is used.
@@ -60,21 +82,9 @@ RUN git checkout ${SOFTHSM2_VERSION} -b ${SOFTHSM2_VERSION} \
 WORKDIR /root
 RUN rm -fr ${SOFTHSM2_SOURCES}
 
-# Install Oracle Instant Client for OracleDB mTLS (Wallet) support
-RUN mkdir -p /opt/oracle && \
-    ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "arm64" ]; then \
-      EXPECTED_SHA="9c9a32051e97f087016fb334b7ad5c0aea8511ca8363afd8e0dc6ec4fc515c32" && \
-      curl -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.arm64-23.26.0.0.0.zip; \
-    else \
-      EXPECTED_SHA="d6c79cbcf0ff209363e779855c690d4fc730aed847e9198a2c439bcf34760af5" && \
-      curl -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.x64-23.26.0.0.0.zip; \
-    fi && \
-    echo "$EXPECTED_SHA  /tmp/instantclient.zip" | sha256sum -c - && \
-    unzip -oq /tmp/instantclient.zip -d /opt/oracle && \
-    rm /tmp/instantclient.zip && \
-    echo /opt/oracle/instantclient_23_26 > /etc/ld.so.conf.d/oracle-instantclient.conf && \
-    ldconfig
+# Oracle Instant Client for OracleDB mTLS (Wallet) support
+COPY --from=oracle /opt/oracle /opt/oracle
+RUN echo /opt/oracle/instantclient_23_26 > /etc/ld.so.conf.d/oracle-instantclient.conf && ldconfig
 
 # Build OpenSSL 3.5.6 for PQC (ML-DSA / SLH-DSA) certificate support.
 WORKDIR /tmp/openssl-pqc-build

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -65,10 +65,10 @@ RUN mkdir -p /opt/oracle && \
     ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then \
       EXPECTED_SHA="9c9a32051e97f087016fb334b7ad5c0aea8511ca8363afd8e0dc6ec4fc515c32" && \
-      curl -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.arm64-23.26.0.0.0.zip; \
+      curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.arm64-23.26.0.0.0.zip; \
     else \
       EXPECTED_SHA="d6c79cbcf0ff209363e779855c690d4fc730aed847e9198a2c439bcf34760af5" && \
-      curl -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.x64-23.26.0.0.0.zip; \
+      curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.x64-23.26.0.0.0.zip; \
     fi && \
     echo "$EXPECTED_SHA  /tmp/instantclient.zip" | sha256sum -c - && \
     unzip -oq /tmp/instantclient.zip -d /opt/oracle && \

--- a/backend/Dockerfile.fips-toolchain
+++ b/backend/Dockerfile.fips-toolchain
@@ -20,6 +20,28 @@
 # removed. Also includes OpenSSL (Apache-2.0), SoftHSM2 (BSD-2-Clause), the Infisical
 # CLI, and Debian packages under their respective licenses.
 
+FROM debian:trixie-slim AS oracle
+RUN apt-get update && apt-get install -y unzip wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Own stage so the 127 MB fetch caches independently and runs in parallel. Better
+# still would be mirroring the zip on artifacts-cli.infisical.com, which drops the
+# third-party CDN dependency instead of retrying around it.
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then \
+        ORACLE_ZIP="instantclient-basic-linux.x64-23.26.0.0.0.zip" && \
+        EXPECTED_SHA="d6c79cbcf0ff209363e779855c690d4fc730aed847e9198a2c439bcf34760af5"; \
+    elif [ "$ARCH" = "arm64" ]; then \
+        ORACLE_ZIP="instantclient-basic-linux.arm64-23.26.0.0.0.zip" && \
+        EXPECTED_SHA="9c9a32051e97f087016fb334b7ad5c0aea8511ca8363afd8e0dc6ec4fc515c32"; \
+    fi && \
+    ORACLE_URL="https://download.oracle.com/otn_software/linux/instantclient/2326000/${ORACLE_ZIP}" && \
+    wget -q "$ORACLE_URL" && \
+    echo "$EXPECTED_SHA  $ORACLE_ZIP" | sha256sum -c - && \
+    mkdir -p /opt/oracle && \
+    unzip "$ORACLE_ZIP" -d /opt/oracle && \
+    rm "$ORACLE_ZIP"
+
 FROM node:22.22.0-trixie-slim
 
 ARG SOFTHSM2_VERSION=2.5.0
@@ -76,20 +98,9 @@ RUN git checkout --detach "${SOFTHSM2_COMMIT}" \
 WORKDIR /root
 RUN rm -fr ${SOFTHSM2_SOURCES}
 
-RUN mkdir -p /opt/oracle && \
-    ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "arm64" ]; then \
-      EXPECTED_SHA="9c9a32051e97f087016fb334b7ad5c0aea8511ca8363afd8e0dc6ec4fc515c32" && \
-      curl -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.arm64-23.26.0.0.0.zip; \
-    else \
-      EXPECTED_SHA="d6c79cbcf0ff209363e779855c690d4fc730aed847e9198a2c439bcf34760af5" && \
-      curl -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.x64-23.26.0.0.0.zip; \
-    fi && \
-    echo "$EXPECTED_SHA  /tmp/instantclient.zip" | sha256sum -c - && \
-    unzip -oq /tmp/instantclient.zip -d /opt/oracle && \
-    rm /tmp/instantclient.zip && \
-    echo /opt/oracle/instantclient_23_26 > /etc/ld.so.conf.d/oracle-instantclient.conf && \
-    ldconfig
+# Oracle Instant Client for OracleDB mTLS (Wallet) support
+COPY --from=oracle /opt/oracle /opt/oracle
+RUN echo /opt/oracle/instantclient_23_26 > /etc/ld.so.conf.d/oracle-instantclient.conf && ldconfig
 
 WORKDIR /openssl-build
 RUN wget https://www.openssl.org/source/openssl-3.1.2.tar.gz \

--- a/backend/Dockerfile.fips-toolchain
+++ b/backend/Dockerfile.fips-toolchain
@@ -80,10 +80,10 @@ RUN mkdir -p /opt/oracle && \
     ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "arm64" ]; then \
       EXPECTED_SHA="9c9a32051e97f087016fb334b7ad5c0aea8511ca8363afd8e0dc6ec4fc515c32" && \
-      curl -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.arm64-23.26.0.0.0.zip; \
+      curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.arm64-23.26.0.0.0.zip; \
     else \
       EXPECTED_SHA="d6c79cbcf0ff209363e779855c690d4fc730aed847e9198a2c439bcf34760af5" && \
-      curl -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.x64-23.26.0.0.0.zip; \
+      curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors -o /tmp/instantclient.zip https://download.oracle.com/otn_software/linux/instantclient/2326000/instantclient-basic-linux.x64-23.26.0.0.0.zip; \
     fi && \
     echo "$EXPECTED_SHA  /tmp/instantclient.zip" | sha256sum -c - && \
     unzip -oq /tmp/instantclient.zip -d /opt/oracle && \


### PR DESCRIPTION
## Context

**1. The Oracle Instant Client download was not isolated.** `backend/Dockerfile.dev` and `backend/Dockerfile.fips-toolchain` fetched a 127 MB zip inline with bare `curl`. Oracle's CDN reset the connection at 96 percent and the build died:

```
96  127M   96  123M    0     0   303M
curl: (56) Recv failure: Connection reset by peer
```

The other three Dockerfiles that need the same client (`Dockerfile.standalone-infisical`, `Dockerfile.fips.standalone-infisical`, `backend/Dockerfile`) already isolate it in a `debian:trixie-slim AS oracle` stage and fetch with `wget`. That is why they have never hit this: `wget` retries 20 times by default, `curl` does not retry at all. The two fragile files were the two that had drifted off the established pattern.

Both now use the same stage and consume it with `COPY --from=oracle`. The fetch caches independently of the rest of the build, runs in parallel with other stages, and inherits `wget`'s retries. The `sha256sum -c` is unchanged, so a truncated download still fails loudly.

**2. The additional-privilege integration tests have been failing since 1 September.** They fail with:

```
Additional privileges are not available for project 'addl-priv-test'.
Use project roles or folder access controls instead.
```

The tests run against a floating published tag, not against the branch. The suite broke when `latest` picked up the gate, not when anyone changed code, and no revert on any branch can fix it. Confirmed by reproducing both states locally: a stale `latest` fails with `column "isLegacyAdditionalPrivilegesEnabled" does not exist`, the current one with the 400 above.

The fix adds `Stack.EnableLegacyAdditionalPrivileges` and calls it from the affected tests. The legacy path still exists for projects created before the change, so this keeps the coverage rather than deleting tests for a feature that still works where it is enabled.

There are five call sites, not the four CI reported. The fifth is in `tests/platform/permission`, which CI never reached because `secretmanager/secrets` failed first.

## Steps to verify the change

```bash
# 1: the oracle stage builds on its own, and the license file survives the COPY
docker build --target oracle -t oracle-stage:test -f backend/Dockerfile.dev backend/
docker run --rm --entrypoint sh oracle-stage:test -c 'ls /opt/oracle/instantclient_23_26/BASIC_LICENSE'

# 1: the full dev image, and the client resolves through ldconfig
docker build -t infisical-dev:test -f backend/Dockerfile.dev backend/
docker run --rm --entrypoint sh infisical-dev:test -c 'ldconfig -p | grep libclntsh'

# 2: the previously failing tests, against the current published image
docker pull infisical/infisical:latest
cd backend-go
go test -tags integration ./tests/secretmanager/secrets/ -run AdditionalPrivilege -count=1 -v

# full suite, serial
go test -tags integration ./tests/... -count=1 -p 1 -timeout 30m
```

### Verified locally

- `oracle` stage builds standalone; `BASIC_LICENSE` present, which the fips-toolchain header requires be kept
- Full `Dockerfile.dev` image builds end to end; `/etc/ld.so.conf.d/oracle-instantclient.conf` correct and four `libclntsh` entries resolve in the ld cache
- Full integration suite serial, 8 of 8 packages pass: auth, externalkms, hsm, kms, permission, projects, ratelimit, secrets
- The four originally failing tests pass against `infisical/infisical:latest` at `sha256:2c5adf28`
- `go vet -tags integration ./tests/...` and `gofmt` clean

Not verified: recovery from an actual mid-download connection reset, which needs Oracle's CDN to drop one. The change is structural plus `wget`'s default retries, and the integrity check after the download is untouched.

### CI coverage

`run-backend-go-tests.yml` fires only on `pull_request` with paths `backend-go/**`, and never on merge to main. It has run five times since the gate landed on 20 August, all on dependency-bump branches, the last on 1 September at 04:00. That is why a break introduced by a published image sat unnoticed for two days and then appeared on an unrelated PR.

Worth raising separately: pinning the test image to a digest, or building it from the branch, would make these tests deterministic. As written, a publish to `latest` can turn CI red on any open PR.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
