### PR TITLE
fix(secret-import): stop hiding cross-project imports when the org loses the entitlement

### DIFF
--- a/backend/src/services/secret-import/secret-import-service.ts
+++ b/backend/src/services/secret-import/secret-import-service.ts
@@ -91,12 +91,13 @@ export const secretImportServiceFactory = ({
     const crossProject = imports.filter((imp) => imp.importEnv.projectId !== projectId);
     if (!crossProject.length) return imports.map((imp) => ({ ...imp, isAccessRevoked: false }));
 
-    // If org-level toggle is disabled, strip cross-project imports entirely
+    // Losing the cross-project entitlement must not hide imports created while it was active
+    // (see backend/CODE_QUALITY.md#license-checks) - mark them revoked the same way an
+    // out-of-scope grant is, rather than removing them from the response.
     const plan = await licenseService.getPlan(actorOrgId);
     if (!(await isCrossProjectEnabled(actorOrgId, orgDAL, plan))) {
-      return imports
-        .filter((imp) => imp.importEnv.projectId === projectId)
-        .map((imp) => ({ ...imp, isAccessRevoked: false }));
+      const crossProjectIds = new Set(crossProject.map((imp) => imp.id));
+      return imports.map((imp) => ({ ...imp, isAccessRevoked: crossProjectIds.has(imp.id) }));
     }
 
     const sourceFolders = await folderDAL.findByManySecretPath(


### PR DESCRIPTION
## Context

`backend/CODE_QUALITY.md` has a whole section on license checks, with the central rule being: a plan/entitlement check should gate *creating or editing* something, never change what a read/list endpoint returns for data that already exists. It even has a worked example of exactly this going wrong for cross-project secret sharing.

I found a second instance of the same anti-pattern in `secret-import-service.ts`. `$annotateCrossProjectImports` is the function every "list secret imports" read path funnels through (`getImports`, `getSecretsFromImports`, `getRawSecretsFromImports`, etc.). When the org's plan doesn't include cross-project secret sharing, it currently does this:

```ts
if (!(await isCrossProjectEnabled(actorOrgId, orgDAL, plan))) {
  return imports
    .filter((imp) => imp.importEnv.projectId === projectId)
    .map((imp) => ({ ...imp, isAccessRevoked: false }));
}
```

That `.filter(...)` strips every cross-project import out of the response. So a team that set up cross-project imports while entitled, then downgraded, doesn't just lose the ability to *create* new ones (which is correctly gated separately in `createImport`) - the existing import rows vanish from the "Secret Imports" list in the UI entirely. Nothing was deleted, but there's no way for an org admin to even see that the import still exists to clean it up.

## Fix

Same function already has a mechanism for exactly this situation: when a cross-project import's source folder grant has been revoked, it's kept in the response but flagged `isAccessRevoked: true`, and the frontend (`SecretImportTableRow.tsx`) already renders that as "Import can no longer be resolved. Re-request access from the source project or remove this import." I applied the same flag to the license-downgrade case instead of filtering the imports out, so the behavior matches what already exists for a structurally identical situation (import object still there, currently non-functional, user can still see/manage it) - no frontend changes were needed.

One thing I deliberately left alone: `secret-reference-fns.ts`'s `expandSecretReferences` has its own `checkCrossProjectAllowed()` check that gates whether an `@project.env.path.KEY`-style cross-project *reference* resolves at all, and it also runs on the read path. Whether that should keep resolving for already-authored references after a downgrade felt like a bigger product decision than this PR should make unilaterally, so I left it as-is and I'm happy to open a separate PR for it if that's wanted.

## Steps to verify the change

1. `npm run type:check` in `backend/` - passes.
2. Traced every caller of `$annotateCrossProjectImports` (`getImports`, `getSecretsFromImports`, `getRawSecretsFromImports`, `getProjectImportCount` call sites) to confirm none of them depend on cross-project imports being absent from the array (they all iterate/map over whatever comes back).
3. Confirmed the frontend already has a rendering path for `isAccessRevoked: true` that doesn't assume the cause was a revoked grant specifically.

## Type

- [x] Fix

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed) - not applicable, internal fix
- [ ] Updated CLAUDE.md files (if needed) - not applicable, no new pattern introduced
- [x] Read the contributing guide

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
