### PR TITLE
feat(secret-sync): detect duplicate Daytona syncs by organization

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -2882,7 +2882,9 @@ export const AppConnections = {
       apiKey: "The Devin service-user API key used to authenticate against the Devin v3 API."
     },
     DAYTONA: {
-      apiKey: "The Daytona API key used to authenticate with Daytona. It must carry the manage:secrets permission."
+      apiKey: "The Daytona API key used to authenticate with Daytona. It must carry the manage:secrets permission.",
+      organizationId:
+        "The Daytona organization the API key belongs to. Resolved from Daytona when the connection is created."
     },
     GITLAB: {
       instanceUrl: "The GitLab instance URL to connect with.",

--- a/backend/src/services/app-connection/daytona/daytona-connection-fns.ts
+++ b/backend/src/services/app-connection/daytona/daytona-connection-fns.ts
@@ -10,6 +10,10 @@ import { TDaytonaConnectionConfig } from "./daytona-connection-types";
 
 const DAYTONA_MANAGE_SECRETS_PERMISSION = "manage:secrets";
 
+type TDaytonaCurrentApiKeyResponse = {
+  organizationId?: string;
+};
+
 export const getDaytonaAuthHeaders = (apiKey: string) => ({
   Authorization: `Bearer ${apiKey}`,
   Accept: "application/json",
@@ -63,5 +67,30 @@ export const validateDaytonaConnectionCredentials = async (config: TDaytonaConne
     });
   }
 
-  return config.credentials;
+  // A Daytona API key is bound to one organization, so this is the only way to learn which one a
+  // connection writes to. It is stored on the connection and used to tell whether two syncs share a
+  // destination, which nothing else about the key reveals.
+  let organizationId: string | undefined;
+  try {
+    const { data } = await safeRequest.get<TDaytonaCurrentApiKeyResponse>(
+      `${IntegrationUrls.DAYTONA_API_URL}/api-keys/current`,
+      { headers: getDaytonaAuthHeaders(apiKey) }
+    );
+    organizationId = data.organizationId;
+  } catch (error: unknown) {
+    throw new BadRequestError({
+      message: `Unable to validate connection: Daytona returned ${
+        isAxiosError(error) ? (error.response?.status ?? "no") : "no"
+      } status when reading the API key's organization. Verify the API key and try again.`
+    });
+  }
+
+  if (!organizationId) {
+    throw new BadRequestError({
+      message:
+        "Unable to validate connection: Daytona did not report an organization for this API key. Create the key under the organization whose secrets you want to sync to."
+    });
+  }
+
+  return { ...config.credentials, organizationId };
 };

--- a/backend/src/services/app-connection/daytona/daytona-connection-schemas.ts
+++ b/backend/src/services/app-connection/daytona/daytona-connection-schemas.ts
@@ -15,19 +15,26 @@ export const DaytonaConnectionApiKeyCredentialsSchema = z.object({
   apiKey: z.string().trim().min(1, "API Key required").max(500).describe(AppConnections.CREDENTIALS.DAYTONA.apiKey)
 });
 
+// A Daytona API key is bound to one organization, so the organization is resolved during validation
+// rather than supplied by the caller. It is stored on the connection and read back to tell whether
+// two syncs write to the same organization.
+export const DaytonaConnectionApiKeyStoredCredentialsSchema = DaytonaConnectionApiKeyCredentialsSchema.extend({
+  organizationId: z.string().trim().min(1).max(255).describe(AppConnections.CREDENTIALS.DAYTONA.organizationId)
+});
+
 const BaseDaytonaConnectionSchema = BaseAppConnectionSchema.extend({
   app: z.literal(AppConnection.Daytona)
 });
 
 export const DaytonaConnectionSchema = BaseDaytonaConnectionSchema.extend({
   method: z.literal(DaytonaConnectionMethod.ApiKey),
-  credentials: DaytonaConnectionApiKeyCredentialsSchema
+  credentials: DaytonaConnectionApiKeyStoredCredentialsSchema
 });
 
 export const SanitizedDaytonaConnectionSchema = z.discriminatedUnion("method", [
   BaseDaytonaConnectionSchema.extend({
     method: z.literal(DaytonaConnectionMethod.ApiKey),
-    credentials: DaytonaConnectionApiKeyCredentialsSchema.pick({})
+    credentials: DaytonaConnectionApiKeyStoredCredentialsSchema.pick({ organizationId: true })
   }).describe(JSON.stringify({ title: `${APP_CONNECTION_NAME_MAP[AppConnection.Daytona]} (API Key)` }))
 ]);
 

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -1,6 +1,7 @@
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { buildAwsConnectionConfig, getAwsAccountId } from "@app/services/app-connection/aws/aws-connection-fns";
 import { TAwsConnection } from "@app/services/app-connection/aws/aws-connection-types";
