### PR TITLE
fix(pam): atomic recording secret mint

### DIFF
--- a/backend/src/ee/services/pam-session-recording/pam-recording-secrets.ts
+++ b/backend/src/ee/services/pam-session-recording/pam-recording-secrets.ts
@@ -73,9 +73,8 @@ export const decryptSessionKey = async ({
   return decrypted.subarray(32, 32 + SESSION_KEY_LENGTH);
 };
 
-// Every rejection keeps the same client-facing message; only the error name differs, so the
-// branch is recoverable from logs without widening what the caller learns. A malformed token and
-// a token that simply does not match point at completely different causes.
+// The message must stay identical across these: the chunk router substring-matches it to write
+// the upload-token audit event.
 export const PamUploadTokenRejection = {
   Missing: "PamUploadTokenMissing",
   MalformedLength: "PamUploadTokenMalformedLength",
@@ -96,8 +95,7 @@ export const verifyGatewayUploadToken = (
     });
   }
 
-  // Buffer.from drops invalid base64 characters rather than throwing, so a bad encoding arrives
-  // here as a short decode, never as an exception.
+  // Buffer.from drops invalid base64 rather than throwing, so a bad encoding lands here short.
   const presentedBuf = Buffer.from(presentedTokenBase64, "base64");
   if (presentedBuf.length !== UPLOAD_TOKEN_LENGTH) {
     throw new BadRequestError({

--- a/backend/src/ee/services/pam-session-recording/pam-recording-secrets.ts
+++ b/backend/src/ee/services/pam-session-recording/pam-recording-secrets.ts
@@ -73,15 +73,15 @@ export const decryptSessionKey = async ({
   return decrypted.subarray(32, 32 + SESSION_KEY_LENGTH);
 };
 
-// The message must stay identical across these: the chunk router substring-matches it to write
-// the upload-token audit event.
-export const PamUploadTokenRejection = {
+const PamUploadTokenRejection = {
   Missing: "PamUploadTokenMissing",
   MalformedLength: "PamUploadTokenMalformedLength",
   StoredHashMalformed: "PamUploadTokenStoredHashMalformed",
   HashMismatch: "PamUploadTokenHashMismatch"
 } as const;
 
+// The chunk router substring-matches this to write the upload-token audit event, and the gateway
+// treats HashMismatch as the one failure worth giving up on, so both are a contract.
 const UPLOAD_TOKEN_INVALID_MESSAGE = "Invalid upload token";
 
 export const verifyGatewayUploadToken = (

--- a/backend/src/ee/services/pam-session-recording/pam-recording-secrets.ts
+++ b/backend/src/ee/services/pam-session-recording/pam-recording-secrets.ts
@@ -73,30 +73,51 @@ export const decryptSessionKey = async ({
   return decrypted.subarray(32, 32 + SESSION_KEY_LENGTH);
 };
 
+// Every rejection keeps the same client-facing message; only the error name differs, so the
+// branch is recoverable from logs without widening what the caller learns. A malformed token and
+// a token that simply does not match point at completely different causes (PAM-463).
+export const PamUploadTokenRejection = {
+  Missing: "PamUploadTokenMissing",
+  MalformedLength: "PamUploadTokenMalformedLength",
+  StoredHashMalformed: "PamUploadTokenStoredHashMalformed",
+  HashMismatch: "PamUploadTokenHashMismatch"
+} as const;
+
+const UPLOAD_TOKEN_INVALID_MESSAGE = "Invalid upload token";
+
 export const verifyGatewayUploadToken = (
   presentedTokenBase64: string | undefined | null,
   storedTokenHash: Buffer | null | undefined
 ) => {
   if (!presentedTokenBase64 || !storedTokenHash) {
     throw new BadRequestError({
+      name: PamUploadTokenRejection.Missing,
       message: "Gateway upload token missing or session not configured for chunked uploads"
     });
   }
-  let presentedBuf: Buffer;
-  try {
-    presentedBuf = Buffer.from(presentedTokenBase64, "base64");
-  } catch {
-    throw new BadRequestError({ message: "Invalid upload token" });
-  }
+
+  // Buffer.from drops invalid base64 characters rather than throwing, so a bad encoding arrives
+  // here as a short decode, never as an exception.
+  const presentedBuf = Buffer.from(presentedTokenBase64, "base64");
   if (presentedBuf.length !== UPLOAD_TOKEN_LENGTH) {
-    throw new BadRequestError({ message: "Invalid upload token" });
+    throw new BadRequestError({
+      name: PamUploadTokenRejection.MalformedLength,
+      message: UPLOAD_TOKEN_INVALID_MESSAGE
+    });
   }
+
   const presentedHash = crypto.nativeCrypto.createHash("sha256").update(presentedBuf).digest();
   if (presentedHash.length !== storedTokenHash.length) {
-    throw new BadRequestError({ message: "Invalid upload token" });
+    throw new BadRequestError({
+      name: PamUploadTokenRejection.StoredHashMalformed,
+      message: UPLOAD_TOKEN_INVALID_MESSAGE
+    });
   }
   if (!crypto.nativeCrypto.timingSafeEqual(presentedHash, storedTokenHash)) {
-    throw new BadRequestError({ message: "Invalid upload token" });
+    throw new BadRequestError({
+      name: PamUploadTokenRejection.HashMismatch,
+      message: UPLOAD_TOKEN_INVALID_MESSAGE
+    });
   }
 };
 

--- a/backend/src/ee/services/pam-session-recording/pam-recording-secrets.ts
+++ b/backend/src/ee/services/pam-session-recording/pam-recording-secrets.ts
@@ -75,7 +75,7 @@ export const decryptSessionKey = async ({
 
 // Every rejection keeps the same client-facing message; only the error name differs, so the
 // branch is recoverable from logs without widening what the caller learns. A malformed token and
-// a token that simply does not match point at completely different causes (PAM-463).
+// a token that simply does not match point at completely different causes.
 export const PamUploadTokenRejection = {
   Missing: "PamUploadTokenMissing",
   MalformedLength: "PamUploadTokenMalformedLength",

--- a/backend/src/ee/services/pam-session/pam-session-dal.ts
+++ b/backend/src/ee/services/pam-session/pam-session-dal.ts
@@ -24,11 +24,8 @@ export const pamSessionDALFactory = (db: TDbClient) => {
     return session;
   };
 
-  // Sets the recording secrets only if the session has none yet, and returns whichever key is
-  // stored afterwards. One statement on the primary, so a caller that loses a concurrent claim
-  // still gets the winner's key back; a follow-up read would go to a replica that may not have
-  // caught up. COALESCE and CASE both see the pre-update value, so the winner is whoever the row
-  // was null for.
+  // Returns whichever key ends up stored, so a caller that loses the claim still gets the
+  // winner's. One statement on the primary, because a follow-up read could hit a lagging replica.
   const claimRecordingSecrets = async (
     sessionId: string,
     encryptedSessionKey: Buffer,

--- a/backend/src/ee/services/pam-session/pam-session-dal.ts
+++ b/backend/src/ee/services/pam-session/pam-session-dal.ts
@@ -24,6 +24,35 @@ export const pamSessionDALFactory = (db: TDbClient) => {
     return session;
   };
 
+  // Sets the recording secrets only if the session has none yet, and returns whichever key is
+  // stored afterwards. One statement on the primary, so a caller that loses a concurrent claim
+  // still gets the winner's key back; a follow-up read would go to a replica that may not have
+  // caught up. COALESCE and CASE both see the pre-update value, so the winner is whoever the row
+  // was null for.
+  const claimRecordingSecrets = async (
+    sessionId: string,
+    encryptedSessionKey: Buffer,
+    gatewayUploadTokenHash: Buffer,
+    tx?: Knex
+  ) => {
+    const [row] = await (tx || db)(TableName.PamSession)
+      .where({ id: sessionId })
+      .update({
+        encryptedSessionKey: db.raw("COALESCE(??, ?)", [
+          "encryptedSessionKey",
+          encryptedSessionKey
+        ]) as unknown as Buffer,
+        gatewayUploadTokenHash: db.raw("CASE WHEN ?? IS NULL THEN ? ELSE ?? END", [
+          "encryptedSessionKey",
+          gatewayUploadTokenHash,
+          "gatewayUploadTokenHash"
+        ]) as unknown as Buffer
+      })
+      .returning(["encryptedSessionKey"]);
+
+    return row as { encryptedSessionKey: Buffer | null } | undefined;
+  };
+
   const countActiveWebSessions = async (userId: string, projectId: string, tx?: Knex): Promise<number> => {
     const result = await (tx || db.replicaNode())(TableName.PamSession)
       .where("userId", userId)
@@ -169,6 +198,7 @@ export const pamSessionDALFactory = (db: TDbClient) => {
   return {
     ...orm,
     findById,
+    claimRecordingSecrets,
     countActiveWebSessions,
     endExpiredWebSessions,
     endSessionById,

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -3,7 +3,7 @@ import RE2 from "re2";
 import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
-import { BadRequestError, ForbiddenRequestError, InternalServerError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { createSshCert, createSshKeyPair, SshCertKeyAlgorithm, SshCertType } from "@app/lib/ssh";
@@ -89,7 +89,7 @@ type TPamSessionServiceFactoryDep = {
     | "endSessionById"
     | "terminateSessionById"
     | "updateById"
-    | "update"
+    | "claimRecordingSecrets"
     | "activateSession"
   >;
   pamAccountDAL: Pick<TPamAccountDALFactory, "findByIdWithDetails" | "findOne">;
@@ -327,16 +327,17 @@ export const pamSessionServiceFactory = ({
       // between check and write to tens of milliseconds. Without the guard both callers mint, the
       // later write wins, and the earlier caller is left holding a session key and upload token the
       // row no longer matches: every chunk upload 400s forever, and whatever did upload is
-      // undecryptable at playback (PAM-463).
-      const [claimed] = await pamSessionDAL.update(
-        { id: sessionId, encryptedSessionKey: null },
-        {
-          encryptedSessionKey: secrets.encryptedSessionKey,
-          gatewayUploadTokenHash: secrets.uploadTokenHash
-        }
+      // undecryptable at playback.
+      const claimed = await pamSessionDAL.claimRecordingSecrets(
+        sessionId,
+        secrets.encryptedSessionKey,
+        secrets.uploadTokenHash
       );
+      if (!claimed?.encryptedSessionKey) {
+        throw new NotFoundError({ message: `Session with ID '${sessionId}' was not found` });
+      }
 
-      if (claimed) {
+      if (claimed.encryptedSessionKey.equals(secrets.encryptedSessionKey)) {
         recording = {
           sessionKey: secrets.sessionKey.toString("base64"),
           uploadToken: secrets.uploadToken.toString("base64"),
@@ -345,14 +346,9 @@ export const pamSessionServiceFactory = ({
           sessionId
         };
       } else {
-        // Another fetch claimed it first; adopt its secrets rather than our own discarded ones.
-        const claimedSession = await pamSessionDAL.findById(sessionId);
-        storedSessionKey = claimedSession?.encryptedSessionKey ?? null;
-        if (!storedSessionKey) {
-          throw new InternalServerError({
-            message: `Recording secrets for session ${sessionId} are missing after a lost mint`
-          });
-        }
+        // Another fetch claimed it first; adopt its key rather than our own discarded one. The
+        // upload token stays empty here, same as any other re-fetch.
+        storedSessionKey = claimed.encryptedSessionKey;
       }
     }
 

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -322,12 +322,8 @@ export const pamSessionServiceFactory = ({
         kmsService
       });
 
-      // Claim the mint in a single statement. Concurrent credential fetches for one session are
-      // routine -- a gateway fetches per connection -- and the KMS call above widens the gap
-      // between check and write to tens of milliseconds. Without the guard both callers mint, the
-      // later write wins, and the earlier caller is left holding a session key and upload token the
-      // row no longer matches: every chunk upload 400s forever, and whatever did upload is
-      // undecryptable at playback.
+      // A gateway fetches credentials per connection, so two can mint at once; without a single
+      // claim the loser keeps a key the row no longer holds and its uploads fail forever.
       const claimed = await pamSessionDAL.claimRecordingSecrets(
         sessionId,
         secrets.encryptedSessionKey,
@@ -346,8 +342,6 @@ export const pamSessionServiceFactory = ({
           sessionId
         };
       } else {
-        // Another fetch claimed it first; adopt its key rather than our own discarded one. The
-        // upload token stays empty here, same as any other re-fetch.
         storedSessionKey = claimed.encryptedSessionKey;
       }
     }

--- a/backend/src/ee/services/pam-session/pam-session-service.ts
+++ b/backend/src/ee/services/pam-session/pam-session-service.ts
@@ -3,7 +3,7 @@ import RE2 from "re2";
 import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { TPermissionServiceFactory } from "@app/ee/services/permission/permission-service-types";
-import { BadRequestError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, ForbiddenRequestError, InternalServerError, NotFoundError } from "@app/lib/errors";
 import { ms } from "@app/lib/ms";
 import { alphaNumericNanoId } from "@app/lib/nanoid";
 import { createSshCert, createSshKeyPair, SshCertKeyAlgorithm, SshCertType } from "@app/lib/ssh";
@@ -89,6 +89,7 @@ type TPamSessionServiceFactoryDep = {
     | "endSessionById"
     | "terminateSessionById"
     | "updateById"
+    | "update"
     | "activateSession"
   >;
   pamAccountDAL: Pick<TPamAccountDALFactory, "findByIdWithDetails" | "findOne">;
@@ -312,32 +313,56 @@ export const pamSessionServiceFactory = ({
       sessionId: string;
     } | null = null;
 
-    if (!session.encryptedSessionKey) {
+    let storedSessionKey = session.encryptedSessionKey ?? null;
+
+    if (!storedSessionKey) {
       const secrets = await generateSessionRecordingSecrets({
         projectId: session.projectId,
         sessionId,
         kmsService
       });
 
-      await pamSessionDAL.updateById(sessionId, {
-        encryptedSessionKey: secrets.encryptedSessionKey,
-        gatewayUploadTokenHash: secrets.uploadTokenHash
-      });
+      // Claim the mint in a single statement. Concurrent credential fetches for one session are
+      // routine -- a gateway fetches per connection -- and the KMS call above widens the gap
+      // between check and write to tens of milliseconds. Without the guard both callers mint, the
+      // later write wins, and the earlier caller is left holding a session key and upload token the
+      // row no longer matches: every chunk upload 400s forever, and whatever did upload is
+      // undecryptable at playback (PAM-463).
+      const [claimed] = await pamSessionDAL.update(
+        { id: sessionId, encryptedSessionKey: null },
+        {
+          encryptedSessionKey: secrets.encryptedSessionKey,
+          gatewayUploadTokenHash: secrets.uploadTokenHash
+        }
+      );
 
-      recording = {
-        sessionKey: secrets.sessionKey.toString("base64"),
-        uploadToken: secrets.uploadToken.toString("base64"),
-        storageBackend: resolvedBackend,
-        projectId: session.projectId,
-        sessionId
-      };
-    } else {
+      if (claimed) {
+        recording = {
+          sessionKey: secrets.sessionKey.toString("base64"),
+          uploadToken: secrets.uploadToken.toString("base64"),
+          storageBackend: resolvedBackend,
+          projectId: session.projectId,
+          sessionId
+        };
+      } else {
+        // Another fetch claimed it first; adopt its secrets rather than our own discarded ones.
+        const claimedSession = await pamSessionDAL.findById(sessionId);
+        storedSessionKey = claimedSession?.encryptedSessionKey ?? null;
+        if (!storedSessionKey) {
+          throw new InternalServerError({
+            message: `Recording secrets for session ${sessionId} are missing after a lost mint`
+          });
+        }
+      }
+    }
+
+    if (!recording && storedSessionKey) {
       // On re-fetch (e.g. gateway restart) return the existing key; empty token since the gateway
       // restores its own from disk and the server only keeps the token hash.
       const sessionKey = await decryptSessionKey({
         projectId: session.projectId,
         sessionId,
-        encryptedSessionKey: session.encryptedSessionKey,
+        encryptedSessionKey: storedSessionKey,
         kmsService
       });
 


### PR DESCRIPTION
## Context

Recording secrets were minted with an unguarded read-decide-write on `encryptedSessionKey`, so two concurrent credential fetches for one session both minted and the later write won, leaving the earlier caller with a session key and upload token the row no longer matched. That gateway's chunk uploads then 400ed forever, and anything it had already uploaded became undecryptable at playback.

Fixes [PAM-463](https://linear.app/infisical/issue/PAM-463/investigate-session-recording-endpoint-error-spike), which accounted for 99.75% of Infisical Cloud US platform errors. The gateway-side half is in Infisical/cli#392.

## Steps to verify the change

Race concurrent credential fetches at one live, never-minted session and check that every response carries the same session key, exactly one carries an upload token, and the stored hash is `sha256` of that token.

Six concurrent fetches through the real stack, before and after:

| | Before | After |
|---|---|---|
| Runs | 6 | 8 |
| Session keys diverged | 5 of 6 | 0 |
| Distinct keys issued for one session | up to 6 | always 1 |
| Verdict | 5 fail | 8/8 pass |

Also verified the guarded `UPDATE` against Postgres directly: eight concurrent claims on one row yield exactly one winner over five runs, where the unguarded version yields eight winners.

The second commit only renames error variants, so the four `verifyGatewayUploadToken` branches are distinguishable in logs. The client-facing message is deliberately unchanged, which keeps the response shape and the router's `PAM_SESSION_UPLOAD_TOKEN_INVALID` audit trigger working. After deploy, group chunk-route errors by `errorName like /PamUploadToken/`: all `PamUploadTokenHashMismatch` confirms the race.

## Type

- [x] Fix

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
