### PR TITLE
feat(ci): maintain a single Northflank preview comment

### DIFF
--- a/.github/scripts/preview-comment.cjs
+++ b/.github/scripts/preview-comment.cjs
@@ -1,0 +1,105 @@
+const BUILD_CONTEXT = "northflank/infisical/infisical-preview/infisical-core";
+const NORTHFLANK_BOT = "northflank-cloud-build-run[bot]";
+const MARKER = "<!-- infisical-northflank-preview -->";
+
+function newest(items) {
+  return items.reduce((latest, item) => !latest || item.id > latest.id ? item : latest, undefined);
+}
+
+function getState(builds, deployment, statuses) {
+  const build = newest(builds);
+  if (build?.state === "pending") return "🟡 Building";
+  if (["failure", "error"].includes(build?.state)) return "🔴 Build failed";
+
+  // A rebuild of the same SHA must not inherit an earlier deployment's success.
+  const started = newest(builds.filter((item) => item.state === "pending"));
+  const current = deployment && (!started || deployment.created_at >= started.created_at);
+  const status = current ? newest(statuses) : undefined;
+  if (status?.state === "success") return "🟢 Ready";
+  if (["failure", "error"].includes(status?.state)) return "🔴 Deployment failed";
+  if (status?.state === "inactive") return "⚪ Inactive";
+  if (build?.state === "success" || current) return "🟡 Deploying";
+  return undefined;
+}
+
+function northflankLink(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol === "https:" && url.hostname === "app.northflank.com") {
+      return url.href.replaceAll("(", "%28").replaceAll(")", "%29");
+    }
+  } catch {}
+  return undefined;
+}
+
+async function resolvePullRequests({ github, context }) {
+  if (context.eventName === "workflow_dispatch") {
+    const number = Number(context.payload.inputs.pr);
+    if (!Number.isSafeInteger(number) || number <= 0) throw new Error("PR must be a positive integer");
+    return [number];
+  }
+  if (context.eventName === "deployment_status") {
+    const deployment = context.payload.deployment;
+    if (deployment.creator?.login !== NORTHFLANK_BOT) return [];
+    const match = /^pr-([1-9]\d*)-infisical-core$/.exec(deployment.environment);
+    return match ? [Number(match[1])] : [];
+  }
+  if (context.eventName !== "status" || context.payload.context !== BUILD_CONTEXT) return [];
+  const pulls = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
+    ...context.repo, commit_sha: context.payload.sha, per_page: 100
+  });
+  return pulls.filter((pr) => pr.state === "open").map((pr) => pr.number);
+}
+
+async function reconcile({ github, context, pr, dryRun = false }) {
+  const repo = context.repo;
+  const { data: pull } = await github.rest.pulls.get({ ...repo, pull_number: pr });
+  if (pull.state !== "open") return;
+  const sha = pull.head.sha;
+  // Read current API state instead of replaying the triggering event. Delayed
+  // events and queued runs therefore reconcile the latest commit/build.
+  const builds = (await github.paginate(github.rest.repos.listCommitStatuses, {
+    ...repo, ref: sha, per_page: 100
+  })).filter((item) => item.context === BUILD_CONTEXT && item.creator?.login === NORTHFLANK_BOT);
+  const deployments = await github.paginate(github.rest.repos.listDeployments, {
+    ...repo, sha, environment: `pr-${pr}-infisical-core`, per_page: 100
+  });
+  const deployment = newest(deployments.filter((item) => item.creator?.login === NORTHFLANK_BOT));
+  const statuses = deployment ? (await github.paginate(github.rest.repos.listDeploymentStatuses, {
+    ...repo, deployment_id: deployment.id, per_page: 100
+  })).filter((item) => item.creator?.login === NORTHFLANK_BOT) : [];
+  const state = getState(builds, deployment, statuses);
+  if (!state) return;
+
+  const buildLink = northflankLink(newest(builds)?.target_url);
+  const deploymentLink = northflankLink(newest(statuses)?.log_url);
+  const body = [
+    MARKER,
+    "## Infisical preview",
+    "",
+    "| Status | Preview | Commit |",
+    "| --- | --- | --- |",
+    `| ${state} | [Open preview](https://pr-${pr}.preview.infisical.com) | [\`${sha.slice(0, 7)}\`](https://github.com/${repo.owner}/${repo.repo}/commit/${sha}) |`,
+    "",
+    [buildLink && `[Build logs](${buildLink})`, deploymentLink && `[Deployment](${deploymentLink})`].filter(Boolean).join(" · "),
+    "",
+    "This comment updates automatically. While building or deploying, the preview may still serve the previous version."
+  ].join("\n");
+  if (dryRun) return body;
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...repo, issue_number: pr, per_page: 100
+  });
+  const existing = comments.find((comment) => comment.user?.login === "github-actions[bot]" && comment.body?.startsWith(MARKER));
+  // Recheck after the API reads in case another commit was pushed meanwhile.
+  const { data: latest } = await github.rest.pulls.get({ ...repo, pull_number: pr });
+  if (latest.state !== "open" || latest.head.sha !== sha) return;
+  if (existing) {
+    if (existing.body !== body) await github.rest.issues.updateComment({ ...repo, comment_id: existing.id, body });
+  } else {
+    await github.rest.issues.createComment({ ...repo, issue_number: pr, body });
+  }
+  return body;
+}
+
+module.exports = { BUILD_CONTEXT, NORTHFLANK_BOT, MARKER, getState, resolvePullRequests, reconcile };

