### PR TITLE
fix(auth): preserve password autofill styling and signup username targeting

### DIFF
--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -162,7 +162,11 @@ export default function UserInfoStep({
   };
 
   return (
-    <div className="mx-auto flex w-full flex-col items-center justify-center">
+    <form
+      className="mx-auto flex w-full flex-col items-center justify-center"
+      onSubmit={handleSubmit(onSubmit)}
+      noValidate
+    >
       <AuthPagePanel>
         <CardHeader className={isInvite ? "mb-6 gap-2" : "mb-4 gap-2"}>
           <CardTitle
@@ -195,14 +199,6 @@ export default function UserInfoStep({
           ) : null}
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
-          <input
-            className="hidden"
-            type="text"
-            name="username"
-            autoComplete="username"
-            value={email}
-            readOnly
-          />
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Field data-invalid={showDangerState && Boolean(errors.firstName)}>
               <FieldLabel className="sr-only" htmlFor="signup-first-name">
@@ -237,14 +233,6 @@ export default function UserInfoStep({
               ) : null}
             </Field>
           </div>
-          {isInvite && (
-            <Field>
-              <FieldLabel className="sr-only" htmlFor="signup-email">
-                Email
-              </FieldLabel>
-              <Input variant="outlined" id="signup-email" type="email" value={email} disabled />
-            </Field>
-          )}
           {!isInvite && (
             <Field data-invalid={showOrganizationNameError}>
               <FieldLabel className="sr-only" htmlFor="signup-organization-name">
@@ -280,6 +268,20 @@ export default function UserInfoStep({
               />
             </Field>
           )}
+          <Field className={isInvite ? undefined : "hidden"}>
+            <FieldLabel className="sr-only" htmlFor="signup-email">
+              Email
+            </FieldLabel>
+            <Input
+              variant="outlined"
+              id="signup-email"
+              name="email"
+              type="email"
+              autoComplete="username"
+              value={email}
+              readOnly
+            />
+          </Field>
           <PasswordField
             variant="outlined"
             id="new-password"
@@ -338,7 +340,6 @@ export default function UserInfoStep({
           </AnimatedCollapse>
           <Button
             type="submit"
-            onClick={handleSubmit(onSubmit)}
             variant="project"
             size="lg"
             isFullWidth
@@ -349,6 +350,6 @@ export default function UserInfoStep({
           </Button>
         </CardContent>
       </AuthPagePanel>
-    </div>
+    </form>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -46,6 +46,12 @@
     box-shadow: 0 0 0 1000px var(--autofill-background, var(--color-background)) inset !important;
   }
 
+  input[data-slot="input-group-control"]:-webkit-autofill {
+    background-clip: text;
+    -webkit-text-fill-color: currentColor;
+    box-shadow: none !important;
+  }
+
   [data-slot="dialog-content"],
   [data-slot="sheet-content"] {
     --autofill-background: var(--color-popover);


### PR DESCRIPTION
## Context

Browser autofill applies the global opaque inset shadow to the input inside an InputGroup. In signup password fields, that square rectangle covers the group border and contrasts with the reveal-button background.

Override autofill rendering only for grouped input controls: clip the native background to the text, retain the current text color, and remove the inset shadow. The group continues to own its background, border, and focus treatment. Standalone inputs and password autocomplete behavior are unchanged.

The signup password step consolidates the hidden username field and invite email display into one explicit `autocomplete="username"` input containing the verified email, hidden with CSS for ordinary signup and read-only rather than disabled for invites. A native form groups the credential fields and handles submission, so password managers do not need to infer a username from the organization field. The signup request continues to use the verified email prop.

## Screenshots

Outlined and default input groups with Chromium's native autofill pseudostate forced in an isolated harness using the actual shared components:

![Grouped password inputs after the autofill fix](https://api-nightly.capy.ai/pr-assets/Aw_q-ytE3ulvflJVg-yj3iDN4AbUtJzA6s8iJQV4jfw)

Signup component verification harness (mocked password policy and breach endpoint):

![Signup with verified email carried invisibly for password managers](https://api-nightly.capy.ai/pr-assets/LMIu1Atff14x6vbE9MFTC1whgM4HsSD5rEkKrdpPD3s)

## Steps to verify the change

1. Open signup and populate the password using a browser suggestion.
2. Focus, hover, and blur the field. Confirm the background remains continuous with the reveal button and the rounded border and focus outline remain intact.
3. Reveal and hide the password; confirm the value and styling remain correct.
4. During ordinary signup, enter an organization name, then select a saved password suggestion. Confirm the organization is not replaced with the saved username. Repeat with an invite.
5. Submit with Enter or the submit button; confirm validation still runs and submission happens once.

Local validation: `make reviewable-ui` passed (ESLint and TypeScript). Chromium checks passed with forced native autofill on outlined/default groups, hover/focus, reveal/hide, and a 375px viewport. The original rendering was reproduced by restoring the old CSS in the harness. Chromium password-manager-internals logs identify `email` as the username in both signup and invite flows. Browser checks verified the email field semantics, preserved organization input, and single Enter/click submissions with the verified email against an intercepted API request (no account created). After rebasing onto main, retained the new attribution field and confirmed Chromium still identifies only email as the username. Frontend lint and type checks passed again after conflict resolution. Selecting a saved credential from the native suggestion popup and Safari's password manager were not tested.

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the conventional commit format.
- [x] Tested locally
- [x] Updated docs (if needed) — not needed; autofill bug fixes.
- [x] Updated CLAUDE.md files (if needed) — not needed.
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M26ZX21MDE73JV8THH4TAMYV"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->