### PR TITLE
improvement(frontend): use Alert and Combobox in Doppler import modal

### DIFF
--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/DopplerSecretImportModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/DopplerSecretImportModal.tsx
@@ -46,6 +46,39 @@ type Props = {
   ) => Promise<void>;
 };
 
+const QueryOrFormError = ({
+  formError,
+  isQueryError,
+  queryMessage,
+  onRetry
+}: {
+  formError?: string;
+  isQueryError: boolean;
+  queryMessage: string;
+  onRetry: () => void;
+}) => {
+  if (formError) {
+    return <FieldError>{formError}</FieldError>;
+  }
+
+  if (!isQueryError) {
+    return <FieldError />;
+  }
+
+  return (
+    <FieldError>
+      {queryMessage}{" "}
+      <button
+        type="button"
+        className="underline underline-offset-4 hover:text-foreground"
+        onClick={onRetry}
+      >
+        Try again
+      </button>
+    </FieldError>
+  );
+};
+
 const formatConfigLabel = (config: TDopplerConfig) => {
   if (config.root) {
     return config.name;
@@ -101,12 +134,14 @@ export const DopplerSecretImportModal = ({
   const {
     data: dopplerProjects = [],
     isPending: isLoadingProjects,
-    isError: isProjectsError
+    isError: isProjectsError,
+    refetch: refetchProjects
   } = useGetDopplerProjects(connectionId);
   const {
     data: dopplerConfigs = [],
     isPending: isLoadingConfigs,
-    isError: isConfigsError
+    isError: isConfigsError,
+    refetch: refetchConfigs
   } = useGetDopplerConfigs(connectionId, selectedDopplerProject || undefined);
 
   const sortedDopplerConfigs = useMemo(() => {
@@ -176,12 +211,18 @@ export const DopplerSecretImportModal = ({
                         setValue("dopplerProject", "");
                         setValue("dopplerEnvironment", "");
                       }}
+                      onClear={() => {
+                        field.onChange("");
+                        setValue("dopplerProject", "");
+                        setValue("dopplerEnvironment", "");
+                      }}
                       options={connections}
                       getOptionValue={(option) => option.id}
                       getOptionLabel={(option) => option.name}
                       placeholder="Select Doppler connection..."
                       searchPlaceholder="Search Doppler connections..."
                       searchAriaLabel="Search Doppler connections"
+                      clearAriaLabel="Clear Doppler connection"
                       emptyMessage="No Doppler connections found."
                       isError={Boolean(error)}
                       modal
@@ -205,6 +246,10 @@ export const DopplerSecretImportModal = ({
                       field.onChange(project.slug);
                       setValue("dopplerEnvironment", "");
                     }}
+                    onClear={() => {
+                      field.onChange("");
+                      setValue("dopplerEnvironment", "");
+                    }}
                     options={dopplerProjects}
                     getOptionValue={(option) => option.slug}
                     getOptionLabel={(option) => option.name}
@@ -217,10 +262,22 @@ export const DopplerSecretImportModal = ({
                     }
                     searchPlaceholder="Search Doppler projects..."
                     searchAriaLabel="Search Doppler projects"
-                    emptyMessage="No Doppler projects found."
+                    clearAriaLabel="Clear source project"
+                    emptyMessage={
+                      isProjectsError
+                        ? "Failed to load Doppler projects."
+                        : "No Doppler projects found."
+                    }
                     modal
                   />
-                  <FieldError>{error?.message}</FieldError>
+                  <QueryOrFormError
+                    formError={error?.message}
+                    isQueryError={isProjectsError}
+                    queryMessage="Failed to load Doppler projects."
+                    onRetry={() => {
+                      refetchProjects();
+                    }}
+                  />
                 </Field>
               )}
             />
@@ -237,6 +294,7 @@ export const DopplerSecretImportModal = ({
                       sortedDopplerConfigs.find((config) => config.name === field.value) ?? null
                     }
                     onValueChange={(config) => field.onChange(config.name)}
+                    onClear={() => field.onChange("")}
                     options={sortedDopplerConfigs}
                     getOptionValue={(option) => option.name}
                     getOptionLabel={formatConfigLabel}
@@ -251,7 +309,12 @@ export const DopplerSecretImportModal = ({
                     }
                     searchPlaceholder="Search Doppler configs..."
                     searchAriaLabel="Search Doppler configs"
-                    emptyMessage="No Doppler configs found."
+                    clearAriaLabel="Clear source config"
+                    emptyMessage={
+                      isConfigsError
+                        ? "Failed to load Doppler configs."
+                        : "No Doppler configs found."
+                    }
                     modal
                     renderOption={(option) => (
                       <div className="min-w-0">
@@ -269,7 +332,14 @@ export const DopplerSecretImportModal = ({
                       </span>
                     )}
                   />
-                  <FieldError>{error?.message}</FieldError>
+                  <QueryOrFormError
+                    formError={error?.message}
+                    isQueryError={isConfigsError}
+                    queryMessage="Failed to load Doppler configs."
+                    onRetry={() => {
+                      refetchConfigs();
+                    }}
+                  />
                 </Field>
               )}
             />

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/DopplerSecretImportModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/DopplerSecretImportModal.tsx
@@ -187,9 +187,11 @@ export const DopplerSecretImportModal = ({
             <InfoIcon />
             <AlertTitle>Import destination</AlertTitle>
             <AlertDescription>
-              Secrets will be imported into environment{" "}
-              <code className="text-xs">{environment}</code> at path{" "}
-              <code className="text-xs">{secretPath}</code>.
+              <p>
+                Secrets will be imported into environment{" "}
+                <code className="text-xs">{environment}</code> at path{" "}
+                <code className="text-xs">{secretPath}</code>.
+              </p>
             </AlertDescription>
           </Alert>
 

--- a/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/DopplerSecretImportModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretDashboardPage/components/ActionBar/DopplerSecretImportModal.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useMemo } from "react";
 import { Controller, useForm } from "react-hook-form";
-import { components, GroupHeadingProps, OptionProps } from "react-select";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { InfoIcon } from "lucide-react";
 import { z } from "zod";
 
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Badge,
   Button,
+  Combobox,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -15,11 +18,9 @@ import {
   DialogHeader,
   DialogTitle,
   Field,
-  FieldContent,
   FieldError,
   FieldLabel
 } from "@app/components/v3";
-import { FilterableSelect } from "@app/components/v3/generic/ReactSelect";
 import { TAvailableAppConnection } from "@app/hooks/api/appConnections/types";
 import { useGetDopplerConfigs, useGetDopplerProjects } from "@app/hooks/api/migration/queries";
 import { TDopplerConfig } from "@app/hooks/api/migration/types";
@@ -45,13 +46,6 @@ type Props = {
   ) => Promise<void>;
 };
 
-const DopplerConfigGroupHeading = (props: GroupHeadingProps<TDopplerConfig>) => (
-  <components.GroupHeading
-    {...props}
-    className="px-2 py-1.5 text-xs font-semibold tracking-wider text-muted uppercase"
-  />
-);
-
 const formatConfigLabel = (config: TDopplerConfig) => {
   if (config.root) {
     return config.name;
@@ -62,18 +56,6 @@ const formatConfigLabel = (config: TDopplerConfig) => {
     ? config.name.slice(prefix.length)
     : config.name;
   return branchName;
-};
-
-const DopplerConfigOption = (props: OptionProps<TDopplerConfig>) => {
-  const { data } = props;
-  return (
-    <components.Option {...props}>
-      <div className="flex items-center gap-2">
-        <span>{formatConfigLabel(data)}</span>
-        {data.root && <Badge variant="project">Root</Badge>}
-      </div>
-    </components.Option>
-  );
 };
 
 export const DopplerSecretImportModal = ({
@@ -89,7 +71,8 @@ export const DopplerSecretImportModal = ({
     handleSubmit,
     watch,
     reset,
-    formState: { errors, isSubmitting }
+    setValue,
+    formState: { isSubmitting }
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: {
@@ -115,20 +98,22 @@ export const DopplerSecretImportModal = ({
     }
   }, [isOpen, reset, connections]);
 
-  const { data: dopplerProjects = [], isPending: isLoadingProjects } =
-    useGetDopplerProjects(connectionId);
-  const { data: dopplerConfigs = [], isPending: isLoadingConfigs } = useGetDopplerConfigs(
-    connectionId,
-    selectedDopplerProject || undefined
-  );
+  const {
+    data: dopplerProjects = [],
+    isPending: isLoadingProjects,
+    isError: isProjectsError
+  } = useGetDopplerProjects(connectionId);
+  const {
+    data: dopplerConfigs = [],
+    isPending: isLoadingConfigs,
+    isError: isConfigsError
+  } = useGetDopplerConfigs(connectionId, selectedDopplerProject || undefined);
 
   const sortedDopplerConfigs = useMemo(() => {
     return [...dopplerConfigs].sort((a, b) => {
-      // Group by environment first
       if (a.environment !== b.environment) {
         return a.environment.localeCompare(b.environment);
       }
-      // Root configs come first within each environment
       if (a.root !== b.root) {
         return a.root ? -1 : 1;
       }
@@ -162,139 +147,148 @@ export const DopplerSecretImportModal = ({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="mb-4 flex items-start gap-3 rounded-md border border-project/20 bg-project/5 p-3 text-sm text-project">
-          <InfoIcon className="mt-0.5 size-4 shrink-0" />
-          <div>
-            <p className="font-medium text-foreground">Import destination</p>
-            <p className="mt-1 text-foreground/75">
+        <div className="space-y-4">
+          <Alert variant="project">
+            <InfoIcon />
+            <AlertTitle>Import destination</AlertTitle>
+            <AlertDescription>
               Secrets will be imported into environment{" "}
               <code className="text-xs">{environment}</code> at path{" "}
               <code className="text-xs">{secretPath}</code>.
-            </p>
-          </div>
-        </div>
+            </AlertDescription>
+          </Alert>
 
-        <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-4">
-          {showConnectionSelector && (
+          <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-4">
+            {showConnectionSelector && (
+              <Controller
+                control={control}
+                name="connectionId"
+                render={({ field, fieldState: { error } }) => (
+                  <Field>
+                    <FieldLabel htmlFor="doppler-import-connection">Doppler Connection</FieldLabel>
+                    <Combobox
+                      id="doppler-import-connection"
+                      value={
+                        connections.find((connection) => connection.id === field.value) ?? null
+                      }
+                      onValueChange={(connection) => {
+                        field.onChange(connection.id);
+                        setValue("dopplerProject", "");
+                        setValue("dopplerEnvironment", "");
+                      }}
+                      options={connections}
+                      getOptionValue={(option) => option.id}
+                      getOptionLabel={(option) => option.name}
+                      placeholder="Select Doppler connection..."
+                      searchPlaceholder="Search Doppler connections..."
+                      searchAriaLabel="Search Doppler connections"
+                      emptyMessage="No Doppler connections found."
+                      isError={Boolean(error)}
+                      modal
+                    />
+                    <FieldError>{error?.message}</FieldError>
+                  </Field>
+                )}
+              />
+            )}
+
             <Controller
               control={control}
-              name="connectionId"
-              render={({ field }) => {
-                const selectedItem = connections.find((c) => c.id === field.value);
-                return (
-                  <Field>
-                    <FieldLabel>Doppler Connection</FieldLabel>
-                    <FieldContent>
-                      <FilterableSelect
-                        value={selectedItem || null}
-                        onChange={(newValue) => {
-                          const single = Array.isArray(newValue) ? newValue[0] : newValue;
-                          if (single && "id" in single) {
-                            field.onChange(single.id);
-                          } else {
-                            field.onChange("");
-                          }
-                        }}
-                        options={connections}
-                        placeholder="Select Doppler connection..."
-                        getOptionLabel={(option) => option.name}
-                        getOptionValue={(option) => option.id}
-                      />
-                    </FieldContent>
-                    <FieldError>{errors.connectionId?.message}</FieldError>
-                  </Field>
-                );
-              }}
+              name="dopplerProject"
+              render={({ field, fieldState: { error } }) => (
+                <Field>
+                  <FieldLabel htmlFor="doppler-import-project">Source Project</FieldLabel>
+                  <Combobox
+                    id="doppler-import-project"
+                    value={dopplerProjects.find((project) => project.slug === field.value) ?? null}
+                    onValueChange={(project) => {
+                      field.onChange(project.slug);
+                      setValue("dopplerEnvironment", "");
+                    }}
+                    options={dopplerProjects}
+                    getOptionValue={(option) => option.slug}
+                    getOptionLabel={(option) => option.name}
+                    getOptionKeywords={(option) => (option.description ? [option.description] : [])}
+                    isDisabled={!connectionId}
+                    isLoading={Boolean(connectionId) && isLoadingProjects}
+                    isError={Boolean(error) || isProjectsError}
+                    placeholder={
+                      connectionId ? "Select source project..." : "Select a connection first..."
+                    }
+                    searchPlaceholder="Search Doppler projects..."
+                    searchAriaLabel="Search Doppler projects"
+                    emptyMessage="No Doppler projects found."
+                    modal
+                  />
+                  <FieldError>{error?.message}</FieldError>
+                </Field>
+              )}
             />
-          )}
 
-          <Controller
-            control={control}
-            name="dopplerProject"
-            render={({ field }) => {
-              const selectedItem = dopplerProjects.find((p) => p.slug === field.value);
-
-              return (
+            <Controller
+              control={control}
+              name="dopplerEnvironment"
+              render={({ field, fieldState: { error } }) => (
                 <Field>
-                  <FieldLabel>Source Project</FieldLabel>
-                  <FieldContent>
-                    <FilterableSelect
-                      value={selectedItem || null}
-                      onChange={(newValue) => {
-                        const singleValue = Array.isArray(newValue) ? newValue[0] : newValue;
-                        if (singleValue && "slug" in singleValue) {
-                          field.onChange(singleValue.slug);
-                        } else {
-                          field.onChange("");
-                        }
-                      }}
-                      isLoading={isLoadingProjects && Boolean(connectionId)}
-                      isDisabled={!connectionId}
-                      options={dopplerProjects}
-                      placeholder="Select source project..."
-                      getOptionLabel={(option) => option.name}
-                      getOptionValue={(option) => option.slug}
-                    />
-                  </FieldContent>
-                  <FieldError>{errors.dopplerProject?.message}</FieldError>
+                  <FieldLabel htmlFor="doppler-import-config">Source Config</FieldLabel>
+                  <Combobox
+                    id="doppler-import-config"
+                    value={
+                      sortedDopplerConfigs.find((config) => config.name === field.value) ?? null
+                    }
+                    onValueChange={(config) => field.onChange(config.name)}
+                    options={sortedDopplerConfigs}
+                    getOptionValue={(option) => option.name}
+                    getOptionLabel={formatConfigLabel}
+                    getOptionKeywords={(option) => [option.environment, option.name]}
+                    isDisabled={!selectedDopplerProject}
+                    isLoading={Boolean(selectedDopplerProject) && isLoadingConfigs}
+                    isError={Boolean(error) || isConfigsError}
+                    placeholder={
+                      selectedDopplerProject
+                        ? "Select source config..."
+                        : "Select a source project first..."
+                    }
+                    searchPlaceholder="Search Doppler configs..."
+                    searchAriaLabel="Search Doppler configs"
+                    emptyMessage="No Doppler configs found."
+                    modal
+                    renderOption={(option) => (
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="truncate">{formatConfigLabel(option)}</span>
+                          {option.root && <Badge variant="project">Root</Badge>}
+                        </div>
+                        <p className="text-xs leading-4 text-muted">{option.environment}</p>
+                      </div>
+                    )}
+                    renderValue={(option) => (
+                      <span className="flex min-w-0 items-center gap-2">
+                        <span className="truncate">{formatConfigLabel(option)}</span>
+                        {option.root && <Badge variant="project">Root</Badge>}
+                      </span>
+                    )}
+                  />
+                  <FieldError>{error?.message}</FieldError>
                 </Field>
-              );
-            }}
-          />
+              )}
+            />
 
-          <Controller
-            control={control}
-            name="dopplerEnvironment"
-            render={({ field }) => {
-              const selectedItem = sortedDopplerConfigs.find((c) => c.name === field.value);
-
-              return (
-                <Field>
-                  <FieldLabel>Source Config</FieldLabel>
-                  <FieldContent>
-                    <FilterableSelect
-                      value={selectedItem || null}
-                      onChange={(newValue) => {
-                        const singleValue = Array.isArray(newValue) ? newValue[0] : newValue;
-                        if (singleValue && "name" in singleValue) {
-                          field.onChange(singleValue.name);
-                        } else {
-                          field.onChange("");
-                        }
-                      }}
-                      isLoading={isLoadingConfigs && Boolean(selectedDopplerProject)}
-                      isDisabled={!selectedDopplerProject}
-                      options={sortedDopplerConfigs}
-                      placeholder="Select source config..."
-                      getOptionLabel={formatConfigLabel}
-                      getOptionValue={(option) => option.name}
-                      groupBy="environment"
-                      components={{
-                        GroupHeading: DopplerConfigGroupHeading,
-                        Option: DopplerConfigOption
-                      }}
-                    />
-                  </FieldContent>
-                  <FieldError>{errors.dopplerEnvironment?.message}</FieldError>
-                </Field>
-              );
-            }}
-          />
-
-          <DialogFooter className="gap-2 sm:gap-2">
-            <Button type="button" variant="ghost" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              variant="project"
-              isPending={isSubmitting}
-              isDisabled={isSubmitting}
-            >
-              Import Secrets
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter className="gap-2 sm:gap-2">
+              <Button type="button" variant="ghost" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                variant="project"
+                isPending={isSubmitting}
+                isDisabled={isSubmitting}
+              >
+                Import Secrets
+              </Button>
+            </DialogFooter>
+          </form>
+        </div>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Fixes [SECRETS-634](https://linear.app/infisical/issue/SECRETS-634/fix-import-from-doppler-alert-usage-and-migrate-inputs-to-combobox).

The Import from Doppler modal used a hand-rolled destination banner that copied Alert styles, and the connection, project, and config fields still used the deprecated `FilterableSelect`. This updates the modal to the v3 `Alert` and `Combobox` contracts used by the other import flows.

- Destination copy now uses `Alert` / `AlertTitle` / `AlertDescription` with the project variant
- Connection, source project, and source config selects now use `Combobox`
- Changing connection or project clears dependent fields
- Config options still show the Root badge and environment context (Combobox does not support grouped headings)

## Steps to verify the change

1. Open a Secret Manager project that has at least one Doppler app connection.
2. Open **Import from Doppler**.
3. Confirm the destination message renders as a project `Alert` with the current environment and path.
4. Confirm the connection (when more than one exists), source project, and source config fields are searchable comboboxes.
5. Change the connection or project and confirm the downstream selections clear.
6. Import secrets from a Doppler config and confirm the request still uses the selected project, config, and connection.

## Type

- [x] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://infisical.slack.com/archives/D0BHB4N0RFG/p1784076073800649?thread_ts=1784076073.800649&cid=D0BHB4N0RFG)

<div><a href="https://cursor.com/agents/bc-eeb7ae0f-9df2-5538-af00-0457317f6ccc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eeb7ae0f-9df2-5538-af00-0457317f6ccc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

