### PR TITLE
fix(ui): show dynamic secret icon in multi-environment view

### DIFF
--- a/frontend/src/pages/secret-manager/OverviewPage/components/DynamicSecretTableRow/DynamicSecretTableRow.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/DynamicSecretTableRow/DynamicSecretTableRow.tsx
@@ -2,7 +2,6 @@ import { subject } from "@casl/ability";
 import {
   AlertTriangleIcon,
   ChevronDownIcon,
-  ChevronRightIcon,
   EditIcon,
   FileKeyIcon,
   FingerprintIcon,
@@ -281,7 +280,11 @@ export const DynamicSecretTableRow = ({
                 setIsExpanded.toggle();
               }}
             >
-              {isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+              {isExpanded ? (
+                <ChevronDownIcon />
+              ) : (
+                <FingerprintIcon className="text-dynamic-secret" />
+              )}
             </IconButton>
           ) : (
             <FingerprintIcon className="text-dynamic-secret" />


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Dynamic secrets showed a generic right-chevron instead of their resource icon in the Secret Manager multi-environment view. This made the row inconsistent with folders, secrets, imports, rotations, honey tokens, and proxied services, which show their resource identity while collapsed.

Collapsed dynamic-secret rows now show the existing fingerprint icon with the semantic dynamic-secret color. Expanded rows continue to show the down-chevron, and the explicit expand/collapse button retains its accessible name and `aria-expanded` state.

Related ticket: [SECRETS-620](https://linear.app/infisical/issue/SECRETS-620/show-an-icon-for-dynamic-secrets-in-multi-environment-view)

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

Current after-change screenshots are outstanding because browser testing was not authorized. The Live Preview can be used to verify the collapsed and expanded row states.

## Steps to verify the change

1. Open a Secret Manager project with at least two environments and a dynamic secret.
2. Open the Secrets Overview in the multi-environment view.
3. Confirm the collapsed dynamic-secret row shows the fingerprint icon in the dynamic-secret semantic color.
4. Expand the row and confirm the fingerprint changes to the down-chevron.
5. Collapse the row using the icon button and confirm its accessible expand/collapse state remains correct.

Local validation:
- Targeted frontend validation passed.
- Serialized frontend lint and TypeScript gate passed with receipt `919c2583…`.
- `git diff --check` passed.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g. `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (not needed)
- [x] Updated CLAUDE.md files (not needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)