### PR TITLE
fix: coalesce concurrent secret reference folder loads

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.test.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { expandSecretReferencesFactory } from "./secret-reference-fns";
+
+vi.mock("@app/lib/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn() } }));
+vi.mock("../project-folder-grant/project-folder-grant-fns", () => ({ isCrossProjectEnabled: vi.fn() }));
+
+describe("expandSecretReferencesFactory", () => {
+  it("should share one folder read when resolving concurrent references to the same folder", async () => {
+    type Args = Parameters<typeof expandSecretReferencesFactory>[0];
+    const findBySecretPath = vi
+      .fn<Args["folderDAL"]["findBySecretPath"]>()
+      .mockResolvedValue({ id: "folder" } as Awaited<ReturnType<Args["folderDAL"]["findBySecretPath"]>>);
+    const findByFolderId = vi.fn<Args["secretDAL"]["findByFolderId"]>().mockResolvedValue([
+      {
+        id: "secret",
+        _id: "secret",
+        key: "SOURCE",
+        version: 1,
+        type: "shared",
+        folderId: "folder",
+        createdAt: new Date(0),
+        updatedAt: new Date(0),
+        encryptedValue: Buffer.from("resolved"),
+        tags: [],
+        secretMetadata: [],
+        userId: null
+      }
+    ]);
+    const { expandSecretReferences } = expandSecretReferencesFactory({
+      projectId: "project",
+      folderDAL: { findBySecretPath },
+      secretDAL: { findByFolderId },
+      decryptSecretValue: (value) => value?.toString(),
+      canExpandValue: vi.fn(() => true)
+    });
+
+    const results = await Promise.all(
+      Array.from({ length: 50 }, (_, index) =>
+        expandSecretReferences({
+          secretKey: `KEY_${index}`,
+          value: `\${SOURCE}`,
+          environment: "prod",
+          secretPath: "/shared"
+        })
+      )
+    );
+
+    expect(results).toEqual(Array(50).fill("resolved"));
+    expect(findBySecretPath).toHaveBeenCalledOnce();
+    expect(findByFolderId).toHaveBeenCalledOnce();
+  });
+});

--- a/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
+++ b/backend/src/services/secret-v2-bridge/secret-reference-fns.ts
@@ -165,22 +165,12 @@ export const expandSecretReferencesFactory = ({
   const getCacheUniqueKey = (environment: string, secretPath: string, srcProjectId?: string) =>
     srcProjectId ? `${srcProjectId}:${environment}-${secretPath}` : `${environment}-${secretPath}`;
 
-  const fetchSecret = async (
-    environment: string,
-    secretPath: string,
-    secretKey: string
-  ): Promise<{ value: string; tags: string[]; exists: boolean }> => {
-    const cacheKey = getCacheUniqueKey(environment, secretPath);
+  const pendingFolderLoads = new Map<string, Promise<void>>();
 
-    if (secretCache?.[cacheKey]) {
-      const cachedSecret = secretCache[cacheKey][secretKey];
-      if (cachedSecret) return { ...cachedSecret };
-      return { value: "", tags: [], exists: false };
-    }
-
+  const loadFolderSecrets = async (environment: string, secretPath: string, cacheKey: string) => {
     try {
       const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
-      if (!folder) return { value: "", tags: [], exists: false };
+      if (!folder) return;
       // When userId is provided, findByFolderId returns both shared and personal secrets.
       // Personal overrides will take precedence over shared secrets in the reduce below.
       const secrets = await secretDAL.findByFolderId({ folderId: folder.id, userId });
@@ -206,14 +196,32 @@ export const expandSecretReferencesFactory = ({
       );
 
       secretCache[cacheKey] = decryptedSecret;
-
-      const fetchedSecret = secretCache[cacheKey][secretKey];
-      if (fetchedSecret) return { ...fetchedSecret };
-      return { value: "", tags: [], exists: false };
     } catch (error) {
       secretCache[cacheKey] = {};
-      return { value: "", tags: [], exists: false };
     }
+  };
+
+  const fetchSecret = async (
+    environment: string,
+    secretPath: string,
+    secretKey: string
+  ): Promise<{ value: string; tags: string[]; exists: boolean }> => {
+    const cacheKey = getCacheUniqueKey(environment, secretPath);
+
+    if (!secretCache[cacheKey]) {
+      let pending = pendingFolderLoads.get(cacheKey);
+      if (!pending) {
+        // Concurrent reference expansion must share the folder read before its result is cached.
+        pending = loadFolderSecrets(environment, secretPath, cacheKey).finally(() => {
+          pendingFolderLoads.delete(cacheKey);
+        });
+        pendingFolderLoads.set(cacheKey, pending);
+      }
+      await pending;
+    }
+
+    const secret = secretCache[cacheKey]?.[secretKey];
+    return secret ? { ...secret } : { value: "", tags: [], exists: false };
   };
 
   const recursivelyExpandSecret = async (dto: {


### PR DESCRIPTION
## Context

When Redis has no cached response, [several secret references can try to load the same folder at once](https://github.com/Infisical/infisical/blob/88bd99cdf396436c13ee5150cb3596d0af6d0bf1/backend/src/services/secret-v2-bridge/secret-v2-bridge-service.ts#L1603-L1621). Previously, each could start its own database read before the in-memory cache was ready.

This change lets those references wait for one shared folder load, then reuse its result. This reduces duplicate database reads and memory used while resolving references within the same expander. Redis caching stays the same.

## Steps to verify the change
I added a test that resolves 50 references to the same folder and checks that it is read only once. It fails on the old code and passes with this fix. Lint passes for the changed files.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore


