### PR TITLE
feat: improves the support secret sharing

### DIFF
--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -3955,8 +3955,19 @@ export const SECRET_SHARING = {
     allowExternalEmails:
       "When true, allows sharing with email addresses that do not belong to Infisical. A password is required when this option is enabled. External recipients will receive the secret link via email and must enter the password to access it."
   },
+  UPDATE: {
+    id: "The ID of the shared secret to update.",
+    name: "An optional name for the shared secret for easier identification.",
+    expiresIn:
+      "The new duration after which the shared secret will expire, measured from now. Accepts formats like '30d', '24h', '1w'.",
+    maxViews:
+      "The maximum number of times the shared secret can be viewed before it expires. Set to null to allow unlimited views."
+  },
   DELETE: {
     id: "The ID of the shared secret to delete."
+  },
+  BULK_DELETE: {
+    ids: "The IDs of the shared secrets to delete."
   }
 } as const;
 

--- a/backend/src/server/routes/v1/secret-sharing-router.ts
+++ b/backend/src/server/routes/v1/secret-sharing-router.ts
@@ -3,6 +3,7 @@ import fastifyMultipart from "@fastify/multipart";
 import { fileTypeFromBuffer } from "file-type";
 import { z } from "zod";
 
+import { SecretSharingSchema } from "@app/db/schemas";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, SECRET_SHARING } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
@@ -436,6 +437,96 @@ export const registerSecretSharingRouter = async (server: FastifyZodProvider) =>
       });
 
       return deletedSharedSecret;
