### PR TITLE
feat(dev): run several dev stacks at once, one per checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,3 +123,16 @@ ifndef TAG
 endif
 	cd upgrade-impact && \
 	npm run generate:dry-run -- --tag $(TAG)
+
+# Host dependencies. The Docker stack installs its own inside the containers,
+# but lint and type checks run against these.
+install:
+	cd backend && npm install
+	cd frontend && npm install
+
+# Run this checkout as its own stack, so several branches can be up at once.
+# See docs/contributing/platform/developing.mdx.
+stack-init stack-up stack-down stack-rm stack-db:
+	@./scripts/stack.sh $(subst stack-,,$@)
+
+.PHONY: install stack-init stack-up stack-down stack-rm stack-db

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,11 +2,11 @@ version: "3.9"
 
 services:
   nginx:
-    container_name: infisical-dev-nginx
+    container_name: ${STACK_NAME:-infisical-dev}-nginx
     image: nginx
     restart: "always"
     ports:
-      - 8080:80
+      - ${STACK_NGINX_PORT:-8080}:80
     volumes:
       - ./nginx/default.dev.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:
@@ -16,7 +16,7 @@ services:
   db:
     image: postgres:14-alpine
     ports:
-      - "5432:5432"
+      - "${STACK_DB_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:
@@ -26,11 +26,11 @@ services:
 
   redis:
     image: redis
-    container_name: infisical-dev-redis
+    container_name: ${STACK_NAME:-infisical-dev}-redis
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
-      - 6379:6379
+      - ${STACK_REDIS_PORT:-6379}:6379
     volumes:
       - redis_data:/data
 
@@ -56,7 +56,7 @@ services:
     profiles: [clickhouse]
 
   redis-commander:
-    container_name: infisical-dev-redis-commander
+    container_name: ${STACK_NAME:-infisical-dev}-redis-commander
     image: ghcr.io/joeferner/redis-commander:0.9.0
     restart: always
     depends_on:
@@ -64,7 +64,7 @@ services:
     environment:
       - REDIS_HOSTS=local:redis:6379
     ports:
-      - "8085:8081"
+      - "${STACK_REDIS_COMMANDER_PORT:-8085}:8081"
 
   bull-board:
     container_name: infisical-dev-bull-board
@@ -93,7 +93,7 @@ services:
     command: postgres -c max_locks_per_transaction=512
 
   backend:
-    container_name: infisical-dev-api
+    container_name: ${STACK_NAME:-infisical-dev}-api
     build:
       context: ./backend
       dockerfile: Dockerfile.dev.fips
@@ -107,9 +107,9 @@ services:
     env_file:
       - .env
     ports:
-      - 4000:4000
-      - 9464:9464 # for OTEL collection of Prometheus metrics
-      - 9229:9229 # For debugger access
+      - ${STACK_API_PORT:-4000}:4000
+      - ${STACK_METRICS_PORT:-9464}:9464 # for OTEL collection of Prometheus metrics
+      - ${STACK_DEBUG_PORT:-9229}:9229 # For debugger access
     environment:
       - NODE_ENV=development
       - DB_CONNECTION_URI=postgres://infisical:infisical@db/infisical?sslmode=disable
@@ -167,7 +167,7 @@ services:
     profiles: [metrics]
 
   frontend:
-    container_name: infisical-dev-frontend
+    container_name: ${STACK_NAME:-infisical-dev}-frontend
     restart: unless-stopped
     depends_on:
       - backend
@@ -216,19 +216,19 @@ services:
       PGADMIN_DEFAULT_EMAIL: admin@example.com
       PGADMIN_DEFAULT_PASSWORD: pass
     ports:
-      - 5050:80
+      - ${STACK_PGADMIN_PORT:-5050}:80
     depends_on:
       - db
 
   smtp-server:
-    container_name: infisical-dev-smtp-server
+    container_name: ${STACK_NAME:-infisical-dev}-smtp-server
     image: jcalonso/mailhog:v1.0.1 # multi-arch fork; upstream mailhog/mailhog is amd64-only
     restart: always
     logging:
       driver: "none" # disable saving logs
     ports:
-      - 1025:1025 # SMTP server
-      - 8025:8025 # Web UI
+      - ${STACK_SMTP_PORT:-1025}:1025 # SMTP server
+      - ${STACK_MAIL_PORT:-8025}:8025 # Web UI
 
   openldap:
     # note: more advanced configuration is available

