### PR TITLE
fix(identity-ua): count client secret uses atomically

### DIFF
--- a/backend/e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts
@@ -141,6 +141,9 @@ describe("Universal Auth client secret usage limit", async () => {
           body: { clientId, clientSecret }
         });
         expect(afterBurst.statusCode).toBe(401);
+        // and it says why. Revoking mid-burst would make this attempt miss the secret entirely and
+        // answer "Invalid credentials", which is both untrue and a failed-credential strike
+        expect(afterBurst.json().message).toBe(USAGE_LIMIT_REACHED_MESSAGE);
         expect((await readClientSecretRow(clientSecretId))?.isClientSecretRevoked).toBe(true);
       } finally {
         await deleteIdentity(identityId);

--- a/backend/e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts
@@ -44,7 +44,9 @@ const createUaIdentity = async (name: string, numUsesLimit: number) => {
     body: {
       accessTokenTTL: 2592000,
       accessTokenMaxTTL: 2592000,
-      accessTokenNumUsesLimit: 0
+      accessTokenNumUsesLimit: 0,
+      // a burst of rejections must not be able to trip the lockout and change what these assert
+      lockoutEnabled: false
     }
   });
   expect(attachRes.statusCode).toBe(200);
@@ -127,7 +129,19 @@ describe("Universal Auth client secret usage limit", async () => {
         // exactly the limit: no increments lost by the winners, none burned by the losers
         const row = await readClientSecretRow(clientSecretId);
         expect(row?.clientSecretNumUses).toBe(numUsesLimit);
-        expect(row?.isClientSecretRevoked).toBe(true);
+
+        // a spent secret is revoked by the next attempt rather than mid-burst. Revoking during the
+        // burst would hide it from the secret lookup and send the rest of the burst down the
+        // invalid-credential path, which feeds the lockout counter for the whole clientId
+        expect(row?.isClientSecretRevoked).toBe(false);
+
+        const afterBurst = await testServer.inject({
+          method: "POST",
+          url: "/api/v1/auth/universal-auth/login",
+          body: { clientId, clientSecret }
+        });
+        expect(afterBurst.statusCode).toBe(401);
+        expect((await readClientSecretRow(clientSecretId))?.isClientSecretRevoked).toBe(true);
       } finally {
         await deleteIdentity(identityId);
       }

--- a/backend/e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * E2E tests for the Universal Auth client-secret usage limit under concurrency.
+ *
+ * Prerequisites (handled by vitest-environment-knex.ts):
+ *   - testServer: running Fastify instance
+ *   - jwtAuthToken: pre-authenticated admin JWT (user session)
+ *   - testDb: knex instance
+ *
+ * numUsesLimit has to hold when logins arrive together, not just in sequence, so
+ * these cover the concurrent case a sequential test cannot reach.
+ *
+ * Rate limiting is only registered for production cloud (server/app.ts), so a
+ * burst of logins here is not throttled.
+ *
+ * Each test creates and tears down its own identity so nothing depends on or
+ * mutates the seeded machine identity.
+ */
+
+import { OrgMembershipRole, TableName } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+
+const CONCURRENCY = 20;
+const USAGE_LIMIT_REACHED_MESSAGE = "Access denied due to client secret usage limit reached";
+
+/** Create a temporary identity with Universal Auth and one client secret capped at numUsesLimit. */
+const createUaIdentity = async (name: string, numUsesLimit: number) => {
+  const createRes = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/identities",
+    headers: { authorization: `Bearer ${jwtAuthToken}` },
+    body: {
+      name,
+      role: OrgMembershipRole.Member,
+      organizationId: seedData1.organization.id
+    }
+  });
+  expect(createRes.statusCode).toBe(200);
+  const identity = createRes.json().identity as { id: string };
+
+  const attachRes = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/auth/universal-auth/identities/${identity.id}`,
+    headers: { authorization: `Bearer ${jwtAuthToken}` },
+    body: {
+      accessTokenTTL: 2592000,
+      accessTokenMaxTTL: 2592000,
+      accessTokenNumUsesLimit: 0
+    }
+  });
+  expect(attachRes.statusCode).toBe(200);
+
+  const csRes = await testServer.inject({
+    method: "POST",
+    url: `/api/v1/auth/universal-auth/identities/${identity.id}/client-secrets`,
+    headers: { authorization: `Bearer ${jwtAuthToken}` },
+    body: { numUsesLimit }
+  });
+  expect(csRes.statusCode).toBe(200);
+
+  return {
+    identityId: identity.id,
+    clientId: attachRes.json().identityUniversalAuth.clientId as string,
+    clientSecret: csRes.json().clientSecret as string,
+    clientSecretId: csRes.json().clientSecretData.id as string
+  };
+};
+
+const deleteIdentity = async (identityId: string) => {
+  await testServer.inject({
+    method: "DELETE",
+    url: `/api/v1/identities/${identityId}`,
+    headers: { authorization: `Bearer ${jwtAuthToken}` }
+  });
+};
+
+const loginConcurrently = (clientId: string, clientSecret: string) =>
+  Promise.all(
+    Array.from({ length: CONCURRENCY }, () =>
+      testServer.inject({
+        method: "POST",
+        url: "/api/v1/auth/universal-auth/login",
+        body: { clientId, clientSecret }
+      })
+    )
+  );
+
+const readClientSecretRow = async (clientSecretId: string) => {
+  const row = await testDb(TableName.IdentityUaClientSecret).where({ id: clientSecretId }).first<{
+    clientSecretNumUses: string | number;
+    isClientSecretRevoked: boolean;
+  }>("clientSecretNumUses", "isClientSecretRevoked");
+
+  // pg hands back int8 as a string, which is why the row schema coerces it
+  return row && { ...row, clientSecretNumUses: Number(row.clientSecretNumUses) };
+};
+
+describe("Universal Auth client secret usage limit", async () => {
+  test.each([
+    { label: "single-use", numUsesLimit: 1 },
+    { label: "multi-use", numUsesLimit: 5 }
+  ])(
+    "a $label client secret mints at most $numUsesLimit tokens under concurrent logins",
+    async ({ label, numUsesLimit }) => {
+      const { identityId, clientId, clientSecret, clientSecretId } = await createUaIdentity(
+        `test-ua-usage-limit-${label}`,
+        numUsesLimit
+      );
+
+      try {
+        const responses = await loginConcurrently(clientId, clientSecret);
+
+        const succeeded = responses.filter((res) => res.statusCode === 200);
+        const rejected = responses.filter((res) => res.statusCode !== 200);
+
+        expect(succeeded).toHaveLength(numUsesLimit);
+        expect(rejected).toHaveLength(CONCURRENCY - numUsesLimit);
+
+        // not an incidental failure, which would make the count above pass for the wrong reason
+        rejected.forEach((res) => {
+          expect(res.statusCode).toBe(401);
+          expect(res.json().message).toBe(USAGE_LIMIT_REACHED_MESSAGE);
+        });
+
+        const tokens = succeeded.map((res) => res.json().accessToken as string);
+        expect(new Set(tokens).size).toBe(numUsesLimit);
+
+        // exactly the limit: no increments lost by the winners, none burned by the losers
+        const row = await readClientSecretRow(clientSecretId);
+        expect(row?.clientSecretNumUses).toBe(numUsesLimit);
+        expect(row?.isClientSecretRevoked).toBe(true);
+      } finally {
+        await deleteIdentity(identityId);
+      }
+    }
+  );
+
+  test(`an unlimited client secret still serves all ${CONCURRENCY} concurrent logins`, async () => {
+    const { identityId, clientId, clientSecret, clientSecretId } = await createUaIdentity(
+      "test-ua-usage-limit-unlimited",
+      0
+    );
+
+    try {
+      const responses = await loginConcurrently(clientId, clientSecret);
+
+      expect(responses.filter((res) => res.statusCode === 200)).toHaveLength(CONCURRENCY);
+
+      // numUses is informational here and its write is debounced, so only usability is assertable
+      const row = await readClientSecretRow(clientSecretId);
+      expect(row?.isClientSecretRevoked).toBe(false);
+    } finally {
+      await deleteIdentity(identityId);
+    }
+  });
+
+  test("a single-use client secret is rejected on a sequential second login", async () => {
+    const { identityId, clientId, clientSecret } = await createUaIdentity("test-ua-usage-limit-sequential", 1);
+
+    try {
+      const first = await testServer.inject({
+        method: "POST",
+        url: "/api/v1/auth/universal-auth/login",
+        body: { clientId, clientSecret }
+      });
+      expect(first.statusCode).toBe(200);
+
+      const second = await testServer.inject({
+        method: "POST",
+        url: "/api/v1/auth/universal-auth/login",
+        body: { clientId, clientSecret }
+      });
+      expect(second.statusCode).toBe(401);
+      expect(second.json().message).toBe(USAGE_LIMIT_REACHED_MESSAGE);
+    } finally {
+      await deleteIdentity(identityId);
+    }
+  });
+});

--- a/backend/e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts
+++ b/backend/e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts
@@ -44,6 +44,7 @@ const createUaIdentity = async (name: string, numUsesLimit: number) => {
     body: {
       accessTokenTTL: 2592000,
       accessTokenMaxTTL: 2592000,
+      // a different counter from the client secret's own numUsesLimit; 0 is unlimited
       accessTokenNumUsesLimit: 0,
       // a burst of rejections must not be able to trip the lockout and change what these assert
       lockoutEnabled: false

--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -498,6 +498,26 @@ export const authAttemptDurationHistogram = infisicalCoreMeter.createHistogram("
   unit: "s"
 });
 
+// error.type buckets every rejected credential into "auth", which cannot tell a spent or
+// out-of-policy credential from a wrong one. The throw sites already carry a reasonCode, so this
+// surfaces it as a label. The list is the label's cardinality bound: add a code here to see it
+// broken out, and anything unlisted reports as "other".
+const AUTH_ATTEMPT_REASONS = new Set([
+  "client_id_not_found",
+  "invalid_client_secret",
+  "client_secret_expired",
+  "client_secret_usage_limit_reached",
+  "client_secret_usage_limit_raced",
+  "temporarily_locked",
+  "sub_org_unauthorized"
+]);
+
+const classifyAuthReason = (err: unknown): string | undefined => {
+  const reason = (err as { detail?: { reasonCode?: unknown } } | null)?.detail?.reasonCode;
+  if (typeof reason !== "string") return undefined;
+  return AUTH_ATTEMPT_REASONS.has(reason) ? reason : "other";
+};
+
 export const recordAuthAttemptMetric = (params: {
   startTime: number;
   method: AuthAttemptAuthMethod;
@@ -510,7 +530,11 @@ export const recordAuthAttemptMetric = (params: {
     "infisical.auth.method": params.method,
     "infisical.auth.result": params.result
   };
-  if (params.error !== undefined) attributes["error.type"] = classifyError(params.error);
+  if (params.error !== undefined) {
+    attributes["error.type"] = classifyError(params.error);
+    const reason = classifyAuthReason(params.error);
+    if (reason) attributes["infisical.auth.reason"] = reason;
+  }
   authAttemptDurationHistogram.record((performance.now() - params.startTime) / 1000, attributes);
 };
 

--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -503,7 +503,6 @@ export const authAttemptDurationHistogram = infisicalCoreMeter.createHistogram("
 // surfaces it as a label. The list is the label's cardinality bound: add a code here to see it
 // broken out, and anything unlisted reports as "other".
 const AUTH_ATTEMPT_REASONS = new Set([
-  "client_id_not_found",
   "invalid_client_secret",
   "client_secret_expired",
   "client_secret_usage_limit_reached",

--- a/backend/src/lib/telemetry/metrics.ts
+++ b/backend/src/lib/telemetry/metrics.ts
@@ -532,7 +532,7 @@ export const recordAuthAttemptMetric = (params: {
   if (params.error !== undefined) {
     attributes["error.type"] = classifyError(params.error);
     const reason = classifyAuthReason(params.error);
-    if (reason) attributes["infisical.auth.reason"] = reason;
+    if (reason) attributes["infisical.auth.failure_reason"] = reason;
   }
   authAttemptDurationHistogram.record((performance.now() - params.startTime) / 1000, attributes);
 };

--- a/backend/src/lib/telemetry/telemetry-attributes.ts
+++ b/backend/src/lib/telemetry/telemetry-attributes.ts
@@ -11,7 +11,7 @@ export const INFISICAL_CORE_METER_ATTRIBUTES = [
   "infisical.auth.result",
   // why an attempt failed, so a policy rejection is distinguishable from a bad credential.
   // Bounded by AUTH_ATTEMPT_REASONS in metrics.ts, which folds anything unlisted into "other"
-  "infisical.auth.reason",
+  "infisical.auth.failure_reason",
   "queue.name",
   "queue.state",
   "job.name",

--- a/backend/src/lib/telemetry/telemetry-attributes.ts
+++ b/backend/src/lib/telemetry/telemetry-attributes.ts
@@ -9,6 +9,9 @@ export const INFISICAL_CORE_METER_ATTRIBUTES = [
   // Bounded enums
   "infisical.auth.method",
   "infisical.auth.result",
+  // why an attempt failed, so a policy rejection is distinguishable from a bad credential.
+  // Bounded by AUTH_ATTEMPT_REASONS in metrics.ts, which folds anything unlisted into "other"
+  "infisical.auth.reason",
   "queue.name",
   "queue.state",
   "job.name",

--- a/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
+++ b/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
@@ -27,11 +27,12 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
   };
 
   // The limit is in the WHERE so the check and the increment are one statement: concurrent
-  // callers serialize on the row and only numUsesLimit of them can claim a use.
+  // callers serialize on the row and only numUsesLimit of them can claim a use. The revoked
+  // flag rides along so a secret revoked after the caller's lookup cannot still claim one.
   const tryClaimUsage = async (id: string, tx?: Knex): Promise<boolean> => {
     try {
       const claimed = await (tx || db)(TableName.IdentityUaClientSecret)
-        .where({ id })
+        .where({ id, isClientSecretRevoked: false })
         .where("clientSecretNumUsesLimit", ">", 0)
         .andWhere(
           "clientSecretNumUses",

--- a/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
+++ b/backend/src/services/identity-ua/identity-ua-client-secret-dal.ts
@@ -26,6 +26,27 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
     }
   };
 
+  // The limit is in the WHERE so the check and the increment are one statement: concurrent
+  // callers serialize on the row and only numUsesLimit of them can claim a use.
+  const tryClaimUsage = async (id: string, tx?: Knex): Promise<boolean> => {
+    try {
+      const claimed = await (tx || db)(TableName.IdentityUaClientSecret)
+        .where({ id })
+        .where("clientSecretNumUsesLimit", ">", 0)
+        .andWhere(
+          "clientSecretNumUses",
+          "<",
+          db.ref("clientSecretNumUsesLimit").withSchema(TableName.IdentityUaClientSecret)
+        )
+        .update({ clientSecretLastUsedAt: new Date() })
+        .increment("clientSecretNumUses", 1)
+        .returning("id");
+      return claimed.length > 0;
+    } catch (error) {
+      throw new DatabaseError({ error, name: "TryClaimUsage" });
+    }
+  };
+
   const removeExpiredClientSecrets = async (tx?: Knex) => {
     const BATCH_SIZE = 10000;
     const MAX_RETRY_ON_FAILURE = 3;
@@ -81,5 +102,5 @@ export const identityUaClientSecretDALFactory = (db: TDbClient) => {
     logger.info(`daily-resource-cleanup: remove expired universal auth client secret completed`);
   };
 
-  return { ...uaClientSecretOrm, incrementUsage, removeExpiredClientSecrets };
+  return { ...uaClientSecretOrm, incrementUsage, tryClaimUsage, removeExpiredClientSecrets };
 };

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -320,27 +320,18 @@ export const identityUaServiceFactory = ({
       const clientSecretId = validClientSecretInfo.id;
       const hasFiniteUsageLimit = clientSecretNumUsesLimit > 0;
 
-      const [didClaimUse, shouldIncrementUsage, shouldRecordLastLogin] = await Promise.all([
-        // the numUses read above is a stale snapshot, so the claim is what enforces the limit
-        hasFiniteUsageLimit ? identityUaClientSecretDAL.tryClaimUsage(clientSecretId) : Promise.resolve(false),
-        hasFiniteUsageLimit
-          ? // the claim already counted it
-            Promise.resolve(false)
-          : // unlimited secret: numUses is informational, so collapse a login storm to one row write per window
-            keyStore
-              .setItemWithExpiryNX(
-                KeyStorePrefixes.IdentityUaClientSecretUsageDebounce(clientSecretId),
-                UA_CLIENT_SECRET_USAGE_DEBOUNCE_SECONDS,
-                "1"
-              )
-              .then(Boolean),
-        shouldRecordIdentityLastLogin(keyStore, identity.id)
-      ]);
-
-      if (hasFiniteUsageLimit && !didClaimUse) {
-        await identityUaClientSecretDAL.updateById(clientSecretId, {
-          isClientSecretRevoked: true
-        });
+      // the numUses read above is a stale snapshot, so the claim is what enforces the limit. It
+      // settles before the debounces below so a rejected login cannot consume one of their windows
+      if (hasFiniteUsageLimit && !(await identityUaClientSecretDAL.tryClaimUsage(clientSecretId))) {
+        // the deny is already decided, so a failure marking the spent secret revoked must not
+        // turn this into a 500; the daily cleanup reaps it on numUses >= numUsesLimit anyway
+        try {
+          await identityUaClientSecretDAL.updateById(clientSecretId, {
+            isClientSecretRevoked: true
+          });
+        } catch (error) {
+          logger.error(error, `Failed to revoke spent client secret [clientSecretId=${clientSecretId}]`);
+        }
         throw new UnauthorizedError({
           message: "Access denied due to client secret usage limit reached",
           detail: {
@@ -352,15 +343,39 @@ export const identityUaServiceFactory = ({
         });
       }
 
-      if (shouldIncrementUsage || shouldRecordLastLogin) {
-        await identityUaDAL.transaction(async (tx) => {
-          if (shouldIncrementUsage) {
-            await identityUaClientSecretDAL.incrementUsage(clientSecretId, tx);
-          }
-          if (shouldRecordLastLogin) {
-            await recordIdentityLastLogin(membershipIdentityDAL, identity, IdentityAuthMethod.UNIVERSAL_AUTH, tx);
-          }
-        });
+      // the use is claimed and cannot be given back, so the caller has earned its token: a failure
+      // past this point must not reject the login, or it would strand a single-use secret for good
+      try {
+        const [shouldIncrementUsage, shouldRecordLastLogin] = await Promise.all([
+          hasFiniteUsageLimit
+            ? // the claim already counted it
+              Promise.resolve(false)
+            : // unlimited secret: numUses is informational, so collapse a login storm to one row write per window
+              keyStore
+                .setItemWithExpiryNX(
+                  KeyStorePrefixes.IdentityUaClientSecretUsageDebounce(clientSecretId),
+                  UA_CLIENT_SECRET_USAGE_DEBOUNCE_SECONDS,
+                  "1"
+                )
+                .then(Boolean),
+          shouldRecordIdentityLastLogin(keyStore, identity.id)
+        ]);
+
+        if (shouldIncrementUsage || shouldRecordLastLogin) {
+          await identityUaDAL.transaction(async (tx) => {
+            if (shouldIncrementUsage) {
+              await identityUaClientSecretDAL.incrementUsage(clientSecretId, tx);
+            }
+            if (shouldRecordLastLogin) {
+              await recordIdentityLastLogin(membershipIdentityDAL, identity, IdentityAuthMethod.UNIVERSAL_AUTH, tx);
+            }
+          });
+        }
+      } catch (error) {
+        logger.error(
+          error,
+          `Failed to record universal auth login bookkeeping [identityId=${identityUa.identityId}] [clientSecretId=${clientSecretId}]`
+        );
       }
 
       const subOrgDetails =

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -343,18 +343,19 @@ export const identityUaServiceFactory = ({
       // the use is claimed and cannot be given back, so a bookkeeping failure must not reject the
       // login and strand a single-use secret. Token issuance below can still throw and consume one
       try {
+        // the claim counted finite-use secrets; for unlimited ones numUses is informational, so one write per window
+        const usageWrite = hasFiniteUsageLimit
+          ? Promise.resolve(false)
+          : keyStore
+              .setItemWithExpiryNX(
+                KeyStorePrefixes.IdentityUaClientSecretUsageDebounce(clientSecretId),
+                UA_CLIENT_SECRET_USAGE_DEBOUNCE_SECONDS,
+                "1"
+              )
+              .then(Boolean);
+
         const [shouldIncrementUsage, shouldRecordLastLogin] = await Promise.all([
-          hasFiniteUsageLimit
-            ? // the claim already counted it
-              Promise.resolve(false)
-            : // unlimited secret: numUses is informational, so collapse a login storm to one row write per window
-              keyStore
-                .setItemWithExpiryNX(
-                  KeyStorePrefixes.IdentityUaClientSecretUsageDebounce(clientSecretId),
-                  UA_CLIENT_SECRET_USAGE_DEBOUNCE_SECONDS,
-                  "1"
-                )
-                .then(Boolean),
+          usageWrite,
           shouldRecordIdentityLastLogin(keyStore, identity.id)
         ]);
 

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -318,11 +318,14 @@ export const identityUaServiceFactory = ({
       }
 
       const clientSecretId = validClientSecretInfo.id;
+      const hasFiniteUsageLimit = clientSecretNumUsesLimit > 0;
 
-      const [shouldIncrementUsage, shouldRecordLastLogin] = await Promise.all([
-        clientSecretNumUsesLimit > 0
-          ? // finite usage limit: count must stay exact, so increment synchronously (low-frequency, no contention)
-            Promise.resolve(true)
+      const [didClaimUse, shouldIncrementUsage, shouldRecordLastLogin] = await Promise.all([
+        // the numUses read above is a stale snapshot, so the claim is what enforces the limit
+        hasFiniteUsageLimit ? identityUaClientSecretDAL.tryClaimUsage(clientSecretId) : Promise.resolve(false),
+        hasFiniteUsageLimit
+          ? // the claim already counted it
+            Promise.resolve(false)
           : // unlimited secret: numUses is informational, so collapse a login storm to one row write per window
             keyStore
               .setItemWithExpiryNX(
@@ -333,6 +336,21 @@ export const identityUaServiceFactory = ({
               .then(Boolean),
         shouldRecordIdentityLastLogin(keyStore, identity.id)
       ]);
+
+      if (hasFiniteUsageLimit && !didClaimUse) {
+        await identityUaClientSecretDAL.updateById(clientSecretId, {
+          isClientSecretRevoked: true
+        });
+        throw new UnauthorizedError({
+          message: "Access denied due to client secret usage limit reached",
+          detail: {
+            reasonCode: "client_secret_usage_limit_reached",
+            identityId: identityUa.identityId,
+            orgId: identity.orgId,
+            identityName: identity.name
+          }
+        });
+      }
 
       if (shouldIncrementUsage || shouldRecordLastLogin) {
         await identityUaDAL.transaction(async (tx) => {

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -335,7 +335,9 @@ export const identityUaServiceFactory = ({
         throw new UnauthorizedError({
           message: "Access denied due to client secret usage limit reached",
           detail: {
-            reasonCode: "client_secret_usage_limit_reached",
+            // distinct from the same rejection above: that one reads a spent counter, this one lost
+            // the claim to a concurrent login, so only this code tracks the behaviour change
+            reasonCode: "client_secret_usage_limit_raced",
             identityId: identityUa.identityId,
             orgId: identity.orgId,
             identityName: identity.name

--- a/backend/src/services/identity-ua/identity-ua-service.ts
+++ b/backend/src/services/identity-ua/identity-ua-service.ts
@@ -323,15 +323,10 @@ export const identityUaServiceFactory = ({
       // the numUses read above is a stale snapshot, so the claim is what enforces the limit. It
       // settles before the debounces below so a rejected login cannot consume one of their windows
       if (hasFiniteUsageLimit && !(await identityUaClientSecretDAL.tryClaimUsage(clientSecretId))) {
-        // the deny is already decided, so a failure marking the spent secret revoked must not
-        // turn this into a 500; the daily cleanup reaps it on numUses >= numUsesLimit anyway
-        try {
-          await identityUaClientSecretDAL.updateById(clientSecretId, {
-            isClientSecretRevoked: true
-          });
-        } catch (error) {
-          logger.error(error, `Failed to revoke spent client secret [clientSecretId=${clientSecretId}]`);
-        }
+        // no revoke here on purpose: the lookup above skips revoked rows, so revoking mid-burst makes
+        // the rest of the burst miss the secret and take the invalid-credential path, which feeds the
+        // lockout counter and locks every secret under this clientId. The stale-read check above still
+        // revokes on the next attempt, and the daily cleanup reaps numUses >= numUsesLimit
         throw new UnauthorizedError({
           message: "Access denied due to client secret usage limit reached",
           detail: {
@@ -345,8 +340,8 @@ export const identityUaServiceFactory = ({
         });
       }
 
-      // the use is claimed and cannot be given back, so the caller has earned its token: a failure
-      // past this point must not reject the login, or it would strand a single-use secret for good
+      // the use is claimed and cannot be given back, so a bookkeeping failure must not reject the
+      // login and strand a single-use secret. Token issuance below can still throw and consume one
       try {
         const [shouldIncrementUsage, shouldRecordLastLogin] = await Promise.all([
           hasFiniteUsageLimit


### PR DESCRIPTION
## Context

`clientSecretNumUsesLimit` caps how many times a Universal Auth client secret can be exchanged for an access token. The count and the cap were settled in two separate steps: the login handler compared a `clientSecretNumUses` value read off a row fetched earlier, and only later asked the database to increment it. Logins that overlap in that window all read the same pre-increment count, all conclude they are under the limit, and all mint a token, so a secret with `numUsesLimit: 1` can serve several logins and the stored count can end up above the limit it was given.

Both now happen in one statement:

```sql
update "identity_ua_client_secret"
set "clientSecretLastUsedAt" = $1, "clientSecretNumUses" = "clientSecretNumUses" + 1
where "id" = $2 and "clientSecretNumUsesLimit" > 0
  and "clientSecretNumUses" < "identity_ua_client_secret"."clientSecretNumUsesLimit"