+    }
+  });
+
+  server.route({
+    method: "PATCH",
+    url: "/:id",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      hide: false,
+      tags: [ApiDocsTags.SecretSharing],
+      description: "Update the settings of an existing shared secret.",
+      operationId: "updateSharedSecret",
+      params: z.object({
+        id: z.string().describe(SECRET_SHARING.UPDATE.id)
+      }),
+      body: z.object({
+        name: z.string().optional().describe(SECRET_SHARING.UPDATE.name),
+        expiresIn: z.string().optional().describe(SECRET_SHARING.UPDATE.expiresIn),
+        maxViews: z.number().nullish().describe(SECRET_SHARING.UPDATE.maxViews)
+      }),
+      response: {
+        200: SecretSharingSchema
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    handler: async (req) => {
+      const updatedSharedSecret = await req.server.services.secretSharing.updateSharedSecretById({
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        orgId: req.permission.orgId,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        sharedSecretId: req.params.id,
+        ...req.body
+      });
+
+      return updatedSharedSecret;
+    }
+  });
+
+  server.route({
+    method: "POST",
+    url: "/bulk-delete",
+    config: {
+      rateLimit: writeLimit
+    },
+    schema: {
+      hide: false,
+      tags: [ApiDocsTags.SecretSharing],
+      description: "Delete multiple shared secrets in a single request.",
+      operationId: "bulkDeleteSharedSecrets",
+      body: z.object({
+        ids: z.string().array().describe(SECRET_SHARING.BULK_DELETE.ids)
+      }),
+      response: {
+        200: z.object({
+          secrets: z.array(SanitizedSecretSharingSchema)
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN]),
+    handler: async (req) => {
+      const deletedSharedSecrets = await req.server.services.secretSharing.bulkDeleteSharedSecrets({
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        orgId: req.permission.orgId,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        sharedSecretIds: req.body.ids
+      });
+
+      await Promise.all(
+        deletedSharedSecrets.map((sharedSecret) =>
+          server.services.auditLog.createAuditLog({
+            orgId: req.permission.orgId,
+            ...req.auditLogInfo,
+            event: {
+              type: EventType.DELETE_SHARED_SECRET,
+              metadata: {
+                id: sharedSecret.id,
+                name: sharedSecret.name || undefined
+              }
+            }
+          })
+        )
+      );
+
+      return { secrets: deletedSharedSecrets };
     }
   });
 

--- a/backend/src/services/secret-sharing/secret-sharing-service.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-service.ts
@@ -26,6 +26,7 @@ import { TUserDALFactory } from "../user/user-dal";
 import { TSecretSharingDALFactory } from "./secret-sharing-dal";
 import {
   SecretSharingType,
+  TBulkDeleteSharedSecretsDTO,
   TCreatePublicSharedSecretDTO,
   TCreateSecretRequestDTO,
   TCreateSharedSecretDTO,
@@ -34,7 +35,8 @@ import {
   TGetSecretRequestByIdDTO,
   TGetSharedSecretsDTO,
   TRevealSecretRequestValueDTO,
-  TSetSecretRequestValueDTO
+  TSetSecretRequestValueDTO,
+  TUpdateSharedSecretDTO
 } from "./secret-sharing-types";
 
 type TSecretSharingServiceFactoryDep = {
@@ -838,6 +840,73 @@ export const secretSharingServiceFactory = ({
     return mapIdentifierToId(deletedSharedSecret);
   };
 
+  const updateSharedSecretById = async (updateSharedSecretInput: TUpdateSharedSecretDTO) => {
+    const { actor, actorId, orgId, actorAuthMethod, actorOrgId, sharedSecretId, name, expiresIn, maxViews } =
+      updateSharedSecretInput;
+
+    const { permission } = await permissionService.getOrgPermission({
+      scope: OrganizationActionScope.Any,
+      actor,
+      actorId,
+      orgId,
+      actorAuthMethod,
+      actorOrgId
+    });
+    if (!permission) throw new ForbiddenRequestError({ name: "User does not belong to the specified organization" });
+
+    const sharedSecret = await secretSharingDAL.findOne({
+      type: SecretSharingType.Share,
+      identifier: Buffer.from(sharedSecretId, "base64url").toString("hex")
+    });
+
+    if (!sharedSecret) {
+      throw new NotFoundError({ message: `Shared secret with ID '${sharedSecretId}' not found` });
+    }
+
+    if (sharedSecret.orgId && sharedSecret.orgId !== orgId) {
+      throw new ForbiddenRequestError({ message: "User does not have permission to update shared secret" });
+    }
+
+    const updatedSharedSecret = await secretSharingDAL.updateById(sharedSecret.id, {
+      ...(name !== undefined && { name }),
+      ...(maxViews !== undefined && { expiresAfterViews: maxViews }),
+      ...(expiresIn !== undefined && { expiresAt: new Date(Date.now() + ms(expiresIn)) })
+    });
+
+    return updatedSharedSecret;
+  };
+
+  const bulkDeleteSharedSecrets = async (bulkDeleteSharedSecretsInput: TBulkDeleteSharedSecretsDTO) => {
+    const { actor, actorId, orgId, actorAuthMethod, actorOrgId, sharedSecretIds } = bulkDeleteSharedSecretsInput;
+
+    const { permission } = await permissionService.getOrgPermission({
+      scope: OrganizationActionScope.Any,
+      actor,
+      actorId,
+      orgId,
+      actorAuthMethod,
+      actorOrgId
+    });
+    if (!permission) throw new ForbiddenRequestError({ name: "User does not belong to the specified organization" });
+
+    const sharedSecrets = await secretSharingDAL.find({
+      $in: { id: sharedSecretIds },
+      orgId,
+      ...(actor === ActorType.USER && { userId: actorId }),
+      ...(actor === ActorType.IDENTITY && { identityId: actorId })
+    });
+
+    if (!sharedSecrets.length) {
+      throw new NotFoundError({ message: "No shared secrets found for the provided IDs" });
+    }
+
+    const deletedSharedSecrets = await secretSharingDAL.transaction(async () => {
+      return Promise.all(sharedSecrets.map((sharedSecret) => secretSharingDAL.deleteById(sharedSecret.id)));
+    });
+
+    return deletedSharedSecrets.map(mapIdentifierToId);
+  };
+
   const getSharedSecretOrgId = async (sharedSecretId: string) => {
     const sharedSecret = await secretSharingDAL.findOne({
       identifier: Buffer.from(sharedSecretId, "base64url").toString("hex"),
@@ -971,6 +1040,8 @@ export const secretSharingServiceFactory = ({
     createPublicSharedSecret,
     getSharedSecrets,
     deleteSharedSecretById,
+    updateSharedSecretById,
+    bulkDeleteSharedSecrets,
     getSharedSecretById,
     accessSharedSecret,
     getSharedSecretOrgId,

--- a/backend/src/services/secret-sharing/secret-sharing-types.ts
+++ b/backend/src/services/secret-sharing/secret-sharing-types.ts
@@ -71,3 +71,14 @@ export type TDeleteSharedSecretDTO = {
   sharedSecretId: string;
   type: SecretSharingType;
 } & TSharedSecretPermission;
+
+export type TUpdateSharedSecretDTO = {
+  sharedSecretId: string;
+  name?: string;
+  expiresIn?: string;
+  maxViews?: number | null;
+} & TSharedSecretPermission;
+
+export type TBulkDeleteSharedSecretsDTO = {
+  sharedSecretIds: string[];
+} & TSharedSecretPermission;

--- a/frontend/src/hooks/api/secretSharing/mutations.ts
+++ b/frontend/src/hooks/api/secretSharing/mutations.ts
@@ -6,6 +6,7 @@ import { secretSharingKeys } from "./queries";
 import {
   TAccessSharedSecretRequest,
   TAccessSharedSecretResponse,
+  TBulkDeleteSharedSecretsRequestDTO,
   TCreatedSharedSecret,
   TCreateSecretRequestRequestDTO,
   TCreateSharedSecretRequest,
@@ -14,7 +15,8 @@ import {
   TRevealedSecretRequest,
   TRevealSecretRequestValueRequest,
   TSetSecretRequestValueRequest,
-  TSharedSecret
+  TSharedSecret,
+  TUpdateSharedSecretRequestDTO
 } from "./types";
 
 export const useCreateSharedSecret = () => {
@@ -110,6 +112,37 @@ export const useDeleteSharedSecret = () => {
     },
     onSuccess: () =>
       queryClient.invalidateQueries({ queryKey: secretSharingKeys.allSharedSecrets() })
+  });
+};
+
+export const useUpdateSharedSecret = () => {
+  const queryClient = useQueryClient();
+  return useMutation<TSharedSecret, { message: string }, TUpdateSharedSecretRequestDTO>({
+    mutationFn: async ({ sharedSecretId, ...inputData }) => {
+      const { data } = await apiRequest.patch<TSharedSecret>(
+        `/api/v1/shared-secrets/${sharedSecretId}`,
+        inputData
+      );
+      return data;
+    },
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: secretSharingKeys.allSharedSecrets() })
+  });
+};
+
+export const useBulkDeleteSharedSecrets = () => {
+  return useMutation<
+    { secrets: TSharedSecret[] },
+    { message: string },
+    TBulkDeleteSharedSecretsRequestDTO
+  >({
+    mutationFn: async ({ sharedSecretIds }) => {
+      const { data } = await apiRequest.post<{ secrets: TSharedSecret[] }>(
+        "/api/v1/shared-secrets/bulk-delete",
+        { ids: sharedSecretIds }
+      );
+      return data;
+    }
   });
 };
 

--- a/frontend/src/hooks/api/secretSharing/types.ts
+++ b/frontend/src/hooks/api/secretSharing/types.ts
@@ -107,8 +107,19 @@ export type TGetSecretRequestByIdResponse = {
   error?: string;
 };
 
+export type TUpdateSharedSecretRequestDTO = {
+  sharedSecretId: string;
+  name?: string;
+  expiresIn?: string;
+  maxViews?: number | null;
+};
+
 export type TDeleteSharedSecretRequestDTO = {
   sharedSecretId: string;
+};
+
+export type TBulkDeleteSharedSecretsRequestDTO = {
+  sharedSecretIds: string[];
 };
 
 export type TDeleteSecretRequestDTO = {

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/EditShareSecretModal.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/EditShareSecretModal.tsx
@@ -1,0 +1,191 @@
+import { Controller, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { createNotification } from "@app/components/notifications";
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Field,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Switch
+} from "@app/components/v3";
+import { useUpdateSharedSecret } from "@app/hooks/api";
+import { TSharedSecret } from "@app/hooks/api/secretSharing";
+import { UsePopUpState } from "@app/hooks/usePopUp";
+
+const expiresInOptions = [
+  { label: "5 min", value: "5m" },
+  { label: "30 min", value: "30m" },
+  { label: "1 hour", value: "1h" },
+  { label: "1 day", value: "1d" },
+  { label: "7 days", value: "7d" },
+  { label: "14 days", value: "14d" },
+  { label: "30 days", value: "30d" }
+];
+
+const schema = z.object({
+  name: z.string().optional(),
+  expiresIn: z.string(),
+  shouldLimitView: z.boolean(),
+  viewLimit: z.string()
+});
+
+type FormData = z.infer<typeof schema>;
+
+type Props = {
+  popUp: UsePopUpState<["editSharedSecret"]>;
+  handlePopUpToggle: (popUpName: keyof UsePopUpState<["editSharedSecret"]>, state?: boolean) => void;
+  handlePopUpClose: (popUpName: keyof UsePopUpState<["editSharedSecret"]>) => void;
+};
+
+export const EditShareSecretModal = ({ popUp, handlePopUpToggle, handlePopUpClose }: Props) => {
+  const sharedSecret = popUp?.editSharedSecret?.data as TSharedSecret | undefined;
+  const updateSharedSecret = useUpdateSharedSecret();
+
+  const {
+    control,
+    handleSubmit,
+    formState: { isSubmitting },
+    watch
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    values: {
+      name: sharedSecret?.name ?? "",
+      expiresIn: "7d",
+      shouldLimitView: sharedSecret?.expiresAfterViews !== null,
+      viewLimit: sharedSecret?.expiresAfterViews?.toString() ?? "1"
+    }
+  });
+
+  const isLimitingView = watch("shouldLimitView");
+
+  const onFormSubmit = async ({ name, expiresIn, shouldLimitView, viewLimit }: FormData) => {
+    if (!sharedSecret) return;
+
+    try {
+      await updateSharedSecret.mutateAsync({
+        sharedSecretId: sharedSecret.id,
+        name,
+        expiresIn,
+        maxViews: shouldLimitView ? Number(viewLimit) : null
+      });
+
+      createNotification({
+        text: "Successfully updated shared secret",
+        type: "success"
+      });
+
+      handlePopUpClose("editSharedSecret");
+    } catch {
+      createNotification({
+        text: "Failed to update shared secret",
+        type: "error"
+      });
+    }
+  };
+
+  return (
+    <Dialog
+      open={popUp?.editSharedSecret?.isOpen}
+      onOpenChange={(isOpen) => handlePopUpToggle("editSharedSecret", isOpen)}
+    >
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Edit Shared Secret</DialogTitle>
+          <DialogDescription>
+            Update the name, expiration, and view limit of this shared secret. The secret value
+            itself cannot be changed.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onFormSubmit)}>
+          <DialogBody className="space-y-4">
+            <Controller
+              control={control}
+              name="name"
+              render={({ field, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel>
+                    Name <span className="text-xs text-muted italic">- Optional</span>
+                  </FieldLabel>
+                  <Input {...field} placeholder="API Key" isError={Boolean(error)} />
+                  {error && <FieldError>{error.message}</FieldError>}
+                </Field>
+              )}
+            />
+            <Controller
+              control={control}
+              name="expiresIn"
+              render={({ field: { onChange, value }, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel>Expires In</FieldLabel>
+                  <Select value={value} onValueChange={onChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {expiresInOptions.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {error && <FieldError>{error.message}</FieldError>}
+                </Field>
+              )}
+            />
+            <Controller
+              control={control}
+              name="shouldLimitView"
+              render={({ field: { onChange, value } }) => (
+                <Field orientation="horizontal">
+                  <Switch variant="project" checked={value} onCheckedChange={onChange} />
+                  <FieldLabel className="flex-auto">Limit number of views</FieldLabel>
+                </Field>
+              )}
+            />
+            {isLimitingView && (
+              <Controller
+                control={control}
+                name="viewLimit"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel>View Limit</FieldLabel>
+                    <Input {...field} type="number" min={1} isError={Boolean(error)} />
+                    {error && <FieldError>{error.message}</FieldError>}
+                  </Field>
+                )}
+              />
+            )}
+          </DialogBody>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handlePopUpClose("editSharedSecret")}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" variant="project" isPending={isSubmitting}>
+              Save
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretTab.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretTab.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ForwardIcon, Trash2 } from "lucide-react";
 
 import { createNotification } from "@app/components/notifications";
@@ -18,12 +19,14 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
-  DocumentationLinkBadge
+  DocumentationLinkBadge,
+  SelectedActionBar
 } from "@app/components/v3";
-import { useDeleteSharedSecret } from "@app/hooks/api";
+import { useBulkDeleteSharedSecrets, useDeleteSharedSecret } from "@app/hooks/api";
 import { usePopUp } from "@app/hooks/usePopUp";
 
 import { AddShareSecretModal } from "./AddShareSecretModal";
+import { EditShareSecretModal } from "./EditShareSecretModal";
 import { ShareSecretsTable } from "./ShareSecretsTable";
 
 type DeleteModalData = { name: string; id: string };
@@ -31,10 +34,32 @@ type DeleteModalData = { name: string; id: string };
 export const ShareSecretTab = () => {
   const { popUp, handlePopUpToggle, handlePopUpClose, handlePopUpOpen } = usePopUp([
     "createSharedSecret",
+    "editSharedSecret",
     "deleteSharedSecretConfirmation"
   ] as const);
 
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+
   const deleteSecretShare = useDeleteSharedSecret();
+  const bulkDeleteSecretShares = useBulkDeleteSharedSecrets();
+
+  const onBulkDelete = async () => {
+    try {
+      await bulkDeleteSecretShares.mutateAsync({ sharedSecretIds: selectedIds });
+
+      createNotification({
+        text: `Successfully deleted ${selectedIds.length} shared secrets`,
+        type: "success"
+      });
+
+      setSelectedIds([]);
+    } catch {
+      createNotification({
+        text: "Failed to delete shared secrets",
+        type: "error"
+      });
+    }
+  };
 
   const onDeleteApproved = async () => {
     deleteSecretShare.mutateAsync({
@@ -49,7 +74,22 @@ export const ShareSecretTab = () => {
   };
 
   return (
-    <Card>
+    <>
+      <SelectedActionBar
+        selectedCount={selectedIds.length}
+        onClearSelection={() => setSelectedIds([])}
+      >
+        <Button
+          variant="danger"
+          size="xs"
+          onClick={onBulkDelete}
+          isPending={bulkDeleteSecretShares.isPending}
+        >
+          <Trash2 className="mr-1 size-4" />
+          Delete
+        </Button>
+      </SelectedActionBar>
+      <Card>
       <CardHeader>
         <CardTitle>
           Shared Secrets
@@ -69,9 +109,18 @@ export const ShareSecretTab = () => {
         </CardAction>
       </CardHeader>
       <CardContent>
-        <ShareSecretsTable handlePopUpOpen={handlePopUpOpen} />
+        <ShareSecretsTable
+          selectedIds={selectedIds}
+          setSelectedIds={setSelectedIds}
+          handlePopUpOpen={handlePopUpOpen}
+        />
       </CardContent>
       <AddShareSecretModal popUp={popUp} handlePopUpToggle={handlePopUpToggle} />
+      <EditShareSecretModal
+        popUp={popUp}
+        handlePopUpToggle={handlePopUpToggle}
+        handlePopUpClose={handlePopUpClose}
+      />
       <AlertDialog
         open={popUp.deleteSharedSecretConfirmation.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("deleteSharedSecretConfirmation", isOpen)}
@@ -94,6 +143,7 @@ export const ShareSecretTab = () => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Card>
+      </Card>
+    </>
   );
 };

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsRow.tsx
@@ -1,8 +1,17 @@
 import { format } from "date-fns";
-import { ClockAlertIcon, ClockIcon, Ellipsis, Mail, MailOpen, Trash2 } from "lucide-react";
+import {
+  ClockAlertIcon,
+  ClockIcon,
+  Ellipsis,
+  Mail,
+  MailOpen,
+  PencilIcon,
+  Trash2
+} from "lucide-react";
 
 import {
   Badge,
+  Checkbox,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -19,18 +28,16 @@ import { UsePopUpState } from "@app/hooks/usePopUp";
 
 export const ShareSecretsRow = ({
   row,
+  isSelected,
+  onToggleSelect,
   handlePopUpOpen
 }: {
   row: TSharedSecret;
+  isSelected: boolean;
+  onToggleSelect: () => void;
   handlePopUpOpen: (
-    popUpName: keyof UsePopUpState<["deleteSharedSecretConfirmation"]>,
-    {
-      name,
-      id
-    }: {
-      name: string;
-      id: string;
-    }
+    popUpName: keyof UsePopUpState<["deleteSharedSecretConfirmation", "editSharedSecret"]>,
+    data: { name: string; id: string } | TSharedSecret
   ) => void;
 }) => {
   const lastViewedAt = row.lastViewedAt
@@ -47,7 +54,18 @@ export const ShareSecretsRow = ({
   }
 
   return (
-    <TableRow key={row.id}>
+    <TableRow key={row.id} data-state={isSelected ? "selected" : undefined}>
+      <TableCell>
+        <Checkbox
+          id={`select-shared-secret-${row.id}`}
+          isChecked={isSelected}
+          variant="project"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleSelect();
+          }}
+        />
+      </TableCell>
       <TableCell>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -87,6 +105,10 @@ export const ShareSecretsRow = ({
             </IconButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => handlePopUpOpen("editSharedSecret", row)}>
+              <PencilIcon />
+              Edit
+            </DropdownMenuItem>
             <DropdownMenuItem
               variant="danger"
               onClick={() =>

--- a/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
+++ b/frontend/src/pages/organization/SecretSharingPage/components/ShareSecret/ShareSecretsTable.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import {
+  Checkbox,
   Empty,
   EmptyDescription,
   EmptyHeader,
@@ -14,25 +15,21 @@ import {
   TableHeader,
   TableRow
 } from "@app/components/v3";
-import { useGetSharedSecrets } from "@app/hooks/api/secretSharing";
+import { TSharedSecret, useGetSharedSecrets } from "@app/hooks/api/secretSharing";
 import { UsePopUpState } from "@app/hooks/usePopUp";
 
 import { ShareSecretsRow } from "./ShareSecretsRow";
 
 type Props = {
+  selectedIds: string[];
+  setSelectedIds: (updater: (prev: string[]) => string[]) => void;
   handlePopUpOpen: (
-    popUpName: keyof UsePopUpState<["deleteSharedSecretConfirmation"]>,
-    {
-      name,
-      id
-    }: {
-      name: string;
-      id: string;
-    }
+    popUpName: keyof UsePopUpState<["deleteSharedSecretConfirmation", "editSharedSecret"]>,
+    data: { name: string; id: string } | TSharedSecret
   ) => void;
 };
 
-export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
+export const ShareSecretsTable = ({ selectedIds, setSelectedIds, handlePopUpOpen }: Props) => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const { isPending, data } = useGetSharedSecrets({
@@ -41,12 +38,38 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
   });
   const hasSecrets = !isPending && data?.secrets && data.secrets.length > 0;
 
+  const pageSecrets = data?.secrets ?? [];
+  const isPageSelected =
+    pageSecrets.length > 0 && pageSecrets.every((secret) => selectedIds.includes(secret.id));
+  const isPageIndeterminate =
+    !isPageSelected && pageSecrets.some((secret) => selectedIds.includes(secret.id));
+
   return (
     <div>
       {(isPending || hasSecrets) && (
         <Table>
           <TableHeader>
             <TableRow>
+              <TableHead className="w-5">
+                <Checkbox
+                  id="shared-secret-page-select"
+                  isChecked={isPageSelected || isPageIndeterminate}
+                  isIndeterminate={isPageIndeterminate}
+                  isDisabled={pageSecrets.length === 0}
+                  variant="project"
+                  onCheckedChange={() => {
+                    if (isPageSelected) {
+                      setSelectedIds((prev) =>
+                        prev.filter((id) => !pageSecrets.some((secret) => secret.id === id))
+                      );
+                    } else {
+                      setSelectedIds((prev) => [
+                        ...new Set([...prev, ...pageSecrets.map((secret) => secret.id)])
+                      ]);
+                    }
+                  }}
+                />
+              </TableHead>
               <TableHead className="w-5" />
               <TableHead className="w-1/4">Name</TableHead>
               <TableHead>Created</TableHead>
@@ -61,7 +84,7 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
               Array.from({ length: 5 }).map((_, i) => (
                 // eslint-disable-next-line react/no-array-index-key
                 <TableRow key={`skeleton-${i}`}>
-                  {Array.from({ length: 7 }).map((__, j) => (
+                  {Array.from({ length: 8 }).map((__, j) => (
                     // eslint-disable-next-line react/no-array-index-key
                     <TableCell key={`skeleton-cell-${j}`}>
                       <Skeleton className="h-4 w-full" />
@@ -71,7 +94,17 @@ export const ShareSecretsTable = ({ handlePopUpOpen }: Props) => {
               ))}
             {hasSecrets &&
               data.secrets.map((row) => (
-                <ShareSecretsRow key={row.id} row={row} handlePopUpOpen={handlePopUpOpen} />
+                <ShareSecretsRow
+                  key={row.id}
+                  row={row}
+                  isSelected={selectedIds.includes(row.id)}
+                  onToggleSelect={() =>
+                    setSelectedIds((prev) =>
+                      prev.includes(row.id) ? prev.filter((id) => id !== row.id) : [...prev, row.id]
+                    )
+                  }
+                  handlePopUpOpen={handlePopUpOpen}
+                />
               ))}
           </TableBody>
         </Table>


### PR DESCRIPTION
## Context

Once a secret is shared, the only action available on it is delete. If someone sets the wrong expiry, mistypes the name, or wants to tighten the view limit after the fact, they have to delete the share and send a brand new link to the recipient — which defeats the point, because the old link is already out there.

This adds two management capabilities to the Shared Secrets tab:

- **Edit an existing share.** `PATCH /api/v1/shared-secrets/:id` updates `name`, `expiresIn`, and `maxViews` on a share. The secret value itself is deliberately not editable — the value is sealed under the root KMS key at creation and re-encrypting it in place would change the semantics of a link that has already been distributed.
- **Bulk delete.** `POST /api/v1/shared-secrets/bulk-delete` deletes several shares in one request. Cleaning up a page of expired shares previously meant one confirmation dialog per row.

The table now supports row selection (per-row and select-all-on-page) and surfaces the bulk action through the shared `SelectedActionBar`, matching the pattern already used in the CMEK and org members tables.

Both endpoints reuse the existing org permission check and the same owner scoping the single delete endpoint already applies, so a share remains visible and mutable only to the user or identity that created it.

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

Steps to verify the change

1. Go to **Organization → Secret Sharing → Shared Secrets** and create two or three shares with different expiries.
2. Open the row menu on one of them and pick **Edit**. Change the name, expiry, and view limit, and save. The row should reflect the new values after the list refetches.
3. Open the share link in an incognito window and confirm the link still resolves and the new view limit is what's enforced.
4. Tick two rows. The selection bar should appear at the bottom of the viewport with a count. Press **Delete**.
5. Confirm the deleted shares are gone and their links now 404.
6. Tick the header checkbox to select the whole page, then press Escape to confirm the selection clears.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [ ] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)