--- a/.github/scripts/preview-comment.md
+++ b/.github/scripts/preview-comment.md
@@ -1,0 +1,37 @@
+# Northflank preview comment
+
+`preview-comment.yml` maintains one `github-actions[bot]` comment per PR using
+Northflank's existing GitHub commit statuses and deployment statuses. It needs
+no Northflank API token or additional webhook service.
+
+The workflow reads the current PR head and latest API state on every event.
+Writes are serialized per PR, and a same-commit rebuild cannot reuse an older
+deployment's success. Only the `northflank-cloud-build-run[bot]` build context
+`northflank/infisical/infisical-preview/infisical-core` and deployments named
+`pr-<number>-infisical-core` are used. The workflow executes the script from
+the default branch, never the deployed PR's checkout.
+
+## Activation
+
+1. Merge the workflow and script into `main`.
+2. Run **Update preview comment** manually for a preview PR, or trigger a build.
+   Verify the marked comment updates through building, deploying, and ready.
+3. In Northflank, open **Infisical Preview → Previews → infisical-preview → Visual**.
+   Open the final **Message** node, enable **Skip node execution**, save the node,
+   and save the blueprint. This stops the old duplicate comments after the new
+   workflow is verified. Existing historical comments are left intact.
+
+The colored dot changes when GitHub delivers status events and the Actions job
+runs; it is not an animated or percentage-based progress indicator. GitHub does
+not deliver an Actions `deployment_status` run for `inactive`, so an inactive
+state is refreshed only on another event or a manual run. The comment is updated
+in place rather than automatically pinned in GitHub's interface.
+
+## Verification
+
+Run `node --test .github/scripts/preview-comment.test.cjs`.
+`reconcile({ github, context, pr, dryRun: true })` returns the rendered Markdown
+without writing a comment, for checking live API data before activation.
+
+To roll back, disable **Update preview comment** in GitHub Actions and uncheck
+**Skip node execution** on the Northflank Message node.

