### PR TITLE
fix: split query into 3 ones to reduce duplicate alloc by joins

### DIFF
--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -414,89 +414,111 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
         userId = undefined;
       }
 
-      const conn = tx || db.replicaNode();
+      const execQueries = async (conn: Knex) => {
+        const secrets = await conn(TableName.SecretV2)
+          .where({ folderId })
+          .where((bd) => {
+            void bd
+              .whereNull(`${TableName.SecretV2}.userId`)
+              .orWhere({ [`${TableName.SecretV2}.userId` as "userId"]: userId || null });
+          })
+          .select(selectAllTableCols(TableName.SecretV2))
+          .orderBy(`${TableName.SecretV2}.key`, "asc");
 
-      const secrets = await conn(TableName.SecretV2)
-        .where({ folderId })
-        .where((bd) => {
-          void bd
-            .whereNull(`${TableName.SecretV2}.userId`)
-            .orWhere({ [`${TableName.SecretV2}.userId` as "userId"]: userId || null });
-        })
-        .select(selectAllTableCols(TableName.SecretV2))
-        .orderBy(`${TableName.SecretV2}.key`, "asc");
+        if (!secrets.length) return [];
 
-      if (!secrets.length) return [];
+        // Use a subquery instead of expanding IDs into bind parameters,
+        // so the query stays safe regardless of folder size.
+        const secretIdsSubquery = conn(TableName.SecretV2)
+          .select("id")
+          .where({ folderId })
+          .where((bd) => {
+            void bd
+              .whereNull(`${TableName.SecretV2}.userId`)
+              .orWhere({ [`${TableName.SecretV2}.userId` as "userId"]: userId || null });
+          });
 
-      const secretIds = secrets.map((s) => s.id);
+        const tagRows = await conn(TableName.SecretV2JnTag)
+          .whereIn(`${TableName.SecretV2JnTag}.${TableName.SecretV2}Id`, secretIdsSubquery)
+          .join(TableName.SecretTag, `${TableName.SecretV2JnTag}.${TableName.SecretTag}Id`, `${TableName.SecretTag}.id`)
+          .select(
+            db.ref(`${TableName.SecretV2}Id`).withSchema(TableName.SecretV2JnTag).as("secretId"),
+            db.ref("id").withSchema(TableName.SecretTag).as("tagId"),
+            db.ref("color").withSchema(TableName.SecretTag).as("tagColor"),
+            db.ref("slug").withSchema(TableName.SecretTag).as("tagSlug"),
+            db.ref("createdAt").withSchema(TableName.SecretTag).as("tagCreatedAt")
+          )
+          .orderBy(`${TableName.SecretTag}.createdAt`, "asc")
+          .orderBy(`${TableName.SecretTag}.id`, "asc");
 
-      const tagRows = await conn(TableName.SecretV2JnTag)
-        .whereIn(`${TableName.SecretV2JnTag}.${TableName.SecretV2}Id`, secretIds)
-        .join(TableName.SecretTag, `${TableName.SecretV2JnTag}.${TableName.SecretTag}Id`, `${TableName.SecretTag}.id`)
-        .select(
-          db.ref(`${TableName.SecretV2}Id`).withSchema(TableName.SecretV2JnTag).as("secretId"),
-          db.ref("id").withSchema(TableName.SecretTag).as("tagId"),
-          db.ref("color").withSchema(TableName.SecretTag).as("tagColor"),
-          db.ref("slug").withSchema(TableName.SecretTag).as("tagSlug"),
-          db.ref("createdAt").withSchema(TableName.SecretTag).as("tagCreatedAt")
-        )
-        .orderBy(`${TableName.SecretTag}.createdAt`, "asc")
-        .orderBy(`${TableName.SecretTag}.id`, "asc");
+        const metadataRows = await conn(TableName.ResourceMetadata)
+          .whereIn("secretId", secretIdsSubquery)
+          .select(
+            db.ref("id").withSchema(TableName.ResourceMetadata).as("metadataId"),
+            db.ref("key").withSchema(TableName.ResourceMetadata).as("metadataKey"),
+            db.ref("value").withSchema(TableName.ResourceMetadata).as("metadataValue"),
+            db.ref("encryptedValue").withSchema(TableName.ResourceMetadata).as("metadataEncryptedValue"),
+            db.ref("secretId").withSchema(TableName.ResourceMetadata)
+          )
+          .orderBy(`${TableName.ResourceMetadata}.createdAt`, "asc")
+          .orderBy(`${TableName.ResourceMetadata}.id`, "asc");
 
-      const metadataRows = await conn(TableName.ResourceMetadata)
-        .whereIn("secretId", secretIds)
-        .whereNotNull("secretId")
-        .select(
-          db.ref("id").withSchema(TableName.ResourceMetadata).as("metadataId"),
-          db.ref("key").withSchema(TableName.ResourceMetadata).as("metadataKey"),
-          db.ref("value").withSchema(TableName.ResourceMetadata).as("metadataValue"),
-          db.ref("encryptedValue").withSchema(TableName.ResourceMetadata).as("metadataEncryptedValue"),
-          db.ref("secretId").withSchema(TableName.ResourceMetadata)
-        )
-        .orderBy(`${TableName.ResourceMetadata}.createdAt`, "asc")
-        .orderBy(`${TableName.ResourceMetadata}.id`, "asc");
-
-      const tagsBySecretId = new Map<string, { id: string; color: string; slug: string; name: string }[]>();
-      for (const t of tagRows) {
-        const sid = t.secretId;
-        let arr = tagsBySecretId.get(sid);
-        if (!arr) {
-          arr = [];
-          tagsBySecretId.set(sid, arr);
+        const tagsBySecretId = new Map<string, { id: string; color: string; slug: string; name: string }[]>();
+        for (const t of tagRows) {
+          const sid = t.secretId;
+          let arr = tagsBySecretId.get(sid);
+          if (!arr) {
+            arr = [];
+            tagsBySecretId.set(sid, arr);
+          }
+          arr.push({
+            id: t.tagId,
+            color: t.tagColor ?? "",
+            slug: t.tagSlug,
+            name: t.tagSlug
+          });
         }
-        arr.push({
-          id: t.tagId,
-          color: t.tagColor ?? "",
-          slug: t.tagSlug,
-          name: t.tagSlug
-        });
+
+        const metaBySecretId = new Map<
+          string,
+          { id: string; key: string; value: string | null; encryptedValue: Buffer | null }[]
+        >();
+        for (const m of metadataRows) {
+          const sid = m.secretId as string;
+          let arr = metaBySecretId.get(sid);
+          if (!arr) {
+            arr = [];
+            metaBySecretId.set(sid, arr);
+          }
+          arr.push({
+            id: m.metadataId,
+            key: m.metadataKey,
+            value: m.metadataValue as string | null,
+            encryptedValue: m.metadataEncryptedValue as Buffer | null
+          });
+        }
+
+        return secrets.map((el) => ({
+          _id: el.id,
+          ...SecretsV2Schema.parse(el),
+          tags: tagsBySecretId.get(el.id) ?? [],
+          secretMetadata: metaBySecretId.get(el.id) ?? []
+        }));
+      };
+
+      if (tx) {
+        return await execQueries(tx);
       }
 
-      const metaBySecretId = new Map<
-        string,
-        { id: string; key: string; value: string | null; encryptedValue: Buffer | null }[]
-      >();
-      for (const m of metadataRows) {
-        const sid = m.secretId as string;
-        let arr = metaBySecretId.get(sid);
-        if (!arr) {
-          arr = [];
-          metaBySecretId.set(sid, arr);
-        }
-        arr.push({
-          id: m.metadataId,
-          key: m.metadataKey,
-          value: m.metadataValue as string | null,
-          encryptedValue: m.metadataEncryptedValue as Buffer | null
-        });
-      }
-
-      return secrets.map((el) => ({
-        _id: el.id,
-        ...SecretsV2Schema.parse(el),
-        tags: tagsBySecretId.get(el.id) ?? [],
-        secretMetadata: metaBySecretId.get(el.id) ?? []
-      }));
+      // Wrap in a read-only REPEATABLE READ transaction so all three queries
+      // see the same snapshot, matching the consistency the old single-JOIN had.
+      return await db.replicaNode().transaction(
+        async (replicaTx) => {
+          await replicaTx.raw("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY");
+          return execQueries(replicaTx);
+        },
+        { isolationLevel: "repeatable read", readOnly: true }
+      );
     } catch (error) {
       throw new DatabaseError({ error, name: "get all secret" });
     }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -414,69 +414,89 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
         userId = undefined;
       }
 
