### PR TITLE
fix(project): accept underscores when reading a project by slug

### DIFF
--- a/backend/src/server/lib/schemas.test.ts
+++ b/backend/src/server/lib/schemas.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+
+import { projectSlugSchema } from "./schemas";
+
+describe("projectSlugSchema", () => {
+  test.each(["repro-proj", "repro_test_proj", "a", "proj1", "a_b-c_d"])("accepts %s", (slug) => {
+    expect(projectSlugSchema.safeParse(slug).success).toBe(true);
+  });
+
+  test.each(["", "_proj", "proj_", "-proj", "proj-", "proj__test", "Proj", "pro j", "pro.j", "a".repeat(65)])(
+    "rejects %s",
+    (slug) => {
+      expect(projectSlugSchema.safeParse(slug).success).toBe(false);
+    }
+  );
+
+  test("trims surrounding whitespace", () => {
+    expect(projectSlugSchema.parse("  repro_test_proj  ")).toBe("repro_test_proj");
+  });
+});

--- a/backend/src/server/lib/schemas.ts
+++ b/backend/src/server/lib/schemas.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { TemporaryPermissionMode } from "@app/db/schemas";
 import { ms } from "@app/lib/ms";
 import { CharacterType, characterValidator } from "@app/lib/validator/validate-string";
+import { re2Validator } from "@app/lib/zod";
 
 interface SlugSchemaInputs {
   min?: number;
@@ -25,6 +26,18 @@ export const slugSchema = ({ min = 1, max = 64, field = "Slug", trim = true }: S
       message: `${field} field can only contain lowercase letters, numbers, and hyphens`
     });
 };
+
+// Project slugs allow underscores as word separators in addition to hyphens, so they cannot reuse
+// `slugSchema`: that validator normalizes with slugify, which rewrites `_` to `-` and therefore
+// rejects slugs the project write paths accept.
+export const projectSlugSchema = z
+  .string()
+  .trim()
+  .max(64, { message: "Slug must be 64 characters or fewer" })
+  .refine(re2Validator(/^[a-z0-9]+(?:[_-][a-z0-9]+)*$/), {
+    message:
+      "Project slug can only contain lowercase letters and numbers, with optional single hyphens (-) or underscores (_) between words. Cannot start or end with a hyphen or underscore."
+  });
 
 export const GenericResourceNameSchema = z
   .string()

--- a/backend/src/server/routes/v1/project-router.ts
+++ b/backend/src/server/routes/v1/project-router.ts
@@ -19,10 +19,9 @@ import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { InfisicalProjectTemplate } from "@app/ee/services/project-template/project-template-types";
 import { ApiDocsTags, PROJECTS } from "@app/lib/api-docs";
 import { CharacterType, characterValidator } from "@app/lib/validator/validate-string";
-import { re2Validator } from "@app/lib/zod";
 import { JobState } from "@app/queue/queue-service";
 import { projectCreationLimit, readLimit, requestAccessLimit, writeLimit } from "@app/server/config/rateLimiter";
-import { slugSchema } from "@app/server/lib/schemas";
+import { projectSlugSchema, slugSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { ActorType, AuthMode } from "@app/services/auth/auth-type";
@@ -380,7 +379,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
         }
       ],
       params: z.object({
-        slug: slugSchema({ max: 64 }).describe("The slug of the project to get.")
+        slug: projectSlugSchema.describe("The slug of the project to get.")
       }),
       response: {
         200: projectWithEnv
@@ -500,16 +499,7 @@ export const registerProjectRouter = async (server: FastifyZodProvider) => {
           .boolean()
           .optional()
           .describe(PROJECTS.UPDATE.enforceEncryptedSecretManagerSecretMetadata),
-        slug: z
-          .string()
-          .trim()
-          .max(64, { message: "Slug must be 64 characters or fewer" })
-          .refine(re2Validator(/^[a-z0-9]+(?:[_-][a-z0-9]+)*$/), {
-            message:
-              "Project slug can only contain lowercase letters and numbers, with optional single hyphens (-) or underscores (_) between words. Cannot start or end with a hyphen or underscore."
-          })
-          .optional()
-          .describe(PROJECTS.UPDATE.slug),
+        slug: projectSlugSchema.optional().describe(PROJECTS.UPDATE.slug),
         secretSharing: z.boolean().optional().describe(PROJECTS.UPDATE.secretSharing),
         showSnapshotsLegacy: z.boolean().optional().describe(PROJECTS.UPDATE.showSnapshotsLegacy),
         secretDetectionIgnoreValues: z


### PR DESCRIPTION
## Context

Closes #7888.

A project slug can be written with underscores but could not be read back by slug. Two validators disagreed about the legal charset:

- **Write** — `PATCH /v1/projects/:projectId` validated the `slug` body field with `re2Validator(/^[a-z0-9]+(?:[_-][a-z0-9]+)*$/)`, which explicitly permits `_`.
- **Read** — `GET /v1/projects/slug/:slug` validated the param with the generic `slugSchema()`, which checks `slugify(v, { lowercase: true }) === v`. `slugify` rewrites `_` to `-`, so `repro_test_proj` never equals its slugified form and the request was rejected with `400 Slug field can only contain lowercase letters, numbers, and hyphens` before it ever reached the handler.

The result: you could rename a project to `a_b`, get a 200, and then be unable to GET it by that slug.

This extracts the write path's validator into a shared `projectSlugSchema` in `backend/src/server/lib/schemas.ts` and uses it for both the update body and the read-by-slug param, so the two paths can no longer drift apart. The change is strictly more permissive on the read path — every slug `slugSchema` accepted still parses — so no existing project becomes unreachable.

`slugSchema` itself is untouched; every other resource that uses it keeps its current, stricter rules.

## Steps to verify the change

1. Create a project, e.g. `repro-proj`.
2. `PATCH /api/v1/projects/<projectId>` with `{ "slug": "repro_test_proj" }` → 200 (unchanged).
3. `GET /api/v1/projects/slug/repro_test_proj` → **200 with the project** (was 400 before this change).
4. `GET /api/v1/projects/slug/_bad` / `bad_` / `a__b` → still 400.

Unit tests: `npm run test:unit` in `backend/` (covers the new `projectSlugSchema` in `backend/src/server/lib/schemas.test.ts`).

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] Tested locally — I was not able to run the backend suite in my environment; the added unit test and the reproduction above are what I'd ask a reviewer to confirm.
- [ ] Updated docs (if needed) — no doc change needed; the endpoint's documented behavior is unchanged, this only makes it match.
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
