### PR TITLE
fix: dont inherit exisitng login browser org when using cli login

### DIFF
--- a/frontend/src/pages/middlewares/restrict-login-signup.tsx
+++ b/frontend/src/pages/middlewares/restrict-login-signup.tsx
@@ -96,10 +96,14 @@ export const Route = createFileRoute("/_restrict-login-signup")({
       if (isOnSelectOrg || (!data.organizationId && location.pathname.endsWith("verify-email")))
         return;
 
+      // org_id makes the select-org page auto-select, so a CLI login must not inherit
+      // this browser's org: it would skip the picker the user is waiting on.
+      const inheritedOrgId = search?.callback_port ? undefined : data.organizationId;
+
       throw redirect({
         to: "/login/select-organization",
         search: {
-          org_id: search?.org_id || data.organizationId,
+          org_id: search?.org_id || inheritedOrgId,
           callback_port: search?.callback_port
         }
       });


### PR DESCRIPTION
## Context

This PR fixes a frontend bug that was preventing users with more than one org from being able to select which org they want to log in to via the CLI, when they were already logged into the browser.

## Screenshots

N/A

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)