### PR TITLE
feat(pam): restore Oracle Database account support

### DIFF
--- a/backend/src/ee/services/gateway-v2/gateway-v2-fns.ts
+++ b/backend/src/ee/services/gateway-v2/gateway-v2-fns.ts
@@ -1,5 +1,7 @@
+import { BadRequestError } from "@app/lib/errors";
 import { GatewayProxyProtocol } from "@app/lib/gateway";
 import { withGatewayV2Proxy } from "@app/lib/gateway-v2/gateway-v2";
+import { callSqlRotateCredential, TSqlRpcResponse } from "@app/lib/gateway-v2/sql-rpc";
 import { callTestConnection, TestConnectionResponse } from "@app/lib/gateway-v2/test-connection-rpc";
 
 import { verifyHostInputValidity } from "../dynamic-secret/dynamic-secret-fns";
@@ -37,4 +39,29 @@ export const testConnectionWithGateway = async (
   } catch {
     return null;
   }
+};
+
+export const rotateSqlCredentialWithGateway = async (
+  targetHost: string,
+  targetPort: number,
+  gatewayId: string,
+  gatewayV2Service: TGatewayDep,
+  request: Record<string, unknown>,
+  timeoutMs: number
+): Promise<TSqlRpcResponse> => {
+  const [host] = await verifyHostInputValidity({ host: targetHost, isGateway: true, isDynamicSecret: false });
+
+  const platform = await gatewayV2Service.getPlatformConnectionDetailsByGatewayId({
+    gatewayId,
+    targetHost: host,
+    targetPort
+  });
+  if (!platform) {
+    throw new BadRequestError({ message: "Unable to reach the gateway for this account" });
+  }
+
+  return withGatewayV2Proxy((proxyPort) => callSqlRotateCredential({ port: proxyPort, body: request, timeoutMs }), {
+    protocol: GatewayProxyProtocol.Sql,
+    ...platform
+  });
 };

--- a/backend/src/ee/services/pam-account-heartbeat/pam-account-heartbeat-service.test.ts
+++ b/backend/src/ee/services/pam-account-heartbeat/pam-account-heartbeat-service.test.ts
@@ -53,6 +53,7 @@ const buildService = (
     [PamAccountType.Postgres]: handler,
     [PamAccountType.MySQL]: handler,
     [PamAccountType.MsSQL]: handler,
+    [PamAccountType.OracleDB]: handler,
     [PamAccountType.Windows]: handler,
     [PamAccountType.WindowsAd]: handler
   } as typeof PAM_ROTATION_FACTORY_MAP;

--- a/backend/src/ee/services/pam-account-heartbeat/pam-account-heartbeat-service.ts
+++ b/backend/src/ee/services/pam-account-heartbeat/pam-account-heartbeat-service.ts
@@ -17,6 +17,8 @@ import { checkAccountAccess, TActorContext } from "../pam/pam-permission";
 import {
   buildGatewayConnectionTest,
   CLOUD_CONNECTION_VALIDATORS,
+  exceedsOraclePasswordLimit,
+  ORACLE_MAX_PASSWORD_LENGTH,
   TestConnectionMode
 } from "../pam-account/pam-account-connection-test";
 import { TPamAccountDALFactory, TPamAccountDetail } from "../pam-account/pam-account-dal";
