### PR TITLE
improvement(audit-log): tag stale-claim drops with stream provider

### DIFF
--- a/backend/src/ee/services/audit-log-stream-outbox/audit-log-stream-outbox-dal.ts
+++ b/backend/src/ee/services/audit-log-stream-outbox/audit-log-stream-outbox-dal.ts
@@ -167,7 +167,7 @@ export const auditLogStreamOutboxDALFactory = (db: TDbClient) => {
   const recoverStaleClaims = async (
     thresholdMs: number,
     maxAttempts: number
-  ): Promise<{ retried: number; dropped: { streamId: string; orgId: string }[] }> => {
+  ): Promise<{ retried: number; dropped: { streamId: string; orgId: string; provider: string | null }[] }> => {
     try {
       return await db.transaction(async (tx) => {
         const staleRows = await tx(TableName.AuditLogStreamOutbox)
@@ -203,18 +203,27 @@ export const auditLogStreamOutboxDALFactory = (db: TDbClient) => {
             });
         }
 
-        if (exhausted.length > 0) {
-          await tx(TableName.AuditLogStreamOutbox)
-            .whereIn(
-              "id",
-              exhausted.map((row) => row.id)
-            )
-            .del();
-        }
+        if (exhausted.length === 0) return { retried: retriable.length, dropped: [] };
+
+        await tx(TableName.AuditLogStreamOutbox)
+          .whereIn(
+            "id",
+            exhausted.map((row) => row.id)
+          )
+          .del();
+
+        const streams = await tx(TableName.AuditLogStream)
+          .whereIn("id", [...new Set(exhausted.map((row) => row.streamId))])
+          .select<{ id: string; provider: string }[]>("id", "provider");
+        const providerByStreamId = new Map(streams.map((stream) => [stream.id, stream.provider]));
 
         return {
           retried: retriable.length,
-          dropped: exhausted.map((row) => ({ streamId: row.streamId, orgId: row.orgId }))
+          dropped: exhausted.map((row) => ({
+            streamId: row.streamId,
+            orgId: row.orgId,
+            provider: providerByStreamId.get(row.streamId) ?? null
+          }))
         };
       });
     } catch (error) {

--- a/backend/src/ee/services/audit-log-stream-outbox/audit-log-stream-outbox-service.test.ts
+++ b/backend/src/ee/services/audit-log-stream-outbox/audit-log-stream-outbox-service.test.ts
@@ -24,6 +24,20 @@ vi.mock("@app/lib/logger", () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }));
 
