### PR TITLE
fix(pki): set intermediate CA parentCaId to null instead of cascading on parent delete

### DIFF
--- a/backend/src/db/migrations/20260909143802_internal-ca-parent-set-null-on-delete.ts
+++ b/backend/src/db/migrations/20260909143802_internal-ca-parent-set-null-on-delete.ts
@@ -1,0 +1,27 @@
+import { Knex } from "knex";
+
+import { TableName } from "../schemas";
+
+export async function up(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasTable(TableName.InternalCertificateAuthority))) return;
+
+  await knex.schema.alterTable(TableName.InternalCertificateAuthority, (t) => {
+    t.dropForeign(["parentCaId"]);
+    t.foreign("parentCaId").references("id").inTable(TableName.CertificateAuthority).onDelete("SET NULL");
+  });
+
+  await knex(TableName.CertificateAuthority)
+    .whereNotIn("id", knex(TableName.InternalCertificateAuthority).select("caId"))
+    .whereNotIn("id", knex(TableName.ExternalCertificateAuthority).select("caId"))
+    .whereNotIn("id", knex(TableName.PkiCertificateProfile).select("caId").whereNotNull("caId"))
+    .delete();
+}
+
+export async function down(knex: Knex): Promise<void> {
+  if (!(await knex.schema.hasTable(TableName.InternalCertificateAuthority))) return;
+
+  await knex.schema.alterTable(TableName.InternalCertificateAuthority, (t) => {
+    t.dropForeign(["parentCaId"]);
+    t.foreign("parentCaId").references("id").inTable(TableName.CertificateAuthority).onDelete("CASCADE");
+  });
+}

--- a/backend/src/db/migrations/20260909143802_internal-ca-parent-set-null-on-delete.ts
+++ b/backend/src/db/migrations/20260909143802_internal-ca-parent-set-null-on-delete.ts
@@ -10,11 +10,24 @@ export async function up(knex: Knex): Promise<void> {
     t.foreign("parentCaId").references("id").inTable(TableName.CertificateAuthority).onDelete("SET NULL");
   });
 
-  await knex(TableName.CertificateAuthority)
-    .whereNotIn("id", knex(TableName.InternalCertificateAuthority).select("caId"))
-    .whereNotIn("id", knex(TableName.ExternalCertificateAuthority).select("caId"))
-    .whereNotIn("id", knex(TableName.PkiCertificateProfile).select("caId").whereNotNull("caId"))
-    .delete();
+  const whereOrphaned = (query: Knex.QueryBuilder) =>
+    query
+      .whereNotIn("id", knex(TableName.InternalCertificateAuthority).select("caId"))
+      .whereNotIn("id", knex(TableName.ExternalCertificateAuthority).select("caId"));
+
+  await knex(TableName.PkiCertificateProfile)
+    .whereNotNull("caId")
+    .whereIn("caId", whereOrphaned(knex(TableName.CertificateAuthority).select("id")))
+    .update({
+      caId: null,
+      issuerType: "self-signed",
+      enrollmentType: "api",
+      estConfigId: null,
+      acmeConfigId: null,
+      scepConfigId: null
+    });
+
+  await whereOrphaned(knex(TableName.CertificateAuthority)).delete();
 }
 
 export async function down(knex: Knex): Promise<void> {


### PR DESCRIPTION
## Context

Deleting a parent CA cascade-deleted its child's internal CA row and left an orphaned certificate_authorities row that was invisible in the UI but still blocked reusing the name, so the parentCaId FK is now ON DELETE SET NULL and the migration reaps existing orphans.

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)