### PR TITLE
chore(dep): node base and npm bump

### DIFF
--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -6,8 +6,10 @@ ARG INFISICAL_CLI_VERSION=0.43.129
 
 FROM node:22.23.2-trixie-slim AS base
 
-# npm is pinned ahead of the base image. node:22.23.2 ships npm 10.9.8, whose bundled
-# tar 7.5.11 carries CVE-2026-59873. Drop this line once the base ships npm >= 10.9.9.
+# The base image ships npm 10.9.8, whose bundled tar 7.5.11 carries CVE-2026-59873;
+# 10.9.9 fixes it. package.json declares npm >= 11.10.0, but the committed lockfile
+# does not install under npm 11, which requires every optional platform entry to be
+# present. Regenerating the lockfile is a separate change; until then this stays on 10.x.
 RUN npm install -g npm@10.9.9
 
 FROM base AS frontend-dependencies

--- a/Dockerfile.fips.standalone-infisical
+++ b/Dockerfile.fips.standalone-infisical
@@ -4,10 +4,11 @@ ARG INTERCOM_ID=intercom-id
 
 ARG INFISICAL_CLI_VERSION=0.43.129
 
-FROM node:22.22.0-trixie-slim AS base
+FROM node:22.23.2-trixie-slim AS base
 
-# Fixes NPM vulnerability: https://security.snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230
-RUN npm install -g npm@10.9.0
+# npm is pinned ahead of the base image. node:22.23.2 ships npm 10.9.8, whose bundled
+# tar 7.5.11 carries CVE-2026-59873. Drop this line once the base ships npm >= 10.9.9.
+RUN npm install -g npm@10.9.9
 
 FROM base AS frontend-dependencies
 WORKDIR /app

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -4,10 +4,11 @@ ARG INTERCOM_ID=intercom-id
 
 ARG INFISICAL_CLI_VERSION=0.43.129
 
-FROM node:22.22.0-trixie-slim AS base
+FROM node:22.23.2-trixie-slim AS base
 
-# Fixes NPM vulnerability: https://security.snyk.io/vuln/SNYK-JS-CROSSSPAWN-8303230
-RUN npm install -g npm@10.9.0
+# npm is pinned ahead of the base image. node:22.23.2 ships npm 10.9.8, whose bundled
+# tar 7.5.11 carries CVE-2026-59873. Drop this line once the base ships npm >= 10.9.9.
+RUN npm install -g npm@10.9.9
 
 FROM base AS frontend-dependencies
 
@@ -303,7 +304,7 @@ LABEL org.opencontainers.image.documentation="https://infisical.com/docs"
 LABEL org.opencontainers.image.source="https://github.com/Infisical/infisical"
 LABEL org.opencontainers.image.vendor="Infisical"
 LABEL org.opencontainers.image.licenses="MIT"
-LABEL org.opencontainers.image.base.name="node:22.22.0-trixie-slim"
+LABEL org.opencontainers.image.base.name="node:22.23.2-trixie-slim"
 
 # OCI Image Labels - Dynamic metadata (set via build args)
 LABEL org.opencontainers.image.version="${INFISICAL_PLATFORM_VERSION}"

--- a/Dockerfile.standalone-infisical
+++ b/Dockerfile.standalone-infisical
@@ -6,8 +6,10 @@ ARG INFISICAL_CLI_VERSION=0.43.129
 
 FROM node:22.23.2-trixie-slim AS base
 
-# npm is pinned ahead of the base image. node:22.23.2 ships npm 10.9.8, whose bundled
-# tar 7.5.11 carries CVE-2026-59873. Drop this line once the base ships npm >= 10.9.9.
+# The base image ships npm 10.9.8, whose bundled tar 7.5.11 carries CVE-2026-59873;
+# 10.9.9 fixes it. package.json declares npm >= 11.10.0, but the committed lockfile
+# does not install under npm 11, which requires every optional platform entry to be
+# present. Regenerating the lockfile is a separate change; until then this stays on 10.x.
 RUN npm install -g npm@10.9.9
 
 FROM base AS frontend-dependencies

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,9 @@ ARG INFISICAL_CLI_VERSION=0.43.129
 
 FROM node:22.23.2-trixie-slim AS build
 
