### PR TITLE
feat(api): point route-not-found 404s at the OpenAPI spec

### DIFF
--- a/backend/e2e-test/not-found-handler.spec.ts
+++ b/backend/e2e-test/not-found-handler.spec.ts
@@ -1,0 +1,54 @@
+// The unknown-route 404 is a public contract: clients that guess at URLs (typically headless
+// agents) rely on the body to find the OpenAPI spec and self-correct. Pin the shape here so the
+// pointer cannot silently disappear.
+
+const DOCS_PATH = "/api/docs/json";
+
+describe("Unknown route 404", () => {
+  test("returns the standard body with a pointer to the OpenAPI spec", async () => {
+    const res = await testServer.inject({ method: "GET", url: "/api/v1/this-route-does-not-exist" });
+
+    expect(res.statusCode).toBe(404);
+    const body = JSON.parse(res.payload) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      statusCode: 404,
+      error: "Not Found",
+      docs: DOCS_PATH
+    });
+    expect(typeof body.reqId).toBe("string");
+    expect((body.reqId as string).length).toBeGreaterThan(0);
+    expect(body.message).toMatch(/^Route GET:\/api\/v1\/this-route-does-not-exist not found\./);
+    expect(body.message).toContain(DOCS_PATH);
+  });
+
+  test("names the method and strips the query string from the reported route", async () => {
+    const res = await testServer.inject({
+      method: "POST",
+      url: "/api/v3/nope?workspaceId=abc&environment=dev",
+      headers: { "content-type": "application/json" },
+      payload: {}
+    });
+
+    expect(res.statusCode).toBe(404);
+    const body = JSON.parse(res.payload) as { message: string };
+    expect(body.message).toMatch(/^Route POST:\/api\/v3\/nope not found\./);
+    expect(body.message).not.toContain("workspaceId");
+  });
+
+  test("the advertised docs path actually resolves to the OpenAPI document", async () => {
+    const res = await testServer.inject({ method: "GET", url: DOCS_PATH });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toContain("application/json");
+    const spec = JSON.parse(res.payload) as { openapi?: string; paths?: Record<string, unknown> };
+    expect(spec.openapi).toBeDefined();
+    expect(Object.keys(spec.paths ?? {}).length).toBeGreaterThan(0);
+  });
+
+  test("known routes are unaffected", async () => {
+    const res = await testServer.inject({ method: "GET", url: "/api/status" });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.payload)).toHaveProperty("message", "Ok");
+  });
+});

--- a/backend/src/server/plugins/error-handler.ts
+++ b/backend/src/server/plugins/error-handler.ts
@@ -389,4 +389,17 @@ export const fastifyErrHandler = fastifyPlugin(async (server: FastifyZodProvider
       });
     }
   });
+
+  // Unknown routes: keep Fastify's default shape and message prefix, but point the caller at the
+  // OpenAPI spec so a client guessing at URLs (typically a headless agent) can self-correct.
+  server.setNotFoundHandler((req, res) => {
+    const path = req.url.split("?")[0];
+    void res.status(HttpStatusCodes.NotFound).send({
+      reqId: req.id,
+      statusCode: HttpStatusCodes.NotFound,
+      error: "Not Found",
+      message: `Route ${req.method}:${path} not found. The OpenAPI spec listing all available routes is at GET /api/docs/json.`,
+      docs: "/api/docs/json"
+    });
+  });
 });


### PR DESCRIPTION
## Context

Unknown routes return Fastify's default 404 body, which says only `Route <METHOD>:<url> not found`. Clients that guess at URLs, in practice headless agents, get nothing to work with and keep guessing.

This registers a `setNotFoundHandler` next to the existing error handler. Unknown routes keep the same body shape and the same `Route <METHOD>:<path> not found` prefix, and now also get a pointer to the OpenAPI spec in the message and in a new `docs` field:

```json
{
  "reqId": "req-...",
  "statusCode": 404,
  "error": "Not Found",
  "message": "Route POST:/api/v1/nope not found. The OpenAPI spec listing all available routes is at GET /api/docs/json.",
  "docs": "/api/docs/json"
}
```

No change for any existing route. Only fires for URLs that do not exist.

**Evidence.** We ran headless agents (Claude Code, Bash only, no docs, no web) against the raw API through a logging proxy. A weak model (Haiku 4.5) guessed 482 non-existent routes across 15 runs because the 404 gave it nothing to work with; it never found `/api/docs/json` on its own. We faked this exact change at the proxy and reran the two tasks it failed worst:

| Haiku, 10 runs | Verified pass | API calls | Invented routes | Hit turn cap |
|---|---|---|---|---|
| Stock 404 | 2 / 10 | 1,199 | 435 | 6 |
| 404 with docs pointer | 10 / 10 | 285 | 15 | 0 |

Every agent read the message, fetched the spec, filtered it with `jq`, and finished. Giving the same model open web access instead did not help (6 / 15, same as no web).

GitHub (`documentation_url`), Stripe, and RFC 9457 all include a docs pointer in error bodies.

Follow-ups in separate PRs: return 4xx instead of the generic 500 for Fastify content-type errors (empty or malformed JSON body); a filtered spec endpoint, since the full document is 16.7 MB.

## Steps to verify the change

0. `npm run test:e2e -- e2e-test/not-found-handler.spec.ts` covers the body shape, request id, query-string stripping, that `/api/docs/json` resolves, and that known routes are unaffected.
1. Start the backend.
2. `curl -s -X POST http://localhost:8080/api/v1/does-not-exist -H 'Content-Type: application/json' -d '{}'`
3. Expect a 404 with the body above: `message` ends with the `/api/docs/json` pointer and a `docs` field is present.
4. `curl -s http://localhost:8080/api/status` still returns 200 with the normal body; existing routes are unaffected.

## Type

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)