### PR TITLE
fix(backend): allow underscores in project slug validation

### DIFF
--- a/backend/src/ee/routes/v1/dynamic-secret-router.ts
+++ b/backend/src/ee/routes/v1/dynamic-secret-router.ts
@@ -626,7 +626,7 @@ echo ""
         apiKey: z.string().min(1).describe("The IBM API Connect API key"),
         clientId: z.string().min(1).describe("The IBM API Connect client ID"),
         clientSecret: z.string().min(1).describe("The IBM API Connect client secret"),
-        projectSlug: slugSchema({ max: 64, field: "Project slug" }).describe(
+        projectSlug: slugSchema({ max: 64, field: "Project slug", allowUnderscore: true }).describe(
           "The slug of the project to configure the dynamic secret in"
         )
       }),
@@ -672,7 +672,7 @@ echo ""
         apiKey: z.string().min(1).describe("The IBM API Connect API key"),
         clientId: z.string().min(1).describe("The IBM API Connect client ID"),
         clientSecret: z.string().min(1).describe("The IBM API Connect client secret"),
-        projectSlug: slugSchema({ max: 64, field: "Project slug" }).describe(
+        projectSlug: slugSchema({ max: 64, field: "Project slug", allowUnderscore: true }).describe(
           "The slug of the project to configure the dynamic secret in"
         )
       }),
@@ -720,7 +720,7 @@ echo ""
         apiKey: z.string().min(1).describe("The IBM API Connect API key"),
         clientId: z.string().min(1).describe("The IBM API Connect client ID"),
         clientSecret: z.string().min(1).describe("The IBM API Connect client secret"),
-        projectSlug: slugSchema({ max: 64, field: "Project slug" }).describe(
+        projectSlug: slugSchema({ max: 64, field: "Project slug", allowUnderscore: true }).describe(
           "The slug of the project to configure the dynamic secret in"
         )
       }),
@@ -765,7 +765,7 @@ echo ""
         tenantId: z.string().min(1).describe("The tenant ID of the Azure Entra ID"),
         applicationId: z.string().min(1).describe("The application ID of the Azure Entra ID App Registration"),
         clientSecret: z.string().min(1).describe("The client secret of the Azure Entra ID App Registration"),
-        projectSlug: slugSchema({ max: 64, field: "Project slug" }).describe(
+        projectSlug: slugSchema({ max: 64, field: "Project slug", allowUnderscore: true }).describe(
           "The slug of the project to configure the dynamic secret in"
         )
       }),

--- a/backend/src/server/lib/schemas.test.ts
+++ b/backend/src/server/lib/schemas.test.ts
@@ -1,0 +1,63 @@
+import { slugSchema } from "./schemas";
+
+describe("slugSchema", () => {
+  describe("default validation (allowUnderscore: false)", () => {
+    const schema = slugSchema({ min: 1, max: 64 });
+
+    it("should accept valid lowercase alphanumeric and hyphenated slugs", () => {
+      expect(schema.safeParse("project-slug-123").success).toBe(true);
+      expect(schema.safeParse("abc").success).toBe(true);
+      expect(schema.safeParse("my-cool-project").success).toBe(true);
+    });
+
+    it("should reject slugs with underscores by default", () => {
+      expect(schema.safeParse("project_slug").success).toBe(false);
+      expect(schema.safeParse("my_cool_project").success).toBe(false);
+    });
+
+    it("should reject slugs with spaces or special characters", () => {
+      expect(schema.safeParse("project slug").success).toBe(false);
+      expect(schema.safeParse("project/slug").success).toBe(false);
+      expect(schema.safeParse("project:slug").success).toBe(false);
+      expect(schema.safeParse("project@slug").success).toBe(false);
+    });
+
+    it("should enforce min and max lengths", () => {
+      const minMaxSchema = slugSchema({ min: 3, max: 10 });
+      expect(minMaxSchema.safeParse("ab").success).toBe(false);
+      expect(minMaxSchema.safeParse("abc").success).toBe(true);
+      expect(minMaxSchema.safeParse("1234567890").success).toBe(true);
+      expect(minMaxSchema.safeParse("12345678901").success).toBe(false);
+    });
+  });
+
+  describe("allowUnderscore: true", () => {
+    const schemaWithUnderscore = slugSchema({ min: 1, max: 64, allowUnderscore: true });
+
+    it("should accept slugs containing underscores", () => {
+      expect(schemaWithUnderscore.safeParse("project_slug").success).toBe(true);
+      expect(schemaWithUnderscore.safeParse("my_cool_project_123").success).toBe(true);
+      expect(schemaWithUnderscore.safeParse("project_with-hyphens_and_underscores").success).toBe(true);
+    });
+
+    it("should accept alphanumeric characters and hyphens", () => {
+      expect(schemaWithUnderscore.safeParse("valid-slug-123").success).toBe(true);
+      expect(schemaWithUnderscore.safeParse("my-app").success).toBe(true);
+    });
+
+    it("should reject invalid characters such as spaces, colons, slashes", () => {
+      expect(schemaWithUnderscore.safeParse("project slug").success).toBe(false);
+      expect(schemaWithUnderscore.safeParse("project/slug").success).toBe(false);
+      expect(schemaWithUnderscore.safeParse("project:slug").success).toBe(false);
+      expect(schemaWithUnderscore.safeParse("project.slug").success).toBe(false);
+      expect(schemaWithUnderscore.safeParse("project!slug").success).toBe(false);
+    });
+
+    it("should enforce min and max lengths with allowUnderscore", () => {
+      const minMaxSchema = slugSchema({ min: 5, max: 20, allowUnderscore: true });
+      expect(minMaxSchema.safeParse("a_b").success).toBe(false);
+      expect(minMaxSchema.safeParse("a_b_c").success).toBe(true);
+      expect(minMaxSchema.safeParse("a_b_c_d_e_f_g_h_i_j_k").success).toBe(false);
+    });
+  });
+});