+# Pinned to match the runtime image; see Dockerfile.standalone-infisical.
+RUN npm install -g npm@10.9.9
+
 WORKDIR /app
 
 # Required for pkcs11js and TDS driver (SAP ASE dynamic secrets)
@@ -48,6 +51,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Production dependencies (runs in parallel with build)
 FROM node:22.23.2-trixie-slim AS prod-deps
 
+# Pinned to match the runtime image; see Dockerfile.standalone-infisical.
+RUN npm install -g npm@10.9.9
+
 WORKDIR /app
 
 # Build tools needed to compile native modules during npm ci
@@ -67,6 +73,10 @@ RUN npm ci --omit=dev
 
 # Production stage
 FROM node:22.23.2-trixie-slim
+
+# Pinned to match the runtime image; see Dockerfile.standalone-infisical.
+RUN npm install -g npm@10.9.9
+
 WORKDIR /app
 
 ENV npm_config_cache /home/node/.npm

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,7 @@
 # Build stage
 ARG INFISICAL_CLI_VERSION=0.43.129
 
-FROM node:22.22.0-trixie-slim AS build
+FROM node:22.23.2-trixie-slim AS build
 
 WORKDIR /app
 
@@ -46,7 +46,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     rm "$ORACLE_ZIP"
 
 # Production dependencies (runs in parallel with build)
-FROM node:22.22.0-trixie-slim AS prod-deps
+FROM node:22.23.2-trixie-slim AS prod-deps
 
 WORKDIR /app
 
@@ -66,7 +66,7 @@ COPY package*.json ./
 RUN npm ci --omit=dev
 
 # Production stage
-FROM node:22.22.0-trixie-slim
+FROM node:22.23.2-trixie-slim
 WORKDIR /app
 
 ENV npm_config_cache /home/node/.npm

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -24,7 +24,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     unzip "$ORACLE_ZIP" -d /opt/oracle && \
     rm "$ORACLE_ZIP"
 
-FROM node:22.22.0-trixie-slim
+FROM node:22.23.2-trixie-slim
 
 # ? Setup a test SoftHSM module. In production a real HSM is used.
 

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -26,6 +26,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 FROM node:22.23.2-trixie-slim
 
+# Pinned to match the runtime image; see Dockerfile.standalone-infisical.
+RUN npm install -g npm@10.9.9
+
 # ? Setup a test SoftHSM module. In production a real HSM is used.
 
 ARG SOFTHSM2_VERSION=2.5.0

--- a/backend/Dockerfile.fips-toolchain
+++ b/backend/Dockerfile.fips-toolchain
@@ -48,6 +48,9 @@ RUN ARCH=$(dpkg --print-architecture) && \
 
 FROM node:22.23.2-trixie-slim
 
+# Pinned to match the runtime image; see Dockerfile.standalone-infisical.
+RUN npm install -g npm@10.9.9
+
 ARG SOFTHSM2_VERSION=2.5.0
 ARG SOFTHSM2_COMMIT=369df0383d101bc8952692c2a368ac8bc887d1b4
 

--- a/backend/Dockerfile.fips-toolchain
+++ b/backend/Dockerfile.fips-toolchain
@@ -46,7 +46,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     unzip "$ORACLE_ZIP" -d /opt/oracle && \
     rm "$ORACLE_ZIP"
 
-FROM node:22.22.0-trixie-slim
+FROM node:22.23.2-trixie-slim
 
 ARG SOFTHSM2_VERSION=2.5.0
 ARG SOFTHSM2_COMMIT=369df0383d101bc8952692c2a368ac8bc887d1b4


### PR DESCRIPTION
## Context

Bump the node base image tag and pin the npm to a newer version. 

## Screenshots

N/A

## Steps to verify the change

Build the images with Dockerfiles and run a smoke test.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)