### PR TITLE
fix(group-service): block sub-org membership changes on parent-owned groups

### DIFF
--- a/backend/src/ee/services/group/group-membership-ownership-boundary.test.ts
+++ b/backend/src/ee/services/group/group-membership-ownership-boundary.test.ts
@@ -20,7 +20,7 @@ const GROUP_SLUG = "the-group";
 const USERNAME = "someone@example.com";
 const IDENTITY_ID = "identity-id";
 
-const OWNERSHIP_MESSAGE = /owned by a parent organization/;
+const OWNERSHIP_MESSAGE = "owned by a parent organization";
 
 const admin = createMongoAbility<MongoAbility>(orgAdminPermissions);
 
@@ -95,7 +95,7 @@ const createService = ({ groupOrgId }: { groupOrgId: string }) => {
 // does not stand up, so they assert only that ownership is not what stopped them.
 const expectNotBlockedByOwnership = async (fn: () => Promise<unknown>) => {
   await fn().catch((err: unknown) => {
-    expect((err as Error).message).not.toMatch(OWNERSHIP_MESSAGE);
+    expect((err as Error).message).not.toContain(OWNERSHIP_MESSAGE);
   });
 };
 
@@ -128,7 +128,7 @@ describe("group membership ownership boundary", () => {
         () => null,
         (e: unknown) => e
       );
-      expect((err as Error | null)?.message).toMatch(OWNERSHIP_MESSAGE);
+      expect((err as Error | null)?.message).toContain(OWNERSHIP_MESSAGE);
 
       expect(svc.userGroupMembershipDAL.insertMany).not.toHaveBeenCalled();
       expect(svc.userGroupMembershipDAL.delete).not.toHaveBeenCalled();
@@ -148,7 +148,7 @@ describe("group membership ownership boundary", () => {
     test("names the group so the caller can tell which one it was", async () => {
       const svc = createService({ groupOrgId: PARENT_ORG_ID });
 
-      await expect(pick(svc)()).rejects.toThrow(new RegExp(GROUP_SLUG));
+      await expect(pick(svc)()).rejects.toThrow(GROUP_SLUG);
     });
 
     test("does not leak the owning organization's id", async () => {
@@ -158,7 +158,7 @@ describe("group membership ownership boundary", () => {
         () => null,
         (e: unknown) => e
       );
-      expect((err as Error | null)?.message).toMatch(OWNERSHIP_MESSAGE);
+      expect((err as Error | null)?.message).toContain(OWNERSHIP_MESSAGE);
       expect((err as Error).message).not.toContain(PARENT_ORG_ID);
     });
   });

--- a/backend/src/ee/services/group/group-membership-ownership-boundary.test.ts
+++ b/backend/src/ee/services/group/group-membership-ownership-boundary.test.ts
@@ -1,0 +1,192 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
+import { vi } from "vitest";
+
+import { OrgMembershipRole } from "@app/db/schemas";
+import { orgAdminPermissions } from "@app/ee/services/permission/org-permission";
+import { ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+
+import { groupServiceFactory } from "./group-service";
+
+// A group belongs to exactly one org. Linking it into a sub-org lends the sub-org the
+// right to use the group, never the right to change who is in it, so every membership
+// mutator has to compare groups.orgId against the actor's org. membershipGroupDAL
+// filters on Membership.scopeOrgId and returns the group's real orgId untouched, which
+// is what makes a linked group reachable here with a foreign orgId on it.
+
+const ORG_ID = "org-id";
+const PARENT_ORG_ID = "parent-org-id";
+const GROUP_ID = "group-id";
+const GROUP_SLUG = "the-group";
+const USERNAME = "someone@example.com";
+const IDENTITY_ID = "identity-id";
+
+const OWNERSHIP_MESSAGE = /owned by a parent organization/;
+
+const admin = createMongoAbility<MongoAbility>(orgAdminPermissions);
+
+const createService = ({ groupOrgId }: { groupOrgId: string }) => {
+  const userGroupMembershipDAL = {
+    find: vi.fn().mockResolvedValue([]),
+    filterProjectsByUserMembership: vi.fn().mockResolvedValue([]),
+    insertMany: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue([])
+  };
+  const identityGroupMembershipDAL = {
+    find: vi.fn().mockResolvedValue([]),
+    insertMany: vi.fn().mockResolvedValue([]),
+    delete: vi.fn().mockResolvedValue([])
+  };
+  const userDAL = { findOne: vi.fn().mockResolvedValue({ id: "user-id", username: USERNAME }) };
+  const membershipDAL = { findOne: vi.fn().mockResolvedValue({ id: "identity-membership-id" }) };
+
+  const service = groupServiceFactory({
+    permissionService: {
+      getOrgPermission: vi.fn().mockResolvedValue({ permission: admin }),
+      getOrgPermissionByRoles: vi.fn().mockResolvedValue([{ permission: admin }])
+    } as never,
+    licenseService: { getPlan: vi.fn().mockResolvedValue({ groups: true }) } as never,
+    orgDAL: {
+      findById: vi.fn().mockResolvedValue({ id: ORG_ID, shouldUseNewPrivilegeSystem: false }),
+      findMembership: vi.fn().mockResolvedValue([])
+    } as never,
+    groupDAL: {
+      transaction: vi.fn().mockImplementation(async (cb: (tx: unknown) => unknown) => cb({}))
+    } as never,
+    membershipGroupDAL: {
+      getGroupById: vi.fn().mockResolvedValue({
+        id: "group-membership-id",
+        group: { id: GROUP_ID, orgId: groupOrgId, slug: GROUP_SLUG, name: GROUP_SLUG },
+        roles: [{ role: OrgMembershipRole.Member }]
+      }),
+      transaction: vi.fn().mockImplementation(async (cb: (tx: unknown) => unknown) => cb({}))
+    } as never,
+    membershipRoleDAL: { create: vi.fn(), delete: vi.fn() } as never,
+    oidcConfigDAL: { findOne: vi.fn().mockResolvedValue(undefined) } as never,
+    userDAL: userDAL as never,
+    userGroupMembershipDAL: userGroupMembershipDAL as never,
+    identityGroupMembershipDAL: identityGroupMembershipDAL as never,
+    identityDAL: { find: vi.fn().mockResolvedValue([]) } as never,
+    membershipDAL: membershipDAL as never,
+    identityAccessTokenService: { bumpIdentityRevocationVersion: vi.fn() } as never,
+    usageMeteringService: { emit: vi.fn() } as never,
+    projectDAL: { find: vi.fn().mockResolvedValue([]) } as never,
+    projectKeyDAL: { find: vi.fn().mockResolvedValue([]), delete: vi.fn() } as never,
+    projectBotDAL: { findOne: vi.fn().mockResolvedValue(undefined) } as never,
+    additionalPrivilegeDAL: { delete: vi.fn() } as never,
+    alertChannelRecipientDAL: { delete: vi.fn() } as never
+  } as never);
+
+  const actor = { actor: "user", actorId: "actor-id", actorAuthMethod: "email", actorOrgId: ORG_ID };
+
+  return {
+    addUser: () => service.addUserToGroup({ id: GROUP_ID, username: USERNAME, ...actor } as never),
+    removeUser: () => service.removeUserFromGroup({ id: GROUP_ID, username: USERNAME, ...actor } as never),
+    addIdentity: () => service.addMachineIdentityToGroup({ id: GROUP_ID, identityId: IDENTITY_ID, ...actor } as never),
+    removeIdentity: () =>
+      service.removeMachineIdentityFromGroup({ id: GROUP_ID, identityId: IDENTITY_ID, ...actor } as never),
+    userDAL,
+    membershipDAL,
+    userGroupMembershipDAL,
+    identityGroupMembershipDAL
+  };
+};
+
+// The locally owned cases run on past the ownership check into teardown this harness
+// does not stand up, so they assert only that ownership is not what stopped them.
+const expectNotBlockedByOwnership = async (fn: () => Promise<unknown>) => {
+  await fn().catch((err: unknown) => {
+    expect((err as Error).message).not.toMatch(OWNERSHIP_MESSAGE);
+  });
+};
+
+describe("group membership ownership boundary", () => {
+  describe.each([
+    ["addUserToGroup", (s: ReturnType<typeof createService>) => s.addUser],
+    ["removeUserFromGroup", (s: ReturnType<typeof createService>) => s.removeUser],
+    ["addMachineIdentityToGroup", (s: ReturnType<typeof createService>) => s.addIdentity],
+    ["removeMachineIdentityFromGroup", (s: ReturnType<typeof createService>) => s.removeIdentity]
+  ])("%s", (_name, pick) => {
+    test("refuses a group owned by another organization", async () => {
+      const svc = createService({ groupOrgId: PARENT_ORG_ID });
+
+      await expect(pick(svc)()).rejects.toThrow(ForbiddenRequestError);
+      await expect(pick(svc)()).rejects.toThrow(OWNERSHIP_MESSAGE);
+    });
+
+    test("allows a group the actor's own organization owns", async () => {
+      const svc = createService({ groupOrgId: ORG_ID });
+
+      await expectNotBlockedByOwnership(pick(svc));
+    });
+
+    test("writes nothing when it refuses", async () => {
+      const svc = createService({ groupOrgId: PARENT_ORG_ID });
+
+      // Assert the refusal came from ownership first. Without it the DAL
+      // expectations below hold for any early failure and prove nothing.
+      const err = await pick(svc)().then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect((err as Error | null)?.message).toMatch(OWNERSHIP_MESSAGE);
+
+      expect(svc.userGroupMembershipDAL.insertMany).not.toHaveBeenCalled();
+      expect(svc.userGroupMembershipDAL.delete).not.toHaveBeenCalled();
+      expect(svc.identityGroupMembershipDAL.insertMany).not.toHaveBeenCalled();
+      expect(svc.identityGroupMembershipDAL.delete).not.toHaveBeenCalled();
+    });
+
+    test("refuses before it resolves the subject, so ownership is checked first", async () => {
+      const svc = createService({ groupOrgId: PARENT_ORG_ID });
+
+      await pick(svc)().catch(() => undefined);
+
+      expect(svc.userDAL.findOne).not.toHaveBeenCalled();
+      expect(svc.membershipDAL.findOne).not.toHaveBeenCalled();
+    });
+
+    test("names the group so the caller can tell which one it was", async () => {
+      const svc = createService({ groupOrgId: PARENT_ORG_ID });
+
+      await expect(pick(svc)()).rejects.toThrow(new RegExp(GROUP_SLUG));
+    });
+
+    test("does not leak the owning organization's id", async () => {
+      const svc = createService({ groupOrgId: PARENT_ORG_ID });
+
+      const err = await pick(svc)().then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect((err as Error | null)?.message).toMatch(OWNERSHIP_MESSAGE);
+      expect((err as Error).message).not.toContain(PARENT_ORG_ID);
+    });
+  });
+
+  // A group with no membership row in the actor's org must stay a 404: the ownership
+  // check only ever runs on groups the caller can already legitimately see, so it
+  // cannot be used to confirm that group ids exist in an org the caller cannot reach.
+  test("a group the actor's org has no membership row for is still not found", async () => {
+    const service = groupServiceFactory({
+      permissionService: {
+        getOrgPermission: vi.fn().mockResolvedValue({ permission: admin })
+      } as never,
+      membershipGroupDAL: { getGroupById: vi.fn().mockResolvedValue(undefined) } as never
+    } as never);
+
+    const actor = { actor: "user", actorId: "actor-id", actorAuthMethod: "email", actorOrgId: ORG_ID };
+
+    await expect(service.addUserToGroup({ id: GROUP_ID, username: USERNAME, ...actor } as never)).rejects.toThrow(
+      NotFoundError
+    );
+    await expect(service.removeUserFromGroup({ id: GROUP_ID, username: USERNAME, ...actor } as never)).rejects.toThrow(
+      NotFoundError
+    );
+    await expect(
+      service.addMachineIdentityToGroup({ id: GROUP_ID, identityId: IDENTITY_ID, ...actor } as never)
+    ).rejects.toThrow(NotFoundError);
+    await expect(
+      service.removeMachineIdentityFromGroup({ id: GROUP_ID, identityId: IDENTITY_ID, ...actor } as never)
+    ).rejects.toThrow(NotFoundError);
+  });
+});

--- a/backend/src/ee/services/group/group-service.ts
+++ b/backend/src/ee/services/group/group-service.ts
@@ -15,6 +15,7 @@ import { DatabaseErrorCode } from "@app/lib/error-codes";
 import {
   BadRequestError,
   DatabaseError,
+  ForbiddenRequestError,
   NotFoundError,
   PermissionBoundaryError,
   UnauthorizedError
@@ -1043,8 +1044,14 @@ export const groupServiceFactory = ({
         message: `Failed to find group with ID ${id}`
       });
 
+    if (groupMembership.group.orgId !== actorOrgId) {
+      throw new ForbiddenRequestError({
+        message: `Group '${groupMembership.group.slug}' is owned by a parent organization. Its members must be managed from that organization.`
+      });
+    }
+
     const oidcConfig = await oidcConfigDAL.findOne({
-      orgId: actorOrgId,
+      orgId: groupMembership.group.orgId,
       isActive: true
     });
 
@@ -1152,6 +1159,12 @@ export const groupServiceFactory = ({
         message: `Failed to find group with ID ${id}`
       });
 
+    if (groupMembership.group.orgId !== actorOrgId) {
+      throw new ForbiddenRequestError({
+        message: `Group '${groupMembership.group.slug}' is owned by a parent organization. Its members must be managed from that organization.`
+      });
+    }
+
     const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
     const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId, {
       ignoreUnresolvedRoles: true
@@ -1233,6 +1246,12 @@ export const groupServiceFactory = ({
       throw new NotFoundError({
         message: `Failed to find group with ID ${id}`
       });
+
+    if (groupMembership.group.orgId !== actorOrgId) {
+      throw new ForbiddenRequestError({
+        message: `Group '${groupMembership.group.slug}' is owned by a parent organization. Its members must be managed from that organization.`
+      });
+    }
 
     const oidcConfig = await oidcConfigDAL.findOne({
       orgId: groupMembership.group.orgId,
@@ -1321,6 +1340,12 @@ export const groupServiceFactory = ({
       throw new NotFoundError({
         message: `Failed to find group with ID ${id}`
       });
+
+    if (groupMembership.group.orgId !== actorOrgId) {
+      throw new ForbiddenRequestError({
+        message: `Group '${groupMembership.group.slug}' is owned by a parent organization. Its members must be managed from that organization.`
+      });
+    }
 
     const groupRoles = resolveMembershipRoleSlugs(groupMembership.roles);
     const rolePermissionDetails = await permissionService.getOrgPermissionByRoles(groupRoles, actorOrgId, {

--- a/frontend/src/hooks/api/groups/queries.tsx
+++ b/frontend/src/hooks/api/groups/queries.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
+import { useOrganization } from "@app/context";
 
 import { OrderByDirection } from "../generic/types";
 import {
@@ -18,6 +19,8 @@ import {
 
 export const groupKeys = {
   getGroupById: (groupId: string) => [{ groupId }, "group"] as const,
+  getGroupByIdForOrg: (orgId: string, groupId: string) =>
+    [...groupKeys.getGroupById(groupId), orgId] as const,
   allGroupUserMemberships: () => ["group-user-memberships"] as const,
   forGroupUserMemberships: (slug: string) =>
     [...groupKeys.allGroupUserMemberships(), slug] as const,
@@ -77,6 +80,7 @@ export const groupKeys = {
   allGroupProjects: () => ["group-projects"] as const,
   forGroupProjects: (groupId: string) => [...groupKeys.allGroupProjects(), groupId] as const,
   specificGroupProjects: ({
+    orgId,
     groupId,
     offset,
     limit,
@@ -85,6 +89,7 @@ export const groupKeys = {
     orderBy,
     orderDirection
   }: {
+    orgId: string;
     groupId: string;
     offset: number;
     limit: number;
@@ -95,14 +100,18 @@ export const groupKeys = {
   }) =>
     [
       ...groupKeys.forGroupProjects(groupId),
+      orgId,
       { offset, limit, search, filter, orderBy, orderDirection }
     ] as const
 };
 
 export const useGetGroupById = (groupId: string) => {
+  const { currentOrg } = useOrganization();
+  const orgId = currentOrg?.id || "";
+
   return useQuery({
     enabled: Boolean(groupId),
-    queryKey: groupKeys.getGroupById(groupId),
+    queryKey: groupKeys.getGroupByIdForOrg(orgId, groupId),
     queryFn: async () => {
       const { data } = await apiRequest.get<TGroup>(`/api/v1/groups/${groupId}`);
 
@@ -276,8 +285,12 @@ export const useListGroupProjects = ({
   orderDirection?: OrderByDirection;
   filter?: FilterReturnedProjects;
 }) => {
+  const { currentOrg } = useOrganization();
+  const orgId = currentOrg?.id || "";
+
   return useQuery({
     queryKey: groupKeys.specificGroupProjects({
+      orgId,
       groupId: id,
       offset,
       limit,

--- a/frontend/src/hooks/api/identities/queries.tsx
+++ b/frontend/src/hooks/api/identities/queries.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { apiRequest } from "@app/config/request";
+import { useOrganization } from "@app/context";
 import { TReactQueryOptions } from "@app/types/reactQuery";
 
 import {
@@ -58,7 +59,11 @@ export const identitiesKeys = {
   getIdentityTokensTokenAuth: (identityId: string) =>
     [{ identityId }, "identity-tokens-token-auth"] as const,
   getIdentityProjectMemberships: (identityId: string) =>
-    [{ identityId }, "identity-project-memberships"] as const
+    [{ identityId }, "identity-project-memberships"] as const,
+  // The membership list is filtered to the viewing org (Membership.scopeOrgId),
+  // so a sub-org and its parent must not share this cache entry.
+  getIdentityProjectMembershipsForOrg: (orgId: string, identityId: string) =>
+    [...identitiesKeys.getIdentityProjectMemberships(identityId), orgId] as const
 };
 
 export const useGetOrgIdentityMembershipById = (identityId: string) => {
@@ -114,9 +119,12 @@ export const useCountOrgIdentityMemberships = (dto: TCountIdentitiesDTO) => {
 };
 
 export const useGetIdentityProjectMemberships = (identityId: string) => {
+  const { currentOrg } = useOrganization();
+  const orgId = currentOrg?.id || "";
+
   return useQuery({
     enabled: Boolean(identityId),
-    queryKey: identitiesKeys.getIdentityProjectMemberships(identityId),
+    queryKey: identitiesKeys.getIdentityProjectMembershipsForOrg(orgId, identityId),
     queryFn: async () => {
       const {
         data: { identityMemberships }


### PR DESCRIPTION
## Context

In sub-organization setups, parent-org groups can appear in a sub-org (linked/inherited groups). Sub-org admins with group edit permission could add or remove users and machine identities on those groups even though the group is owned by the parent organization.

This change adds an ownership check in `addUserToGroup`, `removeUserFromGroup`, `addMachineIdentityToGroup`, and `removeMachineIdentityFromGroup`. When `group.orgId !== actorOrgId`, the API returns `403 ForbiddenRequestError` with a message directing the caller to manage members from the parent org. `addUserToGroup` also resolves OIDC config from the group's owning org (`groupMembership.group.orgId`) instead of the actor's org, matching the remove path.

## Steps to verify the change

1. Set up a root org with at least one sub-org and a group owned by the root org that is visible/linked in the sub-org.
2. Authenticate as a sub-org admin with group edit permission.
3. Attempt to add a user: `POST /api/v1/groups/{parentGroupId}/users/{username}` — expect `403` and message referencing parent organization ownership.
4. Repeat for remove user (`DELETE /api/v1/groups/{parentGroupId}/users/{username}`), add machine identity (`POST /api/v1/groups/{parentGroupId}/machine-identities/{identityId}`), and remove machine identity (`DELETE /api/v1/groups/{parentGroupId}/machine-identities/{identityId}`).
5. From the parent org, confirm the same operations still succeed on the group.
6. From the sub-org, confirm add/remove still works on groups owned by the sub-org itself.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)