### PR TITLE
fix(ui): normalize overlay layers and portal ownership

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -3,7 +3,8 @@ import type { StorybookConfig } from "@storybook/react-vite";
 const config: StorybookConfig = {
   stories: [
     "../src/components/v3/**/*.mdx",
-    "../src/components/v3/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+    "../src/components/v3/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../src/components/overlays/**/*.stories.@(js|jsx|mjs|ts|tsx)"
   ],
   addons: ["@storybook/addon-docs", "@storybook/addon-a11y", "storybook-addon-tag-badges"],
   tags: {

--- a/frontend/eslint-rules/semantic-layers.mjs
+++ b/frontend/eslint-rules/semantic-layers.mjs
@@ -1,0 +1,53 @@
+const rawLayer = /(?:^|[\s:!])(-?z-)(?:\[(-?\d+)\]|(-?\d+))(?=!|\s|$)/g;
+const overlayContent = /(?:Dialog|Modal|Drawer|Sheet|Select|Dropdown(?:Menu|SubMenu)?|Popover|HoverCard|Tooltip|Combobox)(?:Primitive)?\.(?:Content|SubContent|Positioner|Overlay)$|^(?:Dialog|AlertDialog|Modal|Drawer|Sheet|Select|DropdownMenu|DropdownSubMenu|Popover|HoverCard|Tooltip)(?:Content|Overlay|SubContent)$/;
+
+function jsxName(node) {
+  if (node.type === "JSXIdentifier") return node.name;
+  if (node.type === "JSXMemberExpression") return `${jsxName(node.object)}.${jsxName(node.property)}`;
+  return "";
+}
+
+function isOverlayAttribute(node) {
+  let current = node.parent;
+  while (current && current.type !== "JSXAttribute" && current.type !== "Program") current = current.parent;
+  return current?.type === "JSXAttribute" && overlayContent.test(jsxName(current.parent.name));
+}
+
+export default {
+  meta: {
+    type: "problem",
+    schema: [],
+    messages: {
+      semantic: "Use the shared semantic layer contract. Overlay consumers must not override numeric z-index values; component-local stacking may remain local."
+    }
+  },
+  create(context) {
+    function inspectText(node, value) {
+      const matches = [...value.matchAll(rawLayer)];
+      if (matches.some((match) => Math.abs(Number(match[2] ?? match[3])) > 50) ||
+          (matches.length > 0 && isOverlayAttribute(node))) {
+        context.report({ node, messageId: "semantic" });
+      }
+    }
+    return {
+      Literal(node) {
+        if (typeof node.value === "string") inspectText(node, node.value);
+      },
+      TemplateElement(node) {
+        inspectText(node, node.value.raw);
+      },
+      Property(node) {
+        if ((node.key.name ?? node.key.value) !== "zIndex") return;
+        if (typeof node.value.value !== "number") return;
+        let parent = node.parent;
+        while (parent && parent.type !== "Program" &&
+          !(parent.type === "Property" && (parent.key.name ?? parent.key.value) === "menuPortal")) {
+          parent = parent.parent;
+        }
+        if (Math.abs(node.value.value) > 50 || isOverlayAttribute(node) || parent?.type === "Property") {
+          context.report({ node, messageId: "semantic" });
+        }
+      }
+    };
+  }
+};

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -12,6 +12,7 @@ import { FlatCompat } from "@eslint/eslintrc";
 import stylisticPlugin from "@stylistic/eslint-plugin";
 import importPlugin from "eslint-plugin-import";
 import pluginRouter from "@tanstack/eslint-plugin-router";
+import semanticLayers from "./eslint-rules/semantic-layers.mjs";
 
 const compat = new FlatCompat({
   baseDirectory: import.meta.dirname
@@ -38,6 +39,7 @@ export default tseslint.config(
       }
     },
     plugins: {
+      layers: { rules: { semantic: semanticLayers } },
       "react-hooks": reactHooks,
       "react-refresh": reactRefresh,
       "simple-import-sort": simpleImportSort,
@@ -51,6 +53,7 @@ export default tseslint.config(
       }
     },
     rules: {
+      "layers/semantic": "error",
       ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": "off",
       "@typescript-eslint/only-throw-error": "off",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -142,12 +142,14 @@
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-storybook": "^9.1.9",
         "globals": "^15.12.0",
+        "jsdom": "26.1.0",
         "postcss": "^8.4.49",
         "prettier": "3.4.2",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "storybook": "^9.1.19",
         "storybook-addon-tag-badges": "^2.0.4",
         "tailwindcss": "^4.1.14",
+        "tsx": "4.19.3",
         "tw-animate-css": "^1.4.0",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.15.0",
@@ -180,6 +182,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -675,6 +698,121 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@dagrejs/dagre": {
@@ -8277,6 +8415,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -8491,6 +8643,57 @@
       "license": "BSD-2-Clause",
       "peer": true
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -8586,6 +8789,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -10758,6 +10968,19 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -10783,6 +11006,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/https-browserify": {
@@ -10843,6 +11090,19 @@
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "4.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ieee754": {
@@ -11364,6 +11624,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -11615,6 +11882,107 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/jsesc": {
@@ -13022,6 +13390,13 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.27",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.27.tgz",
+      "integrity": "sha512-gQPNF78qebCQ6tvVFBYrvJdBNOrYZm90ZlXgpIFm06p6qHDHq/XC4TnJftN6OMbxVE0UTBAoRgcsDeJBBooITw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -14807,6 +15182,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -14888,6 +15270,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -15526,6 +15928,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
@@ -15666,6 +16075,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-buffer": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
@@ -15692,6 +16121,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -16490,6 +16932,19 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -16517,6 +16972,30 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -16775,6 +17254,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "lint:fix": "eslint --fix ./src --max-warnings 0",
     "type:check": "tsc --noEmit --project ./tsconfig.app.json",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "test:layers": "node scripts/semantic-layers.test.mjs && TSX_TSCONFIG_PATH=./tsconfig.app.json node --import tsx --test scripts/overlay-layer.test.mjs"
   },
   "overrides": {
     "sha.js": "2.4.12",
@@ -173,12 +174,14 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-storybook": "^9.1.9",
     "globals": "^15.12.0",
+    "jsdom": "26.1.0",
     "postcss": "^8.4.49",
     "prettier": "3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "storybook": "^9.1.19",
     "storybook-addon-tag-badges": "^2.0.4",
     "tailwindcss": "^4.1.14",
+    "tsx": "4.19.3",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.15.0",

--- a/frontend/scripts/overlay-layer.test.mjs
+++ b/frontend/scripts/overlay-layer.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { afterEach, test } from "node:test";
+import { JSDOM } from "jsdom";
+
+const dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+  url: "http://localhost",
+  pretendToBeVisual: true
+});
+for (const key of ["window", "document", "HTMLElement", "HTMLInputElement", "HTMLButtonElement", "Element", "Node", "NodeFilter", "MutationObserver", "CustomEvent", "Event", "MouseEvent", "KeyboardEvent", "DocumentFragment", "ShadowRoot"]) {
+  globalThis[key] = dom.window[key];
+}
+Object.defineProperty(globalThis, "navigator", { value: dom.window.navigator, configurable: true });
+globalThis.getComputedStyle = dom.window.getComputedStyle.bind(dom.window);
+globalThis.requestAnimationFrame = dom.window.requestAnimationFrame.bind(dom.window);
+globalThis.cancelAnimationFrame = dom.window.cancelAnimationFrame.bind(dom.window);
+globalThis.ResizeObserver = class { observe() {} unobserve() {} disconnect() {} };
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+globalThis.CSS = { escape: (value) => value.replace(/[^\w-]/g, "\\$&") };
+HTMLElement.prototype.scrollIntoView = () => {};
+const React = await import("react");
+const { act, createElement: h } = React;
+const { createRoot } = await import("react-dom/client");
+const { createPortal } = await import("react-dom");
+const { Dialog, DialogContent, DialogTitle, DialogDescription, DialogTrigger, DialogClose, DialogPortal } = await import("../src/components/v3/generic/Dialog/Dialog.tsx");
+const { Popover, PopoverContent, PopoverTrigger } = await import("../src/components/v3/generic/Popover/Popover.tsx");
+const { Tooltip, TooltipContent, TooltipTrigger } = await import("../src/components/v3/generic/Tooltip/Tooltip.tsx");
+const { ModalLayer, LayerPortal, ToastLayer } = await import("../src/components/overlays/OverlayLayer.tsx");
+
+let root;
+async function render(element) {
+  root ??= createRoot(document.getElementById("root"));
+  await act(async () => { root.render(element); });
+}
+afterEach(async () => {
+  if (root) await act(async () => { root.unmount(); });
+  root = undefined;
+  assertSame(document.querySelectorAll("[data-overlay-layer]").length, 0, "unmount removes owned hosts");
+  document.body.innerHTML = '<div id="root"></div>';
+});
+function content(name, children) {
+  return h(DialogContent, { "data-testid": name },
+    h(DialogTitle, null, name), h(DialogDescription, null, "Layer composition"), children);
+}
+const assertSame = (actual, expected, message) => assert.equal(actual === expected, true, message);
+const hostOf = (id) => document.querySelector(`[data-testid="${id}"]`).closest('[data-overlay-layer="modal"]');
+
+// These are DOM lifecycle tests. Paint order, geometry, and real keyboard navigation still need rendered verification.
+test("sibling modal order follows opening order, including reopening a mounted root", async () => {
+  const app = (a, b) => h(React.Fragment, null,
+    h(Dialog, { open: a }, content("a")), h(Dialog, { open: b }, content("b")));
+  await render(app(true, false));
+  const firstHost = hostOf("a");
+  await render(app(true, true));
+  assertSame(firstHost.nextElementSibling, hostOf("b"));
+  await render(app(false, true));
+  assertSame(firstHost.isConnected, false);
+  await render(app(true, true));
+  assertSame(hostOf("b").nextElementSibling, hostOf("a"));
+});
+
+test("repeated nested dialogs own independent hosts outside content clipping", async () => {
+  await render(h(Dialog, { open: true }, content("outer",
+    h(Dialog, { open: true }, content("middle",
+      h(Dialog, { open: true }, content("inner")))))));
+  assertSame(hostOf("middle").parentElement.closest('[data-overlay-layer="modal"]'), hostOf("outer"));
+  assertSame(hostOf("inner").parentElement.closest('[data-overlay-layer="modal"]'), hostOf("middle"));
+  assertSame(document.querySelector('[data-testid="outer"] > [data-slot="dialog-content"]').contains(hostOf("middle")), false);
+});
+
+test("floating popovers and tooltips use the owning modal host", async () => {
+  await render(h(Dialog, { open: true }, content("owner",
+    h(Popover, { open: true },
+      h(PopoverTrigger, null, "Details"),
+      h(PopoverContent, { "data-testid": "popover" },
+        h(Tooltip, { open: true },
+          h(TooltipTrigger, null, "Help"), h(TooltipContent, { "data-testid": "tooltip" }, "Help text")))))));
+  const host = hostOf("owner");
+  assertSame(document.querySelector('[data-testid="popover"]').closest('[data-overlay-layer]'), host);
+  assertSame(document.querySelector('[data-testid="tooltip"]').closest('[data-overlay-layer]'), host);
+  assertSame(document.querySelector('[data-testid="owner"] > [data-slot="dialog-content"]').contains(document.querySelector('[data-testid="popover"]')), false);
+  const popup = document.querySelector('[data-testid="popover"]');
+  assertSame(popup.closest('[aria-hidden="true"]') === null, true, "owned popup must remain accessible");
+  const input = document.createElement("input");
+  popup.appendChild(input);
+  input.focus();
+  assertSame(document.activeElement === input, true, "dialog focus trap includes portalled inputs");
+  popup.style.overflowY = "auto";
+  Object.defineProperties(popup, { scrollHeight: { value: 300 }, clientHeight: { value: 100 } });
+  const wheel = new window.WheelEvent("wheel", { bubbles: true, cancelable: true, deltaY: 10 });
+  popup.dispatchEvent(wheel);
+  assertSame(wheel.defaultPrevented, false, "owning dialog must not block scrolling its portalled popup");
+});
+
+test("uncontrolled open and close preserve focus return and notify the caller", async () => {
+  const changes = [];
+  await render(h(Dialog, { onOpenChange: (open) => changes.push(open) },
+    h(DialogTrigger, { "data-testid": "trigger" }, "Open"),
+    content("focus", h(DialogClose, { "data-testid": "close" }, "Finish"))));
+  const trigger = document.querySelector('[data-testid="trigger"]');
+  await act(async () => { trigger.focus(); trigger.click(); });
+  assert.ok(hostOf("focus"));
+  await act(async () => { document.querySelector('[data-testid="close"]').click(); });
+  // FocusScope defers unmount autofocus to the next task.
+  await act(async () => { await new Promise((resolve) => setTimeout(resolve, 10)); });
+  assert.deepEqual(changes, [true, false]);
+  assertSame(document.activeElement, trigger);
+});
+
+test("closing does not remove a host while portal exit content remains", async () => {
+  const portal = ({ container, children }) => createPortal(children, container);
+  const app = (open, exiting) => h(ModalLayer, { open }, () =>
+    h(LayerPortal, { portal, modal: true }, exiting ? h("div", { "data-testid": "exit" }) : null));
+  await render(app(true, true));
+  const host = hostOf("exit");
+  await render(app(false, true));
+  assertSame(host.isConnected, true);
+  await render(app(false, false));
+  assertSame(host.isConnected, false);
+});
+
+test("toast-owned dialogs nest above the toast plane and clean up with their owner", async () => {
+  await render(h(ToastLayer, null, h(Dialog, { open: true }, content("toast-dialog"))));
+  assertSame(hostOf("toast-dialog").parentElement.dataset.overlayLayer, "toast");
+  assertSame(hostOf("toast-dialog").parentElement.parentElement, document.body);
+});
+
+test("force-mounted portals retain their host while the root is closed", async () => {
+  await render(h(Dialog, { open: false }, h(DialogPortal, { forceMount: true }, h("div", { "data-testid": "forced" }))));
+  assert.ok(hostOf("forced"));
+});
+
+test("an explicit floating portal container remains supported", async () => {
+  const custom = document.createElement("div");
+  document.body.appendChild(custom);
+  await render(h(Popover, { open: true }, h(PopoverTrigger, null, "Open"),
+    h(PopoverContent, { container: custom, "data-testid": "custom" }, "Custom target")));
+  assertSame(custom.contains(document.querySelector('[data-testid="custom"]')), true);
+});
+
+test("semantic utilities compile and ordering separates content, controls, modals, and toasts", async () => {
+  const { compile } = await import("tailwindcss");
+  const css = await readFile(new URL("../src/index.css", import.meta.url), "utf8");
+  const tokens = [...css.matchAll(/--z-index-layer-([a-z]+): (\d+);/g)];
+  const values = Object.fromEntries(tokens.map(([, name, value]) => [name, Number(value)]));
+  assert.ok(values.backdrop < values.content);
+  assert.ok(values.content < values.floating && values.floating < values.tooltip);
+  assert.ok(values.tooltip < values.modal && values.modal < values.toast);
+  assert.ok(values.action < values.floating);
+  const compiler = await compile(`@theme { ${tokens.map(([definition]) => definition).join("\n")} } @tailwind utilities;`);
+  const output = compiler.build(tokens.map(([, name]) => `z-layer-${name}`));
+  for (const [, name] of tokens) assert.ok(output.includes(`.z-layer-${name}`), name);
+});
+
+test("legacy overlays give ReactSelect menus and their tooltips the same owner", async () => {
+  const { Modal, ModalContent } = await import("../src/components/v2/Modal/Modal.tsx");
+  const { Drawer, DrawerContent } = await import("../src/components/v2/Drawer/Drawer.tsx");
+  const { FilterableSelect } = await import("../src/components/v2/FilterableSelect/FilterableSelect.tsx");
+  await render(h(Modal, { isOpen: true }, h(ModalContent, { title: "Legacy modal" },
+    h(Drawer, { isOpen: true }, h(DrawerContent, { title: "Legacy drawer", "data-testid": "legacy-drawer" },
+      h(FilterableSelect, { menuIsOpen: true, options: [{ label: "Production", value: "prod" }],
+        formatOptionLabel: (option) => h(Tooltip, { open: true },
+          h(TooltipTrigger, null, option.label), h(TooltipContent, { "data-testid": "option-tip" }, "Environment access"))
+      }))))));
+  const drawerHost = hostOf("legacy-drawer");
+  const menu = document.querySelector(".react-select-menu-portal");
+  assert.ok(menu);
+  assertSame(menu.closest('[data-overlay-layer="modal"]'), drawerHost);
+  assertSame(document.querySelector('[data-testid="option-tip"]').closest('[data-overlay-layer="modal"]'), drawerHost);
+  assertSame(menu.closest('[aria-hidden="true"]') === null, true);
+});
+
+test("StrictMode does not leak hosts or lose the mounted interaction scope", async () => {
+  await render(h(React.StrictMode, null, h(Dialog, { defaultOpen: true }, content("strict"))));
+  assertSame(document.querySelectorAll('[data-overlay-layer="modal"]').length, 1);
+  assert.ok(hostOf("strict"));
+});
+
+test("Radix exit presence keeps the panel and host until the scope animation ends", async (t) => {
+  // Browsers return a live CSSStyleDeclaration; jsdom returns a snapshot.
+  const originalGetComputedStyle = globalThis.getComputedStyle;
+  globalThis.getComputedStyle = (element) => new Proxy(originalGetComputedStyle(element), {
+    get(_target, key) {
+      const current = originalGetComputedStyle(element);
+      const value = current[key];
+      return typeof value === "function" ? value.bind(current) : value;
+    }
+  });
+  t.after(() => { globalThis.getComputedStyle = originalGetComputedStyle; });
+  const style = document.createElement("style");
+  style.textContent = '.overlay-content-scope[data-state="closed"] { animation-name: overlay-content-exit; }';
+  document.body.appendChild(style);
+  await render(h(Dialog, { open: true }, content("animated")));
+  const scope = document.querySelector('[data-testid="animated"]');
+  const host = hostOf("animated");
+  await render(h(Dialog, { open: false }, content("animated")));
+  assertSame(scope.isConnected, true, "closing scope retains the exiting panel");
+  assertSame(host.isConnected, true, "closing host retains Radix presence");
+  await act(async () => {
+    const event = new window.Event("animationend", { bubbles: true });
+    Object.defineProperty(event, "animationName", { value: "overlay-content-exit" });
+    scope.dispatchEvent(event);
+  });
+  assertSame(host.isConnected, false, "host is removed after the final exit animation");
+});

--- a/frontend/scripts/semantic-layers.test.mjs
+++ b/frontend/scripts/semantic-layers.test.mjs
@@ -1,0 +1,23 @@
+import { RuleTester } from "eslint";
+import rule from "../eslint-rules/semantic-layers.mjs";
+
+const tester = new RuleTester({ parserOptions: { ecmaVersion: 2022, sourceType: "module", ecmaFeatures: { jsx: true } } });
+tester.run("semantic-layers", rule, {
+  valid: [
+    '<div className="sticky z-50" />',
+    '<DialogContent className="max-w-xl" />',
+    '<DialogPrimitive.Content className="z-layer-content" />',
+    'const style = { zIndex: 10 };',
+    'const styles = { menuPortal: base => ({ ...base, zIndex: "var(--z-index-layer-floating)" }) };',
+    '<TableHeader className="z-[1]" />'
+  ],
+  invalid: [
+    { code: '<TooltipContent className="z-[70]" />', errors: [{ messageId: "semantic" }] },
+    { code: '<DialogContent className="z-20" />', errors: [{ messageId: "semantic" }] },
+    { code: '<DialogPrimitive.Content className="z-50" />', errors: [{ messageId: "semantic" }] },
+    { code: '<div className="z-99999999!" />', errors: [{ messageId: "semantic" }] },
+    { code: '<div className={`fixed z-[100] ${name}`} />', errors: [{ messageId: "semantic" }] },
+    { code: 'const styles = { menuPortal: base => ({ ...base, zIndex: 30 }) };', errors: [{ messageId: "semantic" }] },
+    { code: '<PopoverContent style={{ zIndex: 5 }} />', errors: [{ messageId: "semantic" }] }
+  ]
+});

--- a/frontend/src/components/external-migrations/VaultRoleImportModal.tsx
+++ b/frontend/src/components/external-migrations/VaultRoleImportModal.tsx
@@ -280,11 +280,7 @@ const VaultRoleImportModal = <TRole extends VaultRole>({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       {isOpen && (
         // Match the legacy parent modal's layer; portal order keeps this dialog and its comboboxes above it.
-        <DialogContent
-          className="z-[60] max-w-2xl"
-          overlayClassName="z-[60]"
-          onOpenAutoFocus={(event) => event.preventDefault()}
-        >
+        <DialogContent className="max-w-2xl" onOpenAutoFocus={(event) => event.preventDefault()}>
           <DialogHeader>
             <DialogTitle>{config.title}</DialogTitle>
             <DialogDescription>{config.description}</DialogDescription>

--- a/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
+++ b/frontend/src/components/license/UpgradePlanModal/UpgradePlanModal.tsx
@@ -30,7 +30,7 @@ export const UpgradePlanModal = ({ text, isOpen, onOpenChange }: Props): JSX.Ele
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       {/* Keep upgrade prompts above the dialog or sheet that triggered them. */}
-      <DialogContent className="z-[70] sm:max-w-xl" overlayClassName="z-[70]">
+      <DialogContent className="sm:max-w-xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2.5">
             <SparklesIcon className="size-5 text-muted" />

--- a/frontend/src/components/notifications/Notifications.tsx
+++ b/frontend/src/components/notifications/Notifications.tsx
@@ -53,8 +53,7 @@ const ToastCopyButton = ({ value, name }: { value: string; name: string }) => {
           {isCopying ? <CheckIcon className="size-3!" /> : <CopyIcon className="size-3!" />}
         </IconButton>
       </TooltipTrigger>
-      {/* Render above the sonner toaster (z-index 999999999) so the tooltip isn't occluded. */}
-      <TooltipContent className="z-[2147483647]">{copyText}</TooltipContent>
+      <TooltipContent>{copyText}</TooltipContent>
     </Tooltip>
   );
 };

--- a/frontend/src/components/overlays/OverlayLayer.stories.tsx
+++ b/frontend/src/components/overlays/OverlayLayer.stories.tsx
@@ -1,0 +1,271 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InfoIcon } from "lucide-react";
+
+import { createNotification } from "@app/components/notifications/Notifications";
+import { Drawer, DrawerContent, DrawerTrigger } from "@app/components/v2/Drawer";
+import { Modal, ModalContent, ModalTrigger } from "@app/components/v2/Modal";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogTrigger
+} from "@app/components/v3/generic/AlertDialog";
+import { Button } from "@app/components/v3/generic/Button";
+import { Combobox } from "@app/components/v3/generic/Combobox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger
+} from "@app/components/v3/generic/Dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from "@app/components/v3/generic/Dropdown";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger
+} from "@app/components/v3/generic/HoverCard";
+import { Popover, PopoverContent, PopoverTrigger } from "@app/components/v3/generic/Popover";
+import { FilterableSelect } from "@app/components/v3/generic/ReactSelect";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@app/components/v3/generic/Select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger
+} from "@app/components/v3/generic/Sheet";
+import { Toaster } from "@app/components/v3/generic/Toast";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@app/components/v3/generic/Tooltip";
+
+const environments = [
+  { label: "Development", value: "dev" },
+  { label: "Production", value: "prod" }
+];
+
+const formatEnvironmentOption = (
+  option: (typeof environments)[number],
+  { context }: { context: "menu" | "value" }
+) => (
+  <span className="flex items-center gap-2">
+    {option.label}
+    {context === "menu" && (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button type="button" aria-label={`About ${option.label}`}>
+            <InfoIcon className="size-4" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Access to secrets in {option.label.toLowerCase()}.</TooltipContent>
+      </Tooltip>
+    )}
+  </span>
+);
+
+function OverlayControls() {
+  const [environment, setEnvironment] = useState<(typeof environments)[number] | null>(null);
+  return (
+    <div className="flex flex-col gap-4">
+      <Select defaultValue="dev">
+        <SelectTrigger aria-label="Environment">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="dev">Development</SelectItem>
+          <SelectItem value="prod">Production</SelectItem>
+        </SelectContent>
+      </Select>
+      <Combobox
+        aria-label="Search environments"
+        options={environments}
+        value={environment}
+        onValueChange={setEnvironment}
+        getOptionValue={(option) => option.value}
+        getOptionLabel={(option) => option.label}
+        placeholder="Select environment"
+      />
+      <FilterableSelect
+        aria-label="Additional privileges"
+        options={environments}
+        formatOptionLabel={formatEnvironmentOption}
+      />
+      <div className="flex flex-wrap gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline">Access Actions</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <DropdownMenuItem onSelect={(event) => event.preventDefault()}>
+                  Revoke Access
+                </DropdownMenuItem>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogTitle>Revoke Access</AlertDialogTitle>
+                <AlertDialogDescription>
+                  The member will lose access to this environment.
+                </AlertDialogDescription>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction variant="danger">Revoke Access</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline">Access Details</Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <p className="mb-3 text-sm">Review the environment before changing access.</p>
+          </PopoverContent>
+        </Popover>
+        <HoverCard>
+          <HoverCardTrigger asChild>
+            <Button variant="ghost">Member Details</Button>
+          </HoverCardTrigger>
+          <HoverCardContent>Member of the platform team.</HoverCardContent>
+        </HoverCard>
+      </div>
+    </div>
+  );
+}
+
+function NestedDialog({ depth = 1 }: { depth?: number }) {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button variant="outline">Review Access {depth}</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogTitle>Review Access {depth}</DialogTitle>
+        <DialogDescription>Inspect related access before confirming this change.</DialogDescription>
+        <OverlayControls />
+        <NestedDialog depth={depth + 1} />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+const meta = {
+  title: "Foundations/Overlay Layering",
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Shared layering across v2 and v3. Check pointer and keyboard interaction at laptop and narrow widths. Menus escape scroll clipping, tooltips remain above their menu, and each confirmation covers its owner. Reopen sibling overlays in reverse order to verify opening order."
+      }
+    }
+  },
+  tags: ["autodocs"]
+} satisfies Meta;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DialogComposition: Story = {
+  name: "Example: Dialog and Repeated Nesting",
+  render: () => (
+    <div className="flex gap-2">
+      <NestedDialog />
+      <NestedDialog />
+    </div>
+  )
+};
+
+export const SheetComposition: Story = {
+  name: "Example: Scrollable Sheet",
+  render: () => (
+    <Sheet>
+      <SheetTrigger asChild>
+        <Button>Manage Access</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Manage Access</SheetTitle>
+          <SheetDescription>Choose environments and review member access.</SheetDescription>
+        </SheetHeader>
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <OverlayControls />
+          <div className="h-[60vh]" />
+          <OverlayControls />
+          <NestedDialog />
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+};
+
+export const LegacyComposition: Story = {
+  name: "Example: Legacy Modal and Drawer Parity",
+  render: () => (
+    <div className="flex gap-2">
+      <Modal>
+        <ModalTrigger asChild>
+          <Button>Legacy Create Flow</Button>
+        </ModalTrigger>
+        <ModalContent
+          title="Create Data Source"
+          subTitle="Choose an environment for this data source."
+        >
+          <OverlayControls />
+          <NestedDialog />
+        </ModalContent>
+      </Modal>
+      <Drawer>
+        <DrawerTrigger asChild>
+          <Button>Legacy Secret Details</Button>
+        </DrawerTrigger>
+        <DrawerContent title="Secret Details">
+          <OverlayControls />
+          <NestedDialog />
+        </DrawerContent>
+      </Drawer>
+    </div>
+  )
+};
+
+export const ToastComposition: Story = {
+  name: "Example: Toast Actions and Tooltip",
+  render: () => (
+    <div className="flex gap-2">
+      <Toaster />
+      <NestedDialog />
+      <Button
+        onClick={() =>
+          createNotification(
+            {
+              type: "error",
+              title: "Access Update Failed",
+              text: "Review the request details and try again.",
+              copyActions: [{ name: "Request ID", value: "request-example" }],
+              callToAction: <NestedDialog />
+            },
+            { autoClose: false }
+          )
+        }
+      >
+        Show Error Details
+      </Button>
+    </div>
+  )
+};

--- a/frontend/src/components/overlays/OverlayLayer.tsx
+++ b/frontend/src/components/overlays/OverlayLayer.tsx
@@ -1,0 +1,183 @@
+import {
+  ComponentPropsWithoutRef,
+  ComponentType,
+  createContext,
+  forwardRef,
+  ReactNode,
+  useCallback,
+  useContext,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
+import { createPortal } from "react-dom";
+
+const PortalContainerContext = createContext<HTMLElement | null | undefined>(undefined);
+const ModalContainerContext = createContext<{
+  container: HTMLElement | null;
+  retain: () => () => void;
+} | null>(null);
+
+export const usePortalContainer = () => useContext(PortalContainerContext);
+
+// Keep portal descendants inside Radix's focus/aria/scroll boundary, but outside the
+// positioned, animated panel. A transform or overflow on this scope would break that escape.
+export const LayerContent = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<"div"> & {
+    exitDuration?: number;
+    "data-state"?: string;
+    "data-slot"?: string;
+    "data-size"?: string;
+  }
+>(({ children, className, style, exitDuration = 100, ...props }, forwardedRef) => {
+  const [container, setContainer] = useState<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const setRef = useCallback((element: HTMLDivElement | null) => {
+    containerRef.current = element;
+    setContainer(element);
+  }, []);
+  useImperativeHandle(forwardedRef, () => containerRef.current!, []);
+  return (
+    <div
+      {...props}
+      data-slot="overlay-content-scope"
+      className="overlay-content-scope"
+      style={{ pointerEvents: style?.pointerEvents, animationDuration: `${exitDuration}ms` }}
+      ref={setRef}
+    >
+      <PortalContainerContext.Provider value={container}>
+        <div
+          data-slot={props["data-slot"]}
+          data-state={props["data-state"]}
+          data-size={props["data-size"]}
+          className={className}
+          style={style}
+        >
+          {children}
+        </div>
+      </PortalContainerContext.Provider>
+    </div>
+  );
+});
+LayerContent.displayName = "LayerContent";
+
+function useLayerHost(active: boolean, layer: "modal" | "toast") {
+  const parent = usePortalContainer();
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const [host, setHost] = useState<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    if (!active || (parent === null && layer !== "toast")) return undefined;
+    const container = layer === "toast" ? document.body : (parent ?? document.body);
+    const element = hostRef.current ?? container.ownerDocument.createElement("div");
+    element.dataset.overlayLayer = layer;
+    element.className = "overlay-layer-root";
+    // Opening order is authoritative for sibling dialogs, even when their roots stay mounted.
+    container.appendChild(element);
+    hostRef.current = element;
+    setHost(element);
+    return undefined;
+  }, [active, layer, parent]);
+
+  useLayoutEffect(() => {
+    if (active || !host) return undefined;
+    const removeEmptyHost = () => {
+      // Radix owns exit presence. Keep its portal container until the last exiting child leaves.
+      if (host.childElementCount === 0) {
+        host.remove();
+        hostRef.current = null;
+        setHost(null);
+      }
+    };
+    const observer = new MutationObserver(removeEmptyHost);
+    observer.observe(host, { childList: true });
+    removeEmptyHost();
+    return () => observer.disconnect();
+  }, [active, host]);
+
+  useLayoutEffect(() => () => hostRef.current?.remove(), []);
+  return host;
+}
+
+type ModalLayerProps = {
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: (props: { open: boolean; onOpenChange: (open: boolean) => void }) => ReactNode;
+};
+
+export function ModalLayer({ open, defaultOpen, onOpenChange, children }: ModalLayerProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen ?? false);
+  const [retainedPortals, setRetainedPortals] = useState(0);
+  const isOpen = open ?? uncontrolledOpen;
+  const host = useLayerHost(isOpen || retainedPortals > 0, "modal");
+  const retain = useCallback(() => {
+    setRetainedPortals((count) => count + 1);
+    return () => setRetainedPortals((count) => count - 1);
+  }, []);
+  const context = useMemo(() => ({ container: host, retain }), [host, retain]);
+  return (
+    <ModalContainerContext.Provider value={context}>
+      {children({
+        open: isOpen,
+        onOpenChange: (nextOpen) => {
+          if (open === undefined) setUncontrolledOpen(nextOpen);
+          onOpenChange?.(nextOpen);
+        }
+      })}
+    </ModalContainerContext.Provider>
+  );
+}
+
+type LayerPortalProps = {
+  portal: ComponentType<{
+    children?: ReactNode;
+    container?: Element | DocumentFragment | null;
+    forceMount?: true;
+  }>;
+  children?: ReactNode;
+  container?: Element | DocumentFragment | null;
+  forceMount?: true;
+  modal?: boolean;
+};
+
+export function LayerPortal({
+  portal: Portal,
+  modal = false,
+  container,
+  forceMount,
+  children,
+  ...props
+}: LayerPortalProps) {
+  const parent = usePortalContainer();
+  const modalContext = useContext(ModalContainerContext);
+  useLayoutEffect(() => {
+    if (modal && forceMount) return modalContext?.retain();
+    return undefined;
+  }, [modal, forceMount, modalContext?.retain]);
+  const modalHost = modalContext?.container;
+  if (modal && !modalHost) return null;
+  if (!modal && parent === null && !container) return null;
+  const target = container ?? (modal ? modalHost : parent);
+  return (
+    <PortalContainerContext.Provider
+      value={typeof HTMLElement !== "undefined" && target instanceof HTMLElement ? target : parent}
+    >
+      <Portal container={target} forceMount={forceMount} {...props}>
+        {children}
+      </Portal>
+    </PortalContainerContext.Provider>
+  );
+}
+
+export function ToastLayer({ children }: { children: ReactNode }) {
+  const host = useLayerHost(true, "toast");
+  if (!host) return null;
+  return createPortal(
+    <PortalContainerContext.Provider value={host}>{children}</PortalContainerContext.Provider>,
+    host
+  );
+}