returning "id"
```

### Compatibility

No migration, no schema change, no change to the login endpoint's request or response, no change to permissions. The rejection reuses the existing message and reason code.

One behavior change for the release notes: overlapping logins that previously slipped past the cap are now refused. A workload sharing one finite-use secret across replicas with the limit set below its replica count was getting away with it, and will now see the excess replicas fail to start. The fix is to raise the limit to the replica count, or use an unlimited secret with a short token TTL.

## Steps to verify the change

Create a single-use client secret and try to redeem it several times at once.

In the UI, under Access Control > Identities, create a machine identity, add Universal Auth, then create a client secret with **Max Number of Uses** set to `1`. Note the Client ID and the secret.

Redeem it twenty times in parallel:

```bash
CLIENT_ID=<client id>
CLIENT_SECRET=<client secret>

seq 20 | xargs -P 20 -I{} curl -s -o /dev/null -w '%{http_code}\n' \
  -X POST http://localhost:8080/api/v1/auth/universal-auth/login \
  -H 'Content-Type: application/json' \
  -d "{\"clientId\":\"$CLIENT_ID\",\"clientSecret\":\"$CLIENT_SECRET\"}" \
  | sort | uniq -c
```

Expected on this branch:

```
   1 200
  19 401
```

The e2e spec covers the same three cases if you would rather run it than click through: `e2e-test/routes/v1/identity-ua-client-secret-usage-limit.spec.ts`

### Verified locally

`identity-ua-client-secret-usage-limit.spec.ts`, 4 passed:

- 20 concurrent logins yield exactly 1 token at `numUsesLimit: 1` and exactly 5 at `numUsesLimit: 5`, with distinct tokens, every rejection the usage-limit 401, and the stored count on the limit rather than above it
- An unlimited secret still serves all 20 and stays unrevoked
- A sequential second login on a single-use secret is still refused

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
