### PR TITLE
fix(github-org-sync): match GitHub logins by rule strength, and skip ambiguous ones

### DIFF
--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.test.ts
@@ -96,42 +96,98 @@ describe("buildGithubMemberMatcher", () => {
     user: email === null ? null : { email },
     inviteEmail
   });
+  const matched = (result: ReturnType<ReturnType<typeof buildGithubMemberMatcher>>) =>
+    result.status === "matched" ? { id: (result.member as { id: string }).id, rule: result.rule } : result;
 
-  test("matches a login equal to the email prefix", () => {
-    const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
-    expect(match("Jane.Doe")?.id).toBe("a");
-    expect(match("someone-else")).toBeUndefined();
+  describe("email rule", () => {
+    test("matches a login equal to the email prefix", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
+      expect(matched(match("Jane.Doe"))).toEqual({ id: "a", rule: "email" });
+    });
+
+    test("matches across separator differences between email and login", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com")]);
+      expect(matched(match("janedoe"))).toEqual({ id: "a", rule: "email" });
+      expect(matched(match("jane-doe"))).toEqual({ id: "a", rule: "email" });
+    });
   });
 
-  test("matches a login that appends the domain name to the email prefix", () => {
-    const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
-    expect(match("janeacme")?.id).toBe("a");
-    expect(match("acme")).toBeUndefined();
+  describe("org suffix rule", () => {
+    test("matches a login that appends the organization name to the email prefix", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
+      expect(matched(match("janeacme"))).toEqual({ id: "a", rule: "email-with-org-suffix" });
+    });
+
+    test("does not match the organization name alone", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane@acme.com")]);
+      expect(match("acme").status).toBe("unmatched");
+    });
   });
 
