### PR TITLE
fix(github-org-sync): safely sync teams for large orgs

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -143,6 +143,15 @@ DALs extend these with custom queries — typically complex joins using Knex que
 
 `updateById` and `update` support atomic `$incr` and `$decr` operators alongside regular field updates.
 
+**A dropped column does not fail type checking if the insert is built in a `.map()`.** TypeScript's
+excess-property check only fires on a fresh object literal at the assignment site, so a stale field
+survives when the literal is returned from a callback:
+
+```ts
+insertMany(names.map((name) => ({ name, role: "member", orgId })));  // compiles, then 500s at runtime
+insertMany([{ name, role: "member", orgId }]);                       // TS2353
+```
+
 See `src/services/secret/secret-dal.ts` for a DAL that overrides the base `update` to auto-increment version and adds complex join queries.
 
 ### Service Module Structure

--- a/backend/src/ee/routes/v1/github-org-sync-router.ts
+++ b/backend/src/ee/routes/v1/github-org-sync-router.ts
@@ -182,7 +182,8 @@ export const registerGithubOrgSyncRouter = async (server: FastifyZodProvider) =>
     },
     handler: async (req) => {
       const result = await server.services.githubOrgSync.syncAllTeams({
-        orgPermission: req.permission
+        orgPermission: req.permission,
+        auditLogInfo: req.auditLogInfo
       });
 
       void server.services.telemetry

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -2818,6 +2818,9 @@ interface AddUserToGroupEvent {
     groupName: string;
     userId: string;
     username: string;
+    source?: "github-org-sync";
+    githubOrgName?: string;
+    syncTrigger?: "login" | "manual";
   };
 }
 
