### PR TITLE
chore(deps): bump the bundled CLI to 0.43.129

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -3,7 +3,7 @@ ARG POSTHOG_API_KEY=posthog-api-key
 ARG INTERCOM_ID=intercom-id
 ARG CAPTCHA_SITE_KEY=captcha-site-key
 
-ARG INFISICAL_CLI_VERSION=0.43.128
+ARG INFISICAL_CLI_VERSION=0.43.129
 
 FROM node:22.22.0-trixie-slim AS base
 

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -3,7 +3,7 @@ ARG POSTHOG_API_KEY=posthog-api-key
 ARG INTERCOM_ID=intercom-id
 ARG CAPTCHA_SITE_KEY=captcha-site-key
 
-ARG INFISICAL_CLI_VERSION=0.43.128
+ARG INFISICAL_CLI_VERSION=0.43.129
 
 FROM node:22.22.0-trixie-slim AS base
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-ARG INFISICAL_CLI_VERSION=0.43.128
+ARG INFISICAL_CLI_VERSION=0.43.129
 
 FROM node:22.22.0-trixie-slim AS build
 

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG INFISICAL_CLI_VERSION=0.43.128
+ARG INFISICAL_CLI_VERSION=0.43.129
 
 FROM debian:trixie-slim AS oracle
 RUN apt-get update && apt-get install -y unzip wget ca-certificates \

--- a/backend/Dockerfile.fips-toolchain
+++ b/backend/Dockerfile.fips-toolchain
@@ -20,7 +20,7 @@
 # removed. Also includes OpenSSL (Apache-2.0), SoftHSM2 (BSD-2-Clause), the Infisical
 # CLI, and Debian packages under their respective licenses.
 
-ARG INFISICAL_CLI_VERSION=0.43.128
+ARG INFISICAL_CLI_VERSION=0.43.129
 
 FROM debian:trixie-slim AS oracle
 RUN apt-get update && apt-get install -y unzip wget ca-certificates \

--- a/build-versions.env
+++ b/build-versions.env
@@ -2,4 +2,4 @@
 # Read by the Makefile for compose builds and by CI for image builds.
 # The Dockerfiles carry matching ARG defaults so external builders work unaided;
 # check-dockerfile-pins.yml asserts those defaults still match this file.
-INFISICAL_CLI_VERSION=0.43.128
+INFISICAL_CLI_VERSION=0.43.129


### PR DESCRIPTION
## Context

The image carries 0.43.128, which is built on go1.25.12. A customer container scan flags seven Go standard library advisories against it whose floor is 1.25.13.

0.43.129 is built on go1.25.14 and covers all seven. Verified by installing the pin and reading the toolchain out of the binary.

The bundled tool is used only by secret scanning. Its contract is unchanged: infisical scan exits 77 on a planted secret and 0 on a clean tree, checked against this version.

build-versions.env holds the canonical value and the five Dockerfiles keep matching ARG defaults so external builders work unaided.

## Screenshots

N/A

## Steps to verify the change

### 1. The version lives in one place and every Dockerfile agrees with it
grep INFISICAL_CLI_VERSION build-versions.env
grep -rn 'ARG INFISICAL_CLI_VERSION=' --include='Dockerfile*' .

Six lines, all 0.43.129. The Check Dockerfile pins workflow fails the PR if they drift, and also fails if it finds fewer than five Dockerfiles or any hardcoded install -y infisical=.

### 2. Build every image that installs the CLI
docker build -t t1 -f backend/Dockerfile                  backend/
docker build -t t2 -f backend/Dockerfile.dev              backend/
docker build -t t3 -f backend/Dockerfile.fips-toolchain   backend/
docker build -t t4 -f Dockerfile.standalone-infisical      .
docker build -t t5 -f Dockerfile.fips.standalone-infisical .

### 3. Confirm the pin actually landed in each
for i in t1 t2 t3 t4 t5; do docker run --rm --entrypoint sh $i -c 'infisical --version'; done

Each prints infisical version 0.43.129.

### 4. Confirm the binary is built on a Go toolchain that covers the advisories
docker create --name clix t4 && docker cp clix:/usr/bin/infisical ./cli && docker rm clix
go version -m ./cli | head -1

Prints go1.25.14. The advisories in the customer scan need 1.25.13 or later, so the toolchain is what actually closes them, not the CLI version number. Note the container name has to be at least two characters or docker create rejects it.

### 5. Confirm secret scanning still behaves, since it is the only consumer of the bundled CLI
docker run --rm --entrypoint sh t4 -c '
  mkdir -p /tmp/s && printf "ghp_1a2B3c4D5e6F7g8H9i0JkLmNoPqRsTuVwXyZ12\n" > /tmp/s/a.txt
  infisical scan --exit-code=77 --source /tmp/s --no-git; echo "exit: $?"'

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested build locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)