-  test("matches when the longest email part is contained in the login", () => {
-    const match = buildGithubMemberMatcher([member("a", "j.smithson@acme.com")]);
-    expect(match("smithson-dev")?.id).toBe("a");
+  describe("name part rule", () => {
+    test("matches when a login component equals the longest email part", () => {
+      const match = buildGithubMemberMatcher([member("a", "j.smithson@acme.com")]);
+      expect(matched(match("smithson-dev"))).toEqual({ id: "a", rule: "name-part" });
+    });
+
+    test("does not match a name part buried inside a login component", () => {
+      const match = buildGithubMemberMatcher([member("a", "deep@acme.com"), member("b", "nast@acme.com")]);
+      expect(match("0xarshdeep").status).toBe("unmatched");
+      expect(match("carlosmonastyrski").status).toBe("unmatched");
+    });
+
+    test("does not match a name part shorter than four characters", () => {
+      const match = buildGithubMemberMatcher([member("a", "j.li@acme.com")]);
+      expect(match("li-jones").status).toBe("unmatched");
+    });
   });
 
-  test("does not match on an email part shorter than four characters", () => {
-    const match = buildGithubMemberMatcher([member("a", "j.li@acme.com")]);
-    expect(match("xxliyy")).toBeUndefined();
+  describe("rule precedence", () => {
+    test("an exact email match beats a name part match found earlier in the list", () => {
+      const match = buildGithubMemberMatcher([
+        member("weak", "scott@infisical.com"),
+        member("exact", "scott-ray-wilson@acme.com")
+      ]);
+      expect(matched(match("scott-ray-wilson"))).toEqual({ id: "exact", rule: "email" });
+    });
+
+    test("falls through to the next rule only when no member matches the stronger one", () => {
+      const match = buildGithubMemberMatcher([member("weak", "scott@infisical.com")]);
+      expect(matched(match("scott-ray-wilson"))).toEqual({ id: "weak", rule: "name-part" });
+    });
   });
 
-  test("returns the first matching member, preserving input order", () => {
-    const match = buildGithubMemberMatcher([member("first", "bob@acme.com"), member("second", "bob@other.com")]);
-    expect(match("bob")?.id).toBe("first");
+  describe("ambiguity", () => {
+    test("reports rather than guesses when two members match the same rule", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane.doe@acme.com"), member("b", "janedoe@other.com")]);
+      const result = match("janedoe");
+      expect(result).toEqual({
+        status: "ambiguous",
+        rule: "email",
+        emails: ["jane.doe@acme.com", "janedoe@other.com"]
+      });
+    });
+
+    test("does not report ambiguity for a member listed twice with the same email", () => {
+      const match = buildGithubMemberMatcher([member("a", "jane@acme.com"), member("b", "jane@acme.com")]);
+      expect(match("jane").status).toBe("matched");
+    });
   });
 
-  test("falls back to inviteEmail and skips members with neither", () => {
-    const match = buildGithubMemberMatcher([member("no-email", null), member("invited", null, "bob@acme.com")]);
-    expect(match("bob")?.id).toBe("invited");
-  });
+  describe("input handling", () => {
+    test("falls back to inviteEmail and skips members with neither", () => {
+      const match = buildGithubMemberMatcher([member("no-email", null), member("invited", null, "bob@acme.com")]);
+      expect(matched(match("bob"))).toEqual({ id: "invited", rule: "email" });
+    });
 
-  test("ignores a malformed email instead of throwing", () => {
-    const match = buildGithubMemberMatcher([member("bad", "not-an-email"), member("good", "bob@acme.com")]);
-    expect(() => match("bob")).not.toThrow();
-    expect(match("bob")?.id).toBe("good");
+    test("ignores a malformed email instead of throwing", () => {
+      const match = buildGithubMemberMatcher([member("bad", "not-an-email"), member("good", "bob@acme.com")]);
+      expect(() => match("bob")).not.toThrow();
+      expect(matched(match("bob"))).toEqual({ id: "good", rule: "email" });
+    });
+
+    test("returns unmatched for an empty member list", () => {
+      expect(buildGithubMemberMatcher([])("anyone").status).toBe("unmatched");
+    });
   });
 });

--- a/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
+++ b/backend/src/ee/services/github-org-sync/github-org-sync-service.ts
@@ -206,36 +206,80 @@ export const fetchGithubOrgTeams = async (octokit: Pick<Octokit, "graphql">, org
 
 type TMatchableMember<T> = { user?: { email?: string | null } | null; inviteEmail?: string | null } & T;
 
-// ~16M (login, member) comparisons on a 640-team org, so per-member fields are derived once per
-// sync. Order must stay input order, or `find` picks a different member than before.
+// Weakest rule a login is allowed to match on. A name part shorter than this collides constantly.
+const GITHUB_MIN_NAME_PART_LENGTH = 4;
+
+const AMBIGUOUS_LOGIN_REPORT_LIMIT = 20;
+
+export const GithubMemberMatchRule = {
+  Email: "email",
+  EmailWithOrgSuffix: "email-with-org-suffix",
+  NamePart: "name-part"
+} as const;
+
+export type TGithubMemberMatchRule = (typeof GithubMemberMatchRule)[keyof typeof GithubMemberMatchRule];
+
+export type TGithubMemberMatch<T> =
+  | { status: "matched"; member: T; rule: TGithubMemberMatchRule }
+  | { status: "ambiguous"; rule: TGithubMemberMatchRule; emails: string[] }
+  | { status: "unmatched" };
+
+const SEPARATORS = new RE2(/[._-]/g);
+const stripSeparators = (value: string) => value.replace(SEPARATORS, "");
+
+/**
+ * Resolves a GitHub login to the org member it belongs to.
+ *
+ * Rules are tried strongest first across every member, so an exact email match always beats a name
+ * fragment no matter what order members arrive in. A login that two members match equally well is
+ * reported as ambiguous rather than resolved, because guessing hands one of them the other's
+ * project access.
+ */
 export const buildGithubMemberMatcher = <T>(members: TMatchableMember<T>[]) => {
-  const emailSplitRegex = new RE2(/[._-]/);
+  // ~16M (login, member) comparisons on a 640-team org, so per-member fields are derived once per
+  // sync rather than once per comparison.
   const candidates = members.flatMap((member) => {
     const email = member.user?.email || member.inviteEmail;
     if (!email) return [];
     const [rawPrefix, rawDomain] = email.split("@");
     if (!rawPrefix || !rawDomain) return [];
     const emailPrefix = rawPrefix.toLowerCase();
+    const parts = emailPrefix.split(new RE2(/[._-]/));
     return [
       {
         member,
-        emailPrefix,
-        domainName: rawDomain.toLowerCase().split(".")[0],
-        longestEmailPart: emailPrefix.split(emailSplitRegex).reduce((a, b) => (a.length > b.length ? a : b), "")
+        email: email.toLowerCase(),
+        compactPrefix: stripSeparators(emailPrefix),
+        orgSuffixed: stripSeparators(emailPrefix) + stripSeparators(rawDomain.toLowerCase().split(".")[0]),
+        longestPart: parts.reduce((a, b) => (a.length > b.length ? a : b), "")
       }
     ];
   });
 
-  return (githubLogin: string) => {
-    const githubUsername = githubLogin.toLowerCase();
-    return candidates.find(
-      ({ emailPrefix, domainName, longestEmailPart }) =>
-        emailPrefix === githubUsername ||
-        (githubUsername.endsWith(domainName) &&
-          githubUsername.length > domainName.length &&
-          emailPrefix === githubUsername.slice(0, -domainName.length)) ||
-        (longestEmailPart.length >= 4 && githubUsername.includes(longestEmailPart))
-    )?.member;
+  return (githubLogin: string): TGithubMemberMatch<T> => {
+    const login = githubLogin.toLowerCase();
+    const compactLogin = stripSeparators(login);
+    const loginParts = new Set(login.split(new RE2(/[._-]/)));
+
+    const rules: [TGithubMemberMatchRule, (c: (typeof candidates)[number]) => boolean][] = [
+      [GithubMemberMatchRule.Email, (c) => c.compactPrefix === compactLogin],
+      [GithubMemberMatchRule.EmailWithOrgSuffix, (c) => c.orgSuffixed === compactLogin],
+      [
+        GithubMemberMatchRule.NamePart,
+        (c) => c.longestPart.length >= GITHUB_MIN_NAME_PART_LENGTH && loginParts.has(c.longestPart)
+      ]
+    ];
+
+    for (const [rule, predicate] of rules) {
+      const hits = candidates.filter(predicate);
+      const distinct = [...new Map(hits.map((hit) => [hit.email, hit])).values()];
+      if (distinct.length === 1) return { status: "matched", member: distinct[0].member, rule };
+      if (distinct.length > 1) {
+        return { status: "ambiguous", rule, emails: distinct.map((hit) => hit.email).sort() };
+      }
+    }
+
+    return { status: "unmatched" };
   };
 };
 
@@ -796,6 +840,7 @@ export const githubOrgSyncServiceFactory = ({
 
     const startTime = Date.now();
     const syncErrors: string[] = [];
+    const ambiguousLogins = new Map<string, string[]>();
 
     const octokit = new Octokit({ auth: orgAccessToken });
 
@@ -907,13 +952,15 @@ export const githubOrgSyncServiceFactory = ({
         (githubTeamMembersByName.get(teamName) ?? []).forEach((login) => {
           const githubUsername = login.toLowerCase();
 
-          const matchingMember = matchGithubLogin(githubUsername);
+          const result = matchGithubLogin(githubUsername);
 
-          if (matchingMember?.user?.id) {
-            expectedUserIds.add(matchingMember.user.id);
+          if (result.status === "matched" && result.member.user?.id) {
+            expectedUserIds.add(result.member.user.id);
             logger.info(
-              `Matched GitHub user ${githubUsername} to email ${matchingMember.user?.email || matchingMember.inviteEmail}`
+              `Matched GitHub user ${githubUsername} to email ${result.member.user?.email || result.member.inviteEmail} by ${result.rule}`
             );
+          } else if (result.status === "ambiguous") {
+            ambiguousLogins.set(githubUsername, result.emails);
           }
         });
 
@@ -967,6 +1014,26 @@ export const githubOrgSyncServiceFactory = ({
       // Team membership changes cascade into the group-expanded project identity meters.
       usageMeteringService.emit(orgPermission.orgId, SecretIdentities.key);
       usageMeteringService.emit(orgPermission.orgId, PamIdentities.key);
+    }
+
+    if (ambiguousLogins.size) {
+      logger.warn(
+        { orgId: orgPermission.orgId, count: ambiguousLogins.size },
+        "GitHub org sync skipped logins that more than one organization member matched"
+      );
+      // Capped so a badly aliased org cannot return a response the client has to scroll through.
+      const listed = [...ambiguousLogins.entries()].slice(0, AMBIGUOUS_LOGIN_REPORT_LIMIT);
+      syncErrors.push(
+        ...listed.map(
+          ([login, emails]) =>
+            `GitHub user '${login}' matches more than one organization member (${emails.join(", ")}), so their team memberships were not synced. Align the member's email with their GitHub username.`
+        )
+      );
+      if (ambiguousLogins.size > listed.length) {
+        syncErrors.push(
+          `${ambiguousLogins.size - listed.length} further GitHub users were skipped for the same reason.`
+        );
+      }
     }
 
     const syncDuration = Date.now() - startTime;

--- a/docs/documentation/platform/github-org-sync.mdx
+++ b/docs/documentation/platform/github-org-sync.mdx
@@ -103,6 +103,26 @@ You can manually synchronize GitHub teams for all organization members who have 
     </Step>
 </Steps>
 
+## How members are matched
+
+Manual sync compares each GitHub username against the email address of every member in your
+organization. It tries three rules in order and stops at the first rule that identifies exactly one
+member:
+
+1. The part of the email address before the `@` equals the username, ignoring dots, hyphens and
+   underscores. `jane.doe@acme.com` matches `janedoe`.
+2. The username is that same email prefix followed by your organization's name. `jane@acme.com`
+   matches `janeacme`.
+3. The longest part of the email prefix is one whole part of the username. `j.smithson@acme.com`
+   matches `smithson-dev`.
+
+When two members match the same rule, the sync skips that GitHub user and lists them in the
+**Sync Now** result instead of choosing between them. Give one of the members an email address whose
+prefix matches their GitHub username to resolve it.
+
+A GitHub user who matches no member isn't added to any group. That's expected for accounts with no
+Infisical member, such as bots and outside collaborators.
+
 ## Troubleshooting
 
 <AccordionGroup>


### PR DESCRIPTION
## Context

Stacked on #7998 (base that first). A customer report drove #7998; driving it end to end surfaced this separately.

Bulk sync has to guess which Infisical member each GitHub login belongs to, because unlike the login path it has no OAuth token per user. The heuristic from #4429 had two problems, and both hand one member another member's group membership, and so their project access.

- **No rule precedence.** Rules were tested per candidate, so array order picked the winner. A weak name-fragment hit on an early member beat an exact email match on a later one. Rules are now tried strongest first across all members.
- **The weakest rule matched a fragment anywhere in the login.** A 4+ character email part just had to appear somewhere, so unrelated people inherited teams. It now has to be a whole component of the login.
- **Ambiguity was resolved silently.** A login two members match equally well is now skipped and reported, not guessed.

Measured against a real 2,304-member org:

| GitHub login | Before | After |
| --- | --- | --- |
| `scott-ray-wilson` | `scott@infisical.com` | `scott-ray-wilson@acme-corp.test` (exact email) |
| `0xArshdeep` | `deep@acme-corp.test` | no match |
| `carlosmonastyrski` | `nast@acme-corp.test` | no match |
| `scott-ray-wilson`, with a colliding alias added | `scott@infisical.com` | reported ambiguous, skipped |

`deep` and `nast` are unrelated people with no GitHub presence who were being granted someone else's team.

**This narrows matching**, so a member matched only by an accidental infix loses that group on the next sync. That is the point of the change, and it errs toward removing access rather than granting it. The strongest rule also now ignores separator differences, so `jane.doe@acme.com` matches `janedoe` by email instead of falling through to the fragment rule.

Reported ambiguities populate the `errors` field on the sync response, which was previously declared, returned and never written to.

## Screenshots

N/A

## Steps to verify the change

- [ ] `cd backend && npm run test:unit -- src/ee/services/github-org-sync` passes 18 tests (needs Node 22 for `re2`), covering each rule, precedence, ambiguity, and the infix cases above
- [ ] `cd backend && npx eslint --ext .ts src/ee/services/github-org-sync/ && npx prettier --check src/ee/services/github-org-sync/` is clean
- [ ] `cd backend && NODE_OPTIONS=--max-old-space-size=12288 npm run type:check` reports 0 errors
- [ ] `make lint-docs-branch` is clean
- [ ] With two org members whose emails both reduce to one GitHub username, **Sync Now** skips that user and names both members in the result rather than adding one of them
- [ ] With a member whose email prefix is a substring of an unrelated GitHub username, **Sync Now** no longer adds them to that user's teams

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