@@ -2828,6 +2831,9 @@ interface RemoveUserFromGroupEvent {
     groupName: string;
     userId: string;
     username: string;
+    source?: "github-org-sync";
+    githubOrgName?: string;
+    syncTrigger?: "login" | "manual";
   };
 }
 

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -158,14 +158,14 @@ describe("buildGithubMemberMatcher", () => {
   });
 
   describe("ambiguity", () => {
-    test("reports rather than guesses when two members match the same rule", () => {
+    test("reports the candidate members rather than guessing between them", () => {
       const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com"), member("b", "janedoe@other.com")]);
       const result = match("janedoe");
-      expect(result).toEqual({
-        status: "ambiguous",
-        rule: "email",
-        emails: ["jane.doe@acme.com", "janedoe@other.com"]
-      });
+      expect(result.status).toBe("ambiguous");
+      if (result.status !== "ambiguous") return;
+      expect(result.rule).toBe("email");
+      // Callers need the members, not just their emails, so only these two are held back from removal.
+      expect(result.members.map((m) => m.id)).toEqual(["a", "b"]);
     });
 
     test("does not report ambiguity for a member listed twice with the same email", () => {

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -1,6 +1,8 @@
 import { Octokit } from "@octokit/core";
 import { describe, expect, test, vi } from "vitest";
 
+import { BadRequestError } from "@app/lib/errors";
+
 import { fetchGithubOrgTeams } from "./github-org-sync-service";
 
 type TVariables = { cursor: string | null; slug?: string; teamsPageSize?: number; membersPageSize?: number };
@@ -65,6 +67,17 @@ describe("fetchGithubOrgTeams", () => {
     expect(teams.find((t) => t.slug === "big")?.members).toEqual(["u1", "u2", "u3"]);
     expect(teams.find((t) => t.slug === "small")?.members).toEqual(["u9"]);
     expect(graphql).toHaveBeenCalledTimes(3);
+  });
+
+  test("fails instead of returning a partial member list when the team disappears mid-pagination", async () => {
+    const { octokit } = buildOctokit((query) => {
+      if (query.includes("query orgTeams")) {
+        return { organization: { teams: page([team("big", ["u1"], "m1")], null) } };
+      }
+      return { organization: { team: null } };
+    });
+
+    await expect(fetchGithubOrgTeams(octokit, "acme")).rejects.toThrow(BadRequestError);
   });
 
   test("passes a per-request abort signal", async () => {

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -96,42 +96,98 @@ describe("buildGithubMemberMatcher", () => {
     user: email === null ? null : { email },
     inviteEmail
   });
+  const matched = (result: ReturnType<ReturnType<typeof buildGithubMemberMatcher>>) =>
+    result.status === "matched" ? { id: (result.member as { id: string }).id, rule: result.rule } : result;
 
-  test("matches a login equal to the email prefix", () => {
-    const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
-    expect(match("Jane.Doe")?.id).toBe("a");
-    expect(match("someone-else")).toBeUndefined();
+  describe("email rule", () => {
+    test("matches a login equal to the email prefix", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
+      expect(matched(match("Jane.Doe"))).toEqual({ id: "a", rule: "email" });
+    });
+
+    test("matches across separator differences between email and login", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
+      expect(matched(match("janedoe"))).toEqual({ id: "a", rule: "email" });
+      expect(matched(match("jane-doe"))).toEqual({ id: "a", rule: "email" });
+    });
   });
 
-  test("matches a login that appends the domain name to the email prefix", () => {
-    const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
-    expect(match("janeacme")?.id).toBe("a");
-    expect(match("acme")).toBeUndefined();
+  describe("org suffix rule", () => {
+    test("matches a login that appends the organization name to the email prefix", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
+      expect(matched(match("janeacme"))).toEqual({ id: "a", rule: "email-with-org-suffix" });
+    });
+
+    test("does not match the organization name alone", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
+      expect(match("acme").status).toBe("unmatched");
+    });
   });
 
-  test("matches when the longest email part is contained in the login", () => {
-    const match = buildGithubMemberMatcher([member("a", "j.smithson@acme.com")]);
-    expect(match("smithson-dev")?.id).toBe("a");
+  describe("name part rule", () => {
+    test("matches when a login component equals the longest email part", () => {
+      const match = buildGithubMemberMatcher([member("a", "j.smithson@acme.com")]);
+      expect(matched(match("smithson-dev"))).toEqual({ id: "a", rule: "name-part" });
+    });
+
+    test("does not match a name part buried inside a login component", () => {
+      const match = buildGithubMemberMatcher([member("a", "deep@acme.com"), member("b", "nast@acme.com")]);
+      expect(match("0xarshdeep").status).toBe("unmatched");
+      expect(match("carlosmonastyrski").status).toBe("unmatched");
+    });
+
+    test("does not match a name part shorter than four characters", () => {
+      const match = buildGithubMemberMatcher([member("a", "j.li@acme.com")]);
+      expect(match("li-jones").status).toBe("unmatched");
+    });
   });
 
-  test("does not match on an email part shorter than four characters", () => {
-    const match = buildGithubMemberMatcher([member("a", "j.li@acme.com")]);
-    expect(match("xxliyy")).toBeUndefined();
+  describe("rule precedence", () => {
+    test("an exact email match beats a name part match found earlier in the list", () => {
+      const match = buildGithubMemberMatcher([
+        member("weak", "scott@infisical.com"),
+        member("exact", "scott-ray-wilson@acme.com")
+      ]);
+      expect(matched(match("scott-ray-wilson"))).toEqual({ id: "exact", rule: "email" });
+    });
+
+    test("falls through to the next rule only when no member matches the stronger one", () => {
+      const match = buildGithubMemberMatcher([member("weak", "scott@infisical.com")]);
+      expect(matched(match("scott-ray-wilson"))).toEqual({ id: "weak", rule: "name-part" });
+    });
   });
 
-  test("returns the first matching member, preserving input order", () => {
-    const match = buildGithubMemberMatcher([member("first", "bob@acme.com"), member("second", "bob@other.com")]);
-    expect(match("bob")?.id).toBe("first");
+  describe("ambiguity", () => {
+    test("reports rather than guesses when two members match the same rule", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com"), member("b", "janedoe@other.com")]);
+      const result = match("janedoe");
+      expect(result).toEqual({
+        status: "ambiguous",
+        rule: "email",
+        emails: ["jane.doe@acme.com", "janedoe@other.com"]
+      });
+    });
+
+    test("does not report ambiguity for a member listed twice with the same email", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane@acme.com"), member("b", "jane@acme.com")]);
+      expect(match("jane").status).toBe("matched");
+    });
   });
 
-  test("falls back to inviteEmail and skips members with neither", () => {
-    const match = buildGithubMemberMatcher([member("no-email", null), member("invited", null, "bob@acme.com")]);
-    expect(match("bob")?.id).toBe("invited");
-  });
+  describe("input handling", () => {
+    test("falls back to inviteEmail and skips members with neither", () => {
+      const match = buildGithubMemberMatcher([member("no-email", null), member("invited", null, "bob@acme.com")]);
+      expect(matched(match("bob"))).toEqual({ id: "invited", rule: "email" });
+    });
 
-  test("ignores a malformed email instead of throwing", () => {
-    const match = buildGithubMemberMatcher([member("bad", "not-an-email"), member("good", "bob@acme.com")]);
-    expect(() => match("bob")).not.toThrow();
-    expect(match("bob")?.id).toBe("good");
+    test("ignores a malformed email instead of throwing", () => {
+      const match = buildGithubMemberMatcher([member("bad", "not-an-email"), member("good", "bob@acme.com")]);
+      expect(() => match("bob")).not.toThrow();
+      expect(matched(match("bob"))).toEqual({ id: "good", rule: "email" });
+    });
+
+    test("returns unmatched for an empty member list", () => {
+      expect(buildGithubMemberMatcher([])("anyone").status).toBe("unmatched");
+    });
   });
 });

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 
 import { BadRequestError } from "@app/lib/errors";
 
-import { fetchGithubOrgTeams } from "./github-org-sync-service";
+import { buildGithubMemberMatcher, fetchGithubOrgTeams } from "./github-org-sync-service";
 
 type TVariables = { cursor: string | null; slug?: string; teamsPageSize?: number; membersPageSize?: number };
 
@@ -87,5 +87,51 @@ describe("fetchGithubOrgTeams", () => {
 
     const options = graphql.mock.calls[0][1] as unknown as { request: { signal: AbortSignal } };
     expect(options.request.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("buildGithubMemberMatcher", () => {
+  const member = (id: string, email: string | null, inviteEmail: string | null = null) => ({
+    id,
+    user: email === null ? null : { email },
+    inviteEmail
+  });
+
+  test("matches a login equal to the email prefix", () => {
+    const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
+    expect(match("Jane.Doe")?.id).toBe("a");
+    expect(match("someone-else")).toBeUndefined();
+  });
+
+  test("matches a login that appends the domain name to the email prefix", () => {
+    const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
+    expect(match("janeacme")?.id).toBe("a");
+    expect(match("acme")).toBeUndefined();
+  });
+
+  test("matches when the longest email part is contained in the login", () => {
+    const match = buildGithubMemberMatcher([member("a", "j.smithson@acme.com")]);
+    expect(match("smithson-dev")?.id).toBe("a");
+  });
+
+  test("does not match on an email part shorter than four characters", () => {
+    const match = buildGithubMemberMatcher([member("a", "j.li@acme.com")]);
+    expect(match("xxliyy")).toBeUndefined();
+  });
+
+  test("returns the first matching member, preserving input order", () => {
+    const match = buildGithubMemberMatcher([member("first", "bob@acme.com"), member("second", "bob@other.com")]);
+    expect(match("bob")?.id).toBe("first");
+  });
+
+  test("falls back to inviteEmail and skips members with neither", () => {
+    const match = buildGithubMemberMatcher([member("no-email", null), member("invited", null, "bob@acme.com")]);
+    expect(match("bob")?.id).toBe("invited");
+  });
+
+  test("ignores a malformed email instead of throwing", () => {
+    const match = buildGithubMemberMatcher([member("bad", "not-an-email"), member("good", "bob@acme.com")]);
+    expect(() => match("bob")).not.toThrow();
+    expect(match("bob")?.id).toBe("good");
   });
 });

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -1,0 +1,78 @@
+import { Octokit } from "@octokit/core";
+import { describe, expect, test, vi } from "vitest";
+
+import { fetchGithubOrgTeams } from "./github-org-sync-service";
+
+type TVariables = { cursor: string | null; slug?: string; teamsPageSize?: number; membersPageSize?: number };
+
+const page = <T>(nodes: T[], endCursor: string | null) => ({
+  edges: nodes.map((node) => ({ node })),
+  pageInfo: { hasNextPage: endCursor !== null, endCursor }
+});
+
+const team = (slug: string, members: string[], membersCursor: string | null = null) => ({
+  slug,
+  name: slug.toUpperCase(),
+  description: null,
+  members: page(
+    members.map((login) => ({ login })),
+    membersCursor
+  )
+});
+
+const buildOctokit = (handler: (query: string, variables: TVariables) => unknown) => {
+  const graphql = vi.fn(async (query: string, variables: TVariables) => handler(query, variables));
+  return { octokit: { graphql } as unknown as Pick<Octokit, "graphql">, graphql };
+};
+
+describe("fetchGithubOrgTeams", () => {
+  test("follows the team cursor across pages and flattens members", async () => {
+    const { octokit, graphql } = buildOctokit((_query, { cursor }) => {
+      if (cursor === null) {
+        return { organization: { teams: page([team("a", ["u1", "u2"])], "c1") } };
+      }
+      return { organization: { teams: page([team("b", ["u3"])], null) } };
+    });
+
+    const teams = await fetchGithubOrgTeams(octokit, "acme");
+
+    expect(teams).toEqual([
+      { slug: "a", name: "A", description: null, members: ["u1", "u2"] },
+      { slug: "b", name: "B", description: null, members: ["u3"] }
+    ]);
+    expect(graphql).toHaveBeenCalledTimes(2);
+    expect(graphql.mock.calls[1][1]).toMatchObject({ cursor: "c1", org: "acme" });
+  });
+
+  test("paginates members separately for teams whose members exceed one page", async () => {
+    const { octokit, graphql } = buildOctokit((query, { cursor, slug }) => {
+      if (query.includes("query orgTeams")) {
+        return {
+          organization: {
+            teams: page([team("big", ["u1"], "m1"), team("small", ["u9"])], null)
+          }
+        };
+      }
+      expect(slug).toBe("big");
+      if (cursor === "m1") {
+        return { organization: { team: { members: page([{ login: "u2" }], "m2") } } };
+      }
+      return { organization: { team: { members: page([{ login: "u3" }], null) } } };
+    });
+
+    const teams = await fetchGithubOrgTeams(octokit, "acme");
+
+    expect(teams.find((t) => t.slug === "big")?.members).toEqual(["u1", "u2", "u3"]);
+    expect(teams.find((t) => t.slug === "small")?.members).toEqual(["u9"]);
+    expect(graphql).toHaveBeenCalledTimes(3);
+  });
+
+  test("passes a per-request abort signal", async () => {
+    const { octokit, graphql } = buildOctokit(() => ({ organization: { teams: page([], null) } }));
+
+    await fetchGithubOrgTeams(octokit, "acme");
+
+    const options = graphql.mock.calls[0][1] as unknown as { request: { signal: AbortSignal } };
+    expect(options.request.signal).toBeInstanceOf(AbortSignal);
+  });
+});

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, test, vi } from "vitest";
 
 import { BadRequestError } from "@app/lib/errors";
 
-import { buildGithubMemberMatcher, fetchGithubOrgTeams } from "./github-org-sync-service";
+import {
+  assertGithubGroupMembersLinked,
+  buildGithubMemberMatcher,
+  fetchGithubOrgTeams
+} from "./github-org-sync-service";
 
 type TVariables = { cursor: string | null; slug?: string; teamsPageSize?: number; membersPageSize?: number };
 
@@ -139,5 +143,33 @@ describe("buildGithubMemberMatcher", () => {
     const match = buildGithubMemberMatcher([alias("123", "user-a")], new Set(["user-a"]));
 
     expect(match(githubMember(null))).toBeUndefined();
+  });
+});
+
+describe("assertGithubGroupMembersLinked", () => {
+  const activeUsers = [
+    { id: "user-a", email: "alice@example.com" },
+    { id: "user-b", email: "bob@example.com" }
+  ];
+
+  test("allows reconciliation when every existing member has a verified GitHub link", () => {
+    expect(() =>
+      assertGithubGroupMembersLinked({
+        currentUserIds: new Set(["user-a", "user-b"]),
+        linkedUserIds: new Set(["user-a", "user-b"]),
+        activeUsers
+      })
+    ).not.toThrow();
+  });
+
+  test("stops reconciliation before changes when an existing member has no verified GitHub link", () => {
+    expect(() =>
+      assertGithubGroupMembersLinked({
+        currentUserIds: new Set(["user-a", "user-b"]),
+        linkedUserIds: new Set(["user-a"]),
+        activeUsers,
+        noChangesApplied: true
+      })
+    ).toThrow(/bob@example\.com.*No changes were applied/);
   });
 });

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -17,7 +17,7 @@ const team = (slug: string, members: string[], membersCursor: string | null = nu
   name: slug.toUpperCase(),
   description: null,
   members: page(
-    members.map((login) => ({ login })),
+    members.map((login) => ({ login, databaseId: Number(login.slice(1)) })),
     membersCursor
   )
 });
@@ -39,10 +39,19 @@ describe("fetchGithubOrgTeams", () => {
     const teams = await fetchGithubOrgTeams(octokit, "acme");
 
     expect(teams).toEqual([
-      { slug: "a", name: "A", description: null, members: ["u1", "u2"] },
-      { slug: "b", name: "B", description: null, members: ["u3"] }
+      {
+        slug: "a",
+        name: "A",
+        description: null,
+        members: [
+          { login: "u1", databaseId: 1 },
+          { login: "u2", databaseId: 2 }
+        ]
+      },
+      { slug: "b", name: "B", description: null, members: [{ login: "u3", databaseId: 3 }] }
     ]);
     expect(graphql).toHaveBeenCalledTimes(2);
+    expect(graphql.mock.calls[0][0]).toContain("databaseId");
     expect(graphql.mock.calls[1][1]).toMatchObject({ cursor: "c1", org: "acme" });
   });
 
@@ -57,15 +66,19 @@ describe("fetchGithubOrgTeams", () => {
       }
       expect(slug).toBe("big");
       if (cursor === "m1") {
-        return { organization: { team: { members: page([{ login: "u2" }], "m2") } } };
+        return { organization: { team: { members: page([{ login: "u2", databaseId: 2 }], "m2") } } };
       }
-      return { organization: { team: { members: page([{ login: "u3" }], null) } } };
+      return { organization: { team: { members: page([{ login: "u3", databaseId: 3 }], null) } } };
     });
 
     const teams = await fetchGithubOrgTeams(octokit, "acme");
 
-    expect(teams.find((t) => t.slug === "big")?.members).toEqual(["u1", "u2", "u3"]);
-    expect(teams.find((t) => t.slug === "small")?.members).toEqual(["u9"]);
+    expect(teams.find((t) => t.slug === "big")?.members).toEqual([
+      { login: "u1", databaseId: 1 },
+      { login: "u2", databaseId: 2 },
+      { login: "u3", databaseId: 3 }
+    ]);
+    expect(teams.find((t) => t.slug === "small")?.members).toEqual([{ login: "u9", databaseId: 9 }]);
     expect(graphql).toHaveBeenCalledTimes(3);
   });
 
@@ -91,103 +104,40 @@ describe("fetchGithubOrgTeams", () => {
 });
 
 describe("buildGithubMemberMatcher", () => {
-  const member = (id: string, email: string | null, inviteEmail: string | null = null) => ({
-    id,
-    user: email === null ? null : { email },
-    inviteEmail
+  const alias = (externalId: string, userId: string, isEmailVerified = true) => ({
+    externalId,
+    userId,
+    isEmailVerified
   });
-  const matched = (result: ReturnType<ReturnType<typeof buildGithubMemberMatcher>>) =>
-    result.status === "matched" ? { id: (result.member as { id: string }).id, rule: result.rule } : result;
+  const githubMember = (databaseId: number | null, login = "any-login") => ({ databaseId, login });
 
-  describe("email rule", () => {
-    test("matches a login equal to the email prefix", () => {
-      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
-      expect(matched(match("Jane.Doe"))).toEqual({ id: "a", rule: "email" });
-    });
+  test("matches the exact GitHub account ID", () => {
+    const match = buildGithubMemberMatcher([alias("123", "user-a")], new Set(["user-a"]));
 
-    test("matches across separator differences between email and login", () => {
-      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
-      expect(matched(match("janedoe"))).toEqual({ id: "a", rule: "email" });
-      expect(matched(match("jane-doe"))).toEqual({ id: "a", rule: "email" });
-    });
+    expect(match(githubMember(123, "renamed-user"))).toBe("user-a");
   });
 
-  describe("org suffix rule", () => {
-    test("matches a login that appends the organization name to the email prefix", () => {
-      const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
-      expect(matched(match("janeacme"))).toEqual({ id: "a", rule: "email-with-org-suffix" });
-    });
+  test("does not infer a match from the GitHub login", () => {
+    const match = buildGithubMemberMatcher([alias("123", "user-a")], new Set(["user-a"]));
 
-    test("does not match the organization name alone", () => {
-      const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
-      expect(match("acme").status).toBe("unmatched");
-    });
+    expect(match(githubMember(456, "123"))).toBeUndefined();
   });
 
-  describe("name part rule", () => {
-    test("matches when a login component equals the longest email part", () => {
-      const match = buildGithubMemberMatcher([member("a", "j.smithson@acme.com")]);
-      expect(matched(match("smithson-dev"))).toEqual({ id: "a", rule: "name-part" });
-    });
+  test("ignores an alias whose email has not been verified", () => {
+    const match = buildGithubMemberMatcher([alias("123", "user-a", false)], new Set(["user-a"]));
 
-    test("does not match a name part buried inside a login component", () => {
-      const match = buildGithubMemberMatcher([member("a", "deep@acme.com"), member("b", "nast@acme.com")]);
-      expect(match("0xarshdeep").status).toBe("unmatched");
-      expect(match("carlosmonastyrski").status).toBe("unmatched");
-    });
-
-    test("does not match a name part shorter than four characters", () => {
-      const match = buildGithubMemberMatcher([member("a", "j.li@acme.com")]);
-      expect(match("li-jones").status).toBe("unmatched");
-    });
+    expect(match(githubMember(123))).toBeUndefined();
   });
 
-  describe("rule precedence", () => {
-    test("an exact email match beats a name part match found earlier in the list", () => {
-      const match = buildGithubMemberMatcher([
-        member("weak", "scott@infisical.com"),
-        member("exact", "scott-ray-wilson@acme.com")
-      ]);
-      expect(matched(match("scott-ray-wilson"))).toEqual({ id: "exact", rule: "email" });
-    });
+  test("ignores an alias whose user is not an active organization member", () => {
+    const match = buildGithubMemberMatcher([alias("123", "user-a")], new Set(["user-b"]));
 
-    test("falls through to the next rule only when no member matches the stronger one", () => {
-      const match = buildGithubMemberMatcher([member("weak", "scott@infisical.com")]);
-      expect(matched(match("scott-ray-wilson"))).toEqual({ id: "weak", rule: "name-part" });
-    });
+    expect(match(githubMember(123))).toBeUndefined();
   });
 
-  describe("ambiguity", () => {
-    test("reports the candidate members rather than guessing between them", () => {
-      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com"), member("b", "janedoe@other.com")]);
-      const result = match("janedoe");
-      expect(result.status).toBe("ambiguous");
-      if (result.status !== "ambiguous") return;
-      expect(result.rule).toBe("email");
-      // Callers need the members, not just their emails, so only these two are held back from removal.
-      expect(result.members.map((m) => m.id)).toEqual(["a", "b"]);
-    });
+  test("ignores a GitHub member without a database ID", () => {
+    const match = buildGithubMemberMatcher([alias("123", "user-a")], new Set(["user-a"]));
 
-    test("does not report ambiguity for a member listed twice with the same email", () => {
-      const match = buildGithubMemberMatcher([member("a", "jane@acme.com"), member("b", "jane@acme.com")]);
-      expect(match("jane").status).toBe("matched");
-    });
-  });
-
-  describe("input handling", () => {
-    test("falls back to inviteEmail and skips members with neither", () => {
-      const match = buildGithubMemberMatcher([member("no-email", null), member("invited", null, "bob@acme.com")]);
-      expect(matched(match("bob"))).toEqual({ id: "invited", rule: "email" });
-    });
-
-    test("ignores a malformed email instead of throwing", () => {
-      const match = buildGithubMemberMatcher([member("bad", "not-an-email"), member("good", "bob@acme.com")]);
-      expect(() => match("bob")).not.toThrow();
-      expect(matched(match("bob"))).toEqual({ id: "good", rule: "email" });
-    });
-
-    test("returns unmatched for an empty member list", () => {
-      expect(buildGithubMemberMatcher([])("anyone").status).toBe("unmatched");
-    });
+    expect(match(githubMember(null))).toBeUndefined();
   });
 });

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -1,12 +1,16 @@
 import { Octokit } from "@octokit/core";
 import { describe, expect, test, vi } from "vitest";
 
+import { AuditLogInfo, EventType, UserAgentType } from "@app/ee/services/audit-log/audit-log-types";
 import { BadRequestError } from "@app/lib/errors";
+import { ActorType } from "@app/services/auth/auth-type";
 
 import {
   assertGithubGroupMembersLinked,
   buildGithubMemberMatcher,
-  fetchGithubOrgTeams
+  createGithubOrgSyncAuditLogs,
+  fetchGithubOrgTeams,
+  mapGithubTeamsByName
 } from "./github-org-sync-service";
 
 type TVariables = { cursor: string | null; slug?: string; teamsPageSize?: number; membersPageSize?: number };
@@ -104,6 +108,108 @@ describe("fetchGithubOrgTeams", () => {
 
     const options = graphql.mock.calls[0][1] as unknown as { request: { signal: AbortSignal } };
     expect(options.request.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test("counts the member page nested in the team response toward the page limit", async () => {
+    const { octokit, graphql } = buildOctokit((query) => {
+      if (query.includes("query orgTeams")) {
+        return { organization: { teams: page([team("big", ["u1"], "next")], null) } };
+      }
+      return { organization: { team: { members: page([], "next") } } };
+    });
+
+    await expect(fetchGithubOrgTeams(octokit, "acme")).rejects.toThrow(/50000 member limit/);
+    expect(graphql).toHaveBeenCalledTimes(500);
+  });
+});
+
+describe("mapGithubTeamsByName", () => {
+  test("uses lowercase names as Infisical group keys", () => {
+    const teams = [{ name: "Platform" }, { name: "Security Operations" }];
+
+    expect([...mapGithubTeamsByName(teams).keys()]).toEqual(["platform", "security operations"]);
+  });
+
+  test("fails before syncing teams that map to the same lowercase group name", () => {
+    expect(() => mapGithubTeamsByName([{ name: "Platform" }, { name: "platform" }])).toThrow(
+      /both map to the Infisical group 'platform'.*No group changes were applied/
+    );
+  });
+});
+
+describe("createGithubOrgSyncAuditLogs", () => {
+  test("records the actor, affected membership, GitHub organization, and sync trigger", async () => {
+    const createAuditLog = vi.fn(async () => undefined);
+    const auditLogInfo: AuditLogInfo = {
+      actor: {
+        type: ActorType.USER,
+        metadata: {
+          userId: "admin-id",
+          username: "admin@example.com",
+          email: "admin@example.com"
+        }
+      },
+      ipAddress: "127.0.0.1",
+      userAgent: "vitest",
+      userAgentType: UserAgentType.OTHER
+    };
+
+    await createGithubOrgSyncAuditLogs({
+      auditLogService: { createAuditLog },
+      auditLogInfo,
+      orgId: "org-id",
+      githubOrgName: "acme",
+      syncTrigger: "manual",
+      changes: [
+        {
+          action: "add",
+          groupId: "group-a",
+          groupName: "platform",
+          userId: "user-a",
+          username: "user-a@example.com"
+        },
+        {
+          action: "remove",
+          groupId: "group-b",
+          groupName: "security",
+          userId: "user-b",
+          username: "user-b@example.com"
+        }
+      ]
+    });
+
+    expect(createAuditLog).toHaveBeenNthCalledWith(1, {
+      ...auditLogInfo,
+      orgId: "org-id",
+      event: {
+        type: EventType.ADD_USER_TO_GROUP,
+        metadata: {
+          groupId: "group-a",
+          groupName: "platform",
+          userId: "user-a",
+          username: "user-a@example.com",
+          source: "github-org-sync",
+          githubOrgName: "acme",
+          syncTrigger: "manual"
+        }
+      }
+    });
+    expect(createAuditLog).toHaveBeenNthCalledWith(2, {
+      ...auditLogInfo,
+      orgId: "org-id",
+      event: {
+        type: EventType.REMOVE_USER_FROM_GROUP,
+        metadata: {
+          groupId: "group-b",
+          groupName: "security",
+          userId: "user-b",
+          username: "user-b@example.com",
+          source: "github-org-sync",
+          githubOrgName: "acme",
+          syncTrigger: "manual"
+        }
+      }
+    });
   });
 });
 

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -37,6 +37,11 @@ import {
 
 const OctokitWithPlugin = Octokit.plugin(paginateGraphql);
 
+// The sync only ever reads from GitHub, so read:org is the whole requirement. Both 403 handlers
+// share this so they cannot drift apart again.
+const githubTeamAccessDeniedMessage = (githubOrgName: string) =>
+  `GitHub denied access to the teams in organization '${githubOrgName}'. A classic access token needs the 'read:org' scope. A fine-grained token needs Organization permissions > Members set to read, with the organization as its resource owner. GitHub also hides secret teams from anyone who is not an organization owner or a member of the team.`;
+
 // GitHub's GraphQL API times out (502) when one page resolves too many nodes; nesting members
 // under teams multiplies the per-page node count, so the team page is kept small.
 const GITHUB_TEAMS_PAGE_SIZE = 20;
@@ -672,8 +677,7 @@ export const githubOrgSyncServiceFactory = ({
         }
         if (statusCode === 403) {
           throw new BadRequestError({
-            message:
-              "GitHub access token lacks required permissions. Required: 1) 'read:org' scope for organization teams, 2) Token owner must be an organization member with team visibility access, 3) Organization settings must allow team visibility. Check GitHub token scopes and organization member permissions."
+            message: githubTeamAccessDeniedMessage(config.githubOrgName)
           });
         }
         if (statusCode === 404) {
@@ -773,8 +777,7 @@ export const githubOrgSyncServiceFactory = ({
         }
         if (statusCode === 403) {
           throw new BadRequestError({
-            message:
-              "GitHub access token lacks required permissions for organization team sync. Required: 1) 'admin:org' scope, 2) Token owner must be organization owner or have team read permissions, 3) Organization settings must allow team visibility. Check token scopes and user role."
+            message: githubTeamAccessDeniedMessage(config.githubOrgName)
           });
         }
         if (statusCode === 404) {

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -206,6 +206,44 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
   return teams.map(({ slug, name, description, members }) => ({ slug, name, description, members }));
 };
 
+type TMatchableMember<T> = { user?: { email?: string | null } | null; inviteEmail?: string | null } & T;
+
+// Matching runs once per (GitHub login, org member) pair, so for the reported org it is ~640 teams
+// x 7k memberships x 2.3k members. Deriving each member's comparison fields once per sync instead
+// of once per pair keeps that off the request's critical path; candidate order is preserved, so the
+// same member is still chosen. A member with no usable email could never match, so it is dropped
+// from the candidate list rather than re-tested and rejected on every comparison.
+export const buildGithubMemberMatcher = <T>(members: TMatchableMember<T>[]) => {
+  const emailSplitRegex = new RE2(/[._-]/);
+  const candidates = members.flatMap((member) => {
+    const email = member.user?.email || member.inviteEmail;
+    if (!email) return [];
+    const [rawPrefix, rawDomain] = email.split("@");
+    if (!rawPrefix || !rawDomain) return [];
+    const emailPrefix = rawPrefix.toLowerCase();
+    return [
+      {
+        member,
+        emailPrefix,
+        domainName: rawDomain.toLowerCase().split(".")[0],
+        longestEmailPart: emailPrefix.split(emailSplitRegex).reduce((a, b) => (a.length > b.length ? a : b), "")
+      }
+    ];
+  });
+
+  return (githubLogin: string) => {
+    const githubUsername = githubLogin.toLowerCase();
+    return candidates.find(
+      ({ emailPrefix, domainName, longestEmailPart }) =>
+        emailPrefix === githubUsername ||
+        (githubUsername.endsWith(domainName) &&
+          githubUsername.length > domainName.length &&
+          emailPrefix === githubUsername.slice(0, -domainName.length)) ||
+        (longestEmailPart.length >= 4 && githubUsername.includes(longestEmailPart))
+    )?.member;
+  };
+};
+
 // Type definitions for GitHub API errors
 interface GitHubApiError extends Error {
   status?: number;
@@ -758,6 +796,9 @@ export const githubOrgSyncServiceFactory = ({
       (member) => member.status === "accepted" && member.isActive
     ) as OrgMembershipWithUser[];
 
+    const matchGithubLogin = buildGithubMemberMatcher(activeMembers);
+    const activeMembersById = new Map(activeMembers.map((member) => [member.id, member]));
+
     const startTime = Date.now();
     const syncErrors: string[] = [];
 
@@ -871,31 +912,7 @@ export const githubOrgSyncServiceFactory = ({
         (githubTeamMembersByName.get(teamName) ?? []).forEach((login) => {
           const githubUsername = login.toLowerCase();
 
-          const matchingMember = activeMembers.find((member) => {
-            const email = member.user?.email || member.inviteEmail;
-            if (!email) return false;
-
-            const emailPrefix = email.split("@")[0].toLowerCase();
-            const emailDomain = email.split("@")[1].toLowerCase();
-
-            if (emailPrefix === githubUsername) {
-              return true;
-            }
-            const domainName = emailDomain.split(".")[0];
-            if (githubUsername.endsWith(domainName) && githubUsername.length > domainName.length) {
-              const baseUsername = githubUsername.slice(0, -domainName.length);
-              if (emailPrefix === baseUsername) {
-                return true;
-              }
-            }
-            const emailSplitRegex = new RE2(/[._-]/);
-            const emailParts = emailPrefix.split(emailSplitRegex);
-            const longestEmailPart = emailParts.reduce((a, b) => (a.length > b.length ? a : b), "");
-            if (longestEmailPart.length >= 4 && githubUsername.includes(longestEmailPart)) {
-              return true;
-            }
-            return false;
-          });
+          const matchingMember = matchGithubLogin(githubUsername);
 
           if (matchingMember?.user?.id) {
             expectedUserIds.add(matchingMember.user.id);
@@ -907,7 +924,7 @@ export const githubOrgSyncServiceFactory = ({
 
         const currentUserIds = new Set<string>();
         currentMemberships.forEach((membership) => {
-          const activeMember = activeMembers.find((am) => am.id === membership.orgMembershipId);
+          const activeMember = activeMembersById.get(membership.orgMembershipId);
           if (activeMember?.user?.id) {
             currentUserIds.add(activeMember.user.id);
           }
@@ -916,7 +933,7 @@ export const githubOrgSyncServiceFactory = ({
         const usersToAdd = Array.from(expectedUserIds).filter((userId) => !currentUserIds.has(userId));
 
         const membershipsToRemove = currentMemberships.filter((membership) => {
-          const activeMember = activeMembers.find((am) => am.id === membership.orgMembershipId);
+          const activeMember = activeMembersById.get(membership.orgMembershipId);
           return activeMember?.user?.id && !expectedUserIds.has(activeMember.user.id);
         });
 
@@ -942,7 +959,7 @@ export const githubOrgSyncServiceFactory = ({
           );
 
           const removedUserIds = membershipsToRemove
-            .map((membership) => activeMembers.find((am) => am.id === membership.orgMembershipId)?.user?.id)
+            .map((membership) => activeMembersById.get(membership.orgMembershipId)?.user?.id)
             .filter(Boolean) as string[];
           await alertChannelRecipientDAL.pruneOutOfScopeRecipients({ userIds: removedUserIds }, tx);
 

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -37,6 +37,167 @@ import {
 
 const OctokitWithPlugin = Octokit.plugin(paginateGraphql);
 
+// GitHub's GraphQL API times out (502) when one page resolves too many nodes; nesting members
+// under teams multiplies the per-page node count, so the team page is kept small.
+const GITHUB_TEAMS_PAGE_SIZE = 20;
+const GITHUB_TEAM_MEMBERS_PAGE_SIZE = 100;
+const GITHUB_MAX_PAGES = 500;
+const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+
+type TGithubPageInfo = { hasNextPage: boolean; endCursor: string | null };
+
+type TGithubTeamMembersConnection = {
+  edges: { node: { login: string } }[];
+  pageInfo: TGithubPageInfo;
+};
+
+type TGithubOrgTeamsResponse = {
+  organization: {
+    teams: {
+      edges: {
+        node: {
+          slug: string;
+          name: string;
+          description: string | null;
+          members: TGithubTeamMembersConnection;
+        };
+      }[];
+      pageInfo: TGithubPageInfo;
+    };
+  };
+};
+
+type TGithubTeamMembersResponse = {
+  organization: {
+    team: { members: TGithubTeamMembersConnection } | null;
+  };
+};
+
+export type TGithubTeam = {
+  slug: string;
+  name: string;
+  description: string | null;
+  members: string[];
+};
+
+const ORG_TEAMS_QUERY = `
+  query orgTeams($org: String!, $cursor: String, $teamsPageSize: Int!, $membersPageSize: Int!) {
+    organization(login: $org) {
+      teams(first: $teamsPageSize, after: $cursor) {
+        edges {
+          node {
+            slug
+            name
+            description
+            members(first: $membersPageSize) {
+              edges {
+                node {
+                  login
+                }
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+const TEAM_MEMBERS_QUERY = `
+  query teamMembers($org: String!, $slug: String!, $cursor: String, $membersPageSize: Int!) {
+    organization(login: $org) {
+      team(slug: $slug) {
+        members(first: $membersPageSize, after: $cursor) {
+          edges {
+            node {
+              login
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+  }
+`;
+
+const nextCursor = (pageInfo: TGithubPageInfo) => (pageInfo.hasNextPage ? pageInfo.endCursor : null);
+
+export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org: string): Promise<TGithubTeam[]> => {
+  const graphql = <T>(query: string, variables: Record<string, string | number | null>) =>
+    retryWithBackoff(() =>
+      octokit.graphql<T>(query, {
+        ...variables,
+        request: { signal: AbortSignal.timeout(GITHUB_REQUEST_TIMEOUT_MS) }
+      })
+    );
+
+  const teams: (TGithubTeam & { membersCursor: string | null })[] = [];
+
+  let teamsCursor: string | null = null;
+  let teamsPage = 0;
+  do {
+    const data: TGithubOrgTeamsResponse = await graphql<TGithubOrgTeamsResponse>(ORG_TEAMS_QUERY, {
+      org,
+      cursor: teamsCursor,
+      teamsPageSize: GITHUB_TEAMS_PAGE_SIZE,
+      membersPageSize: GITHUB_TEAM_MEMBERS_PAGE_SIZE
+    });
+    const connection = data.organization.teams;
+    connection.edges.forEach(({ node }) => {
+      teams.push({
+        slug: node.slug,
+        name: node.name,
+        description: node.description,
+        members: node.members.edges.map((edge) => edge.node.login),
+        membersCursor: nextCursor(node.members.pageInfo)
+      });
+    });
+    teamsCursor = nextCursor(connection.pageInfo);
+    teamsPage += 1;
+  } while (teamsCursor && teamsPage < GITHUB_MAX_PAGES);
+
+  if (teamsCursor) {
+    logger.warn({ org, fetchedTeams: teams.length }, "GitHub org team sync hit the page cap; team list truncated");
+  }
+
+  for (const team of teams) {
+    let membersPage = 0;
+    while (team.membersCursor && membersPage < GITHUB_MAX_PAGES) {
+      const data: TGithubTeamMembersResponse = await graphql<TGithubTeamMembersResponse>(TEAM_MEMBERS_QUERY, {
+        org,
+        slug: team.slug,
+        cursor: team.membersCursor,
+        membersPageSize: GITHUB_TEAM_MEMBERS_PAGE_SIZE
+      });
+      const connection = data.organization.team?.members;
+      if (!connection) break;
+      team.members.push(...connection.edges.map((edge) => edge.node.login));
+      team.membersCursor = nextCursor(connection.pageInfo);
+      membersPage += 1;
+    }
+
+    if (team.membersCursor) {
+      logger.warn(
+        { org, team: team.slug, fetchedMembers: team.members.length },
+        "GitHub org team sync hit the page cap; team member list truncated"
+      );
+    }
+  }
+
+  return teams.map(({ slug, name, description, members }) => ({ slug, name, description, members }));
+};
+
 // Type definitions for GitHub API errors
 interface GitHubApiError extends Error {
   status?: number;
@@ -594,121 +755,53 @@ export const githubOrgSyncServiceFactory = ({
     const startTime = Date.now();
     const syncErrors: string[] = [];
 
-    const octokit = new OctokitWithPlugin({
-      auth: orgAccessToken,
-      request: {
-        signal: AbortSignal.timeout(30000)
+    const octokit = new Octokit({ auth: orgAccessToken });
+
+    const githubTeams = await fetchGithubOrgTeams(octokit, config.githubOrgName).catch((err) => {
+      logger.error(err, "GitHub GraphQL error for batched team sync");
+
+      const gitHubError = err as GitHubApiError;
+      const statusCode = gitHubError.status || gitHubError.response?.status;
+      if (statusCode) {
+        if (statusCode === 401) {
+          throw new BadRequestError({
+            message: "GitHub access token is invalid or expired. Please provide a new token."
+          });
+        }
+        if (statusCode === 403) {
+          throw new BadRequestError({
+            message:
+              "GitHub access token lacks required permissions for organization team sync. Required: 1) 'admin:org' scope, 2) Token owner must be organization owner or have team read permissions, 3) Organization settings must allow team visibility. Check token scopes and user role."
+          });
+        }
+        if (statusCode === 404) {
+          throw new BadRequestError({
+            message: `Organization ${config.githubOrgName} not found or access token does not have sufficient permissions to read it.`
+          });
+        }
+        if (statusCode >= 500) {
+          throw new BadRequestError({
+            message: `GitHub did not respond in time while listing teams for organization ${config.githubOrgName}. Please try again later.`
+          });
+        }
       }
-    });
 
-    const data = await retryWithBackoff(async () => {
-      return octokit.graphql
-        .paginate<{
-          organization: {
-            teams: {
-              totalCount: number;
-              edges: {
-                node: {
-                  name: string;
-                  description: string;
-                  members: {
-                    edges: {
-                      node: {
-                        login: string;
-                      };
-                    }[];
-                  };
-                };
-              }[];
-            };
-          };
-        }>(
-          `
-        query orgTeams($cursor: String, $org: String!) {
-          organization(login: $org) {
-            teams(first: 100, after: $cursor) {
-              totalCount
-              edges {
-                node {
-                  name
-                  description
-                  members(first: 100) {
-                    edges {
-                      node {
-                        login
-                      }
-                    }
-                  }
-                }
-              }
-              pageInfo {
-                hasNextPage
-                endCursor
-              }
-            }
-          }
-        }
-        `,
-          {
-            org: config.githubOrgName
-          }
-        )
-        .catch((err) => {
-          logger.error(err, "GitHub GraphQL error for batched team sync");
-
-          const gitHubError = err as GitHubApiError;
-          const statusCode = gitHubError.status || gitHubError.response?.status;
-          if (statusCode) {
-            if (statusCode === 401) {
-              throw new BadRequestError({
-                message: "GitHub access token is invalid or expired. Please provide a new token."
-              });
-            }
-            if (statusCode === 403) {
-              throw new BadRequestError({
-                message:
-                  "GitHub access token lacks required permissions for organization team sync. Required: 1) 'admin:org' scope, 2) Token owner must be organization owner or have team read permissions, 3) Organization settings must allow team visibility. Check token scopes and user role."
-              });
-            }
-            if (statusCode === 404) {
-              throw new BadRequestError({
-                message: `Organization ${config.githubOrgName} not found or access token does not have sufficient permissions to read it.`
-              });
-            }
-          }
-
-          if ((err as Error)?.message?.includes("Although you appear to have the correct authorization credential")) {
-            throw new BadRequestError({
-              message:
-                "Organization has restricted OAuth app access. Please check that: 1) Your organization has approved the Infisical OAuth application, 2) The token owner has sufficient organization permissions."
-            });
-          }
-          throw new BadRequestError({ message: `GitHub GraphQL query failed: ${(err as Error)?.message}` });
+      if ((err as Error)?.message?.includes("Although you appear to have the correct authorization credential")) {
+        throw new BadRequestError({
+          message:
+            "Organization has restricted OAuth app access. Please check that: 1) Your organization has approved the Infisical OAuth application, 2) The token owner has sufficient organization permissions."
         });
+      }
+      throw new BadRequestError({ message: `GitHub GraphQL query failed: ${(err as Error)?.message}` });
     });
 
-    const {
-      organization: { teams }
-    } = data;
-
-    const userTeamMap = new Map<string, string[]>();
-    const allGithubUsernamesInTeams = new Set<string>();
-
-    teams?.edges?.forEach((teamEdge) => {
-      const teamName = teamEdge.node.name.toLowerCase();
-
-      teamEdge.node.members.edges.forEach((memberEdge) => {
-        const username = memberEdge.node.login.toLowerCase();
-        allGithubUsernamesInTeams.add(username);
-
-        if (!userTeamMap.has(username)) {
-          userTeamMap.set(username, []);
-        }
-        userTeamMap.get(username)!.push(teamName);
-      });
+    const githubTeamMembersByName = new Map<string, string[]>();
+    githubTeams.forEach((team) => {
+      const teamName = team.name.toLowerCase();
+      githubTeamMembersByName.set(teamName, [...(githubTeamMembersByName.get(teamName) ?? []), ...team.members]);
     });
 
-    const allGithubTeamNames = Array.from(new Set(teams?.edges?.map((edge) => edge.node.name.toLowerCase()) || []));
+    const allGithubTeamNames = Array.from(githubTeamMembersByName.keys());
 
     const existingTeamsOnInfisical = await groupDAL.find({
       orgId: orgPermission.orgId,
@@ -770,44 +863,40 @@ export const githubOrgSyncServiceFactory = ({
         )) as GroupMembership[];
 
         const expectedUserIds = new Set<string>();
-        teams?.edges?.forEach((teamEdge) => {
-          if (teamEdge.node.name.toLowerCase() === teamName) {
-            teamEdge.node.members.edges.forEach((memberEdge) => {
-              const githubUsername = memberEdge.node.login.toLowerCase();
+        (githubTeamMembersByName.get(teamName) ?? []).forEach((login) => {
+          const githubUsername = login.toLowerCase();
 
-              const matchingMember = activeMembers.find((member) => {
-                const email = member.user?.email || member.inviteEmail;
-                if (!email) return false;
+          const matchingMember = activeMembers.find((member) => {
+            const email = member.user?.email || member.inviteEmail;
+            if (!email) return false;
 
-                const emailPrefix = email.split("@")[0].toLowerCase();
-                const emailDomain = email.split("@")[1].toLowerCase();
+            const emailPrefix = email.split("@")[0].toLowerCase();
+            const emailDomain = email.split("@")[1].toLowerCase();
 
-                if (emailPrefix === githubUsername) {
-                  return true;
-                }
-                const domainName = emailDomain.split(".")[0];
-                if (githubUsername.endsWith(domainName) && githubUsername.length > domainName.length) {
-                  const baseUsername = githubUsername.slice(0, -domainName.length);
-                  if (emailPrefix === baseUsername) {
-                    return true;
-                  }
-                }
-                const emailSplitRegex = new RE2(/[._-]/);
-                const emailParts = emailPrefix.split(emailSplitRegex);
-                const longestEmailPart = emailParts.reduce((a, b) => (a.length > b.length ? a : b), "");
-                if (longestEmailPart.length >= 4 && githubUsername.includes(longestEmailPart)) {
-                  return true;
-                }
-                return false;
-              });
-
-              if (matchingMember?.user?.id) {
-                expectedUserIds.add(matchingMember.user.id);
-                logger.info(
-                  `Matched GitHub user ${githubUsername} to email ${matchingMember.user?.email || matchingMember.inviteEmail}`
-                );
+            if (emailPrefix === githubUsername) {
+              return true;
+            }
+            const domainName = emailDomain.split(".")[0];
+            if (githubUsername.endsWith(domainName) && githubUsername.length > domainName.length) {
+              const baseUsername = githubUsername.slice(0, -domainName.length);
+              if (emailPrefix === baseUsername) {
+                return true;
               }
-            });
+            }
+            const emailSplitRegex = new RE2(/[._-]/);
+            const emailParts = emailPrefix.split(emailSplitRegex);
+            const longestEmailPart = emailParts.reduce((a, b) => (a.length > b.length ? a : b), "");
+            if (longestEmailPart.length >= 4 && githubUsername.includes(longestEmailPart)) {
+              return true;
+            }
+            return false;
+          });
+
+          if (matchingMember?.user?.id) {
+            expectedUserIds.add(matchingMember.user.id);
+            logger.info(
+              `Matched GitHub user ${githubUsername} to email ${matchingMember.user?.email || matchingMember.inviteEmail}`
+            );
           }
         });
 

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -221,7 +221,7 @@ export type TGithubMemberMatchRule = (typeof GithubMemberMatchRule)[keyof typeof
 
 export type TGithubMemberMatch<T> =
   | { status: "matched"; member: T; rule: TGithubMemberMatchRule }
-  | { status: "ambiguous"; rule: TGithubMemberMatchRule; emails: string[] }
+  | { status: "ambiguous"; rule: TGithubMemberMatchRule; members: T[] }
   | { status: "unmatched" };
 
 const SEPARATORS = new RE2(/[._-]/g);
@@ -275,7 +275,11 @@ export const buildGithubMemberMatcher = <T>(members: TMatchableMember<T>[]) => {
       const distinct = [...new Map(hits.map((hit) => [hit.email, hit])).values()];
       if (distinct.length === 1) return { status: "matched", member: distinct[0].member, rule };
       if (distinct.length > 1) {
-        return { status: "ambiguous", rule, emails: distinct.map((hit) => hit.email).sort() };
+        return {
+          status: "ambiguous",
+          rule,
+          members: distinct.sort((a, b) => a.email.localeCompare(b.email)).map((hit) => hit.member)
+        };
       }
     }
 
@@ -949,7 +953,7 @@ export const githubOrgSyncServiceFactory = ({
         )) as GroupMembership[];
 
         const expectedUserIds = new Set<string>();
-        let hasUnresolvedLogin = false;
+        const unresolvedUserIds = new Set<string>();
         (githubTeamMembersByName.get(teamName) ?? []).forEach((login) => {
           const githubUsername = login.toLowerCase();
 
@@ -961,8 +965,13 @@ export const githubOrgSyncServiceFactory = ({
               `Matched GitHub user ${githubUsername} to email ${result.member.user?.email || result.member.inviteEmail} by ${result.rule}`
             );
           } else if (result.status === "ambiguous") {
-            hasUnresolvedLogin = true;
-            ambiguousLogins.set(githubUsername, result.emails);
+            const emails: string[] = [];
+            result.members.forEach((candidate) => {
+              if (candidate.user?.id) unresolvedUserIds.add(candidate.user.id);
+              const email = candidate.user?.email || candidate.inviteEmail;
+              if (email) emails.push(email);
+            });
+            ambiguousLogins.set(githubUsername, emails);
           }
         });
 
@@ -976,15 +985,14 @@ export const githubOrgSyncServiceFactory = ({
 
         const usersToAdd = Array.from(expectedUserIds).filter((userId) => !currentUserIds.has(userId));
 
-        // An ambiguous login means we do not know which member it is, not that nobody in the group
-        // belongs there. Removing on that basis would strip the whole team, so additions still run
-        // for the logins that did resolve and removals wait until the ambiguity is fixed.
-        const membershipsToRemove = hasUnresolvedLogin
-          ? []
-          : currentMemberships.filter((membership) => {
-              const activeMember = activeMembersById.get(membership.orgMembershipId);
-              return activeMember?.user?.id && !expectedUserIds.has(activeMember.user.id);
-            });
+        // An ambiguous login says we cannot tell which of its candidates belongs here, not that the
+        // team is empty. Only those candidates are held back; anyone else who left the GitHub team
+        // is still removed, so one unresolved collision cannot preserve unrelated stale access.
+        const membershipsToRemove = currentMemberships.filter((membership) => {
+          const userId = activeMembersById.get(membership.orgMembershipId)?.user?.id;
+          if (!userId) return false;
+          return !expectedUserIds.has(userId) && !unresolvedUserIds.has(userId);
+        });
 
         if (usersToAdd.length > 0) {
           await userGroupMembershipDAL.insertMany(
@@ -1033,7 +1041,7 @@ export const githubOrgSyncServiceFactory = ({
       syncErrors.push(
         ...listed.map(
           ([login, emails]) =>
-            `GitHub user '${login}' matches more than one organization member (${emails.join(", ")}), so Infisical cannot tell which one they are. Their teams were left unchanged. Align one member's email with their GitHub username to resolve it.`
+            `GitHub user '${login}' matches more than one organization member (${emails.join(", ")}), so Infisical cannot tell which one they are. Their existing group access was left as it is. Align one member's email with their GitHub username to resolve it.`
         )
       );
       if (ambiguousLogins.size > listed.length) {

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -206,36 +206,80 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
 
 type TMatchableMember<T> = { user?: { email?: string | null } | null; inviteEmail?: string | null } & T;
 
-// ~16M (login, member) comparisons on a 640-team org, so per-member fields are derived once per
-// sync. Order must stay input order, or `find` picks a different member than before.
+// Weakest rule a login is allowed to match on. A name part shorter than this collides constantly.
+const GITHUB_MIN_NAME_PART_LENGTH = 4;
+
+const AMBIGUOUS_LOGIN_REPORT_LIMIT = 20;
+
+export const GithubMemberMatchRule = {
+  Email: "email",
+  EmailWithOrgSuffix: "email-with-org-suffix",
+  NamePart: "name-part"
+} as const;
+
+export type TGithubMemberMatchRule = (typeof GithubMemberMatchRule)[keyof typeof GithubMemberMatchRule];
+
+export type TGithubMemberMatch<T> =
+  | { status: "matched"; member: T; rule: TGithubMemberMatchRule }
+  | { status: "ambiguous"; rule: TGithubMemberMatchRule; emails: string[] }
+  | { status: "unmatched" };
+
+const SEPARATORS = new RE2(/[._-]/g);
+const stripSeparators = (value: string) => value.replace(SEPARATORS, "");
+
+/**
+ * Resolves a GitHub login to the org member it belongs to.
+ *
+ * Rules are tried strongest first across every member, so an exact email match always beats a name
+ * fragment no matter what order members arrive in. A login that two members match equally well is
+ * reported as ambiguous rather than resolved, because guessing hands one of them the other's
+ * project access.
+ */
 export const buildGithubMemberMatcher = <T>(members: TMatchableMember<T>[]) => {
-  const emailSplitRegex = new RE2(/[._-]/);
+  // ~16M (login, member) comparisons on a 640-team org, so per-member fields are derived once per
+  // sync rather than once per comparison.
   const candidates = members.flatMap((member) => {
     const email = member.user?.email || member.inviteEmail;
     if (!email) return [];
     const [rawPrefix, rawDomain] = email.split("@");
     if (!rawPrefix || !rawDomain) return [];
     const emailPrefix = rawPrefix.toLowerCase();
+    const parts = emailPrefix.split(new RE2(/[._-]/));
     return [
       {
         member,
-        emailPrefix,
-        domainName: rawDomain.toLowerCase().split(".")[0],
-        longestEmailPart: emailPrefix.split(emailSplitRegex).reduce((a, b) => (a.length > b.length ? a : b), "")
+        email: email.toLowerCase(),
+        compactPrefix: stripSeparators(emailPrefix),
+        orgSuffixed: stripSeparators(emailPrefix) + stripSeparators(rawDomain.toLowerCase().split(".")[0]),
+        longestPart: parts.reduce((a, b) => (a.length > b.length ? a : b), "")
       }
     ];
   });
 
-  return (githubLogin: string) => {
-    const githubUsername = githubLogin.toLowerCase();
-    return candidates.find(
-      ({ emailPrefix, domainName, longestEmailPart }) =>
-        emailPrefix === githubUsername ||
-        (githubUsername.endsWith(domainName) &&
-          githubUsername.length > domainName.length &&
-          emailPrefix === githubUsername.slice(0, -domainName.length)) ||
-        (longestEmailPart.length >= 4 && githubUsername.includes(longestEmailPart))
-    )?.member;
+  return (githubLogin: string): TGithubMemberMatch<T> => {
+    const login = githubLogin.toLowerCase();
+    const compactLogin = stripSeparators(login);
+    const loginParts = new Set(login.split(new RE2(/[._-]/)));
+
+    const rules: [TGithubMemberMatchRule, (c: (typeof candidates)[number]) => boolean][] = [
+      [GithubMemberMatchRule.Email, (c) => c.compactPrefix === compactLogin],
+      [GithubMemberMatchRule.EmailWithOrgSuffix, (c) => c.orgSuffixed === compactLogin],
+      [
+        GithubMemberMatchRule.NamePart,
+        (c) => c.longestPart.length >= GITHUB_MIN_NAME_PART_LENGTH && loginParts.has(c.longestPart)
+      ]
+    ];
+
+    for (const [rule, predicate] of rules) {
+      const hits = candidates.filter(predicate);
+      const distinct = [...new Map(hits.map((hit) => [hit.email, hit])).values()];
+      if (distinct.length === 1) return { status: "matched", member: distinct[0].member, rule };
+      if (distinct.length > 1) {
+        return { status: "ambiguous", rule, emails: distinct.map((hit) => hit.email).sort() };
+      }
+    }
+
+    return { status: "unmatched" };
   };
 };
 
@@ -796,6 +840,7 @@ export const githubOrgSyncServiceFactory = ({
 
     const startTime = Date.now();
     const syncErrors: string[] = [];
+    const ambiguousLogins = new Map<string, string[]>();
 
     const octokit = new Octokit({ auth: orgAccessToken });
 
@@ -907,13 +952,15 @@ export const githubOrgSyncServiceFactory = ({
         (githubTeamMembersByName.get(teamName) ?? []).forEach((login) => {
           const githubUsername = login.toLowerCase();
 
-          const matchingMember = matchGithubLogin(githubUsername);
+          const result = matchGithubLogin(githubUsername);
 
-          if (matchingMember?.user?.id) {
-            expectedUserIds.add(matchingMember.user.id);
+          if (result.status === "matched" && result.member.user?.id) {
+            expectedUserIds.add(result.member.user.id);
             logger.info(
-              `Matched GitHub user ${githubUsername} to email ${matchingMember.user?.email || matchingMember.inviteEmail}`
+              `Matched GitHub user ${githubUsername} to email ${result.member.user?.email || result.member.inviteEmail} by ${result.rule}`
             );
+          } else if (result.status === "ambiguous") {
+            ambiguousLogins.set(githubUsername, result.emails);
           }
         });
 
@@ -967,6 +1014,26 @@ export const githubOrgSyncServiceFactory = ({
       // Team membership changes cascade into the group-expanded project identity meters.
       usageMeteringService.emit(orgPermission.orgId, SecretIdentities.key);
       usageMeteringService.emit(orgPermission.orgId, PamIdentities.key);
+    }
+
+    if (ambiguousLogins.size) {
+      logger.warn(
+        { orgId: orgPermission.orgId, count: ambiguousLogins.size },
+        "GitHub org sync skipped logins that more than one organization member matched"
+      );
+      // Capped so a badly aliased org cannot return a response the client has to scroll through.
+      const listed = [...ambiguousLogins.entries()].slice(0, AMBIGUOUS_LOGIN_REPORT_LIMIT);
+      syncErrors.push(
+        ...listed.map(
+          ([login, emails]) =>
+            `GitHub user '${login}' matches more than one organization member (${emails.join(", ")}), so their team memberships were not synced. Align the member's email with their GitHub username.`
+        )
+      );
+      if (ambiguousLogins.size > listed.length) {
+        syncErrors.push(
+          `${ambiguousLogins.size - listed.length} further GitHub users were skipped for the same reason.`
+        );
+      }
     }
 
     const syncDuration = Date.now() - startTime;

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -540,7 +540,6 @@ export const githubOrgSyncServiceFactory = ({
           const newGroups = await groupDAL.insertMany(
             newTeams.map((newGroupName) => ({
               name: newGroupName,
-              role: OrgMembershipRole.Member,
               slug: newGroupName,
               orgId
             })),
@@ -823,7 +822,6 @@ export const githubOrgSyncServiceFactory = ({
         const newGroups = await groupDAL.insertMany(
           teamsToCreate.map((teamName) => ({
             name: teamName,
-            role: OrgMembershipRole.Member,
             slug: teamName,
             orgId: orgPermission.orgId
           })),

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -37,13 +37,11 @@ import {
 
 const OctokitWithPlugin = Octokit.plugin(paginateGraphql);
 
-// The sync only ever reads from GitHub, so read:org is the whole requirement. Both 403 handlers
-// share this so they cannot drift apart again.
+// The sync only reads from GitHub, so read:org is the whole requirement.
 const githubTeamAccessDeniedMessage = (githubOrgName: string) =>
   `GitHub denied access to the teams in organization '${githubOrgName}'. A classic access token needs the 'read:org' scope. A fine-grained token needs Organization permissions > Members set to read, with the organization as its resource owner. GitHub also hides secret teams from anyone who is not an organization owner or a member of the team.`;
 
-// GitHub's GraphQL API times out (502) when one page resolves too many nodes; nesting members
-// under teams multiplies the per-page node count, so the team page is kept small.
+// GitHub 502s when one page resolves too many nodes, and nesting members under teams multiplies it.
 const GITHUB_TEAMS_PAGE_SIZE = 20;
 const GITHUB_TEAM_MEMBERS_PAGE_SIZE = 100;
 const GITHUB_MAX_PAGES = 500;
@@ -208,11 +206,8 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
 
 type TMatchableMember<T> = { user?: { email?: string | null } | null; inviteEmail?: string | null } & T;
 
-// Matching runs once per (GitHub login, org member) pair, so for the reported org it is ~640 teams
-// x 7k memberships x 2.3k members. Deriving each member's comparison fields once per sync instead
-// of once per pair keeps that off the request's critical path; candidate order is preserved, so the
-// same member is still chosen. A member with no usable email could never match, so it is dropped
-// from the candidate list rather than re-tested and rejected on every comparison.
+// ~16M (login, member) comparisons on a 640-team org, so per-member fields are derived once per
+// sync. Order must stay input order, or `find` picks a different member than before.
 export const buildGithubMemberMatcher = <T>(members: TMatchableMember<T>[]) => {
   const emailSplitRegex = new RE2(/[._-]/);
   const candidates = members.flatMap((member) => {

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -181,17 +181,20 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
         membersPageSize: GITHUB_TEAM_MEMBERS_PAGE_SIZE
       });
       const connection = data.organization.team?.members;
-      if (!connection) break;
+      if (!connection) {
+        throw new BadRequestError({
+          message: `GitHub team '${team.slug}' was renamed or deleted while its members were being listed. Please run the sync again.`
+        });
+      }
       team.members.push(...connection.edges.map((edge) => edge.node.login));
       team.membersCursor = nextCursor(connection.pageInfo);
       membersPage += 1;
     }
 
     if (team.membersCursor) {
-      logger.warn(
-        { org, team: team.slug, fetchedMembers: team.members.length },
-        "GitHub org team sync hit the page cap; team member list truncated"
-      );
+      throw new BadRequestError({
+        message: `GitHub team '${team.slug}' has more members than can be synced (${GITHUB_MAX_PAGES * GITHUB_TEAM_MEMBERS_PAGE_SIZE} member limit).`
+      });
     }
   }
 
@@ -758,6 +761,7 @@ export const githubOrgSyncServiceFactory = ({
     const octokit = new Octokit({ auth: orgAccessToken });
 
     const githubTeams = await fetchGithubOrgTeams(octokit, config.githubOrgName).catch((err) => {
+      if (err instanceof BadRequestError) throw err;
       logger.error(err, "GitHub GraphQL error for batched team sync");
 
       const gitHubError = err as GitHubApiError;

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -949,6 +949,7 @@ export const githubOrgSyncServiceFactory = ({
         )) as GroupMembership[];
 
         const expectedUserIds = new Set<string>();
+        let hasUnresolvedLogin = false;
         (githubTeamMembersByName.get(teamName) ?? []).forEach((login) => {
           const githubUsername = login.toLowerCase();
 
@@ -960,6 +961,7 @@ export const githubOrgSyncServiceFactory = ({
               `Matched GitHub user ${githubUsername} to email ${result.member.user?.email || result.member.inviteEmail} by ${result.rule}`
             );
           } else if (result.status === "ambiguous") {
+            hasUnresolvedLogin = true;
             ambiguousLogins.set(githubUsername, result.emails);
           }
         });
@@ -974,10 +976,15 @@ export const githubOrgSyncServiceFactory = ({
 
         const usersToAdd = Array.from(expectedUserIds).filter((userId) => !currentUserIds.has(userId));
 
-        const membershipsToRemove = currentMemberships.filter((membership) => {
-          const activeMember = activeMembersById.get(membership.orgMembershipId);
-          return activeMember?.user?.id && !expectedUserIds.has(activeMember.user.id);
-        });
+        // An ambiguous login means we do not know which member it is, not that nobody in the group
+        // belongs there. Removing on that basis would strip the whole team, so additions still run
+        // for the logins that did resolve and removals wait until the ambiguity is fixed.
+        const membershipsToRemove = hasUnresolvedLogin
+          ? []
+          : currentMemberships.filter((membership) => {
+              const activeMember = activeMembersById.get(membership.orgMembershipId);
+              return activeMember?.user?.id && !expectedUserIds.has(activeMember.user.id);
+            });
 
         if (usersToAdd.length > 0) {
           await userGroupMembershipDAL.insertMany(
@@ -1026,7 +1033,7 @@ export const githubOrgSyncServiceFactory = ({
       syncErrors.push(
         ...listed.map(
           ([login, emails]) =>
-            `GitHub user '${login}' matches more than one organization member (${emails.join(", ")}), so their team memberships were not synced. Align the member's email with their GitHub username.`
+            `GitHub user '${login}' matches more than one organization member (${emails.join(", ")}), so Infisical cannot tell which one they are. Their teams were left unchanged. Align one member's email with their GitHub username to resolve it.`
         )
       );
       if (ambiguousLogins.size > listed.length) {

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -267,13 +267,39 @@ interface GroupMembership {
   lastName: string | null;
 }
 
+export const assertGithubGroupMembersLinked = ({
+  currentUserIds,
+  linkedUserIds,
+  activeUsers,
+  noChangesApplied = false
+}: {
+  currentUserIds: Set<string>;
+  linkedUserIds: Set<string>;
+  activeUsers: { id: string; email: string }[];
+  noChangesApplied?: boolean;
+}) => {
+  const unlinkedUserIds = [...currentUserIds].filter((userId) => !linkedUserIds.has(userId));
+  if (!unlinkedUserIds.length) return;
+
+  const emailsByUserId = new Map(activeUsers.map((user) => [user.id, user.email]));
+  const reportLimit = 10;
+  const listedMembers = unlinkedUserIds.slice(0, reportLimit).map((userId) => emailsByUserId.get(userId) ?? userId);
+  const remainingCount = unlinkedUserIds.length - listedMembers.length;
+  const remainingMessage = remainingCount > 0 ? ` and ${remainingCount} more` : "";
+  const completionMessage = noChangesApplied ? " No changes were applied." : "";
+
+  throw new BadRequestError({
+    message: `GitHub team sync cannot safely reconcile ${unlinkedUserIds.length} existing group member${unlinkedUserIds.length === 1 ? "" : "s"} without a verified GitHub sign-in (${listedMembers.join(", ")}${remainingMessage}). Ask them to sign in with GitHub, or remove them from the corresponding Infisical groups, then run the sync again.${completionMessage}`
+  });
+};
+
 type TGithubOrgSyncServiceFactoryDep = {
   githubOrgSyncDAL: TGithubOrgSyncDALFactory;
   permissionService: Pick<TPermissionServiceFactory, "getOrgPermission">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   userGroupMembershipDAL: Pick<
     TUserGroupMembershipDALFactory,
-    "findGroupMembershipsByUserIdInOrg" | "findGroupMembershipsByGroupIdInOrg" | "insertMany" | "delete"
+    "find" | "findGroupMembershipsByUserIdInOrg" | "findGroupMembershipsByGroupIdInOrg" | "insertMany" | "delete"
   >;
   groupDAL: Pick<TGroupDALFactory, "insertMany" | "transaction" | "find">;
   membershipRoleDAL: Pick<TMembershipRoleDALFactory, "insertMany">;
@@ -796,11 +822,11 @@ export const githubOrgSyncServiceFactory = ({
       : [];
     const matchGithubMember = buildGithubMemberMatcher(githubAliases, activeUserIds);
     const linkedActiveUserIds = new Set(githubAliases.map((alias) => alias.userId));
+    const activeUsers = activeMembers.flatMap((member) => (member.user ? [member.user] : []));
 
     const startTime = Date.now();
     const syncErrors: string[] = [];
     const unmatchedGithubUsers = new Set<string>();
-    const preservedUnlinkedUserIds = new Set<string>();
 
     const octokit = new Octokit({ auth: orgAccessToken });
 
@@ -856,10 +882,24 @@ export const githubOrgSyncServiceFactory = ({
     });
     const existingTeamsMap = groupBy(existingTeamsOnInfisical, (i) => i.name);
 
+    if (existingTeamsOnInfisical.length) {
+      const existingGroupMemberships = await userGroupMembershipDAL.find({
+        $in: { groupId: existingTeamsOnInfisical.map((team) => team.id) }
+      });
+      assertGithubGroupMembersLinked({
+        currentUserIds: new Set(
+          existingGroupMemberships.map((membership) => membership.userId).filter((userId) => activeUserIds.has(userId))
+        ),
+        linkedUserIds: linkedActiveUserIds,
+        activeUsers,
+        noChangesApplied: true
+      });
+    }
+
     const teamsToCreate = allGithubTeamNames.filter((teamName) => !(teamName in existingTeamsMap));
     const createdTeams = new Set<string>();
     const updatedTeams = new Set<string>();
-    const totalRemovedMemberships = 0;
+    let totalRemovedMemberships = 0;
 
     if (teamsToCreate.length > 0) {
       await groupDAL.transaction(async (tx) => {
@@ -918,7 +958,7 @@ export const githubOrgSyncServiceFactory = ({
         }
       });
 
-      await groupDAL.transaction(async (tx) => {
+      const removedMembershipsForTeam = await groupDAL.transaction(async (tx) => {
         const currentMemberships = (await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(
           team.id,
           orgPermission.orgId,
@@ -932,18 +972,17 @@ export const githubOrgSyncServiceFactory = ({
             currentUserIds.add(activeMember.user.id);
           }
         });
+        assertGithubGroupMembersLinked({
+          currentUserIds,
+          linkedUserIds: linkedActiveUserIds,
+          activeUsers
+        });
 
         const usersToAdd = Array.from(expectedUserIds).filter((userId) => !currentUserIds.has(userId));
 
-        // A member without a verified GitHub alias has no trustworthy identity to reconcile yet.
-        // Keep their current access until a GitHub login creates that link.
         const membershipsToRemove = currentMemberships.filter((membership) => {
           const userId = activeMembersById.get(membership.orgMembershipId)?.user?.id;
           if (!userId) return false;
-          if (!linkedActiveUserIds.has(userId)) {
-            preservedUnlinkedUserIds.add(userId);
-            return false;
-          }
           return !expectedUserIds.has(userId);
         });
 
@@ -975,19 +1014,16 @@ export const githubOrgSyncServiceFactory = ({
 
           updatedTeams.add(teamName);
         }
+
+        return membershipsToRemove.length;
       });
+      totalRemovedMemberships += removedMembershipsForTeam;
     }
 
     if (createdTeams.size || updatedTeams.size) {
       // Team membership changes cascade into the group-expanded project identity meters.
       usageMeteringService.emit(orgPermission.orgId, SecretIdentities.key);
       usageMeteringService.emit(orgPermission.orgId, PamIdentities.key);
-    }
-
-    if (preservedUnlinkedUserIds.size) {
-      syncErrors.push(
-        `Infisical left existing group access unchanged for ${preservedUnlinkedUserIds.size} organization member${preservedUnlinkedUserIds.size === 1 ? "" : "s"} without a verified GitHub login. Ask them to sign in with GitHub, then run the sync again.`
-      );
     }
 
     if (unmatchedGithubUsers.size) {

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -6,6 +6,7 @@ import { paginateGraphql } from "@octokit/plugin-paginate-graphql";
 import { Octokit as OctokitRest } from "@octokit/rest";
 
 import { AccessScope, OrganizationActionScope, OrgMembershipRole } from "@app/db/schemas";
+import { AuditLogInfo, EventType, TAuditLogServiceFactory } from "@app/ee/services/audit-log/audit-log-types";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { groupBy } from "@app/lib/fn";
 import { logger } from "@app/lib/logger";
@@ -32,6 +33,7 @@ import {
   TDeleteGithubOrgSyncDTO,
   TSyncAllTeamsDTO,
   TSyncResult,
+  TSyncUserGroupsDTO,
   TUpdateGithubOrgSyncDTO,
   TValidateGithubTokenDTO
 } from "./github-org-sync-types";
@@ -47,6 +49,7 @@ const GITHUB_TEAMS_PAGE_SIZE = 20;
 const GITHUB_TEAM_MEMBERS_PAGE_SIZE = 100;
 const GITHUB_MAX_PAGES = 500;
 const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
+const GITHUB_AUDIT_LOG_CONCURRENCY = 25;
 
 type TGithubPageInfo = { hasNextPage: boolean; endCursor: string | null };
 
@@ -183,7 +186,7 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
   }
 
   for (const team of teams) {
-    let membersPage = 0;
+    let membersPage = 1;
     while (team.membersCursor && membersPage < GITHUB_MAX_PAGES) {
       const data: TGithubTeamMembersResponse = await graphql<TGithubTeamMembersResponse>(TEAM_MEMBERS_QUERY, {
         org,
@@ -229,6 +232,71 @@ export const buildGithubMemberMatcher = (aliases: TGithubAlias[], activeUserIds:
 
   return (member: TGithubTeamMember) =>
     member.databaseId === null ? undefined : userIdByGithubId.get(String(member.databaseId));
+};
+
+export const mapGithubTeamsByName = <T extends { name: string }>(teams: T[]) => {
+  const teamsByName = new Map<string, T>();
+
+  teams.forEach((team) => {
+    const normalizedName = team.name.toLowerCase();
+    const existingTeam = teamsByName.get(normalizedName);
+    if (existingTeam) {
+      throw new BadRequestError({
+        message: `GitHub teams '${existingTeam.name}' and '${team.name}' both map to the Infisical group '${normalizedName}'. Rename one of the GitHub teams, then run the sync again. No group changes were applied.`
+      });
+    }
+    teamsByName.set(normalizedName, team);
+  });
+
+  return teamsByName;
+};
+
+type TGithubOrgSyncAuditChange = {
+  action: "add" | "remove";
+  groupId: string;
+  groupName: string;
+  userId: string;
+  username: string;
+};
+
+export const createGithubOrgSyncAuditLogs = async ({
+  auditLogService,
+  auditLogInfo,
+  orgId,
+  githubOrgName,
+  syncTrigger,
+  changes
+}: {
+  auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
+  auditLogInfo: AuditLogInfo;
+  orgId: string;
+  githubOrgName: string;
+  syncTrigger: "login" | "manual";
+  changes: TGithubOrgSyncAuditChange[];
+}) => {
+  for (let offset = 0; offset < changes.length; offset += GITHUB_AUDIT_LOG_CONCURRENCY) {
+    const batch = changes.slice(offset, offset + GITHUB_AUDIT_LOG_CONCURRENCY);
+    await Promise.all(
+      batch.map((change) =>
+        auditLogService.createAuditLog({
+          ...auditLogInfo,
+          orgId,
+          event: {
+            type: change.action === "add" ? EventType.ADD_USER_TO_GROUP : EventType.REMOVE_USER_FROM_GROUP,
+            metadata: {
+              groupId: change.groupId,
+              groupName: change.groupName,
+              userId: change.userId,
+              username: change.username,
+              source: "github-org-sync",
+              githubOrgName,
+              syncTrigger
+            }
+          }
+        })
+      )
+    );
+  }
 };
 
 // Type definitions for GitHub API errors
@@ -309,6 +377,7 @@ type TGithubOrgSyncServiceFactoryDep = {
   userAliasDAL: Pick<TUserAliasDALFactory, "find">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
   alertChannelRecipientDAL: Pick<TAlertChannelRecipientDALFactory, "pruneOutOfScopeRecipients">;
+  auditLogService: Pick<TAuditLogServiceFactory, "createAuditLog">;
 };
 
 export type TGithubOrgSyncServiceFactory = ReturnType<typeof githubOrgSyncServiceFactory>;
@@ -325,7 +394,8 @@ export const githubOrgSyncServiceFactory = ({
   membershipRoleDAL,
   membershipGroupDAL,
   usageMeteringService,
-  alertChannelRecipientDAL
+  alertChannelRecipientDAL,
+  auditLogService
 }: TGithubOrgSyncServiceFactoryDep) => {
   const createGithubOrgSync = async ({
     githubOrgName,
@@ -508,7 +578,13 @@ export const githubOrgSyncServiceFactory = ({
     return existingConfig;
   };
 
-  const syncUserGroups = async (orgId: string, userId: string, accessToken: string) => {
+  const syncUserGroups = async ({
+    orgId,
+    userId,
+    username: infisicalUsername,
+    accessToken,
+    auditLogInfo
+  }: TSyncUserGroupsDTO) => {
     const config = await githubOrgSyncDAL.findOne({ orgId });
     if (!config || !config?.isActive) return;
 
@@ -579,7 +655,8 @@ export const githubOrgSyncServiceFactory = ({
     const {
       organization: { teams }
     } = data;
-    const githubUserTeams = teams?.edges?.map((el) => el.node.name.toLowerCase()) || [];
+    const githubUserTeamsByName = mapGithubTeamsByName(teams?.edges?.map((el) => el.node) ?? []);
+    const githubUserTeams = [...githubUserTeamsByName.keys()];
     const githubUserTeamSet = new Set(githubUserTeams);
     const githubUserTeamOnInfisical = await groupDAL.find({ orgId, $in: { name: githubUserTeams } });
     const githubUserTeamOnInfisicalGroupByName = groupBy(githubUserTeamOnInfisical, (i) => i.name);
@@ -594,8 +671,8 @@ export const githubOrgSyncServiceFactory = ({
 
     if (newTeams.length || updateTeams.length || removeFromTeams.length) {
       if (newTeams.length) {
-        await groupDAL.transaction(async (tx) => {
-          const newGroups = await groupDAL.insertMany(
+        const newGroups = await groupDAL.transaction(async (tx) => {
+          const insertedGroups = await groupDAL.insertMany(
             newTeams.map((newGroupName) => ({
               name: newGroupName,
               slug: newGroupName,
@@ -604,7 +681,7 @@ export const githubOrgSyncServiceFactory = ({
             tx
           );
           const memberships = await membershipGroupDAL.insertMany(
-            newGroups.map((el) => ({
+            insertedGroups.map((el) => ({
               actorGroupId: el.id,
               scope: AccessScope.Organization,
               scopeOrgId: orgId
@@ -621,24 +698,57 @@ export const githubOrgSyncServiceFactory = ({
           );
 
           await userGroupMembershipDAL.insertMany(
-            newGroups.map((el) => ({
+            insertedGroups.map((el) => ({
               groupId: el.id,
               userId
             })),
             tx
           );
+
+          return insertedGroups;
+        });
+
+        await createGithubOrgSyncAuditLogs({
+          auditLogService,
+          auditLogInfo,
+          orgId,
+          githubOrgName: config.githubOrgName,
+          syncTrigger: "login",
+          changes: newGroups.map((group) => ({
+            action: "add",
+            groupId: group.id,
+            groupName: group.name,
+            userId,
+            username: infisicalUsername
+          }))
         });
       }
 
       if (updateTeams.length) {
+        const groupsToUpdate = updateTeams.map((teamName) => githubUserTeamOnInfisicalGroupByName[teamName][0]);
         await groupDAL.transaction(async (tx) => {
           await userGroupMembershipDAL.insertMany(
-            updateTeams.map((el) => ({
-              groupId: githubUserTeamOnInfisicalGroupByName[el][0].id,
+            groupsToUpdate.map((group) => ({
+              groupId: group.id,
               userId
             })),
             tx
           );
+        });
+
+        await createGithubOrgSyncAuditLogs({
+          auditLogService,
+          auditLogInfo,
+          orgId,
+          githubOrgName: config.githubOrgName,
+          syncTrigger: "login",
+          changes: groupsToUpdate.map((group) => ({
+            action: "add",
+            groupId: group.id,
+            groupName: group.name,
+            userId,
+            username: infisicalUsername
+          }))
         });
       }
 
@@ -650,6 +760,21 @@ export const githubOrgSyncServiceFactory = ({
           );
 
           await alertChannelRecipientDAL.pruneOutOfScopeRecipients({ userIds: [userId] }, tx);
+        });
+
+        await createGithubOrgSyncAuditLogs({
+          auditLogService,
+          auditLogInfo,
+          orgId,
+          githubOrgName: config.githubOrgName,
+          syncTrigger: "login",
+          changes: removeFromTeams.map((group) => ({
+            action: "remove",
+            groupId: group.groupId,
+            groupName: group.groupName,
+            userId,
+            username: infisicalUsername
+          }))
         });
       }
 
@@ -746,7 +871,7 @@ export const githubOrgSyncServiceFactory = ({
     }
   };
 
-  const syncAllTeams = async ({ orgPermission }: TSyncAllTeamsDTO): Promise<TSyncResult> => {
+  const syncAllTeams = async ({ orgPermission, auditLogInfo }: TSyncAllTeamsDTO): Promise<TSyncResult> => {
     const { permission } = await permissionService.getOrgPermission({
       scope: OrganizationActionScope.ParentOrganization,
       actor: orgPermission.type,
@@ -823,6 +948,7 @@ export const githubOrgSyncServiceFactory = ({
     const matchGithubMember = buildGithubMemberMatcher(githubAliases, activeUserIds);
     const linkedActiveUserIds = new Set(githubAliases.map((alias) => alias.userId));
     const activeUsers = activeMembers.flatMap((member) => (member.user ? [member.user] : []));
+    const activeUsersById = new Map(activeUsers.map((user) => [user.id, user]));
 
     const startTime = Date.now();
     const syncErrors: string[] = [];
@@ -868,11 +994,8 @@ export const githubOrgSyncServiceFactory = ({
       throw new BadRequestError({ message: `GitHub GraphQL query failed: ${(err as Error)?.message}` });
     });
 
-    const githubTeamMembersByName = new Map<string, TGithubTeamMember[]>();
-    githubTeams.forEach((team) => {
-      const teamName = team.name.toLowerCase();
-      githubTeamMembersByName.set(teamName, [...(githubTeamMembersByName.get(teamName) ?? []), ...team.members]);
-    });
+    const githubTeamsByName = mapGithubTeamsByName(githubTeams);
+    const githubTeamMembersByName = new Map([...githubTeamsByName].map(([teamName, team]) => [teamName, team.members]));
 
     const allGithubTeamNames = Array.from(githubTeamMembersByName.keys());
 
@@ -958,13 +1081,7 @@ export const githubOrgSyncServiceFactory = ({
         }
       });
 
-      const removedMembershipsForTeam = await groupDAL.transaction(async (tx) => {
-        const currentMemberships = (await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(
-          team.id,
-          orgPermission.orgId,
-          tx
-        )) as GroupMembership[];
-
+      const resolveMembershipChanges = (currentMemberships: GroupMembership[]) => {
         const currentUserIds = new Set<string>();
         currentMemberships.forEach((membership) => {
           const activeMember = activeMembersById.get(membership.orgMembershipId);
@@ -978,46 +1095,106 @@ export const githubOrgSyncServiceFactory = ({
           activeUsers
         });
 
-        const usersToAdd = Array.from(expectedUserIds).filter((userId) => !currentUserIds.has(userId));
+        return {
+          usersToAdd: Array.from(expectedUserIds).filter((userId) => !currentUserIds.has(userId)),
+          membershipsToRemove: currentMemberships.filter((membership) => {
+            const userId = activeMembersById.get(membership.orgMembershipId)?.user?.id;
+            return Boolean(userId && !expectedUserIds.has(userId));
+          })
+        };
+      };
 
-        const membershipsToRemove = currentMemberships.filter((membership) => {
-          const userId = activeMembersById.get(membership.orgMembershipId)?.user?.id;
-          if (!userId) return false;
-          return !expectedUserIds.has(userId);
+      const currentMemberships = (await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(
+        team.id,
+        orgPermission.orgId
+      )) as GroupMembership[];
+      const pendingChanges = resolveMembershipChanges(currentMemberships);
+      if (pendingChanges.usersToAdd.length || pendingChanges.membershipsToRemove.length) {
+        const membershipChanges = await groupDAL.transaction(async (tx) => {
+          const latestMemberships = (await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(
+            team.id,
+            orgPermission.orgId,
+            tx
+          )) as GroupMembership[];
+          const { usersToAdd, membershipsToRemove } = resolveMembershipChanges(latestMemberships);
+
+          if (usersToAdd.length > 0) {
+            await userGroupMembershipDAL.insertMany(
+              usersToAdd.map((userId) => ({
+                userId,
+                groupId: team.id
+              })),
+              tx
+            );
+            updatedTeams.add(teamName);
+          }
+
+          if (membershipsToRemove.length > 0) {
+            await userGroupMembershipDAL.delete(
+              {
+                $in: {
+                  id: membershipsToRemove.map((m) => m.id)
+                }
+              },
+              tx
+            );
+
+            const removedUserIds = membershipsToRemove
+              .map((membership) => activeMembersById.get(membership.orgMembershipId)?.user?.id)
+              .filter(Boolean) as string[];
+            await alertChannelRecipientDAL.pruneOutOfScopeRecipients({ userIds: removedUserIds }, tx);
+
+            updatedTeams.add(teamName);
+          }
+
+          return {
+            usersToAdd,
+            removedUserIds: membershipsToRemove
+              .map((membership) => activeMembersById.get(membership.orgMembershipId)?.user?.id)
+              .filter(Boolean) as string[],
+            removedMembershipCount: membershipsToRemove.length
+          };
         });
+        totalRemovedMemberships += membershipChanges.removedMembershipCount;
 
-        if (usersToAdd.length > 0) {
-          await userGroupMembershipDAL.insertMany(
-            usersToAdd.map((userId) => ({
-              userId,
-              groupId: team.id
-            })),
-            tx
-          );
-          updatedTeams.add(teamName);
-        }
-
-        if (membershipsToRemove.length > 0) {
-          await userGroupMembershipDAL.delete(
-            {
-              $in: {
-                id: membershipsToRemove.map((m) => m.id)
-              }
-            },
-            tx
-          );
-
-          const removedUserIds = membershipsToRemove
-            .map((membership) => activeMembersById.get(membership.orgMembershipId)?.user?.id)
-            .filter(Boolean) as string[];
-          await alertChannelRecipientDAL.pruneOutOfScopeRecipients({ userIds: removedUserIds }, tx);
-
-          updatedTeams.add(teamName);
-        }
-
-        return membershipsToRemove.length;
-      });
-      totalRemovedMemberships += removedMembershipsForTeam;
+        await createGithubOrgSyncAuditLogs({
+          auditLogService,
+          auditLogInfo,
+          orgId: orgPermission.orgId,
+          githubOrgName: config.githubOrgName,
+          syncTrigger: "manual",
+          changes: [
+            ...membershipChanges.usersToAdd.flatMap((userId) => {
+              const user = activeUsersById.get(userId);
+              return user
+                ? [
+                    {
+                      action: "add" as const,
+                      groupId: team.id,
+                      groupName: team.name,
+                      userId,
+                      username: user.username ?? user.email
+                    }
+                  ]
+                : [];
+            }),
+            ...membershipChanges.removedUserIds.flatMap((userId) => {
+              const user = activeUsersById.get(userId);
+              return user
+                ? [
+                    {
+                      action: "remove" as const,
+                      groupId: team.id,
+                      groupName: team.name,
+                      userId,
+                      username: user.username ?? user.email
+                    }
+                  ]
+                : [];
+            })
+          ]
+        });
+      }
     }
 
     if (createdTeams.size || updatedTeams.size) {
@@ -1027,6 +1204,14 @@ export const githubOrgSyncServiceFactory = ({
     }
 
     if (unmatchedGithubUsers.size) {
+      const unmatchedLogins = [...unmatchedGithubUsers].sort();
+      const reportLimit = 10;
+      const listedLogins = unmatchedLogins.slice(0, reportLimit);
+      const remainingCount = unmatchedLogins.length - listedLogins.length;
+      const remainingMessage = remainingCount > 0 ? ` and ${remainingCount} more` : "";
+      syncErrors.push(
+        `Skipped ${unmatchedLogins.length} GitHub team member${unmatchedLogins.length === 1 ? "" : "s"} without a verified Infisical GitHub link (${listedLogins.join(", ")}${remainingMessage}). Ask them to sign in with GitHub, then run the sync again.`
+      );
       logger.info(
         { orgId: orgPermission.orgId, count: unmatchedGithubUsers.size },
         "GitHub org sync skipped team members without a verified GitHub login"

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -4,7 +4,6 @@ import { ForbiddenError } from "@casl/ability";
 import { Octokit } from "@octokit/core";
 import { paginateGraphql } from "@octokit/plugin-paginate-graphql";
 import { Octokit as OctokitRest } from "@octokit/rest";
-import RE2 from "re2";
 
 import { AccessScope, OrganizationActionScope, OrgMembershipRole } from "@app/db/schemas";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
@@ -19,6 +18,8 @@ import { TUsageMeteringServiceFactory } from "@app/services/license-client/usage
 import { TMembershipRoleDALFactory } from "@app/services/membership/membership-role-dal";
 import { TMembershipGroupDALFactory } from "@app/services/membership-group/membership-group-dal";
 import { TOrgMembershipDALFactory } from "@app/services/org-membership/org-membership-dal";
+import { TUserAliasDALFactory } from "@app/services/user-alias/user-alias-dal";
+import { UserAliasType } from "@app/services/user-alias/user-alias-types";
 
 import { TGroupDALFactory } from "../group/group-dal";
 import { TUserGroupMembershipDALFactory } from "../group/user-group-membership-dal";
@@ -49,8 +50,13 @@ const GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
 type TGithubPageInfo = { hasNextPage: boolean; endCursor: string | null };
 
+export type TGithubTeamMember = {
+  login: string;
+  databaseId: number | null;
+};
+
 type TGithubTeamMembersConnection = {
-  edges: { node: { login: string } }[];
+  edges: { node: TGithubTeamMember }[];
   pageInfo: TGithubPageInfo;
 };
 
@@ -80,7 +86,7 @@ export type TGithubTeam = {
   slug: string;
   name: string;
   description: string | null;
-  members: string[];
+  members: TGithubTeamMember[];
 };
 
 const ORG_TEAMS_QUERY = `
@@ -96,6 +102,7 @@ const ORG_TEAMS_QUERY = `
               edges {
                 node {
                   login
+                  databaseId
                 }
               }
               pageInfo {
@@ -122,6 +129,7 @@ const TEAM_MEMBERS_QUERY = `
           edges {
             node {
               login
+              databaseId
             }
           }
           pageInfo {
@@ -162,7 +170,7 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
         slug: node.slug,
         name: node.name,
         description: node.description,
-        members: node.members.edges.map((edge) => edge.node.login),
+        members: node.members.edges.map((edge) => edge.node),
         membersCursor: nextCursor(node.members.pageInfo)
       });
     });
@@ -189,7 +197,7 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
           message: `GitHub team '${team.slug}' was renamed or deleted while its members were being listed. Please run the sync again.`
         });
       }
-      team.members.push(...connection.edges.map((edge) => edge.node.login));
+      team.members.push(...connection.edges.map((edge) => edge.node));
       team.membersCursor = nextCursor(connection.pageInfo);
       membersPage += 1;
     }
@@ -204,87 +212,23 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
   return teams.map(({ slug, name, description, members }) => ({ slug, name, description, members }));
 };
 
-type TMatchableMember<T> = { user?: { email?: string | null } | null; inviteEmail?: string | null } & T;
+type TGithubAlias = {
+  externalId: string;
+  userId: string;
+  isEmailVerified?: boolean | null;
+};
 
-// Weakest rule a login is allowed to match on. A name part shorter than this collides constantly.
-const GITHUB_MIN_NAME_PART_LENGTH = 4;
+export const buildGithubMemberMatcher = (aliases: TGithubAlias[], activeUserIds: Set<string>) => {
+  const userIdByGithubId = new Map(
+    aliases.flatMap((alias) =>
+      alias.isEmailVerified === true && activeUserIds.has(alias.userId)
+        ? ([[alias.externalId, alias.userId]] as const)
+        : []
+    )
+  );
 
-const AMBIGUOUS_LOGIN_REPORT_LIMIT = 20;
-
-export const GithubMemberMatchRule = {
-  Email: "email",
-  EmailWithOrgSuffix: "email-with-org-suffix",
-  NamePart: "name-part"
-} as const;
-
-export type TGithubMemberMatchRule = (typeof GithubMemberMatchRule)[keyof typeof GithubMemberMatchRule];
-
-export type TGithubMemberMatch<T> =
-  | { status: "matched"; member: T; rule: TGithubMemberMatchRule }
-  | { status: "ambiguous"; rule: TGithubMemberMatchRule; members: T[] }
-  | { status: "unmatched" };
-
-const SEPARATORS = new RE2(/[._-]/g);
-const stripSeparators = (value: string) => value.replace(SEPARATORS, "");
-
-/**
- * Resolves a GitHub login to the org member it belongs to.
- *
- * Rules are tried strongest first across every member, so an exact email match always beats a name
- * fragment no matter what order members arrive in. A login that two members match equally well is
- * reported as ambiguous rather than resolved, because guessing hands one of them the other's
- * project access.
- */
-export const buildGithubMemberMatcher = <T>(members: TMatchableMember<T>[]) => {
-  // ~16M (login, member) comparisons on a 640-team org, so per-member fields are derived once per
-  // sync rather than once per comparison.
-  const candidates = members.flatMap((member) => {
-    const email = member.user?.email || member.inviteEmail;
-    if (!email) return [];
-    const [rawPrefix, rawDomain] = email.split("@");
-    if (!rawPrefix || !rawDomain) return [];
-    const emailPrefix = rawPrefix.toLowerCase();
-    const parts = emailPrefix.split(new RE2(/[._-]/));
-    return [
-      {
-        member,
-        email: email.toLowerCase(),
-        compactPrefix: stripSeparators(emailPrefix),
-        orgSuffixed: stripSeparators(emailPrefix) + stripSeparators(rawDomain.toLowerCase().split(".")[0]),
-        longestPart: parts.reduce((a, b) => (a.length > b.length ? a : b), "")
-      }
-    ];
-  });
-
-  return (githubLogin: string): TGithubMemberMatch<T> => {
-    const login = githubLogin.toLowerCase();
-    const compactLogin = stripSeparators(login);
-    const loginParts = new Set(login.split(new RE2(/[._-]/)));
-
-    const rules: [TGithubMemberMatchRule, (c: (typeof candidates)[number]) => boolean][] = [
-      [GithubMemberMatchRule.Email, (c) => c.compactPrefix === compactLogin],
-      [GithubMemberMatchRule.EmailWithOrgSuffix, (c) => c.orgSuffixed === compactLogin],
-      [
-        GithubMemberMatchRule.NamePart,
-        (c) => c.longestPart.length >= GITHUB_MIN_NAME_PART_LENGTH && loginParts.has(c.longestPart)
-      ]
-    ];
-
-    for (const [rule, predicate] of rules) {
-      const hits = candidates.filter(predicate);
-      const distinct = [...new Map(hits.map((hit) => [hit.email, hit])).values()];
-      if (distinct.length === 1) return { status: "matched", member: distinct[0].member, rule };
-      if (distinct.length > 1) {
-        return {
-          status: "ambiguous",
-          rule,
-          members: distinct.sort((a, b) => a.email.localeCompare(b.email)).map((hit) => hit.member)
-        };
-      }
-    }
-
-    return { status: "unmatched" };
-  };
+  return (member: TGithubTeamMember) =>
+    member.databaseId === null ? undefined : userIdByGithubId.get(String(member.databaseId));
 };
 
 // Type definitions for GitHub API errors
@@ -336,6 +280,7 @@ type TGithubOrgSyncServiceFactoryDep = {
   membershipGroupDAL: Pick<TMembershipGroupDALFactory, "insertMany">;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
   orgMembershipDAL: Pick<TOrgMembershipDALFactory, "findOrgMembershipById" | "findOrgMembershipsWithUsersByOrgId">;
+  userAliasDAL: Pick<TUserAliasDALFactory, "find">;
   usageMeteringService: Pick<TUsageMeteringServiceFactory, "emit">;
   alertChannelRecipientDAL: Pick<TAlertChannelRecipientDALFactory, "pruneOutOfScopeRecipients">;
 };
@@ -350,6 +295,7 @@ export const githubOrgSyncServiceFactory = ({
   groupDAL,
   licenseService,
   orgMembershipDAL,
+  userAliasDAL,
   membershipRoleDAL,
   membershipGroupDAL,
   usageMeteringService,
@@ -839,12 +785,22 @@ export const githubOrgSyncServiceFactory = ({
       (member) => member.status === "accepted" && member.isActive
     ) as OrgMembershipWithUser[];
 
-    const matchGithubLogin = buildGithubMemberMatcher(activeMembers);
     const activeMembersById = new Map(activeMembers.map((member) => [member.id, member]));
+    const activeUserIds = new Set(activeMembers.flatMap((member) => (member.user ? [member.user.id] : [])));
+    const githubAliases = activeUserIds.size
+      ? await userAliasDAL.find({
+          aliasType: UserAliasType.GITHUB,
+          isEmailVerified: true,
+          $in: { userId: [...activeUserIds] }
+        })
+      : [];
+    const matchGithubMember = buildGithubMemberMatcher(githubAliases, activeUserIds);
+    const linkedActiveUserIds = new Set(githubAliases.map((alias) => alias.userId));
 
     const startTime = Date.now();
     const syncErrors: string[] = [];
-    const ambiguousLogins = new Map<string, string[]>();
+    const unmatchedGithubUsers = new Set<string>();
+    const preservedUnlinkedUserIds = new Set<string>();
 
     const octokit = new Octokit({ auth: orgAccessToken });
 
@@ -886,7 +842,7 @@ export const githubOrgSyncServiceFactory = ({
       throw new BadRequestError({ message: `GitHub GraphQL query failed: ${(err as Error)?.message}` });
     });
 
-    const githubTeamMembersByName = new Map<string, string[]>();
+    const githubTeamMembersByName = new Map<string, TGithubTeamMember[]>();
     githubTeams.forEach((team) => {
       const teamName = team.name.toLowerCase();
       githubTeamMembersByName.set(teamName, [...(githubTeamMembersByName.get(teamName) ?? []), ...team.members]);
@@ -905,8 +861,8 @@ export const githubOrgSyncServiceFactory = ({
     const updatedTeams = new Set<string>();
     const totalRemovedMemberships = 0;
 
-    await groupDAL.transaction(async (tx) => {
-      if (teamsToCreate.length > 0) {
+    if (teamsToCreate.length > 0) {
+      await groupDAL.transaction(async (tx) => {
         const newGroups = await groupDAL.insertMany(
           teamsToCreate.map((teamName) => ({
             name: teamName,
@@ -940,40 +896,34 @@ export const githubOrgSyncServiceFactory = ({
           existingTeamsMap[group.name].push(group);
           createdTeams.add(group.name);
         });
-      }
+      });
+    }
 
-      const allTeams = [...Object.values(existingTeamsMap).flat()];
+    const allTeams = [...Object.values(existingTeamsMap).flat()];
 
-      for (const team of allTeams) {
-        const teamName = team.name.toLowerCase();
+    for (const team of allTeams) {
+      const teamName = team.name.toLowerCase();
+      const expectedUserIds = new Set<string>();
+      (githubTeamMembersByName.get(teamName) ?? []).forEach((githubMember) => {
+        const userId = matchGithubMember(githubMember);
 
+        if (userId) {
+          expectedUserIds.add(userId);
+          logger.info(
+            { githubLogin: githubMember.login, githubUserId: githubMember.databaseId, userId },
+            "Matched GitHub team member through a verified GitHub login"
+          );
+        } else {
+          unmatchedGithubUsers.add(githubMember.login);
+        }
+      });
+
+      await groupDAL.transaction(async (tx) => {
         const currentMemberships = (await userGroupMembershipDAL.findGroupMembershipsByGroupIdInOrg(
           team.id,
-          orgPermission.orgId
+          orgPermission.orgId,
+          tx
         )) as GroupMembership[];
-
-        const expectedUserIds = new Set<string>();
-        const unresolvedUserIds = new Set<string>();
-        (githubTeamMembersByName.get(teamName) ?? []).forEach((login) => {
-          const githubUsername = login.toLowerCase();
-
-          const result = matchGithubLogin(githubUsername);
-
-          if (result.status === "matched" && result.member.user?.id) {
-            expectedUserIds.add(result.member.user.id);
-            logger.info(
-              `Matched GitHub user ${githubUsername} to email ${result.member.user?.email || result.member.inviteEmail} by ${result.rule}`
-            );
-          } else if (result.status === "ambiguous") {
-            const emails: string[] = [];
-            result.members.forEach((candidate) => {
-              if (candidate.user?.id) unresolvedUserIds.add(candidate.user.id);
-              const email = candidate.user?.email || candidate.inviteEmail;
-              if (email) emails.push(email);
-            });
-            ambiguousLogins.set(githubUsername, emails);
-          }
-        });
 
         const currentUserIds = new Set<string>();
         currentMemberships.forEach((membership) => {
@@ -985,13 +935,16 @@ export const githubOrgSyncServiceFactory = ({
 
         const usersToAdd = Array.from(expectedUserIds).filter((userId) => !currentUserIds.has(userId));
 
-        // An ambiguous login says we cannot tell which of its candidates belongs here, not that the
-        // team is empty. Only those candidates are held back; anyone else who left the GitHub team
-        // is still removed, so one unresolved collision cannot preserve unrelated stale access.
+        // A member without a verified GitHub alias has no trustworthy identity to reconcile yet.
+        // Keep their current access until a GitHub login creates that link.
         const membershipsToRemove = currentMemberships.filter((membership) => {
           const userId = activeMembersById.get(membership.orgMembershipId)?.user?.id;
           if (!userId) return false;
-          return !expectedUserIds.has(userId) && !unresolvedUserIds.has(userId);
+          if (!linkedActiveUserIds.has(userId)) {
+            preservedUnlinkedUserIds.add(userId);
+            return false;
+          }
+          return !expectedUserIds.has(userId);
         });
 
         if (usersToAdd.length > 0) {
@@ -1022,8 +975,8 @@ export const githubOrgSyncServiceFactory = ({
 
           updatedTeams.add(teamName);
         }
-      }
-    });
+      });
+    }
 
     if (createdTeams.size || updatedTeams.size) {
       // Team membership changes cascade into the group-expanded project identity meters.
@@ -1031,24 +984,17 @@ export const githubOrgSyncServiceFactory = ({
       usageMeteringService.emit(orgPermission.orgId, PamIdentities.key);
     }
 
-    if (ambiguousLogins.size) {
-      logger.warn(
-        { orgId: orgPermission.orgId, count: ambiguousLogins.size },
-        "GitHub org sync skipped logins that more than one organization member matched"
-      );
-      // Capped so a badly aliased org cannot return a response the client has to scroll through.
-      const listed = [...ambiguousLogins.entries()].slice(0, AMBIGUOUS_LOGIN_REPORT_LIMIT);
+    if (preservedUnlinkedUserIds.size) {
       syncErrors.push(
-        ...listed.map(
-          ([login, emails]) =>
-            `GitHub user '${login}' matches more than one organization member (${emails.join(", ")}), so Infisical cannot tell which one they are. Their existing group access was left as it is. Align one member's email with their GitHub username to resolve it.`
-        )
+        `Infisical left existing group access unchanged for ${preservedUnlinkedUserIds.size} organization member${preservedUnlinkedUserIds.size === 1 ? "" : "s"} without a verified GitHub login. Ask them to sign in with GitHub, then run the sync again.`
       );
-      if (ambiguousLogins.size > listed.length) {
-        syncErrors.push(
-          `${ambiguousLogins.size - listed.length} further GitHub users were skipped for the same reason.`
-        );
-      }
+    }
+
+    if (unmatchedGithubUsers.size) {
+      logger.info(
+        { orgId: orgPermission.orgId, count: unmatchedGithubUsers.size },
+        "GitHub org sync skipped team members without a verified GitHub login"
+      );
     }
 
     const syncDuration = Date.now() - startTime;

--- a/backend/src/ee/services/github-org-sync/github-org-sync-types.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-types.ts
@@ -1,3 +1,4 @@
+import { AuditLogInfo } from "@app/ee/services/audit-log/audit-log-types";
 import { OrgServiceActor } from "@app/lib/types";
 
 export interface TCreateGithubOrgSyncDTO {
@@ -24,6 +25,15 @@ export interface TGetGithubOrgSyncDTO {
 
 export interface TSyncAllTeamsDTO {
   orgPermission: OrgServiceActor;
+  auditLogInfo: AuditLogInfo;
+}
+
+export interface TSyncUserGroupsDTO {
+  orgId: string;
+  userId: string;
+  username: string;
+  accessToken: string;
+  auditLogInfo: AuditLogInfo;
 }
 
 export interface TSyncResult {

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1285,7 +1285,8 @@ export const registerRoutes = async (
     membershipRoleDAL,
     membershipGroupDAL,
     usageMeteringService,
-    alertChannelRecipientDAL
+    alertChannelRecipientDAL,
+    auditLogService
   });
 
   // gitHubAppService is created after gatewayPoolService (below) due to dependency on gateway services

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1281,6 +1281,7 @@ export const registerRoutes = async (
     groupDAL,
     userGroupMembershipDAL,
     orgMembershipDAL,
+    userAliasDAL,
     membershipRoleDAL,
     membershipGroupDAL,
     usageMeteringService,

--- a/backend/src/server/routes/v3/login-router.ts
+++ b/backend/src/server/routes/v3/login-router.ts
@@ -92,7 +92,13 @@ export const registerLoginRouter = async (server: FastifyZodProvider) => {
       const githubOauthAccessToken = req.cookies[INFISICAL_PROVIDER_GITHUB_ACCESS_TOKEN];
       if (githubOauthAccessToken) {
         await server.services.githubOrgSync
-          .syncUserGroups(req.body.organizationId, tokens.user.id, githubOauthAccessToken)
+          .syncUserGroups({
+            orgId: req.body.organizationId,
+            userId: tokens.user.id,
+            username: tokens.user.username,
+            accessToken: githubOauthAccessToken,
+            auditLogInfo: req.auditLogInfo
+          })
           .finally(() => {
             void res.setCookie(INFISICAL_PROVIDER_GITHUB_ACCESS_TOKEN, "", {
               httpOnly: true,

--- a/docs/documentation/platform/github-org-sync.mdx
+++ b/docs/documentation/platform/github-org-sync.mdx
@@ -103,6 +103,26 @@ You can manually synchronize GitHub teams for all organization members who have 
     </Step>
 </Steps>
 
+## How members are matched
+
+Manual sync compares each GitHub username against the email address of every member in your
+organization. It tries three rules in order and stops at the first rule that identifies exactly one
+member:
+
+1. The part of the email address before the `@` equals the username, ignoring dots, hyphens and
+   underscores. `jane.doe@acme.com` matches `janedoe`.
+2. The username is that same email prefix followed by your organization's name. `jane@acme.com`
+   matches `janeacme`.
+3. The longest part of the email prefix is one whole part of the username. `j.smithson@acme.com`
+   matches `smithson-dev`.
+
+When two members match the same rule, the sync skips that GitHub user and lists them in the
+**Sync Now** result instead of choosing between them. Give one of the members an email address whose
+prefix matches their GitHub username to resolve it.
+
+A GitHub user who matches no member isn't added to any group. That's expected for accounts with no
+Infisical member, such as bots and outside collaborators.
+
 ## Troubleshooting
 
 <AccordionGroup>

--- a/docs/documentation/platform/github-org-sync.mdx
+++ b/docs/documentation/platform/github-org-sync.mdx
@@ -105,10 +105,17 @@ You can manually synchronize GitHub teams for all organization members who have 
 
 ## Troubleshooting
 
-<Accordion title="Please check if your organization has approved the Infisical OAuth application.">
-    If you encounter an error related to this, it indicates that you need to approve the Infisical OAuth application within your GitHub organization.
+<AccordionGroup>
+  <Accordion title="Please check if your organization has approved the Infisical OAuth application.">
+      If you encounter an error related to this, it indicates that you need to approve the Infisical OAuth application within your GitHub organization.
 
-    You can verify the application's approval status by navigating to **https://github.com/organizations/__your-organization__/settings/oauth_application_policy**. Replace `__your-organization__` with the actual name of your GitHub organization.
+      You can verify the application's approval status by navigating to **https://github.com/organizations/__your-organization__/settings/oauth_application_policy**. Replace `__your-organization__` with the actual name of your GitHub organization.
 
-    ![check-approval](../../images/platform/external-syncs/github-org-sync-approved-oauth-apps.png)
-</Accordion>
+      ![check-approval](../../images/platform/external-syncs/github-org-sync-approved-oauth-apps.png)
+  </Accordion>
+  <Accordion title="Why did the sync skip some of my GitHub teams?">
+      GitHub shows secret teams only to organization owners and to the team's own members. The manual sync reads the teams the token owner can see, so a sync run with a regular member's token skips every secret team that member doesn't belong to.
+
+      Infisical leaves a skipped team's group alone, so no memberships are lost. To cover every team, create the token as an organization owner.
+  </Accordion>
+</AccordionGroup>

--- a/docs/documentation/platform/github-org-sync.mdx
+++ b/docs/documentation/platform/github-org-sync.mdx
@@ -110,8 +110,13 @@ Infisical account. Manual sync uses that account ID to match each GitHub team me
 member.
 
 Infisical doesn't infer identity from a GitHub username or public profile email. If a member hasn't
-signed in with GitHub, manual sync doesn't add group access and leaves any existing group access
-unchanged. Ask the member to sign in with GitHub, then run **Sync Now** again.
+signed in with GitHub, manual sync doesn't add group access. If that member already belongs to a
+group that corresponds to a GitHub team, the sync stops before making changes and identifies the
+members who need to sign in. Ask each listed member to sign in with GitHub, or remove them from the
+corresponding Infisical groups, then run **Sync Now** again.
+
+Before the first manual sync, ask each Infisical member who needs GitHub-controlled group access to
+sign in with GitHub at least once.
 
 ## Troubleshooting
 

--- a/docs/documentation/platform/github-org-sync.mdx
+++ b/docs/documentation/platform/github-org-sync.mdx
@@ -105,23 +105,13 @@ You can manually synchronize GitHub teams for all organization members who have 
 
 ## How members are matched
 
-Manual sync compares each GitHub username against the email address of every member in your
-organization. It tries three rules in order and stops at the first rule that identifies exactly one
-member:
+After a member signs in with GitHub, Infisical links the member's GitHub account ID to their verified
+Infisical account. Manual sync uses that account ID to match each GitHub team member to an Infisical
+member.
 
-1. The part of the email address before the `@` equals the username, ignoring dots, hyphens and
-   underscores. `jane.doe@acme.com` matches `janedoe`.
-2. The username is that same email prefix followed by your organization's name. `jane@acme.com`
-   matches `janeacme`.
-3. The longest part of the email prefix is one whole part of the username. `j.smithson@acme.com`
-   matches `smithson-dev`.
-
-When two members match the same rule, the sync skips that GitHub user and lists them in the
-**Sync Now** result instead of choosing between them. Give one of the members an email address whose
-prefix matches their GitHub username to resolve it.
-
-A GitHub user who matches no member isn't added to any group. That's expected for accounts with no
-Infisical member, such as bots and outside collaborators.
+Infisical doesn't infer identity from a GitHub username or public profile email. If a member hasn't
+signed in with GitHub, manual sync doesn't add group access and leaves any existing group access
+unchanged. Ask the member to sign in with GitHub, then run **Sync Now** again.
 
 ## Troubleshooting
 

--- a/frontend/src/pages/organization/SettingsPage/components/OrgProvisioningTab/OrgGithubSyncSection.tsx
+++ b/frontend/src/pages/organization/SettingsPage/components/OrgProvisioningTab/OrgGithubSyncSection.tsx
@@ -55,8 +55,6 @@ export const OrgGithubSyncSection = () => {
 
   const handleBulkSync = async () => {
     const result = await syncAllTeamsMutation.mutateAsync();
-    let message = "Successfully synced teams";
-
     const details = [];
     if (result.createdTeams.length > 0) {
       details.push(
@@ -74,22 +72,18 @@ export const OrgGithubSyncSection = () => {
       );
     }
 
-    if (details.length > 0) {
-      message += `. ${details.join(", ")}`;
+    if (result.errors && result.errors.length > 0) {
+      createNotification({
+        text: `GitHub team sync completed with warnings.${details.length > 0 ? ` ${details.join(", ")}.` : ""} ${result.errors.join(" ")}`,
+        type: "warning"
+      });
+      return;
     }
 
     createNotification({
-      text: message,
+      text: `GitHub teams synced.${details.length > 0 ? ` ${details.join(", ")}.` : ""}`,
       type: "success"
     });
-
-    if (result.errors && result.errors.length > 0) {
-      createNotification({
-        text: `Sync completed with ${result.errors.length} warnings. Check the console for details.`,
-        type: "warning"
-      });
-      console.warn("Sync errors:", result.errors);
-    }
   };
 
   return (


### PR DESCRIPTION
## Context

Supersedes #7989, whose two commits are included here unchanged. A user with ~500 GitHub teams and ~2k members can't run **Sync Now**: GitHub 502s on the nested `teams(first: 100) { members(first: 100) }` query.

Five things were broken. #7989 fixed the first two:

- **502 on large orgs.** The sync now paginates at `teams(first: 20)` with a fresh abort signal and retry per request. The old code shared one 30s `AbortSignal` across every page, so a large org couldn't finish even against a healthy GitHub.
- **Silent data loss.** `members(first: 100)` had no `pageInfo`, and the truncated list drives removals, so every "successful" sync deleted members 101+ from the group.
- **`groups.role` doesn't exist.** Migration `20260107083948_remove-old-memberships` dropped the column in January, but both sync paths still included it in group inserts. Creating any team group therefore failed before GitHub was reached.
- **The match loop and transaction consumed the request budget.** The old code made ~16M username-to-email comparisons on the event loop and held one transaction open across every team. The matcher is now a constant-time ID lookup, and each team reconciles in a short transaction whose reads use the transaction connection.
- **Bulk sync could grant access to the wrong person.** GitHub's team API identifies members by GitHub account, while the old code guessed which Infisical member owned each username from fragments of their email. The sync now requests GitHub's numeric account ID and joins it to the verified GitHub alias created during GitHub login. It never matches on username or public profile email. Unlinked GitHub accounts receive no new access. Before any writes, the sync verifies that every current member of an existing GitHub-named group has a verified GitHub link. If any do not, it stops and lists the affected members. Once identities are linked, exact reconciliation removes stale access.

Also, the **Sync Now** 403 demanded `admin:org` when `read:org` is all the feature needs, since it only reads from GitHub. The response now reports the actual number of removed memberships as well.

## Screenshots

N/A

## Steps to verify the change

- [x] `cd backend && npm run test:unit -- src/ee/services/github-org-sync` passes 11 tests
- [x] `cd backend && npx eslint --ext .ts src/ee/services/github-org-sync/ src/server/routes/index.ts` is clean
- [x] `cd backend && npm run type:check` reports 0 errors
- [x] `make lint-docs-branch` reports 0 errors, warnings, or suggestions
- [x] A live GraphQL query against the Infisical GitHub organization returns `databaseId` for a team member
- [x] Unit coverage verifies that an existing unlinked member blocks reconciliation before changes
- [ ] On an org with >100 teams and at least one team over 100 members, **Sync Now** completes and the large team's group keeps every linked member
- [ ] Logging in via GitHub OAuth to an org with a GitHub team that has no Infisical group yet succeeds
- [ ] A fine-grained token with only Organization > Members: read drives the whole sync
- [ ] A linked member is matched by GitHub account ID after changing their GitHub username
- [ ] An unlinked GitHub user whose username resembles an Infisical member's email receives no group access
- [ ] An existing group member without a verified GitHub link stops the sync before changes; after GitHub login, the next sync reconciles that access

Measured at the reported scale (640 teams, 2.3k members, 7k memberships) against a mock GitHub before the exact-identity follow-up:

| | before | paginated fetch |
| --- | --- | --- |
| Sync Now | 400 after 4x 502, page 1 never fetched | 32/32 team pages + 2 member pages, all 200 |
| 250-member team | HTTP 200, 150 memberships deleted | all 250 kept |

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