-      const secs = await (tx || db.replicaNode())(TableName.SecretV2)
+      const conn = tx || db.replicaNode();
+
+      const secrets = await conn(TableName.SecretV2)
         .where({ folderId })
         .where((bd) => {
           void bd
             .whereNull(`${TableName.SecretV2}.userId`)
             .orWhere({ [`${TableName.SecretV2}.userId` as "userId"]: userId || null });
         })
-        .leftJoin(
-          TableName.SecretV2JnTag,
-          `${TableName.SecretV2}.id`,
-          `${TableName.SecretV2JnTag}.${TableName.SecretV2}Id`
-        )
-        .leftJoin(
-          TableName.SecretTag,
-          `${TableName.SecretV2JnTag}.${TableName.SecretTag}Id`,
-          `${TableName.SecretTag}.id`
-        )
-        .leftJoin(TableName.ResourceMetadata, `${TableName.SecretV2}.id`, `${TableName.ResourceMetadata}.secretId`)
         .select(selectAllTableCols(TableName.SecretV2))
-        .select(db.ref("id").withSchema(TableName.SecretTag).as("tagId"))
-        .select(db.ref("color").withSchema(TableName.SecretTag).as("tagColor"))
-        .select(db.ref("slug").withSchema(TableName.SecretTag).as("tagSlug"))
+        .orderBy(`${TableName.SecretV2}.key`, "asc");
+
+      if (!secrets.length) return [];
+
+      const secretIds = secrets.map((s) => s.id);
+
+      const tagRows = await conn(TableName.SecretV2JnTag)
+        .whereIn(`${TableName.SecretV2JnTag}.${TableName.SecretV2}Id`, secretIds)
+        .join(TableName.SecretTag, `${TableName.SecretV2JnTag}.${TableName.SecretTag}Id`, `${TableName.SecretTag}.id`)
+        .select(
+          db.ref(`${TableName.SecretV2}Id`).withSchema(TableName.SecretV2JnTag).as("secretId"),
+          db.ref("id").withSchema(TableName.SecretTag).as("tagId"),
+          db.ref("color").withSchema(TableName.SecretTag).as("tagColor"),
+          db.ref("slug").withSchema(TableName.SecretTag).as("tagSlug"),
+          db.ref("createdAt").withSchema(TableName.SecretTag).as("tagCreatedAt")
+        )
+        .orderBy(`${TableName.SecretTag}.createdAt`, "asc")
+        .orderBy(`${TableName.SecretTag}.id`, "asc");
+
+      const metadataRows = await conn(TableName.ResourceMetadata)
+        .whereIn("secretId", secretIds)
+        .whereNotNull("secretId")
         .select(
           db.ref("id").withSchema(TableName.ResourceMetadata).as("metadataId"),
           db.ref("key").withSchema(TableName.ResourceMetadata).as("metadataKey"),
           db.ref("value").withSchema(TableName.ResourceMetadata).as("metadataValue"),
-          db.ref("encryptedValue").withSchema(TableName.ResourceMetadata).as("metadataEncryptedValue")
+          db.ref("encryptedValue").withSchema(TableName.ResourceMetadata).as("metadataEncryptedValue"),
+          db.ref("secretId").withSchema(TableName.ResourceMetadata)
         )
-        // Order by key (name) to match Go sidecar; secondary order by createdAt+id for deterministic tag/metadata order
-        .orderBy(`${TableName.SecretV2}.key`, "asc")
-        .orderBy(`${TableName.ResourceMetadata}.createdAt`, "asc", "first")
-        .orderBy(`${TableName.ResourceMetadata}.id`, "asc", "first")
-        .orderBy(`${TableName.SecretTag}.createdAt`, "asc", "first")
-        .orderBy(`${TableName.SecretTag}.id`, "asc", "first");
+        .orderBy(`${TableName.ResourceMetadata}.createdAt`, "asc")
+        .orderBy(`${TableName.ResourceMetadata}.id`, "asc");
 
-      const data = sqlNestRelationships({
-        data: secs,
-        key: "id",
-        parentMapper: (el) => ({ _id: el.id, ...SecretsV2Schema.parse(el) }),
-        childrenMapper: [
-          {
-            key: "tagId",
-            label: "tags" as const,
-            mapper: ({ tagId: id, tagColor: color, tagSlug: slug }) => ({
-              id,
-              color,
-              slug,
-              name: slug
-            })
-          },
-          {
-            key: "metadataId",
-            label: "secretMetadata" as const,
-            mapper: ({ metadataKey, metadataValue, metadataEncryptedValue, metadataId }) => ({
-              id: metadataId,
-              key: metadataKey,
-              value: metadataValue,
-              encryptedValue: metadataEncryptedValue
-            })
-          }
-        ]
-      });
-      return data;
+      const tagsBySecretId = new Map<string, { id: string; color: string; slug: string; name: string }[]>();
+      for (const t of tagRows) {
+        const sid = t.secretId;
+        let arr = tagsBySecretId.get(sid);
+        if (!arr) {
+          arr = [];
+          tagsBySecretId.set(sid, arr);
+        }
+        arr.push({
+          id: t.tagId,
+          color: t.tagColor ?? "",
+          slug: t.tagSlug,
+          name: t.tagSlug
+        });
+      }
+
+      const metaBySecretId = new Map<
+        string,
+        { id: string; key: string; value: string | null; encryptedValue: Buffer | null }[]
+      >();
+      for (const m of metadataRows) {
+        const sid = m.secretId as string;
+        let arr = metaBySecretId.get(sid);
+        if (!arr) {
+          arr = [];
+          metaBySecretId.set(sid, arr);
+        }
+        arr.push({
+          id: m.metadataId,
+          key: m.metadataKey,
+          value: m.metadataValue as string | null,
+          encryptedValue: m.metadataEncryptedValue as Buffer | null
+        });
+      }
+
+      return secrets.map((el) => ({
+        _id: el.id,
+        ...SecretsV2Schema.parse(el),
+        tags: tagsBySecretId.get(el.id) ?? [],
+        secretMetadata: metaBySecretId.get(el.id) ?? []
+      }));
     } catch (error) {
       throw new DatabaseError({ error, name: "get all secret" });
     }

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -463,9 +463,17 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
           .orderBy(`${TableName.ResourceMetadata}.createdAt`, "asc")
           .orderBy(`${TableName.ResourceMetadata}.id`, "asc");
 