@@ -215,8 +217,15 @@ export const pamAccountHeartbeatServiceFactory = ({
     const probeCredentials =
       accountType === PamAccountType.SSH ? await mintEphemeralSshCertificate(account, credentials) : credentials;
 
+    if (exceedsOraclePasswordLimit(accountType, credentials)) {
+      return {
+        status: PamHeartbeatStatus.CannotCheck,
+        message: `This account's password is longer than ${ORACLE_MAX_PASSWORD_LENGTH} characters, so this credential was not checked`
+      };
+    }
+
     const test = await buildGatewayConnectionTest(accountType, connectionDetails, probeCredentials, orgId, {
-      allowWindowsAuthSql: true
+      allowNewerGatewayTests: true
     });
     if (!test) {
       return { status: PamHeartbeatStatus.Unknown, message: "This account type cannot be checked yet" };

--- a/backend/src/ee/services/pam-account-heartbeat/pam-account-heartbeat-service.ts
+++ b/backend/src/ee/services/pam-account-heartbeat/pam-account-heartbeat-service.ts
@@ -35,6 +35,8 @@ import {
   classifyCloudProbeError,
   computeNextHeartbeatAt,
   describeFailure,
+  GATEWAY_MISSING_CHECK_NOTE,
+  gatewayIsMissingCheckSupport,
   HEARTBEAT_SSH_CERT_TTL_SECONDS,
   HEARTBEAT_TIMEOUT_MS,
   isHeartbeatScheduled,
@@ -263,6 +265,9 @@ export const pamAccountHeartbeatServiceFactory = ({
       return { status: PamHeartbeatStatus.CannotCheck, message: "The gateway could not be reached" };
     }
     if (!result.ok) {
+      if (gatewayIsMissingCheckSupport(result.errorMessage)) {
+        return { status: PamHeartbeatStatus.CannotCheck, message: GATEWAY_MISSING_CHECK_NOTE };
+      }
       return {
         status: statusForFailureKind(result.kind),
         message: describeFailure(result.kind, result.errorMessage)

--- a/backend/src/ee/services/pam-account-heartbeat/pam-heartbeat-fns.test.ts
+++ b/backend/src/ee/services/pam-account-heartbeat/pam-heartbeat-fns.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   classifyCloudProbeError,
   describeFailure,
+  gatewayIsMissingCheckSupport,
   isHeartbeatScheduled,
   pausesHeartbeatForRoutingChange,
   UNCLASSIFIED_FAILURE_NOTE
@@ -93,5 +94,17 @@ describe("pausesHeartbeatForRoutingChange", () => {
 
   test("leaves the schedule alone when nothing about the routing changed", () => {
     expect(pausesHeartbeatForRoutingChange({ ...base, routingChanged: false })).toBe(false);
+  });
+});
+
+describe("gatewayIsMissingCheckSupport", () => {
+  test("recognises a gateway that has never heard of the account type's dialect", () => {
+    expect(gatewayIsMissingCheckSupport('unsupported SQL dialect: "oracle"')).toBe(true);
+    expect(gatewayIsMissingCheckSupport('unsupported test-connection mode: "sql"')).toBe(true);
+  });
+
+  test("leaves a real answer from the target alone", () => {
+    expect(gatewayIsMissingCheckSupport("ORA-01017: invalid username/password; logon denied")).toBe(false);
+    expect(gatewayIsMissingCheckSupport(undefined)).toBe(false);
   });
 });

--- a/backend/src/ee/services/pam-account-heartbeat/pam-heartbeat-fns.ts
+++ b/backend/src/ee/services/pam-account-heartbeat/pam-heartbeat-fns.ts
@@ -1,6 +1,9 @@
+import RE2 from "re2";
+
 import { GatewayFailureKind } from "@app/lib/gateway-v2/test-connection-rpc";
 
 import { PamHeartbeatStatus } from "../pam/pam-enums";
+import { ORACLE_MIN_GATEWAY_VERSION } from "../pam-account/pam-account-schemas";
 import { TPamHeartbeatConfig } from "../pam-account-template/pam-account-template-schemas";
 
 export const HEARTBEAT_TIMEOUT_MS = 15_000;
@@ -60,6 +63,13 @@ export const statusForFailureKind = (kind: GatewayFailureKind | null): PamHeartb
 // rather than an answer from the target.
 export const UNCLASSIFIED_FAILURE_NOTE =
   "This gateway is too old to tell a rejected credential from an unreachable target. Update the gateway for an accurate result.";
+
+const GATEWAY_MISSING_CHECK_PATTERN = new RE2("unsupported (SQL dialect|test-connection mode)", "i");
+
+export const GATEWAY_MISSING_CHECK_NOTE = `This account's gateway does not support checking this account type. Update the gateway to ${ORACLE_MIN_GATEWAY_VERSION} or later.`;
+
+export const gatewayIsMissingCheckSupport = (message?: string): boolean =>
+  Boolean(message && GATEWAY_MISSING_CHECK_PATTERN.test(message));
 
 export const describeFailure = (kind: GatewayFailureKind | null, message?: string): string | undefined => {
   if (kind !== null) return message;

--- a/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.test.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.test.ts
@@ -383,7 +383,7 @@ describe("rotateScheduledAccount recovery probe", () => {
     expect(newPassword.length).toBe(48);
   });
 
-  const buildOracleDelegatedPair = (rotatorService: string) => {
+  const buildOracleDelegatedPair = (rotatorService: string, rotatorHost = "oracle.internal") => {
     const account = {
       ...buildAccount(),
       accountType: PamAccountType.OracleDB,
@@ -402,7 +402,7 @@ describe("rotateScheduledAccount recovery probe", () => {
       accountType: PamAccountType.OracleDB,
       encryptedCredentials: blobOf({ username: "rotuser", password: "rot-pw" }),
       encryptedConnectionDetails: blobOf({
-        host: "oracle.internal",
+        host: rotatorHost,
         port: 1521,
         database: rotatorService,
         sslEnabled: false,
@@ -434,6 +434,15 @@ describe("rotateScheduledAccount recovery probe", () => {
     const result = await service.rotateScheduledAccount("acc-1");
 
     expect(result?.message ?? "").not.toContain("service name");
+  });
+
+  test("treats a host that differs only in case as the same resource", async () => {
+    const { account, rotator } = buildOracleDelegatedPair("PDB1", "ORACLE.INTERNAL");
+    const { service } = buildService((pw) => pw === CURRENT_PASSWORD, { account, rotator });
+
+    const result = await service.rotateScheduledAccount("acc-1");
+
+    expect(result?.message ?? "").not.toContain("same resource");
   });
 
   test("allows an Oracle delegated rotation within the same service name", async () => {

--- a/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.test.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.test.ts
@@ -328,7 +328,7 @@ describe("rotateScheduledAccount recovery probe", () => {
     expect(newPassword.length).toBe(30);
   });
 
-  test("caps an Oracle password whose required minimums sum above the ceiling", async () => {
+  test("refuses to rotate when the template's minimums cannot fit Oracle's ceiling", async () => {
     const account = {
       ...buildAccount(),
       accountType: PamAccountType.OracleDB,
@@ -343,13 +343,13 @@ describe("rotateScheduledAccount recovery probe", () => {
     };
     const { service, applyPasswordChange } = buildService((pw) => pw === CURRENT_PASSWORD, { account });
 
-    await service.rotateScheduledAccount("acc-1");
+    const result = await service.rotateScheduledAccount("acc-1");
 
-    const { newPassword } = applyPasswordChange.mock.calls[0][0] as { newPassword: string };
-    expect(newPassword.length).toBe(30);
+    expect(result?.rotationStatus).toBe(ROTATION_STATUS.Failed);
+    expect(applyPasswordChange).not.toHaveBeenCalled();
   });
 
-  test("keeps every character class the template asked for when it caps", async () => {
+  test("caps only the length when the template's character mix still fits", async () => {
     const account = {
       ...buildAccount(),
       accountType: PamAccountType.OracleDB,
@@ -357,7 +357,7 @@ describe("rotateScheduledAccount recovery probe", () => {
         rotation: { enabled: true, intervalSeconds: 3600 as number | null },
         passwordRequirements: {
           length: 80,
-          required: { lowercase: 20, uppercase: 20, digits: 20, symbols: 20 },
+          required: { lowercase: 5, uppercase: 5, digits: 5, symbols: 5 },
           allowedSymbols: "-_.~!*"
         }
       }

--- a/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.test.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.test.ts
@@ -60,6 +60,7 @@ const buildService = (
     [PamAccountType.Postgres]: handler,
     [PamAccountType.MySQL]: handler,
     [PamAccountType.MsSQL]: handler,
+    [PamAccountType.OracleDB]: handler,
     [PamAccountType.Windows]: handler,
     [PamAccountType.WindowsAd]: handler
   };
@@ -314,5 +315,171 @@ describe("rotateScheduledAccount recovery probe", () => {
     // Nothing may leave: no probe (testCredential) and no apply against the redirected target.
     expect(testCredential).not.toHaveBeenCalled();
     expect(applyPasswordChange).not.toHaveBeenCalled();
+  });
+
+  test("caps the generated Oracle password so the credential stays verifiable", async () => {
+    const account = { ...buildAccount(), accountType: PamAccountType.OracleDB };
+    const { service, applyPasswordChange } = buildService((pw) => pw === CURRENT_PASSWORD, { account });
+
+    await service.rotateScheduledAccount("acc-1");
+
+    expect(applyPasswordChange).toHaveBeenCalled();
+    const { newPassword } = applyPasswordChange.mock.calls[0][0] as { newPassword: string };
+    expect(newPassword.length).toBe(30);
+  });
+
+  test("caps an Oracle password whose required minimums sum above the ceiling", async () => {
+    const account = {
+      ...buildAccount(),
+      accountType: PamAccountType.OracleDB,
+      templateSettings: {
+        rotation: { enabled: true, intervalSeconds: 3600 as number | null },
+        passwordRequirements: {
+          length: 100,
+          required: { lowercase: 0, uppercase: 40, digits: 40, symbols: 20 },
+          allowedSymbols: "-_.~!*"
+        }
+      }
+    };
+    const { service, applyPasswordChange } = buildService((pw) => pw === CURRENT_PASSWORD, { account });
+
+    await service.rotateScheduledAccount("acc-1");
+
+    const { newPassword } = applyPasswordChange.mock.calls[0][0] as { newPassword: string };
+    expect(newPassword.length).toBe(30);
+  });
+
+  test("keeps every character class the template asked for when it caps", async () => {
+    const account = {
+      ...buildAccount(),
+      accountType: PamAccountType.OracleDB,
+      templateSettings: {
+        rotation: { enabled: true, intervalSeconds: 3600 as number | null },
+        passwordRequirements: {
+          length: 80,
+          required: { lowercase: 20, uppercase: 20, digits: 20, symbols: 20 },
+          allowedSymbols: "-_.~!*"
+        }
+      }
+    };
+    const { service, applyPasswordChange } = buildService((pw) => pw === CURRENT_PASSWORD, { account });
+
+    await service.rotateScheduledAccount("acc-1");
+
+    const { newPassword } = applyPasswordChange.mock.calls[0][0] as { newPassword: string };
+    expect(newPassword.length).toBe(30);
+    expect(newPassword).toMatch(/[a-z]/);
+    expect(newPassword).toMatch(/[A-Z]/);
+    expect(newPassword).toMatch(/[0-9]/);
+    expect(newPassword).toMatch(/[-_.~!*]/);
+  });
+
+  test("leaves the generated password length alone for the other SQL dialects", async () => {
+    const { service, applyPasswordChange } = buildService((pw) => pw === CURRENT_PASSWORD);
+
+    await service.rotateScheduledAccount("acc-1");
+
+    const { newPassword } = applyPasswordChange.mock.calls[0][0] as { newPassword: string };
+    expect(newPassword.length).toBe(48);
+  });
+
+  const buildOracleDelegatedPair = (rotatorService: string) => {
+    const account = {
+      ...buildAccount(),
+      accountType: PamAccountType.OracleDB,
+      rotationAccountId: "rot-1",
+      encryptedConnectionDetails: blobOf({
+        host: "oracle.internal",
+        port: 1521,
+        database: "PDB1",
+        sslEnabled: false,
+        sslRejectUnauthorized: false
+      })
+    };
+    const rotator = {
+      id: "rot-1",
+      projectId: "proj-1",
+      accountType: PamAccountType.OracleDB,
+      encryptedCredentials: blobOf({ username: "rotuser", password: "rot-pw" }),
+      encryptedConnectionDetails: blobOf({
+        host: "oracle.internal",
+        port: 1521,
+        database: rotatorService,
+        sslEnabled: false,
+        sslRejectUnauthorized: false
+      }),
+      gatewayId: null,
+      gatewayPoolId: null,
+      templateGatewayId: null,
+      templateGatewayPoolId: null
+    };
+    return { account, rotator };
+  };
+
+  test("aborts an Oracle delegated rotation when the rotator reaches a different service name", async () => {
+    const { account, rotator } = buildOracleDelegatedPair("PDB2");
+    const { service, applyPasswordChange } = buildService(() => true, { account, rotator });
+
+    const result = await service.rotateScheduledAccount("acc-1");
+
+    expect(result?.rotationStatus).toBe(ROTATION_STATUS.Failed);
+    expect(result?.message).toContain("service name");
+    expect(applyPasswordChange).not.toHaveBeenCalled();
+  });
+
+  test("treats a service name that differs only in case as the same resource", async () => {
+    const { account, rotator } = buildOracleDelegatedPair("pdb1");
+    const { service } = buildService((pw) => pw === CURRENT_PASSWORD, { account, rotator });
+
+    const result = await service.rotateScheduledAccount("acc-1");
+
+    expect(result?.message ?? "").not.toContain("service name");
+  });
+
+  test("allows an Oracle delegated rotation within the same service name", async () => {
+    const { account, rotator } = buildOracleDelegatedPair("PDB1");
+    const { service } = buildService(() => true, { account, rotator });
+
+    const result = await service.rotateScheduledAccount("acc-1");
+
+    expect(result?.rotationStatus).not.toBe(ROTATION_STATUS.Failed);
+    expect(result?.message ?? "").not.toContain("same resource");
+  });
+
+  test("keeps Postgres delegated rotation working across different databases on one server", async () => {
+    const account = {
+      ...buildAccount(),
+      rotationAccountId: "rot-1",
+      encryptedConnectionDetails: blobOf({ ...connectionDetails, database: "app" })
+    };
+    const rotator = {
+      id: "rot-1",
+      projectId: "proj-1",
+      accountType: PamAccountType.Postgres,
+      encryptedCredentials: blobOf({ username: "rotuser", password: "rot-pw" }),
+      encryptedConnectionDetails: blobOf({ ...connectionDetails, database: "rotdb" }),
+      gatewayId: null,
+      gatewayPoolId: null,
+      templateGatewayId: null,
+      templateGatewayPoolId: null
+    };
+    const { service } = buildService(() => true, { account, rotator });
+
+    const result = await service.rotateScheduledAccount("acc-1");
+
+    expect(result?.rotationStatus).not.toBe(ROTATION_STATUS.Failed);
+    expect(result?.message ?? "").not.toContain("same resource");
+  });
+});
+
+describe("sqlRotationHandler.validateTarget", () => {
+  test("allows an Oracle account, whose SSL settings are handled by the gateway", () => {
+    const validate = PAM_ROTATION_FACTORY_MAP[PamAccountType.OracleDB].validateTarget;
+    expect(() => validate({ accountType: PamAccountType.OracleDB })).not.toThrow();
+  });
+
+  test("still refuses MSSQL Windows authentication", () => {
+    const validate = PAM_ROTATION_FACTORY_MAP[PamAccountType.MsSQL].validateTarget;
+    expect(() => validate({ accountType: PamAccountType.MsSQL, authMethod: "ntlm" })).toThrow(/SQL Server/);
   });
 });

--- a/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.ts
@@ -163,17 +163,15 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
   ): TGeneratedPasswordRequirements => {
     if (accountType !== PamAccountType.OracleDB) return requirements;
     const effective = requirements ?? DEFAULT_PASSWORD_REQUIREMENTS;
+    if (effective.length <= ORACLE_MAX_PASSWORD_LENGTH) return requirements;
+
     const requiredTotal = Object.values(effective.required).reduce((sum, count) => sum + count, 0);
-    if (effective.length <= ORACLE_MAX_PASSWORD_LENGTH && requiredTotal <= ORACLE_MAX_PASSWORD_LENGTH) {
-      return requirements;
+    if (requiredTotal > ORACLE_MAX_PASSWORD_LENGTH) {
+      throw new BadRequestError({
+        message: `This account's template requires at least ${requiredTotal} characters, which is more than the ${ORACLE_MAX_PASSWORD_LENGTH} an Oracle password allows. Lower the character requirements on the template, then rotate again`
+      });
     }
-    return {
-      ...effective,
-      length: Math.min(effective.length, ORACLE_MAX_PASSWORD_LENGTH),
-      required: Object.fromEntries(
-        Object.entries(effective.required).map(([type, count]) => [type, count > 0 ? 1 : 0])
-      ) as typeof effective.required
-    };
+    return { ...effective, length: ORACLE_MAX_PASSWORD_LENGTH };
   };
 
   const getPasswordRequirements = (templateSettings: unknown) =>

--- a/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.ts
@@ -329,16 +329,15 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
     a: Record<string, unknown>,
     b: Record<string, unknown>
   ): boolean => {
-    if (accountType === PamAccountType.WindowsAd) return a.dcAddress === b.dcAddress && a.domain === b.domain;
-    if (isWindowsRotatableType(accountType)) return a.host === b.host;
+    const sameField = (field: string) =>
+      (a[field] as string | undefined)?.toLowerCase() === (b[field] as string | undefined)?.toLowerCase();
+
+    if (accountType === PamAccountType.WindowsAd) return sameField("dcAddress") && sameField("domain");
+    if (isWindowsRotatableType(accountType)) return sameField("host");
     if (accountType === PamAccountType.OracleDB) {
-      return (
-        a.host === b.host &&
-        a.port === b.port &&
-        (a.database as string | undefined)?.toLowerCase() === (b.database as string | undefined)?.toLowerCase()
-      );
+      return sameField("host") && a.port === b.port && sameField("database");
     }
-    return a.host === b.host && a.port === b.port;
+    return sameField("host") && a.port === b.port;
   };
 
   const assertRotatorSameResource = (
@@ -574,12 +573,12 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
     const targetUsername = targetCredentials.username;
     const handler = rotationHandlers[accountType];
 
+    handler.validateTarget({ accountType, authMethod: targetCredentials.authMethod });
+
     const connectionDetails = resolveConnectionDetails(
       accountType,
       await decrypt(projectId, account.encryptedConnectionDetails)
     );
-
-    handler.validateTarget({ accountType, authMethod: targetCredentials.authMethod });
     const gatewayId = account.gatewayId ?? account.templateGatewayId;
     const gatewayPoolId = account.gatewayPoolId ?? account.templateGatewayPoolId;
     const now = new Date();

--- a/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-account-rotation-service.ts
@@ -5,7 +5,7 @@ import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gatewa
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
 import { ResourcePermissionPamResourceActions } from "@app/ee/services/permission/resource-permission";
-import { generatePassword } from "@app/ee/services/secret-rotation-v2/shared/utils";
+import { DEFAULT_PASSWORD_REQUIREMENTS, generatePassword } from "@app/ee/services/secret-rotation-v2/shared/utils";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { BadRequestError, NotFoundError } from "@app/lib/errors";
 import { WinRmRpcEndpoint } from "@app/lib/gateway-v2/winrm-rpc";
@@ -23,6 +23,7 @@ import {
   TActorContext,
   verifyProductMembership
 } from "../pam/pam-permission";
+import { ORACLE_MAX_PASSWORD_LENGTH } from "../pam-account/pam-account-connection-test";
 import { TPamAccountDALFactory, TPamAccountDetail } from "../pam-account/pam-account-dal";
 import { validateConnectionDetails, validateCredentials } from "../pam-account/pam-account-schemas";
 import { computeNextHeartbeatAt, isHeartbeatScheduled } from "../pam-account-heartbeat/pam-heartbeat-fns";
@@ -56,6 +57,8 @@ import {
   winrmPortFromConn,
   winrmTransportFromConn
 } from "./pam-rotation-handlers";
+
+type TGeneratedPasswordRequirements = Parameters<typeof generatePassword>[0];
 
 export const ROTATION_STATUS = { Success: "success", Failed: "failed" } as const;
 
@@ -153,6 +156,25 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
 
   const getRotationConfig = (templateSettings: unknown) =>
     PamTemplateSettingsSchema.safeParse(templateSettings).data?.rotation;
+
+  const capRequirementsForAccountType = (
+    accountType: PamAccountType,
+    requirements: TGeneratedPasswordRequirements
+  ): TGeneratedPasswordRequirements => {
+    if (accountType !== PamAccountType.OracleDB) return requirements;
+    const effective = requirements ?? DEFAULT_PASSWORD_REQUIREMENTS;
+    const requiredTotal = Object.values(effective.required).reduce((sum, count) => sum + count, 0);
+    if (effective.length <= ORACLE_MAX_PASSWORD_LENGTH && requiredTotal <= ORACLE_MAX_PASSWORD_LENGTH) {
+      return requirements;
+    }
+    return {
+      ...effective,
+      length: Math.min(effective.length, ORACLE_MAX_PASSWORD_LENGTH),
+      required: Object.fromEntries(
+        Object.entries(effective.required).map(([type, count]) => [type, count > 0 ? 1 : 0])
+      ) as typeof effective.required
+    };
+  };
 
   const getPasswordRequirements = (templateSettings: unknown) =>
     PamTemplateSettingsSchema.safeParse(templateSettings).data?.passwordRequirements;
@@ -302,7 +324,8 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
   };
 
   // A delegated rotator must sit on the same resource as its target so its credential can reach it: same
-  // host for SQL / local Windows, same domain controller for Windows AD.
+  // host for SQL / local Windows, same domain controller for Windows AD. Oracle users live in a PDB rather
+  // than the instance, so a rotator reaching a different service name cannot see the target user.
   const isSameResource = (
     accountType: PamAccountType,
     a: Record<string, unknown>,
@@ -310,6 +333,13 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
   ): boolean => {
     if (accountType === PamAccountType.WindowsAd) return a.dcAddress === b.dcAddress && a.domain === b.domain;
     if (isWindowsRotatableType(accountType)) return a.host === b.host;
+    if (accountType === PamAccountType.OracleDB) {
+      return (
+        a.host === b.host &&
+        a.port === b.port &&
+        (a.database as string | undefined)?.toLowerCase() === (b.database as string | undefined)?.toLowerCase()
+      );
+    }
     return a.host === b.host && a.port === b.port;
   };
 
@@ -322,11 +352,13 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
     let detail = "on the same resource (host and port) as";
     if (accountType === PamAccountType.WindowsAd) detail = "in the same domain as";
     else if (isWindowsRotatableType(accountType)) detail = "on the same host as";
+    else if (accountType === PamAccountType.OracleDB) detail = "on the same resource (host, port and service name) as";
     throw new BadRequestError({ message: `Rotation account is no longer ${detail} this account` });
   };
 
   // Stable key for the identity an account authenticates as, to detect two PAM objects on the same credential:
-  // domain accounts on domain, local Windows on host, SQL on host+port, all on the bare name. Null if not rotatable.
+  // domain accounts on domain, local Windows on host, SQL on host+port (plus service name for Oracle), all on
+  // the bare name. Null if not rotatable.
   const identityKey = (accountType: PamAccountType, conn: Record<string, unknown>, username: string): string | null => {
     const user = toBareAccountName(username).toLowerCase();
     if (accountType === PamAccountType.WindowsAd) {
@@ -339,7 +371,12 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
     }
     if (isSqlRotatableType(accountType)) {
       const host = (conn.host as string | undefined)?.toLowerCase();
-      return host ? `sql|${host}|${String(conn.port)}|${user}` : null;
+      if (!host) return null;
+      if (accountType === PamAccountType.OracleDB) {
+        const service = (conn.database as string | undefined)?.toLowerCase();
+        return service ? `sql|${host}|${String(conn.port)}|${service}|${user}` : null;
+      }
+      return `sql|${host}|${String(conn.port)}|${user}`;
     }
     return null;
   };
@@ -539,12 +576,12 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
     const targetUsername = targetCredentials.username;
     const handler = rotationHandlers[accountType];
 
-    handler.validateTarget({ accountType, authMethod: targetCredentials.authMethod });
-
     const connectionDetails = resolveConnectionDetails(
       accountType,
       await decrypt(projectId, account.encryptedConnectionDetails)
     );
+
+    handler.validateTarget({ accountType, authMethod: targetCredentials.authMethod });
     const gatewayId = account.gatewayId ?? account.templateGatewayId;
     const gatewayPoolId = account.gatewayPoolId ?? account.templateGatewayPoolId;
     const now = new Date();
@@ -558,6 +595,7 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
       gatewayId: rotatorGatewayId,
       gatewayPoolId: rotatorGatewayPoolId
     } = await resolveRotator(account, targetCredentials, connectionDetails, { gatewayId, gatewayPoolId });
+    handler.validateRotatorCredential?.({ accountType, password: auth.password });
     if (isDelegated) assertRotatorSameResource(accountType, rotatorConnectionDetails, connectionDetails);
     // A delegated local account can't be logged in as to verify, so validate via the admin rotator instead.
     const verifyVia = isDelegated && accountType === PamAccountType.Windows ? auth : undefined;
@@ -633,7 +671,7 @@ export const pamAccountRotationServiceFactory = (deps: TPamAccountRotationServic
       }
     }
 
-    const requirements = getPasswordRequirements(account.templateSettings);
+    const requirements = capRequirementsForAccountType(accountType, getPasswordRequirements(account.templateSettings));
     const newPassword = generatePassword(requirements);
     const encryptedPending = await encrypt(projectId, { ...targetCredentials, password: newPassword });
 

--- a/backend/src/ee/services/pam-account-rotation/pam-rotation-fns.test.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-rotation-fns.test.ts
@@ -14,10 +14,11 @@ vi.mock("@app/lib/logger", () => ({
 }));
 
 describe("isRotatableAccountType", () => {
-  test("accepts the three SQL types", () => {
+  test("accepts the SQL types", () => {
     expect(isRotatableAccountType(PamAccountType.Postgres)).toBe(true);
     expect(isRotatableAccountType(PamAccountType.MySQL)).toBe(true);
     expect(isRotatableAccountType(PamAccountType.MsSQL)).toBe(true);
+    expect(isRotatableAccountType(PamAccountType.OracleDB)).toBe(true);
   });
 
   test("accepts Windows local and domain accounts", () => {

--- a/backend/src/ee/services/pam-account-rotation/pam-rotation-fns.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-rotation-fns.ts
@@ -71,11 +71,12 @@ export const withGatewayRetry = async (
 // PamAccountType -> AppConnection, so we can reuse the per-dialect ALTER statement map keyed by AppConnection.
 export const PAM_ROTATION_APP_MAP: Record<
   TSqlRotatableType,
-  AppConnection.Postgres | AppConnection.MySql | AppConnection.MsSql
+  AppConnection.Postgres | AppConnection.MySql | AppConnection.MsSql | AppConnection.OracleDB
 > = {
   [PamAccountType.Postgres]: AppConnection.Postgres,
   [PamAccountType.MySQL]: AppConnection.MySql,
-  [PamAccountType.MsSQL]: AppConnection.MsSql
+  [PamAccountType.MsSQL]: AppConnection.MsSql,
+  [PamAccountType.OracleDB]: AppConnection.OracleDB
 };
 
 export enum PamRotationReadinessIssue {

--- a/backend/src/ee/services/pam-account-rotation/pam-rotation-handlers.test.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-rotation-handlers.test.ts
@@ -14,6 +14,8 @@ vi.mock("@app/lib/logger", () => ({
 }));
 
 // eslint-disable-next-line import/first
+import { GATEWAY_RETRY_ATTEMPTS } from "./pam-rotation-fns";
+// eslint-disable-next-line import/first
 import { PAM_ROTATION_FACTORY_MAP } from "./pam-rotation-handlers";
 
 describe("Oracle testCredential distinguishes a rejected credential from an unreachable target", () => {
@@ -38,6 +40,7 @@ describe("Oracle testCredential distinguishes a rejected credential from an unre
   test("a null result (gateway unreachable) throws instead of returning false", async () => {
     testConnectionWithGateway.mockResolvedValue(null);
     await expect(invoke()).rejects.toThrow(/could not reach the target/i);
+    expect(testConnectionWithGateway).toHaveBeenCalledTimes(GATEWAY_RETRY_ATTEMPTS);
   });
 
   test("a transport-kind failure throws instead of returning false", async () => {
@@ -53,6 +56,7 @@ describe("Oracle testCredential distinguishes a rejected credential from an unre
   test("an auth-kind failure returns false", async () => {
     testConnectionWithGateway.mockResolvedValue({ ok: false, status: 502, errorMessage: "ORA-01017", kind: "auth" });
     await expect(invoke()).resolves.toBe(false);
+    expect(testConnectionWithGateway).toHaveBeenCalledTimes(1);
   });
 
   test("a successful probe returns true", async () => {

--- a/backend/src/ee/services/pam-account-rotation/pam-rotation-handlers.test.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-rotation-handlers.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { PamAccountType } from "../pam/pam-enums";
+
+const testConnectionWithGateway = vi.fn();
+
+vi.mock("@app/ee/services/gateway-v2/gateway-v2-fns", () => ({
+  testConnectionWithGateway: (...args: unknown[]) => testConnectionWithGateway(...args) as unknown,
+  rotateSqlCredentialWithGateway: vi.fn()
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+}));
+
+// eslint-disable-next-line import/first
+import { PAM_ROTATION_FACTORY_MAP } from "./pam-rotation-handlers";
+
+describe("Oracle testCredential distinguishes a rejected credential from an unreachable target", () => {
+  const { testCredential } = PAM_ROTATION_FACTORY_MAP[PamAccountType.OracleDB];
+
+  const invoke = () =>
+    testCredential(
+      {
+        accountType: PamAccountType.OracleDB,
+        connectionDetails: { host: "db.example.com", port: 2484, database: "FREEPDB1", sslEnabled: true },
+        auth: { username: "PAMROT", password: "short-pw" },
+        gatewayId: "11111111-1111-1111-1111-111111111111"
+      } as never,
+      {
+        gatewayV2Service: {},
+        gatewayPoolService: { resolveEffectiveGatewayId: vi.fn().mockResolvedValue("gw") }
+      } as never
+    );
+
+  beforeEach(() => testConnectionWithGateway.mockReset());
+
+  test("a null result (gateway unreachable) throws instead of returning false", async () => {
+    testConnectionWithGateway.mockResolvedValue(null);
+    await expect(invoke()).rejects.toThrow(/could not reach the target/i);
+  });
+
+  test("a transport-kind failure throws instead of returning false", async () => {
+    testConnectionWithGateway.mockResolvedValue({
+      ok: false,
+      status: 502,
+      errorMessage: "dial tcp",
+      kind: "transport"
+    });
+    await expect(invoke()).rejects.toThrow(/could not reach the target/i);
+  });
+
+  test("an auth-kind failure returns false", async () => {
+    testConnectionWithGateway.mockResolvedValue({ ok: false, status: 502, errorMessage: "ORA-01017", kind: "auth" });
+    await expect(invoke()).resolves.toBe(false);
+  });
+
+  test("a successful probe returns true", async () => {
+    testConnectionWithGateway.mockResolvedValue({ ok: true, status: 200 });
+    await expect(invoke()).resolves.toBe(true);
+  });
+});

--- a/backend/src/ee/services/pam-account-rotation/pam-rotation-handlers.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-rotation-handlers.ts
@@ -8,7 +8,7 @@ import {
 } from "@app/services/app-connection/shared/sql";
 
 import { PamAccountType, PamPostgresAuthMethod } from "../pam/pam-enums";
-import { ORACLE_MAX_PASSWORD_LENGTH } from "../pam-account/pam-account-connection-test";
+import { ORACLE_MAX_PASSWORD_LENGTH, ORACLE_MIN_GATEWAY_VERSION } from "../pam-account/pam-account-connection-test";
 import { TWindowsAdConnectionDetails, TWindowsConnectionDetails } from "../pam-account/pam-account-schemas";
 import { DEFAULT_WINRM_PORT, ldapBindCheckViaGateway, winrmRpcWithGateway } from "../pam-discovery/pam-discovery-fns";
 import {
@@ -83,8 +83,7 @@ const assertOracleCredentialIsUsable = (password: string) => {
   }
 };
 
-const ORACLE_GATEWAY_TOO_OLD =
-  "This account's gateway does not support Oracle credential rotation. Update the gateway to v0.43.130 or later.";
+const ORACLE_GATEWAY_TOO_OLD = `This account's gateway does not support Oracle credential rotation. Update the gateway to ${ORACLE_MIN_GATEWAY_VERSION} or later.`;
 
 const oracleGatewayRequest = (
   connectionDetails: TPamSqlConnectionDetails,
@@ -225,7 +224,10 @@ const sqlRotationHandler: TPamRotationHandler = {
     const connectionDetails = input.connectionDetails as TPamSqlConnectionDetails;
 
     if (accountType === PamAccountType.OracleDB) {
-      return verifyOracleViaGateway({ connectionDetails, auth, gatewayId, gatewayPoolId }, deps);
+      return withGatewayRetry(
+        () => verifyOracleViaGateway({ connectionDetails, auth, gatewayId, gatewayPoolId }, deps),
+        "verify"
+      );
     }
 
     try {

--- a/backend/src/ee/services/pam-account-rotation/pam-rotation-handlers.ts
+++ b/backend/src/ee/services/pam-account-rotation/pam-rotation-handlers.ts
@@ -1,3 +1,4 @@
+import { rotateSqlCredentialWithGateway, testConnectionWithGateway } from "@app/ee/services/gateway-v2/gateway-v2-fns";
 import { BadRequestError } from "@app/lib/errors";
 import { WinRmRpcEndpoint } from "@app/lib/gateway-v2/winrm-rpc";
 import {
@@ -7,6 +8,7 @@ import {
 } from "@app/services/app-connection/shared/sql";
 
 import { PamAccountType, PamPostgresAuthMethod } from "../pam/pam-enums";
+import { ORACLE_MAX_PASSWORD_LENGTH } from "../pam-account/pam-account-connection-test";
 import { TWindowsAdConnectionDetails, TWindowsConnectionDetails } from "../pam-account/pam-account-schemas";
 import { DEFAULT_WINRM_PORT, ldapBindCheckViaGateway, winrmRpcWithGateway } from "../pam-discovery/pam-discovery-fns";
 import {
@@ -49,13 +51,125 @@ type TTestCredentialInput = {
 
 export type TPamRotationHandler = {
   validateTarget: (input: { accountType: TRotatableType; authMethod?: string }) => void;
+  validateRotatorCredential?: (input: { accountType: TRotatableType; password?: string }) => void;
   applyPasswordChange: (input: TApplyPasswordChangeInput, deps: TPamRotationGatewayDeps) => Promise<void>;
   // Returns whether the credential authenticates. THROWS only when verification can't complete (transient
   // transport error); callers treat a throw as inconclusive and defer, never as a wrong password.
   testCredential: (input: TTestCredentialInput, deps: TPamRotationGatewayDeps) => Promise<boolean>;
 };
 
+const ORACLE_ROTATE_TIMEOUT_MS = 30_000;
+
+const resolveRotationGatewayId = async (
+  deps: TPamRotationGatewayDeps,
+  gatewayId?: string | null,
+  gatewayPoolId?: string | null
+): Promise<string> => {
+  const resolved = gatewayPoolId
+    ? await deps.gatewayPoolService.resolveEffectiveGatewayId({ gatewayId, gatewayPoolId })
+    : gatewayId;
+  if (!resolved) throw new BadRequestError({ message: "No healthy gateway is available to rotate this account" });
+  return resolved;
+};
+
+const isGatewayProtocolUnsupported = (err: unknown) =>
+  err instanceof Error && /no application protocol|alert number 120/i.test(err.message);
+
+const assertOracleCredentialIsUsable = (password: string) => {
+  if (password.length > ORACLE_MAX_PASSWORD_LENGTH) {
+    throw new BadRequestError({
+      message: `Oracle credentials longer than ${ORACLE_MAX_PASSWORD_LENGTH} characters cannot be used to rotate. Shorten the rotation account's password and try again.`
+    });
+  }
+};
+
+const ORACLE_GATEWAY_TOO_OLD =
+  "This account's gateway does not support Oracle credential rotation. Update the gateway to v0.43.130 or later.";
+
+const oracleGatewayRequest = (
+  connectionDetails: TPamSqlConnectionDetails,
+  auth: { username: string; password: string }
+) => ({
+  dialect: "oracle",
+  username: auth.username,
+  password: auth.password,
+  database: connectionDetails.database,
+  sslEnabled: connectionDetails.sslEnabled,
+  sslRejectUnauthorized: connectionDetails.sslRejectUnauthorized,
+  sslCertificate: connectionDetails.sslCertificate
+});
+
+const verifyOracleViaGateway = async (
+  input: {
+    connectionDetails: TPamSqlConnectionDetails;
+    auth: { username: string; password: string };
+    gatewayId?: string | null;
+    gatewayPoolId?: string | null;
+  },
+  deps: TPamRotationGatewayDeps
+): Promise<boolean> => {
+  const { connectionDetails, auth } = input;
+  const gatewayId = await resolveRotationGatewayId(deps, input.gatewayId, input.gatewayPoolId);
+  const result = await testConnectionWithGateway(
+    connectionDetails.host,
+    connectionDetails.port,
+    gatewayId,
+    deps.gatewayV2Service,
+    { mode: "sql", ...oracleGatewayRequest(connectionDetails, auth) },
+    ORACLE_ROTATE_TIMEOUT_MS
+  );
+
+  if (!result) {
+    throw new Error("Could not reach the target through the gateway to verify its credentials");
+  }
+  if (result.ok) return true;
+  if (result.kind === "transport") {
+    throw new Error(`Could not reach the target through the gateway to verify its credentials: ${result.errorMessage}`);
+  }
+  return false;
+};
+
+const rotateOracleViaGateway = async (
+  input: {
+    connectionDetails: TPamSqlConnectionDetails;
+    auth: { username: string; password: string };
+    targetUsername: string;
+    newPassword: string;
+    gatewayId?: string | null;
+    gatewayPoolId?: string | null;
+  },
+  deps: TPamRotationGatewayDeps
+) => {
+  const { connectionDetails, auth, targetUsername, newPassword } = input;
+  const gatewayId = await resolveRotationGatewayId(deps, input.gatewayId, input.gatewayPoolId);
+
+  let result;
+  try {
+    result = await rotateSqlCredentialWithGateway(
+      connectionDetails.host,
+      connectionDetails.port,
+      gatewayId,
+      deps.gatewayV2Service,
+      { ...oracleGatewayRequest(connectionDetails, auth), targetUsername, newPassword },
+      ORACLE_ROTATE_TIMEOUT_MS
+    );
+  } catch (err) {
+    if (isGatewayProtocolUnsupported(err)) {
+      throw new BadRequestError({ message: ORACLE_GATEWAY_TOO_OLD });
+    }
+    throw new Error(redactRotationError(err, [newPassword, auth.password]));
+  }
+
+  if (!result.ok) {
+    throw new Error(redactRotationError(new Error(result.errorMessage), [newPassword, auth.password]));
+  }
+};
+
 const sqlRotationHandler: TPamRotationHandler = {
+  validateRotatorCredential: ({ accountType, password }) => {
+    if (accountType === PamAccountType.OracleDB && password) assertOracleCredentialIsUsable(password);
+  },
+
   validateTarget: ({ accountType, authMethod }) => {
     // MSSQL Windows-auth (ntlm/kerberos) logins have no SQL-managed password to change, so only sql-login rotates.
     if (accountType === PamAccountType.MsSQL && authMethod !== "sql-login") {
@@ -72,6 +186,15 @@ const sqlRotationHandler: TPamRotationHandler = {
   applyPasswordChange: async (input, deps) => {
     const { accountType, auth, targetUsername, newPassword, gatewayId, gatewayPoolId } = input;
     const connectionDetails = input.connectionDetails as TPamSqlConnectionDetails;
+
+    if (accountType === PamAccountType.OracleDB) {
+      await rotateOracleViaGateway(
+        { connectionDetails, auth, targetUsername, newPassword, gatewayId, gatewayPoolId },
+        deps
+      );
+      return;
+    }
+
     // Strip the PlanetScale `<user>.<branch>` suffix so the ALTER targets the real role.
     const roleUsername = getRoleUsernameForHost(targetUsername, connectionDetails.host);
     const [statement, bindings] = SQL_CONNECTION_ALTER_LOGIN_STATEMENT[
@@ -100,6 +223,11 @@ const sqlRotationHandler: TPamRotationHandler = {
   testCredential: async (input, deps) => {
     const { accountType, auth, gatewayId, gatewayPoolId } = input;
     const connectionDetails = input.connectionDetails as TPamSqlConnectionDetails;
+
+    if (accountType === PamAccountType.OracleDB) {
+      return verifyOracleViaGateway({ connectionDetails, auth, gatewayId, gatewayPoolId }, deps);
+    }
+
     try {
       await withPamSqlClient(
         { accountType: accountType as TSqlRotatableType, connectionDetails, auth, gatewayId, gatewayPoolId },
@@ -144,18 +272,6 @@ const winrmRotationTargetHost = (accountType: TRotatableType, connectionDetails:
   const conn = connectionDetails as TWindowsConnectionDetails;
   if (!conn.host) throw new BadRequestError({ message: "Windows account is missing a host" });
   return conn.host;
-};
-
-const resolveRotationGatewayId = async (
-  deps: TPamRotationGatewayDeps,
-  gatewayId?: string | null,
-  gatewayPoolId?: string | null
-): Promise<string> => {
-  const resolved = gatewayPoolId
-    ? await deps.gatewayPoolService.resolveEffectiveGatewayId({ gatewayId, gatewayPoolId })
-    : gatewayId;
-  if (!resolved) throw new BadRequestError({ message: "No healthy gateway available for Windows rotation" });
-  return resolved;
 };
 
 // Set-ADAccountPassword -Identity and Set-LocalUser -Name want a bare sAMAccountName, not DOMAIN\user or a
@@ -280,6 +396,7 @@ export const PAM_ROTATION_FACTORY_MAP: Record<TRotatableType, TPamRotationHandle
   [PamAccountType.Postgres]: sqlRotationHandler,
   [PamAccountType.MySQL]: sqlRotationHandler,
   [PamAccountType.MsSQL]: sqlRotationHandler,
+  [PamAccountType.OracleDB]: sqlRotationHandler,
   [PamAccountType.Windows]: windowsRotationHandler,
   [PamAccountType.WindowsAd]: windowsRotationHandler
 };

--- a/backend/src/ee/services/pam-account-template/pam-account-template-service.ts
+++ b/backend/src/ee/services/pam-account-template/pam-account-template-service.ts
@@ -12,6 +12,7 @@ import {
   validateRecordingConnection,
   validateRecordingS3Config
 } from "../pam/pam-validators";
+import { ORACLE_MAX_PASSWORD_LENGTH } from "../pam-account/pam-account-connection-test";
 import { TPamAccountDALFactory } from "../pam-account/pam-account-dal";
 import { ACCOUNT_TYPE_CONFIGS } from "../pam-account/pam-account-schemas";
 import { isRotatableAccountType, ROTATABLE_ACCOUNT_TYPES } from "../pam-account-rotation/pam-rotation-fns";
@@ -80,6 +81,16 @@ export const pamAccountTemplateServiceFactory = (deps: TPamAccountTemplateServic
       if (invalid.length > 0) {
         throw new BadRequestError({ message: `Allowed symbols may only include: ${SAFE_PASSWORD_SYMBOLS}` });
       }
+    }
+    const requestedLength = settings.passwordRequirements?.length;
+    if (
+      accountType === PamAccountType.OracleDB &&
+      requestedLength !== undefined &&
+      requestedLength > ORACLE_MAX_PASSWORD_LENGTH
+    ) {
+      throw new BadRequestError({
+        message: `Oracle passwords are limited to ${ORACLE_MAX_PASSWORD_LENGTH} characters, so a template cannot request a longer one`
+      });
     }
   };
 

--- a/backend/src/ee/services/pam-account/pam-account-connection-test.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-connection-test.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "vitest";
 
 import { PamAccountType, PamSshAuthMethod } from "../pam/pam-enums";
-import { buildGatewayConnectionTest, TestConnectionMode } from "./pam-account-connection-test";
+import {
+  buildGatewayConnectionTest,
+  ORACLE_MAX_PASSWORD_LENGTH,
+  TestConnectionMode
+} from "./pam-account-connection-test";
 
 const ORG_ID = "11111111-1111-1111-1111-111111111111";
 
@@ -20,7 +24,7 @@ describe("buildGatewayConnectionTest: MSSQL Windows authentication", () => {
       connectionDetails,
       { authMethod: "ntlm", username: "svc_app", password: "pw", domain: "CORP" },
       ORG_ID,
-      { allowWindowsAuthSql: true }
+      { allowNewerGatewayTests: true }
     );
 
     expect(result?.request.mode).toBe(TestConnectionMode.SQL);
@@ -40,7 +44,7 @@ describe("buildGatewayConnectionTest: MSSQL Windows authentication", () => {
         spn: "MSSQLSvc/sql.corp.example.com:1433"
       },
       ORG_ID,
-      { allowWindowsAuthSql: true }
+      { allowNewerGatewayTests: true }
     );
 
     expect(result?.request.mode).toBe(TestConnectionMode.SQL);
@@ -126,5 +130,115 @@ describe("buildGatewayConnectionTest: SSH certificate authentication", () => {
     );
 
     expect(result?.request).toMatchObject({ mode: TestConnectionMode.SSH, password: "pw" });
+  });
+});
+
+describe("buildGatewayConnectionTest: Oracle", () => {
+  const connectionDetails = {
+    host: "oracle.corp.example.com",
+    port: 1521,
+    database: "FREEPDB1",
+    sslEnabled: false,
+    sslRejectUnauthorized: true
+  };
+
+  test("authenticates against the service name using the oracle dialect", async () => {
+    const result = await buildGatewayConnectionTest(
+      PamAccountType.OracleDB,
+      connectionDetails,
+      { username: "system", password: "pw" },
+      ORG_ID,
+      { allowNewerGatewayTests: true }
+    );
+
+    expect(result).toMatchObject({ host: "oracle.corp.example.com", port: 1521 });
+    expect(result?.request).toMatchObject({
+      mode: TestConnectionMode.SQL,
+      dialect: "oracle",
+      username: "system",
+      password: "pw",
+      database: "FREEPDB1"
+    });
+  });
+
+  test("carries the SSL settings the gateway needs to pin the CA", async () => {
+    const result = await buildGatewayConnectionTest(
+      PamAccountType.OracleDB,
+      { ...connectionDetails, port: 2484, sslEnabled: true, sslCertificate: "-----BEGIN CERTIFICATE-----" },
+      { username: "system", password: "pw" },
+      ORG_ID,
+      { allowNewerGatewayTests: true }
+    );
+
+    expect(result?.request).toMatchObject({
+      sslEnabled: true,
+      sslRejectUnauthorized: true,
+      sslCertificate: "-----BEGIN CERTIFICATE-----"
+    });
+  });
+
+  test("sends no Windows auth fields, which belong to MSSQL only", async () => {
+    const result = await buildGatewayConnectionTest(
+      PamAccountType.OracleDB,
+      connectionDetails,
+      { username: "system", password: "pw" },
+      ORG_ID,
+      { allowNewerGatewayTests: true }
+    );
+
+    expect(result?.request).not.toHaveProperty("authMethod");
+    expect(result?.request).not.toHaveProperty("domain");
+    expect(result?.request).not.toHaveProperty("spn");
+  });
+
+  test("an account with no credential falls back to a reachability check", async () => {
+    const result = await buildGatewayConnectionTest(PamAccountType.OracleDB, connectionDetails, null, ORG_ID);
+    expect(result?.request.mode).toBe(TestConnectionMode.Tcp);
+  });
+
+  test("callers that omit the opt keep a reachability check", async () => {
+    const result = await buildGatewayConnectionTest(
+      PamAccountType.OracleDB,
+      connectionDetails,
+      { username: "system", password: "pw" },
+      ORG_ID
+    );
+
+    expect(result?.request.mode).toBe(TestConnectionMode.Tcp);
+  });
+
+  test("a password over the probe limit degrades to a reachability check", async () => {
+    const result = await buildGatewayConnectionTest(
+      PamAccountType.OracleDB,
+      connectionDetails,
+      { username: "system", password: "a".repeat(ORACLE_MAX_PASSWORD_LENGTH + 1) },
+      ORG_ID,
+      { allowNewerGatewayTests: true }
+    );
+
+    expect(result?.request.mode).toBe(TestConnectionMode.Tcp);
+  });
+
+  test("a password exactly at the probe limit still authenticates", async () => {
+    const result = await buildGatewayConnectionTest(
+      PamAccountType.OracleDB,
+      connectionDetails,
+      { username: "system", password: "a".repeat(ORACLE_MAX_PASSWORD_LENGTH) },
+      ORG_ID,
+      { allowNewerGatewayTests: true }
+    );
+
+    expect(result?.request).toMatchObject({ mode: TestConnectionMode.SQL, dialect: "oracle" });
+  });
+
+  test("the limit is Oracle-only and does not touch the other dialects", async () => {
+    const result = await buildGatewayConnectionTest(
+      PamAccountType.Postgres,
+      { ...connectionDetails, port: 5432 },
+      { authMethod: "password", username: "postgres", password: "a".repeat(64) },
+      ORG_ID
+    );
+
+    expect(result?.request).toMatchObject({ mode: TestConnectionMode.SQL, dialect: "postgres" });
   });
 });

--- a/backend/src/ee/services/pam-account/pam-account-connection-test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-connection-test.ts
@@ -8,7 +8,14 @@ import {
 } from "../pam-session/aws-iam/aws-iam-federation";
 import { AZURE_SCOPES, getAzureAccessToken } from "../pam-session/azure/azure-federation";
 import { mintGcpAccessToken } from "../pam-session/gcp/gcp-federation";
-import { extractGatewayTarget, isCredentialConfigured, qualifyUsernameWithDomain } from "./pam-account-schemas";
+import {
+  extractGatewayTarget,
+  isCredentialConfigured,
+  ORACLE_MAX_PASSWORD_LENGTH,
+  qualifyUsernameWithDomain
+} from "./pam-account-schemas";
+
+export { ORACLE_MAX_PASSWORD_LENGTH };
 
 export enum TestConnectionMode {
   SQL = "sql",
@@ -90,8 +97,6 @@ const SQL_DIALECTS = {
 } as const;
 
 const tcp = (host: string, port: number) => ({ host, port, request: { mode: TestConnectionMode.Tcp } as const });
-
-export const ORACLE_MAX_PASSWORD_LENGTH = 30;
 
 export const exceedsOraclePasswordLimit = (
   accountType: PamAccountType,

--- a/backend/src/ee/services/pam-account/pam-account-connection-test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-connection-test.ts
@@ -24,7 +24,7 @@ export enum TestConnectionMode {
 export type TestConnectionRequest =
   | {
       mode: TestConnectionMode.SQL;
-      dialect: "postgres" | "mysql" | "mssql";
+      dialect: "postgres" | "mysql" | "mssql" | "oracle";
       username: string;
       password?: string;
       database: string;
@@ -85,10 +85,21 @@ export type TestConnectionRequest =
 const SQL_DIALECTS = {
   [PamAccountType.Postgres]: "postgres",
   [PamAccountType.MySQL]: "mysql",
-  [PamAccountType.MsSQL]: "mssql"
+  [PamAccountType.MsSQL]: "mssql",
+  [PamAccountType.OracleDB]: "oracle"
 } as const;
 
 const tcp = (host: string, port: number) => ({ host, port, request: { mode: TestConnectionMode.Tcp } as const });
+
+export const ORACLE_MAX_PASSWORD_LENGTH = 30;
+
+export const exceedsOraclePasswordLimit = (
+  accountType: PamAccountType,
+  credentials: Record<string, unknown> | null
+): boolean =>
+  accountType === PamAccountType.OracleDB &&
+  typeof credentials?.password === "string" &&
+  credentials.password.length > ORACLE_MAX_PASSWORD_LENGTH;
 
 // resolves the gateway target and the per-type auth request
 export const buildGatewayConnectionTest = async (
@@ -96,8 +107,8 @@ export const buildGatewayConnectionTest = async (
   connectionDetails: Record<string, unknown>,
   credentials: Record<string, unknown> | null,
   orgId: string,
-  // Off for account create and update, which must not fail against a gateway predating the proxy handshake.
-  opts?: { allowWindowsAuthSql?: boolean }
+  // Off for account create and update, which must not fail against a gateway predating the test they need.
+  opts?: { allowNewerGatewayTests?: boolean }
 ): Promise<{ host: string; port: number; request: TestConnectionRequest } | null> => {
   const creds = credentials && isCredentialConfigured(accountType, credentials) ? credentials : null;
 
@@ -114,7 +125,8 @@ export const buildGatewayConnectionTest = async (
   switch (accountType) {
     case PamAccountType.Postgres:
     case PamAccountType.MySQL:
-    case PamAccountType.MsSQL: {
+    case PamAccountType.MsSQL:
+    case PamAccountType.OracleDB: {
       const cd = connectionDetails as {
         database: string;
         sslEnabled?: boolean;
@@ -133,9 +145,11 @@ export const buildGatewayConnectionTest = async (
         spn?: string;
       } | null;
       if (!c) return tcp(host, port);
-      if (accountType === PamAccountType.MsSQL && c.authMethod !== "sql-login" && !opts?.allowWindowsAuthSql) {
-        return tcp(host, port);
-      }
+      const needsNewerGateway =
+        (accountType === PamAccountType.MsSQL && c.authMethod !== "sql-login") ||
+        accountType === PamAccountType.OracleDB;
+      if (needsNewerGateway && !opts?.allowNewerGatewayTests) return tcp(host, port);
+      if (exceedsOraclePasswordLimit(accountType, c)) return tcp(host, port);
       // An IAM login's password is a token Infisical mints per connection, so the test mints its own
       const password =
         c.authMethod === PamPostgresAuthMethod.AwsIam

--- a/backend/src/ee/services/pam-account/pam-account-connection-test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-connection-test.ts
@@ -12,10 +12,11 @@ import {
   extractGatewayTarget,
   isCredentialConfigured,
   ORACLE_MAX_PASSWORD_LENGTH,
+  ORACLE_MIN_GATEWAY_VERSION,
   qualifyUsernameWithDomain
 } from "./pam-account-schemas";
 
-export { ORACLE_MAX_PASSWORD_LENGTH };
+export { ORACLE_MAX_PASSWORD_LENGTH, ORACLE_MIN_GATEWAY_VERSION };
 
 export enum TestConnectionMode {
   SQL = "sql",

--- a/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.test.ts
@@ -140,6 +140,30 @@ describe("buildPamAccountTypeMetadata", () => {
     });
   });
 
+  test("derives Oracle connection and credential fields, labelling the service name", () => {
+    const oracle = byType.get(PamAccountType.OracleDB);
+    expect(oracle).toBeDefined();
+    expect(oracle?.name).toBe("Oracle Database");
+    expect(oracle?.supportsWebAccess).toBe(false);
+
+    expect(oracle?.connectionFields.map((f) => f.key)).toEqual([
+      "host",
+      "port",
+      "database",
+      "sslEnabled",
+      "sslRejectUnauthorized",
+      "sslCertificate"
+    ]);
+    expect(fieldByKey(oracle!.connectionFields, "database")).toMatchObject({
+      label: "Service Name",
+      required: true
+    });
+    expect(fieldByKey(oracle!.connectionFields, "port")).toMatchObject({ widget: "number", defaultValue: 1521 });
+
+    expect(fieldByKey(oracle!.credentialFields, "username")).toMatchObject({ required: true, secret: false });
+    expect(fieldByKey(oracle!.credentialFields, "password")).toMatchObject({ widget: "password", secret: true });
+  });
+
   test("derives Redis connection and credential fields from the schema", () => {
     const redis = byType.get(PamAccountType.Redis);
     expect(redis).toBeDefined();

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -339,9 +339,7 @@ export const ACCOUNT_TYPE_CONFIGS = {
       password: z
         .string()
         .trim()
-        .max(ORACLE_MAX_PASSWORD_LENGTH, {
-          message: `Oracle passwords are limited to ${ORACLE_MAX_PASSWORD_LENGTH} characters`
-        })
+        .max(256)
         .transform((v) => v || undefined)
         .optional()
     }),

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -83,6 +83,8 @@ type TFieldForcedRuleHint = { when: TFieldConditionHint; value: string | number 
 // Source of truth for account types: per-type schemas + sparse UI hints
 export const ORACLE_MAX_PASSWORD_LENGTH = 30;
 
+export const ORACLE_MIN_GATEWAY_VERSION = "v0.43.131";
+
 export const ACCOUNT_TYPE_CONFIGS = {
   [PamAccountType.Postgres]: {
     name: "PostgreSQL",

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -81,6 +81,8 @@ type TFieldConditionHint = { field: string; equals: string | boolean };
 type TFieldForcedRuleHint = { when: TFieldConditionHint; value: string | number | boolean; reason: string };
 
 // Source of truth for account types: per-type schemas + sparse UI hints
+export const ORACLE_MAX_PASSWORD_LENGTH = 30;
+
 export const ACCOUNT_TYPE_CONFIGS = {
   [PamAccountType.Postgres]: {
     name: "PostgreSQL",
@@ -337,7 +339,9 @@ export const ACCOUNT_TYPE_CONFIGS = {
       password: z
         .string()
         .trim()
-        .max(256)
+        .max(ORACLE_MAX_PASSWORD_LENGTH, {
+          message: `Oracle passwords are limited to ${ORACLE_MAX_PASSWORD_LENGTH} characters`
+        })
         .transform((v) => v || undefined)
         .optional()
     }),

--- a/backend/src/ee/services/pam-account/pam-account-schemas.ts
+++ b/backend/src/ee/services/pam-account/pam-account-schemas.ts
@@ -313,6 +313,55 @@ export const ACCOUNT_TYPE_CONFIGS = {
     }
   },
 
+  [PamAccountType.OracleDB]: {
+    name: "Oracle Database",
+    icon: "Oracle.png",
+    connectionDetails: z.object({
+      host: z.string().trim().min(1).max(255),
+      port: z.coerce.number().int().min(1).max(65535),
+      database: z
+        .string()
+        .trim()
+        .min(1)
+        .max(255)
+        .regex(
+          new RE2(/^[A-Za-z0-9][A-Za-z0-9_.\-#$]*$/),
+          "Must start with a letter or digit and contain only letters, digits, underscores, dots, hyphens, # or $"
+        ),
+      sslEnabled: z.boolean(),
+      sslRejectUnauthorized: z.boolean(),
+      sslCertificate: optionalTrimmedString
+    }),
+    credentials: z.object({
+      username: z.string().trim().min(1).max(128),
+      password: z
+        .string()
+        .trim()
+        .max(256)
+        .transform((v) => v || undefined)
+        .optional()
+    }),
+    sanitizedCredentials: z.object({ username: z.string() }),
+    ui: {
+      port: { defaultValue: 1521 },
+      database: {
+        label: "Service Name",
+        tooltip: "The Oracle service name. For example FREEPDB1 or ORCL."
+      },
+      sslEnabled: { label: "SSL Enabled" },
+      sslRejectUnauthorized: {
+        label: "Reject Unauthorized",
+        showWhen: { field: "sslEnabled", equals: true }
+      },
+      sslCertificate: {
+        label: "SSL Certificate",
+        widget: PamFieldWidget.Textarea,
+        showWhen: { field: "sslEnabled", equals: true }
+      },
+      password: { widget: PamFieldWidget.Password, secret: true }
+    }
+  },
+
   [PamAccountType.MongoDB]: {
     name: "MongoDB",
     icon: "MongoDB.png",
@@ -787,7 +836,8 @@ export type TWindowsAdConnectionDetails = z.infer<
 export const SQL_ROTATABLE_ACCOUNT_TYPES = [
   PamAccountType.Postgres,
   PamAccountType.MySQL,
-  PamAccountType.MsSQL
+  PamAccountType.MsSQL,
+  PamAccountType.OracleDB
 ] as const;
 
 // Windows accounts rotate over WinRM through the gateway: local accounts on their host, domain accounts
@@ -849,6 +899,7 @@ export const extractGatewayTarget = async (
     case PamAccountType.Postgres:
     case PamAccountType.MySQL:
     case PamAccountType.MsSQL:
+    case PamAccountType.OracleDB:
     case PamAccountType.Redis:
     case PamAccountType.Windows:
       return {
@@ -898,7 +949,7 @@ export const extractGatewayTarget = async (
     case PamAccountType.AzureCli:
       return { host: "management.azure.com", port: 443 };
     default:
-      throw new Error(`No gateway target extraction defined for account type '${accountType}'`);
+      throw new Error(`No gateway target extraction defined for account type '${accountType as PamAccountType}'`);
   }
 };
 

--- a/backend/src/ee/services/pam-account/pam-account-service.ts
+++ b/backend/src/ee/services/pam-account/pam-account-service.ts
@@ -78,6 +78,7 @@ import {
   isCredentialConfigured,
   noRevealableCredentialMessage,
   normalizeCredentialAuthMethod,
+  ORACLE_MAX_PASSWORD_LENGTH,
   PamAccountAccessibilityIssue,
   parseInternalMetadata,
   sanitizeCredentials,
@@ -130,6 +131,15 @@ type TPamAccountServiceFactoryDep = {
     "getAccessStatusBatch" | "getFolderPolicyConfigured" | "cleanupAccountResources" | "checkGrant"
   >;
   licenseService: Pick<TLicenseServiceFactory, "getPlan">;
+};
+
+const assertOraclePasswordIsUsable = (accountType: PamAccountType, credentials: unknown) => {
+  if (accountType !== PamAccountType.OracleDB) return;
+  const { password } = credentials as { password?: string };
+  if (!password || password.length <= ORACLE_MAX_PASSWORD_LENGTH) return;
+  throw new BadRequestError({
+    message: `The gateway cannot sign in to Oracle with a password longer than ${ORACLE_MAX_PASSWORD_LENGTH} characters, so this account could not be checked or rotated. Use a password of ${ORACLE_MAX_PASSWORD_LENGTH} characters or fewer.`
+  });
 };
 
 const assertPasswordMeetsRequirements = (credentials: unknown, templateSettings: unknown) => {
@@ -633,6 +643,7 @@ export const pamAccountServiceFactory = (deps: TPamAccountServiceFactoryDep) => 
     });
     const validatedConnectionDetails = validateConnectionDetails(accountType, forced.connectionDetails);
     const validatedCredentials = validateCredentials(accountType, forced.credentials);
+    assertOraclePasswordIsUsable(accountType, validatedCredentials);
     assertPasswordMeetsRequirements(validatedCredentials, template.settings);
 
     // discovery import creates accounts in bulk from a scan that already reached them, so it skips the test
@@ -851,6 +862,9 @@ export const pamAccountServiceFactory = (deps: TPamAccountServiceFactoryDep) => 
         const templateSettings = templateId
           ? (await pamAccountTemplateDAL.findById(templateId))?.settings
           : existing.templateSettings;
+        if ((credentials as { password?: string }).password) {
+          assertOraclePasswordIsUsable(accountType, effectiveCredentials);
+        }
         assertPasswordMeetsRequirements(effectiveCredentials, templateSettings);
       }
 

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -743,7 +743,8 @@ export const pamSessionServiceFactory = ({
         (account.accountType === PamAccountType.Postgres ||
           account.accountType === PamAccountType.MySQL ||
           account.accountType === PamAccountType.MongoDB ||
-          account.accountType === PamAccountType.MsSQL) &&
+          account.accountType === PamAccountType.MsSQL ||
+          account.accountType === PamAccountType.OracleDB) &&
         rawConnectionDetails.database
       ) {
         metadata.database = rawConnectionDetails.database as string;

--- a/backend/src/lib/gateway-v2/gateway-v2.ts
+++ b/backend/src/lib/gateway-v2/gateway-v2.ts
@@ -143,7 +143,8 @@ export const createGatewayConnection = async (
     [GatewayProxyProtocol.Adcs]: ["infisical-adcs"],
     [GatewayProxyProtocol.Discovery]: ["infisical-discovery"],
     [GatewayProxyProtocol.ConnectionTest]: ["infisical-connection-test"],
-    [GatewayProxyProtocol.WinRm]: ["infisical-winrm"]
+    [GatewayProxyProtocol.WinRm]: ["infisical-winrm"],
+    [GatewayProxyProtocol.Sql]: ["infisical-sql"]
   };
 
   const tlsOptions: tls.ConnectionOptions = {

--- a/backend/src/lib/gateway-v2/sql-rpc.ts
+++ b/backend/src/lib/gateway-v2/sql-rpc.ts
@@ -1,0 +1,38 @@
+import { postGatewayRpc } from "./gateway-rpc";
+import { GatewayFailureKind } from "./test-connection-rpc";
+
+const SQL_RPC_TIMEOUT_MS = 60_000;
+
+const MAX_RPC_RESPONSE_BYTES = 1024 * 1024;
+
+export type TSqlRpcResponse = { ok: true } | { ok: false; errorMessage: string; kind: GatewayFailureKind | null };
+
+export const callSqlRotateCredential = async (args: {
+  port: number;
+  body: Record<string, unknown>;
+  timeoutMs: number;
+}): Promise<TSqlRpcResponse> => {
+  const { status, text } = await postGatewayRpc({
+    port: args.port,
+    path: "/v1/rotate-credential",
+    payload: JSON.stringify({ ...args.body, timeoutMs: args.timeoutMs }),
+    timeoutMs: SQL_RPC_TIMEOUT_MS,
+    maxResponseBytes: MAX_RPC_RESPONSE_BYTES,
+    label: "SQL rotation"
+  });
+
+  if (status >= 200 && status < 300) return { ok: true };
+
+  const errEnv = (() => {
+    try {
+      return (JSON.parse(text) as { error?: { message?: string; kind?: GatewayFailureKind } }).error;
+    } catch {
+      return undefined;
+    }
+  })();
+  return {
+    ok: false,
+    errorMessage: errEnv?.message ?? `Gateway returned HTTP ${status}`,
+    kind: errEnv?.kind ?? null
+  };
+};

--- a/backend/src/lib/gateway/types.ts
+++ b/backend/src/lib/gateway/types.ts
@@ -16,7 +16,8 @@ export enum GatewayProxyProtocol {
   Adcs = "adcs",
   Discovery = "discovery",
   ConnectionTest = "connection-test",
-  WinRm = "winrm"
+  WinRm = "winrm",
+  Sql = "sql"
 }
 
 export enum GatewayHttpProxyActions {

--- a/docs/cli/commands/pam.mdx
+++ b/docs/cli/commands/pam.mdx
@@ -130,6 +130,21 @@ Based on the account's template, the CLI connects you directly or starts the app
     Connection string format: `redis://127.0.0.1:<port>`
   </Accordion>
 
+  <Accordion title="Oracle">
+    Starts a local Oracle proxy on `127.0.0.1`.
+
+    ```bash
+    # Example
+    infisical pam access production/billing-db --duration 2h
+    ```
+
+    Oracle's login protocol requires the client to send a password, so type `password` literally. The Gateway swaps in the real credential during login.
+
+    ```bash
+    sqlplus <username>/password@127.0.0.1:<port>/<service-name>
+    ```
+  </Accordion>
+
   <Accordion title="SSH">
     Connects you straight to a shell on the target.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -698,6 +698,7 @@
                       "documentation/platform/pam/accounts/postgresql",
                       "documentation/platform/pam/accounts/mysql",
                       "documentation/platform/pam/accounts/mssql",
+                      "documentation/platform/pam/accounts/oracledb",
                       "documentation/platform/pam/accounts/mongodb",
                       "documentation/platform/pam/accounts/redis",
                       "documentation/platform/pam/accounts/ssh",
@@ -718,6 +719,7 @@
                       "documentation/platform/pam/product-reference/credential-rotation/postgresql",
                       "documentation/platform/pam/product-reference/credential-rotation/mysql",
                       "documentation/platform/pam/product-reference/credential-rotation/mssql",
+                      "documentation/platform/pam/product-reference/credential-rotation/oracledb",
                       "documentation/platform/pam/product-reference/credential-rotation/windows"
                     ]
                   },

--- a/docs/documentation/platform/pam/accounts/oracledb.mdx
+++ b/docs/documentation/platform/pam/accounts/oracledb.mdx
@@ -1,0 +1,71 @@
+---
+title: "Oracle accounts"
+sidebarTitle: "Oracle"
+description: "Add and connect to Oracle databases."
+---
+
+Oracle accounts let you manage access to your Oracle databases. Users connect through the CLI, which starts a local proxy, and every [session](/documentation/platform/pam/sessions/overview) is recorded.
+
+## Creating an account
+
+<Steps>
+  <Step title="Start adding an account">
+    Go to **Privileged Access Management → Accounts** and select **Add Account**.
+  </Step>
+  <Step title="Select a folder and template">
+    Choose which [folder](/documentation/platform/pam/folders/overview) to add the account to, then select an Oracle [template](/documentation/platform/pam/templates/overview).
+  </Step>
+  <Step title="Enter connection details">
+    | Field | Description |
+    |-------|-------------|
+    | **Name** | A descriptive name (e.g., `billing-db`) |
+    | **Host** | Database hostname or IP |
+    | **Port** | Listener port (default: 1521, or 2484 for TCPS) |
+    | **Service Name** | The Oracle service name, such as `ORCL` or `FREEPDB1` |
+    | **SSL Enabled** | Connect to the TCPS listener |
+    | **Reject Unauthorized** | Reject connections with invalid certificates (only if SSL enabled) |
+    | **SSL Certificate** | Custom CA certificate (only if SSL enabled) |
+  </Step>
+  <Step title="Enter credentials">
+    | Field | Description |
+    |-------|-------------|
+    | **Username** | The Oracle username, exactly as Oracle stores it. Unquoted names are stored uppercase |
+    | **Password** | The Oracle password. Maximum 30 characters |
+  </Step>
+  <Step title="Save">
+    Select **Create**.
+  </Step>
+</Steps>
+
+Infisical checks it can reach the host before saving, so a wrong host or port fails at **Create**. The username and password are verified by the first [credential health check](/documentation/platform/pam/product-reference/credential-health/overview), which reports **Out of Sync** if Oracle rejects them.
+
+## Connecting
+
+The CLI starts a local proxy that you connect to with your preferred Oracle client.
+
+```bash
+infisical pam access my-folder/billing-db
+```
+
+The command outputs the local port to connect to, along with the username and service name.
+
+Then use `sqlplus`, SQL Developer, or any Oracle client:
+
+```bash
+sqlplus <username>/password@127.0.0.1:<port>/<service-name>
+```
+
+**Flags:**
+- `--port <port>`: use a specific local port (otherwise one is assigned automatically)
+- `--reason <reason>`: provide an access reason (if required by template)
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Oracle credential rotation" icon="rotate" href="/documentation/platform/pam/product-reference/credential-rotation/oracledb">
+    Rotate Oracle account passwords on a schedule.
+  </Card>
+  <Card title="Sessions" icon="display" href="/documentation/platform/pam/sessions/overview">
+    View and manage sessions.
+  </Card>
+</CardGroup>

--- a/docs/documentation/platform/pam/accounts/overview.mdx
+++ b/docs/documentation/platform/pam/accounts/overview.mdx
@@ -17,6 +17,7 @@ PAM supports the following account types:
 | [**PostgreSQL**](/documentation/platform/pam/accounts/postgresql) | PostgreSQL databases | ✓ |
 | [**MySQL**](/documentation/platform/pam/accounts/mysql) | MySQL databases | ✓ |
 | [**MS SQL**](/documentation/platform/pam/accounts/mssql) | Microsoft SQL Server | |
+| [**Oracle**](/documentation/platform/pam/accounts/oracledb) | Oracle databases | |
 | [**MongoDB**](/documentation/platform/pam/accounts/mongodb) | MongoDB databases | |
 | [**Redis**](/documentation/platform/pam/accounts/redis) | Redis databases | ✓ |
 | [**SSH**](/documentation/platform/pam/accounts/ssh) | Linux/Unix servers | ✓ |

--- a/docs/documentation/platform/pam/product-reference/credential-health/overview.mdx
+++ b/docs/documentation/platform/pam/product-reference/credential-health/overview.mdx
@@ -51,7 +51,7 @@ Checks are spread across the interval rather than fired together, so a template 
 </Note>
 
 <Note>
-  Checking an Oracle credential needs a gateway running v0.43.130 or later, and a password of 30 characters or fewer. An Oracle account that doesn't meet both shows as **Unreachable**.
+  Checking an Oracle credential needs a gateway running v0.43.131 or later, and a password of 30 characters or fewer. An Oracle account that doesn't meet both shows as **Unreachable**.
 </Note>
 
 ## Configuring a template

--- a/docs/documentation/platform/pam/product-reference/credential-health/overview.mdx
+++ b/docs/documentation/platform/pam/product-reference/credential-health/overview.mdx
@@ -34,6 +34,7 @@ Each check signs in the same way a session would, using the account's own authen
 | --- | --- |
 | PostgreSQL, MySQL, Microsoft SQL Server | Signs in and runs a trivial query |
 | Microsoft SQL Server with Windows authentication | Completes an NTLM or Kerberos handshake |
+| Oracle | Signs in and runs a trivial query |
 | MongoDB | Signs in and pings the server |
 | Redis | Sends `AUTH`, then `PING` |
 | Windows Active Directory | Binds to the domain controller |
@@ -47,6 +48,10 @@ Checks are spread across the interval rather than fired together, so a template 
 
 <Note>
   Microsoft SQL Server accounts using Windows authentication need a gateway running a version that supports the Windows authentication handshake. An older gateway reports these accounts as **Out of Sync** even when the credential is valid. Update the gateway to get an accurate result.
+</Note>
+
+<Note>
+  Checking an Oracle credential needs a gateway running v0.43.130 or later, and a password of 30 characters or fewer. An Oracle account that doesn't meet both shows as **Unreachable**.
 </Note>
 
 ## Configuring a template

--- a/docs/documentation/platform/pam/product-reference/credential-rotation/oracledb.mdx
+++ b/docs/documentation/platform/pam/product-reference/credential-rotation/oracledb.mdx
@@ -1,0 +1,51 @@
+---
+title: "Oracle credential rotation"
+sidebarTitle: "Oracle"
+description: "Rotate Oracle account passwords with Infisical PAM."
+---
+
+This page covers what is specific to rotating an [Oracle account](/documentation/platform/pam/accounts/oracledb). For how rotation is configured and scheduled, see the [overview](/documentation/platform/pam/product-reference/credential-rotation/overview).
+
+<Note>
+  Rotating an Oracle account needs a [Gateway](/documentation/platform/gateways/overview) running v0.43.130 or later. Rotation fails on an older Gateway.
+</Note>
+
+## How the password is changed
+
+When an Oracle account rotates, the rotation account connects to the target and runs:
+
+```sql
+ALTER USER "<target_username>" IDENTIFIED BY "<generated_password>";
+```
+
+The connection uses the account's existing connection details, including the SSL settings.
+
+The statement matches the stored username exactly, so an account whose username doesn't match the case Oracle stored fails to rotate even though its sessions launch fine. Oracle reports this as a privilege error, not a missing user.
+
+## Rotation account requirements
+
+- **Self-rotation**: an Oracle user can change its own password, so no extra privileges are needed beyond `CREATE SESSION`.
+- **Delegated rotation**: the rotation account needs the `ALTER USER` system privilege to change another user's password. Without it Oracle returns `ORA-01031: insufficient privileges`.
+
+An example setup for a dedicated delegated rotation user:
+
+```sql
+-- the user Infisical connects as to perform rotations
+CREATE USER infisical_rotator IDENTIFIED BY "temporary_password";
+GRANT CREATE SESSION TO infisical_rotator;
+GRANT ALTER USER TO infisical_rotator;
+
+-- the account whose password gets rotated
+CREATE USER app_user IDENTIFIED BY "temporary_password";
+GRANT CREATE SESSION TO app_user;
+```
+
+<Note>
+  A delegated rotation account has to use the same service name as its target, not just the same host and port. Oracle scopes a user to a single database, so a rotation account pointed at a different service can't see the target user.
+</Note>
+
+## Password length
+
+An Oracle template won't accept a password length above 30 characters, and rotation never generates a longer one.
+
+The same limit applies to the rotation account itself. If its own password is longer than 30 characters it can't sign in to perform the rotation, so shorten it first.

--- a/docs/documentation/platform/pam/product-reference/credential-rotation/oracledb.mdx
+++ b/docs/documentation/platform/pam/product-reference/credential-rotation/oracledb.mdx
@@ -7,7 +7,7 @@ description: "Rotate Oracle account passwords with Infisical PAM."
 This page covers what is specific to rotating an [Oracle account](/documentation/platform/pam/accounts/oracledb). For how rotation is configured and scheduled, see the [overview](/documentation/platform/pam/product-reference/credential-rotation/overview).
 
 <Note>
-  Rotating an Oracle account needs a [Gateway](/documentation/platform/gateways/overview) running v0.43.130 or later. Rotation fails on an older Gateway.
+  Rotating an Oracle account needs a [Gateway](/documentation/platform/gateways/overview) running v0.43.131 or later. Rotation fails on an older Gateway.
 </Note>
 
 ## How the password is changed
@@ -26,7 +26,12 @@ ALTER USER "<target_username>" IDENTIFIED BY "<generated_password>" REPLACE "<cu
 
 The connection uses the account's existing connection details, including the SSL settings.
 
-The statement matches the stored username exactly, so an account whose username doesn't match the case Oracle stored fails to rotate even though its sessions launch fine. Oracle reports this as a privilege error, not a missing user.
+The statement matches the stored username exactly, so an account whose username doesn't match the case Oracle stored fails to rotate even though its sessions launch fine. Oracle names two different reasons for the same mistake, depending on who is rotating:
+
+- **Self-rotation** returns `ORA-01031: insufficient privileges`, because changing a user other than the one signed in needs the `ALTER USER` privilege, and the name that doesn't exist counts as another user.
+- **Delegated rotation** returns `ORA-01918: user does not exist`, because the rotation account holds `ALTER USER` and gets past the privilege check.
+
+Either way the fix is the same: correct the account's username to the case Oracle stored, which is uppercase unless the user was created with a quoted name.
 
 ## Rotation account requirements
 
@@ -53,5 +58,7 @@ GRANT CREATE SESSION TO app_user;
 ## Password length
 
 An Oracle template won't accept a password length above 30 characters, and rotation never generates a longer one.
+
+The limit is the Gateway's Oracle client, not Oracle. Oracle accepts a longer password and other clients sign in with it, but the Gateway can't, so a rotation that generated one would leave an account Infisical could no longer reach, check, or rotate back. Treat 30 as a hard ceiling rather than a conservative default.
 
 The same limit applies to the rotation account itself. If its own password is longer than 30 characters it can't sign in to perform the rotation, so shorten it first.

--- a/docs/documentation/platform/pam/product-reference/credential-rotation/oracledb.mdx
+++ b/docs/documentation/platform/pam/product-reference/credential-rotation/oracledb.mdx
@@ -18,6 +18,12 @@ When an Oracle account rotates, the rotation account connects to the target and 
 ALTER USER "<target_username>" IDENTIFIED BY "<generated_password>";
 ```
 
+An account that rotates its own password restates the old one, which Oracle requires when a password policy is in force:
+
+```sql
+ALTER USER "<target_username>" IDENTIFIED BY "<generated_password>" REPLACE "<current_password>";
+```
+
 The connection uses the account's existing connection details, including the SSL settings.
 
 The statement matches the stored username exactly, so an account whose username doesn't match the case Oracle stored fails to rotate even though its sessions launch fine. Oracle reports this as a privilege error, not a missing user.

--- a/docs/documentation/platform/pam/product-reference/credential-rotation/overview.mdx
+++ b/docs/documentation/platform/pam/product-reference/credential-rotation/overview.mdx
@@ -85,6 +85,9 @@ Each resource type applies the password change differently and has its own requi
   <Card title="Microsoft SQL Server" icon="database" href="/documentation/platform/pam/product-reference/credential-rotation/mssql">
     Rotates a SQL Server login's password with `ALTER LOGIN`.
   </Card>
+  <Card title="Oracle" icon="database" href="/documentation/platform/pam/product-reference/credential-rotation/oracledb">
+    Rotates an Oracle user's password with `ALTER USER`.
+  </Card>
   <Card title="Windows" icon="windows" href="/documentation/platform/pam/product-reference/credential-rotation/windows">
     Rotates local Windows and Active Directory account passwords over WinRM.
   </Card>

--- a/frontend/src/hooks/api/pam/enums.ts
+++ b/frontend/src/hooks/api/pam/enums.ts
@@ -38,6 +38,11 @@ export const ROTATABLE_PAM_ACCOUNT_TYPES = [
 export const isRotatablePamAccountType = (type: PamAccountType | string) =>
   (ROTATABLE_PAM_ACCOUNT_TYPES as string[]).includes(type);
 
+export const ORACLE_MAX_PASSWORD_LENGTH = 30;
+
+export const maxGeneratedPasswordLength = (type: PamAccountType | string | undefined) =>
+  type === PamAccountType.OracleDB ? ORACLE_MAX_PASSWORD_LENGTH : 250;
+
 export enum PamHeartbeatStatus {
   Healthy = "healthy",
   InvalidCredentials = "invalid-credentials",

--- a/frontend/src/hooks/api/pam/enums.ts
+++ b/frontend/src/hooks/api/pam/enums.ts
@@ -30,6 +30,7 @@ export const ROTATABLE_PAM_ACCOUNT_TYPES = [
   PamAccountType.Postgres,
   PamAccountType.MySQL,
   PamAccountType.MsSQL,
+  PamAccountType.OracleDB,
   PamAccountType.Windows,
   PamAccountType.WindowsAd
 ];

--- a/frontend/src/hooks/api/pam/enums.ts
+++ b/frontend/src/hooks/api/pam/enums.ts
@@ -38,6 +38,8 @@ export const ROTATABLE_PAM_ACCOUNT_TYPES = [
 export const isRotatablePamAccountType = (type: PamAccountType | string) =>
   (ROTATABLE_PAM_ACCOUNT_TYPES as string[]).includes(type);
 
+// Mirrors ORACLE_MAX_PASSWORD_LENGTH in backend/src/ee/services/pam-account/pam-account-schemas.ts, which is
+// what actually rejects a longer one. Change both together.
 export const ORACLE_MAX_PASSWORD_LENGTH = 30;
 
 export const maxGeneratedPasswordLength = (type: PamAccountType | string | undefined) =>

--- a/frontend/src/pages/pam/PamTemplatesPage/components/TemplateDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamTemplatesPage/components/TemplateDetailSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import axios from "axios";
@@ -59,89 +59,90 @@ const configSchema = z.object({
 
 type ConfigForm = z.infer<typeof configSchema>;
 
-const settingsSchema = z
-  .object({
-    gatewayId: z.string().nullable(),
-    gatewayPoolId: z.string().nullable(),
-    recordingStorageBackend: z.enum(["postgres", "aws-s3"]),
-    recordingConnectionId: z.string().nullable(),
-    s3Bucket: z.string().optional(),
-    s3Region: z.string().optional(),
-    s3KeyPrefix: z.string().optional(),
-    policies: z.record(z.unknown()),
-    settings: z.object({
-      sessionLogMaskingPatterns: z.string().optional(),
-      rotationEnabled: z.boolean().optional(),
-      heartbeatEnabled: z.boolean().optional(),
-      heartbeatIntervalSeconds: z.number().optional(),
-      rotationIntervalSeconds: z.number().nullable().optional(),
-      pwLength: z.coerce.number().optional(),
-      pwUppercase: z.coerce.number().optional(),
-      pwLowercase: z.coerce.number().optional(),
-      pwDigits: z.coerce.number().optional(),
-      pwSymbols: z.coerce.number().optional(),
-      pwAllowedSymbols: z.string().optional()
+const buildSettingsSchema = (maxPwLength: number) =>
+  z
+    .object({
+      gatewayId: z.string().nullable(),
+      gatewayPoolId: z.string().nullable(),
+      recordingStorageBackend: z.enum(["postgres", "aws-s3"]),
+      recordingConnectionId: z.string().nullable(),
+      s3Bucket: z.string().optional(),
+      s3Region: z.string().optional(),
+      s3KeyPrefix: z.string().optional(),
+      policies: z.record(z.unknown()),
+      settings: z.object({
+        sessionLogMaskingPatterns: z.string().optional(),
+        rotationEnabled: z.boolean().optional(),
+        heartbeatEnabled: z.boolean().optional(),
+        heartbeatIntervalSeconds: z.number().optional(),
+        rotationIntervalSeconds: z.number().nullable().optional(),
+        pwLength: z.coerce.number().optional(),
+        pwUppercase: z.coerce.number().optional(),
+        pwLowercase: z.coerce.number().optional(),
+        pwDigits: z.coerce.number().optional(),
+        pwSymbols: z.coerce.number().optional(),
+        pwAllowedSymbols: z.string().optional()
+      })
     })
-  })
-  .superRefine((data, ctx) => {
-    if (data.recordingStorageBackend === "aws-s3") {
-      if (!data.recordingConnectionId) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["recordingConnectionId"],
-          message: "Select an AWS connection"
-        });
+    .superRefine((data, ctx) => {
+      if (data.recordingStorageBackend === "aws-s3") {
+        if (!data.recordingConnectionId) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["recordingConnectionId"],
+            message: "Select an AWS connection"
+          });
+        }
+        if (!data.s3Bucket?.trim()) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["s3Bucket"],
+            message: "Bucket is required"
+          });
+        }
       }
-      if (!data.s3Bucket?.trim()) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["s3Bucket"],
-          message: "Bucket is required"
-        });
-      }
-    }
 
-    const length = data.settings.pwLength ?? 32;
-    const mins = {
-      uppercase: data.settings.pwUppercase ?? 0,
-      lowercase: data.settings.pwLowercase ?? 0,
-      digits: data.settings.pwDigits ?? 0,
-      symbols: data.settings.pwSymbols ?? 0
-    };
-    if (length < 1 || length > 250) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["settings", "pwLength"],
-        message: "Length must be between 1 and 250"
-      });
-    }
-    (["pwUppercase", "pwLowercase", "pwDigits", "pwSymbols"] as const).forEach((key) => {
-      const value = data.settings[key];
-      if (value !== undefined && value < 0) {
+      const length = data.settings.pwLength ?? Math.min(32, maxPwLength);
+      const mins = {
+        uppercase: data.settings.pwUppercase ?? 0,
+        lowercase: data.settings.pwLowercase ?? 0,
+        digits: data.settings.pwDigits ?? 0,
+        symbols: data.settings.pwSymbols ?? 0
+      };
+      if (length < 1 || length > maxPwLength) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ["settings", key],
-          message: "Cannot be negative"
+          path: ["settings", "pwLength"],
+          message: `Length must be between 1 and ${maxPwLength}`
+        });
+      }
+      (["pwUppercase", "pwLowercase", "pwDigits", "pwSymbols"] as const).forEach((key) => {
+        const value = data.settings[key];
+        if (value !== undefined && value < 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["settings", key],
+            message: "Cannot be negative"
+          });
+        }
+      });
+      const totalRequired = mins.uppercase + mins.lowercase + mins.digits + mins.symbols;
+      if (totalRequired === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["settings", "pwLength"],
+          message: "Require at least one character type"
+        });
+      } else if (totalRequired > length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["settings", "pwLength"],
+          message: "Length must be at least the sum of the minimums"
         });
       }
     });
-    const totalRequired = mins.uppercase + mins.lowercase + mins.digits + mins.symbols;
-    if (totalRequired === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["settings", "pwLength"],
-        message: "Require at least one character type"
-      });
-    } else if (totalRequired > length) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["settings", "pwLength"],
-        message: "Length must be at least the sum of the minimums"
-      });
-    }
-  });
 
-type SettingsForm = z.infer<typeof settingsSchema>;
+type SettingsForm = z.infer<ReturnType<typeof buildSettingsSchema>>;
 
 type Props = {
   isOpen: boolean;
@@ -270,6 +271,10 @@ const SettingsTab = ({
   );
   const { map: accountTypeMap } = usePamAccountTypeMap();
 
+  const maxPwLength = maxGeneratedPasswordLength(template?.type);
+  const defaultPwLength = Math.min(32, maxPwLength);
+  const settingsSchema = useMemo(() => buildSettingsSchema(maxPwLength), [maxPwLength]);
+
   const {
     control,
     handleSubmit,
@@ -295,7 +300,7 @@ const SettingsTab = ({
         heartbeatEnabled: false,
         heartbeatIntervalSeconds: 86400,
         rotationIntervalSeconds: 86400,
-        pwLength: 32,
+        pwLength: defaultPwLength,
         pwUppercase: 1,
         pwLowercase: 1,
         pwDigits: 1,
@@ -304,9 +309,6 @@ const SettingsTab = ({
       }
     }
   });
-
-  const maxPwLength = maxGeneratedPasswordLength(template?.type);
-  const defaultPwLength = Math.min(32, maxPwLength);
 
   useEffect(() => {
     onDirtyChange?.(isDirty);
@@ -591,6 +593,9 @@ const SettingsTab = ({
                         onChange={(e) => field.onChange(Number(e.target.value))}
                         onWheel={(e) => e.currentTarget.blur()}
                       />
+                      {name === "settings.pwLength" && !fieldState.error && (
+                        <FieldDescription>1 to {maxPwLength} characters</FieldDescription>
+                      )}
                       {fieldState.error && <FieldError>{fieldState.error.message}</FieldError>}
                     </Field>
                   )}

--- a/frontend/src/pages/pam/PamTemplatesPage/components/TemplateDetailSheet.tsx
+++ b/frontend/src/pages/pam/PamTemplatesPage/components/TemplateDetailSheet.tsx
@@ -36,6 +36,7 @@ import { AppConnection, useListAvailableAppConnections } from "@app/hooks/api/ap
 import {
   accountTypeRequiresRecording,
   isRotatablePamAccountType,
+  maxGeneratedPasswordLength,
   PAM_ROTATION_INTERVAL_OPTIONS,
   PamAccountType,
   useGetPamAccountTemplate,
@@ -304,6 +305,9 @@ const SettingsTab = ({
     }
   });
 
+  const maxPwLength = maxGeneratedPasswordLength(template?.type);
+  const defaultPwLength = Math.min(32, maxPwLength);
+
   useEffect(() => {
     onDirtyChange?.(isDirty);
     return () => onDirtyChange?.(false);
@@ -350,7 +354,7 @@ const SettingsTab = ({
               heartbeatIntervalSeconds: heartbeat.intervalSeconds ?? 86400,
               rotationIntervalSeconds:
                 rotation.intervalSeconds !== undefined ? rotation.intervalSeconds : 86400,
-              pwLength: pw.length ?? 32,
+              pwLength: pw.length ?? defaultPwLength,
               pwUppercase: pw.required?.uppercase ?? 1,
               pwLowercase: pw.required?.lowercase ?? 1,
               pwDigits: pw.required?.digits ?? 1,
@@ -425,7 +429,7 @@ const SettingsTab = ({
         intervalSeconds: isRotationOn ? (data.settings.rotationIntervalSeconds ?? 86400) : null
       };
       settings.passwordRequirements = {
-        length: data.settings.pwLength ?? 32,
+        length: data.settings.pwLength ?? defaultPwLength,
         required: {
           uppercase: data.settings.pwUppercase ?? 0,
           lowercase: data.settings.pwLowercase ?? 0,
@@ -582,6 +586,7 @@ const SettingsTab = ({
                       <FieldLabel>{label}</FieldLabel>
                       <Input
                         type="number"
+                        max={name === "settings.pwLength" ? maxPwLength : undefined}
                         value={field.value ?? 0}
                         onChange={(e) => field.onChange(Number(e.target.value))}
                         onWheel={(e) => e.currentTarget.blur()}


### PR DESCRIPTION
## Context

Oracle Database is available in Infisical PAM again. You can add an Oracle account, launch a session to it, see at a glance whether its stored password still works, and rotate that password on a schedule, either the account changing its own password, or a separate admin account doing it on its behalf.

Because Oracle logs in differently from the other databases, rotation and health checks are handled by the Gateway rather than by Infisical directly, which also means Oracle databases requiring an encrypted connection are supported.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [x] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)