--- a/backend/src/server/lib/schemas.ts
+++ b/backend/src/server/lib/schemas.ts
@@ -10,9 +10,16 @@ interface SlugSchemaInputs {
   max?: number;
   field?: string;
   trim?: boolean;
+  allowUnderscore?: boolean;
 }
 
-export const slugSchema = ({ min = 1, max = 64, field = "Slug", trim = true }: SlugSchemaInputs = {}) => {
+export const slugSchema = ({
+  min = 1,
+  max = 64,
+  field = "Slug",
+  trim = true,
+  allowUnderscore = false
+}: SlugSchemaInputs = {}) => {
   const base = trim ? z.string().trim() : z.string();
   return base
     .min(min, {
@@ -21,9 +28,17 @@ export const slugSchema = ({ min = 1, max = 64, field = "Slug", trim = true }: S
     .max(max, {
       message: `${field} field must be at most ${max} lowercase character${max === 1 ? "" : "s"}`
     })
-    .refine((v) => slugify(v, { lowercase: true }) === v, {
-      message: `${field} field can only contain lowercase letters, numbers, and hyphens`
-    });
+    .refine(
+      (v) =>
+        allowUnderscore
+          ? characterValidator([CharacterType.AlphaNumeric, CharacterType.Hyphen, CharacterType.Underscore])(v)
+          : slugify(v, { lowercase: true }) === v,
+      {
+        message: allowUnderscore
+          ? `${field} field can only contain letters, numbers, hyphens, and underscores`
+          : `${field} field can only contain lowercase letters, numbers, and hyphens`
+      }
+    );
 };
 
 export const GenericResourceNameSchema = z

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -213,7 +213,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
           .max(1024, { message: "Description must be 1024 or fewer characters" })
           .optional()
           .describe(PROJECTS.CREATE.projectDescription),
-        slug: slugSchema({ min: 5, max: 64 }).optional().describe(PROJECTS.CREATE.slug),
+        slug: slugSchema({ min: 5, max: 64, allowUnderscore: true }).optional().describe(PROJECTS.CREATE.slug),
         kmsKeyId: z.string().optional(),
         template: slugSchema({ field: "Template Name", max: 64 })
           .optional()
@@ -380,7 +380,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         }
       ],
       params: z.object({
-        slug: slugSchema({ max: 64 }).describe("The slug of the project to get.")
+        slug: slugSchema({ max: 64, allowUnderscore: true }).describe("The slug of the project to get.")
       }),
       response: {
         200: projectWithEnv

--- a/backend/src/server/routes/v2/deprecated-project-router.ts
+++ b/backend/src/server/routes/v2/deprecated-project-router.ts
@@ -185,7 +185,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         }
       ],
       params: z.object({
-        slug: slugSchema({ min: 5, max: 64 }).describe("The slug of the project to delete.")
+        slug: slugSchema({ min: 5, max: 64, allowUnderscore: true }).describe("The slug of the project to delete.")
       }),
       response: {
         200: SanitizedProjectSchema
@@ -238,7 +238,7 @@ export const registerDeprecatedProjectRouter = async (server: FastifyZodProvider
         }
       ],
       params: z.object({
-        slug: slugSchema({ max: 64 }).describe("The slug of the project to get.")
+        slug: slugSchema({ max: 64, allowUnderscore: true }).describe("The slug of the project to get.")
       }),
       response: {
         200: projectWithEnv


### PR DESCRIPTION
### Description
This PR resolves an issue where endpoints accepting a project slug parameter (such as `GET /v1/projects/slug/:slug`, `POST /v1/projects`, etc.) rejected valid project slugs containing underscores (`_`).

### Changes
- Updated `slugSchema` in `src/server/lib/schemas.ts` to support an optional `allowUnderscore` parameter utilizing `characterValidator` for `[a-zA-Z0-9_-]+`.
- Enabled `allowUnderscore: true` on project slug route parameters and schemas across `project-router.ts`, `deprecated-project-router.ts`, and `dynamic-secret-router.ts`.
- Added unit tests in `schemas.test.ts` verifying default slug behavior and underscore-enabled validation.

Fixes #7888