### PR TITLE
fix: unix rotation prompt fragmentation

### DIFF
--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
@@ -42,9 +42,10 @@ export const lineAt = (text: string, index: number) => {
 };
 
 export type TExpectAdvanceContext = {
-  readonly pending: string;
+  /** Accumulated remote output not yet consumed by a successful match. */
+  readonly unmatched: string;
   consume: (match: RegExpExecArray) => void;
-  clearPending: () => void;
+  clearUnmatched: () => void;
   write: (data: string) => void;
   finish: () => void;
   safeReject: (error: Error) => void;
@@ -95,7 +96,7 @@ export const runExpectSession = ({
     const transcript = createTranscript(secrets);
     const decoder = new StringDecoder("utf8");
 
-    let pending = "";
+    let unmatched = "";
     let settled = false;
     let closing = false;
 
@@ -122,14 +123,14 @@ export const runExpectSession = ({
     }, timeoutMs);
 
     const ctx: TExpectAdvanceContext = {
-      get pending() {
-        return pending;
+      get unmatched() {
+        return unmatched;
       },
       consume: (match: RegExpExecArray) => {
-        pending = pending.slice(match.index + match[0].length);
+        unmatched = unmatched.slice(match.index + match[0].length);
       },
-      clearPending: () => {
-        pending = "";
+      clearUnmatched: () => {
+        unmatched = "";
       },
       write: (data: string) => stream.write(data),
       finish,
@@ -144,14 +145,14 @@ export const runExpectSession = ({
       if (!text) return;
 
       transcript.append(text);
-      pending += text;
+      unmatched += text;
 
       let progressed = true;
       while (progressed && !settled && !closing) {
         progressed = advance(ctx);
       }
 
-      if (!settled && !closing && pending.length > maxBufferSize) {
+      if (!settled && !closing && unmatched.length > maxBufferSize) {
         safeReject(new Error(overflowMessage(transcript.read())));
       }
     });

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
@@ -19,20 +19,24 @@ const createTranscript = (secrets: (string | undefined)[]) => {
   const redact = (value: string) =>
     knownSecrets.reduce((redacted, secret) => redacted.replaceAll(secret, "***"), value);
 
-  let text = "";
-  let truncated = false;
+  // Raw text is kept unredacted so a secret split across two data events is
+  // still intact when redact() runs.  The buffer lives only for the duration
+  // of one runExpectSession call (bounded by SHELL_TIMEOUT and the overflow
+  // check on the unmatched buffer), so it needs no independent cap.
+  let raw = "";
 
   return {
     append: (chunk: string) => {
-      text += chunk;
-      text = redact(text);
-      if (text.length > MAX_TRANSCRIPT_SIZE) {
-        text = text.slice(-MAX_TRANSCRIPT_SIZE);
-        truncated = true;
-      }
+      raw += chunk;
     },
     redact,
-    read: () => (truncated ? `...${redact(text)}` : redact(text))
+    read: () => {
+      const redacted = redact(raw);
+      if (redacted.length > MAX_TRANSCRIPT_SIZE) {
+        return `...${redacted.slice(-MAX_TRANSCRIPT_SIZE)}`;
+      }
+      return redacted;
+    }
   };
 };
 

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
@@ -89,10 +89,10 @@ export type TExpectSessionConfig = {
  *
  * Callers provide:
  *   - `advance`: the state machine. Called repeatedly until it returns false (no progress).
- *     Reads `ctx.pending`, calls `ctx.consume` / `ctx.clearPending` / `ctx.write` /
- *     `ctx.finish` / `ctx.safeReject` as needed.
+ *     Reads `ctx.pending`, calls `ctx.consume`, `ctx.clearPending`, `ctx.write`,
+ *     `ctx.finish`, or `ctx.safeReject` as needed.
  *   - `resolveOnClose`: called once on stream close to decide resolve vs. reject.
- *   - `overflowMessage` / `timeoutMessage`: build the error string for each failure mode.
+ *   - `overflowMessage` or `timeoutMessage`: build the error string for each failure mode.
  */
 export const runExpectSession = ({
   stream,

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
@@ -20,14 +20,21 @@ const createTranscript = (secrets: (string | undefined)[]) => {
     knownSecrets.reduce((redacted, secret) => redacted.replaceAll(secret, "***"), value);
 
   // Raw text is kept unredacted so a secret split across two data events is
-  // still intact when redact() runs.  The buffer lives only for the duration
-  // of one runExpectSession call (bounded by SHELL_TIMEOUT and the overflow
-  // check on the unmatched buffer), so it needs no independent cap.
+  // still intact when redact() runs on read().  advance() consumes the
+  // separate unmatched buffer, so a cooperating host can keep unmatched small
+  // while raw grows; capping raw at MAX_BUFFER_SIZE bounds that.  The 60 KiB
+  // gap between the raw cap and MAX_TRANSCRIPT_SIZE means a partial secret at
+  // the raw-cap boundary is always discarded by the final output slice.
   let raw = "";
+  let truncated = false;
 
   return {
     append: (chunk: string) => {
       raw += chunk;
+      if (raw.length > MAX_BUFFER_SIZE) {
+        raw = raw.slice(-MAX_BUFFER_SIZE);
+        truncated = true;
+      }
     },
     redact,
     read: () => {
@@ -35,7 +42,7 @@ const createTranscript = (secrets: (string | undefined)[]) => {
       if (redacted.length > MAX_TRANSCRIPT_SIZE) {
         return `...${redacted.slice(-MAX_TRANSCRIPT_SIZE)}`;
       }
-      return redacted;
+      return truncated ? `...${redacted}` : redacted;
     }
   };
 };

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
@@ -1,0 +1,191 @@
+import { StringDecoder } from "node:string_decoder";
+
+export const SHELL_TIMEOUT = 15_000;
+export const MAX_BUFFER_SIZE = 64 * 1024;
+const MAX_TRANSCRIPT_SIZE = 4 * 1024;
+
+export type TInteractiveShellStream = {
+  on(event: "data", listener: (chunk: Buffer) => void): void;
+  on(event: "close", listener: () => void): void;
+  on(event: "error", listener: (err: Error) => void): void;
+  write(data: string): void;
+  end(): void;
+};
+
+const createTranscript = (secrets: (string | undefined)[]) => {
+  const knownSecrets = secrets.filter((secret): secret is string => Boolean(secret));
+  const redact = (value: string) =>
+    knownSecrets.reduce((redacted, secret) => redacted.replaceAll(secret, "***"), value);
+
+  let text = "";
+  let truncated = false;
+
+  return {
+    append: (chunk: string) => {
+      text += chunk;
+      if (text.length > MAX_TRANSCRIPT_SIZE) {
+        text = text.slice(-MAX_TRANSCRIPT_SIZE);
+        truncated = true;
+      }
+    },
+    redact,
+    read: () => (truncated ? `...${redact(text)}` : redact(text))
+  };
+};
+
+export const escapeForPattern = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export const lineAt = (text: string, index: number) => {
+  const start = text.lastIndexOf("\n", index) + 1;
+  const end = text.indexOf("\n", index);
+  return (end === -1 ? text.slice(start) : text.slice(start, end)).trim();
+};
+
+export type TExpectAdvanceContext = {
+  readonly pending: string;
+  consume: (match: RegExpExecArray) => void;
+  clearPending: () => void;
+  write: (data: string) => void;
+  finish: () => void;
+  safeReject: (error: Error) => void;
+  transcript: {
+    redact: (value: string) => string;
+    read: () => string;
+  };
+};
+
+export type TExpectCloseContext = {
+  transcript: {
+    read: () => string;
+  };
+};
+
+export type TExpectCloseDecision = { resolve: true } | { resolve: false; error: Error };
+
+export type TExpectSessionConfig = {
+  stream: TInteractiveShellStream;
+  secrets: (string | undefined)[];
+  advance: (ctx: TExpectAdvanceContext) => boolean;
+  resolveOnClose: (ctx: TExpectCloseContext) => TExpectCloseDecision;
+  overflowMessage: (transcriptRead: string) => string;
+  timeoutMessage: (transcriptRead: string) => string;
+  timeoutMs?: number;
+  maxBufferSize?: number;
+};
+
+/**
+ * Drives an interactive PTY stream through a caller-defined state machine.
+ *
+ * The engine handles the low-level plumbing that every PTY-driven exchange needs:
+ *   - Accumulating chunks through a StringDecoder (so multi-byte characters split across
+ *     reads are reassembled, not replaced with U+FFFD).
+ *   - Matching against everything received so far, not just the arriving chunk, so a prompt
+ *     split across any number of data events is still recognised.
+ *   - Re-running the state machine in a loop until nothing more matches, so a host that
+ *     coalesces several prompts into one chunk gets all of them answered.
+ *   - Bounding the pending buffer (MAX_BUFFER_SIZE) and the retained transcript
+ *     (MAX_TRANSCRIPT_SIZE), with automatic secret redaction on every error path.
+ *   - Timeout, settlement guards, and stream cleanup.
+ *
+ * Callers provide:
+ *   - `advance`: the state machine. Called repeatedly until it returns false (no progress).
+ *     Reads `ctx.pending`, calls `ctx.consume` / `ctx.clearPending` / `ctx.write` /
+ *     `ctx.finish` / `ctx.safeReject` as needed.
+ *   - `resolveOnClose`: called once on stream close to decide resolve vs. reject.
+ *   - `overflowMessage` / `timeoutMessage`: build the error string for each failure mode.
+ */
+export const runExpectSession = ({
+  stream,
+  secrets,
+  advance,
+  resolveOnClose,
+  overflowMessage,
+  timeoutMessage,
+  timeoutMs = SHELL_TIMEOUT,
+  maxBufferSize = MAX_BUFFER_SIZE
+}: TExpectSessionConfig): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const transcript = createTranscript(secrets);
+    const decoder = new StringDecoder("utf8");
+
+    let pending = "";
+    let settled = false;
+    let closing = false;
+
+    // eslint-disable-next-line prefer-const
+    let timeout: ReturnType<typeof setTimeout>;
+
+    const safeReject = (error: Error) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timeout);
+        stream.end();
+        reject(error);
+      }
+    };
+
+    const finish = () => {
+      closing = true;
+      clearTimeout(timeout);
+      stream.end();
+    };
+
+    timeout = setTimeout(() => {
+      safeReject(new Error(timeoutMessage(transcript.read())));
+    }, timeoutMs);
+
+    const ctx: TExpectAdvanceContext = {
+      get pending() {
+        return pending;
+      },
+      consume: (match: RegExpExecArray) => {
+        pending = pending.slice(match.index + match[0].length);
+      },
+      clearPending: () => {
+        pending = "";
+      },
+      write: (data: string) => stream.write(data),
+      finish,
+      safeReject,
+      transcript
+    };
+
+    stream.on("data", (chunk: Buffer) => {
+      if (settled || closing) return;
+
+      const text = decoder.write(chunk);
+      if (!text) return;
+
+      transcript.append(text);
+      pending += text;
+
+      let progressed = true;
+      while (progressed && !settled && !closing) {
+        progressed = advance(ctx);
+      }
+
+      if (!settled && !closing && pending.length > maxBufferSize) {
+        safeReject(new Error(overflowMessage(transcript.read())));
+      }
+    });
+
+    stream.on("close", () => {
+      clearTimeout(timeout);
+      const tail = decoder.end();
+      if (tail) transcript.append(tail);
+      if (settled) return;
+      settled = true;
+
+      const decision = resolveOnClose({ transcript });
+      if (decision.resolve) {
+        resolve();
+      } else {
+        reject(decision.error);
+      }
+    });
+
+    stream.on("error", (streamErr: Error) => {
+      safeReject(new Error(`Stream error: ${streamErr.message}`));
+    });
+  });
+};

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
@@ -73,27 +73,14 @@ export type TExpectSessionConfig = {
   maxBufferSize?: number;
 };
 
-/**
- * Drives an interactive PTY stream through a caller-defined state machine.
- *
- * The engine handles the low-level plumbing that every PTY-driven exchange needs:
- *   - Accumulating chunks through a StringDecoder (so multi-byte characters split across
- *     reads are reassembled, not replaced with U+FFFD).
- *   - Matching against everything received so far, not just the arriving chunk, so a prompt
- *     split across any number of data events is still recognised.
- *   - Re-running the state machine in a loop until nothing more matches, so a host that
- *     coalesces several prompts into one chunk gets all of them answered.
- *   - Bounding the pending buffer (MAX_BUFFER_SIZE) and the retained transcript
- *     (MAX_TRANSCRIPT_SIZE), with automatic secret redaction on every error path.
- *   - Timeout, settlement guards, and stream cleanup.
- *
- * Callers provide:
- *   - `advance`: the state machine. Called repeatedly until it returns false (no progress).
- *     Reads `ctx.pending`, calls `ctx.consume`, `ctx.clearPending`, `ctx.write`,
- *     `ctx.finish`, or `ctx.safeReject` as needed.
- *   - `resolveOnClose`: called once on stream close to decide resolve vs. reject.
- *   - `overflowMessage` or `timeoutMessage`: build the error string for each failure mode.
- */
+// An SSH channel over a PTY re-segments output wherever the network splits the bytes, and a
+// gateway-backed connection copies between TCP and QUIC with no framing at all. The same
+// `passwd` exchange can arrive as one chunk or twenty, so matching against only the latest
+// chunk is unreliable: 11 of the 49 split points inside AIX's "root's New password:\r\n"
+// break a per-chunk match. This engine accumulates everything into a pending buffer and
+// re-runs the caller's `advance` function in a loop, so a prompt split across any number of
+// data events is still recognised and a host that coalesces several prompts into one chunk
+// gets all of them answered instead of stalling.
 export const runExpectSession = ({
   stream,
   secrets,

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/pty-expect-engine.ts
@@ -13,7 +13,9 @@ export type TInteractiveShellStream = {
 };
 
 const createTranscript = (secrets: (string | undefined)[]) => {
-  const knownSecrets = secrets.filter((secret): secret is string => Boolean(secret));
+  const knownSecrets = secrets
+    .filter((secret): secret is string => Boolean(secret))
+    .sort((a, b) => b.length - a.length);
   const redact = (value: string) =>
     knownSecrets.reduce((redacted, secret) => redacted.replaceAll(secret, "***"), value);
 
@@ -23,6 +25,7 @@ const createTranscript = (secrets: (string | undefined)[]) => {
   return {
     append: (chunk: string) => {
       text += chunk;
+      text = redact(text);
       if (text.length > MAX_TRANSCRIPT_SIZE) {
         text = text.slice(-MAX_TRANSCRIPT_SIZE);
         truncated = true;

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.test.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.test.ts
@@ -7,9 +7,11 @@ import {
   TInteractiveShellStream
 } from "./unix-linux-local-account-rotation-fns";
 
-const OLD_PASSWORD = "0ld-P@ssw0rd";
-const NEW_PASSWORD = "n3w-P@ssw0rd";
-const APP_CONNECTION_PASSWORD = "svc-P@ssw0rd";
+// Deliberately not credential-shaped: the handlers only ever echo these back, and the tests need
+// three strings they can tell apart in the write log and look for in an error message.
+const CURRENT_SENTINEL = "unit-test-sentinel-current";
+const ROTATED_SENTINEL = "unit-test-sentinel-rotated";
+const SUDO_SENTINEL = "unit-test-sentinel-sudo";
 
 type TFakeStream = {
   stream: TInteractiveShellStream;
@@ -60,7 +62,7 @@ const LINUX_SELF_TRANSCRIPT =
 
 const driveManagedChange = (chunks: string[]) => {
   const fake = createFakeStream();
-  const result = runManagedPasswordChange(fake.stream, NEW_PASSWORD, APP_CONNECTION_PASSWORD);
+  const result = runManagedPasswordChange(fake.stream, ROTATED_SENTINEL, SUDO_SENTINEL);
   chunks.forEach((chunk) => fake.feed(chunk));
   fake.close();
   return { writes: fake.writes, result };
@@ -68,7 +70,7 @@ const driveManagedChange = (chunks: string[]) => {
 
 const driveSelfChange = (chunks: string[]) => {
   const fake = createFakeStream();
-  const result = runSelfPasswordChange(fake.stream, OLD_PASSWORD, NEW_PASSWORD);
+  const result = runSelfPasswordChange(fake.stream, CURRENT_SENTINEL, ROTATED_SENTINEL);
   chunks.forEach((chunk) => fake.feed(chunk));
   fake.close();
   return { writes: fake.writes, result };
@@ -83,9 +85,9 @@ const everySplitOf = (transcript: string) => {
 };
 
 const MANAGED_TRANSCRIPTS: [string, string, string[]][] = [
-  ["Linux passwd", LINUX_MANAGED_TRANSCRIPT, [`${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]],
-  ["AIX 7.2 passwd", AIX_MANAGED_TRANSCRIPT, [`${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]],
-  ["sudo passwd", SUDO_MANAGED_TRANSCRIPT, [`${APP_CONNECTION_PASSWORD}\n`, `${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]]
+  ["Linux passwd", LINUX_MANAGED_TRANSCRIPT, [`${ROTATED_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`]],
+  ["AIX 7.2 passwd", AIX_MANAGED_TRANSCRIPT, [`${ROTATED_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`]],
+  ["sudo passwd", SUDO_MANAGED_TRANSCRIPT, [`${SUDO_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`]]
 ];
 
 describe("runManagedPasswordChange", () => {
@@ -126,13 +128,13 @@ describe("runManagedPasswordChange", () => {
     await Promise.all(runs.map(({ result }) => expect(result).resolves.toBeUndefined()));
 
     runs.forEach(({ writes }) => {
-      expect(writes.filter((write) => write === `${NEW_PASSWORD}\n`)).toHaveLength(2);
+      expect(writes.filter((write) => write === `${ROTATED_SENTINEL}\n`)).toHaveLength(2);
     });
   });
 
   test("rejects when the host floods the channel without a recognized prompt", async () => {
     const fake = createFakeStream();
-    const result = runManagedPasswordChange(fake.stream, NEW_PASSWORD);
+    const result = runManagedPasswordChange(fake.stream, ROTATED_SENTINEL);
 
     fake.feed("motd line\r\n".repeat(7_000));
 
@@ -147,27 +149,28 @@ describe("runManagedPasswordChange", () => {
     ]);
 
     await expect(result).rejects.toThrow(/passwd: password unchanged/);
-    expect(writes).toEqual([`${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]);
+    expect(writes).toEqual([`${ROTATED_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`]);
   });
 
   test("reassembles a multi-byte character split across two data events", async () => {
     const fake = createFakeStream();
-    const result = runManagedPasswordChange(fake.stream, NEW_PASSWORD);
+    const result = runManagedPasswordChange(fake.stream, ROTATED_SENTINEL);
     const banner = Buffer.from("motd: caf\u00e9\r\n", "utf8");
 
     fake.feedBytes(banner.subarray(0, 10));
     fake.feedBytes(banner.subarray(10));
     fake.close();
 
-    const error = await result.catch((err: unknown) => err as Error);
+    const error = await result.catch((err: unknown) => err);
 
-    expect(error.message).toContain("motd: caf\u00e9");
-    expect(error.message).not.toContain("\ufffd");
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("motd: caf\u00e9");
+    expect((error as Error).message).not.toContain("\ufffd");
   });
 
   test("rejects with sudoers guidance when sudo asks for a password we do not have", async () => {
     const fake = createFakeStream();
-    const result = runManagedPasswordChange(fake.stream, NEW_PASSWORD);
+    const result = runManagedPasswordChange(fake.stream, ROTATED_SENTINEL);
 
     fake.feed(SUDO_MANAGED_TRANSCRIPT);
 
@@ -178,7 +181,7 @@ describe("runManagedPasswordChange", () => {
 
 describe("runSelfPasswordChange", () => {
   test("answers every prompt identically however the transcript is split", async () => {
-    const expectedWrites = [`${OLD_PASSWORD}\n`, `${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`];
+    const expectedWrites = [`${CURRENT_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`];
     const runs = everySplitOf(LINUX_SELF_TRANSCRIPT).map(({ offset, chunks }) => ({
       offset,
       ...driveSelfChange(chunks)
@@ -198,33 +201,33 @@ describe("runSelfPasswordChange", () => {
     ]);
 
     await expect(result).rejects.toThrow(/passwd: password unchanged/);
-    expect(writes).toEqual([`${OLD_PASSWORD}\n`, `${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]);
+    expect(writes).toEqual([`${CURRENT_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`, `${ROTATED_SENTINEL}\n`]);
   });
 
   test("keeps passwords out of the rejection message when the tty echoes them", async () => {
     const fake = createFakeStream();
-    const result = runSelfPasswordChange(fake.stream, OLD_PASSWORD, NEW_PASSWORD);
+    const result = runSelfPasswordChange(fake.stream, CURRENT_SENTINEL, ROTATED_SENTINEL);
 
     // Echo is still on until passwd disables it, so a password written at the wrong moment comes
     // straight back and would otherwise be persisted as the rotation's last error.
     fake.feed("Current password: ");
-    fake.feed(`${OLD_PASSWORD}\r\nNew password: `);
-    fake.feed(`${NEW_PASSWORD}\r\n`);
+    fake.feed(`${CURRENT_SENTINEL}\r\nNew password: `);
+    fake.feed(`${ROTATED_SENTINEL}\r\n`);
     fake.close();
 
-    const error = await result.catch((err: unknown) => err as Error);
+    const error = await result.catch((err: unknown) => err);
 
     expect(error).toBeInstanceOf(Error);
-    expect(error.message).not.toContain(OLD_PASSWORD);
-    expect(error.message).not.toContain(NEW_PASSWORD);
-    expect(error.message).toContain("***");
+    expect((error as Error).message).not.toContain(CURRENT_SENTINEL);
+    expect((error as Error).message).not.toContain(ROTATED_SENTINEL);
+    expect((error as Error).message).toContain("***");
   });
 });
 
 describe("runSuLoginVerification", () => {
   test("answers a password prompt split across data events", async () => {
     const fake = createFakeStream();
-    const result = runSuLoginVerification(fake.stream, "root", NEW_PASSWORD);
+    const result = runSuLoginVerification(fake.stream, "root", ROTATED_SENTINEL);
 
     fake.feed("Pass");
     fake.feed("word: ");
@@ -233,19 +236,20 @@ describe("runSuLoginVerification", () => {
     fake.close();
 
     await expect(result).resolves.toBeUndefined();
-    expect(fake.writes).toEqual([`${NEW_PASSWORD}\n`, "whoami\n", "exit\n"]);
+    expect(fake.writes).toEqual([`${ROTATED_SENTINEL}\n`, "whoami\n", "exit\n"]);
   });
 
   test("rejects on an authentication failure without leaking the password", async () => {
     const fake = createFakeStream();
-    const result = runSuLoginVerification(fake.stream, "root", NEW_PASSWORD);
+    const result = runSuLoginVerification(fake.stream, "root", ROTATED_SENTINEL);
 
     fake.feed("Password: ");
-    fake.feed(`${NEW_PASSWORD}\r\nsu: Authentication failure\r\n`);
+    fake.feed(`${ROTATED_SENTINEL}\r\nsu: Authentication failure\r\n`);
 
-    const error = await result.catch((err: unknown) => err as Error);
+    const error = await result.catch((err: unknown) => err);
 
-    expect(error.message).toMatch(/su authentication failed for user root/);
-    expect(error.message).not.toContain(NEW_PASSWORD);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/su authentication failed for user root/);
+    expect((error as Error).message).not.toContain(ROTATED_SENTINEL);
   });
 });

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.test.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  runManagedPasswordChange,
+  runSelfPasswordChange,
+  runSuLoginVerification,
+  TInteractiveShellStream
+} from "./unix-linux-local-account-rotation-fns";
+
+const OLD_PASSWORD = "0ld-P@ssw0rd";
+const NEW_PASSWORD = "n3w-P@ssw0rd";
+const APP_CONNECTION_PASSWORD = "svc-P@ssw0rd";
+
+type TFakeStream = {
+  stream: TInteractiveShellStream;
+  writes: string[];
+  feed: (text: string) => void;
+  feedBytes: (chunk: Buffer) => void;
+  close: () => void;
+};
+
+const createFakeStream = (): TFakeStream => {
+  const writes: string[] = [];
+  const dataListeners: ((chunk: Buffer) => void)[] = [];
+  const closeListeners: (() => void)[] = [];
+
+  const stream = {
+    on: (event: string, listener: unknown) => {
+      if (event === "data") dataListeners.push(listener as (chunk: Buffer) => void);
+      if (event === "close") closeListeners.push(listener as () => void);
+    },
+    write: (data: string) => {
+      writes.push(data);
+    },
+    end: () => {}
+  } as unknown as TInteractiveShellStream;
+
+  const feedBytes = (chunk: Buffer) => dataListeners.forEach((listener) => listener(chunk));
+
+  return {
+    stream,
+    writes,
+    feed: (text: string) => feedBytes(Buffer.from(text, "utf8")),
+    feedBytes,
+    close: () => closeListeners.forEach((listener) => listener())
+  };
+};
+
+// Real transcripts, `\r\n` included, because the handlers read a PTY where ONLCR is on.
+const LINUX_MANAGED_TRANSCRIPT = "New password: \r\nRetype new password: \r\npasswd: password updated successfully\r\n";
+
+const AIX_MANAGED_TRANSCRIPT =
+  "Changing password for \"root\"\r\nroot's New password: \r\nRe-enter root's new password: \r\n";
+
+const SUDO_MANAGED_TRANSCRIPT =
+  "[sudo] password for svc: \r\nChanging password for \"root\"\r\nroot's New password: \r\nRe-enter root's new password: \r\n";
+
+const LINUX_SELF_TRANSCRIPT =
+  "Changing password for jdoe.\r\nCurrent password: \r\nNew password: \r\nRetype new password: \r\npasswd: password updated successfully\r\n";
+
+const driveManagedChange = (chunks: string[]) => {
+  const fake = createFakeStream();
+  const result = runManagedPasswordChange(fake.stream, NEW_PASSWORD, APP_CONNECTION_PASSWORD);
+  chunks.forEach((chunk) => fake.feed(chunk));
+  fake.close();
+  return { writes: fake.writes, result };
+};
+
+const driveSelfChange = (chunks: string[]) => {
+  const fake = createFakeStream();
+  const result = runSelfPasswordChange(fake.stream, OLD_PASSWORD, NEW_PASSWORD);
+  chunks.forEach((chunk) => fake.feed(chunk));
+  fake.close();
+  return { writes: fake.writes, result };
+};
+
+const everySplitOf = (transcript: string) => {
+  const splits: { offset: number; chunks: string[] }[] = [];
+  for (let offset = 0; offset <= transcript.length; offset += 1) {
+    splits.push({ offset, chunks: [transcript.slice(0, offset), transcript.slice(offset)] });
+  }
+  return splits;
+};
+
+const MANAGED_TRANSCRIPTS: [string, string, string[]][] = [
+  ["Linux passwd", LINUX_MANAGED_TRANSCRIPT, [`${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]],
+  ["AIX 7.2 passwd", AIX_MANAGED_TRANSCRIPT, [`${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]],
+  ["sudo passwd", SUDO_MANAGED_TRANSCRIPT, [`${APP_CONNECTION_PASSWORD}\n`, `${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]]
+];
+
+describe("runManagedPasswordChange", () => {
+  test.each(MANAGED_TRANSCRIPTS)(
+    "%s: answers every prompt identically however the transcript is split",
+    async (_name, transcript, expectedWrites) => {
+      const runs = everySplitOf(transcript).map(({ offset, chunks }) => ({
+        offset,
+        ...driveManagedChange(chunks)
+      }));
+
+      await Promise.all(runs.map(({ result }) => expect(result).resolves.toBeUndefined()));
+
+      runs.forEach(({ offset, writes }) => {
+        expect(writes, `split at offset ${offset}`).toEqual(expectedWrites);
+      });
+    }
+  );
+
+  test.each(MANAGED_TRANSCRIPTS)(
+    "%s: completes when the host coalesces the whole transcript into one chunk",
+    async (_name, transcript, expectedWrites) => {
+      const { writes, result } = driveManagedChange([transcript]);
+
+      await expect(result).resolves.toBeUndefined();
+      expect(writes).toEqual(expectedWrites);
+    }
+  );
+
+  test("sends the new password exactly twice, never a third time", async () => {
+    // AIX names the password twice ("root's New password", "Re-enter root's new password"), so an
+    // unconsumed buffer would let the first prompt satisfy the confirmation as well.
+    const runs = [
+      driveManagedChange([AIX_MANAGED_TRANSCRIPT]),
+      ...everySplitOf(AIX_MANAGED_TRANSCRIPT).map(({ chunks }) => driveManagedChange(chunks))
+    ];
+
+    await Promise.all(runs.map(({ result }) => expect(result).resolves.toBeUndefined()));
+
+    runs.forEach(({ writes }) => {
+      expect(writes.filter((write) => write === `${NEW_PASSWORD}\n`)).toHaveLength(2);
+    });
+  });
+
+  test("rejects when the host floods the channel without a recognized prompt", async () => {
+    const fake = createFakeStream();
+    const result = runManagedPasswordChange(fake.stream, NEW_PASSWORD);
+
+    fake.feed("motd line\r\n".repeat(7_000));
+
+    await expect(result).rejects.toThrow(/without a recognized prompt/);
+    expect(fake.writes).toEqual([]);
+  });
+
+  test("treats `passwd: password unchanged` as a failure, not a successful rotation", async () => {
+    const { writes, result } = driveManagedChange([
+      "New password: \r\nRetype new password: \r\n",
+      "passwd: password unchanged\r\n"
+    ]);
+
+    await expect(result).rejects.toThrow(/passwd: password unchanged/);
+    expect(writes).toEqual([`${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]);
+  });
+
+  test("reassembles a multi-byte character split across two data events", async () => {
+    const fake = createFakeStream();
+    const result = runManagedPasswordChange(fake.stream, NEW_PASSWORD);
+    const banner = Buffer.from("motd: caf\u00e9\r\n", "utf8");
+
+    fake.feedBytes(banner.subarray(0, 10));
+    fake.feedBytes(banner.subarray(10));
+    fake.close();
+
+    const error = await result.catch((err: unknown) => err as Error);
+
+    expect(error.message).toContain("motd: caf\u00e9");
+    expect(error.message).not.toContain("\ufffd");
+  });
+
+  test("rejects with sudoers guidance when sudo asks for a password we do not have", async () => {
+    const fake = createFakeStream();
+    const result = runManagedPasswordChange(fake.stream, NEW_PASSWORD);
+
+    fake.feed(SUDO_MANAGED_TRANSCRIPT);
+
+    await expect(result).rejects.toThrow(/NOPASSWD in sudoers/);
+    expect(fake.writes).toEqual([]);
+  });
+});
+
+describe("runSelfPasswordChange", () => {
+  test("answers every prompt identically however the transcript is split", async () => {
+    const expectedWrites = [`${OLD_PASSWORD}\n`, `${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`];
+    const runs = everySplitOf(LINUX_SELF_TRANSCRIPT).map(({ offset, chunks }) => ({
+      offset,
+      ...driveSelfChange(chunks)
+    }));
+
+    await Promise.all(runs.map(({ result }) => expect(result).resolves.toBeUndefined()));
+
+    runs.forEach(({ offset, writes }) => {
+      expect(writes, `split at offset ${offset}`).toEqual(expectedWrites);
+    });
+  });
+
+  test("treats `passwd: password unchanged` as a failure, not a successful rotation", async () => {
+    const { writes, result } = driveSelfChange([
+      "Current password: \r\nNew password: \r\nRetype new password: \r\n",
+      "passwd: password unchanged\r\n"
+    ]);
+
+    await expect(result).rejects.toThrow(/passwd: password unchanged/);
+    expect(writes).toEqual([`${OLD_PASSWORD}\n`, `${NEW_PASSWORD}\n`, `${NEW_PASSWORD}\n`]);
+  });
+
+  test("keeps passwords out of the rejection message when the tty echoes them", async () => {
+    const fake = createFakeStream();
+    const result = runSelfPasswordChange(fake.stream, OLD_PASSWORD, NEW_PASSWORD);
+
+    // Echo is still on until passwd disables it, so a password written at the wrong moment comes
+    // straight back and would otherwise be persisted as the rotation's last error.
+    fake.feed("Current password: ");
+    fake.feed(`${OLD_PASSWORD}\r\nNew password: `);
+    fake.feed(`${NEW_PASSWORD}\r\n`);
+    fake.close();
+
+    const error = await result.catch((err: unknown) => err as Error);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).not.toContain(OLD_PASSWORD);
+    expect(error.message).not.toContain(NEW_PASSWORD);
+    expect(error.message).toContain("***");
+  });
+});
+
+describe("runSuLoginVerification", () => {
+  test("answers a password prompt split across data events", async () => {
+    const fake = createFakeStream();
+    const result = runSuLoginVerification(fake.stream, "root", NEW_PASSWORD);
+
+    fake.feed("Pass");
+    fake.feed("word: ");
+    fake.feed("\r\n[root@host ~]# ");
+    fake.feed("whoami\r\nroot\r\n[root@host ~]# ");
+    fake.close();
+
+    await expect(result).resolves.toBeUndefined();
+    expect(fake.writes).toEqual([`${NEW_PASSWORD}\n`, "whoami\n", "exit\n"]);
+  });
+
+  test("rejects on an authentication failure without leaking the password", async () => {
+    const fake = createFakeStream();
+    const result = runSuLoginVerification(fake.stream, "root", NEW_PASSWORD);
+
+    fake.feed("Password: ");
+    fake.feed(`${NEW_PASSWORD}\r\nsu: Authentication failure\r\n`);
+
+    const error = await result.catch((err: unknown) => err as Error);
+
+    expect(error.message).toMatch(/su authentication failed for user root/);
+    expect(error.message).not.toContain(NEW_PASSWORD);
+  });
+});

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.test.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.test.ts
@@ -168,6 +168,25 @@ describe("runManagedPasswordChange", () => {
     expect((error as Error).message).not.toContain("\ufffd");
   });
 
+  test("redacts overlapping secrets when one password is a substring of the other", async () => {
+    const shortPassword = "secret";
+    const longPassword = "my-secret-value";
+    const fake = createFakeStream();
+    const result = runManagedPasswordChange(fake.stream, shortPassword, longPassword);
+
+    // The sudo prompt echoes the long password (which contains the short one as a substring),
+    // then the session closes without completing passwd.
+    fake.feed(`[sudo] password for svc: ${longPassword}\r\n`);
+    fake.feed(`New password: ${shortPassword}\r\n`);
+    fake.close();
+
+    const error = await result.catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain(shortPassword);
+    expect((error as Error).message).not.toContain(longPassword);
+  });
+
   test("rejects with sudoers guidance when sudo asks for a password we do not have", async () => {
     const fake = createFakeStream();
     const result = runManagedPasswordChange(fake.stream, ROTATED_SENTINEL);
@@ -221,6 +240,29 @@ describe("runSelfPasswordChange", () => {
     expect((error as Error).message).not.toContain(CURRENT_SENTINEL);
     expect((error as Error).message).not.toContain(ROTATED_SENTINEL);
     expect((error as Error).message).toContain("***");
+  });
+
+  test("redacts a password that would straddle the 4 KiB transcript boundary", async () => {
+    const fake = createFakeStream();
+    const result = runSelfPasswordChange(fake.stream, CURRENT_SENTINEL, ROTATED_SENTINEL);
+
+    // Fill the transcript so the secret sits right at the 4 KiB truncation point.
+    // MAX_TRANSCRIPT_SIZE is 4096 internally; we pad with filler lines, then echo
+    // the password so it would straddle the boundary if redaction happened after truncation.
+    const fillerSize = 4096 - Math.floor(ROTATED_SENTINEL.length / 2);
+    const filler = "x".repeat(fillerSize);
+
+    fake.feed(filler);
+    fake.feed("Current password: ");
+    fake.feed(`${CURRENT_SENTINEL}\r\nNew password: `);
+    fake.feed(`${ROTATED_SENTINEL}\r\n`);
+    fake.close();
+
+    const error = await result.catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain(CURRENT_SENTINEL);
+    expect((error as Error).message).not.toContain(ROTATED_SENTINEL);
   });
 });
 

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.test.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.test.ts
@@ -187,6 +187,27 @@ describe("runManagedPasswordChange", () => {
     expect((error as Error).message).not.toContain(longPassword);
   });
 
+  test("redacts a secret split across two data events when a shorter secret overlaps", async () => {
+    const shortPassword = "secret";
+    const longPassword = "my-secret-value";
+    const fake = createFakeStream();
+    const result = runManagedPasswordChange(fake.stream, shortPassword, longPassword);
+
+    // The network splits the echoed long password across two chunks, right
+    // through the shorter secret.  An eager per-chunk redactor would replace
+    // "secret" in the first chunk, leaving "-value" visible in the second.
+    fake.feed("[sudo] password for svc: my-secret");
+    fake.feed(`-value\r\nNew password: ${shortPassword}\r\n`);
+    fake.close();
+
+    const error = await result.catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).not.toContain(shortPassword);
+    expect((error as Error).message).not.toContain(longPassword);
+    expect((error as Error).message).not.toContain("-value");
+  });
+
   test("rejects with sudoers guidance when sudo asks for a password we do not have", async () => {
     const fake = createFakeStream();
     const result = runManagedPasswordChange(fake.stream, ROTATED_SENTINEL);

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
@@ -1,3 +1,6 @@
+import { StringDecoder } from "node:string_decoder";
+
+import RE2 from "re2";
 import { Client, ClientChannel } from "ssh2";
 
 import {
@@ -27,6 +30,59 @@ import {
 } from "./unix-linux-local-account-rotation-types";
 
 const SHELL_TIMEOUT = 15_000;
+const MAX_BUFFER_SIZE = 64 * 1024;
+const MAX_TRANSCRIPT_SIZE = 4 * 1024;
+
+const SUDO_PROMPT = new RE2("\\[sudo\\]", "i");
+const ANY_PASSWORD_PROMPT = new RE2("password", "i");
+const NEW_PASSWORD_PROMPT = new RE2("new\\s+password", "i");
+const CONFIRM_PASSWORD_PROMPT = new RE2("retype|re-?enter|again|new\\s+password", "i");
+const PASSWORD_CHANGE_SUCCEEDED = new RE2("\\b(?:success(?:fully)?|updated|changed)\\b", "i");
+const MANAGED_PASSWORD_CHANGE_FAILED = new RE2(
+  "\\bauthentication\\s+failure\\b|\\bsorry\\b|\\bunknown\\s+user\\b|\\buser\\s+not\\s+known\\b|\\bdoes\\s+not\\s+exist\\b|\\bunchanged\\b",
+  "i"
+);
+const SELF_PASSWORD_CHANGE_FAILED = new RE2("\\berror\\b|\\bfail(?:ed|ure|s)?\\b|\\bunchanged\\b", "i");
+const SU_LOGIN_FAILED = new RE2("\\bauthentication\\s+failure\\b|\\bincorrect\\s+password\\b|\\bsu:", "i");
+
+export type TInteractiveShellStream = {
+  on(event: "data", listener: (chunk: Buffer) => void): void;
+  on(event: "close", listener: () => void): void;
+  on(event: "error", listener: (err: Error) => void): void;
+  write(data: string): void;
+  end(): void;
+};
+
+const escapeForPattern = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const lineAt = (text: string, index: number) => {
+  const start = text.lastIndexOf("\n", index) + 1;
+  const end = text.indexOf("\n", index);
+  return (end === -1 ? text.slice(start) : text.slice(start, end)).trim();
+};
+
+// The transcript is interpolated into rotation errors, which are persisted and rendered in the UI,
+// so bounding and redaction live here: no individual error site can forget to apply them.
+const createTranscript = (secrets: (string | undefined)[]) => {
+  const knownSecrets = secrets.filter((secret): secret is string => Boolean(secret));
+  const redact = (value: string) =>
+    knownSecrets.reduce((redacted, secret) => redacted.replaceAll(secret, "***"), value);
+
+  let text = "";
+  let truncated = false;
+
+  return {
+    append: (chunk: string) => {
+      text += chunk;
+      if (text.length > MAX_TRANSCRIPT_SIZE) {
+        text = text.slice(-MAX_TRANSCRIPT_SIZE);
+        truncated = true;
+      }
+    },
+    redact,
+    read: () => (truncated ? `...${redact(text)}` : redact(text))
+  };
+};
 
 // Execute a command via SSH exec with a PTY (no login shell, no MOTD)
 // Returns a stream that can be used for interactive I/O
@@ -38,6 +94,163 @@ const execCommandWithPty = (client: Client, command: string): Promise<ClientChan
         return;
       }
       resolve(stream);
+    });
+  });
+};
+
+// Drives the prompts of `passwd <username>` for managed rotation (admin changing another user's
+// password). Prompts are matched against everything received so far, not just the arriving chunk:
+// a PTY behind an SSH channel and a gateway tunnel re-segments freely, so a prompt can straddle
+// two data events.
+export const runManagedPasswordChange = (
+  stream: TInteractiveShellStream,
+  newPassword: string,
+  appConnectionPassword?: string
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const transcript = createTranscript([newPassword, appConnectionPassword]);
+    const decoder = new StringDecoder("utf8");
+
+    let pending = "";
+    let step = 0;
+    let completed = false;
+    let settled = false;
+    let closing = false;
+    let errorMessage = "";
+
+    const safeReject = (error: Error) => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    };
+
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        stream.end();
+        safeReject(new Error(`Password change timed out. Output: ${transcript.read()}`));
+      }
+    }, SHELL_TIMEOUT);
+
+    const finish = () => {
+      closing = true;
+      clearTimeout(timeout);
+      stream.end();
+    };
+
+    // Matched text is dropped so the same bytes cannot satisfy a later step as well, which would
+    // send the new password a third time or read the first prompt as its own confirmation.
+    const consume = (match: RegExpExecArray) => {
+      pending = pending.slice(match.index + match[0].length);
+    };
+
+    const advance = (): boolean => {
+      const failure = MANAGED_PASSWORD_CHANGE_FAILED.exec(pending);
+      if (failure) {
+        errorMessage = transcript.redact(lineAt(pending, failure.index));
+        consume(failure);
+        finish();
+        return false;
+      }
+
+      if (step === 0) {
+        const sudoPrompt = SUDO_PROMPT.exec(pending);
+        if (sudoPrompt) {
+          if (!appConnectionPassword) {
+            clearTimeout(timeout);
+            safeReject(
+              new Error(
+                "sudo is requesting a password but the app connection uses SSH key authentication. Configure the app connection with password authentication, or configure NOPASSWD in sudoers for this user."
+              )
+            );
+            stream.end();
+            return false;
+          }
+          consume(sudoPrompt);
+          stream.write(`${appConnectionPassword}\n`);
+          // Still step 0: the new-password prompt follows, and may already be in this buffer.
+          return true;
+        }
+
+        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(pending);
+        if (newPasswordPrompt) {
+          consume(newPasswordPrompt);
+          stream.write(`${newPassword}\n`);
+          step = 1;
+          return true;
+        }
+
+        return false;
+      }
+
+      if (step === 1) {
+        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(pending);
+        if (confirmPrompt) {
+          consume(confirmPrompt);
+          stream.write(`${newPassword}\n`);
+          step = 2;
+          return true;
+        }
+
+        return false;
+      }
+
+      const success = PASSWORD_CHANGE_SUCCEEDED.exec(pending);
+      if (success) {
+        consume(success);
+        completed = true;
+        finish();
+      }
+
+      return false;
+    };
+
+    stream.on("data", (chunk: Buffer) => {
+      if (settled || closing) return;
+
+      const text = decoder.write(chunk);
+      if (!text) return;
+
+      transcript.append(text);
+      pending += text;
+
+      // A host can coalesce several prompts into one chunk, and once it is waiting on our answer no
+      // further data event arrives, so advance until nothing more matches instead of once per event.
+      let progressed = true;
+      while (progressed && !settled && !closing) {
+        progressed = advance();
+      }
+
+      if (!settled && !closing && pending.length > MAX_BUFFER_SIZE) {
+        clearTimeout(timeout);
+        stream.end();
+        safeReject(
+          new Error(
+            `Password change failed: the host sent more than ${MAX_BUFFER_SIZE / 1024} KB of output without a recognized prompt. Output: ${transcript.read()}`
+          )
+        );
+      }
+    });
+
+    stream.on("close", () => {
+      clearTimeout(timeout);
+      const tail = decoder.end();
+      if (tail) transcript.append(tail);
+      if (settled) return;
+      settled = true;
+
+      if (errorMessage && !completed) {
+        reject(new Error(`Password change failed: ${errorMessage}`));
+      } else if (completed || step >= 2) {
+        resolve();
+      } else {
+        reject(new Error(`Password change incomplete (step ${step}). Output: ${transcript.read()}`));
+      }
+    });
+
+    stream.on("error", (streamErr: Error) => {
+      clearTimeout(timeout);
+      safeReject(new Error(`Stream error: ${streamErr.message}`));
     });
   });
 };
@@ -55,11 +268,25 @@ const changeManagedPassword = async (
   const command = useSudo ? `LC_ALL=C sudo passwd ${targetUsername}` : `LC_ALL=C passwd ${targetUsername}`;
   const stream = await execCommandWithPty(client, command);
 
+  return runManagedPasswordChange(stream, newPassword, appConnectionPassword);
+};
+
+// Drives the prompts of `passwd` for self rotation (user changing their own password), matching
+// against everything received so far for the same reason as the managed handler.
+export const runSelfPasswordChange = (
+  stream: TInteractiveShellStream,
+  oldPassword: string,
+  newPassword: string
+): Promise<void> => {
   return new Promise((resolve, reject) => {
-    let output = "";
+    const transcript = createTranscript([oldPassword, newPassword]);
+    const decoder = new StringDecoder("utf8");
+
+    let pending = "";
     let step = 0;
     let completed = false;
     let settled = false;
+    let closing = false;
     let errorMessage = "";
 
     const safeReject = (error: Error) => {
@@ -72,69 +299,115 @@ const changeManagedPassword = async (
     const timeout = setTimeout(() => {
       if (!settled) {
         stream.end();
-        safeReject(new Error(`Password change timed out. Output: ${output}`));
+        safeReject(new Error(`Password change timed out. Output: ${transcript.read()}`));
       }
     }, SHELL_TIMEOUT);
 
-    stream.on("data", (data: Buffer) => {
-      if (settled) return;
+    const finish = () => {
+      closing = true;
+      clearTimeout(timeout);
+      stream.end();
+    };
 
-      const text = data.toString();
-      output += text;
-      const lower = text.toLowerCase();
+    const consume = (match: RegExpExecArray) => {
+      pending = pending.slice(match.index + match[0].length);
+    };
 
-      if (step === 0 && lower.includes("[sudo]")) {
-        // sudo is asking for the logged-in user's password
-        if (!appConnectionPassword) {
-          clearTimeout(timeout);
-          safeReject(
-            new Error(
-              "sudo is requesting a password but the app connection uses SSH key authentication. Configure the app connection with password authentication, or configure NOPASSWD in sudoers for this user."
-            )
-          );
-          stream.end();
-          return;
+    const advance = (): boolean => {
+      if (step >= 1) {
+        const failure = SELF_PASSWORD_CHANGE_FAILED.exec(pending);
+        if (failure) {
+          errorMessage = transcript.redact(lineAt(pending, failure.index));
+          consume(failure);
+          finish();
+          return false;
         }
-        stream.write(`${appConnectionPassword}\n`);
-        // stay at step 0 to catch "New password" next
-      } else if (step === 0 && lower.includes("new password")) {
-        stream.write(`${newPassword}\n`);
-        step = 1;
-      } else if (
-        step === 1 &&
-        (lower.includes("retype") || lower.includes("again") || lower.includes("new password"))
-      ) {
-        stream.write(`${newPassword}\n`);
-        step = 2;
-      } else if (step >= 2 && (lower.includes("success") || lower.includes("updated") || lower.includes("changed"))) {
+      }
+
+      if (step === 0) {
+        const currentPasswordPrompt = ANY_PASSWORD_PROMPT.exec(pending);
+        if (currentPasswordPrompt) {
+          consume(currentPasswordPrompt);
+          stream.write(`${oldPassword}\n`);
+          step = 1;
+          return true;
+        }
+
+        return false;
+      }
+
+      if (step === 1) {
+        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(pending);
+        if (newPasswordPrompt) {
+          consume(newPasswordPrompt);
+          stream.write(`${newPassword}\n`);
+          step = 2;
+          return true;
+        }
+
+        return false;
+      }
+
+      if (step === 2) {
+        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(pending);
+        if (confirmPrompt) {
+          consume(confirmPrompt);
+          stream.write(`${newPassword}\n`);
+          step = 3;
+          return true;
+        }
+
+        return false;
+      }
+
+      const success = PASSWORD_CHANGE_SUCCEEDED.exec(pending);
+      if (success) {
+        consume(success);
         completed = true;
+        finish();
+      }
+
+      return false;
+    };
+
+    stream.on("data", (chunk: Buffer) => {
+      if (settled || closing) return;
+
+      const text = decoder.write(chunk);
+      if (!text) return;
+
+      transcript.append(text);
+      pending += text;
+
+      let progressed = true;
+      while (progressed && !settled && !closing) {
+        progressed = advance();
+      }
+
+      if (!settled && !closing && pending.length > MAX_BUFFER_SIZE) {
         clearTimeout(timeout);
         stream.end();
-      } else if (
-        step >= 0 &&
-        (lower.includes("authentication failure") ||
-          lower.includes("sorry") ||
-          lower.includes("unknown user") ||
-          lower.includes("user not known") ||
-          lower.includes("does not exist"))
-      ) {
-        errorMessage = text.trim();
-        clearTimeout(timeout);
-        stream.end();
+        safeReject(
+          new Error(
+            `Password change failed: the host sent more than ${MAX_BUFFER_SIZE / 1024} KB of output without a recognized prompt. Output: ${transcript.read()}`
+          )
+        );
       }
     });
 
     stream.on("close", () => {
       clearTimeout(timeout);
+      const tail = decoder.end();
+      if (tail) transcript.append(tail);
       if (settled) return;
       settled = true;
 
       if (errorMessage && !completed) {
         reject(new Error(`Password change failed: ${errorMessage}`));
-      } else if (completed || step >= 2) {
+      } else if (completed || step >= 3) {
         resolve();
       } else {
-        reject(new Error(`Password change incomplete (step ${step}). Output: ${output}`));
+        reject(new Error(`Password change incomplete (step ${step}). Output: ${transcript.read()}`));
       }
     });
 
@@ -151,12 +424,26 @@ const changeManagedPassword = async (
 const changeSelfPassword = async (client: Client, oldPassword: string, newPassword: string): Promise<void> => {
   const stream = await execCommandWithPty(client, "LC_ALL=C passwd");
 
+  return runSelfPasswordChange(stream, oldPassword, newPassword);
+};
+
+// Drives the prompts of `su - <username>`, matching against everything received so far for the same
+// reason as the password handlers.
+export const runSuLoginVerification = (
+  stream: TInteractiveShellStream,
+  targetUsername: string,
+  targetPassword: string
+): Promise<void> => {
   return new Promise((resolve, reject) => {
-    let output = "";
+    const transcript = createTranscript([targetPassword]);
+    const decoder = new StringDecoder("utf8");
+    const whoamiReply = new RE2(escapeForPattern(targetUsername), "i");
+
+    let pending = "";
     let step = 0;
     let completed = false;
     let settled = false;
-    let errorMessage = "";
+    let closing = false;
 
     const safeReject = (error: Error) => {
       if (!settled) {
@@ -168,57 +455,100 @@ const changeSelfPassword = async (client: Client, oldPassword: string, newPasswo
     const timeout = setTimeout(() => {
       if (!settled) {
         stream.end();
-        safeReject(new Error(`Password change timed out. Output: ${output}`));
+        safeReject(new Error(`su verification timed out. Output: ${transcript.read()}`));
       }
     }, SHELL_TIMEOUT);
 
-    stream.on("data", (data: Buffer) => {
-      if (settled) return;
+    const finish = () => {
+      closing = true;
+      clearTimeout(timeout);
+      stream.end();
+    };
 
-      const text = data.toString();
-      output += text;
-      const lower = text.toLowerCase();
+    const consume = (match: RegExpExecArray) => {
+      pending = pending.slice(match.index + match[0].length);
+    };
 
-      // Handle passwd prompts step by step
-      if (step === 0 && lower.includes("password")) {
-        // Current/old password prompt (could be "Current password:", "Old password:", etc.)
-        stream.write(`${oldPassword}\n`);
-        step = 1;
-      } else if (step === 1 && lower.includes("new password")) {
-        // New password prompt
-        stream.write(`${newPassword}\n`);
+    const advance = (): boolean => {
+      if (step >= 1) {
+        const failure = SU_LOGIN_FAILED.exec(pending);
+        if (failure) {
+          const diagnostic = transcript.redact(lineAt(pending, failure.index));
+          consume(failure);
+          clearTimeout(timeout);
+          safeReject(new Error(`su authentication failed for user ${targetUsername}. Output: ${diagnostic}`));
+          stream.end();
+          return false;
+        }
+      }
+
+      if (step === 0) {
+        const passwordPrompt = ANY_PASSWORD_PROMPT.exec(pending);
+        if (passwordPrompt) {
+          consume(passwordPrompt);
+          stream.write(`${targetPassword}\n`);
+          step = 1;
+          return true;
+        }
+
+        return false;
+      }
+
+      if (step === 1) {
+        // Anything buffered here is su's own banner or shell prompt; only the reply to whoami names
+        // the user we ended up as, so it is dropped rather than sliced.
+        if (!pending.trim()) return false;
+        pending = "";
+        stream.write("whoami\n");
         step = 2;
-      } else if (
-        step === 2 &&
-        (lower.includes("retype") || lower.includes("again") || lower.includes("new password"))
-      ) {
-        // Confirm new password prompt
-        stream.write(`${newPassword}\n`);
-        step = 3;
-      } else if (step === 3 && (lower.includes("success") || lower.includes("updated") || lower.includes("changed"))) {
-        // Password changed successfully
+        return true;
+      }
+
+      if (whoamiReply.test(pending)) {
         completed = true;
+        stream.write("exit\n");
+        finish();
+      }
+
+      return false;
+    };
+
+    stream.on("data", (chunk: Buffer) => {
+      if (settled || closing) return;
+
+      const text = decoder.write(chunk);
+      if (!text) return;
+
+      transcript.append(text);
+      pending += text;
+
+      let progressed = true;
+      while (progressed && !settled && !closing) {
+        progressed = advance();
+      }
+
+      if (!settled && !closing && pending.length > MAX_BUFFER_SIZE) {
         clearTimeout(timeout);
         stream.end();
-      } else if (step >= 1 && (lower.includes("error") || lower.includes("fail") || lower.includes("unchanged"))) {
-        // Password change failed
-        errorMessage = text.trim();
-        clearTimeout(timeout);
-        stream.end();
+        safeReject(
+          new Error(
+            `su verification failed for user ${targetUsername}: the host sent more than ${MAX_BUFFER_SIZE / 1024} KB of output without a recognized prompt. Output: ${transcript.read()}`
+          )
+        );
       }
     });
 
     stream.on("close", () => {
       clearTimeout(timeout);
+      const tail = decoder.end();
+      if (tail) transcript.append(tail);
       if (settled) return;
       settled = true;
 
-      if (errorMessage && !completed) {
-        reject(new Error(`Password change failed: ${errorMessage}`));
-      } else if (completed || step >= 3) {
+      if (completed) {
         resolve();
       } else {
-        reject(new Error(`Password change incomplete (step ${step}). Output: ${output}`));
+        reject(new Error(`su verification failed for user ${targetUsername}. Output: ${transcript.read()}`));
       }
     });
 
@@ -235,73 +565,7 @@ const changeSelfPassword = async (client: Client, oldPassword: string, newPasswo
 const verifySuLogin = async (client: Client, targetUsername: string, targetPassword: string): Promise<void> => {
   const stream = await execCommandWithPty(client, `LC_ALL=C su - ${targetUsername}`);
 
-  return new Promise((resolve, reject) => {
-    let output = "";
-    let step = 0;
-    let completed = false;
-    let settled = false;
-
-    const safeReject = (error: Error) => {
-      if (!settled) {
-        settled = true;
-        reject(error);
-      }
-    };
-
-    const timeout = setTimeout(() => {
-      if (!settled) {
-        stream.end();
-        safeReject(new Error(`su verification timed out. Output: ${output}`));
-      }
-    }, SHELL_TIMEOUT);
-
-    stream.on("data", (data: Buffer) => {
-      if (settled) return;
-
-      const text = data.toString();
-      output += text;
-      const lower = text.toLowerCase();
-
-      if (step === 0 && lower.includes("password")) {
-        // su is asking for the target user's password
-        stream.write(`${targetPassword}\n`);
-        step = 1;
-      } else if (step === 1) {
-        if (lower.includes("authentication failure") || lower.includes("incorrect password") || lower.includes("su:")) {
-          clearTimeout(timeout);
-          safeReject(new Error(`su authentication failed for user ${targetUsername}. Output: ${text.trim()}`));
-          stream.end();
-          return;
-        }
-        // After successful su, run whoami
-        stream.write("whoami\n");
-        step = 2;
-      } else if (step === 2 && lower.includes(targetUsername.toLowerCase())) {
-        // whoami confirmed we are the target user
-        completed = true;
-        clearTimeout(timeout);
-        stream.write("exit\n");
-        stream.end();
-      }
-    });
-
-    stream.on("close", () => {
-      clearTimeout(timeout);
-      if (settled) return;
-      settled = true;
-
-      if (completed) {
-        resolve();
-      } else {
-        reject(new Error(`su verification failed for user ${targetUsername}. Output: ${output}`));
-      }
-    });
-
-    stream.on("error", (streamErr: Error) => {
-      clearTimeout(timeout);
-      safeReject(new Error(`Stream error: ${streamErr.message}`));
-    });
-  });
+  return runSuLoginVerification(stream, targetUsername, targetPassword);
 };
 
 export const unixLinuxLocalAccountRotationFactory: TRotationFactory<

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
@@ -79,16 +79,16 @@ export const runManagedPasswordChange = (
     secrets: [newPassword, appConnectionPassword],
 
     advance: (ctx) => {
-      const failure = MANAGED_PASSWORD_CHANGE_FAILED.exec(ctx.pending);
+      const failure = MANAGED_PASSWORD_CHANGE_FAILED.exec(ctx.unmatched);
       if (failure) {
-        errorMessage = ctx.transcript.redact(lineAt(ctx.pending, failure.index));
+        errorMessage = ctx.transcript.redact(lineAt(ctx.unmatched, failure.index));
         ctx.consume(failure);
         ctx.finish();
         return false;
       }
 
       if (step === 0) {
-        const sudoPrompt = SUDO_PROMPT.exec(ctx.pending);
+        const sudoPrompt = SUDO_PROMPT.exec(ctx.unmatched);
         if (sudoPrompt) {
           if (!appConnectionPassword) {
             ctx.safeReject(
@@ -103,7 +103,7 @@ export const runManagedPasswordChange = (
           return true;
         }
 
-        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(ctx.pending);
+        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (newPasswordPrompt) {
           ctx.consume(newPasswordPrompt);
           ctx.write(`${newPassword}\n`);
@@ -115,7 +115,7 @@ export const runManagedPasswordChange = (
       }
 
       if (step === 1) {
-        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(ctx.pending);
+        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (confirmPrompt) {
           ctx.consume(confirmPrompt);
           ctx.write(`${newPassword}\n`);
@@ -126,7 +126,7 @@ export const runManagedPasswordChange = (
         return false;
       }
 
-      const success = PASSWORD_CHANGE_SUCCEEDED.exec(ctx.pending);
+      const success = PASSWORD_CHANGE_SUCCEEDED.exec(ctx.unmatched);
       if (success) {
         ctx.consume(success);
         completed = true;
@@ -182,9 +182,9 @@ export const runSelfPasswordChange = (
 
     advance: (ctx) => {
       if (step >= 1) {
-        const failure = SELF_PASSWORD_CHANGE_FAILED.exec(ctx.pending);
+        const failure = SELF_PASSWORD_CHANGE_FAILED.exec(ctx.unmatched);
         if (failure) {
-          errorMessage = ctx.transcript.redact(lineAt(ctx.pending, failure.index));
+          errorMessage = ctx.transcript.redact(lineAt(ctx.unmatched, failure.index));
           ctx.consume(failure);
           ctx.finish();
           return false;
@@ -192,7 +192,7 @@ export const runSelfPasswordChange = (
       }
 
       if (step === 0) {
-        const currentPasswordPrompt = ANY_PASSWORD_PROMPT.exec(ctx.pending);
+        const currentPasswordPrompt = ANY_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (currentPasswordPrompt) {
           ctx.consume(currentPasswordPrompt);
           ctx.write(`${oldPassword}\n`);
@@ -204,7 +204,7 @@ export const runSelfPasswordChange = (
       }
 
       if (step === 1) {
-        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(ctx.pending);
+        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (newPasswordPrompt) {
           ctx.consume(newPasswordPrompt);
           ctx.write(`${newPassword}\n`);
@@ -216,7 +216,7 @@ export const runSelfPasswordChange = (
       }
 
       if (step === 2) {
-        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(ctx.pending);
+        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (confirmPrompt) {
           ctx.consume(confirmPrompt);
           ctx.write(`${newPassword}\n`);
@@ -227,7 +227,7 @@ export const runSelfPasswordChange = (
         return false;
       }
 
-      const success = PASSWORD_CHANGE_SUCCEEDED.exec(ctx.pending);
+      const success = PASSWORD_CHANGE_SUCCEEDED.exec(ctx.unmatched);
       if (success) {
         ctx.consume(success);
         completed = true;
@@ -277,9 +277,9 @@ export const runSuLoginVerification = (
 
     advance: (ctx) => {
       if (step >= 1) {
-        const failure = SU_LOGIN_FAILED.exec(ctx.pending);
+        const failure = SU_LOGIN_FAILED.exec(ctx.unmatched);
         if (failure) {
-          const diagnostic = ctx.transcript.redact(lineAt(ctx.pending, failure.index));
+          const diagnostic = ctx.transcript.redact(lineAt(ctx.unmatched, failure.index));
           ctx.consume(failure);
           ctx.safeReject(new Error(`su authentication failed for user ${targetUsername}. Output: ${diagnostic}`));
           return false;
@@ -287,7 +287,7 @@ export const runSuLoginVerification = (
       }
 
       if (step === 0) {
-        const passwordPrompt = ANY_PASSWORD_PROMPT.exec(ctx.pending);
+        const passwordPrompt = ANY_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (passwordPrompt) {
           ctx.consume(passwordPrompt);
           ctx.write(`${targetPassword}\n`);
@@ -299,14 +299,14 @@ export const runSuLoginVerification = (
       }
 
       if (step === 1) {
-        if (!ctx.pending.trim()) return false;
-        ctx.clearPending();
+        if (!ctx.unmatched.trim()) return false;
+        ctx.clearUnmatched();
         ctx.write("whoami\n");
         step = 2;
         return true;
       }
 
-      if (whoamiReply.test(ctx.pending)) {
+      if (whoamiReply.test(ctx.unmatched)) {
         completed = true;
         ctx.write("exit\n");
         ctx.finish();

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
@@ -1,5 +1,3 @@
-import { StringDecoder } from "node:string_decoder";
-
 import RE2 from "re2";
 import { Client, ClientChannel } from "ssh2";
 
@@ -22,6 +20,13 @@ import {
 import { generatePasswordWithConstraints } from "@app/services/secret-validation-rule/secret-validation-rule-password-generator";
 
 import { generatePassword } from "../shared/utils";
+import {
+  escapeForPattern,
+  lineAt,
+  MAX_BUFFER_SIZE,
+  runExpectSession,
+  TInteractiveShellStream
+} from "./pty-expect-engine";
 import { UnixLinuxLocalAccountRotationMethod } from "./unix-linux-local-account-rotation-schemas";
 import {
   TUnixLinuxLocalAccountRotationGeneratedCredentials,
@@ -29,9 +34,7 @@ import {
   TUnixLinuxLocalAccountRotationWithConnection
 } from "./unix-linux-local-account-rotation-types";
 
-const SHELL_TIMEOUT = 15_000;
-const MAX_BUFFER_SIZE = 64 * 1024;
-const MAX_TRANSCRIPT_SIZE = 4 * 1024;
+export type { TInteractiveShellStream } from "./pty-expect-engine";
 
 const SUDO_PROMPT = new RE2("\\[sudo\\]", "i");
 const ANY_PASSWORD_PROMPT = new RE2("password", "i");
@@ -45,47 +48,11 @@ const MANAGED_PASSWORD_CHANGE_FAILED = new RE2(
 const SELF_PASSWORD_CHANGE_FAILED = new RE2("\\berror\\b|\\bfail(?:ed|ure|s)?\\b|\\bunchanged\\b", "i");
 const SU_LOGIN_FAILED = new RE2("\\bauthentication\\s+failure\\b|\\bincorrect\\s+password\\b|\\bsu:", "i");
 
-export type TInteractiveShellStream = {
-  on(event: "data", listener: (chunk: Buffer) => void): void;
-  on(event: "close", listener: () => void): void;
-  on(event: "error", listener: (err: Error) => void): void;
-  write(data: string): void;
-  end(): void;
-};
+const passwdOverflowMessage = (t: string) =>
+  `Password change failed: the host sent more than ${MAX_BUFFER_SIZE / 1024} KB of output without a recognized prompt. Output: ${t}`;
 
-const escapeForPattern = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const passwdTimeoutMessage = (t: string) => `Password change timed out. Output: ${t}`;
 
-const lineAt = (text: string, index: number) => {
-  const start = text.lastIndexOf("\n", index) + 1;
-  const end = text.indexOf("\n", index);
-  return (end === -1 ? text.slice(start) : text.slice(start, end)).trim();
-};
-
-// The transcript is interpolated into rotation errors, which are persisted and rendered in the UI,
-// so bounding and redaction live here: no individual error site can forget to apply them.
-const createTranscript = (secrets: (string | undefined)[]) => {
-  const knownSecrets = secrets.filter((secret): secret is string => Boolean(secret));
-  const redact = (value: string) =>
-    knownSecrets.reduce((redacted, secret) => redacted.replaceAll(secret, "***"), value);
-
-  let text = "";
-  let truncated = false;
-
-  return {
-    append: (chunk: string) => {
-      text += chunk;
-      if (text.length > MAX_TRANSCRIPT_SIZE) {
-        text = text.slice(-MAX_TRANSCRIPT_SIZE);
-        truncated = true;
-      }
-    },
-    redact,
-    read: () => (truncated ? `...${redact(text)}` : redact(text))
-  };
-};
-
-// Execute a command via SSH exec with a PTY (no login shell, no MOTD)
-// Returns a stream that can be used for interactive I/O
 const execCommandWithPty = (client: Client, command: string): Promise<ClientChannel> => {
   return new Promise((resolve, reject) => {
     client.exec(command, { pty: true }, (err, stream) => {
@@ -98,84 +65,48 @@ const execCommandWithPty = (client: Client, command: string): Promise<ClientChan
   });
 };
 
-// Drives the prompts of `passwd <username>` for managed rotation (admin changing another user's
-// password). Prompts are matched against everything received so far, not just the arriving chunk:
-// a PTY behind an SSH channel and a gateway tunnel re-segments freely, so a prompt can straddle
-// two data events.
 export const runManagedPasswordChange = (
   stream: TInteractiveShellStream,
   newPassword: string,
   appConnectionPassword?: string
 ): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    const transcript = createTranscript([newPassword, appConnectionPassword]);
-    const decoder = new StringDecoder("utf8");
+  let step = 0;
+  let completed = false;
+  let errorMessage = "";
 
-    let pending = "";
-    let step = 0;
-    let completed = false;
-    let settled = false;
-    let closing = false;
-    let errorMessage = "";
+  return runExpectSession({
+    stream,
+    secrets: [newPassword, appConnectionPassword],
 
-    const safeReject = (error: Error) => {
-      if (!settled) {
-        settled = true;
-        reject(error);
-      }
-    };
-
-    const timeout = setTimeout(() => {
-      if (!settled) {
-        stream.end();
-        safeReject(new Error(`Password change timed out. Output: ${transcript.read()}`));
-      }
-    }, SHELL_TIMEOUT);
-
-    const finish = () => {
-      closing = true;
-      clearTimeout(timeout);
-      stream.end();
-    };
-
-    // Matched text is dropped so the same bytes cannot satisfy a later step as well, which would
-    // send the new password a third time or read the first prompt as its own confirmation.
-    const consume = (match: RegExpExecArray) => {
-      pending = pending.slice(match.index + match[0].length);
-    };
-
-    const advance = (): boolean => {
-      const failure = MANAGED_PASSWORD_CHANGE_FAILED.exec(pending);
+    advance: (ctx) => {
+      const failure = MANAGED_PASSWORD_CHANGE_FAILED.exec(ctx.pending);
       if (failure) {
-        errorMessage = transcript.redact(lineAt(pending, failure.index));
-        consume(failure);
-        finish();
+        errorMessage = ctx.transcript.redact(lineAt(ctx.pending, failure.index));
+        ctx.consume(failure);
+        ctx.finish();
         return false;
       }
 
       if (step === 0) {
-        const sudoPrompt = SUDO_PROMPT.exec(pending);
+        const sudoPrompt = SUDO_PROMPT.exec(ctx.pending);
         if (sudoPrompt) {
           if (!appConnectionPassword) {
-            clearTimeout(timeout);
-            safeReject(
+            ctx.safeReject(
               new Error(
                 "sudo is requesting a password but the app connection uses SSH key authentication. Configure the app connection with password authentication, or configure NOPASSWD in sudoers for this user."
               )
             );
-            stream.end();
             return false;
           }
-          consume(sudoPrompt);
-          stream.write(`${appConnectionPassword}\n`);
-          // Still step 0: the new-password prompt follows, and may already be in this buffer.
+          ctx.consume(sudoPrompt);
+          ctx.write(`${appConnectionPassword}\n`);
           return true;
         }
 
-        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(pending);
+        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(ctx.pending);
         if (newPasswordPrompt) {
-          consume(newPasswordPrompt);
-          stream.write(`${newPassword}\n`);
+          ctx.consume(newPasswordPrompt);
+          ctx.write(`${newPassword}\n`);
           step = 1;
           return true;
         }
@@ -184,10 +115,10 @@ export const runManagedPasswordChange = (
       }
 
       if (step === 1) {
-        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(pending);
+        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(ctx.pending);
         if (confirmPrompt) {
-          consume(confirmPrompt);
-          stream.write(`${newPassword}\n`);
+          ctx.consume(confirmPrompt);
+          ctx.write(`${newPassword}\n`);
           step = 2;
           return true;
         }
@@ -195,69 +126,34 @@ export const runManagedPasswordChange = (
         return false;
       }
 
-      const success = PASSWORD_CHANGE_SUCCEEDED.exec(pending);
+      const success = PASSWORD_CHANGE_SUCCEEDED.exec(ctx.pending);
       if (success) {
-        consume(success);
+        ctx.consume(success);
         completed = true;
-        finish();
+        ctx.finish();
       }
 
       return false;
-    };
+    },
 
-    stream.on("data", (chunk: Buffer) => {
-      if (settled || closing) return;
-
-      const text = decoder.write(chunk);
-      if (!text) return;
-
-      transcript.append(text);
-      pending += text;
-
-      // A host can coalesce several prompts into one chunk, and once it is waiting on our answer no
-      // further data event arrives, so advance until nothing more matches instead of once per event.
-      let progressed = true;
-      while (progressed && !settled && !closing) {
-        progressed = advance();
-      }
-
-      if (!settled && !closing && pending.length > MAX_BUFFER_SIZE) {
-        clearTimeout(timeout);
-        stream.end();
-        safeReject(
-          new Error(
-            `Password change failed: the host sent more than ${MAX_BUFFER_SIZE / 1024} KB of output without a recognized prompt. Output: ${transcript.read()}`
-          )
-        );
-      }
-    });
-
-    stream.on("close", () => {
-      clearTimeout(timeout);
-      const tail = decoder.end();
-      if (tail) transcript.append(tail);
-      if (settled) return;
-      settled = true;
-
+    resolveOnClose: (ctx) => {
       if (errorMessage && !completed) {
-        reject(new Error(`Password change failed: ${errorMessage}`));
-      } else if (completed || step >= 2) {
-        resolve();
-      } else {
-        reject(new Error(`Password change incomplete (step ${step}). Output: ${transcript.read()}`));
+        return { resolve: false, error: new Error(`Password change failed: ${errorMessage}`) };
       }
-    });
+      if (completed || step >= 2) {
+        return { resolve: true };
+      }
+      return {
+        resolve: false,
+        error: new Error(`Password change incomplete (step ${step}). Output: ${ctx.transcript.read()}`)
+      };
+    },
 
-    stream.on("error", (streamErr: Error) => {
-      clearTimeout(timeout);
-      safeReject(new Error(`Stream error: ${streamErr.message}`));
-    });
+    overflowMessage: passwdOverflowMessage,
+    timeoutMessage: passwdTimeoutMessage
   });
 };
 
-// Change password for managed rotation (admin changing another user's password)
-// Uses `sudo passwd <username>` (or `passwd <username>`) executed via PTY
-// LC_ALL=C forces English prompts regardless of system locale
 const changeManagedPassword = async (
   client: Client,
   targetUsername: string,
@@ -271,64 +167,35 @@ const changeManagedPassword = async (
   return runManagedPasswordChange(stream, newPassword, appConnectionPassword);
 };
 
-// Drives the prompts of `passwd` for self rotation (user changing their own password), matching
-// against everything received so far for the same reason as the managed handler.
 export const runSelfPasswordChange = (
   stream: TInteractiveShellStream,
   oldPassword: string,
   newPassword: string
 ): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    const transcript = createTranscript([oldPassword, newPassword]);
-    const decoder = new StringDecoder("utf8");
+  let step = 0;
+  let completed = false;
+  let errorMessage = "";
 
-    let pending = "";
-    let step = 0;
-    let completed = false;
-    let settled = false;
-    let closing = false;
-    let errorMessage = "";
+  return runExpectSession({
+    stream,
+    secrets: [oldPassword, newPassword],
 
-    const safeReject = (error: Error) => {
-      if (!settled) {
-        settled = true;
-        reject(error);
-      }
-    };
-
-    const timeout = setTimeout(() => {
-      if (!settled) {
-        stream.end();
-        safeReject(new Error(`Password change timed out. Output: ${transcript.read()}`));
-      }
-    }, SHELL_TIMEOUT);
-
-    const finish = () => {
-      closing = true;
-      clearTimeout(timeout);
-      stream.end();
-    };
-
-    const consume = (match: RegExpExecArray) => {
-      pending = pending.slice(match.index + match[0].length);
-    };
-
-    const advance = (): boolean => {
+    advance: (ctx) => {
       if (step >= 1) {
-        const failure = SELF_PASSWORD_CHANGE_FAILED.exec(pending);
+        const failure = SELF_PASSWORD_CHANGE_FAILED.exec(ctx.pending);
         if (failure) {
-          errorMessage = transcript.redact(lineAt(pending, failure.index));
-          consume(failure);
-          finish();
+          errorMessage = ctx.transcript.redact(lineAt(ctx.pending, failure.index));
+          ctx.consume(failure);
+          ctx.finish();
           return false;
         }
       }
 
       if (step === 0) {
-        const currentPasswordPrompt = ANY_PASSWORD_PROMPT.exec(pending);
+        const currentPasswordPrompt = ANY_PASSWORD_PROMPT.exec(ctx.pending);
         if (currentPasswordPrompt) {
-          consume(currentPasswordPrompt);
-          stream.write(`${oldPassword}\n`);
+          ctx.consume(currentPasswordPrompt);
+          ctx.write(`${oldPassword}\n`);
           step = 1;
           return true;
         }
@@ -337,10 +204,10 @@ export const runSelfPasswordChange = (
       }
 
       if (step === 1) {
-        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(pending);
+        const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(ctx.pending);
         if (newPasswordPrompt) {
-          consume(newPasswordPrompt);
-          stream.write(`${newPassword}\n`);
+          ctx.consume(newPasswordPrompt);
+          ctx.write(`${newPassword}\n`);
           step = 2;
           return true;
         }
@@ -349,10 +216,10 @@ export const runSelfPasswordChange = (
       }
 
       if (step === 2) {
-        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(pending);
+        const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(ctx.pending);
         if (confirmPrompt) {
-          consume(confirmPrompt);
-          stream.write(`${newPassword}\n`);
+          ctx.consume(confirmPrompt);
+          ctx.write(`${newPassword}\n`);
           step = 3;
           return true;
         }
@@ -360,133 +227,70 @@ export const runSelfPasswordChange = (
         return false;
       }
 
-      const success = PASSWORD_CHANGE_SUCCEEDED.exec(pending);
+      const success = PASSWORD_CHANGE_SUCCEEDED.exec(ctx.pending);
       if (success) {
-        consume(success);
+        ctx.consume(success);
         completed = true;
-        finish();
+        ctx.finish();
       }
 
       return false;
-    };
+    },
 
-    stream.on("data", (chunk: Buffer) => {
-      if (settled || closing) return;
-
-      const text = decoder.write(chunk);
-      if (!text) return;
-
-      transcript.append(text);
-      pending += text;
-
-      let progressed = true;
-      while (progressed && !settled && !closing) {
-        progressed = advance();
-      }
-
-      if (!settled && !closing && pending.length > MAX_BUFFER_SIZE) {
-        clearTimeout(timeout);
-        stream.end();
-        safeReject(
-          new Error(
-            `Password change failed: the host sent more than ${MAX_BUFFER_SIZE / 1024} KB of output without a recognized prompt. Output: ${transcript.read()}`
-          )
-        );
-      }
-    });
-
-    stream.on("close", () => {
-      clearTimeout(timeout);
-      const tail = decoder.end();
-      if (tail) transcript.append(tail);
-      if (settled) return;
-      settled = true;
-
+    resolveOnClose: (ctx) => {
       if (errorMessage && !completed) {
-        reject(new Error(`Password change failed: ${errorMessage}`));
-      } else if (completed || step >= 3) {
-        resolve();
-      } else {
-        reject(new Error(`Password change incomplete (step ${step}). Output: ${transcript.read()}`));
+        return { resolve: false, error: new Error(`Password change failed: ${errorMessage}`) };
       }
-    });
+      if (completed || step >= 3) {
+        return { resolve: true };
+      }
+      return {
+        resolve: false,
+        error: new Error(`Password change incomplete (step ${step}). Output: ${ctx.transcript.read()}`)
+      };
+    },
 
-    stream.on("error", (streamErr: Error) => {
-      clearTimeout(timeout);
-      safeReject(new Error(`Stream error: ${streamErr.message}`));
-    });
+    overflowMessage: passwdOverflowMessage,
+    timeoutMessage: passwdTimeoutMessage
   });
 };
 
-// Change password for self rotation (user changing their own password)
-// Uses `passwd` executed via PTY to handle interactive prompts
-// LC_ALL=C forces English prompts regardless of system locale
 const changeSelfPassword = async (client: Client, oldPassword: string, newPassword: string): Promise<void> => {
   const stream = await execCommandWithPty(client, "LC_ALL=C passwd");
 
   return runSelfPasswordChange(stream, oldPassword, newPassword);
 };
 
-// Drives the prompts of `su - <username>`, matching against everything received so far for the same
-// reason as the password handlers.
 export const runSuLoginVerification = (
   stream: TInteractiveShellStream,
   targetUsername: string,
   targetPassword: string
 ): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    const transcript = createTranscript([targetPassword]);
-    const decoder = new StringDecoder("utf8");
-    const whoamiReply = new RE2(escapeForPattern(targetUsername), "i");
+  const whoamiReply = new RE2(escapeForPattern(targetUsername), "i");
 
-    let pending = "";
-    let step = 0;
-    let completed = false;
-    let settled = false;
-    let closing = false;
+  let step = 0;
+  let completed = false;
 
-    const safeReject = (error: Error) => {
-      if (!settled) {
-        settled = true;
-        reject(error);
-      }
-    };
+  return runExpectSession({
+    stream,
+    secrets: [targetPassword],
 
-    const timeout = setTimeout(() => {
-      if (!settled) {
-        stream.end();
-        safeReject(new Error(`su verification timed out. Output: ${transcript.read()}`));
-      }
-    }, SHELL_TIMEOUT);
-
-    const finish = () => {
-      closing = true;
-      clearTimeout(timeout);
-      stream.end();
-    };
-
-    const consume = (match: RegExpExecArray) => {
-      pending = pending.slice(match.index + match[0].length);
-    };
-
-    const advance = (): boolean => {
+    advance: (ctx) => {
       if (step >= 1) {
-        const failure = SU_LOGIN_FAILED.exec(pending);
+        const failure = SU_LOGIN_FAILED.exec(ctx.pending);
         if (failure) {
-          const diagnostic = transcript.redact(lineAt(pending, failure.index));
-          consume(failure);
-          clearTimeout(timeout);
-          safeReject(new Error(`su authentication failed for user ${targetUsername}. Output: ${diagnostic}`));
-          stream.end();
+          const diagnostic = ctx.transcript.redact(lineAt(ctx.pending, failure.index));
+          ctx.consume(failure);
+          ctx.safeReject(new Error(`su authentication failed for user ${targetUsername}. Output: ${diagnostic}`));
           return false;
         }
       }
 
       if (step === 0) {
-        const passwordPrompt = ANY_PASSWORD_PROMPT.exec(pending);
+        const passwordPrompt = ANY_PASSWORD_PROMPT.exec(ctx.pending);
         if (passwordPrompt) {
-          consume(passwordPrompt);
-          stream.write(`${targetPassword}\n`);
+          ctx.consume(passwordPrompt);
+          ctx.write(`${targetPassword}\n`);
           step = 1;
           return true;
         }
@@ -495,73 +299,38 @@ export const runSuLoginVerification = (
       }
 
       if (step === 1) {
-        // Anything buffered here is su's own banner or shell prompt; only the reply to whoami names
-        // the user we ended up as, so it is dropped rather than sliced.
-        if (!pending.trim()) return false;
-        pending = "";
-        stream.write("whoami\n");
+        if (!ctx.pending.trim()) return false;
+        ctx.clearPending();
+        ctx.write("whoami\n");
         step = 2;
         return true;
       }
 
-      if (whoamiReply.test(pending)) {
+      if (whoamiReply.test(ctx.pending)) {
         completed = true;
-        stream.write("exit\n");
-        finish();
+        ctx.write("exit\n");
+        ctx.finish();
       }
 
       return false;
-    };
+    },
 
-    stream.on("data", (chunk: Buffer) => {
-      if (settled || closing) return;
-
-      const text = decoder.write(chunk);
-      if (!text) return;
-
-      transcript.append(text);
-      pending += text;
-
-      let progressed = true;
-      while (progressed && !settled && !closing) {
-        progressed = advance();
-      }
-
-      if (!settled && !closing && pending.length > MAX_BUFFER_SIZE) {
-        clearTimeout(timeout);
-        stream.end();
-        safeReject(
-          new Error(
-            `su verification failed for user ${targetUsername}: the host sent more than ${MAX_BUFFER_SIZE / 1024} KB of output without a recognized prompt. Output: ${transcript.read()}`
-          )
-        );
-      }
-    });
-
-    stream.on("close", () => {
-      clearTimeout(timeout);
-      const tail = decoder.end();
-      if (tail) transcript.append(tail);
-      if (settled) return;
-      settled = true;
-
+    resolveOnClose: (ctx) => {
       if (completed) {
-        resolve();
-      } else {
-        reject(new Error(`su verification failed for user ${targetUsername}. Output: ${transcript.read()}`));
+        return { resolve: true };
       }
-    });
+      return {
+        resolve: false,
+        error: new Error(`su verification failed for user ${targetUsername}. Output: ${ctx.transcript.read()}`)
+      };
+    },
 
-    stream.on("error", (streamErr: Error) => {
-      clearTimeout(timeout);
-      safeReject(new Error(`Stream error: ${streamErr.message}`));
-    });
+    overflowMessage: (t) =>
+      `su verification failed for user ${targetUsername}: the host sent more than ${MAX_BUFFER_SIZE / 1024} KB of output without a recognized prompt. Output: ${t}`,
+    timeoutMessage: (t) => `su verification timed out. Output: ${t}`
   });
 };
 
-// Verify credentials by using `su - <username>` via an existing SSH connection
-// Used as fallback when direct SSH login is not allowed for the target account
-// LC_ALL=C forces English prompts regardless of system locale
 const verifySuLogin = async (client: Client, targetUsername: string, targetPassword: string): Promise<void> => {
   const stream = await execCommandWithPty(client, `LC_ALL=C su - ${targetUsername}`);
 
@@ -617,14 +386,13 @@ export const unixLinuxLocalAccountRotationFactory: TRotationFactory<
       }
     };
 
-    // Attempt 1: Direct SSH login with target credentials
     let directSshError: string | undefined;
     try {
       await executeWithPotentialGateway(verifyConfig, gatewayV2Service, async (targetHost, targetPort) => {
         const client = await getSshConnectionClient(verifyConfig, targetHost, targetPort);
         client.destroy();
       });
-      return; // Direct SSH worked
+      return;
     } catch (error) {
       directSshError = (error as Error).message;
       logger.info(
@@ -634,7 +402,6 @@ export const unixLinuxLocalAccountRotationFactory: TRotationFactory<
       );
     }
 
-    // Attempt 2: SSH with app connection, then su to target user
     const appConnConfig: TSshConnectionConfig = {
       method: conn.method,
       app: conn.app,
@@ -664,7 +431,6 @@ export const unixLinuxLocalAccountRotationFactory: TRotationFactory<
     }
   };
 
-  // Main password rotation logic
   const $rotatePassword = async (currentPassword?: string): Promise<{ username: string; password: string }> => {
     const conn = await getResolvedConnection();
     const { credentials } = conn;
@@ -728,7 +494,6 @@ export const unixLinuxLocalAccountRotationFactory: TRotationFactory<
       }
     });
 
-    // Verify the new credentials work
     await $verifyCredentials(username, newPassword);
 
     return { username, password: newPassword };
@@ -746,9 +511,6 @@ export const unixLinuxLocalAccountRotationFactory: TRotationFactory<
     TUnixLinuxLocalAccountRotationGeneratedCredentials
   > = async (credentialsToRevoke, callback) => {
     const currentPassword = credentialsToRevoke[activeIndex].password;
-    // We just rotate to a new password, essentially revoking old credentials
-    // For self rotation: we need current password to authenticate
-    // For managed rotation: admin uses their own credentials
     await $rotatePassword(currentPassword);
     return callback();
   };
@@ -756,9 +518,6 @@ export const unixLinuxLocalAccountRotationFactory: TRotationFactory<
   const rotateCredentials: TRotationFactoryRotateCredentials<
     TUnixLinuxLocalAccountRotationGeneratedCredentials
   > = async (_, callback, activeCredentials) => {
-    // For both methods, pass the current password
-    // Self rotation: needed to authenticate as the user
-    // Managed rotation: admin doesn't need it but it's harmless to pass
     const credentials = await $rotatePassword(activeCredentials.password);
     return callback(credentials);
   };

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
@@ -36,6 +36,25 @@ import {
 
 export type { TInteractiveShellStream } from "./pty-expect-engine";
 
+enum ManagedPasswdStep {
+  AwaitNewPasswordPrompt,
+  AwaitConfirmPrompt,
+  AwaitResult
+}
+
+enum SelfPasswdStep {
+  AwaitCurrentPasswordPrompt,
+  AwaitNewPasswordPrompt,
+  AwaitConfirmPrompt,
+  AwaitResult
+}
+
+enum SuVerifyStep {
+  AwaitPasswordPrompt,
+  AwaitShellReady,
+  AwaitWhoamiReply
+}
+
 const SUDO_PROMPT = new RE2("\\[sudo\\]", "i");
 const ANY_PASSWORD_PROMPT = new RE2("password", "i");
 const NEW_PASSWORD_PROMPT = new RE2("new\\s+password", "i");
@@ -70,7 +89,7 @@ export const runManagedPasswordChange = (
   newPassword: string,
   appConnectionPassword?: string
 ): Promise<void> => {
-  let step = 0;
+  let step: ManagedPasswdStep = ManagedPasswdStep.AwaitNewPasswordPrompt;
   let completed = false;
   let errorMessage = "";
 
@@ -87,7 +106,7 @@ export const runManagedPasswordChange = (
         return false;
       }
 
-      if (step === 0) {
+      if (step === ManagedPasswdStep.AwaitNewPasswordPrompt) {
         const sudoPrompt = SUDO_PROMPT.exec(ctx.unmatched);
         if (sudoPrompt) {
           if (!appConnectionPassword) {
@@ -107,19 +126,19 @@ export const runManagedPasswordChange = (
         if (newPasswordPrompt) {
           ctx.consume(newPasswordPrompt);
           ctx.write(`${newPassword}\n`);
-          step = 1;
+          step = ManagedPasswdStep.AwaitConfirmPrompt;
           return true;
         }
 
         return false;
       }
 
-      if (step === 1) {
+      if (step === ManagedPasswdStep.AwaitConfirmPrompt) {
         const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (confirmPrompt) {
           ctx.consume(confirmPrompt);
           ctx.write(`${newPassword}\n`);
-          step = 2;
+          step = ManagedPasswdStep.AwaitResult;
           return true;
         }
 
@@ -140,12 +159,12 @@ export const runManagedPasswordChange = (
       if (errorMessage && !completed) {
         return { resolve: false, error: new Error(`Password change failed: ${errorMessage}`) };
       }
-      if (completed || step >= 2) {
+      if (completed || step >= ManagedPasswdStep.AwaitResult) {
         return { resolve: true };
       }
       return {
         resolve: false,
-        error: new Error(`Password change incomplete (step ${step}). Output: ${ctx.transcript.read()}`)
+        error: new Error(`Password change incomplete (step: ${ManagedPasswdStep[step]}). Output: ${ctx.transcript.read()}`)
       };
     },
 
@@ -172,7 +191,7 @@ export const runSelfPasswordChange = (
   oldPassword: string,
   newPassword: string
 ): Promise<void> => {
-  let step = 0;
+  let step: SelfPasswdStep = SelfPasswdStep.AwaitCurrentPasswordPrompt;
   let completed = false;
   let errorMessage = "";
 
@@ -181,7 +200,7 @@ export const runSelfPasswordChange = (
     secrets: [oldPassword, newPassword],
 
     advance: (ctx) => {
-      if (step >= 1) {
+      if (step >= SelfPasswdStep.AwaitNewPasswordPrompt) {
         const failure = SELF_PASSWORD_CHANGE_FAILED.exec(ctx.unmatched);
         if (failure) {
           errorMessage = ctx.transcript.redact(lineAt(ctx.unmatched, failure.index));
@@ -191,36 +210,36 @@ export const runSelfPasswordChange = (
         }
       }
 
-      if (step === 0) {
+      if (step === SelfPasswdStep.AwaitCurrentPasswordPrompt) {
         const currentPasswordPrompt = ANY_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (currentPasswordPrompt) {
           ctx.consume(currentPasswordPrompt);
           ctx.write(`${oldPassword}\n`);
-          step = 1;
+          step = SelfPasswdStep.AwaitNewPasswordPrompt;
           return true;
         }
 
         return false;
       }
 
-      if (step === 1) {
+      if (step === SelfPasswdStep.AwaitNewPasswordPrompt) {
         const newPasswordPrompt = NEW_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (newPasswordPrompt) {
           ctx.consume(newPasswordPrompt);
           ctx.write(`${newPassword}\n`);
-          step = 2;
+          step = SelfPasswdStep.AwaitConfirmPrompt;
           return true;
         }
 
         return false;
       }
 
-      if (step === 2) {
+      if (step === SelfPasswdStep.AwaitConfirmPrompt) {
         const confirmPrompt = CONFIRM_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (confirmPrompt) {
           ctx.consume(confirmPrompt);
           ctx.write(`${newPassword}\n`);
-          step = 3;
+          step = SelfPasswdStep.AwaitResult;
           return true;
         }
 
@@ -241,12 +260,12 @@ export const runSelfPasswordChange = (
       if (errorMessage && !completed) {
         return { resolve: false, error: new Error(`Password change failed: ${errorMessage}`) };
       }
-      if (completed || step >= 3) {
+      if (completed || step >= SelfPasswdStep.AwaitResult) {
         return { resolve: true };
       }
       return {
         resolve: false,
-        error: new Error(`Password change incomplete (step ${step}). Output: ${ctx.transcript.read()}`)
+        error: new Error(`Password change incomplete (step: ${SelfPasswdStep[step]}). Output: ${ctx.transcript.read()}`)
       };
     },
 
@@ -268,7 +287,7 @@ export const runSuLoginVerification = (
 ): Promise<void> => {
   const whoamiReply = new RE2(escapeForPattern(targetUsername), "i");
 
-  let step = 0;
+  let step: SuVerifyStep = SuVerifyStep.AwaitPasswordPrompt;
   let completed = false;
 
   return runExpectSession({
@@ -276,7 +295,7 @@ export const runSuLoginVerification = (
     secrets: [targetPassword],
 
     advance: (ctx) => {
-      if (step >= 1) {
+      if (step >= SuVerifyStep.AwaitShellReady) {
         const failure = SU_LOGIN_FAILED.exec(ctx.unmatched);
         if (failure) {
           const diagnostic = ctx.transcript.redact(lineAt(ctx.unmatched, failure.index));
@@ -286,23 +305,23 @@ export const runSuLoginVerification = (
         }
       }
 
-      if (step === 0) {
+      if (step === SuVerifyStep.AwaitPasswordPrompt) {
         const passwordPrompt = ANY_PASSWORD_PROMPT.exec(ctx.unmatched);
         if (passwordPrompt) {
           ctx.consume(passwordPrompt);
           ctx.write(`${targetPassword}\n`);
-          step = 1;
+          step = SuVerifyStep.AwaitShellReady;
           return true;
         }
 
         return false;
       }
 
-      if (step === 1) {
+      if (step === SuVerifyStep.AwaitShellReady) {
         if (!ctx.unmatched.trim()) return false;
         ctx.clearUnmatched();
         ctx.write("whoami\n");
-        step = 2;
+        step = SuVerifyStep.AwaitWhoamiReply;
         return true;
       }
 

--- a/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
+++ b/backend/src/ee/services/secret-rotation-v2/unix-linux-local-account-rotation/unix-linux-local-account-rotation-fns.ts
@@ -164,7 +164,9 @@ export const runManagedPasswordChange = (
       }
       return {
         resolve: false,
-        error: new Error(`Password change incomplete (step: ${ManagedPasswdStep[step]}). Output: ${ctx.transcript.read()}`)
+        error: new Error(
+          `Password change incomplete (step: ${ManagedPasswdStep[step]}). Output: ${ctx.transcript.read()}`
+        )
       };
     },
 


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Linux/Unix password rotations can fail depending on how ssh streams the data to our server, usually it happens in chunks and there's a risk of a chunk not matching our expect placeholders: `new password` for example. This can be sent as 2 chunks: `new ` and `password`.

Now we keep track of all unmatched output sent by SSH so we can concatenate the chunks and match the whole thing. Preventing our rotation from failing due to placeholders being sent in different chunks.

## Steps to verify the change

1. Review unit tests
2. Test rotation to check for regressions

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)