### PR TITLE
fix(helm): bump default infisical image tag from v0.158.0 to v0.165.8

### DIFF
--- a/helm-charts/infisical-standalone-postgres/CHANGELOG.md
+++ b/helm-charts/infisical-standalone-postgres/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.1 (September 9, 2026)
+Changes:
+* Updated the default `infisical.image.tag` value to `v0.165.8`. The chart had been pinning `v0.158.0` (January 2026), so fresh installs missed months of fixes - including the SSO-enforcement email-verification skip reported in #8052 (fixed in `v0.160.11`).
+
 ## 1.10.0 (July 3, 2026)
 Changes:
 * Added configurable `securityContext` via `infisical.podSecurityContext` and `infisical.containerSecurityContext`, with secure defaults so the Infisical Deployment and the auto-bootstrap Job run under the Kubernetes Pod Security "restricted" standard out of the box.

--- a/helm-charts/infisical-standalone-postgres/Chart.yaml
+++ b/helm-charts/infisical-standalone-postgres/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-charts/infisical-standalone-postgres/README.md
+++ b/helm-charts/infisical-standalone-postgres/README.md
@@ -1,6 +1,6 @@
 # infisical-standalone
 
-![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
+![Version: 1.10.1](https://img.shields.io/badge/Version-1.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.1](https://img.shields.io/badge/AppVersion-1.0.1-informational?style=flat-square)
 
 A helm chart to deploy Infisical
 

--- a/helm-charts/infisical-standalone-postgres/values.yaml
+++ b/helm-charts/infisical-standalone-postgres/values.yaml
@@ -65,7 +65,7 @@ infisical:
     # -- Image repository for the Infisical service
     repository: infisical/infisical
     # -- Specific version tag of the Infisical image. View the latest version here https://hub.docker.com/r/infisical/infisical
-    tag: "v0.158.0"
+    tag: "v0.165.8"
     # -- Pulls image only if not already present on the node
     pullPolicy: IfNotPresent
     # -- Secret references for pulling the image, if needed


### PR DESCRIPTION
Refs #8052.

The app-side fix for #8052 landed in `v0.160.11` (commit `e527bd6da`), but the `infisical-standalone-postgres` chart still pins `v0.158.0` (January) as its default `infisical.image.tag` - so anyone installing from the chart today runs a seven-month-old image and hits the enforced-OIDC email-code bug the app already fixed.

- `values.yaml`: default tag `v0.158.0` -> `v0.165.8` (current release at PR time)
- `Chart.yaml`: `1.10.0` -> `1.10.1`
- `CHANGELOG.md`: entry in the existing convention

Config-only change; until this ships, the immediate workaround for #8052 is overriding `infisical.image.tag` to a current release.

> Built by breken, your AI support engineer - breken.ai - this one's on us.