### PR TITLE
docs(go-sdk): fix 'Wether' typo to 'Whether' in example docs

### DIFF
--- a/docs/sdks/languages/cpp.mdx
+++ b/docs/sdks/languages/cpp.mdx
@@ -308,7 +308,7 @@ const auto secrets = client.secrets().listSecrets(listSecretsOptions);
 - `withProjectId(string)`: Specify the ID of the project to fetch secrets from.
 - `withSecretPath(string)`: Specify the secret path to fetch secrets from. Defaults to `/`
 - `withExpandSecretReferences(bool)` _(optional)_: Whether or not to expand secret references automatically. Defaults to `true`.
-- `withRecursive(bool)` _(optional)_: Wether or not to recursively fetch secrets from sub-folders. If set to true, all secrets from the secret path specified with `withSecretPath()` and downwards will be fetched.
+- `withRecursive(bool)` _(optional)_: Whether or not to recursively fetch secrets from sub-folders. If set to true, all secrets from the secret path specified with `withSecretPath()` and downwards will be fetched.
 - `withAddSecretsToEnvironmentVariables(bool)` _(optional)_: If set to true, the fetched secrets will be automatically set as environment variables, making them accessible with `std::getenv` or equivalent by secret key.
 - `build()`: Returns the `ListSecretsOptions` class that can be passed into the `listSecrets()` method.
 

--- a/docs/sdks/languages/go.mdx
+++ b/docs/sdks/languages/go.mdx
@@ -26,7 +26,7 @@ func main() {
 
 	client := infisical.NewInfisicalClient(context.Background(), infisical.Config{
 		SiteUrl: "https://app.infisical.com", // Optional, default is https://app.infisical.com
-    AutoTokenRefresh: true, // Wether or not to let the SDK handle the access token lifecycle. Defaults to true if not specified.
+    AutoTokenRefresh: true, // Whether or not to let the SDK handle the access token lifecycle. Defaults to true if not specified.
 	})
 
 	_, err := client.Auth().UniversalAuthLogin("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET")


### PR DESCRIPTION
Fixes #7923

### Summary of Changes
- Fixed "Wether" → "Whether" typo in Go SDK example docs (docs/sdks/languages/go.mdx)
- Fixed same typo in C++ SDK docs (docs/sdks/languages/cpp.mdx)

### Checklist
- [x] I have read and followed the repository's CONTRIBUTING guidelines.
- [x] All automated tests pass locally.
- [x] Linters and formatters passed with zero warnings.