--- a/.github/scripts/preview-comment.test.cjs
+++ b/.github/scripts/preview-comment.test.cjs
@@ -1,0 +1,116 @@
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { BUILD_CONTEXT, NORTHFLANK_BOT, MARKER, getState, reconcile, resolvePullRequests } = require("./preview-comment.cjs");
+
+const pending = { id: 1, state: "pending", created_at: "2026-09-05T01:00:00Z" };
+const success = { id: 2, state: "success", created_at: "2026-09-05T01:05:00Z" };
+const deployment = { id: 1, created_at: "2026-09-05T01:06:00Z" };
+
+test("build, deployment, and failure transitions", () => {
+  assert.equal(getState([], undefined, []), undefined);
+  assert.equal(getState([pending], undefined, []), "🟡 Building");
+  assert.equal(getState([pending, success], undefined, []), "🟡 Deploying");
+  assert.equal(getState([pending, success], deployment, [{ id: 1, state: "success" }]), "🟢 Ready");
+  assert.equal(getState([{ ...success, state: "failure" }], undefined, []), "🔴 Build failed");
+  assert.equal(getState([success], deployment, [{ id: 1, state: "failure" }]), "🔴 Deployment failed");
+  assert.equal(getState([success], deployment, [{ id: 1, state: "success" }, { id: 2, state: "inactive" }]), "⚪ Inactive");
+});
+
+test("same-SHA rebuild does not reuse the previous deployment's success", () => {
+  const rebuild = { ...pending, id: 3, created_at: "2026-09-05T02:00:00Z" };
+  const deployed = [{ id: 1, state: "success" }];
+  assert.equal(getState([success, rebuild], deployment, deployed), "🟡 Building");
+  assert.equal(getState([rebuild, { ...success, id: 4 }], deployment, deployed), "🟡 Deploying");
+});
+
+function fixture({ comments = [], moved = false, closed = false, foreign = false } = {}) {
+  const calls = [];
+  let reads = 0;
+  const sha = "a".repeat(40);
+  const pull = { state: closed ? "closed" : "open", head: { sha } };
+  const github = {
+    rest: {
+      pulls: { get: async () => ({ data: ++reads > 1 && moved ? { ...pull, head: { sha: "b".repeat(40) } } : pull }) },
+      repos: {
+        listCommitStatuses: "builds", listDeployments: "deployments", listDeploymentStatuses: "statuses",
+        listPullRequestsAssociatedWithCommit: "pulls"
+      },
+      issues: {
+        listComments: "comments",
+        createComment: async (args) => calls.push({ kind: "create", ...args }),
+        updateComment: async (args) => calls.push({ kind: "update", ...args })
+      }
+    },
+    paginate: async (route, args) => {
+      assert.equal(args.per_page, 100);
+      const creator = { login: foreign ? "someone-else" : NORTHFLANK_BOT };
+      return {
+        builds: [{ ...pending, context: BUILD_CONTEXT, creator, target_url: "https://app.northflank.com/builds/example" }],
+        deployments: [], statuses: [], comments,
+        pulls: [{ number: 7951, state: "open" }, { number: 1, state: "closed" }]
+      }[route];
+    }
+  };
+  return { github, context: { repo: { owner: "Infisical", repo: "infisical" } }, pr: 7951, calls };
+}
+
+test("creates one marked comment using current head, not event SHA", async () => {
+  const f = fixture();
+  f.context.payload = { sha: "old-sha" };
+  await reconcile(f);
+  assert.equal(f.calls.length, 1);
+  assert.equal(f.calls[0].kind, "create");
+  assert.match(f.calls[0].body, /🟡 Building/);
+  assert.match(f.calls[0].body, /aaaaaaa/);
+  assert.match(f.calls[0].body, /pr-7951.preview.infisical.com/);
+});
+
+test("updates only its own marked comment and skips identical writes", async () => {
+  const f = fixture({ comments: [
+    { id: 1, user: { login: "someone-else" }, body: MARKER },
+    { id: 2, user: { login: "github-actions[bot]" }, body: MARKER }
+  ] });
+  const body = await reconcile(f);
+  assert.equal(f.calls[0].kind, "update");
+  assert.equal(f.calls[0].comment_id, 2);
+  const same = fixture({ comments: [{ id: 2, user: { login: "github-actions[bot]" }, body }] });
+  await reconcile(same);
+  assert.deepEqual(same.calls, []);
+});
+
+test("does not write for closed PRs, changed heads, or unrelated status creators", async () => {
+  for (const options of [{ closed: true }, { moved: true }, { foreign: true }]) {
+    const f = fixture(options);
+    await reconcile(f);
+    assert.deepEqual(f.calls, []);
+  }
+});
+
+test("dry run renders without writing", async () => {
+  const f = fixture();
+  assert.match(await reconcile({ ...f, dryRun: true }), /Infisical preview/);
+  assert.deepEqual(f.calls, []);
+});
+
+test("resolves Northflank events and rejects unrelated deployments", async () => {
+  const f = fixture();
+  f.context.eventName = "status";
+  f.context.payload = { context: BUILD_CONTEXT, sha: "a".repeat(40) };
+  assert.deepEqual(await resolvePullRequests(f), [7951]);
+  f.context.eventName = "deployment_status";
+  f.context.payload = { deployment: { creator: { login: NORTHFLANK_BOT }, environment: "pr-7951-infisical-core" } };
+  assert.deepEqual(await resolvePullRequests(f), [7951]);
+  f.context.payload.deployment.environment = "production";
+  assert.deepEqual(await resolvePullRequests(f), []);
+  f.context.payload.deployment = { creator: { login: "someone-else" }, environment: "pr-7951-infisical-core" };
+  assert.deepEqual(await resolvePullRequests(f), []);
+});
+
+test("manual refresh validates PR number", async () => {
+  const f = fixture();
+  f.context.eventName = "workflow_dispatch";
+  f.context.payload = { inputs: { pr: "7951" } };
+  assert.deepEqual(await resolvePullRequests(f), [7951]);
+  f.context.payload.inputs.pr = "0";
+  await assert.rejects(resolvePullRequests(f), /positive integer/);
+});

