### PR TITLE
fix(integrations): paginate cloudflare pages projects and workers scripts

### DIFF
--- a/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.test.ts
+++ b/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.test.ts
@@ -1,0 +1,302 @@
+import { AxiosError } from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppConnection } from "@app/services/app-connection/app-connection-enums";
+
+import { CloudflareConnectionMethod } from "./cloudflare-connection-enum";
+import {
+  getCloudflareErrorMessage,
+  listCloudflarePagesProjects,
+  listCloudflarePermissionGroups,
+  listCloudflareWorkersScripts,
+  listCloudflareZones
+} from "./cloudflare-connection-fns";
+import { TCloudflareConnection } from "./cloudflare-connection-types";
+
+const { loggerMock, safeRequestMock } = vi.hoisted(() => ({
+  loggerMock: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  },
+  safeRequestMock: {
+    get: vi.fn()
+  }
+}));
+
+vi.mock("@app/lib/validator", () => ({
+  safeRequest: safeRequestMock
+}));
+
+vi.mock("@app/lib/logger", () => ({
+  logger: loggerMock,
+  sanitizeUrlForLog: (url: string) => url
+}));
+
+describe("cloudflare-connection-fns", () => {
+  const mockConnection = {
+    id: "conn-123",
+    app: AppConnection.Cloudflare,
+    method: CloudflareConnectionMethod.APIToken,
+    name: "Test Cloudflare",
+    orgId: "org-123",
+    version: 1,
+    isAutoRotationEnabled: false,
+    credentials: {
+      accountId: "acc-123",
+      apiToken: "test-token"
+    },
+    createdAt: new Date(),
+    updatedAt: new Date()
+  } as unknown as TCloudflareConnection;
+
+  beforeEach(() => {
+    safeRequestMock.get.mockReset();
+    loggerMock.warn.mockReset();
+  });
+
+  describe("listCloudflarePagesProjects", () => {
+    it("fetches single page of pages projects", async () => {
+      safeRequestMock.get.mockResolvedValueOnce({
+        data: {
+          result: [
+            { id: "proj-1", name: "project-1" },
+            { id: "proj-2", name: "project-2" }
+          ],
+          result_info: { total_pages: 1 }
+        }
+      });
+
+      const projects = await listCloudflarePagesProjects(mockConnection);
+
+      expect(safeRequestMock.get).toHaveBeenCalledTimes(1);
+      expect(safeRequestMock.get).toHaveBeenCalledWith(
+        "https://api.cloudflare.com/client/v4/accounts/acc-123/pages/projects",
+        {
+          headers: {
+            Authorization: "Bearer test-token",
+            Accept: "application/json"
+          },
+          params: { page: 1, per_page: 50 }
+        }
+      );
+      expect(projects).toEqual([
+        { id: "proj-1", name: "project-1" },
+        { id: "proj-2", name: "project-2" }
+      ]);
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+    });
+
+    it("paginates across multiple pages of pages projects", async () => {
+      safeRequestMock.get
+        .mockResolvedValueOnce({
+          data: {
+            result: [{ id: "proj-1", name: "project-1" }],
+            result_info: { total_pages: 2 }
+          }
+        })
+        .mockResolvedValueOnce({
+          data: {
+            result: [{ id: "proj-2", name: "project-2" }],
+            result_info: { total_pages: 2 }
+          }
+        });
+
+      const projects = await listCloudflarePagesProjects(mockConnection);
+
+      expect(safeRequestMock.get).toHaveBeenCalledTimes(2);
+      expect(safeRequestMock.get).toHaveBeenNthCalledWith(
+        1,
+        "https://api.cloudflare.com/client/v4/accounts/acc-123/pages/projects",
+        {
+          headers: {
+            Authorization: "Bearer test-token",
+            Accept: "application/json"
+          },
+          params: { page: 1, per_page: 50 }
+        }
+      );
+      expect(safeRequestMock.get).toHaveBeenNthCalledWith(
+        2,
+        "https://api.cloudflare.com/client/v4/accounts/acc-123/pages/projects",
+        {
+          headers: {
+            Authorization: "Bearer test-token",
+            Accept: "application/json"
+          },
+          params: { page: 2, per_page: 50 }
+        }
+      );
+      expect(projects).toEqual([
+        { id: "proj-1", name: "project-1" },
+        { id: "proj-2", name: "project-2" }
+      ]);
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+    });
+
+    it("terminates pagination at max pages cap and logs a warning when total_pages exceeds limit", async () => {
+      safeRequestMock.get.mockResolvedValue({
+        data: {
+          result: [{ id: "proj-1", name: "project-1" }],
+          result_info: { total_pages: 150 }
+        }
+      });
+
+      const projects = await listCloudflarePagesProjects(mockConnection);
+
+      expect(safeRequestMock.get).toHaveBeenCalledTimes(100);
+      expect(projects).toHaveLength(100);
+      expect(loggerMock.warn).toHaveBeenCalledTimes(1);
+      expect(loggerMock.warn).toHaveBeenCalledWith(
+        "Stopped listing Cloudflare resources from https://api.cloudflare.com/client/v4/accounts/acc-123/pages/projects after 100 pages; some results were not returned"
+      );
+    });
+  });
+
+  describe("listCloudflareWorkersScripts", () => {
+    it("fetches single page of workers scripts", async () => {
+      safeRequestMock.get.mockResolvedValueOnce({
+        data: {
+          result: [{ id: "script-1" }, { id: "script-2" }],
+          result_info: { total_pages: 1 }
+        }
+      });
+
+      const scripts = await listCloudflareWorkersScripts(mockConnection);
+
+      expect(safeRequestMock.get).toHaveBeenCalledTimes(1);
+      expect(safeRequestMock.get).toHaveBeenCalledWith(
+        "https://api.cloudflare.com/client/v4/accounts/acc-123/workers/scripts-search",
+        {
+          headers: {
+            Authorization: "Bearer test-token",
+            Accept: "application/json"
+          },
+          params: { page: 1, per_page: 50 }
+        }
+      );
+      expect(scripts).toEqual([{ id: "script-1" }, { id: "script-2" }]);
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+    });
+
+    it("paginates across multiple pages of workers scripts", async () => {
+      safeRequestMock.get
+        .mockResolvedValueOnce({
+          data: {
+            result: [{ id: "script-1" }],
+            result_info: { total_pages: 2 }
+          }
+        })
+        .mockResolvedValueOnce({
+          data: {
+            result: [{ id: "script-2" }],
+            result_info: { total_pages: 2 }
+          }
+        });
+
+      const scripts = await listCloudflareWorkersScripts(mockConnection);
+
+      expect(safeRequestMock.get).toHaveBeenCalledTimes(2);
+      expect(safeRequestMock.get).toHaveBeenNthCalledWith(
+        1,
+        "https://api.cloudflare.com/client/v4/accounts/acc-123/workers/scripts-search",
+        {
+          headers: {
+            Authorization: "Bearer test-token",
+            Accept: "application/json"
+          },
+          params: { page: 1, per_page: 50 }
+        }
+      );
+      expect(safeRequestMock.get).toHaveBeenNthCalledWith(
+        2,
+        "https://api.cloudflare.com/client/v4/accounts/acc-123/workers/scripts-search",
+        {
+          headers: {
+            Authorization: "Bearer test-token",
+            Accept: "application/json"
+          },
+          params: { page: 2, per_page: 50 }
+        }
+      );
+      expect(scripts).toEqual([{ id: "script-1" }, { id: "script-2" }]);
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listCloudflareZones", () => {
+    it("paginates across multiple pages of zones", async () => {
+      safeRequestMock.get
+        .mockResolvedValueOnce({
+          data: {
+            result: [{ id: "zone-1", name: "example.com" }],
+            result_info: { total_pages: 2 }
+          }
+        })
+        .mockResolvedValueOnce({
+          data: {
+            result: [{ id: "zone-2", name: "test.com" }],
+            result_info: { total_pages: 2 }
+          }
+        });
+
+      const zones = await listCloudflareZones(mockConnection);
+
+      expect(safeRequestMock.get).toHaveBeenCalledTimes(2);
+      expect(zones).toEqual([
+        { id: "zone-1", name: "example.com" },
+        { id: "zone-2", name: "test.com" }
+      ]);
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("listCloudflarePermissionGroups", () => {
+    it("returns permission groups in a single call", async () => {
+      safeRequestMock.get.mockResolvedValueOnce({
+        data: {
+          result: [
+            { id: "group-1", name: "Group 1", scopes: ["com.cloudflare.api.account.zone"] },
+            { id: "group-2", name: "Group 2" }
+          ]
+        }
+      });
+
+      const groups = await listCloudflarePermissionGroups(mockConnection);
+
+      expect(safeRequestMock.get).toHaveBeenCalledTimes(1);
+      expect(groups).toEqual([
+        { id: "group-1", name: "Group 1", scopes: ["com.cloudflare.api.account.zone"] },
+        { id: "group-2", name: "Group 2", scopes: [] }
+      ]);
+      expect(loggerMock.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getCloudflareErrorMessage", () => {
+    it("extracts error message from AxiosError with Cloudflare error response", () => {
+      const axiosError = new AxiosError("Request failed with status code 400");
+      axiosError.response = {
+        data: {
+          errors: [{ message: "Invalid token" }]
+        },
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        config: {} as never
+      };
+
+      expect(getCloudflareErrorMessage(axiosError)).toBe("Invalid token");
+    });
+
+    it("falls back to error message from standard Error", () => {
+      const error = new Error("Network failure");
+      expect(getCloudflareErrorMessage(error)).toBe("Network failure");
+    });
+
+    it("returns Unknown error for non-error types", () => {
+      expect(getCloudflareErrorMessage("string error")).toBe("Unknown error");
+    });
+  });
+});

--- a/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.ts
+++ b/backend/src/services/app-connection/cloudflare/cloudflare-connection-fns.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from "axios";
 
 import { BadRequestError } from "@app/lib/errors";
-import { logger } from "@app/lib/logger";
+import { logger, sanitizeUrlForLog } from "@app/lib/logger";
 import { safeRequest } from "@app/lib/validator";
 import { AppConnection } from "@app/services/app-connection/app-connection-enums";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
@@ -44,10 +44,15 @@ export const getCloudflareErrorMessage = (error: unknown) => {
 };
 
 /** Walks a paginated Cloudflare list endpoint using the `result_info.total_pages` it reports. */
-const $paginateCloudflare = async <T>(
-  url: string,
-  { apiToken, params }: { apiToken: string; params?: Record<string, unknown> }
-): Promise<T[]> => {
+const $paginateCloudflare = async <T>({
+  url,
+  apiToken,
+  params
+}: {
+  url: string;
+  apiToken: string;
+  params?: Record<string, unknown>;
+}): Promise<T[]> => {
   const results: T[] = [];
 
   let page = 1;
@@ -64,6 +69,12 @@ const $paginateCloudflare = async <T>(
 
     totalPages = data.result_info?.total_pages ?? 1;
     page += 1;
+  }
+
+  if (totalPages > CLOUDFLARE_MAX_PAGES) {
+    logger.warn(
+      `Stopped listing Cloudflare resources from ${sanitizeUrlForLog(url)} after ${CLOUDFLARE_MAX_PAGES} pages; some results were not returned`
+    );
   }
 
   return results;
@@ -84,12 +95,12 @@ export const listCloudflarePagesProjects = async (
     credentials: { apiToken, accountId }
   } = appConnection;
 
-  const { data } = await safeRequest.get<{ result: { name: string; id: string }[] }>(
-    `${IntegrationUrls.CLOUDFLARE_API_URL}/client/v4/accounts/${accountId}/pages/projects`,
-    { headers: getCloudflareAuthHeaders(apiToken) }
-  );
+  const projects = await $paginateCloudflare<{ name: string; id: string }>({
+    url: `${IntegrationUrls.CLOUDFLARE_API_URL}/client/v4/accounts/${accountId}/pages/projects`,
+    apiToken
+  });
 
-  return data.result.map((a) => ({
+  return projects.map((a) => ({
     name: a.name,
     id: a.id
   }));
@@ -102,12 +113,12 @@ export const listCloudflareWorkersScripts = async (
     credentials: { apiToken, accountId }
   } = appConnection;
 
-  const { data } = await safeRequest.get<{ result: { id: string }[] }>(
-    `${IntegrationUrls.CLOUDFLARE_API_URL}/client/v4/accounts/${accountId}/workers/scripts`,
-    { headers: getCloudflareAuthHeaders(apiToken) }
-  );
+  const scripts = await $paginateCloudflare<{ id: string }>({
+    url: `${IntegrationUrls.CLOUDFLARE_API_URL}/client/v4/accounts/${accountId}/workers/scripts-search`,
+    apiToken
+  });
 
-  return data.result.map((a) => ({
+  return scripts.map((a) => ({
     id: a.id
   }));
 };
@@ -117,10 +128,10 @@ export const listCloudflareZones = async (appConnection: TCloudflareConnection):
     credentials: { apiToken }
   } = appConnection;
 
-  const zones = await $paginateCloudflare<{ id: string; name: string }>(
-    `${IntegrationUrls.CLOUDFLARE_API_URL}/client/v4/zones`,
-    { apiToken }
-  );
+  const zones = await $paginateCloudflare<{ id: string; name: string }>({
+    url: `${IntegrationUrls.CLOUDFLARE_API_URL}/client/v4/zones`,
+    apiToken
+  });
 
   return zones.map((a) => ({
     name: a.name,


### PR DESCRIPTION

## Context

When listing Cloudflare resources via the Cloudflare App Connection, `listCloudflarePagesProjects` and `listCloudflareWorkersScripts` issued a single unpaginated `GET` request. Because Cloudflare's API caps default page sizes to 50 items (or 20 items), accounts with more than one page of Pages projects or Workers scripts received only the first page. Subsequent pages were silently omitted, causing resource pickers in the UI to truncate available resources.

This change updates both `listCloudflarePagesProjects` and `listCloudflareWorkersScripts` to use the internal `$paginateCloudflare` helper, traversing all available pages up to `CLOUDFLARE_MAX_PAGES` and logging a warning if the page limit cap is reached, matching the pagination behavior of `listCloudflareZones`.

## Steps to verify the change

1. Run the newly added unit test suite covering single-page, multi-page pagination accumulation, and max page capping:
   ```bash
   cd backend && npm run test:unit -- src/services/app-connection/cloudflare/cloudflare-connection-fns.test.ts
   ```
2. Verify full backend type checking and linting pass:
   ```bash
   make reviewable-api

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)