--- a/frontend/src/components/overlays/README.md
+++ b/frontend/src/components/overlays/README.md
@@ -1,0 +1,142 @@
+# Overlay layering
+
+The semantic tokens in `src/index.css` own document-level stacking. Numeric
+values are private to that token table. Components use `z-layer-*` utilities;
+style-based adapters use the matching CSS variable.
+
+| Role | Utility | Owner |
+| --- | --- | --- |
+| Page chrome | `z-layer-chrome` | Navigation and sticky page UI |
+| Floating action bar | `z-layer-action` | Selected-action bar |
+| Backdrop | `z-layer-backdrop` | Inside a modal host |
+| Modal/sheet content | `z-layer-content` | Inside a modal host |
+| Floating control | `z-layer-floating` | Select, menu, popover, hover card |
+| Tooltip | `z-layer-tooltip` | Annotation above its owning controls |
+| Modal host | `z-layer-modal` | Dialog, AlertDialog, Sheet, v2 Modal/Drawer |
+| Toast host | `z-layer-toast` | Global Sonner instance and toast-owned overlays |
+
+Backdrop/content and chrome/action roles share values because they belong to
+different stacking contexts. The small, spaced values express ordering only;
+they do not allocate numeric ranges to nesting depth.
+
+## Ownership and repeated nesting
+
+`ModalLayer` maintains the existing controlled or uncontrolled open contract. On
+open, it appends an isolated, viewport-sized host to the owning portal container
+(or `document.body` at the top level). `LayerPortal` sends the library's backdrop
+and content into that host. `LayerContent` separates Radix's untransformed
+focus/aria/scroll scope from the visual panel, and provides that scope to
+descendants as their default portal destination. The host has no transform, containment, overflow clipping,
+or pointer target of its own.
+
+Menus, selects, popovers, and tooltips portal beside the scrollable panel,
+inside its interaction scope. Portal descendants wait for that scope to mount,
+so initially open children never briefly attach to the body and inherit stale
+`aria-hidden` state. This keeps input focus, assistive-technology
+visibility, and wheel/touch scrolling under the owning dialog's control. A nested modal gets another isolated host inside its parent's
+host. Its backdrop covers the entire parent composition, including tooltips.
+This works repeatedly without multiplying z-index values. Sibling modal hosts
+follow opening order, including when an earlier root reopens. Independent
+modal roots should be siblings in the React tree when they represent
+independent tasks; a descendant modal is owned by its ancestor and closes with
+it.
+
+The app root and Storybook canvas are isolated so local sticky cells and controls
+cannot compete with document-level portals. Local layering inside those
+boundaries stays local; do not mass-replace table headers, resize handles,
+editor decorations, graph nodes, or badges.
+
+Radix and Base UI still own focus, dismissal, keyboard handling, and presence.
+The host stays connected until exiting portal children are gone. An inert
+visibility animation on the interaction scope preserves the panel's exit
+duration without creating a transform or clipping boundary. Force-mounted
+Radix portals retain their host even while the root is closed. Floating
+components retain their existing open state and DOM order behavior; a submenu
+portals into the same owning scope to escape menu clipping.
+
+## Portal containers and third-party controls
+
+Use the default owner-aware portal destination for ordinary product UI.
+`usePortalContainer` is the adapter for ReactSelect and Base UI. ReactSelect
+uses fixed menu positioning and restores pointer events on the menu portal.
+Tooltips in its options inherit the same owner and sit above the menu.
+
+Existing explicit container APIs remain supported for bounded embeddings.
+An explicit container changes the stacking and clipping boundary: callers must
+supply an unclipped container in the intended owner. In particular, targeting
+`document.body` from inside a modal bypasses ownership, and targeting a
+transformed/scrolling content element does not guarantee viewport escape. Do
+not use either as a workaround for a missing layer. Passing `null` to a
+ReactSelect portal target keeps its existing library behavior; Base UI's null
+container falls back to the owner-aware default.
+
+A toast host always mounts at document level. Sonner uses the content layer
+inside it; a toast-owned tooltip uses the tooltip layer, and a dialog launched
+from a toast owns a modal host inside the toast plane. Ordinary application
+modals do not cover notifications. Toast pointer interaction and the existing
+outside-interaction guards remain intact.
+
+## Remediation ledger
+
+| Boundary | Disposition |
+| --- | --- |
+| v3 Dialog, AlertDialog, Sheet; v2 Modal, Drawer | Shared owned host; equivalent backdrop/content ordering. Drawer no longer splits its backdrop below page controls. |
+| v3/v2 selects, dropdowns/submenus, popovers, hover cards, tooltips | Semantic roles and owner-aware portals; existing APIs preserved. |
+| v3 Combobox and both generations of ReactSelect/CreatableSelect | Owner-aware adapter; no numeric menu-portal escalation. |
+| Secret scanning legacy modal; Upgrade Plan; Vault import; toast error/validation dialogs | Remove lowered/raised content and backdrop overrides. |
+| Access/secret approval menus, popovers, hover cards; gateway and role pickers; PKI alert menu; recording picker; identity-token and GitHub integration menus | Remove numeric content overrides. |
+| Navbar notification dropdown and tooltip | Remove 999/1000; use ordinary floating/tooltip layers below modal hosts. |
+| Toast copy tooltip | Remove max-integer override; inherit the toast host. |
+| v2/v3 secret-input popovers, secret-path input, PKI host-command suggestions | Adapt direct Radix portals without changing their editing behavior. |
+| Additional-privilege editors, GCP sync fields, alert recipients, audit-stream products, workflow integrations, webhook form | Remove explicit dialog-node/ref plumbing; shared owner escapes the scroll container. |
+| Selected-action bar | Semantic action layer; owner-aware destination. |
+| Secret rotation create flow, Secret Detail Drawer overrides, Compare Environments extreme value | The old implementations/overrides are absent at this baseline; no replacement-only edits. Existing shared consumers receive the foundation. |
+
+### Retained component-local stacking
+
+The following values are not document-level portal escapes:
+
+- Sticky table headers, DataGrid search/resize handles, verification-code
+  decoration, graph node ordering, and scroll fades stay in their local context.
+- AccessTree's expanded/undocked graph is an in-page visualization, despite its
+  historical `Modal` view-mode name. Its local stacking stays inside the app.
+- PAM data-explorer context menus and audit-search suggestion panels remain
+  page-local. A future clipping fix should use the shared floating contract.
+- Authentication and secret-migration loading masks, the legacy password
+  generator, and the public share card retain their in-page ordering. They do
+  not receive authority to cover independently portalled modals or toasts.
+
+These exceptions end when their containing composition is migrated or its
+portal boundary changes; they are not examples for new document-level values.
+
+## Enforcement and verification
+
+The `layers/semantic` ESLint rule rejects numeric classes/styles on known overlay
+content and numeric ReactSelect menu-portal styles. It also rejects new extreme
+numeric classes or z-index styles above the historical local maximum, including
+important and arbitrary-class syntax. It permits ordinary local stacking.
+Dynamic runtime strings and external-library CSS still require review.
+
+Run `npm run test:layers` for the focused DOM lifecycle tests, Tailwind utility
+compilation, and lint-rule cases. DOM tests check ownership, open order, cleanup,
+focus return, explicit containers, and force mounting; they cannot prove paint,
+layout, or real pointer/keyboard behavior.
+
+Storybook's **Foundations / Overlay Layering** provides Dialog, scrollable Sheet,
+legacy Modal/Drawer, ReactSelect option tooltip, nested confirmation, repeated
+nesting, and toast-action compositions. Check each at laptop and narrow widths,
+with pointer and keyboard input, Escape, outside interaction, focus return, and
+scrolling near the bottom of the container.
+
+Application acceptance covers Additional Privileges, secret scanning and
+rotation creation, Upgrade Plan from a legacy modal, Secret Detail menus,
+access-request sheets, navbar notifications, toast error/validation details,
+and Compare Environments selection. These remain separate from static/DOM
+checks and require a running application and explicit rendered-test scope.
+
+## Rollback
+
+Revert the foundation, primitive adapters, and call-site removals together.
+Restoring only numeric defaults or only removing hosts reintroduces generation
+inversions. No persisted data, API contracts, environment variables, or database
+migrations are involved.

