### PR TITLE
feat: added support to send region to license server

### DIFF
--- a/backend/src/services/license-client/license-client-backends.test.ts
+++ b/backend/src/services/license-client/license-client-backends.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { licenseServerBackend } from "./license-client-backends";
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}));
+
+vi.mock("jsonwebtoken", () => ({
+  default: { sign: () => "service-token" }
+}));
+
+const SERVER_URL = "https://license.example.com";
+const ORG_ID = "org-1";
+
+const mockFetchReturning = (body: unknown) =>
+  vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    headers: new Headers(),
+    json: async () => body
+  })) as unknown as typeof fetch;
+
+const readBody = (fetchMock: typeof fetch): Record<string, unknown> =>
+  JSON.parse(vi.mocked(fetchMock).mock.calls[0][1]?.body as string) as Record<string, unknown>;
+
+// Region is insert-only on the license server: it is read only by the call that creates the license,
+// so every license-creating call has to carry this deployment's region or the org is recorded as "us".
+describe("licenseServerBackend region on license-creating calls", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("buyProduct sends the deployment region alongside the payload", async () => {
+    const fetchMock = mockFetchReturning({ outcome: "subscription_updated" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await licenseServerBackend(SERVER_URL, "key", "eu").buyProduct(ORG_ID, { productId: "boost", plan: "pro" });
+
+    expect(readBody(fetchMock)).toMatchObject({ productId: "boost", plan: "pro", region: "eu" });
+  });
+
+  test("changeCommitments sends the deployment region alongside the payload", async () => {
+    const fetchMock = mockFetchReturning({ outcome: "subscription_updated" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await licenseServerBackend(SERVER_URL, "key", "eu").changeCommitments(ORG_ID, {
+      productId: "boost",
+      dimensions: []
+    });
+
+    expect(readBody(fetchMock)).toMatchObject({ productId: "boost", region: "eu" });
+  });
+
+  test("startTrial sends the deployment region alongside the payload", async () => {
+    const fetchMock = mockFetchReturning({ outcome: "trial_started" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await licenseServerBackend(SERVER_URL, "key", "eu").startTrial(ORG_ID, {
+      productKey: "boost",
+      planKey: "pro"
+    });
+
+    expect(readBody(fetchMock)).toMatchObject({ product_key: "boost", plan_key: "pro", region: "eu" });
+  });
+
+  test("omits region entirely when the deployment has none configured", async () => {
+    const fetchMock = mockFetchReturning({ outcome: "subscription_updated" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await licenseServerBackend(SERVER_URL, "key").buyProduct(ORG_ID, { productId: "boost", plan: "pro" });
+
+    expect(readBody(fetchMock)).not.toHaveProperty("region");
+  });
+});

--- a/backend/src/services/license-client/license-client-backends.ts
+++ b/backend/src/services/license-client/license-client-backends.ts
@@ -224,7 +224,7 @@ export const licenseServerBackend = (
     const res = await fetch(url, {
       method: "POST",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}`, "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ ...payload, region }),
       redirect: "manual"
     });
     await throwIfResponseError(res);
@@ -281,7 +281,7 @@ export const licenseServerBackend = (
     const res = await fetch(url, {
       method: "PUT",
       headers: { Authorization: `Bearer ${mintServiceToken(signingKey)}`, "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
+      body: JSON.stringify({ ...payload, region }),
       redirect: "manual"
     });
     await throwIfResponseError(res);
@@ -300,7 +300,8 @@ export const licenseServerBackend = (
         email: payload.email,
         name: payload.name,
         declaredUsage: payload.declaredUsage,
-        returnUrl: payload.returnUrl
+        returnUrl: payload.returnUrl,
+        region
       }),
       redirect: "manual"
     });


### PR DESCRIPTION
## Context

This PR adds support to send region to license server client in various session starts

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)