+        // Deduplicate tags by tagId per secret: the junction table has no unique
+        // constraint on the FK pair, and the PIT update path can reinsert duplicates.
         const tagsBySecretId = new Map<string, { id: string; color: string; slug: string; name: string }[]>();
+        const seenTags = new Set<string>();
         for (const t of tagRows) {
           const sid = t.secretId;
+          const dedupeKey = `${sid}:${t.tagId}`;
+          // eslint-disable-next-line no-continue
+          if (seenTags.has(dedupeKey)) continue;
+          seenTags.add(dedupeKey);
+
           let arr = tagsBySecretId.get(sid);
           if (!arr) {
             arr = [];
@@ -483,8 +491,14 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
           string,
           { id: string; key: string; value: string | null; encryptedValue: Buffer | null }[]
         >();
+        const seenMeta = new Set<string>();
         for (const m of metadataRows) {
           const sid = m.secretId as string;
+          const dedupeKey = `${sid}:${m.metadataId}`;
+          // eslint-disable-next-line no-continue
+          if (seenMeta.has(dedupeKey)) continue;
+          seenMeta.add(dedupeKey);
+
           let arr = metaBySecretId.get(sid);
           if (!arr) {
             arr = [];


### PR DESCRIPTION
## Context

findByFolderId in `secret-v2-bridge-dal.ts` uses a single query with two LEFT JOINs (tags via junction table + metadata). This creates a Cartesian product: a folder with 500 secrets, 3 tags each, and 2 metadata each produces 500 × 3 × 2 = 3,000 rows instead of 500.

The fix is to split that single query into 3 different queries and merging them together using NodeJS.

Benchmark results (500 secrets, 3 tags, 2 metadata each, 20 iterations):

| | Time (avg) | Heap (avg) | Heap (max) |
|---|---|---|---|
| OLD (single JOIN) | 60.8ms | 13.94 MB | 26.53 MB |
| NEW (three queries) | 21.7ms | 4.43 MB | 10.45 MB |
| **Delta** | **64% faster** | **68% less** | **61% less** |

Benchmark results (3000 secrets, 3 tags, 2 metadata each, 20 iterations):

| | Time (avg) | Heap (avg) | Heap (max) |
|---|---|---|---|
| OLD (single JOIN) | 392.8ms | 6.61 MB | 44.61 MB |
| NEW (three queries) | 92.6ms | 3.72 MB | 30.03 MB |
| **Delta** | **76% faster** | **44% less** | **33% less** |

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)