### PR TITLE
fix: make many-to-one aws sm sync only target one secret

### DIFF
--- a/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
@@ -518,9 +518,7 @@ export const AwsSecretsManagerSyncFns = {
       if (syncOptions.tags !== undefined) {
         const { tagsToAdd, tagKeysToRemove } = processTags({
           syncTagsRecord,
-          awsTagsRecord: Object.fromEntries(
-            existingDescription?.Tags?.map((tag) => [tag.Key!, tag.Value!]) ?? []
-          )
+          awsTagsRecord: Object.fromEntries(existingDescription?.Tags?.map((tag) => [tag.Key!, tag.Value!]) ?? [])
         });
 
         if (tagsToAdd.length) {

--- a/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
@@ -8,6 +8,7 @@ import {
   DescribeSecretCommand,
   type DescribeSecretCommandInput,
   type DescribeSecretResponse,
+  GetSecretValueCommand,
   ListSecretsCommand,
   type SecretListEntry,
   SecretsManagerClient,
@@ -311,6 +312,27 @@ const processTags = ({
   return { tagsToAdd, tagKeysToRemove };
 };
 
+const getSingleSecretValue = async (
+  client: SecretsManagerClient,
+  secretId: string,
+  attempt = 0
+): Promise<SecretValueEntry | null> => {
+  try {
+    return await client.send(new GetSecretValueCommand({ SecretId: secretId }));
+  } catch (e) {
+    if (isAwsError(e, "ResourceNotFoundException")) {
+      return null;
+    }
+
+    if (isAwsError(e, "ThrottlingException") && attempt < MAX_RETRIES) {
+      await sleep();
+      return getSingleSecretValue(client, secretId, attempt + 1);
+    }
+
+    throw e;
+  }
+};
+
 export const AwsSecretsManagerSyncFns = {
   syncSecrets: async (
     secretSync: TAwsSecretsManagerSyncWithCredentials,
@@ -321,12 +343,6 @@ export const AwsSecretsManagerSyncFns = {
 
     const client = await getSecretsManagerClient(secretSync);
 
-    const awsSecretsRecord = await getSecretsRecord(client, environment?.slug || "", syncOptions.keySchema);
-
-    const awsValuesRecord = await getSecretValuesRecord(client, awsSecretsRecord);
-
-    const awsDescriptionsRecord = await getSecretDescriptionsRecord(client, awsSecretsRecord);
-
     const syncTagsRecord = Object.fromEntries(syncOptions.tags?.map((tag) => [tag.key, tag.value]) ?? []);
 
     const keyId = syncOptions.keyId ?? "alias/aws/secretsmanager";
@@ -336,6 +352,11 @@ export const AwsSecretsManagerSyncFns = {
     const deletedSecretKeys: string[] = [];
 
     if (destinationConfig.mappingBehavior === AwsSecretsManagerSyncMappingBehavior.OneToOne) {
+      const awsSecretsRecord = await getSecretsRecord(client, environment?.slug || "", syncOptions.keySchema);
+
+      const awsValuesRecord = await getSecretValuesRecord(client, awsSecretsRecord);
+
+      const awsDescriptionsRecord = await getSecretDescriptionsRecord(client, awsSecretsRecord);
       for await (const entry of Object.entries(secretMap)) {
         const [key, { value, secretMetadata }] = entry;
 
@@ -434,7 +455,7 @@ export const AwsSecretsManagerSyncFns = {
         }
       }
     } else {
-      // Many-To-One Mapping
+      // Many-To-One Mapping: only fetch the single target secret instead of listing all secrets
 
       const secretValue = JSON.stringify(
         Object.fromEntries(Object.entries(unmodifiedSecretMap).map(([key, secretData]) => [key, secretData.value]))
@@ -446,9 +467,16 @@ export const AwsSecretsManagerSyncFns = {
         schema: syncOptions.keySchema
       });
 
-      const secretExists = Boolean(awsSecretsRecord[secretName]);
-      const hasValueChanged = awsValuesRecord[secretName]?.SecretString !== secretValue;
-      const hasKmsKeyChanged = keyId !== awsDescriptionsRecord[secretName]?.KmsKeyId;
+      const existingSecretValue = await getSingleSecretValue(client, secretName);
+      const secretExists = existingSecretValue !== null;
+
+      let existingDescription: DescribeSecretResponse | undefined;
+      if (secretExists) {
+        existingDescription = await describeSecret(client, { SecretId: secretName });
+      }
+
+      const hasValueChanged = existingSecretValue?.SecretString !== secretValue;
+      const hasKmsKeyChanged = keyId !== existingDescription?.KmsKeyId;
 
       if (secretExists && (hasValueChanged || hasKmsKeyChanged)) {
         await updateSecret(client, {
@@ -470,7 +498,7 @@ export const AwsSecretsManagerSyncFns = {
         const { tagsToAdd, tagKeysToRemove } = processTags({
           syncTagsRecord,
           awsTagsRecord: Object.fromEntries(
-            awsDescriptionsRecord[secretName]?.Tags?.map((tag) => [tag.Key!, tag.Value!]) ?? []
+            existingDescription?.Tags?.map((tag) => [tag.Key!, tag.Value!]) ?? []
           )
         });
 
@@ -503,16 +531,12 @@ export const AwsSecretsManagerSyncFns = {
   getSecrets: async (secretSync: TAwsSecretsManagerSyncWithCredentials): Promise<TSecretMap> => {
     const client = await getSecretsManagerClient(secretSync);
 
-    const awsSecretsRecord = await getSecretsRecord(
-      client,
-      secretSync.environment?.slug || "",
-      secretSync.syncOptions.keySchema
-    );
-    const awsValuesRecord = await getSecretValuesRecord(client, awsSecretsRecord);
-
     const { destinationConfig, environment, syncOptions } = secretSync;
 
     if (destinationConfig.mappingBehavior === AwsSecretsManagerSyncMappingBehavior.OneToOne) {
+      const awsSecretsRecord = await getSecretsRecord(client, environment?.slug || "", syncOptions.keySchema);
+      const awsValuesRecord = await getSecretValuesRecord(client, awsSecretsRecord);
+
       return Object.fromEntries(
         Object.keys(awsSecretsRecord)
           .filter((key) => Object.hasOwn(awsValuesRecord, key))
@@ -520,7 +544,7 @@ export const AwsSecretsManagerSyncFns = {
       );
     }
 
-    // Many-To-One Mapping
+    // Many-To-One Mapping: fetch only the single target secret
 
     const secretName = getKeyWithSchema({
       key: destinationConfig.secretName,
@@ -528,7 +552,7 @@ export const AwsSecretsManagerSyncFns = {
       schema: syncOptions.keySchema
     });
 
-    const secretValueEntry = awsValuesRecord[secretName];
+    const secretValueEntry = await getSingleSecretValue(client, secretName);
 
     if (!secretValueEntry) return {};
 
@@ -552,9 +576,9 @@ export const AwsSecretsManagerSyncFns = {
 
     const client = await getSecretsManagerClient(secretSync);
 
-    const awsSecretsRecord = await getSecretsRecord(client, environment?.slug || "", syncOptions.keySchema);
-
     if (destinationConfig.mappingBehavior === AwsSecretsManagerSyncMappingBehavior.OneToOne) {
+      const awsSecretsRecord = await getSecretsRecord(client, environment?.slug || "", syncOptions.keySchema);
+
       for await (const secretKey of Object.keys(awsSecretsRecord)) {
         if (secretKey in secretMap) {
           try {

--- a/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
@@ -312,6 +312,27 @@ const processTags = ({
   return { tagsToAdd, tagKeysToRemove };
 };
 
+const describeSecretIfExists = async (
+  client: SecretsManagerClient,
+  secretId: string,
+  attempt = 0
+): Promise<DescribeSecretResponse | null> => {
+  try {
+    return await client.send(new DescribeSecretCommand({ SecretId: secretId }));
+  } catch (e) {
+    if (isAwsError(e, "ResourceNotFoundException")) {
+      return null;
+    }
+
+    if (isAwsError(e, "ThrottlingException") && attempt < MAX_RETRIES) {
+      await sleep();
+      return describeSecretIfExists(client, secretId, attempt + 1);
+    }
+
+    throw e;
+  }
+};
+
 const getSingleSecretValue = async (
   client: SecretsManagerClient,
   secretId: string,
@@ -467,12 +488,12 @@ export const AwsSecretsManagerSyncFns = {
         schema: syncOptions.keySchema
       });
 
-      const existingSecretValue = await getSingleSecretValue(client, secretName);
-      const secretExists = existingSecretValue !== null;
+      const existingDescription = await describeSecretIfExists(client, secretName);
+      const secretExists = existingDescription !== null;
 
-      let existingDescription: DescribeSecretResponse | undefined;
+      let existingSecretValue: SecretValueEntry | null = null;
       if (secretExists) {
-        existingDescription = await describeSecret(client, { SecretId: secretName });
+        existingSecretValue = await getSingleSecretValue(client, secretName);
       }
 
       const hasValueChanged = existingSecretValue?.SecretString !== secretValue;


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

If a customer configure AWS SM sync to save all secrets into one SM secret and provide a credential that only has access to that given secret, it fails today because we try to fetch all secrets.

This PR updates the behavior and ensures Many-to-One only manages the specific secret provided in the configuration.

## Steps to verify the change

1. AWS SM One-to-One secrets syncs are still functional
2. Create a new role or user with the permission to manage one specific secret (e.g. MY_SECRET-*)
3. Create a Many-To-One secret sync
4. Secret sync works

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)