--- a/frontend/src/components/pki-syncs/forms/HostCommandInput.tsx
+++ b/frontend/src/components/pki-syncs/forms/HostCommandInput.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
 import { TextArea } from "@app/components/v3";
 import { cn } from "@app/components/v3/utils";
 
@@ -130,13 +131,13 @@ export const HostCommandInput = ({
           }}
         />
       </PopoverPrimitive.Trigger>
-      <PopoverPrimitive.Portal>
+      <LayerPortal portal={PopoverPrimitive.Portal}>
         <PopoverPrimitive.Content
           ref={contentRef}
           align="start"
           onOpenAutoFocus={(event) => event.preventDefault()}
           onMouseDown={(event) => event.preventDefault()}
-          className="relative top-2 z-[100] max-h-80 thin-scrollbar overflow-auto rounded-md border border-border bg-popover text-foreground shadow-md"
+          className="relative top-2 z-layer-floating max-h-80 thin-scrollbar overflow-auto rounded-md border border-border bg-popover text-foreground shadow-md"
           style={{ width: "var(--radix-popover-trigger-width)", minWidth: "320px" }}
         >
           <div className="px-2 py-1.5 text-[10px] font-semibold tracking-wider text-muted uppercase">
@@ -165,7 +166,7 @@ export const HostCommandInput = ({
             </button>
           ))}
         </PopoverPrimitive.Content>
-      </PopoverPrimitive.Portal>
+      </LayerPortal>
     </PopoverPrimitive.Root>
   );
 };

--- a/frontend/src/components/secret-scanning/CreateSecretScanningDataSourceModal.tsx
+++ b/frontend/src/components/secret-scanning/CreateSecretScanningDataSourceModal.tsx
@@ -102,11 +102,7 @@ export const CreateSecretScanningDataSourceModal = ({ onOpenChange, isOpen, ...p
         onOpenChange(open);
       }}
     >
-      {/* z-50 (not the v2 default z-[60]) so the inline "Create Connection" Sheet and its v3 Select
-          menus (all z-50, portaled later) stack above this modal instead of being buried behind it,
-          while the backdrop still covers page chrome up to z-50 by portal order. */}
       <ModalContent