+// There is no DLQ: once a row is dropped this counter is the only record that audit events were
+// lost, and the provider attribute is what lets an operator route that loss to a team. Spying on
+// the instrument is the only way to assert the attributes, since the real one is a no-op unless a
+// MeterProvider is installed.
+const { exhaustedCounterAdd, deliveryDurationRecord } = vi.hoisted(() => ({
+  exhaustedCounterAdd: vi.fn<(value: number, attrs: Record<string, string>) => void>(),
+  deliveryDurationRecord: vi.fn<(value: number, attrs: Record<string, string>) => void>()
+}));
+
+vi.mock("@app/lib/telemetry/metrics", () => ({
+  auditLogStreamDeliveryExhaustedCounter: { add: exhaustedCounterAdd },
+  auditLogStreamDeliveryDurationHistogram: { record: deliveryDurationRecord }
+}));
+
 // Keep the real product-filter helpers (auditLogMatchesStreamFilter, resolveAuditLogProduct) so
 // the fanout filtering tests exercise actual behavior; only credential decryption is stubbed.
 vi.mock("@app/ee/services/audit-log-stream/audit-log-stream-fns", async (importOriginal) => ({
@@ -514,5 +528,69 @@ describe("audit-log-stream-outbox-service pruneDeliveredRows", () => {
     // delivered rows still serve their dedup-guard purpose — guards against accidental
     // tightening down toward that window.
     expect(retentionMs).toBeGreaterThanOrEqual(5 * 60_000);
+  });
+});
+
+describe("audit-log-stream-outbox-service sweepStaleClaims", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const sweepWith = async (dropped: { streamId: string; orgId: string; provider: string | null }[], retried = 0) => {
+    const { service, auditLogStreamOutboxDAL } = createService();
+    auditLogStreamOutboxDAL.recoverStaleClaims = vi.fn(async () => ({ retried, dropped })) as never;
+    await service.sweepStaleClaims();
+    return auditLogStreamOutboxDAL;
+  };
+
+  test("labels a drop with the stream's provider so sum by(provider) accounts for it", async () => {
+    await sweepWith([{ streamId: STREAM_ID, orgId: ORG_ID, provider: LogProvider.Datadog }]);
+
+    expect(exhaustedCounterAdd).toHaveBeenCalledTimes(1);
+    expect(exhaustedCounterAdd).toHaveBeenCalledWith(1, {
+      "audit_log_stream.id": STREAM_ID,
+      "audit_log_stream.provider": LogProvider.Datadog
+    });
+  });
+
+  // A stream deleted mid-flight is one of the reasons a claim goes stale, so the DAL can genuinely
+  // fail to resolve a provider. The attribute has to be absent rather than a stringified "null",
+  // which would otherwise show up as a provider of its own on every dashboard.
+  test("omits the provider attribute when the stream is already gone", async () => {
+    await sweepWith([{ streamId: STREAM_ID, orgId: ORG_ID, provider: null }]);
+
+    expect(exhaustedCounterAdd).toHaveBeenCalledTimes(1);
+    const [count, attrs] = exhaustedCounterAdd.mock.calls[0];
+    expect(count).toBe(1);
+    expect(attrs).toEqual({ "audit_log_stream.id": STREAM_ID });
+    expect(Object.keys(attrs)).not.toContain("audit_log_stream.provider");
+  });
+
+  test("counts per stream, keeping each provider's losses separate", async () => {
+    await sweepWith([
+      { streamId: "stream-a", orgId: ORG_ID, provider: LogProvider.Datadog },
+      { streamId: "stream-a", orgId: ORG_ID, provider: LogProvider.Datadog },
+      { streamId: "stream-b", orgId: ORG_ID, provider: LogProvider.Splunk },
+      { streamId: "stream-c", orgId: ORG_ID, provider: null }
+    ]);
+
+    expect(exhaustedCounterAdd).toHaveBeenCalledTimes(3);
+    expect(exhaustedCounterAdd).toHaveBeenCalledWith(2, {
+      "audit_log_stream.id": "stream-a",
+      "audit_log_stream.provider": LogProvider.Datadog
+    });
+    expect(exhaustedCounterAdd).toHaveBeenCalledWith(1, {
+      "audit_log_stream.id": "stream-b",
+      "audit_log_stream.provider": LogProvider.Splunk
+    });
+    expect(exhaustedCounterAdd).toHaveBeenCalledWith(1, { "audit_log_stream.id": "stream-c" });
+  });
+
+  // Recovering a claim is not a loss: those rows go back to 'retry' with an attempt spent and are
+  // still deliverable, so counting them would inflate the one signal that means events are gone.
+  test("records nothing when stale claims were recovered rather than dropped", async () => {
+    await sweepWith([], 5);
+
+    expect(exhaustedCounterAdd).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/ee/services/audit-log-stream-outbox/audit-log-stream-outbox-service.ts
+++ b/backend/src/ee/services/audit-log-stream-outbox/audit-log-stream-outbox-service.ts
@@ -379,15 +379,19 @@ export const auditLogStreamOutboxServiceFactory = ({
     }
     if (dropped.length > 0) {
       // Stale claims that used up their attempts are dropped (no DLQ); count them alongside
-      // delivery-path exhaustions, keyed by stream. No provider attribute here — the row doesn't carry
-      // it and the sweep isn't tied to a specific delivery attempt.
-      const droppedCountByStream = new Map<string, number>();
-      for (const { streamId } of dropped) {
-        droppedCountByStream.set(streamId, (droppedCountByStream.get(streamId) ?? 0) + 1);
+      // delivery-path exhaustions so both losses show up on the same counter, keyed the same way.
+      // The provider is resolved by the DAL and is null only when the stream itself is already gone,
+      // which is one of the reasons a claim goes stale.
+      const droppedCountByStream = new Map<string, { provider: string | null; count: number }>();
+      for (const { streamId, provider } of dropped) {
+        const existing = droppedCountByStream.get(streamId);
+        if (existing) existing.count += 1;
+        else droppedCountByStream.set(streamId, { provider, count: 1 });
       }
-      for (const [streamId, count] of droppedCountByStream) {
+      for (const [streamId, { provider, count }] of droppedCountByStream) {
         auditLogStreamDeliveryExhaustedCounter.add(count, {
-          "audit_log_stream.id": streamId
+          "audit_log_stream.id": streamId,
+          ...(provider && { "audit_log_stream.provider": provider })
         });
       }
     }


### PR DESCRIPTION
## Context

Audit log stream events that exhaust retries are counted on `auditLogStreamDeliveryExhaustedCounter`. Delivery-path drops already carry `audit_log_stream.provider`; stale-claim drops from the sweeper did not, so the same loss showed up under a different series and could not be broken down by provider.

`recoverStaleClaims` now looks up the stream provider before deleting exhausted rows and returns it with each drop. The sweeper emits the same counter attributes as the delivery path (`audit_log_stream.id` plus `audit_log_stream.provider` when the stream still exists). Provider is omitted only when the stream row is already gone, one reason a claim goes stale.

## Steps to verify the change

1. Configure an audit log stream and force a worker crash while rows are `processing` with `attempts` already at `MAX_ATTEMPTS - 1` (or leave them locked past `STALE_CLAIM_THRESHOLD_MS` = 10 minutes).
2. Run the stale-claim sweeper (`sweepStaleClaims`). Confirm the exhausted outbox rows are deleted.
3. Check `auditLogStreamDeliveryExhaustedCounter` for an increment labeled `audit_log_stream.id=<streamId>` and `audit_log_stream.provider=<provider>`.
4. Repeat after deleting the stream first. Confirm the counter still increments by stream id and does not include a provider attribute.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)