### PR TITLE
fix(secrets-access-requests): auto open review sheet when request ID present

### DIFF
--- a/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
+++ b/backend/src/ee/services/access-approval-request/access-approval-request-service.ts
@@ -364,8 +364,8 @@ export const accessApprovalRequestServiceFactory = ({
 
       const requesterFullName = `${requestedByUser.firstName} ${requestedByUser.lastName}`;
       const projectPath = `/organizations/${project.orgId}/projects/secret-management/${project.id}`;
-      // Deep-link approvers straight to the Access Requests tab
-      const approvalPath = `${projectPath}/approval?selectedTab=resource-requests`;
+      // Deep-link approvers straight to this request on the Access Requests tab
+      const approvalPath = `${projectPath}/approval?selectedTab=resource-requests&requestId=${encodeURIComponent(approvalRequest.id)}`;
       const approvalUrl = `${cfg.SITE_URL}${approvalPath}`;
 
       await triggerWorkflowIntegrationNotification({
@@ -565,8 +565,8 @@ export const accessApprovalRequestServiceFactory = ({
       const requesterFullName = `${requestedByUser.firstName} ${requestedByUser.lastName}`;
       const editorFullName = `${editedByUser.firstName} ${editedByUser.lastName}`;
       const projectPath = `/organizations/${project.orgId}/projects/secret-management/${project.id}`;
-      // Deep-link approvers straight to the Access Requests tab
-      const approvalPath = `${projectPath}/approval?selectedTab=resource-requests`;
+      // Deep-link approvers straight to this request on the Access Requests tab
+      const approvalPath = `${projectPath}/approval?selectedTab=resource-requests&requestId=${encodeURIComponent(requestId)}`;
       const approvalUrl = `${cfg.SITE_URL}${approvalPath}`;
 
       await triggerWorkflowIntegrationNotification({
@@ -1007,8 +1007,8 @@ export const accessApprovalRequestServiceFactory = ({
               .map((appUser) => appUser.email)
               .filter((email): email is string => !!email);
 
-            // Deep-link approvers straight to the Access Requests tab
-            const approvalPath = `/organizations/${project.orgId}/projects/secret-management/${project.id}/approval?selectedTab=resource-requests`;
+            // Deep-link approvers straight to this request on the Access Requests tab
+            const approvalPath = `/organizations/${project.orgId}/projects/secret-management/${project.id}/approval?selectedTab=resource-requests&requestId=${encodeURIComponent(accessApprovalRequest.id)}`;
             const approvalUrl = `${cfg.SITE_URL}${approvalPath}`;
 
             await notificationService.createUserNotifications(

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable react/jsx-no-useless-fragment */
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useSearch } from "@tanstack/react-router";
 import { format, formatDistance } from "date-fns";
 import {
   BanIcon,
@@ -61,6 +62,7 @@ import {
   TooltipTrigger
 } from "@app/components/v3";
 import { cn } from "@app/components/v3/utils";
+import { ROUTE_PATHS } from "@app/const/routes";
 import {
   ProjectPermissionMemberActions,
   ProjectPermissionSub,
@@ -144,6 +146,12 @@ export const AccessApprovalRequest = ({
     ProjectPermissionMemberActions.Read,
     ProjectPermissionSub.Member
   );
+
+  const searchParams = useSearch({
+    from: ROUTE_PATHS.SecretManager.ApprovalPage.id
+  });
+
+  const { requestId } = searchParams;
 
   const { data: members, isPending: areMembersPending } = useGetWorkspaceUsers(projectId, true);
   const membersGroupById = useMemo(
@@ -501,6 +509,15 @@ export const AccessApprovalRequest = ({
       validRequestedByFilter ||
       (statusFilter === "close" && closedRequestFilters.length < CLOSED_REQUEST_FILTERS.length)
   );
+
+  useEffect(() => {
+    if (requestId && !selectedRequest) {
+      const foundRequest = filteredRequests.find((r) => r.id === requestId);
+      if (foundRequest) {
+        handleSelectRequest(foundRequest);
+      }
+    }
+  }, [requestId, filteredRequests]);
 
   return (
     <>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/AccessApprovalRequest.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 /* eslint-disable react/jsx-no-useless-fragment */
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSearch } from "@tanstack/react-router";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { format, formatDistance } from "date-fns";
 import {
   BanIcon,
@@ -146,7 +146,9 @@ export const AccessApprovalRequest = ({
     ProjectPermissionMemberActions.Read,
     ProjectPermissionSub.Member
   );
-
+  const navigate = useNavigate({
+    from: ROUTE_PATHS.SecretManager.ApprovalPage.path
+  });
   const searchParams = useSearch({
     from: ROUTE_PATHS.SecretManager.ApprovalPage.id
   });
@@ -484,6 +486,8 @@ export const AccessApprovalRequest = ({
       const details = generateRequestDetails(request);
       const memberUser = membersGroupById?.[request.requestedByUserId]?.user;
 
+      navigate({ search: (prev) => ({ ...prev, requestId: request.id }) });
+
       setSelectedRequest({
         ...request,
         user: details.isRequestedByCurrentUser
@@ -511,13 +515,13 @@ export const AccessApprovalRequest = ({
   );
 
   useEffect(() => {
-    if (requestId && !selectedRequest) {
-      const foundRequest = filteredRequests.find((r) => r.id === requestId);
+    if (requestId && !selectedRequest && requests?.length) {
+      const foundRequest = requests.find((r) => r.id === requestId);
       if (foundRequest) {
         handleSelectRequest(foundRequest);
       }
     }
-  }, [requestId, filteredRequests]);
+  }, [requestId, requests]);
 
   return (
     <>
@@ -958,7 +962,11 @@ export const AccessApprovalRequest = ({
           request={selectedRequest}
           members={members || []}
           isOpen={popUp.reviewRequest.isOpen}
-          onOpenChange={() => {
+          onOpenChange={(open) => {
+            if (!open) {
+              navigate({ search: (prev) => ({ ...prev, requestId: "" }) });
+            }
+
             handlePopUpClose("reviewRequest");
             setSelectedRequest(null);
             refetchRequests();


### PR DESCRIPTION
## Context

Added support for automatically opening the associated access request when access request ID is present in URL.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)