-        overlayClassName="z-50"
         title={
           selectedDataSource ? (
             <SecretScanningDataSourceModalHeader isConfigured={false} type={selectedDataSource} />
@@ -117,7 +113,7 @@ export const CreateSecretScanningDataSourceModal = ({ onOpenChange, isOpen, ...p
             </div>
           )
         }
-        className={selectedDataSource ? "z-50 max-w-2xl" : "z-50 max-w-3xl"}
+        className={selectedDataSource ? "max-w-2xl" : "max-w-3xl"}
         subTitle={
           selectedDataSource ? undefined : "Select a data source to configure secret scanning for."
         }

--- a/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncDestinationFields/GcpSyncFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { FormatOptionLabelMeta, MultiValue, SingleValue } from "react-select";
 import { Info, TriangleAlert } from "lucide-react";
@@ -99,17 +99,6 @@ export const GcpSyncFields = () => {
     hasConfiguredReplicaRegions || hasAccordionError ? ADVANCED_ITEM_VALUE : ""
   );
 
-  // The accordion content clips its children (overflow-hidden for the height animation), so the
-  // select menu is portaled to the enclosing sheet. The ref must sit on a plain, always-mounted
-  // element: v3 components don't forward refs on React 18, and the accordion content only exists
-  // in the DOM while open.
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(null);
-
-  useEffect(() => {
-    setMenuPortalTarget(containerRef.current?.closest<HTMLElement>('[role="dialog"]') ?? null);
-  }, []);
-
   useEffect(() => {
     if (hasAccordionError) setOpenItem(ADVANCED_ITEM_VALUE);
   }, [hasAccordionError, formState.submitCount]);
@@ -152,7 +141,7 @@ export const GcpSyncFields = () => {
   ]);
 
   return (
-    <div ref={containerRef} className="contents">
+    <div className="contents">
       <FieldGroup className="min-h-0 flex-1">
         <SecretSyncConnectionField
           onChange={() => {
@@ -332,7 +321,6 @@ export const GcpSyncFields = () => {
                           placeholder="Automatic replication"
                           getOptionValue={(option) => option.locationId}
                           formatOptionLabel={formatOptionLabel}
-                          menuPortalTarget={menuPortalTarget ?? undefined}
                           menuPosition="fixed"
                           menuPlacement="auto"
                         />

--- a/frontend/src/components/v2/CreatableSelect/CreatableSelect.tsx
+++ b/frontend/src/components/v2/CreatableSelect/CreatableSelect.tsx
@@ -2,20 +2,38 @@ import { GroupBase } from "react-select";
 import ReactSelectCreatable, { CreatableProps } from "react-select/creatable";
 import { twMerge } from "tailwind-merge";
 
+import { usePortalContainer } from "@app/components/overlays/OverlayLayer";
+
 import { ClearIndicator, DropdownIndicator, MultiValueRemove, Option } from "../Select/components";
 
 export const CreatableSelect = <T,>({
   isMulti,
   closeMenuOnSelect,
+  menuPortalTarget,
+  menuIsOpen,
+  menuPosition = "fixed",
   ...props
 }: CreatableProps<T, boolean, GroupBase<T>>) => {
+  const layerContainer = usePortalContainer();
   return (
     <ReactSelectCreatable
       isMulti={isMulti}
       closeMenuOnSelect={closeMenuOnSelect ?? !isMulti}
       hideSelectedOptions={false}
+      menuIsOpen={layerContainer === null && menuPortalTarget === undefined ? false : menuIsOpen}
+      menuPosition={menuPosition}
+      menuPortalTarget={
+        menuPortalTarget === undefined
+          ? (layerContainer ?? (typeof document === "undefined" ? undefined : document.body))
+          : menuPortalTarget
+      }
       unstyled
       styles={{
+        menuPortal: (base) => ({
+          ...base,
+          zIndex: "var(--z-index-layer-floating)",
+          pointerEvents: "auto"
+        }),
         input: (base) => ({
           ...base,
           "input:focus": {
@@ -34,6 +52,7 @@ export const CreatableSelect = <T,>({
       }}
       components={{ DropdownIndicator, ClearIndicator, MultiValueRemove, Option }}
       classNames={{
+        menuPortal: () => "react-select-menu-portal",
         container: () => "w-full font-inter",
         control: ({ isFocused }) =>
           twMerge(

--- a/frontend/src/components/v2/Drawer/Drawer.tsx
+++ b/frontend/src/components/v2/Drawer/Drawer.tsx
@@ -5,6 +5,8 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { cva, VariantProps } from "cva";
 import { twMerge } from "tailwind-merge";
 
+import { LayerContent, LayerPortal, ModalLayer } from "@app/components/overlays/OverlayLayer";
+
 import { Card, CardBody, CardFooter, CardTitle } from "../Card";
 import { IconButton } from "../IconButton";
 
@@ -17,7 +19,7 @@ export type DrawerContentProps = DialogPrimitive.DialogContentProps & {
 } & VariantProps<typeof drawerContentVariation>;
 
 const drawerContentVariation = cva(
-  "fixed ease-in-out duration-300 z-90 border border-mineshaft-600 drop-shadow-2xl",
+  "fixed ease-in-out duration-300 z-layer-content border border-mineshaft-600 drop-shadow-2xl",
   {
     variants: {
       direction: {
@@ -46,9 +48,9 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
     },
     forwardedRef
   ) => (
-    <DialogPrimitive.Portal>
+    <LayerPortal portal={DialogPrimitive.Portal} modal>
       <DialogPrimitive.Overlay
-        className="fixed inset-0 z-20 h-full w-full"
+        className="fixed inset-0 z-layer-backdrop h-full w-full"
         style={{ backgroundColor: "rgba(0, 0, 0, 0.7)" }}
       />
       <DialogPrimitive.Content
@@ -68,34 +70,37 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(
           }
           props.onPointerDownOutside?.(e);
         }}
+        asChild
       >
-        <Card isRounded={false} className="dark h-full w-full">
-          {title && (
-            <CardTitle subTitle={subTitle} className="mb-0 px-4">
-              {title}
-            </CardTitle>
-          )}
-          <CardBody
-            className={twMerge(
-              "grow overflow-x-hidden overflow-y-auto px-4 pt-4 dark:scheme-dark",
-              cardBodyClassName
+        <LayerContent exitDuration={0}>
+          <Card isRounded={false} className="dark h-full w-full">
+            {title && (
+              <CardTitle subTitle={subTitle} className="mb-0 px-4">
+                {title}
+              </CardTitle>
             )}
-          >
-            {children}
-          </CardBody>
-          {footerContent && <CardFooter>{footerContent}</CardFooter>}{" "}
-          <DialogPrimitive.Close aria-label="Close" asChild onClick={onClose}>
-            <IconButton
-              variant="plain"
-              ariaLabel="close"
-              className="absolute top-4 right-6 rounded-sm text-bunker-400 hover:text-bunker-50"
+            <CardBody
+              className={twMerge(
+                "grow overflow-x-hidden overflow-y-auto px-4 pt-4 dark:scheme-dark",
+                cardBodyClassName
+              )}
             >
-              <FontAwesomeIcon icon={faTimes} size="lg" className="cursor-pointer" />
-            </IconButton>
-          </DialogPrimitive.Close>
-        </Card>
+              {children}
+            </CardBody>
+            {footerContent && <CardFooter>{footerContent}</CardFooter>}{" "}
+            <DialogPrimitive.Close aria-label="Close" asChild onClick={onClose}>
+              <IconButton
+                variant="plain"
+                ariaLabel="close"
+                className="absolute top-4 right-6 rounded-sm text-bunker-400 hover:text-bunker-50"
+              >
+                <FontAwesomeIcon icon={faTimes} size="lg" className="cursor-pointer" />
+              </IconButton>
+            </DialogPrimitive.Close>
+          </Card>
+        </LayerContent>
       </DialogPrimitive.Content>
-    </DialogPrimitive.Portal>
+    </LayerPortal>
   )
 );
 
@@ -103,7 +108,9 @@ DrawerContent.displayName = "ModalContent";
 
 export type DrawerProps = Omit<DialogPrimitive.DialogProps, "open"> & { isOpen?: boolean };
 export const Drawer = ({ isOpen, ...props }: DrawerProps) => (
-  <DialogPrimitive.Root open={isOpen} {...props} />
+  <ModalLayer {...props} open={isOpen}>
+    {(layerProps) => <DialogPrimitive.Root {...props} {...layerProps} />}
+  </ModalLayer>
 );
 
 export const DrawerTrigger = DialogPrimitive.Trigger;

--- a/frontend/src/components/v2/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/v2/Dropdown/Dropdown.tsx
@@ -2,6 +2,8 @@ import { ComponentPropsWithRef, ElementType, forwardRef, ReactNode, Ref } from "
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { twMerge } from "tailwind-merge";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 // Main menu or parent container
 export type DropdownMenuProps = DropdownMenuPrimitive.DropdownMenuProps;
 export const DropdownMenu = DropdownMenuPrimitive.Root;
@@ -18,19 +20,19 @@ export type DropdownMenuContentProps = DropdownMenuPrimitive.DropdownMenuContent
 export const DropdownMenuContent = forwardRef<HTMLDivElement, DropdownMenuContentProps>(
   ({ children, className, ...props }, forwardedRef) => {
     return (
-      <DropdownMenuPrimitive.Portal>
+      <LayerPortal portal={DropdownMenuPrimitive.Portal}>
         <DropdownMenuPrimitive.Content
           sideOffset={-8}
           {...props}
           ref={forwardedRef}
           className={twMerge(
-            "data-[side=bottom]:animate-slide-up-and-fade data-[side=left]:animate-slide-right-and-fade data-[side=right]:animate-slide-left-and-fade data-[side=top]:animate-slide-down-and-fade z-[60] min-w-[220px] overflow-y-auto rounded-md border border-mineshaft-600 bg-mineshaft-900 text-bunker-300 shadow-sm will-change-auto",
+            "data-[side=bottom]:animate-slide-up-and-fade data-[side=left]:animate-slide-right-and-fade data-[side=right]:animate-slide-left-and-fade data-[side=top]:animate-slide-down-and-fade z-layer-floating min-w-[220px] overflow-y-auto rounded-md border border-mineshaft-600 bg-mineshaft-900 text-bunker-300 shadow-sm will-change-auto",
             className
           )}
         >
           {children}
         </DropdownMenuPrimitive.Content>
-      </DropdownMenuPrimitive.Portal>
+      </LayerPortal>
     );
   }
 );
@@ -42,19 +44,19 @@ export type DropdownSubMenuContentProps = DropdownMenuPrimitive.DropdownMenuSubC
 export const DropdownSubMenuContent = forwardRef<HTMLDivElement, DropdownSubMenuContentProps>(
   ({ children, className, ...props }, forwardedRef) => {
     return (
-      <DropdownMenuPrimitive.Portal>
+      <LayerPortal portal={DropdownMenuPrimitive.Portal}>
         <DropdownMenuPrimitive.SubContent
           sideOffset={2}
           {...props}
           ref={forwardedRef}
           className={twMerge(
-            "data-[side=bottom]:animate-slide-up-and-fade data-[side=left]:animate-slide-right-and-fade data-[side=right]:animate-slide-left-and-fade data-[side=top]:animate-slide-down-and-fade z-[60] min-w-[220px] rounded-md border border-mineshaft-600 bg-mineshaft-900 text-bunker-300 shadow-sm will-change-auto",
+            "data-[side=bottom]:animate-slide-up-and-fade data-[side=left]:animate-slide-right-and-fade data-[side=right]:animate-slide-left-and-fade data-[side=top]:animate-slide-down-and-fade z-layer-floating min-w-[220px] rounded-md border border-mineshaft-600 bg-mineshaft-900 text-bunker-300 shadow-sm will-change-auto",
             className
           )}
         >
           {children}
         </DropdownMenuPrimitive.SubContent>
-      </DropdownMenuPrimitive.Portal>
+      </LayerPortal>
     );
   }
 );

--- a/frontend/src/components/v2/FilterableSelect/FilterableSelect.tsx
+++ b/frontend/src/components/v2/FilterableSelect/FilterableSelect.tsx
@@ -1,6 +1,8 @@
 import Select, { Props } from "react-select";
 import { twMerge } from "tailwind-merge";
 
+import { usePortalContainer } from "@app/components/overlays/OverlayLayer";
+
 import {
   ClearIndicator,
   DropdownIndicator,
@@ -21,12 +23,16 @@ export const FilterableSelect = <T,>({
   getGroupHeaderLabel = null,
   options = [],
   menuListClassName,
+  menuPortalTarget,
+  menuIsOpen,
+  menuPosition = "fixed",
   ...props
 }: Props<T> & {
   groupBy?: string | null;
   getGroupHeaderLabel?: ((groupValue: any) => string) | null;
   menuListClassName?: string;
 }) => {
+  const layerContainer = usePortalContainer();
   let processedOptions = options;
 
   if (groupBy && Array.isArray(options)) {
@@ -73,9 +79,17 @@ export const FilterableSelect = <T,>({
         }),
         menuPortal: (provided) => ({
           ...provided,
-          zIndex: 99999
+          zIndex: "var(--z-index-layer-floating)",
+          pointerEvents: "auto"
         })
       }}
+      menuPortalTarget={
+        menuPortalTarget === undefined
+          ? (layerContainer ?? (typeof document === "undefined" ? undefined : document.body))
+          : menuPortalTarget
+      }
+      menuIsOpen={layerContainer === null && menuPortalTarget === undefined ? false : menuIsOpen}
+      menuPosition={menuPosition}
       tabSelectsValue={tabSelectsValue}
       components={{
         DropdownIndicator,
@@ -86,6 +100,7 @@ export const FilterableSelect = <T,>({
         ...props.components
       }}
       classNames={{
+        menuPortal: () => "react-select-menu-portal",
         container: ({ isDisabled }) =>
           twMerge("w-full font-inter text-sm", isDisabled && "pointer-events-auto! opacity-50"),
         control: ({ isFocused, isDisabled }) =>

--- a/frontend/src/components/v2/HoverCard/HoverCard.tsx
+++ b/frontend/src/components/v2/HoverCard/HoverCard.tsx
@@ -2,6 +2,8 @@ import { IconProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as HoverCard from "@radix-ui/react-hover-card";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 type Props = {
   text: string;
   icon: IconProp;
@@ -17,8 +19,8 @@ export const HoverObject = ({ text, icon, color }: Props): JSX.Element => (
         <FontAwesomeIcon icon={icon} className={`text-${color}`} />
       </a>
     </HoverCard.Trigger>
-    <HoverCard.Portal>
-      <HoverCard.Content className="HoverCardContent z-300" sideOffset={5}>
+    <LayerPortal portal={HoverCard.Portal}>
+      <HoverCard.Content className="HoverCardContent z-layer-floating" sideOffset={5}>
         <div className="rounded-md border border-mineshaft-600 bg-bunker-700 p-2 text-bunker-300 drop-shadow-xl">
           <div style={{ display: "flex", flexDirection: "column", gap: 15 }}>
             <div>
@@ -29,7 +31,7 @@ export const HoverObject = ({ text, icon, color }: Props): JSX.Element => (
 
         <HoverCard.Arrow className="border-mineshaft-600" />
       </HoverCard.Content>
-    </HoverCard.Portal>
+    </LayerPortal>
   </HoverCard.Root>
 );
 

--- a/frontend/src/components/v2/HoverCardv2/HoverCardv2.tsx
+++ b/frontend/src/components/v2/HoverCardv2/HoverCardv2.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from "react";
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 import { twMerge } from "tailwind-merge";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 export const HoverCardTrigger = HoverCardPrimitive.Trigger;
 
 export const HoverCard = HoverCardPrimitive.Root;
@@ -11,16 +13,16 @@ export type HoverCardContentProps = {
 } & HoverCardPrimitive.HoverCardContentProps;
 
 export const HoverCardContent = ({ children, className, ...props }: HoverCardContentProps) => (
-  <HoverCardPrimitive.Portal>
+  <LayerPortal portal={HoverCardPrimitive.Portal}>
     <HoverCardPrimitive.Content
       {...props}
       className={twMerge(
-        "relative w-64 rounded-md bg-mineshaft-600 fill-mineshaft-600 p-4 pt-6 font-inter text-gray-200 shadow-md",
+        "relative z-layer-floating w-64 rounded-md bg-mineshaft-600 fill-mineshaft-600 p-4 pt-6 font-inter text-gray-200 shadow-md",
         className
       )}
     >
       {children}
       <HoverCardPrimitive.Arrow className="fill-inherit stroke-inherit" />
     </HoverCardPrimitive.Content>
-  </HoverCardPrimitive.Portal>
+  </LayerPortal>
 );

--- a/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v2/InfisicalSecretInput/InfisicalSecretInput.tsx
@@ -5,6 +5,7 @@ import * as Popover from "@radix-ui/react-popover";
 import { useNavigate } from "@tanstack/react-router";
 
 import { createNotification } from "@app/components/notifications";
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
 import { SecretReferenceWizard } from "@app/components/v3/platform/SecretInput/SecretReferenceWizard";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useProject, useProjectPermission } from "@app/context";
@@ -492,14 +493,14 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
             onClickSegment={handleClickSegment}
           />
         </Popover.Trigger>
-        <Popover.Portal>
+        <LayerPortal portal={Popover.Portal}>
           <Popover.Content
             align="start"
             onOpenAutoFocus={(e) => e.preventDefault()}
             onMouseDown={(e) => {
               if (showWizard) e.preventDefault();
             }}
-            className={`relative top-2 z-100 max-h-80 thin-scrollbar overflow-auto rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md ${showWizard ? "w-64" : "min-w-80"}`}
+            className={`relative top-2 z-layer-floating max-h-80 thin-scrollbar overflow-auto rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md ${showWizard ? "w-64" : "min-w-80"}`}
             style={showWizard ? undefined : { width: "var(--radix-popover-trigger-width)" }}
           >
             {showWizard ? (
@@ -590,7 +591,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
               </div>
             )}
           </Popover.Content>
-        </Popover.Portal>
+        </LayerPortal>
       </Popover.Root>
     );
   }

--- a/frontend/src/components/v2/Modal/Modal.tsx
+++ b/frontend/src/components/v2/Modal/Modal.tsx
@@ -4,6 +4,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { twMerge } from "tailwind-merge";
 
+import { LayerContent, LayerPortal, ModalLayer } from "@app/components/overlays/OverlayLayer";
+
 import { Card, CardBody, CardFooter, CardTitle } from "../Card";
 import { IconButton } from "../IconButton";
 
@@ -35,9 +37,12 @@ export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
     },
     forwardedRef
   ) => (
-    <DialogPrimitive.Portal>
+    <LayerPortal portal={DialogPrimitive.Portal} modal>
       <DialogPrimitive.Overlay
-        className={twMerge("animate-fade-in fixed inset-0 z-[60] h-full w-full", overlayClassName)}
+        className={twMerge(
+          "animate-fade-in fixed inset-0 z-layer-backdrop h-full w-full",
+          overlayClassName
+        )}
         style={{ backgroundColor: "rgba(0, 0, 0, 0.7)" }}
       />
       <DialogPrimitive.Content
@@ -56,43 +61,46 @@ export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
           }
           props.onPointerDownOutside?.(e);
         }}
+        asChild
       >
-        <Card
-          isRounded
-          className={twMerge(
-            "animate-pop-in fixed top-1/2 left-1/2 z-[60] thin-scrollbar max-w-xl -translate-x-2/4 -translate-y-2/4 border border-mineshaft-600 drop-shadow-2xl dark:scheme-dark",
-            className
-          )}
-          style={{ maxHeight: "90%" }}
-        >
-          {title && (
-            <DialogPrimitive.Title>
-              <CardTitle subTitle={subTitle}>
-                <div className={showCloseButton ? "pr-8" : undefined}>{title}</div>
-              </CardTitle>
-            </DialogPrimitive.Title>
-          )}
-          <CardBody
-            className={twMerge("overflow-x-hidden overflow-y-auto", bodyClassName)}
+        <LayerContent exitDuration={0}>
+          <Card
+            isRounded
+            className={twMerge(
+              "animate-pop-in fixed top-1/2 left-1/2 z-layer-content thin-scrollbar max-w-xl -translate-x-2/4 -translate-y-2/4 border border-mineshaft-600 drop-shadow-2xl dark:scheme-dark",
+              className
+            )}
             style={{ maxHeight: "90%" }}
           >
-            {children}
-          </CardBody>
-          {footerContent && <CardFooter>{footerContent}</CardFooter>}
-          {showCloseButton && (
-            <DialogPrimitive.Close aria-label="Close" asChild onClick={onClose}>
-              <IconButton
-                variant="plain"
-                ariaLabel="close"
-                className="absolute top-4 right-6 rounded-sm text-bunker-400 hover:text-bunker-50"
-              >
-                <FontAwesomeIcon icon={faTimes} size="lg" className="cursor-pointer" />
-              </IconButton>
-            </DialogPrimitive.Close>
-          )}
-        </Card>
+            {title && (
+              <DialogPrimitive.Title>
+                <CardTitle subTitle={subTitle}>
+                  <div className={showCloseButton ? "pr-8" : undefined}>{title}</div>
+                </CardTitle>
+              </DialogPrimitive.Title>
+            )}
+            <CardBody
+              className={twMerge("overflow-x-hidden overflow-y-auto", bodyClassName)}
+              style={{ maxHeight: "90%" }}
+            >
+              {children}
+            </CardBody>
+            {footerContent && <CardFooter>{footerContent}</CardFooter>}
+            {showCloseButton && (
+              <DialogPrimitive.Close aria-label="Close" asChild onClick={onClose}>
+                <IconButton
+                  variant="plain"
+                  ariaLabel="close"
+                  className="absolute top-4 right-6 rounded-sm text-bunker-400 hover:text-bunker-50"
+                >
+                  <FontAwesomeIcon icon={faTimes} size="lg" className="cursor-pointer" />
+                </IconButton>
+              </DialogPrimitive.Close>
+            )}
+          </Card>
+        </LayerContent>
       </DialogPrimitive.Content>
-    </DialogPrimitive.Portal>
+    </LayerPortal>
   )
 );
 
@@ -102,7 +110,9 @@ export type ModalProps = Omit<DialogPrimitive.DialogProps, "open"> & {
   isOpen?: boolean;
 };
 export const Modal = ({ isOpen, ...props }: ModalProps) => (
-  <DialogPrimitive.Root open={isOpen} {...props} />
+  <ModalLayer {...props} open={isOpen}>
+    {(layerProps) => <DialogPrimitive.Root {...props} {...layerProps} />}
+  </ModalLayer>
 );
 
 export const ModalTrigger = DialogPrimitive.Trigger;

--- a/frontend/src/components/v2/Popover/Popover.tsx
+++ b/frontend/src/components/v2/Popover/Popover.tsx
@@ -2,6 +2,8 @@ import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as Popover from "@radix-ui/react-popover";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 type Props = {
   children: any;
   text: string;
@@ -19,9 +21,9 @@ export const PopoverObject = ({ children, text, onChangeHandler, id }: Props) =>
     >
       {children}
     </Popover.Trigger>
-    <Popover.Portal>
+    <LayerPortal portal={Popover.Portal}>
       <Popover.Content
-        className="data-[state=open]:data-[side=bottom]:animate-slide-up-and-fade data-[state=open]:data-[side=left]:animate-slide-right-and-fade data-[state=open]:data-[side=right]:animate-slide-left-and-fade data-[state=open]:data-[side=top]:animate-slide-down-and-fade focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)] z-100 min-h-fit w-[460px] rounded-sm border border-chicago-700 bg-mineshaft-600 p-3 shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] will-change-[transform,opacity]"
+        className="data-[state=open]:data-[side=bottom]:animate-slide-up-and-fade data-[state=open]:data-[side=left]:animate-slide-right-and-fade data-[state=open]:data-[side=right]:animate-slide-left-and-fade data-[state=open]:data-[side=top]:animate-slide-down-and-fade focus:shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2),0_0_0_2px_theme(colors.violet7)] z-layer-floating min-h-fit w-[460px] rounded-sm border border-chicago-700 bg-mineshaft-600 p-3 shadow-[0_10px_38px_-10px_hsla(206,22%,7%,.35),0_10px_20px_-15px_hsla(206,22%,7%,.2)] will-change-[transform,opacity]"
         sideOffset={5}
         hideWhenDetached
         side="left"
@@ -45,7 +47,7 @@ export const PopoverObject = ({ children, text, onChangeHandler, id }: Props) =>
         </Popover.Close>
         <Popover.Arrow className="fill-chicago-700" />
       </Popover.Content>
-    </Popover.Portal>
+    </LayerPortal>
   </Popover.Root>
 );
 

--- a/frontend/src/components/v2/Popoverv2/Popoverv2.tsx
+++ b/frontend/src/components/v2/Popoverv2/Popoverv2.tsx
@@ -4,6 +4,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { twMerge } from "tailwind-merge";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 import { IconButton } from "../IconButton";
 
 export const PopoverTrigger = PopoverPrimitive.Trigger;
@@ -23,11 +25,11 @@ export const PopoverContent = ({
   arrowClassName,
   ...props
 }: PopoverContentProps) => (
-  <PopoverPrimitive.Portal>
+  <LayerPortal portal={PopoverPrimitive.Portal}>
     <PopoverPrimitive.Content
       className={twMerge(
         [
-          "relative z-100 w-64 rounded-md bg-mineshaft-600 fill-mineshaft-600 p-4 pt-6 font-inter text-gray-200 shadow-md",
+          "relative z-layer-floating w-64 rounded-md bg-mineshaft-600 fill-mineshaft-600 p-4 pt-6 font-inter text-gray-200 shadow-md",
           // animation
           "data-[state=open]:data-[side=bottom]:animate-slide-up-and-fade",
           "data-[state=open]:data-[side=top]:animate-slide-down-and-fade",
@@ -54,5 +56,5 @@ export const PopoverContent = ({
         <PopoverPrimitive.Arrow className={twMerge("fill-inherit", arrowClassName)} />
       </div>
     </PopoverPrimitive.Content>
-  </PopoverPrimitive.Portal>
+  </LayerPortal>
 );

--- a/frontend/src/components/v2/SecretPathInput/SecretPathInput.tsx
+++ b/frontend/src/components/v2/SecretPathInput/SecretPathInput.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as Popover from "@radix-ui/react-popover";
 import { twMerge } from "tailwind-merge";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
 import { useProject } from "@app/context";
 import { useDebounce } from "@app/hooks";
 import { useGetFoldersByEnv } from "@app/hooks/api";
@@ -130,12 +131,12 @@ const SecretPathInputBase = ({
           className={containerClassName}
         />
       </Popover.Trigger>
-      <Popover.Portal>
+      <LayerPortal portal={Popover.Portal}>
         <Popover.Content
           align="start"
           onOpenAutoFocus={(e) => e.preventDefault()}
           className={twMerge(
-            "relative top-2 z-100 overflow-hidden rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md"
+            "relative top-2 z-layer-floating overflow-hidden rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md"
           )}
           style={{
             width: "var(--radix-popover-trigger-width)",
@@ -172,7 +173,7 @@ const SecretPathInputBase = ({
             ))}
           </div>
         </Popover.Content>
-      </Popover.Portal>
+      </LayerPortal>
     </Popover.Root>
   );
 };

--- a/frontend/src/components/v2/Select/Select.tsx
+++ b/frontend/src/components/v2/Select/Select.tsx
@@ -6,6 +6,8 @@ import { LucideIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 import { twMerge } from "tailwind-merge";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 import { Spinner } from "../Spinner";
 
 type Props = {
@@ -82,11 +84,11 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
               />
             </SelectPrimitive.Icon>
           </SelectPrimitive.Trigger>
-          <SelectPrimitive.Portal>
+          <LayerPortal portal={SelectPrimitive.Portal}>
             <SelectPrimitive.Content
               side={side}
               className={twMerge(
-                "relative top-1 z-100 max-w-sm overflow-hidden rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md",
+                "relative top-1 z-layer-floating max-w-sm overflow-hidden rounded-md border border-mineshaft-600 bg-mineshaft-900 font-inter text-bunker-100 shadow-md",
                 position === "popper" && "max-h-72",
                 dropdownContainerClassName
               )}
@@ -114,7 +116,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
                 </div>
               </SelectPrimitive.ScrollDownButton>
             </SelectPrimitive.Content>
-          </SelectPrimitive.Portal>
+          </LayerPortal>
         </SelectPrimitive.Root>
       </div>
     );

--- a/frontend/src/components/v2/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/v2/Tooltip/Tooltip.tsx
@@ -3,6 +3,8 @@ import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { TooltipProps as RootProps } from "@radix-ui/react-tooltip";
 import { twMerge } from "tailwind-merge";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 export type TooltipProps = Omit<TooltipPrimitive.TooltipContentProps, "open" | "content"> & {
   children: ReactNode;
   content?: ReactNode;
@@ -45,14 +47,14 @@ export const Tooltip = ({
       onOpenChange={onOpenChange}
     >
       <TooltipPrimitive.Trigger asChild={asChild}>{children}</TooltipPrimitive.Trigger>
-      <TooltipPrimitive.Portal>
+      <LayerPortal portal={TooltipPrimitive.Portal}>
         <TooltipPrimitive.Content
           side={position}
           align="center"
           sideOffset={5}
           {...props}
           className={twMerge(
-            "data-[state=delayed-open]:data-[side=bottom]:animate-slide-up-and-fade data-[state=delayed-open]:data-[side=left]:animate-slide-right-and-fade data-[state=delayed-open]:data-[side=right]:animate-slide-left-and-fade data-[state=delayed-open]:data-[side=top]:animate-slide-down-and-fade z-[70] max-w-60 border border-mineshaft-600 bg-mineshaft-800 font-light text-bunker-200 shadow-md select-none",
+            "data-[state=delayed-open]:data-[side=bottom]:animate-slide-up-and-fade data-[state=delayed-open]:data-[side=left]:animate-slide-right-and-fade data-[state=delayed-open]:data-[side=right]:animate-slide-left-and-fade data-[state=delayed-open]:data-[side=top]:animate-slide-down-and-fade z-layer-tooltip max-w-60 border border-mineshaft-600 bg-mineshaft-800 font-light text-bunker-200 shadow-md select-none",
             isDisabled && "hidden!",
             center && "text-center",
             size === "sm" && "rounded-xs px-2 py-1 text-xs",
@@ -63,7 +65,7 @@ export const Tooltip = ({
           {content}
           <TooltipPrimitive.Arrow width={11} height={5} className="fill-mineshaft-600" />
         </TooltipPrimitive.Content>
-      </TooltipPrimitive.Portal>
+      </LayerPortal>
     </TooltipPrimitive.Root>
   ) : (
     // eslint-disable-next-line react/jsx-no-useless-fragment

--- a/frontend/src/components/v3/generic/AlertDialog/AlertDialog.tsx
+++ b/frontend/src/components/v3/generic/AlertDialog/AlertDialog.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
+import { LayerContent, LayerPortal, ModalLayer } from "@app/components/overlays/OverlayLayer";
+
 import { cn } from "../../utils";
 import { Button } from "../Button";
 import { DIALOG_CONTENT_WIDTH_CLASSNAME } from "../Dialog";
@@ -49,11 +51,11 @@ function AlertDialog(alertDialogProps: AlertDialogProps) {
 
   return (
     <AlertDialogConfirmationContext.Provider value={confirmationContextValue}>
-      <AlertDialogPrimitive.Root
-        data-slot="alert-dialog"
-        onOpenChange={handleOpenChange}
-        {...props}
-      />
+      <ModalLayer {...props} onOpenChange={handleOpenChange}>
+        {(layerProps) => (
+          <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} {...layerProps} />
+        )}
+      </ModalLayer>
     </AlertDialogConfirmationContext.Provider>
   );
 }
@@ -65,28 +67,38 @@ function AlertDialogTrigger({
 }
 
 function AlertDialogPortal({ ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
-  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />;
-}
-
-function AlertDialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
   return (
-    <AlertDialogPrimitive.Overlay
-      data-slot="alert-dialog-overlay"
-      className={cn(
-        "fixed inset-0 z-50 bg-black/10 data-closed:animate-out data-closed:duration-100 data-closed:ease-in data-closed:fade-out-0 data-open:animate-in data-open:duration-150 data-open:ease-in data-open:fade-in-0 supports-backdrop-filter:backdrop-blur-xs",
-        className
-      )}
+    <LayerPortal
+      portal={AlertDialogPrimitive.Portal}
+      modal
+      data-slot="alert-dialog-portal"
       {...props}
     />
   );
 }
 
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentProps<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => {
+  return (
+    <AlertDialogPrimitive.Overlay
+      ref={ref}
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-layer-backdrop bg-black/10 data-closed:animate-out data-closed:duration-100 data-closed:ease-in data-closed:fade-out-0 data-open:animate-in data-open:duration-150 data-open:ease-in data-open:fade-in-0 supports-backdrop-filter:backdrop-blur-xs",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+AlertDialogOverlay.displayName = "AlertDialogOverlay";
+
 function AlertDialogContent({
   className,
   size = "default",
+  children,
   ...props
 }: React.ComponentProps<typeof AlertDialogPrimitive.Content> & {
   size?: "default" | "sm";
@@ -98,12 +110,15 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-popover p-4 text-foreground ring-1 ring-foreground/10 outline-none data-closed:animate-out data-closed:duration-100 data-closed:ease-in data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:duration-150 data-open:ease-in data-open:fade-in-0 data-open:zoom-in-95 data-[size=sm]:max-w-sm",
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-layer-content grid -translate-x-1/2 -translate-y-1/2 gap-4 rounded-lg bg-popover p-4 text-foreground ring-1 ring-foreground/10 outline-none data-closed:animate-out data-closed:duration-100 data-closed:ease-in data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:duration-150 data-open:ease-in data-open:fade-in-0 data-open:zoom-in-95 data-[size=sm]:max-w-sm",
           DIALOG_CONTENT_WIDTH_CLASSNAME,
           className
         )}
         {...props}
-      />
+        asChild
+      >
+        <LayerContent>{children}</LayerContent>
+      </AlertDialogPrimitive.Content>
     </AlertDialogPortal>
   );
 }

--- a/frontend/src/components/v3/generic/Combobox/Combobox.tsx
+++ b/frontend/src/components/v3/generic/Combobox/Combobox.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import { Combobox as ComboboxPrimitive } from "@base-ui/react/combobox";
 import { CheckIcon, ChevronDownIcon, Loader2Icon, XIcon } from "lucide-react";
 
+import { usePortalContainer } from "@app/components/overlays/OverlayLayer";
+
 import { cn } from "../../utils";
 import { useScrollEdges } from "../../utils/useScrollEdges";
 
@@ -212,37 +214,41 @@ const ComboboxPopup = ({
   className,
   initialFocus,
   portalContainer
-}: ComboboxPopupProps) => (
-  <ComboboxPrimitive.Portal
-    // Base UI treats an explicit null container as "not yet resolved" and never renders
-    // the popup, so a null (e.g. a ref read before attachment) must degrade to the
-    // document.body default. Prefer passing the RefObject itself: it is resolved lazily
-    // at open time.
-    container={portalContainer ?? undefined}
-    data-slot="combobox-portal"
-    className="pointer-events-auto"
-  >
-    <ComboboxPrimitive.Positioner
-      anchor={anchor}
-      align="start"
-      sideOffset={4}
-      collisionPadding={8}
-      className="isolate z-[60] max-w-[calc(100vw-1rem)] outline-none"
+}: ComboboxPopupProps) => {
+  const layerContainer = usePortalContainer();
+  if (layerContainer === null && !portalContainer) return null;
+  return (
+    <ComboboxPrimitive.Portal
+      // Base UI treats an explicit null container as "not yet resolved" and never renders
+      // the popup, so a null (e.g. a ref read before attachment) must degrade to the
+      // owner-aware default. Prefer passing the RefObject itself: it is resolved lazily
+      // at open time.
+      container={portalContainer ?? layerContainer ?? undefined}
+      data-slot="combobox-portal"
+      className="pointer-events-auto"
     >
-      <ComboboxPrimitive.Popup
-        aria-label={ariaLabel}
-        initialFocus={initialFocus}
-        className={cn(
-          "text-popover-foreground w-(--anchor-width) max-w-(--available-width) origin-(--transform-origin) overflow-hidden rounded-md border border-border bg-popover shadow-md outline-none",
-          "transition-[transform,scale,opacity] duration-100 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0",
-          className
-        )}
+      <ComboboxPrimitive.Positioner
+        anchor={anchor}
+        align="start"
+        sideOffset={4}
+        collisionPadding={8}
+        className="isolate z-layer-floating max-w-[calc(100vw-1rem)] outline-none"
       >
-        {children}
-      </ComboboxPrimitive.Popup>
-    </ComboboxPrimitive.Positioner>
-  </ComboboxPrimitive.Portal>
-);
+        <ComboboxPrimitive.Popup
+          aria-label={ariaLabel}
+          initialFocus={initialFocus}
+          className={cn(
+            "text-popover-foreground w-(--anchor-width) max-w-(--available-width) origin-(--transform-origin) overflow-hidden rounded-md border border-border bg-popover shadow-md outline-none",
+            "transition-[transform,scale,opacity] duration-100 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0",
+            className
+          )}
+        >
+          {children}
+        </ComboboxPrimitive.Popup>
+      </ComboboxPrimitive.Positioner>
+    </ComboboxPrimitive.Portal>
+  );
+};
 
 const useComboboxFilter = <TOption,>({
   getOptionKeywords,

--- a/frontend/src/components/v3/generic/Dialog/Dialog.tsx
+++ b/frontend/src/components/v3/generic/Dialog/Dialog.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
 
+import { LayerContent, LayerPortal, ModalLayer } from "@app/components/overlays/OverlayLayer";
+
 import { cn } from "../../utils";
 
 const DIALOG_CONTENT_WIDTH_CLASSNAME = "w-[calc(100%-2rem)] max-w-lg";
@@ -14,7 +16,11 @@ const isAllowedOutsideInteraction = (target: EventTarget | null) =>
   );
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+  return (
+    <ModalLayer {...props}>
+      {(layerProps) => <DialogPrimitive.Root data-slot="dialog" {...props} {...layerProps} />}
+    </ModalLayer>
+  );
 }
 
 function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
@@ -22,28 +28,30 @@ function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive
 }
 
 function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+  return <LayerPortal portal={DialogPrimitive.Portal} modal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
   return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentProps<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => {
   return (
     <DialogPrimitive.Overlay
+      ref={ref}
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=closed]:ease-in data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:duration-150 data-[state=open]:ease-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-layer-backdrop bg-black/50 data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=closed]:ease-in data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:duration-150 data-[state=open]:ease-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
     />
   );
-}
+});
+DialogOverlay.displayName = "DialogOverlay";
 
 function DialogContent({
   className,
@@ -63,7 +71,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 flex max-h-[calc(100dvh-2rem)] thin-scrollbar translate-x-[-50%] translate-y-[-50%] flex-col gap-6 overflow-y-auto overscroll-none rounded-lg border border-border bg-popover p-6 text-foreground shadow-lg outline-none has-data-[slot=dialog-footer]:pb-0 data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=closed]:ease-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:duration-150 data-[state=open]:ease-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "fixed top-[50%] left-[50%] z-layer-content flex max-h-[calc(100dvh-2rem)] thin-scrollbar translate-x-[-50%] translate-y-[-50%] flex-col gap-6 overflow-y-auto overscroll-none rounded-lg border border-border bg-popover p-6 text-foreground shadow-lg outline-none has-data-[slot=dialog-footer]:pb-0 data-[state=closed]:animate-out data-[state=closed]:duration-100 data-[state=closed]:ease-in data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:duration-150 data-[state=open]:ease-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           DIALOG_CONTENT_WIDTH_CLASSNAME,
           className
         )}
@@ -82,17 +90,20 @@ function DialogContent({
           onInteractOutside?.(e);
         }}
         {...props}
+        asChild
       >
-        {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close
-            data-slot="dialog-close"
-            className="data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
-          >
-            <XIcon />
-            <span className="sr-only">Close</span>
-          </DialogPrimitive.Close>
-        )}
+        <LayerContent>
+          {children}
+          {showCloseButton && (
+            <DialogPrimitive.Close
+              data-slot="dialog-close"
+              className="data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </DialogPrimitive.Close>
+          )}
+        </LayerContent>
       </DialogPrimitive.Content>
     </DialogPortal>
   );

--- a/frontend/src/components/v3/generic/Dropdown/Dropdown.tsx
+++ b/frontend/src/components/v3/generic/Dropdown/Dropdown.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { CheckIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
 import { cn } from "@app/components/v3/utils";
 
 function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
@@ -11,7 +12,13 @@ function DropdownMenu({ ...props }: React.ComponentProps<typeof DropdownMenuPrim
 function DropdownMenuPortal({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
-  return <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
+  return (
+    <LayerPortal
+      portal={DropdownMenuPrimitive.Portal}
+      data-slot="dropdown-menu-portal"
+      {...props}
+    />
+  );
 }
 
 const DropdownMenuTrigger = React.forwardRef<
@@ -30,7 +37,7 @@ function DropdownMenuContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
   return (
-    <DropdownMenuPrimitive.Portal>
+    <LayerPortal portal={DropdownMenuPrimitive.Portal}>
       <DropdownMenuPrimitive.Content
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
@@ -38,12 +45,12 @@ function DropdownMenuContent({
         className={cn(
           "max-h-(--radix-dropdown-menu-content-available-height) origin-(--radix-dropdown-menu-content-transform-origin)",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-          "z-50 thin-scrollbar overflow-x-hidden overflow-y-auto rounded-[6px] border border-border bg-popover p-1.5 text-sm text-foreground shadow-md",
+          "z-layer-floating thin-scrollbar overflow-x-hidden overflow-y-auto rounded-[6px] border border-border bg-popover p-1.5 text-sm text-foreground shadow-md",
           className
         )}
         {...props}
       />
-    </DropdownMenuPrimitive.Portal>
+    </LayerPortal>
   );
 }
 
@@ -223,16 +230,18 @@ function DropdownMenuSubContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
   return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[6px] border border-border bg-popover p-1 text-foreground shadow-lg",
-        className
-      )}
-      sideOffset={sideOffset}
-      collisionPadding={collisionPadding}
-      {...props}
-    />
+    <LayerPortal portal={DropdownMenuPrimitive.Portal}>
+      <DropdownMenuPrimitive.SubContent
+        data-slot="dropdown-menu-sub-content"
+        className={cn(
+          "z-layer-floating min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-[6px] border border-border bg-popover p-1 text-foreground shadow-lg",
+          className
+        )}
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
+        {...props}
+      />
+    </LayerPortal>
   );
 }
 

--- a/frontend/src/components/v3/generic/HoverCard/HoverCard.tsx
+++ b/frontend/src/components/v3/generic/HoverCard/HoverCard.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 import { cn } from "../../utils";
 
 function HoverCard({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
@@ -19,14 +21,14 @@ function HoverCardContent({
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
   return (
-    <HoverCardPrimitive.Portal data-slot="hover-card-portal">
+    <LayerPortal portal={HoverCardPrimitive.Portal} data-slot="hover-card-portal">
       <HoverCardPrimitive.Content
         data-slot="hover-card-content"
         align={align}
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg bg-popover p-2.5",
+          "z-layer-floating w-64 origin-(--radix-hover-card-content-transform-origin) rounded-lg bg-popover p-2.5",
           "border border-border text-sm text-foreground/90 shadow-md outline-hidden",
           "duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2",
@@ -36,7 +38,7 @@ function HoverCardContent({
         )}
         {...props}
       />
-    </HoverCardPrimitive.Portal>
+    </LayerPortal>
   );
 }
 

--- a/frontend/src/components/v3/generic/Popover/Popover.tsx
+++ b/frontend/src/components/v3/generic/Popover/Popover.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 import { cn } from "../../utils";
 
 function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
@@ -26,19 +28,19 @@ function PopoverContent({
   container?: React.ComponentProps<typeof PopoverPrimitive.Portal>["container"];
 }) {
   return (
-    <PopoverPrimitive.Portal container={container}>
+    <LayerPortal portal={PopoverPrimitive.Portal} container={container}>
       <PopoverPrimitive.Content
         data-slot="popover-content"
         align={align}
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-lg border border-border bg-popover p-4 text-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "z-layer-floating w-72 origin-(--radix-popover-content-transform-origin) rounded-lg border border-border bg-popover p-4 text-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
           className
         )}
         {...props}
       />
-    </PopoverPrimitive.Portal>
+    </LayerPortal>
   );
 }
 

--- a/frontend/src/components/v3/generic/ReactSelect/CreatableSelect.tsx
+++ b/frontend/src/components/v3/generic/ReactSelect/CreatableSelect.tsx
@@ -1,6 +1,8 @@
 import { GroupBase } from "react-select";
 import ReactSelectCreatable, { CreatableProps } from "react-select/creatable";
 
+import { usePortalContainer } from "@app/components/overlays/OverlayLayer";
+
 import {
   ClearIndicator,
   DropdownIndicator,
@@ -15,10 +17,12 @@ export const CreatableSelect = <T,>({
   closeMenuOnSelect,
   isError,
   components,
-  menuPortalTarget = typeof document === "undefined" ? undefined : document.body,
+  menuPortalTarget,
+  menuIsOpen,
   menuPosition = "fixed",
   ...props
 }: CreatableProps<T, boolean, GroupBase<T>> & { isError?: boolean }) => {
+  const layerContainer = usePortalContainer();
   return (
     <ReactSelectCreatable
       isMulti={isMulti}
@@ -26,7 +30,12 @@ export const CreatableSelect = <T,>({
       hideSelectedOptions={false}
       unstyled
       data-slot="creatable-select"
-      menuPortalTarget={menuPortalTarget}
+      menuPortalTarget={
+        menuPortalTarget === undefined
+          ? (layerContainer ?? (typeof document === "undefined" ? undefined : document.body))
+          : menuPortalTarget
+      }
+      menuIsOpen={layerContainer === null && menuPortalTarget === undefined ? false : menuIsOpen}
       menuPosition={menuPosition}
       styles={selectStyles as any}
       components={{

--- a/frontend/src/components/v3/generic/ReactSelect/FilterableSelect.tsx
+++ b/frontend/src/components/v3/generic/ReactSelect/FilterableSelect.tsx
@@ -1,5 +1,7 @@
 import Select, { GroupBase, Props } from "react-select";
 
+import { usePortalContainer } from "@app/components/overlays/OverlayLayer";
+
 import {
   ClearIndicator,
   DropdownIndicator,
@@ -23,7 +25,8 @@ export const FilterableSelect = <T,>({
   options = [],
   isError,
   components,
-  menuPortalTarget = typeof document === "undefined" ? undefined : document.body,
+  menuPortalTarget,
+  menuIsOpen,
   menuPosition = "fixed",
   ...props
 }: Props<T, boolean, GroupBase<T>> & {
@@ -31,6 +34,7 @@ export const FilterableSelect = <T,>({
   getGroupHeaderLabel?: ((groupValue: any) => string) | null;
   isError?: boolean;
 }) => {
+  const layerContainer = usePortalContainer();
   let processedOptions: Props<T, boolean, GroupBase<T>>["options"] = options;
 
   if (groupBy && Array.isArray(options)) {
@@ -63,7 +67,12 @@ export const FilterableSelect = <T,>({
       unstyled
       options={processedOptions}
       tabSelectsValue={tabSelectsValue}
-      menuPortalTarget={menuPortalTarget}
+      menuPortalTarget={
+        menuPortalTarget === undefined
+          ? (layerContainer ?? (typeof document === "undefined" ? undefined : document.body))
+          : menuPortalTarget
+      }
+      menuIsOpen={layerContainer === null && menuPortalTarget === undefined ? false : menuIsOpen}
       menuPosition={menuPosition}
       styles={selectStyles as any}
       components={{

--- a/frontend/src/components/v3/generic/ReactSelect/styles.ts
+++ b/frontend/src/components/v3/generic/ReactSelect/styles.ts
@@ -54,7 +54,7 @@ export const selectStyles: StylesConfig<unknown, boolean, GroupBase<unknown>> = 
   }),
   menuPortal: (provided) => ({
     ...provided,
-    zIndex: 60,
+    zIndex: "var(--z-index-layer-floating)",
     pointerEvents: "auto"
   })
 };

--- a/frontend/src/components/v3/generic/Select/Select.tsx
+++ b/frontend/src/components/v3/generic/Select/Select.tsx
@@ -4,6 +4,8 @@ import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { Select as SelectPrimitive } from "radix-ui";
 import { twMerge } from "tailwind-merge";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 import { cn } from "../../utils";
 
 function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
@@ -116,12 +118,12 @@ function SelectContent({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
   return (
-    <SelectPrimitive.Portal>
+    <LayerPortal portal={SelectPrimitive.Portal}>
       <SelectPrimitive.Content
         data-slot="select-content"
         data-align-trigger={position === "item-aligned"}
         className={cn(
-          "relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover text-foreground shadow-md duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "relative z-layer-floating max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border border-border bg-popover text-foreground shadow-md duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className
@@ -143,7 +145,7 @@ function SelectContent({
         </SelectPrimitive.Viewport>
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
-    </SelectPrimitive.Portal>
+    </LayerPortal>
   );
 }
 

--- a/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
+++ b/frontend/src/components/v3/generic/SelectedActionBar/SelectedActionBar.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { createPortal } from "react-dom";
 
+import { usePortalContainer } from "@app/components/overlays/OverlayLayer";
 import { cn } from "@app/components/v3/utils";
 
 import { Button } from "../Button";
@@ -33,6 +34,7 @@ function SelectedActionBar({
   "aria-label": ariaLabel = "Selection actions",
   ...props
 }: SelectedActionBarProps) {
+  const portalContainer = usePortalContainer();
   const isVisible = selectedCount > 0;
   const clearSelectionRef = React.useRef(onClearSelection);
   const lastVisibleContent = React.useRef({ children, selectedCount, selectionLabel });
@@ -67,13 +69,13 @@ function SelectedActionBar({
     ? { children, selectedCount, selectionLabel }
     : lastVisibleContent.current;
 
-  if (typeof document === "undefined") return null;
+  if (typeof document === "undefined" || portalContainer === null) return null;
 
   return createPortal(
     <div
       data-slot="selected-action-bar-positioner"
       className={cn(
-        "pointer-events-none fixed inset-x-4 bottom-8 z-40 flex justify-center",
+        "pointer-events-none fixed inset-x-4 bottom-8 z-layer-action flex justify-center",
         "transition-[opacity,translate,filter,scale] ease-out motion-reduce:transition-none",
         isVisible
           ? "translate-y-0 scale-100 opacity-100 blur-none duration-200"
@@ -119,7 +121,7 @@ function SelectedActionBar({
         </div>
       </div>
     </div>,
-    document.body
+    portalContainer ?? document.body
   );
 }
 

--- a/frontend/src/components/v3/generic/Sheet/Sheet.tsx
+++ b/frontend/src/components/v3/generic/Sheet/Sheet.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import * as SheetPrimitive from "@radix-ui/react-dialog";
 import { XIcon } from "lucide-react";
 
+import { LayerContent, LayerPortal, ModalLayer } from "@app/components/overlays/OverlayLayer";
+
 import { cn } from "../../utils";
 
 const isAllowedOutsideInteraction = (target: EventTarget | null) =>
@@ -14,7 +16,11 @@ const isAllowedOutsideInteraction = (target: EventTarget | null) =>
   );
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+  return (
+    <ModalLayer {...props}>
+      {(layerProps) => <SheetPrimitive.Root data-slot="sheet" {...props} {...layerProps} />}
+    </ModalLayer>
+  );
 }
 
 function SheetTrigger({ ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
@@ -26,24 +32,26 @@ function SheetClose({ ...props }: React.ComponentProps<typeof SheetPrimitive.Clo
 }
 
 function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+  return <LayerPortal portal={SheetPrimitive.Portal} modal data-slot="sheet-portal" {...props} />;
 }
 
-function SheetOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentProps<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => {
   return (
     <SheetPrimitive.Overlay
+      ref={ref}
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 ease-out data-[state=closed]:animate-out data-[state=closed]:duration-250 data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0",
+        "fixed inset-0 z-layer-backdrop bg-black/50 ease-out data-[state=closed]:animate-out data-[state=closed]:duration-250 data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0",
         className
       )}
       {...props}
     />
   );
-}
+});
+SheetOverlay.displayName = "SheetOverlay";
 
 function SheetContent({
   className,
@@ -75,7 +83,7 @@ function SheetContent({
           onInteractOutside?.(e);
         }}
         className={cn(
-          "fixed z-50 flex thin-scrollbar flex-col border-border bg-popover text-foreground shadow-lg outline-0 transition ease-out data-[state=closed]:animate-out data-[state=closed]:duration-250 data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0",
+          "fixed z-layer-content flex thin-scrollbar flex-col border-border bg-popover text-foreground shadow-lg outline-0 transition ease-out data-[state=closed]:animate-out data-[state=closed]:duration-250 data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:duration-200 data-[state=open]:fade-in-0",
           side === "right" &&
             "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right-8 data-[state=open]:slide-in-from-right-2 sm:max-w-md",
           side === "left" &&
@@ -87,12 +95,15 @@ function SheetContent({
           className
         )}
         {...props}
+        asChild
       >
-        {children}
-        <SheetPrimitive.Close className="data-[state=open]:bg-secondary absolute top-4 right-4 z-20 cursor-pointer rounded-xs text-foreground opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
+        <LayerContent exitDuration={250}>
+          {children}
+          <SheetPrimitive.Close className="data-[state=open]:bg-secondary absolute top-4 right-4 z-20 cursor-pointer rounded-xs text-foreground opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        </LayerContent>
       </SheetPrimitive.Content>
     </SheetPortal>
   );

--- a/frontend/src/components/v3/generic/Toast/Toast.tsx
+++ b/frontend/src/components/v3/generic/Toast/Toast.tsx
@@ -7,52 +7,57 @@ import {
 } from "lucide-react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
+import { ToastLayer } from "@app/components/overlays/OverlayLayer";
+
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
-    <Sonner
-      theme="dark"
-      position="bottom-center"
-      closeButton
-      className="toaster group"
-      icons={{
-        success: <CircleCheckIcon className="size-4 text-success" />,
-        info: <InfoIcon className="size-4 text-info" />,
-        warning: <TriangleAlertIcon className="size-4 text-warning" />,
-        error: <OctagonXIcon className="size-4 text-danger" />,
-        loading: <Loader2Icon className="size-4 animate-spin text-foreground/60" />
-      }}
-      toastOptions={{
-        classNames: {
-          toast: "!pointer-events-auto !items-start !rounded-md !pl-5 !py-3",
-          icon: "!mt-0.5",
-          title: "!text-sm !font-medium !text-foreground whitespace-pre-line",
-          description: "!text-xs !text-foreground/75 whitespace-pre-line",
-          closeButton:
-            "!left-auto !right-2 !top-2 !transform-none !rounded-sm !border-transparent !bg-transparent !text-foreground/60 hover:!bg-foreground/10 hover:!text-foreground",
-          actionButton:
-            "!self-end !rounded-sm !border !border-border !bg-transparent !text-foreground hover:!bg-foreground/10 hover:!border-foreground/20",
-          cancelButton:
-            "!self-end !rounded !border !border-border !bg-transparent !text-foreground/80 hover:!bg-foreground/10",
-          success:
-            "!border-l-0 !bg-[linear-gradient(to_right,var(--color-success)_4px,transparent_4px)]",
-          info: "!border-l-0 !bg-[linear-gradient(to_right,var(--color-info)_4px,transparent_4px)]",
-          warning:
-            "!border-l-0 !bg-[linear-gradient(to_right,var(--color-warning)_4px,transparent_4px)]",
-          error:
-            "!border-l-0 !bg-[linear-gradient(to_right,var(--color-danger)_4px,transparent_4px)]"
+    <ToastLayer>
+      <Sonner
+        theme="dark"
+        position="bottom-center"
+        closeButton
+        className="toaster group"
+        icons={{
+          success: <CircleCheckIcon className="size-4 text-success" />,
+          info: <InfoIcon className="size-4 text-info" />,
+          warning: <TriangleAlertIcon className="size-4 text-warning" />,
+          error: <OctagonXIcon className="size-4 text-danger" />,
+          loading: <Loader2Icon className="size-4 animate-spin text-foreground/60" />
+        }}
+        toastOptions={{
+          classNames: {
+            toast: "!pointer-events-auto !items-start !rounded-md !pl-5 !py-3",
+            icon: "!mt-0.5",
+            title: "!text-sm !font-medium !text-foreground whitespace-pre-line",
+            description: "!text-xs !text-foreground/75 whitespace-pre-line",
+            closeButton:
+              "!left-auto !right-2 !top-2 !transform-none !rounded-sm !border-transparent !bg-transparent !text-foreground/60 hover:!bg-foreground/10 hover:!text-foreground",
+            actionButton:
+              "!self-end !rounded-sm !border !border-border !bg-transparent !text-foreground hover:!bg-foreground/10 hover:!border-foreground/20",
+            cancelButton:
+              "!self-end !rounded !border !border-border !bg-transparent !text-foreground/80 hover:!bg-foreground/10",
+            success:
+              "!border-l-0 !bg-[linear-gradient(to_right,var(--color-success)_4px,transparent_4px)]",
+            info: "!border-l-0 !bg-[linear-gradient(to_right,var(--color-info)_4px,transparent_4px)]",
+            warning:
+              "!border-l-0 !bg-[linear-gradient(to_right,var(--color-warning)_4px,transparent_4px)]",
+            error:
+              "!border-l-0 !bg-[linear-gradient(to_right,var(--color-danger)_4px,transparent_4px)]"
+          }
+        }}
+        style={
+          {
+            "--width": "400px",
+            zIndex: "var(--z-index-layer-content)",
+            "--border-radius": "0.375rem",
+            "--normal-bg": "var(--color-container)",
+            "--normal-border": "var(--color-border)",
+            "--normal-text": "var(--color-foreground)"
+          } as React.CSSProperties
         }
-      }}
-      style={
-        {
-          "--width": "400px",
-          "--border-radius": "0.375rem",
-          "--normal-bg": "var(--color-container)",
-          "--normal-border": "var(--color-border)",
-          "--normal-text": "var(--color-foreground)"
-        } as React.CSSProperties
-      }
-      {...props}
-    />
+        {...props}
+      />
+    </ToastLayer>
   );
 };
 

--- a/frontend/src/components/v3/generic/Tooltip/Tooltip.tsx
+++ b/frontend/src/components/v3/generic/Tooltip/Tooltip.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
+
 import { cn } from "../../utils";
 
 function TooltipProvider({
@@ -38,21 +40,21 @@ function TooltipContent({
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
   return (
-    <TooltipPrimitive.Portal>
+    <LayerPortal portal={TooltipPrimitive.Portal}>
       <TooltipPrimitive.Content
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         collisionPadding={collisionPadding}
         className={cn(
-          "!pointer-events-none z-[70] w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-sm bg-border px-3 py-1.5 text-xs text-pretty text-foreground shadow-md fade-in-0 select-none zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "!pointer-events-none z-layer-tooltip w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-sm bg-border px-3 py-1.5 text-xs text-pretty text-foreground shadow-md fade-in-0 select-none zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-[70] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[1px] bg-border fill-border" />
+        <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[1px] bg-border fill-border" />
       </TooltipPrimitive.Content>
-    </TooltipPrimitive.Portal>
+    </LayerPortal>
   );
 }
 

--- a/frontend/src/components/v3/platform/GatewayPicker/GatewayPicker.tsx
+++ b/frontend/src/components/v3/platform/GatewayPicker/GatewayPicker.tsx
@@ -104,7 +104,7 @@ export const GatewayPicker = ({
       <SelectTrigger className={className ?? "w-full"} isError={isError}>
         <SelectValue placeholder={placeholder ?? "Select gateway..."} />
       </SelectTrigger>
-      <SelectContent position="popper" className="z-[70]">
+      <SelectContent position="popper">
         {!isRequired && (
           <SelectItem value="internet">
             <span className="flex items-center gap-2">

--- a/frontend/src/components/v3/platform/SecretInput/InfisicalSecretInput.tsx
+++ b/frontend/src/components/v3/platform/SecretInput/InfisicalSecretInput.tsx
@@ -3,6 +3,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { useNavigate } from "@tanstack/react-router";
 
 import { createNotification } from "@app/components/notifications";
+import { LayerPortal } from "@app/components/overlays/OverlayLayer";
 import { ROUTE_PATHS } from "@app/const/routes";
 import { useProject, useProjectPermission } from "@app/context";
 import { ProjectPermissionSecretActions } from "@app/context/ProjectPermissionContext/types";
@@ -245,13 +246,13 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
             onClickSegment={handleClickSegment}
           />
         </PopoverPrimitive.Trigger>
-        <PopoverPrimitive.Portal>
+        <LayerPortal portal={PopoverPrimitive.Portal}>
           <PopoverPrimitive.Content
             align="start"
             collisionPadding={8}
             onOpenAutoFocus={(e) => e.preventDefault()}
             onMouseDown={(e) => e.preventDefault()}
-            className="relative top-2 z-[100] max-h-80 thin-scrollbar overflow-auto rounded-md border border-border bg-popover text-foreground shadow-md"
+            className="relative top-2 z-layer-floating max-h-80 thin-scrollbar overflow-auto rounded-md border border-border bg-popover text-foreground shadow-md"
             style={{ width: "var(--radix-popover-trigger-width)", minWidth: "320px" }}
           >
             <SecretReferenceWizard
@@ -265,7 +266,7 @@ export const InfisicalSecretInput = forwardRef<HTMLTextAreaElement, Props>(
               }
             />
           </PopoverPrimitive.Content>
-        </PopoverPrimitive.Portal>
+        </LayerPortal>
       </PopoverPrimitive.Root>
     );
   }

--- a/frontend/src/hooks/api/reactQuery.tsx
+++ b/frontend/src/hooks/api/reactQuery.tsx
@@ -58,8 +58,7 @@ function ValidationErrorModal({
         }
       }}
     >
-      {/* z-[70] keeps this dialog above v2 Modals (z-[60]) hosting the form that errored */}
-      <DialogContent className="z-[70] sm:max-w-2xl" overlayClassName="z-[70]">
+      <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Validation Error Details</DialogTitle>
           <DialogDescription>These fields did not pass validation.</DialogDescription>
@@ -210,8 +209,7 @@ export const onRequestError = (
                 Show more
               </Button>
             </DialogTrigger>
-            {/* z-[70] keeps this dialog above v2 Modals (z-[60]) hosting the form that errored */}
-            <DialogContent className="z-[70] sm:max-w-2xl" overlayClassName="z-[70]">
+            <DialogContent className="sm:max-w-2xl">
               <DialogHeader>
                 <DialogTitle>Validation Rules</DialogTitle>
                 <DialogDescription>Please review the allowed rules below.</DialogDescription>
@@ -279,7 +277,7 @@ export const onRequestError = (
                 Show more
               </Button>
             </DialogTrigger>
-            <DialogContent className="z-[70] sm:max-w-2xl" overlayClassName="z-[70]">
+            <DialogContent className="sm:max-w-2xl">
               <DialogHeader>
                 <DialogTitle>Missing Permissions</DialogTitle>
                 <DialogDescription>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -68,6 +68,14 @@
 }
 
 @theme {
+  --z-index-layer-chrome: 10;
+  --z-index-layer-action: 20;
+  --z-index-layer-backdrop: 10;
+  --z-index-layer-content: 20;
+  --z-index-layer-floating: 30;
+  --z-index-layer-tooltip: 40;
+  --z-index-layer-modal: 50;
+  --z-index-layer-toast: 60;
   --breakpoint-dashboard: 1400px;
 
   /* Fonts */
@@ -534,4 +542,40 @@ input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   margin: 0;
+}
+
+/* Page-local sticky controls cannot compete with document-level portals. */
+#root,
+#storybook-root {
+  isolation: isolate;
+}
+
+.overlay-layer-root {
+  position: fixed;
+  inset: 0;
+  isolation: isolate;
+  pointer-events: none;
+}
+
+[data-overlay-layer="modal"] {
+  z-index: var(--z-index-layer-modal);
+}
+
+[data-overlay-layer="toast"] {
+  z-index: var(--z-index-layer-toast);
+}
+
+/* Portal hosts must not intercept the viewport; their actual surfaces remain interactive. */
+.overlay-layer-root > :not(.overlay-layer-root) {
+  pointer-events: auto;
+}
+
+/* The scope participates in Radix presence without becoming a containing block. */
+.overlay-content-scope[data-state="closed"] {
+  animation-name: overlay-content-exit;
+}
+
+@keyframes overlay-content-exit {
+  from { visibility: visible; }
+  to { visibility: visible; }
 }

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/Notification.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/Notification.tsx
@@ -37,11 +37,7 @@ export const Notification = ({ notification, onDelete }: Props) => {
               />
             </div>
           )}
-          <Tooltip
-            content={<Markdown>{notification.title}</Markdown>}
-            delayDuration={300}
-            className="z-1000"
-          >
+          <Tooltip content={<Markdown>{notification.title}</Markdown>} delayDuration={300}>
             <span className="overflow-hidden text-sm leading-5 font-medium text-ellipsis whitespace-nowrap text-mineshaft-100">
               <Markdown components={{ p: "span" }}>{notification.title}</Markdown>
             </span>

--- a/frontend/src/layouts/OrganizationLayout/components/NavBar/NotificationDropdown.tsx
+++ b/frontend/src/layouts/OrganizationLayout/components/NavBar/NotificationDropdown.tsx
@@ -74,7 +74,7 @@ export const NotificationDropdown = () => {
       <DropdownMenuContent
         align="end"
         side="bottom"
-        className="z-999 mt-3 flex h-[550px] w-[400px] overflow-hidden rounded-lg"
+        className="mt-3 flex h-[550px] w-[400px] overflow-hidden rounded-lg"
       >
         <div className="flex w-full flex-col">
           <div className="flex items-center justify-between border-b border-mineshaft-500 px-3 py-2">

--- a/frontend/src/pages/cert-manager/CertificatesPage/components/FilterBuilder.tsx
+++ b/frontend/src/pages/cert-manager/CertificatesPage/components/FilterBuilder.tsx
@@ -172,7 +172,6 @@ const FilterRow = ({
             placeholder="Select..."
             className="w-full text-sm"
             maxMenuHeight={160}
-            menuPortalTarget={document.body}
             menuPosition="fixed"
             {...(serverSearch
               ? {

--- a/frontend/src/pages/organization/AuditLogsPage/components/AuditLogStreamTab/AuditLogStreamForm/AuditLogStreamProductsField.tsx
+++ b/frontend/src/pages/organization/AuditLogsPage/components/AuditLogStreamTab/AuditLogStreamForm/AuditLogStreamProductsField.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 import { components, MultiValue, OptionProps } from "react-select";
 import { Building2Icon, CheckIcon, GlobeIcon, Info, type LucideIcon } from "lucide-react";
@@ -111,15 +110,6 @@ const ProductOptionItem = ({ isSelected, children, ...props }: OptionProps<Produ
 export const ProductsField = () => {
   const { control } = useFormContext<FilterFormShape>();
   const { field } = useController({ control, name: "filters.products" });
-  const containerRef = useRef<HTMLDivElement>(null);
-  // Portal the menu into the enclosing modal so it can overflow the modal's scrollable body
-  // instead of being clipped. Targeting the dialog (not document.body) keeps it inside Radix's
-  // focus trap so options stay clickable. Falls back to inline rendering outside a modal.
-  const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(null);
-
-  useEffect(() => {
-    setMenuPortalTarget(containerRef.current?.closest<HTMLElement>('[role="dialog"]') ?? null);
-  }, []);
 
   const selected = field.value ?? [];
   const value = PRODUCT_OPTIONS.filter((option) =>
@@ -141,7 +131,7 @@ export const ProductsField = () => {
           </TooltipContent>
         </Tooltip>
       </FieldLabel>
-      <div ref={containerRef}>
+      <div>
         <FilterableSelect
           inputId="products"
           isMulti
@@ -167,7 +157,6 @@ export const ProductsField = () => {
           getOptionValue={(option) => option.value}
           getOptionLabel={(option) => option.label}
           components={{ Option: ProductOptionItem }}
-          menuPortalTarget={menuPortalTarget ?? undefined}
           menuPosition="fixed"
           menuPlacement="auto"
         />

--- a/frontend/src/pages/organization/IdentityDetailsByIDPage/components/IdentityAuthenticationSection/IdentityTokens.tsx
+++ b/frontend/src/pages/organization/IdentityDetailsByIDPage/components/IdentityAuthenticationSection/IdentityTokens.tsx
@@ -83,7 +83,7 @@ export const IdentityTokens = ({ identityId, handlePopUpOpen }: Props) => {
                   </IconButton>
                 </Tooltip>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="z-101 p-1">
+              <DropdownMenuContent align="start" className="p-1">
                 <DropdownMenuItem
                   onClick={async () => {
                     handlePopUpOpen("token", {

--- a/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/components/PoolDetailSheet.tsx
+++ b/frontend/src/pages/organization/NetworkingPage/components/GatewayTab/components/PoolDetailSheet.tsx
@@ -264,7 +264,7 @@ export const PoolDetailSheet = ({ isOpen, onOpenChange, pool }: Props) => {
                               <FontAwesomeIcon icon={faEllipsisV} />
                             </IconButton>
                           </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" className="z-[60] min-w-[180px]">
+                          <DropdownMenuContent align="end" className="min-w-[180px]">
                             {!gw.isV1 && (
                               <DropdownMenuItem onSelect={() => handleHealthCheck(gw.id)}>
                                 <FontAwesomeIcon icon={faHeartPulse} />

--- a/frontend/src/pages/pam/PamAccountsPage/components/RecordingConnectionPicker.tsx
+++ b/frontend/src/pages/pam/PamAccountsPage/components/RecordingConnectionPicker.tsx
@@ -26,7 +26,7 @@ export const RecordingConnectionPicker = ({ value, onChange, isError, includeNon
       <SelectTrigger className="w-full" isError={isError}>
         <SelectValue placeholder="Select an S3 connection..." />
       </SelectTrigger>
-      <SelectContent position="popper" className="z-[70]">
+      <SelectContent position="popper">
         {includeNone && <SelectItem value={NONE_VALUE}>None</SelectItem>}
         {awsConnections.length === 0 && (
           <div className="px-2 py-3 text-center text-xs text-muted">

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityProjectAdditionalPrivilegeSection/IdentityProjectAdditionalPrivilegeModifySection.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityProjectAdditionalPrivilegeSection/IdentityProjectAdditionalPrivilegeModifySection.tsx
@@ -62,7 +62,6 @@ type Props = {
   identityId: string;
   onGoBack: () => void;
   isDisabled?: boolean;
-  menuPortalContainerRef?: React.RefObject<HTMLElement | null>;
   initialPermissions?: z.infer<typeof formSchema>["permissions"];
 };
 
@@ -91,7 +90,6 @@ export const IdentityProjectAdditionalPrivilegeModifySection = ({
   onGoBack,
   identityId,
   isDisabled,
-  menuPortalContainerRef,
   initialPermissions
 }: Props) => {
   const isCreate = !privilegeId;
@@ -424,7 +422,6 @@ export const IdentityProjectAdditionalPrivilegeModifySection = ({
                       projectType={currentProject.type}
                       projectId={projectId}
                       allowedSubjects={filteredPermissionSubjects}
-                      portalContainer={menuPortalContainerRef}
                     />
                   )}
                 </div>
@@ -457,7 +454,6 @@ export const IdentityProjectAdditionalPrivilegeModifySection = ({
                               prev.includes(permissionSubject) ? prev : [...prev, permissionSubject]
                             )
                           }
-                          menuPortalContainerRef={menuPortalContainerRef}
                           isConditional={isConditionalSubjects(permissionSubject)}
                         >
                           {renderConditionalComponents(permissionSubject, isDisabled)}

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityProjectAdditionalPrivilegeSection/IdentityProjectAdditionalPrivilegeSection.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityProjectAdditionalPrivilegeSection/IdentityProjectAdditionalPrivilegeSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { subject } from "@casl/ability";
 import { format, formatDistance } from "date-fns";
 import { ClockAlertIcon, ClockIcon, EllipsisIcon, PlusIcon } from "lucide-react";
@@ -66,7 +66,6 @@ type Props = {
 };
 
 export const IdentityProjectAdditionalPrivilegeSection = ({ identityMembershipDetails }: Props) => {
-  const sheetContainerRef = useRef<HTMLDivElement>(null);
   const { popUp, handlePopUpOpen, handlePopUpToggle, handlePopUpClose } = usePopUp([
     "deletePrivilege",
     "modifyPrivilege"
@@ -342,7 +341,7 @@ export const IdentityProjectAdditionalPrivilegeSection = ({ identityMembershipDe
         open={popUp.modifyPrivilege.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("modifyPrivilege", isOpen)}
       >
-        <SheetContent ref={sheetContainerRef} className="flex h-full flex-col gap-y-0 sm:max-w-6xl">
+        <SheetContent className="flex h-full flex-col gap-y-0 sm:max-w-6xl">
           <SheetHeader className="border-b">
             <SheetTitle>Additional Privileges</SheetTitle>
             <SheetDescription>
@@ -361,7 +360,6 @@ export const IdentityProjectAdditionalPrivilegeSection = ({ identityMembershipDe
                 })
               ) || !canModifyIdentityPrivileges
             }
-            menuPortalContainerRef={sheetContainerRef}
           />
         </SheetContent>
       </Sheet>

--- a/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityRoleDetailsSection/IdentityRoleModify.tsx
+++ b/frontend/src/pages/project/IdentityDetailsByIDPage/components/IdentityRoleDetailsSection/IdentityRoleModify.tsx
@@ -160,7 +160,7 @@ export const IdentityRoleAssignmentRow = ({
               <SelectTrigger id={selectId} className="w-full">
                 <SelectValue />
               </SelectTrigger>
-              <SelectContent position="popper" className="z-[70]">
+              <SelectContent position="popper">
                 {getRolesForSelect(field.value).map(({ name, slug, id }) => {
                   const isAssignable = assignableRoleSlugs.has(slug);
                   return (
@@ -204,7 +204,6 @@ export const IdentityRoleAssignmentRow = ({
           </Tooltip>
           <PopoverContent
             side="right"
-            className="z-[70]"
             onWheel={(event) => event.stopPropagation()}
             onOpenAutoFocus={(event) => event.preventDefault()}
           >

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberProjectAdditionalPrivilegeSection/MemberProjectAdditionalPrivilegeSection.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberProjectAdditionalPrivilegeSection/MemberProjectAdditionalPrivilegeSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { format, formatDistance } from "date-fns";
 import {
@@ -83,7 +83,6 @@ type Props = {
 };
 
 export const MemberProjectAdditionalPrivilegeSection = ({ membershipDetails }: Props) => {
-  const sheetContainerRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
   const { user } = useUser();
   const userId = user?.id;
@@ -444,7 +443,7 @@ export const MemberProjectAdditionalPrivilegeSection = ({ membershipDetails }: P
         open={popUp.modifyPrivilege.isOpen}
         onOpenChange={(isOpen) => handlePopUpToggle("modifyPrivilege", isOpen)}
       >
-        <SheetContent ref={sheetContainerRef} className="flex h-full flex-col gap-y-0 sm:max-w-6xl">
+        <SheetContent className="flex h-full flex-col gap-y-0 sm:max-w-6xl">
           <SheetHeader className="border-b">
             <SheetTitle>Additional Privileges</SheetTitle>
             <SheetDescription>
@@ -459,7 +458,6 @@ export const MemberProjectAdditionalPrivilegeSection = ({ membershipDetails }: P
               isOwnProjectMembershipDetails ||
               permission.cannot(ProjectPermissionMemberActions.Edit, ProjectPermissionSub.Member)
             }
-            menuPortalContainerRef={sheetContainerRef}
           />
         </SheetContent>
       </Sheet>

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberProjectAdditionalPrivilegeSection/MembershipProjectAdditionalPrivilegeModifySection.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberProjectAdditionalPrivilegeSection/MembershipProjectAdditionalPrivilegeModifySection.tsx
@@ -65,7 +65,6 @@ type Props = {
   projectMembershipId: string;
   onGoBack: () => void;
   isDisabled?: boolean;
-  menuPortalContainerRef?: React.RefObject<HTMLElement | null>;
   initialPermissions?: z.infer<typeof formSchema>["permissions"];
 };
 
@@ -94,7 +93,6 @@ export const MembershipProjectAdditionalPrivilegeModifySection = ({
   onGoBack,
   projectMembershipId,
   isDisabled,
-  menuPortalContainerRef,
   initialPermissions
 }: Props) => {
   const isCreate = !privilegeId;
@@ -467,7 +465,6 @@ export const MembershipProjectAdditionalPrivilegeModifySection = ({
                       projectType={currentProject.type}
                       projectId={projectId}
                       allowedSubjects={filteredPermissionSubjects}
-                      portalContainer={menuPortalContainerRef}
                     />
                   )}
                 </div>
@@ -500,7 +497,6 @@ export const MembershipProjectAdditionalPrivilegeModifySection = ({
                               prev.includes(permissionSubject) ? prev : [...prev, permissionSubject]
                             )
                           }
-                          menuPortalContainerRef={menuPortalContainerRef}
                           isConditional={isConditionalSubjects(permissionSubject)}
                         >
                           {renderConditionalComponents(permissionSubject, isFormDisabled)}

--- a/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/RoleAssignmentRow.tsx
+++ b/frontend/src/pages/project/MemberDetailsByIDPage/components/MemberRoleDetailsSection/RoleAssignmentRow.tsx
@@ -131,7 +131,7 @@ export const RoleAssignmentRow = ({
                 <SelectTrigger id={roleSelectId} className="w-full">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent position="popper" className="z-[70]">
+                <SelectContent position="popper">
                   {rolesForSelect.map(({ name, slug, id }) => {
                     const isAssignable = assignableRoleSlugs.has(slug);
                     return (
@@ -176,7 +176,6 @@ export const RoleAssignmentRow = ({
           </Tooltip>
           <PopoverContent
             side="right"
-            className="z-[70]"
             onWheel={(e) => e.stopPropagation()}
             onOpenAutoFocus={(e) => e.preventDefault()}
           >

--- a/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
+++ b/frontend/src/pages/project/RoleDetailsBySlugPage/components/GeneralPermissionPolicies.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, Fragment, RefObject, useEffect, useMemo, useRef } from "react";
+import { cloneElement, Fragment, useEffect, useMemo, useRef } from "react";
 import {
   Control,
   Controller,
@@ -62,7 +62,6 @@ type Props<T extends AnyPermissionSubject> = {
   isOpen?: boolean;
   onPolicyAdded?: () => void;
   onShowAccessTree?: (subject: string) => void;
-  menuPortalContainerRef?: RefObject<HTMLElement | null>;
   subjectScope: PermissionScope;
 };
 
@@ -73,7 +72,6 @@ type ActionsMultiSelectProps = {
   isDisabled?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   control: Control<any>;
-  menuPortalContainerRef?: RefObject<HTMLElement | null>;
   subjectScope: PermissionScope;
 };
 
@@ -83,7 +81,6 @@ const ActionsMultiSelect = ({
   actions,
   isDisabled,
   control,
-  menuPortalContainerRef,
   subjectScope
 }: ActionsMultiSelectProps) => {
   const { setValue, trigger } = useFormContext();
@@ -199,7 +196,6 @@ const ActionsMultiSelect = ({
         placeholder="Select actions..."
         isDisabled={isDisabled}
         className="w-full"
-        portalContainer={menuPortalContainerRef}
         isError={Boolean(actionsError)}
       />
       {actionsError && (
@@ -231,7 +227,6 @@ export const GeneralPermissionPolicies = <T extends AnyPermissionSubject>({
   isOpen = false,
   onPolicyAdded,
   onShowAccessTree,
-  menuPortalContainerRef,
   subjectScope
 }: Props<T>) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -376,7 +371,6 @@ export const GeneralPermissionPolicies = <T extends AnyPermissionSubject>({
                         actions={actions}
                         isDisabled={isDisabled}
                         control={control}
-                        menuPortalContainerRef={menuPortalContainerRef}
                         subjectScope={subjectScope}
                       />
                     </div>

--- a/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretAccessInsights.tsx
+++ b/frontend/src/pages/secret-manager/OverviewPage/components/SecretTableRow/SecretAccessInsights.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { subject } from "@casl/ability";
 import { Link } from "@tanstack/react-router";
 import {
@@ -411,7 +411,6 @@ export function SecretAccessInsights({ secretKey, environment, secretPath }: Pro
   const { currentProject } = useProject();
   const { permission } = useProjectPermission();
   const { user: currentUser } = useUser();
-  const sheetContainerRef = useRef<HTMLDivElement>(null);
   const [editingPrivilege, setEditingPrivilege] = useState<EditingPrivilege | null>(null);
   const [searchFilter, setSearchFilter] = useState("");
   const [typeFilters, setTypeFilters] = useState<Set<AccessRowType>>(() => new Set());
@@ -834,7 +833,7 @@ export function SecretAccessInsights({ secretKey, environment, secretPath }: Pro
           if (!isOpen) setEditingPrivilege(null);
         }}
       >
-        <SheetContent ref={sheetContainerRef} className="flex h-full flex-col gap-y-0 sm:max-w-6xl">
+        <SheetContent className="flex h-full flex-col gap-y-0 sm:max-w-6xl">
           <SheetHeader className="border-b">
             <SheetTitle>Add Additional Privilege for {editingPrivilege?.name}</SheetTitle>
             <SheetDescription>
@@ -846,7 +845,6 @@ export function SecretAccessInsights({ secretKey, environment, secretPath }: Pro
               key={editingPrivilege.membershipId}
               projectMembershipId={editingPrivilege.membershipId}
               onGoBack={() => setEditingPrivilege(null)}
-              menuPortalContainerRef={sheetContainerRef}
               initialPermissions={initialPermissions}
             />
           )}
@@ -855,7 +853,6 @@ export function SecretAccessInsights({ secretKey, environment, secretPath }: Pro
               key={editingPrivilege.identityId}
               identityId={editingPrivilege.identityId}
               onGoBack={() => setEditingPrivilege(null)}
-              menuPortalContainerRef={sheetContainerRef}
               initialPermissions={initialPermissions}
             />
           )}

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/ReviewAccessModal.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/AccessApprovalRequest/components/ReviewAccessModal.tsx
@@ -601,7 +601,7 @@ export const ReviewAccessRequestModal = ({
         </PopoverTrigger>
         <PopoverContent
           align="end"
-          className="z-[70] max-h-64 thin-scrollbar w-72 overflow-y-auto px-3 py-2.5"
+          className="max-h-64 thin-scrollbar w-72 overflow-y-auto px-3 py-2.5"
           aria-label={`Reviewer progress for approval step ${approver.sequence ?? 1}`}
         >
           <div className="mb-2 text-sm font-medium text-foreground">Reviewer Progress</div>
@@ -905,7 +905,7 @@ export const ReviewAccessRequestModal = ({
                                   {group.conditions.length === 1 ? "condition" : "conditions"}
                                 </button>
                               </HoverCardTrigger>
-                              <HoverCardContent align="end" className="z-[70] w-auto max-w-xs">
+                              <HoverCardContent align="end" className="w-auto max-w-xs">
                                 <div className="mb-1.5 text-xs font-medium text-foreground">
                                   Conditions
                                 </div>

--- a/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
+++ b/frontend/src/pages/secret-manager/SecretApprovalsPage/components/SecretApprovalRequest/components/SecretApprovalRequestChanges.tsx
@@ -431,7 +431,7 @@ export const SecretApprovalRequestChanges = ({
                     <ChevronDownIcon />
                   </IconButton>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="end" className="z-[80]">
+                <DropdownMenuContent align="end">
                   <DropdownMenuItem onClick={() => handleReview(ApprovalStatus.APPROVED)}>
                     <CheckIcon />
                     Approve
@@ -477,7 +477,7 @@ export const SecretApprovalRequestChanges = ({
           {myReview ? "Update Review" : "Review Changes"}
         </Button>
       </PopoverTrigger>
-      <PopoverContent align={myReview ? "end" : "start"} className="z-[70] w-96">
+      <PopoverContent align={myReview ? "end" : "start"} className="w-96">
         {reviewForm}
       </PopoverContent>
     </Popover>

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/AddWebhookForm.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WebhooksTab/AddWebhookForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { components, OptionProps } from "react-select";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -117,7 +117,6 @@ export const AddWebhookForm = ({
 
   const selectedWebhookType = watch("type");
   const selectedEnvironment = watch("environment");
-  const modalContainer = useRef<HTMLDivElement>(null);
 
   const generalFormFields = (
     <>
@@ -191,7 +190,7 @@ export const AddWebhookForm = ({
   return (
     <Sheet open={isOpen} onOpenChange={onOpenChange}>
       <SheetContent className="sm:max-w-lg">
-        <div ref={modalContainer} className="flex h-full min-h-0 flex-col">
+        <div className="flex h-full min-h-0 flex-col">
           <form onSubmit={handleSubmit(onCreateWebhook)} className="flex h-full min-h-0 flex-col">
             <SheetHeader>
               <SheetTitle>Create a new webhook</SheetTitle>
@@ -311,7 +310,6 @@ export const AddWebhookForm = ({
                               getOptionValue={(option) => option.value}
                               getOptionLabel={(option) => option.label}
                               placeholder="Select events..."
-                              menuPortalTarget={modalContainer.current}
                               menuPosition="fixed"
                               menuPlacement="bottom"
                               closeMenuOnSelect={false}

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WorkflowIntegrationSection/components/AddWorkflowIntegrationSheet.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WorkflowIntegrationSection/components/AddWorkflowIntegrationSheet.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { BsMicrosoftTeams, BsSlack } from "react-icons/bs";
 
 import {
@@ -42,7 +42,6 @@ export const AddWorkflowIntegrationSheet = ({ isOpen, onOpenChange }: Props) => 
   const [selectedPlatform, setSelectedPlatform] = useState<WorkflowIntegrationPlatform | null>(
     null
   );
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const { currentProject } = useProject();
   const { data: slackConfig } = useGetWorkspaceWorkflowIntegrationConfig({
@@ -69,7 +68,7 @@ export const AddWorkflowIntegrationSheet = ({ isOpen, onOpenChange }: Props) => 
   return (
     <Sheet open={isOpen} onOpenChange={handleOpenChange}>
       <SheetContent className="sm:max-w-lg">
-        <div ref={containerRef} className="flex h-full min-h-0 flex-col">
+        <div className="flex h-full min-h-0 flex-col">
           <SheetHeader>
             <SheetTitle>
               {selectedPlatform
@@ -121,14 +120,12 @@ export const AddWorkflowIntegrationSheet = ({ isOpen, onOpenChange }: Props) => 
             <SlackIntegrationForm
               onClose={() => handleOpenChange(false)}
               onBack={() => setSelectedPlatform(null)}
-              menuContainer={containerRef}
             />
           )}
           {selectedPlatform === WorkflowIntegrationPlatform.MICROSOFT_TEAMS && (
             <MicrosoftTeamsIntegrationForm
               onClose={() => handleOpenChange(false)}
               onBack={() => setSelectedPlatform(null)}
-              menuContainer={containerRef}
             />
           )}
         </div>

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WorkflowIntegrationSection/components/EditWorkflowIntegrationSheet.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WorkflowIntegrationSection/components/EditWorkflowIntegrationSheet.tsx
@@ -1,5 +1,3 @@
-import { useRef } from "react";
-
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@app/components/v3";
 import { WorkflowIntegrationPlatform } from "@app/hooks/api/workflowIntegrations/types";
 
@@ -14,8 +12,6 @@ type Props = {
 };
 
 export const EditWorkflowIntegrationSheet = ({ isOpen, onClose, integration }: Props) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-
   const platformLabel = integration ? WORKFLOW_INTEGRATION_PLATFORM_LABELS[integration] : "";
 
   return (
@@ -28,7 +24,7 @@ export const EditWorkflowIntegrationSheet = ({ isOpen, onClose, integration }: P
       }}
     >
       <SheetContent className="sm:max-w-lg">
-        <div ref={containerRef} className="flex h-full min-h-0 flex-col">
+        <div className="flex h-full min-h-0 flex-col">
           <SheetHeader>
             <SheetTitle>Edit {platformLabel} Integration</SheetTitle>
             <SheetDescription>
@@ -36,10 +32,10 @@ export const EditWorkflowIntegrationSheet = ({ isOpen, onClose, integration }: P
             </SheetDescription>
           </SheetHeader>
           {integration === WorkflowIntegrationPlatform.SLACK && (
-            <SlackIntegrationForm onClose={onClose} menuContainer={containerRef} />
+            <SlackIntegrationForm onClose={onClose} />
           )}
           {integration === WorkflowIntegrationPlatform.MICROSOFT_TEAMS && (
-            <MicrosoftTeamsIntegrationForm onClose={onClose} menuContainer={containerRef} />
+            <MicrosoftTeamsIntegrationForm onClose={onClose} />
           )}
         </div>
       </SheetContent>

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WorkflowIntegrationSection/components/MicrosoftTeamsIntegrationForm.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WorkflowIntegrationSection/components/MicrosoftTeamsIntegrationForm.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useEffect } from "react";
+import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Link } from "@tanstack/react-router";
@@ -100,10 +100,9 @@ type TChannelOption = {
 type Props = {
   onClose: () => void;
   onBack?: () => void;
-  menuContainer: RefObject<HTMLDivElement | null>;
 };
 
-export const MicrosoftTeamsIntegrationForm = ({ onClose, onBack, menuContainer }: Props) => {
+export const MicrosoftTeamsIntegrationForm = ({ onClose, onBack }: Props) => {
   const { currentProject } = useProject();
   const { data: microsoftTeamsConfig } = useGetWorkspaceWorkflowIntegrationConfig({
     projectId: currentProject?.id ?? "",
@@ -250,7 +249,6 @@ export const MicrosoftTeamsIntegrationForm = ({ onClose, onBack, menuContainer }
                 }
                 isLoading={isLoadingMicrosoftTeamsIntegrationTeams}
                 isError={Boolean(error)}
-                menuPortalTarget={menuContainer.current}
                 menuPosition="fixed"
                 menuPlacement="bottom"
               />
@@ -280,7 +278,6 @@ export const MicrosoftTeamsIntegrationForm = ({ onClose, onBack, menuContainer }
                 isDisabled={!selectedTeamId}
                 isLoading={isLoadingMicrosoftTeamsIntegrationTeams}
                 isError={Boolean(error)}
-                menuPortalTarget={menuContainer.current}
                 menuPosition="fixed"
                 menuPlacement="bottom"
                 closeMenuOnSelect={false}

--- a/frontend/src/pages/secret-manager/SettingsPage/components/WorkflowIntegrationSection/components/SlackIntegrationForm.tsx
+++ b/frontend/src/pages/secret-manager/SettingsPage/components/WorkflowIntegrationSection/components/SlackIntegrationForm.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useEffect } from "react";
+import { useEffect } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Link } from "@tanstack/react-router";
@@ -54,7 +54,6 @@ type TSlackConfigForm = z.infer<typeof formSchema>;
 type Props = {
   onClose: () => void;
   onBack?: () => void;
-  menuContainer: RefObject<HTMLDivElement | null>;
 };
 
 type TChannelsFieldProps = {
@@ -64,7 +63,6 @@ type TChannelsFieldProps = {
   error?: { message?: string };
   channels?: SlackIntegrationChannel[];
   isLoading: boolean;
-  menuContainer: RefObject<HTMLDivElement | null>;
 };
 
 const ChannelsField = ({
@@ -73,8 +71,7 @@ const ChannelsField = ({
   onChange,
   error,
   channels,
-  isLoading,
-  menuContainer
+  isLoading
 }: TChannelsFieldProps) => (
   <Field>
     <FieldLabel htmlFor={inputId}>Slack channels</FieldLabel>
@@ -91,7 +88,6 @@ const ChannelsField = ({
       placeholder="Select channels..."
       isLoading={isLoading}
       isError={Boolean(error)}
-      menuPortalTarget={menuContainer.current}
       menuPosition="fixed"
       menuPlacement="bottom"
       closeMenuOnSelect={false}
@@ -101,7 +97,7 @@ const ChannelsField = ({
   </Field>
 );
 
-export const SlackIntegrationForm = ({ onClose, onBack, menuContainer }: Props) => {
+export const SlackIntegrationForm = ({ onClose, onBack }: Props) => {
   const { currentProject } = useProject();
   const { data: slackConfig } = useGetWorkspaceWorkflowIntegrationConfig({
     projectId: currentProject?.id ?? "",
@@ -305,7 +301,6 @@ export const SlackIntegrationForm = ({ onClose, onBack, menuContainer }: Props) 
                     error={error}
                     channels={sortedSlackChannels}
                     isLoading={isSlackChannelsLoading}
-                    menuContainer={menuContainer}
                   />
                 )}
               />
@@ -342,7 +337,6 @@ export const SlackIntegrationForm = ({ onClose, onBack, menuContainer }: Props) 
                     error={error}
                     channels={sortedSlackChannels}
                     isLoading={isSlackChannelsLoading}
-                    menuContainer={menuContainer}
                   />
                 )}
               />
@@ -379,7 +373,6 @@ export const SlackIntegrationForm = ({ onClose, onBack, menuContainer }: Props) 
                     error={error}
                     channels={sortedSlackChannels}
                     isLoading={isSlackChannelsLoading}
-                    menuContainer={menuContainer}
                   />
                 )}
               />

--- a/frontend/src/pages/secret-manager/integrations/GithubConfigurePage/GithubConfigurePage.tsx
+++ b/frontend/src/pages/secret-manager/integrations/GithubConfigurePage/GithubConfigurePage.tsx
@@ -430,7 +430,7 @@ export const GithubConfigurePage = () => {
                           </DropdownMenuTrigger>
                           <DropdownMenuContent
                             align="start"
-                            className="z-100 max-h-80 thin-scrollbar overflow-y-scroll"
+                            className="max-h-80 thin-scrollbar overflow-y-scroll"
                           >
                             {integrationAuthApps.length > 0 ? (
                               integrationAuthApps.map((integrationAuthApp) => {
@@ -567,7 +567,7 @@ export const GithubConfigurePage = () => {
                               </DropdownMenuTrigger>
                               <DropdownMenuContent
                                 align="start"
-                                className="z-100 max-h-80 thin-scrollbar overflow-y-scroll"
+                                className="max-h-80 thin-scrollbar overflow-y-scroll"
                               >
                                 {selectedOrganization ? (
                                   selectedOrganization.map((integrationAuthApp) => {

--- a/frontend/src/views/Alerts/ChannelRecipientsField.tsx
+++ b/frontend/src/views/Alerts/ChannelRecipientsField.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef, useState } from "react";
 import { UserIcon, UsersIcon } from "lucide-react";
 
 import { FilterableSelect } from "@app/components/v3";
@@ -63,13 +62,6 @@ const RecipientSelect = ({
   onChange,
   isError
 }: SelectProps & { options: RecipientOption[]; labelledOptions?: RecipientOption[] }) => {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [menuPortalTarget, setMenuPortalTarget] = useState<HTMLElement | null>(null);
-
-  useEffect(() => {
-    setMenuPortalTarget(containerRef.current?.closest<HTMLElement>('[role="dialog"]') ?? null);
-  }, []);
-
   const byKey = new Map(
     (labelledOptions ?? options).map((o) => [`${o.principalType}-${o.principalId}`, o])
   );
@@ -84,7 +76,7 @@ const RecipientSelect = ({
   );
 
   return (
-    <div ref={containerRef}>
+    <div>
       <FilterableSelect<RecipientOption>
         isMulti
         placeholder="Add users or groups..."
@@ -96,7 +88,6 @@ const RecipientSelect = ({
         getOptionValue={(option) => `${option.principalType}-${option.principalId}`}
         getOptionLabel={(option) => option.label}
         formatOptionLabel={formatOptionLabel}
-        menuPortalTarget={menuPortalTarget ?? undefined}
         menuPosition="fixed"
         menuPlacement="auto"
         onChange={(newValue) =>

--- a/frontend/src/views/PkiAlertsV2Page/components/CreatePkiAlertV2FormSteps.tsx
+++ b/frontend/src/views/PkiAlertsV2Page/components/CreatePkiAlertV2FormSteps.tsx
@@ -715,7 +715,7 @@ export const CreatePkiAlertV2FormSteps = ({
                   Add Channel
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" sideOffset={4} className="z-[70]">
+              <DropdownMenuContent align="end" sideOffset={4}>
                 <DropdownMenuItem onClick={() => addChannel(PkiAlertChannelTypeV2.EMAIL)}>
                   <FontAwesomeIcon icon={faEnvelope} className="mr-2" />
                   Email


### PR DESCRIPTION
## Context

<!-- What problem does this solve? What was the behavior before, and what is it now? Add all relevant context. Link related issues/tickets. -->

Implements [PLATFOR-644](https://linear.app/infisical/issue/PLATFOR-644), using the layering research recorded in parent [PLATFOR-642](https://linear.app/infisical/issue/PLATFOR-642).

Dialogs, sheets, menus, and tooltips previously competed through unrelated numeric z-index values and caller-supplied portal containers. Legacy and v3 overlays could invert their ordering, and portalling controls into a scrolling panel could clip them.

This change adds semantic layers and shared portal ownership across v2/v3 components. Floating controls escape the animated or scrolling panel while remaining inside its focus, accessibility, and scroll boundary. Nested modals own isolated hosts, siblings follow opening order, and toast-owned controls inherit the toast layer. Hosts remain mounted through exit animations.

Removes the corresponding numeric overrides and manual container/ref plumbing from affected product flows. Adds a lint rule, focused lifecycle tests, four Storybook compositions, and a contract/remediation ledger in `frontend/src/components/overlays/README.md`. Local table, graph, and editor stacking remains scoped to the app root.

Adds only test dependencies (`jsdom` and explicit `tsx`); no API, environment, Docker configuration, or migration changes.

## Screenshots

Captured from Storybook at commit `406b904` in Chromium, at **1366 × 900** (laptop) and **390 × 844** (narrow), using only the stories’ example data. No backend or login required.

<details>
<summary>Dialog: menu, child backdrop, repeated nesting</summary>

| State | Laptop | Narrow |
| --- | --- | --- |
| dialog menu | ![laptop-dialog-menu](https://api-nightly.capy.ai/pr-assets/fw13C2ihU8f_yjhkHBklgHa-Km2dzMAZLHugglXhzCw) | ![narrow-dialog-menu](https://api-nightly.capy.ai/pr-assets/NaWqpG4NX8T1M5PyyELwDd7hJEQD6y0Pe6QRibNEd6o) |
| dialog child backdrop | ![laptop-dialog-child-backdrop](https://api-nightly.capy.ai/pr-assets/CpWsjVQ1i_a4jhFRg_zzVm_riLczL-63Yd7GzF6sWTk) | ![narrow-dialog-child-backdrop](https://api-nightly.capy.ai/pr-assets/AAOQyWlaqAlQV88vvnCfw3cSWXtvHTq_6NqJMYaCrj0) |
| dialog repeated | ![laptop-dialog-repeated](https://api-nightly.capy.ai/pr-assets/Rq5UNTcpMXyXyCy5O4iBP3XzWHM3f2zF7iSo3DNdIdE) | ![narrow-dialog-repeated](https://api-nightly.capy.ai/pr-assets/29scLQ4mkQjFVtuzpd6bjVzhZ5b2g7ULvDmMAF-nPug) |

</details>

<details>
<summary>Sheet: bottom controls and option tooltip</summary>

| State | Laptop | Narrow |
| --- | --- | --- |
| sheet bottom select tooltip | ![laptop-sheet-bottom-select-tooltip](https://api-nightly.capy.ai/pr-assets/jfWzIv1KGv9ny44gsb7dAgthHjPTBHfKPOmhjPO_siM) | ![narrow-sheet-bottom-select-tooltip](https://api-nightly.capy.ai/pr-assets/7rjC_Gw-XTzHwuSv6E5sLCCrI9QodsFyrh4t5SkKlT0) |

</details>

<details>
<summary>Legacy modal and drawer: option tooltips and nested v3 dialogs</summary>

| State | Laptop | Narrow |
| --- | --- | --- |
| legacy modal tooltip | ![laptop-legacy-modal-tooltip](https://api-nightly.capy.ai/pr-assets/Py_5QRQ4zJD4rP5PY_TmkzzlSKNI77EwjO9lK-exjh0) | ![narrow-legacy-modal-tooltip](https://api-nightly.capy.ai/pr-assets/X4JU4UcODq1UBKrxsYa9TCVqdXhKg7D1XsOaPiE4T1I) |
| legacy modal nested | ![laptop-legacy-modal-nested](https://api-nightly.capy.ai/pr-assets/TrONLUqYNfemFDrQd-knaHoPCAM264Xz_8K9DMl4wUQ) | ![narrow-legacy-modal-nested](https://api-nightly.capy.ai/pr-assets/B4IQVTvnqglksgwtv8wF9peO6wTqlneOQ08ovVYWEEs) |
| legacy drawer tooltip | ![laptop-legacy-drawer-tooltip](https://api-nightly.capy.ai/pr-assets/GnClH0HQLGqZEsBz1ua_L4AlSlfL2_UTikOHoqG93M8) | ![narrow-legacy-drawer-tooltip](https://api-nightly.capy.ai/pr-assets/9edI72agPVCrhAgo6yh_IkgvXrfVxpEi1hulgYJwrAc) |
| legacy drawer nested | ![laptop-legacy-drawer-nested](https://api-nightly.capy.ai/pr-assets/oHXqAkgDdKAkP3XjxQFNLPqxINJMUaY0trxcWTaZrLs) | ![narrow-legacy-drawer-nested](https://api-nightly.capy.ai/pr-assets/DMu84O8cB_lRSdlyOI1UKxXR1e52KA0u97zXKZzxkFM) |

</details>

<details>
<summary>Toast: copy tooltip and details dialog</summary>

| State | Laptop | Narrow |
| --- | --- | --- |
| toast tooltip | ![laptop-toast-tooltip](https://api-nightly.capy.ai/pr-assets/5J6kj_JO5u5EOhBDQAOesZySxy8m8ID_4lQa1GgtLIc) | ![narrow-toast-tooltip](https://api-nightly.capy.ai/pr-assets/ZNLI-PPSf8L4MOcaMs1sU1OrHQ5l6DQHetZ3-JaiNXU) |
| toast dialog | ![laptop-toast-dialog](https://api-nightly.capy.ai/pr-assets/ZR9KVasgGSYkwxy-xr2sELkOwCCCVIG-95-feeGQdKc) | ![narrow-toast-dialog](https://api-nightly.capy.ai/pr-assets/njuBWiMVB6n01SRjIpfn3NUDmANnC08aDRrJ8sLqb9s) |

</details>

Reproduce with `npm --prefix frontend run storybook` and the `foundations-overlay-layering--dialog-composition`, `--sheet-composition`, `--legacy-composition`, and `--toast-composition` stories. Repeated nesting was exercised through **Review Access 4**; the confirmation capture shows its backdrop covering the owner. The sheet capture shows the bottom ReactSelect and option tooltip; a browser DOM assertion also confirms the menu is outside the scrolling panel.

## Steps to verify the change

1. Run `npm --prefix frontend ci` and `npm --prefix frontend run test:layers`. The lint-rule cases and all 12 DOM/lifecycle tests pass, covering sibling/repeated nesting, focus and scrolling, cleanup, force mounting, explicit containers, legacy ReactSelect tooltips, StrictMode, and exit presence.
2. Run `make reviewable-ui`. Full frontend ESLint and TypeScript validation passed for this content.
3. Run `npm --prefix frontend run build-storybook`. The static build passed and includes all four overlay compositions.
4. Exercise the Storybook routes above with pointer and keyboard: Escape, outside interaction, focus return, scrolling, repeated nesting, and sibling reopening. Verified in Chromium: Escape, outside dismissal, focus restoration, Tab confinement, real wheel scrolling, searchable Combobox selection, Radix Select keyboard selection, repeated nesting, and sibling reopening. All four compositions were captured at laptop and narrow widths.
5. In a running application, verify Additional Privileges, secret-scanning/rotation creation, Upgrade Plan from a legacy modal, Secret Detail menus, access-request sheets, navbar notifications, toast details, and Compare Environments selection. The README contains the acceptance matrix and retained local exceptions.

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (if needed)
- [x] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

Storybook browser verification and visual captures are complete for `406b904`. Authenticated application flows in step 5 remain unverified by this review. No CLAUDE.md updates were needed.