--- a/docs/.vale/styles/config/vocabularies/Infisical/canonical/accept.txt
+++ b/docs/.vale/styles/config/vocabularies/Infisical/canonical/accept.txt
@@ -622,3 +622,6 @@ iss
 # --- Surfaced by the code-signing pages ---
 # Vale strips a trailing `'s`, so the possessive needs no separate entry.
 MSBuild
+
+# --- Surfaced by the parallel dev environments page ---
+portless

--- a/docs/contributing/platform/developing.mdx
+++ b/docs/contributing/platform/developing.mdx
@@ -94,6 +94,69 @@ Once running, access the BullBoard UI at [http://localhost:3008](http://localhos
 docker compose -f docker-compose.dev.yml down
 ```
 
+## Installing dependencies
+
+The Docker stack installs its own dependencies inside the containers, so the
+steps above need nothing on your machine. Lint and type checks run against the
+host instead, so install those once before using them:
+
+```bash
+$ make install
+```
+
+## Running several stacks at once
+
+The stack above uses fixed ports, so only one can run at a time.
+To keep a second branch running, for example to review a pull request without
+tearing down your own work, run each checkout as its own stack.
+
+Each stack gets its own database, Redis instance, mail server and hostname, so
+nothing is shared. The stack is named after the checkout's directory, lowercased
+and shortened, and its ports come from hashing that name. They are therefore
+stable across runs and differ between checkouts, and switching branches inside a
+checkout never moves its ports.
+
+This needs [portless](https://portless.sh) to map each stack to a hostname:
+
+```bash
+$ npm install -g portless
+$ portless proxy start --tld test
+```
+
+Then, in any checkout or `git worktree`:
+
+```bash
+$ make stack-init
+$ make stack-up
+```
+
+`stack-init` writes the stack's name and ports into `.env`, creates its database
+volume and registers the hostnames. It prints the name it chose, and `stack-up`
+prints every address the stack listens on.
+
+| Command | What it does |
+| --- | --- |
+| `make stack-init` | Prepare this checkout: `.env`, ports, volume, hostnames |
+| `make stack-up` | Launch the stack |
+| `make stack-down` | Stop it, keeping the database and hostnames |
+| `make stack-rm` | Remove containers, volumes, images and hostnames |
+| `make stack-db` | Open `psql` against this stack's database |
+
+A new stack starts empty and migrates on first boot. Seeding it from a copy of
+an existing volume is quicker: `stack-init` writes `STACK_SEED_VOLUME` into
+`.env`, and you can point that at any volume or blank it to always start empty.
+
+<Warning>
+  Seeded data only reads back with the `ENCRYPTION_KEY` that wrote it, so `.env`
+  must carry the same key. Otherwise the backend starts but cannot decrypt.
+</Warning>
+
+`make stack-rm` leaves the checkout in place. Remove a worktree afterwards with
+`git worktree remove`.
+
+If a port is already taken, two stack names have hashed to the same number. Set
+a different `STACK_NAME` in `.env` and run `make stack-init` again.
+
 ## Starting Infisical docs locally
 
 We use [Mintlify](https://mintlify.com/) for our docs.

--- a/scripts/stack.sh
+++ b/scripts/stack.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env sh
+# Runs this checkout as its own Infisical stack, so several branches can be up
+# at once. Reached through `make stack-<cmd>`; see
+# docs/contributing/platform/developing.mdx.
+#
+# Every host port in docker-compose.dev.yml is parameterised with a default, so
+# this only has to put the right values in .env. With none set, the dev stack
+# behaves exactly as it always has.
+set -eu
+
+# Written into .env on first init so it is visible and editable there. Point it
+# at another volume to seed from that instead, or blank it to always start with
+# an empty database.
+DEFAULT_SEED_VOLUME=infisical_postgres-data1
+
+usage() {
+  echo "usage: $0 {init|up|down|rm|db}" >&2
+  exit 64
+}
+
+# --- .env helpers -----------------------------------------------------------
+get() { [ -f .env ] && sed -n "s/^$1=\\(.*\\)$/\\1/p" .env | head -1 | grep . || return 1; }
+
+set_var() {
+  if [ -f .env ] && grep -q "^$1=" .env; then
+    tmp=$(mktemp) && sed "s|^$1=.*|$1=$2|" .env > "$tmp" && mv "$tmp" .env
+  else
+    printf '%s=%s\n' "$1" "$2" >> .env
+  fi
+}
+
+# Ports are derived from the stack name, so they are identical on every run and
+# differ between checkouts. cksum is POSIX, so macOS and Linux agree. The range
+# sits above the well-known ports and below the ephemeral range.
+port_for() {
+  printf '%s' $(( 20000 + ($(printf '%s' "$1" | cksum | cut -d' ' -f1) % 20000) ))
+}
+
+stack_name() {
+  get STACK_NAME && return 0
+  # The directory, not the branch: switching branches inside a checkout must
+  # not move its ports or orphan its database.
+  printf '%s' "$(basename "$(pwd)")" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9-\n' '-' \
+    | sed 's/--*/-/g; s/^-*//; s/-*$//' | cut -c1-40 | sed 's/-*$//'
+}
+
+require_stack() {
+  [ -f .env ] || { echo "No .env here. Run 'make stack-init' first." >&2; exit 1; }
+  NAME=$(get STACK_NAME) || { echo "No STACK_NAME in .env. Run 'make stack-init' first." >&2; exit 1; }
+}
+
+compose() {
+  docker compose --env-file .env -p "$NAME" -f docker-compose.dev.yml "$@"
+}
+
+# --- commands ---------------------------------------------------------------
+cmd_init() {
+  if [ ! -f .env ]; then
+    [ -f .env.example ] || { echo "Run this from the repo root." >&2; exit 1; }
+    cp .env.example .env
+    echo "Created .env from .env.example."
+  fi
+
+  NAME=$(stack_name)
+  [ -n "$NAME" ] || { echo "Could not determine a stack name." >&2; exit 1; }
+
+  set_var STACK_NAME "$NAME"
+  set_var SITE_URL "https://$NAME.test"
+  set_var VITE_ALLOWED_HOSTS "$NAME.test"
+  set_var STACK_NGINX_PORT  "$(port_for "$NAME")"
+  set_var STACK_DB_PORT  "$(port_for "db-$NAME")"
+  set_var STACK_REDIS_PORT  "$(port_for "redis-$NAME")"
+  set_var STACK_MAIL_PORT  "$(port_for "mail-$NAME")"
+  set_var STACK_SMTP_PORT  "$(port_for "smtp-$NAME")"
+  set_var STACK_API_PORT  "$(port_for "api-$NAME")"
+  set_var STACK_METRICS_PORT  "$(port_for "metrics-$NAME")"
+  set_var STACK_DEBUG_PORT  "$(port_for "debug-$NAME")"
+  set_var STACK_PGADMIN_PORT  "$(port_for "pgadmin-$NAME")"
+  set_var STACK_REDIS_COMMANDER_PORT  "$(port_for "rediscmd-$NAME")"
+
+  # Compose names the volume <project>_postgres-data and the project is the
+  # stack name, so creating it here is what compose will pick up. Seeding from
+  # an existing volume is far quicker than migrating an empty database, but the
+  # data only reads back with the ENCRYPTION_KEY that wrote it.
+  grep -q '^STACK_SEED_VOLUME=' .env || set_var STACK_SEED_VOLUME "$DEFAULT_SEED_VOLUME"
+  seed=$(get STACK_SEED_VOLUME || true)
+
+  volume="${NAME}_postgres-data"
+  if ! docker volume inspect "$volume" >/dev/null 2>&1; then
+    docker volume create "$volume" >/dev/null
+    if [ -z "$seed" ]; then
+      echo "STACK_SEED_VOLUME is empty, so starting empty. Migrations run on first boot."
+    elif docker volume inspect "$seed" >/dev/null 2>&1; then
+      echo "Seeding $volume from $seed..."
+      docker run --rm -v "$seed":/from:ro -v "$volume":/to alpine sh -c 'cp -a /from/. /to/'
+      grep -q '^ENCRYPTION_KEY=.' .env \
+        || echo "Warning: .env has no ENCRYPTION_KEY, so seeded data will not decrypt." >&2
+    else
+      echo "$seed not found, so starting empty. Migrations run on first boot."
+    fi
+  fi
+
+  if command -v portless >/dev/null 2>&1; then
+    portless alias "$NAME" "$(get STACK_NGINX_PORT)" --tld test --force >/dev/null 2>&1 || true
+    portless alias "mail.$NAME" "$(get STACK_MAIL_PORT)" --tld test --force >/dev/null 2>&1 || true
+  else
+    echo "portless not installed, so no .test hostname. See the contributing guide." >&2
+  fi
+
+  echo "Stack '$NAME' initialised. Run 'make stack-up'."
+}
+
+cmd_up() {
+  require_stack
+  compose up --build -d
+  printf '\nStack %s is running:\n' "$NAME"
+  echo "  App:      https://$NAME.test"
+  echo "  Mail:     https://mail.$NAME.test"
+  echo "  Postgres: localhost:$(get STACK_DB_PORT)"
+}
+
+cmd_down() { require_stack; compose down; }
+
+cmd_rm() {
+  require_stack
+  compose down -v
+  docker image rm "infisical-dev-backend:$NAME" "infisical-dev-frontend:$NAME" >/dev/null 2>&1 || true
+  portless alias --remove "$NAME" >/dev/null 2>&1 || true
+  portless alias --remove "mail.$NAME" >/dev/null 2>&1 || true
+  echo "Stack '$NAME' removed. The checkout itself is untouched."
+}
+
+cmd_db() {
+  require_stack
+  PGPASSWORD=infisical psql -h localhost -p "$(get STACK_DB_PORT)" -U infisical -d infisical -P pager=off
+}
+
+[ $# -eq 1 ] || usage
+case "$1" in
+  init) cmd_init ;;
+  up)   cmd_up ;;
+  down) cmd_down ;;
+  rm)   cmd_rm ;;
+  db)   cmd_db ;;
+  *)    usage ;;
+esac


### PR DESCRIPTION
## Context

The dev stack uses fixed host ports and container names, so only one can run at a time. Switching branches means tearing down whatever is running, which is a real cost when reviewing a pull request while your own work is up. This lets each checkout run as its own stack instead, with its own database, Redis instance, mail server and hostname.

**Compose:** every host port and container name in `docker-compose.dev.yml` is now parameterised with its current value as the default, for example `${STACK_NGINX_PORT:-8080}:80` and `${STACK_NAME:-infisical-dev}-nginx`. There is no second Compose file; the same one covers both modes. With no `STACK_*` variables set the file resolves exactly as it did before, so `make up-dev`, a plain `docker compose -f docker-compose.dev.yml up`, and the five CI workflows that use it are all unaffected. I checked that by diffing `docker compose config` against `main` with both an empty `.env` and `.env.example`: byte-identical in both cases.

**Ports:** `scripts/stack.sh` derives them by hashing the checkout's directory name, so they are stable across runs and differ between checkouts, with no configuration and no port registry. It writes them into `.env` alongside `STACK_NAME`, creates the stack's database volume, and registers the portless hostnames. The name comes from the directory rather than the branch on purpose: switching branches inside a checkout must not move its ports or orphan its database.

**Seeding:** a new stack starts empty and migrates on first boot. `stack-init` also writes `STACK_SEED_VOLUME` into `.env`, and when that names an existing Docker volume the stack is seeded from a copy of it, which is much quicker. Point it at any volume or blank it to always start empty. Seeded data only reads back with the `ENCRYPTION_KEY` that wrote it, so that key stays in `.env` rather than being hardcoded anywhere.

**Naming:** the stack variables are prefixed `STACK_` because the obvious names are taken. `DB_PORT` is the backend's Postgres port and `SMTP_PORT` its mail client port, so reusing either would have pointed the app at the wrong service.

**Commands:** five `make` targets delegate to the script, so there is no new tool to install. `make install` is also added, since lint and type checks run against host `node_modules` and nothing installed them.

**Docs:** documented as two sections in the existing local development guide rather than a separate page, so both workflows sit together.

**Dependency:** portless, for the hostnames. Nothing else.

**Opting out:** nothing to do. The stack path only activates when you deliberately run `make stack-init`.

## Steps to verify the change

1. Confirm nothing changed for the existing flow: `make up-dev`, then browse to http://localhost:8080 as before.
2. `npm install -g portless && portless proxy start --tld test`
3. `git worktree add ../infisical-review some-branch && cd ../infisical-review`
4. `make stack-init && make stack-up`
5. Open `https://infisical-review.test` and confirm the app loads.
6. With the first stack still running, repeat 3 to 5 in another checkout and confirm both stay up on their own hostnames.
7. `make stack-rm` in each to tear down.

## Type

- [ ] Fix
- [x] Feature
- [x] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