+import { TDaytonaConnection } from "@app/services/app-connection/daytona";
 import { GcpSyncScope } from "@app/services/secret-sync/gcp/gcp-sync-enums";
 import { SecretSync, SecretSyncPlanType } from "@app/services/secret-sync/secret-sync-enums";
 import { DestinationDuplicateCheckFn } from "@app/services/secret-sync/secret-sync-types";
@@ -250,6 +251,29 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
   return existingAccountId === newAccountId;
 };
 
+// A Daytona API key is bound to one organization and nothing scopes below it, so two syncs collide
+// exactly when their connections resolve to the same organization, whether or not they share a
+// connection.
+const daytonaDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, newSync, decryptConnection }) => {
+  // Without a connection on either side there is no organization to compare, and an empty Daytona
+  // config matches every other sync, so treating that as a collision would block them all.
+  if (!newSync.connectionId || !existingSync.connectionId) return false;
+
+  if (existingSync.connectionId === newSync.connectionId) return true;
+
+  const [existingConn, newConn] = await Promise.all([
+    decryptConnection(existingSync.connectionId),
+    decryptConnection(newSync.connectionId)
+  ]);
+
+  const existingOrgId = (existingConn as TDaytonaConnection).credentials.organizationId;
+  const newOrgId = (newConn as TDaytonaConnection).credentials.organizationId;
+
+  if (!existingOrgId || !newOrgId) return false;
+
+  return existingOrgId === newOrgId;
+};
+
 const gcpDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, newSync }) => {
   const existingConfig = existingSync.destinationConfig;
   const newConfig = newSync.destinationConfig;
@@ -339,11 +363,7 @@ export const DESTINATION_DUPLICATE_CHECK_MAP: Record<SecretSync, DestinationDupl
   [SecretSync.Qovery]: defaultDuplicateCheck,
   [SecretSync.Cloud66]: defaultDuplicateCheck,
   [SecretSync.Spacelift]: defaultDuplicateCheck,
-  // Daytona has an empty destination config, so checkDuplicateDestination returns early and never
-  // reaches this. Kept accurate rather than defaulted: a Daytona API key is bound to one organization
-  // and nothing scopes below it, so two syncs sharing a connection do write the same secrets.
-  [SecretSync.Daytona]: async ({ existingSync, newSync }) =>
-    Boolean(newSync.connectionId) && existingSync.connectionId === newSync.connectionId
+  [SecretSync.Daytona]: daytonaDuplicateCheck
 };
 
 /**

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -255,7 +255,6 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
 // exactly when their connections resolve to the same organization, whether or not they share a
 // connection.
 const daytonaDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, newSync, decryptConnection }) => {
-
   if (!newSync.connectionId || !existingSync.connectionId) return false;
 
   if (existingSync.connectionId === newSync.connectionId) return true;

--- a/backend/src/services/secret-sync/secret-sync-maps.ts
+++ b/backend/src/services/secret-sync/secret-sync-maps.ts
@@ -255,8 +255,7 @@ const awsDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, ne
 // exactly when their connections resolve to the same organization, whether or not they share a
 // connection.
 const daytonaDuplicateCheck: DestinationDuplicateCheckFn = async ({ existingSync, newSync, decryptConnection }) => {
-  // Without a connection on either side there is no organization to compare, and an empty Daytona
-  // config matches every other sync, so treating that as a collision would block them all.
+
   if (!newSync.connectionId || !existingSync.connectionId) return false;
 
   if (existingSync.connectionId === newSync.connectionId) return true;

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -276,7 +276,10 @@ export const secretSyncServiceFactory = ({
       ProjectPermissionSub.SecretSyncs
     );
 
-    if (!destinationConfig || Object.keys(destinationConfig).length === 0) {
+    // An absent config means the caller has not filled the form in yet, so there is nothing to
+    // compare. An empty one is different: a destination whose scope comes entirely from its
+    // connection has no fields to send, and skipping those would leave them with no check at all.
+    if (!destinationConfig) {
       return { hasDuplicate: false, duplicateProjectId: undefined };
     }
 

--- a/docs/integrations/app-connections/daytona.mdx
+++ b/docs/integrations/app-connections/daytona.mdx
@@ -54,7 +54,7 @@ A Daytona API key belongs to exactly one organization. The key you choose theref
                 ![Daytona Connection Form](/images/app-connections/daytona/daytona-app-connection-form.png)
             </Step>
             <Step title="Connection created">
-                Infisical validates the key against Daytona. Once it passes, the connection is ready to use in your project.
+                Infisical validates the key against Daytona and records the organization it belongs to. Once it passes, the connection is ready to use in your project.
             </Step>
         </Steps>
     </Tab>


### PR DESCRIPTION
## Context

Daytona API keys are bound to one organization, and nothing in Daytona's API scopes below the organization. Two Daytona syncs therefore write to the same place exactly when their connections resolve to the same organization.

Until now nothing about a key revealed which organization that was. `GET /api-keys/current` returned only `name`, `permissions` and `expiresAt`, and `GET /organizations` rejects an org-scoped key with a 401. Daytona support has since added `organizationId` to `/api-keys/current`, which is deployed and confirmed working with a key carrying only `manage:secrets`:

```json
{
  "name": "test2",
  "permissions": ["manage:secrets"],
  "organizationId": "6c678b2e-7af7-495a-9bf6-f12e5696fd8d"
}
```

That makes duplicate detection possible, and this adds it.

**The connection stores its organization.** `validateDaytonaConnectionCredentials` reads `/api-keys/current` after the existing capability check and returns `organizationId` alongside the API key, so it is encrypted and stored with the connection. It is not sensitive, so the sanitized schema exposes it. The existing `GET /secret/paginated` call stays as the capability check rather than being replaced by a `permissions` test, because a Full Access key may not list `manage:secrets` literally and would then be wrongly rejected.

**The comparator resolves it from both connections.** `daytonaDuplicateCheck` mirrors `awsDuplicateCheck`, which resolves a live AWS account ID the same way. Reading it from the connection rather than from stored sync config means a sync created before a connection's key moved to another organization is still judged on where it writes today.

This catches two cases: two syncs sharing one connection, and two different connections holding different keys in the same organization. Comparing connection IDs only ever caught the first.

### One shared-code change

`checkDuplicateDestination` treated an empty `destinationConfig` the same as an absent one and returned before any comparator ran. A destination whose scope comes entirely from its connection has no fields to send, so that left it with no duplicate check at all. Absent still returns early, since it means the caller has not filled in the form yet.

Daytona is the only destination this reaches. Every other one requires at least one `destinationConfig` field, checked against the generated OpenAPI schema for all 49 destinations, and no destination's `SECRET_SYNC_SKIP_FIELDS_MAP` entry covers all of its own fields, so no other pair can newly compare equal.

`blockDuplicateSecretSyncDestinations` is respected without further change, since that gate sits upstream of this function.

### What this does not do

Nothing is stored on the sync itself. The organization is derived from the connection wherever it is needed, so there is no copy to fall out of date and nothing new for a caller to supply.

## Steps to verify the change

Manual, against a real Daytona account with two API keys in the same organization and one in a different organization.

1. Create a Daytona connection. Confirm it still validates with a key carrying only `manage:secrets`, and that the organization appears on the connection.
2. Confirm a key without `manage:secrets` is still rejected with the message naming the permission.
3. Enable **Block duplicate secret sync destinations** for the org.
4. Create a sync. Create a second sync on the same connection and confirm it is blocked.
5. Create a second connection with a different key in the same organization. Create a sync on it and confirm it is blocked.
6. Create a third connection with a key in a different organization. Create a sync on it and confirm it is allowed.
7. Turn the org setting off and confirm all of the above are allowed again.
8. Confirm the wizard's live duplicate warning matches what creation does, rather than reporting no duplicate and then failing on submit.

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