--- a/.github/workflows/preview-comment.yml
+++ b/.github/workflows/preview-comment.yml
@@ -1,0 +1,70 @@
+name: Update preview comment
+
+on:
+  status:
+  deployment_status:
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number to refresh
+        type: number
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'status' && github.event.context == 'northflank/infisical/infisical-preview/infisical-core') ||
+      (github.event_name == 'deployment_status' && github.event.deployment.creator.login == 'northflank-cloud-build-run[bot]' && startsWith(github.event.deployment.environment, 'pr-'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      prs: ${{ steps.resolve.outputs.result }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Deployment events refer to PR commits. Only execute trusted main code.
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - id: resolve
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { resolvePullRequests } = require('./.github/scripts/preview-comment.cjs');
+            return await resolvePullRequests({ github, context });
+
+  comment:
+    needs: resolve
+    if: needs.resolve.outputs.prs != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJSON(needs.resolve.outputs.prs) }}
+    concurrency:
+      group: northflank-preview-comment-${{ matrix.pr }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      statuses: read
+      deployments: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        env:
+          PREVIEW_PR: ${{ matrix.pr }}
+        with:
+          script: |
+            const { reconcile } = require('./.github/scripts/preview-comment.cjs');
+            await reconcile({ github, context, pr: Number(process.env.PREVIEW_PR) });


### PR DESCRIPTION
## Context

Northflank currently posts a new preview URL comment after every successful preview build. Maintain one GitHub Actions comment per PR instead, updating its colored status indicator through Building, Deploying, Ready, and failure states, with the preview URL, current commit, and Northflank logs.

The workflow consumes Northflank's existing GitHub commit-status and deployment-status events; no new webhook service or Northflank credentials are required. It reads current API state, serializes writes per PR, verifies the PR head before writing, and prevents same-SHA rebuilds from reusing an older deployment's success. Both jobs explicitly check out the default branch, never PR code.

Activation requires this change on main. After verifying a live comment update, enable Skip node execution on the final Message node in the Northflank infisical-preview blueprint. The existing message node has not been changed. Historical comments are retained. The new comment is updated in place, not automatically pinned; its dot changes on status events rather than showing percentage progress.

## Screenshots

Read-only rendering against live GitHub data for PR #7951 produced:

| Status | Preview | Commit |
| --- | --- | --- |
| 🟡 Building | Open preview | 4e790d3 |

The actual comment includes links to the preview, commit, and Northflank build logs. No live comment was posted during validation.

## Steps to verify the change

1. Run `node --test .github/scripts/preview-comment.test.cjs` — all 8 tests pass, including duplicate avoidance, stale heads, same-SHA rebuilds, failures, and untrusted status creators.
2. Run `actionlint .github/workflows/preview-comment.yml` — passes.
3. After merge, manually run Update preview comment for an active preview PR and verify the rendered comment.
4. Push another commit to a preview PR and confirm the same comment updates from Building through Deploying to Ready. Verify failure handling with a failed preview build.
5. Disable the old Northflank Message node only after the replacement is verified. Rollback and activation instructions are in `.github/scripts/preview-comment.md`.

## Type

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed) — no application architecture changes
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
