### PR TITLE
improvement(security): derive cookie signing key from KMS root key

### DIFF
--- a/backend/src/@types/fastify.d.ts
+++ b/backend/src/@types/fastify.d.ts
@@ -286,6 +286,7 @@ declare module "fastify" {
 
   interface FastifyInstance {
     redis: Redis | Cluster;
+    cookieSigningKey: string;
     services: {
       login: TAuthLoginFactory;
       password: TAuthPasswordFactory;

--- a/backend/src/ee/routes/v1/ldap-router.ts
+++ b/backend/src/ee/routes/v1/ldap-router.ts
@@ -18,6 +18,7 @@ import { TLDAPConfig } from "@app/ee/services/ldap-config/ldap-config-types";
 import { isValidLdapFilter, searchGroups } from "@app/ee/services/ldap-config/ldap-fns";
 import { ApiDocsTags, LdapSso } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
+import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -30,7 +31,7 @@ import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 export const registerLdapRouter = async (server: FastifyZodProvider) => {
   const appCfg = getConfig();
   const passport = new Authenticator({ key: "ldap", userProperty: "passportUser" });
-  await server.register(fastifySession, { secret: appCfg.COOKIE_SECRET_SIGN_KEY });
+  await server.register(fastifySession, { secret: getCookieSigningKey() });
   await server.register(passport.initialize());
   await server.register(passport.secureSession());
 

--- a/backend/src/ee/routes/v1/ldap-router.ts
+++ b/backend/src/ee/routes/v1/ldap-router.ts
@@ -18,7 +18,6 @@ import { TLDAPConfig } from "@app/ee/services/ldap-config/ldap-config-types";
 import { isValidLdapFilter, searchGroups } from "@app/ee/services/ldap-config/ldap-fns";
 import { ApiDocsTags, LdapSso } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
-import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -31,7 +30,7 @@ import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 export const registerLdapRouter = async (server: FastifyZodProvider) => {
   const appCfg = getConfig();
   const passport = new Authenticator({ key: "ldap", userProperty: "passportUser" });
-  await server.register(fastifySession, { secret: getCookieSigningKey() });
+  await server.register(fastifySession, { secret: server.cookieSigningKey });
   await server.register(passport.initialize());
   await server.register(passport.secureSession());
 

--- a/backend/src/ee/routes/v1/oidc-router.ts
+++ b/backend/src/ee/routes/v1/oidc-router.ts
@@ -15,6 +15,7 @@ import { OidcConfigsSchema } from "@app/db/schemas";
 import { OIDCConfigurationType, OIDCJWTSignatureAlgorithm } from "@app/ee/services/oidc/oidc-config-types";
 import { ApiDocsTags, OidcSSo } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
+import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { authRateLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -56,7 +57,7 @@ export const registerOidcRouter = async (server: FastifyZodProvider) => {
   });
 
   await server.register(fastifySession, {
-    secret: appCfg.COOKIE_SECRET_SIGN_KEY,
+    secret: getCookieSigningKey(),
     store: redisStore,
     cookie: {
       secure: appCfg.HTTPS_ENABLED,

--- a/backend/src/ee/routes/v1/oidc-router.ts
+++ b/backend/src/ee/routes/v1/oidc-router.ts
@@ -15,7 +15,6 @@ import { OidcConfigsSchema } from "@app/db/schemas";
 import { OIDCConfigurationType, OIDCJWTSignatureAlgorithm } from "@app/ee/services/oidc/oidc-config-types";
 import { ApiDocsTags, OidcSSo } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
-import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { authRateLimit, readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -57,7 +56,7 @@ export const registerOidcRouter = async (server: FastifyZodProvider) => {
   });
 
   await server.register(fastifySession, {
-    secret: getCookieSigningKey(),
+    secret: server.cookieSigningKey,
     store: redisStore,
     cookie: {
       secure: appCfg.HTTPS_ENABLED,

--- a/backend/src/ee/routes/v1/saml-router.ts
+++ b/backend/src/ee/routes/v1/saml-router.ts
@@ -17,7 +17,6 @@ import { z } from "zod";
 import { SamlProviders, TGetSamlCfgDTO } from "@app/ee/services/saml-config/saml-config-types";
 import { ApiDocsTags, SamlSso } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
-import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
@@ -49,7 +48,7 @@ type TSAMLConfig = {
 export const registerSamlRouter = async (server: FastifyZodProvider) => {
   const appCfg = getConfig();
   const passport = new Authenticator({ key: "saml", userProperty: "passportUser" });
-  await server.register(fastifySession, { secret: getCookieSigningKey() });
+  await server.register(fastifySession, { secret: server.cookieSigningKey });
   await server.register(passport.initialize());
   await server.register(passport.secureSession());
   server.decorateRequest("ssoConfig");

--- a/backend/src/ee/routes/v1/saml-router.ts
+++ b/backend/src/ee/routes/v1/saml-router.ts
@@ -17,6 +17,7 @@ import { z } from "zod";
 import { SamlProviders, TGetSamlCfgDTO } from "@app/ee/services/saml-config/saml-config-types";
 import { ApiDocsTags, SamlSso } from "@app/lib/api-docs";
 import { getConfig } from "@app/lib/config/env";
+import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { BadRequestError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
@@ -48,7 +49,7 @@ type TSAMLConfig = {
 export const registerSamlRouter = async (server: FastifyZodProvider) => {
   const appCfg = getConfig();
   const passport = new Authenticator({ key: "saml", userProperty: "passportUser" });
-  await server.register(fastifySession, { secret: appCfg.COOKIE_SECRET_SIGN_KEY });
+  await server.register(fastifySession, { secret: getCookieSigningKey() });
   await server.register(passport.initialize());
   await server.register(passport.secureSession());
   server.decorateRequest("ssoConfig");

--- a/backend/src/lib/config/env.ts
+++ b/backend/src/lib/config/env.ts
@@ -253,10 +253,7 @@ const envSchema = z
     SMTP_CUSTOM_CA_CERT: zpStr(
       z.string().optional().describe("Base64 encoded custom CA certificate PEM(s) for the SMTP server")
     ),
-    COOKIE_SECRET_SIGN_KEY: z
-      .string()
-      .min(32)
-      .default("#5VihU%rbXHcHwWwCot5L3vyPsx$7dWYw^iGk!EJg2bC*f$PD$%KCqx^R@#^LSEf"),
+    COOKIE_SECRET_SIGN_KEY: zpStr(z.string().min(32).optional()),
 
     // Ensure that the SITE_URL never ends with a trailing slash
     SITE_URL: zpStr(z.string().transform((val) => (val ? removeTrailingSlash(val) : val))).optional(),

--- a/backend/src/lib/crypto/cookie-signing-key.test.ts
+++ b/backend/src/lib/crypto/cookie-signing-key.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { deriveSecretValueBlindIndexKey } from "./blind-index";
+import { deriveCookieSigningKey } from "./cookie-signing-key";
+
+const ROOT_KEY = Buffer.from("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "hex");
+
+describe("deriveCookieSigningKey", () => {
+  // Pins the context string, the empty salt, SHA-256 and the 32 byte length together. Changing any
+  // of them changes every deployment's key on upgrade, which logs out every SSO login in flight, so
+  // that has to be a deliberate edit to this vector rather than a silent side effect.
+  it("matches the known answer for a fixed root key", () => {
+    expect(deriveCookieSigningKey(ROOT_KEY)).toBe("uFYvATtAEhzPYlypzAyQnrPGMoUA3GwqtIEVO6PlBqY=");
+  });
+
+  it("returns 32 bytes of base64", () => {
+    const key = deriveCookieSigningKey(ROOT_KEY);
+    expect(Buffer.from(key, "base64")).toHaveLength(32);
+  });
+
+  // Every process on a deployment derives independently from the same stored root key and has to
+  // land on the same value, or one task rejects another task's cookies.
+  it("is deterministic across calls", () => {
+    expect(deriveCookieSigningKey(ROOT_KEY)).toBe(deriveCookieSigningKey(Buffer.from(ROOT_KEY)));
+  });
+
+  it("differs for a root key that differs by a single bit", () => {
+    const neighbour = Buffer.from(ROOT_KEY);
+    neighbour[31] -= 1; // 0x1f to 0x1e, one bit apart
+    expect(deriveCookieSigningKey(neighbour)).not.toBe(deriveCookieSigningKey(ROOT_KEY));
+  });
+
+  it("differs from the root key it came from", () => {
+    expect(deriveCookieSigningKey(ROOT_KEY)).not.toBe(ROOT_KEY.toString("base64"));
+  });
+
+  // Same root key, same HKDF, different context. If the contexts ever collide, a cookie signing key
+  // and a blind index key become the same secret used for two unrelated purposes.
+  it("is domain separated from the blind index derivation over the same root key", async () => {
+    const blindIndexKey = await deriveSecretValueBlindIndexKey(ROOT_KEY);
+    expect(deriveCookieSigningKey(ROOT_KEY)).not.toBe(blindIndexKey.toString("base64"));
+  });
+});
+
+describe("the resolved cookie signing key", () => {
+  // The module holds the resolved key as process state, so each case takes a fresh copy rather than
+  // inheriting whatever the previous one set.
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("is refused before the root key has been loaded", async () => {
+    const { getCookieSigningKey } = await import("./cookie-signing-key");
+    expect(() => getCookieSigningKey()).toThrowError(/before the KMS root key was loaded/);
+  });
+
+  it("returns a configured key verbatim, without deriving or transforming it", async () => {
+    const { getCookieSigningKey, setCookieSigningKey } = await import("./cookie-signing-key");
+    const configured = "an-operator-supplied-key-of-at-least-32-chars";
+
+    setCookieSigningKey(configured);
+
+    expect(getCookieSigningKey()).toBe(configured);
+  });
+
+  it("takes the most recently set key", async () => {
+    const { getCookieSigningKey, setCookieSigningKey } = await import("./cookie-signing-key");
+
+    setCookieSigningKey("first-key-first-key-first-key-first");
+    setCookieSigningKey("second-key-second-key-second-key-se");
+
+    expect(getCookieSigningKey()).toBe("second-key-second-key-second-key-se");
+  });
+});

--- a/backend/src/lib/crypto/cookie-signing-key.test.ts
+++ b/backend/src/lib/crypto/cookie-signing-key.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { deriveSecretValueBlindIndexKey } from "./blind-index";
 import { deriveCookieSigningKey } from "./cookie-signing-key";
@@ -39,36 +39,5 @@ describe("deriveCookieSigningKey", () => {
   it("is domain separated from the blind index derivation over the same root key", async () => {
     const blindIndexKey = await deriveSecretValueBlindIndexKey(ROOT_KEY);
     expect(deriveCookieSigningKey(ROOT_KEY)).not.toBe(blindIndexKey.toString("base64"));
-  });
-});
-
-describe("the resolved cookie signing key", () => {
-  // The module holds the resolved key as process state, so each case takes a fresh copy rather than
-  // inheriting whatever the previous one set.
-  beforeEach(() => {
-    vi.resetModules();
-  });
-
-  it("is refused before the root key has been loaded", async () => {
-    const { getCookieSigningKey } = await import("./cookie-signing-key");
-    expect(() => getCookieSigningKey()).toThrowError(/before the KMS root key was loaded/);
-  });
-
-  it("returns a configured key verbatim, without deriving or transforming it", async () => {
-    const { getCookieSigningKey, setCookieSigningKey } = await import("./cookie-signing-key");
-    const configured = "an-operator-supplied-key-of-at-least-32-chars";
-
-    setCookieSigningKey(configured);
-
-    expect(getCookieSigningKey()).toBe(configured);
-  });
-
-  it("takes the most recently set key", async () => {
-    const { getCookieSigningKey, setCookieSigningKey } = await import("./cookie-signing-key");
-
-    setCookieSigningKey("first-key-first-key-first-key-first");
-    setCookieSigningKey("second-key-second-key-second-key-se");
-
-    expect(getCookieSigningKey()).toBe("second-key-second-key-second-key-se");
   });
 });

--- a/backend/src/lib/crypto/cookie-signing-key.ts
+++ b/backend/src/lib/crypto/cookie-signing-key.ts
@@ -1,10 +1,6 @@
 import crypto from "node:crypto";
 
-import { InternalServerError } from "@app/lib/errors";
-
 const COOKIE_SIGNING_KEY_CONTEXT = "infisical-cookie-signing-key-v1";
-
-let cookieSigningKey: string | undefined;
 
 /**
  * Derives the cookie signing key from the KMS root key, which is already generated and persisted
@@ -13,17 +9,3 @@ let cookieSigningKey: string | undefined;
  */
 export const deriveCookieSigningKey = (rootKey: Buffer) =>
   Buffer.from(crypto.hkdfSync("sha256", rootKey, Buffer.alloc(0), COOKIE_SIGNING_KEY_CONTEXT, 32)).toString("base64");
-
-export const setCookieSigningKey = (key: string) => {
-  cookieSigningKey = key;
-};
-
-export const getCookieSigningKey = () => {
-  if (!cookieSigningKey) {
-    throw new InternalServerError({
-      message: "Cookie signing key was requested before the KMS root key was loaded"
-    });
-  }
-
-  return cookieSigningKey;
-};

--- a/backend/src/lib/crypto/cookie-signing-key.ts
+++ b/backend/src/lib/crypto/cookie-signing-key.ts
@@ -1,0 +1,29 @@
+import crypto from "node:crypto";
+
+import { InternalServerError } from "@app/lib/errors";
+
+const COOKIE_SIGNING_KEY_CONTEXT = "infisical-cookie-signing-key-v1";
+
+let cookieSigningKey: string | undefined;
+
+/**
+ * Derives the cookie signing key from the KMS root key, which is already generated and persisted
+ * per instance at first boot. That keeps the key unique to the deployment without a second secret
+ * at rest, and stable across restarts, replicas, and KEK rotations.
+ */
+export const deriveCookieSigningKey = (rootKey: Buffer) =>
+  Buffer.from(crypto.hkdfSync("sha256", rootKey, Buffer.alloc(0), COOKIE_SIGNING_KEY_CONTEXT, 32)).toString("base64");
+
+export const setCookieSigningKey = (key: string) => {
+  cookieSigningKey = key;
+};
+
+export const getCookieSigningKey = () => {
+  if (!cookieSigningKey) {
+    throw new InternalServerError({
+      message: "Cookie signing key was requested before the KMS root key was loaded"
+    });
+  }
+
+  return cookieSigningKey;
+};

--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -2,8 +2,6 @@
 import path from "node:path";
 
 import type { ClickHouseClient } from "@clickhouse/client";
-import type { FastifyCookieOptions } from "@fastify/cookie";
-import cookie, { signerFactory } from "@fastify/cookie";
 import type { FastifyCorsOptions } from "@fastify/cors";
 import cors from "@fastify/cors";
 import fastifyEtag from "@fastify/etag";
@@ -20,7 +18,6 @@ import { Knex } from "knex";
 import { THsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
 import { TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, IS_PACKAGED, TEnvConfig } from "@app/lib/config/env";
-import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { CustomLogger } from "@app/lib/logger/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
@@ -114,19 +111,6 @@ export const main = async ({
   });
 
   try {
-    let cookieSigner: ReturnType<typeof signerFactory> | undefined;
-    const getCookieSigner = () => {
-      if (!cookieSigner) cookieSigner = signerFactory(getCookieSigningKey());
-      return cookieSigner;
-    };
-
-    await server.register<FastifyCookieOptions>(cookie, {
-      secret: {
-        sign: (value) => getCookieSigner().sign(value),
-        unsign: (value) => getCookieSigner().unsign(value)
-      }
-    });
-
     await server.register(fastifyEtag);
 
     await server.register<FastifyCorsOptions>(cors, {

--- a/backend/src/server/app.ts
+++ b/backend/src/server/app.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 import type { ClickHouseClient } from "@clickhouse/client";
 import type { FastifyCookieOptions } from "@fastify/cookie";
-import cookie from "@fastify/cookie";
+import cookie, { signerFactory } from "@fastify/cookie";
 import type { FastifyCorsOptions } from "@fastify/cors";
 import cors from "@fastify/cors";
 import fastifyEtag from "@fastify/etag";
@@ -20,6 +20,7 @@ import { Knex } from "knex";
 import { THsmServiceFactory } from "@app/ee/services/hsm/hsm-service";
 import { TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, IS_PACKAGED, TEnvConfig } from "@app/lib/config/env";
+import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { CustomLogger } from "@app/lib/logger/logger";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { RequestContextKey } from "@app/lib/request-context/request-context-keys";
@@ -113,8 +114,17 @@ export const main = async ({
   });
 
   try {
+    let cookieSigner: ReturnType<typeof signerFactory> | undefined;
+    const getCookieSigner = () => {
+      if (!cookieSigner) cookieSigner = signerFactory(getCookieSigningKey());
+      return cookieSigner;
+    };
+
     await server.register<FastifyCookieOptions>(cookie, {
-      secret: appCfg.COOKIE_SECRET_SIGN_KEY
+      secret: {
+        sign: (value) => getCookieSigner().sign(value),
+        unsign: (value) => getCookieSigner().unsign(value)
+      }
     });
 
     await server.register(fastifyEtag);

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -199,6 +199,7 @@ import { keyValueStoreDALFactory } from "@app/keystore/key-value-store-dal";
 import { TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, TEnvConfig } from "@app/lib/config/env";
 import { cronJobFactory } from "@app/lib/cron/cron-job";
+import { setCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError } from "@app/lib/errors";
 import { initGatewayLoadTracker } from "@app/lib/gateway-v2/gateway-load-tracker";
@@ -3994,6 +3995,8 @@ export const registerRoutes = async (
   }
 
   await kmsService.startService(hsmStatus);
+  setCookieSigningKey(appCfg.COOKIE_SECRET_SIGN_KEY || kmsService.getCookieSigningKey());
+
   // Register all cron jobs (synchronous registrations) before starting the scheduler
   encryptionKeyRotationService.init();
   telemetryQueue.startTelemetryCheck();

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -201,7 +201,6 @@ import { keyValueStoreDALFactory } from "@app/keystore/key-value-store-dal";
 import { TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, TEnvConfig } from "@app/lib/config/env";
 import { cronJobFactory } from "@app/lib/cron/cron-job";
-import { getCookieSigningKey, setCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError } from "@app/lib/errors";
 import { initGatewayLoadTracker } from "@app/lib/gateway-v2/gateway-load-tracker";
@@ -3997,9 +3996,9 @@ export const registerRoutes = async (
   }
 
   await kmsService.startService(hsmStatus);
-  setCookieSigningKey(appCfg.COOKIE_SECRET_SIGN_KEY || kmsService.getCookieSigningKey());
 
-  await server.register<FastifyCookieOptions>(cookie, { secret: getCookieSigningKey() });
+  server.decorate("cookieSigningKey", appCfg.COOKIE_SECRET_SIGN_KEY || kmsService.getCookieSigningKey());
+  await server.register<FastifyCookieOptions>(cookie, { secret: server.cookieSigningKey });
 
   // Register all cron jobs (synchronous registrations) before starting the scheduler
   encryptionKeyRotationService.init();

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -1,5 +1,7 @@
 import { registerBddNockRouter } from "@bdd_routes/bdd-nock-router";
 import type { ClickHouseClient } from "@clickhouse/client";
+import type { FastifyCookieOptions } from "@fastify/cookie";
+import cookie from "@fastify/cookie";
 import { CronJob } from "cron";
 import { Cluster, Redis } from "ioredis";
 import { Knex } from "knex";
@@ -199,7 +201,7 @@ import { keyValueStoreDALFactory } from "@app/keystore/key-value-store-dal";
 import { TKeyStoreFactory } from "@app/keystore/keystore";
 import { getConfig, TEnvConfig } from "@app/lib/config/env";
 import { cronJobFactory } from "@app/lib/cron/cron-job";
-import { setCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
+import { getCookieSigningKey, setCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { BadRequestError } from "@app/lib/errors";
 import { initGatewayLoadTracker } from "@app/lib/gateway-v2/gateway-load-tracker";
@@ -3996,6 +3998,8 @@ export const registerRoutes = async (
 
   await kmsService.startService(hsmStatus);
   setCookieSigningKey(appCfg.COOKIE_SECRET_SIGN_KEY || kmsService.getCookieSigningKey());
+
+  await server.register<FastifyCookieOptions>(cookie, { secret: getCookieSigningKey() });
 
   // Register all cron jobs (synchronous registrations) before starting the scheduler
   encryptionKeyRotationService.init();

--- a/backend/src/server/routes/v1/identity-ldap-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-ldap-auth-router.ts
@@ -18,7 +18,6 @@ import { IdentityLdapAuthsSchema } from "@app/db/schemas/identity-ldap-auths";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { isValidLdapFilter } from "@app/ee/services/ldap-config/ldap-fns";
 import { ApiDocsTags, LDAP_AUTH } from "@app/lib/api-docs";
-import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { UnauthorizedError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -33,7 +32,7 @@ import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider) => {
   const passport = new Authenticator({ key: "ldap-identity-auth", userProperty: "passportMachineIdentity" });
-  await server.register(fastifySession, { secret: getCookieSigningKey() });
+  await server.register(fastifySession, { secret: server.cookieSigningKey });
   await server.register(passport.initialize());
   await server.register(passport.secureSession());
 

--- a/backend/src/server/routes/v1/identity-ldap-auth-router.ts
+++ b/backend/src/server/routes/v1/identity-ldap-auth-router.ts
@@ -18,7 +18,7 @@ import { IdentityLdapAuthsSchema } from "@app/db/schemas/identity-ldap-auths";
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { isValidLdapFilter } from "@app/ee/services/ldap-config/ldap-fns";
 import { ApiDocsTags, LDAP_AUTH } from "@app/lib/api-docs";
-import { getConfig } from "@app/lib/config/env";
+import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { UnauthorizedError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
@@ -32,9 +32,8 @@ import { isSuperAdmin } from "@app/services/super-admin/super-admin-fns";
 import { PostHogEventTypes } from "@app/services/telemetry/telemetry-types";
 
 export const registerIdentityLdapAuthRouter = async (server: FastifyZodProvider) => {
-  const appCfg = getConfig();
   const passport = new Authenticator({ key: "ldap-identity-auth", userProperty: "passportMachineIdentity" });
-  await server.register(fastifySession, { secret: appCfg.COOKIE_SECRET_SIGN_KEY });
+  await server.register(fastifySession, { secret: getCookieSigningKey() });
   await server.register(passport.initialize());
   await server.register(passport.secureSession());
 

--- a/backend/src/server/routes/v1/sso-router.ts
+++ b/backend/src/server/routes/v1/sso-router.ts
@@ -18,6 +18,7 @@ import { z } from "zod";
 
 import { INFISICAL_PROVIDER_GITHUB_ACCESS_TOKEN } from "@app/lib/config/const";
 import { getConfig } from "@app/lib/config/env";
+import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
@@ -425,7 +426,7 @@ export const registerSsoRouter = async (server: FastifyZodProvider) => {
   });
 
   await server.register(fastifySession, {
-    secret: appCfg.COOKIE_SECRET_SIGN_KEY,
+    secret: getCookieSigningKey(),
     store: redisStore,
     cookie: {
       secure: appCfg.HTTPS_ENABLED,

--- a/backend/src/server/routes/v1/sso-router.ts
+++ b/backend/src/server/routes/v1/sso-router.ts
@@ -18,7 +18,6 @@ import { z } from "zod";
 
 import { INFISICAL_PROVIDER_GITHUB_ACCESS_TOKEN } from "@app/lib/config/const";
 import { getConfig } from "@app/lib/config/env";
-import { getCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { logger } from "@app/lib/logger";
 import { ms } from "@app/lib/ms";
@@ -426,7 +425,7 @@ export const registerSsoRouter = async (server: FastifyZodProvider) => {
   });
 
   await server.register(fastifySession, {
-    secret: getCookieSigningKey(),
+    secret: server.cookieSigningKey,
     store: redisStore,
     cookie: {
       secure: appCfg.HTTPS_ENABLED,

--- a/backend/src/services/kms/kms-service.test.ts
+++ b/backend/src/services/kms/kms-service.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { kmsServiceFactory } from "./kms-service";
+
+describe("kmsService.getCookieSigningKey", () => {
+  const buildUnstartedService = () => kmsServiceFactory({} as unknown as Parameters<typeof kmsServiceFactory>[0]);
+
+  it("refuses to hand out a key before the root key is loaded", () => {
+    expect(() => buildUnstartedService().getCookieSigningKey()).toThrowError(/KMS root key is not loaded/);
+  });
+});

--- a/backend/src/services/kms/kms-service.ts
+++ b/backend/src/services/kms/kms-service.ts
@@ -18,6 +18,7 @@ import { withCache } from "@app/lib/cache/with-cache";
 import { getOriginalConfig, TEnvConfig } from "@app/lib/config/env";
 import { generateSecretValueBlindIndexFromKmsKey } from "@app/lib/crypto/blind-index";
 import { symmetricCipherService, SymmetricKeyAlgorithm } from "@app/lib/crypto/cipher";
+import { deriveCookieSigningKey } from "@app/lib/crypto/cookie-signing-key";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { HmacAlgorithm, hmacService } from "@app/lib/crypto/hmac";
 import { setLegacyKeyMaterial, TLegacyKeyMaterial, TLegacyKeySnapshot } from "@app/lib/crypto/legacy-key";
@@ -1796,6 +1797,13 @@ export const kmsServiceFactory = ({
     await $ensureKekHistory();
   };
 
+  const getCookieSigningKey = () => {
+    if (!ROOT_ENCRYPTION_KEY.length) {
+      throw new InternalServerError({ message: "KMS root key is not loaded" });
+    }
+    return deriveCookieSigningKey(ROOT_ENCRYPTION_KEY);
+  };
+
   /** How a rotation stages a key the instance is not running with yet. */
   const encryptRootKeyForKek = (kekBuffer: Buffer) => {
     if (!ROOT_ENCRYPTION_KEY.length) {
@@ -1892,6 +1900,7 @@ export const kmsServiceFactory = ({
 
   return {
     startService,
+    getCookieSigningKey,
     encryptRootKeyForKek,
     getCurrentKekLabel,
     generateKmsKey,

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -26,8 +26,9 @@ Used to configure platform-specific security and operational settings.
 </ParamField>
 
 <ParamField query="COOKIE_SECRET_SIGN_KEY" type="string" default="generated per instance">
-  Signs the session cookies used by the SAML, OIDC, and LDAP login flows. Left unset, each
-  instance derives its own key at startup, so no two deployments share one. Set it to a random
+  Signs the session cookies used by the OAuth SSO, SAML, OIDC, and LDAP login flows. Left unset,
+  Infisical derives a deterministic key from the KMS root key persisted for the deployment. All
+  replicas for that deployment use the same key. Set it to a random
   32-byte base64 string, generated with `openssl rand -base64 32`, to manage the key yourself.
   Changing the value ends every login already in progress.
 </ParamField>

--- a/docs/self-hosting/configuration/envars.mdx
+++ b/docs/self-hosting/configuration/envars.mdx
@@ -25,6 +25,13 @@ Used to configure platform-specific security and operational settings.
   -base64 32`.
 </ParamField>
 
+<ParamField query="COOKIE_SECRET_SIGN_KEY" type="string" default="generated per instance">
+  Signs the session cookies used by the SAML, OIDC, and LDAP login flows. Left unset, each
+  instance derives its own key at startup, so no two deployments share one. Set it to a random
+  32-byte base64 string, generated with `openssl rand -base64 32`, to manage the key yourself.
+  Changing the value ends every login already in progress.
+</ParamField>
+
 <ParamField query="SITE_URL" type="string" default="none" required>
   Must be an absolute URL including the protocol (e.g.
   https://app.infisical.com).


### PR DESCRIPTION
## Context

Self-hosted installs that never set `COOKIE_SECRET_SIGN_KEY` all used the same hardcoded default from `env.ts`. That meant session cookies for SAML, OIDC, and LDAP flows could be signed with a predictable, shared secret across deployments.

This change removes that default and derives a per-instance cookie signing key from the KMS root key (HKDF, context `infisical-cookie-signing-key-v1`) after `kmsService.startService()` runs. The key is stable across restarts, replicas, and KEK rotations, and does not require a second secret at rest. Operators can still set `COOKIE_SECRET_SIGN_KEY` explicitly (`openssl rand -base64 32`); when set, it takes precedence over the derived key.

`@fastify/cookie` registration moves from `app.ts` to `routes/index.ts` so signing happens only after the KMS root key is loaded. All SSO session routers (SAML, OIDC, LDAP, SSO, identity LDAP) read the key via `getCookieSigningKey()` instead of config directly.

**Note:** Upgrades on instances that relied on the old default will get a new signing key and invalidate in-flight SSO/login sessions. Instances that already set `COOKIE_SECRET_SIGN_KEY` are unaffected.

## Steps to verify the change

1. Start a fresh self-hosted instance **without** `COOKIE_SECRET_SIGN_KEY` and confirm the backend boots and `@fastify/cookie` registers after KMS init.
2. Complete an SSO flow (SAML, OIDC, or LDAP) and confirm session cookies are set and subsequent authenticated requests succeed.
3. Restart the backend and repeat the SSO flow; confirm existing sessions remain valid (derived key is stable).
4. Set `COOKIE_SECRET_SIGN_KEY` to an explicit 32+ byte value, restart, and confirm SSO still works with the env-provided key.
5. Confirm `docs/self-hosting/configuration/envars.mdx` documents the optional env var and per-instance default behavior.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)