### PR TITLE
feat(secret-sync): recursive secret syncs, stage one

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -79,6 +79,7 @@ module.exports = {
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-unsafe-enum-comparison": "off",
     "no-void": "off",
+    "no-continue": "off",
     "consistent-return": "off", // my style
     "import/order": "off", // for simple-import-order
     "import/prefer-default-export": "off", // why

--- a/backend/e2e-test/fakes/aws-parameter-store-sync-fns.ts
+++ b/backend/e2e-test/fakes/aws-parameter-store-sync-fns.ts
@@ -1,6 +1,7 @@
 import { TAwsParameterStoreSyncWithCredentials } from "@app/services/secret-sync/aws-parameter-store/aws-parameter-store-sync-types";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 // Type-only, and by a path the aliases do not match, so this does not resolve back to here.
@@ -82,7 +83,8 @@ export const fakeParameterStore = {
 };
 
 export const AwsParameterStoreSyncFns = {
-  syncSecrets: (secretSync: TAwsParameterStoreSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: (secretSync: TAwsParameterStoreSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { syncOptions, environment } = secretSync;
     const store = storeForSync(secretSync);
 
@@ -137,7 +139,8 @@ export const AwsParameterStoreSyncFns = {
       Object.fromEntries(Object.entries(storeForSync(secretSync).secrets).map(([key, value]) => [key, { value }]))
     ),
 
-  removeSecrets: (secretSync: TAwsParameterStoreSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: (secretSync: TAwsParameterStoreSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const store = storeForSync(secretSync);
 
     if (store.writeError) {

--- a/backend/e2e-test/routes/v1/secret-sync-recursive-duplicates.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-sync-recursive-duplicates.spec.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from "node:crypto";
+
+import { createFolder } from "e2e-test/testUtils/folders";
+import {
+  createAwsAppConnection,
+  createSecretSync,
+  deleteAppConnection,
+  deleteSecretSync
+} from "e2e-test/testUtils/secret-syncs";
+import { createSecretV2 } from "e2e-test/testUtils/secrets";
+
+import { TableName } from "@app/db/schemas";
+import { initEnvConfig } from "@app/lib/config/env";
+import { initLogger, logger } from "@app/lib/logger";
+import { SecretSyncInitialSyncBehavior } from "@app/services/secret-sync/secret-sync-enums";
+
+// A destination that stores secrets in one flat list cannot hold the same name twice, so a
+// recursive sync whose subtree reuses a name is broken from the moment it is saved. The
+// job-time check still exists for the sync that only clashes later.
+
+const ENV = "dev";
+const REGION = "us-east-1";
+
+const adminHeaders = { authorization: `Bearer ${jwtAuthToken}` };
+
+describe("A recursive secret sync is refused when two folders use the same secret name", async () => {
+  vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+  let projectId: string;
+  let connectionId: string;
+  const createdSyncIds: string[] = [];
+
+  const newSync = async (dto: { name: string; recursive: boolean; expectStatusCode?: number }) => {
+    const result = await createSecretSync({
+      name: dto.name,
+      projectId,
+      connectionId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      region: REGION,
+      destinationPath: `/${dto.name}/`,
+      initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+      recursive: dto.recursive,
+      isAutoSyncEnabled: false,
+      authToken: jwtAuthToken,
+      expectStatusCode: dto.expectStatusCode
+    });
+
+    if (result.secretSync) createdSyncIds.push(result.secretSync.id);
+
+    return result;
+  };
+
+  beforeAll(async () => {
+    initLogger();
+    await initEnvConfig(testHsmService, testKmsRootConfigDAL, testSuperAdminDAL, logger);
+
+    const suffix = randomUUID().slice(0, 8);
+
+    const projectRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: adminHeaders,
+      body: { projectName: `secret-sync-recursive-dupes-${suffix}` }
+    });
+    expect(projectRes.statusCode).toBe(200);
+    projectId = projectRes.json().project.id as string;
+
+    connectionId = await createAwsAppConnection({
+      name: `secret-sync-recursive-dupes-${suffix}`,
+      authToken: jwtAuthToken
+    });
+
+    await createFolder({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/",
+      name: "backend"
+    });
+    await createFolder({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      name: "api"
+    });
+
+    await createSecretV2({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      key: "DB_URL",
+      value: "postgres://backend"
+    });
+    await createSecretV2({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend/api",
+      key: "DB_URL",
+      value: "postgres://api"
+    });
+  });
+
+  afterAll(async () => {
+    for (const syncId of createdSyncIds) {
+      // eslint-disable-next-line no-await-in-loop
+      await deleteSecretSync({ syncId, authToken: jwtAuthToken });
+    }
+
+    await deleteAppConnection({ connectionId, authToken: jwtAuthToken });
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/projects/${projectId}`,
+      headers: adminHeaders
+    });
+  });
+
+  test("creating it is refused, naming the secret and both folders", async () => {
+    const { error } = await newSync({ name: "recursive-duplicate", recursive: true, expectStatusCode: 400 });
+
+    expect(error.message).toContain("DB_URL");
+    expect(error.message).toContain("/backend");
+    expect(error.message).toContain("/backend/api");
+  });
+
+  test("the refused request leaves no sync behind", async () => {
+    const rows = await testDb(TableName.SecretSync).where({ projectId, name: "recursive-duplicate" });
+
+    expect(rows).toHaveLength(0);
+  });
+
+  test("creating the same sync without subfolders succeeds", async () => {
+    const { secretSync } = await newSync({ name: "non-recursive-duplicate", recursive: false });
+
+    expect(secretSync).toEqual(expect.objectContaining({ name: "non-recursive-duplicate" }));
+  });
+
+  test("turning subfolders on for an existing sync is refused", async () => {
+    const { secretSync } = await newSync({ name: "recursive-turned-on-later", recursive: false });
+
+    const res = await testServer.inject({
+      method: "PATCH",
+      url: `/api/v1/secret-syncs/aws-parameter-store/${secretSync!.id}`,
+      headers: adminHeaders,
+      body: {
+        syncOptions: {
+          initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+          recursive: true
+        }
+      }
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().message).toContain("DB_URL");
+    expect(res.json().message).toContain("/backend/api");
+  });
+});

--- a/backend/e2e-test/routes/v1/secret-sync-recursive-permissions.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-sync-recursive-permissions.spec.ts
@@ -1,0 +1,236 @@
+import { randomUUID } from "node:crypto";
+
+import { createFolder } from "e2e-test/testUtils/folders";
+import {
+  createAwsAppConnection,
+  createSecretSync,
+  deleteAppConnection,
+  deleteSecretSync
+} from "e2e-test/testUtils/secret-syncs";
+import { createSecretV2 } from "e2e-test/testUtils/secrets";
+import jwt from "jsonwebtoken";
+
+import {
+  AccessScope,
+  OrgMembershipRole,
+  OrgMembershipStatus,
+  ProjectMembershipRole,
+  SecretFolderRole,
+  TableName
+} from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+import { getConfig, initEnvConfig } from "@app/lib/config/env";
+import { initLogger, logger } from "@app/lib/logger";
+import { alphaNumericNanoId } from "@app/lib/nanoid";
+import { AuthMethod, AuthTokenType } from "@app/services/auth/auth-type";
+import { SecretSyncInitialSyncBehavior } from "@app/services/secret-sync/secret-sync-enums";
+
+// The sync worker reads every folder a sync covers with authorization disabled
+// (canExpandValue and hasSecretAccess both return true), so create and update are the only
+// gate. A folder grant is what makes the escalation reachable: it can give an actor read on a
+// parent folder while the base project role denies every child.
+
+const ENV = "dev";
+const REGION = "us-east-1";
+const ORG_ID = seedData1.organization.id;
+
+const adminHeaders = { authorization: `Bearer ${jwtAuthToken}` };
+
+describe("A secret sync is refused when it would read a folder the actor cannot", async () => {
+  vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+  let projectId: string;
+  let connectionId: string;
+  let actorUserId: string;
+  let actorJwt: string;
+  const actorSessionId = randomUUID();
+  const createdSyncIds: string[] = [];
+
+  const newSync = async (dto: { name: string; recursive: boolean; expectStatusCode?: number }) => {
+    const result = await createSecretSync({
+      name: dto.name,
+      projectId,
+      connectionId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      region: REGION,
+      destinationPath: `/${dto.name}/`,
+      initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+      recursive: dto.recursive,
+      isAutoSyncEnabled: false,
+      authToken: actorJwt,
+      expectStatusCode: dto.expectStatusCode
+    });
+
+    if (result.secretSync) createdSyncIds.push(result.secretSync.id);
+
+    return result;
+  };
+
+  beforeAll(async () => {
+    initLogger();
+    await initEnvConfig(testHsmService, testKmsRootConfigDAL, testSuperAdminDAL, logger);
+
+    const suffix = randomUUID().slice(0, 8);
+
+    const projectRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: adminHeaders,
+      body: { projectName: `secret-sync-recursive-perms-${suffix}` }
+    });
+    expect(projectRes.statusCode).toBe(200);
+    projectId = projectRes.json().project.id as string;
+
+    connectionId = await createAwsAppConnection({
+      name: `secret-sync-recursive-perms-${suffix}`,
+      authToken: jwtAuthToken
+    });
+
+    await createFolder({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/",
+      name: "backend"
+    });
+    await createFolder({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      name: "api"
+    });
+
+    await createSecretV2({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      key: "BACKEND_KEY",
+      value: "backend-value"
+    });
+    await createSecretV2({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend/api",
+      key: "API_KEY",
+      value: "api-value"
+    });
+
+    const username = `sync-recursive-perms-${alphaNumericNanoId(8)}@example.com`.toLowerCase();
+    const [user] = await testDb(TableName.Users)
+      .insert({ username, email: username, isGhost: false, isAccepted: true, authMethods: [AuthMethod.EMAIL] })
+      .returning("*");
+    actorUserId = user.id;
+
+    const [orgMembership] = await testDb(TableName.Membership)
+      .insert({
+        scope: AccessScope.Organization,
+        scopeOrgId: ORG_ID,
+        actorUserId,
+        status: OrgMembershipStatus.Accepted,
+        isActive: true
+      })
+      .returning("*");
+    await testDb(TableName.MembershipRole).insert({ membershipId: orgMembership.id, role: OrgMembershipRole.Member });
+
+    const [projectMembership] = await testDb(TableName.Membership)
+      .insert({
+        scope: AccessScope.Project,
+        scopeOrgId: ORG_ID,
+        scopeProjectId: projectId,
+        actorUserId
+      })
+      .returning("*");
+    // The base role grants nothing, so every folder the grant below does not name is denied.
+    await testDb(TableName.MembershipRole).insert({
+      membershipId: projectMembership.id,
+      role: ProjectMembershipRole.NoAccess
+    });
+
+    await testDb(TableName.AuthTokenSession).insert({
+      id: actorSessionId,
+      userId: actorUserId,
+      ip: "127.0.0.1",
+      userAgent: "e2e-secret-sync-recursive-perms",
+      accessVersion: 1,
+      refreshVersion: 1,
+      lastUsed: new Date()
+    } as never);
+
+    actorJwt = jwt.sign(
+      {
+        authTokenType: AuthTokenType.ACCESS_TOKEN,
+        userId: actorUserId,
+        tokenVersionId: actorSessionId,
+        authMethod: AuthMethod.EMAIL,
+        organizationId: ORG_ID,
+        accessVersion: 1
+      },
+      getConfig().AUTH_SECRET,
+      { expiresIn: 3600 }
+    );
+
+    // Manage is the lowest tier carrying secret sync create, and a folder grant applies to the
+    // named folder only, so "/backend/api" falls back to the no-access base role.
+    const grantRes = await testServer.inject({
+      method: "POST",
+      url: `/api/v1/projects/${projectId}/users/${actorUserId}/secret-folder-access`,
+      headers: adminHeaders,
+      body: { environmentSlug: ENV, secretPath: "/backend", permission: SecretFolderRole.Manage }
+    });
+    expect(grantRes.statusCode).toBe(200);
+  });
+
+  afterAll(async () => {
+    for (const syncId of createdSyncIds) {
+      // eslint-disable-next-line no-await-in-loop
+      await deleteSecretSync({ syncId, authToken: jwtAuthToken });
+    }
+
+    await deleteAppConnection({ connectionId, authToken: jwtAuthToken });
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/projects/${projectId}`,
+      headers: adminHeaders
+    });
+
+    await testDb(TableName.AuthTokenSession).where({ id: actorSessionId }).del();
+    await testDb(TableName.Membership).where({ actorUserId }).del();
+    await testDb(TableName.Users).where({ id: actorUserId }).del();
+  });
+
+  test("creating a sync that includes subfolders is refused, naming the folder that is denied", async () => {
+    const { error } = await newSync({ name: "recursive-denied", recursive: true, expectStatusCode: 403 });
+
+    expect(error.message).toContain("/backend/api");
+    expect(error.message).toContain(ENV);
+  });
+
+  test("creating the same sync without subfolders succeeds", async () => {
+    const { secretSync } = await newSync({ name: "non-recursive-allowed", recursive: false });
+
+    expect(secretSync).toEqual(expect.objectContaining({ name: "non-recursive-allowed" }));
+  });
+
+  test("turning subfolders on for an existing sync is refused", async () => {
+    const { secretSync } = await newSync({ name: "recursive-turned-on-later", recursive: false });
+
+    const res = await testServer.inject({
+      method: "PATCH",
+      url: `/api/v1/secret-syncs/aws-parameter-store/${secretSync!.id}`,
+      headers: { authorization: `Bearer ${actorJwt}` },
+      body: {
+        syncOptions: {
+          initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+          recursive: true
+        }
+      }
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().message).toContain("/backend/api");
+  });
+});

--- a/backend/e2e-test/routes/v1/secret-sync-recursive-permissions.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-sync-recursive-permissions.spec.ts
@@ -215,6 +215,37 @@ describe("A secret sync is refused when it would read a folder the actor cannot"
     expect(secretSync).toEqual(expect.objectContaining({ name: "non-recursive-allowed" }));
   });
 
+  test("repointing an existing recursive sync at another destination is refused", async () => {
+    // The admin can read the whole subtree, so this sync is legitimate at the moment it is made.
+    // The Manage grant then gives the actor Edit on it, scoped to "/backend", while leaving
+    // "/backend/api" denied. Without a check on this path the actor sends the denied folder to a
+    // destination of their choosing without ever touching the sync's source.
+    const { secretSync } = await createSecretSync({
+      name: "recursive-created-by-admin",
+      projectId,
+      connectionId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      region: REGION,
+      destinationPath: "/recursive-created-by-admin/",
+      initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+      recursive: true,
+      isAutoSyncEnabled: false,
+      authToken: jwtAuthToken
+    });
+    createdSyncIds.push(secretSync!.id);
+
+    const res = await testServer.inject({
+      method: "PATCH",
+      url: `/api/v1/secret-syncs/aws-parameter-store/${secretSync!.id}`,
+      headers: { authorization: `Bearer ${actorJwt}` },
+      body: { destinationConfig: { region: REGION, path: "/actor-controlled/" } }
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(res.json().message).toContain("/backend/api");
+  });
+
   test("turning subfolders on for an existing sync is refused", async () => {
     const { secretSync } = await newSync({ name: "recursive-turned-on-later", recursive: false });
 

--- a/backend/e2e-test/routes/v1/secret-sync-recursive-trigger.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-sync-recursive-trigger.spec.ts
@@ -7,7 +7,6 @@ import {
   createSecretSync,
   deleteAppConnection,
   deleteSecretSync,
-  expectDestinationUnchanged,
   setAutoSync,
   waitForDestinationSecrets,
   waitForSyncRun
@@ -18,11 +17,6 @@ import { initEnvConfig } from "@app/lib/config/env";
 import { initLogger, logger } from "@app/lib/logger";
 import { SecretSyncInitialSyncBehavior } from "@app/services/secret-sync/secret-sync-enums";
 
-// A write inside a recursive sync's subtree must still queue that sync, and a write inside a
-// non-recursive sync's subtree must not queue it. Both halves matter equally: the first is the
-// bug (auto-sync silently stops covering subfolders), the second guards against over-triggering
-// (syncing secrets the sync was never configured to cover).
-//
 // Each test waits for the auto-sync-enable run to finish (via waitForSyncRun) before writing the
 // subfolder secret. Skipping that wait would let the enable-time run, which always resolves the
 // full recursive subtree at whatever the DB holds when it executes, pick up the later write by
@@ -73,6 +67,13 @@ describe("A write in a subfolder triggers only the recursive sync above it", asy
       environmentSlug: ENV,
       secretPath: "/backend",
       name: "api"
+    });
+    await createFolder({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      name: "web"
     });
   });
 
@@ -138,6 +139,7 @@ describe("A write in a subfolder triggers only the recursive sync above it", asy
 
   test("a write at a subfolder does not reach a non-recursive sync rooted above it", async () => {
     const destinationPath = "/non-recursive-trigger-target/";
+    const controlDestinationPath = "/non-recursive-trigger-control/";
 
     const { secretSync } = await createSecretSync({
       name: "non-recursive-trigger",
@@ -154,6 +156,27 @@ describe("A write in a subfolder triggers only the recursive sync above it", asy
     });
     createdSyncIds.push(secretSync!.id);
 
+    // A control sync rooted exactly on the folder that is about to change. Its own trigger is
+    // the ordinary exact-match path, unaffected by the change under test, so waiting for it to
+    // pick up the write below gives a real signal that the queue has processed that write and
+    // made its trigger decisions for every sync watching the project, including the
+    // non-recursive one. Asserting against that signal, rather than a fixed delay, means a
+    // reintroduced over-trigger bug cannot hide behind a slow CI runner.
+    const { secretSync: controlSync } = await createSecretSync({
+      name: "non-recursive-trigger-control",
+      projectId,
+      connectionId,
+      environmentSlug: ENV,
+      secretPath: "/backend/web",
+      region: REGION,
+      destinationPath: controlDestinationPath,
+      initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+      recursive: false,
+      isAutoSyncEnabled: false,
+      authToken: jwtAuthToken
+    });
+    createdSyncIds.push(controlSync!.id);
+
     const runCountBeforeEnable = fakeParameterStore.at(REGION, destinationPath).runCount();
     await setAutoSync({ syncId: secretSync!.id, isAutoSyncEnabled: true, authToken: jwtAuthToken });
     await waitForSyncRun({
@@ -166,19 +189,33 @@ describe("A write in a subfolder triggers only the recursive sync above it", asy
 
     expect(fakeParameterStore.at(REGION, destinationPath).read()).toEqual({});
 
+    const controlRunCountBeforeEnable = fakeParameterStore.at(REGION, controlDestinationPath).runCount();
+    await setAutoSync({ syncId: controlSync!.id, isAutoSyncEnabled: true, authToken: jwtAuthToken });
+    await waitForSyncRun({
+      syncId: controlSync!.id,
+      region: REGION,
+      destinationPath: controlDestinationPath,
+      runCountBefore: controlRunCountBeforeEnable,
+      authToken: jwtAuthToken
+    });
+
+    expect(fakeParameterStore.at(REGION, controlDestinationPath).read()).toEqual({});
+
     await createSecretV2({
       authToken: jwtAuthToken,
       workspaceId: projectId,
       environmentSlug: ENV,
-      secretPath: "/backend/api",
-      key: "API_KEY",
-      value: "api-value"
+      secretPath: "/backend/web",
+      key: "WEB_KEY",
+      value: "web-value"
     });
 
-    await expectDestinationUnchanged({
+    await waitForDestinationSecrets({
       region: REGION,
-      destinationPath,
-      expected: {}
+      destinationPath: controlDestinationPath,
+      expected: { WEB_KEY: "web-value" }
     });
+
+    expect(fakeParameterStore.at(REGION, destinationPath).read()).toEqual({});
   });
 });

--- a/backend/e2e-test/routes/v1/secret-sync-recursive-trigger.spec.ts
+++ b/backend/e2e-test/routes/v1/secret-sync-recursive-trigger.spec.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from "node:crypto";
+
+import { fakeParameterStore } from "e2e-test/fakes/aws-parameter-store-sync-fns";
+import { createFolder } from "e2e-test/testUtils/folders";
+import {
+  createAwsAppConnection,
+  createSecretSync,
+  deleteAppConnection,
+  deleteSecretSync,
+  expectDestinationUnchanged,
+  setAutoSync,
+  waitForDestinationSecrets,
+  waitForSyncRun
+} from "e2e-test/testUtils/secret-syncs";
+import { createSecretV2 } from "e2e-test/testUtils/secrets";
+
+import { initEnvConfig } from "@app/lib/config/env";
+import { initLogger, logger } from "@app/lib/logger";
+import { SecretSyncInitialSyncBehavior } from "@app/services/secret-sync/secret-sync-enums";
+
+// A write inside a recursive sync's subtree must still queue that sync, and a write inside a
+// non-recursive sync's subtree must not queue it. Both halves matter equally: the first is the
+// bug (auto-sync silently stops covering subfolders), the second guards against over-triggering
+// (syncing secrets the sync was never configured to cover).
+//
+// Each test waits for the auto-sync-enable run to finish (via waitForSyncRun) before writing the
+// subfolder secret. Skipping that wait would let the enable-time run, which always resolves the
+// full recursive subtree at whatever the DB holds when it executes, pick up the later write by
+// coincidence and mask a missing trigger.
+
+const ENV = "dev";
+const REGION = "us-east-1";
+
+const adminHeaders = { authorization: `Bearer ${jwtAuthToken}` };
+
+describe("A write in a subfolder triggers only the recursive sync above it", async () => {
+  vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
+  let projectId: string;
+  let connectionId: string;
+  const createdSyncIds: string[] = [];
+
+  beforeAll(async () => {
+    initLogger();
+    await initEnvConfig(testHsmService, testKmsRootConfigDAL, testSuperAdminDAL, logger);
+
+    const suffix = randomUUID().slice(0, 8);
+
+    const projectRes = await testServer.inject({
+      method: "POST",
+      url: "/api/v1/projects",
+      headers: adminHeaders,
+      body: { projectName: `secret-sync-recursive-trigger-${suffix}` }
+    });
+    expect(projectRes.statusCode).toBe(200);
+    projectId = projectRes.json().project.id as string;
+
+    connectionId = await createAwsAppConnection({
+      name: `secret-sync-recursive-trigger-${suffix}`,
+      authToken: jwtAuthToken
+    });
+
+    await createFolder({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/",
+      name: "backend"
+    });
+    await createFolder({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      name: "api"
+    });
+  });
+
+  afterAll(async () => {
+    for (const syncId of createdSyncIds) {
+      // eslint-disable-next-line no-await-in-loop
+      await deleteSecretSync({ syncId, authToken: jwtAuthToken });
+    }
+
+    await deleteAppConnection({ connectionId, authToken: jwtAuthToken });
+    await testServer.inject({
+      method: "DELETE",
+      url: `/api/v1/projects/${projectId}`,
+      headers: adminHeaders
+    });
+  });
+
+  test("a write at a subfolder reaches the recursive sync rooted above it", async () => {
+    const destinationPath = "/recursive-trigger-target/";
+
+    const { secretSync } = await createSecretSync({
+      name: "recursive-trigger",
+      projectId,
+      connectionId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      region: REGION,
+      destinationPath,
+      initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+      recursive: true,
+      isAutoSyncEnabled: false,
+      authToken: jwtAuthToken
+    });
+    createdSyncIds.push(secretSync!.id);
+
+    const runCountBeforeEnable = fakeParameterStore.at(REGION, destinationPath).runCount();
+    await setAutoSync({ syncId: secretSync!.id, isAutoSyncEnabled: true, authToken: jwtAuthToken });
+    await waitForSyncRun({
+      syncId: secretSync!.id,
+      region: REGION,
+      destinationPath,
+      runCountBefore: runCountBeforeEnable,
+      authToken: jwtAuthToken
+    });
+
+    expect(fakeParameterStore.at(REGION, destinationPath).read()).toEqual({});
+
+    await createSecretV2({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend/api",
+      key: "SUBFOLDER_KEY",
+      value: "subfolder-value"
+    });
+
+    await waitForDestinationSecrets({
+      region: REGION,
+      destinationPath,
+      expected: { SUBFOLDER_KEY: "subfolder-value" }
+    });
+  });
+
+  test("a write at a subfolder does not reach a non-recursive sync rooted above it", async () => {
+    const destinationPath = "/non-recursive-trigger-target/";
+
+    const { secretSync } = await createSecretSync({
+      name: "non-recursive-trigger",
+      projectId,
+      connectionId,
+      environmentSlug: ENV,
+      secretPath: "/backend",
+      region: REGION,
+      destinationPath,
+      initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+      recursive: false,
+      isAutoSyncEnabled: false,
+      authToken: jwtAuthToken
+    });
+    createdSyncIds.push(secretSync!.id);
+
+    const runCountBeforeEnable = fakeParameterStore.at(REGION, destinationPath).runCount();
+    await setAutoSync({ syncId: secretSync!.id, isAutoSyncEnabled: true, authToken: jwtAuthToken });
+    await waitForSyncRun({
+      syncId: secretSync!.id,
+      region: REGION,
+      destinationPath,
+      runCountBefore: runCountBeforeEnable,
+      authToken: jwtAuthToken
+    });
+
+    expect(fakeParameterStore.at(REGION, destinationPath).read()).toEqual({});
+
+    await createSecretV2({
+      authToken: jwtAuthToken,
+      workspaceId: projectId,
+      environmentSlug: ENV,
+      secretPath: "/backend/api",
+      key: "API_KEY",
+      value: "api-value"
+    });
+
+    await expectDestinationUnchanged({
+      region: REGION,
+      destinationPath,
+      expected: {}
+    });
+  });
+});

--- a/backend/e2e-test/testUtils/secret-syncs.ts
+++ b/backend/e2e-test/testUtils/secret-syncs.ts
@@ -66,6 +66,7 @@ export const createSecretSync = async (dto: {
   initialSyncBehavior?: SecretSyncInitialSyncBehavior;
   keySchema?: string;
   disableSecretDeletion?: boolean;
+  recursive?: boolean;
   isAutoSyncEnabled?: boolean;
   authToken: string;
   expectStatusCode?: number;
@@ -84,7 +85,8 @@ export const createSecretSync = async (dto: {
       syncOptions: {
         initialSyncBehavior: dto.initialSyncBehavior ?? SecretSyncInitialSyncBehavior.OverwriteDestination,
         ...(dto.keySchema ? { keySchema: dto.keySchema } : {}),
-        ...(dto.disableSecretDeletion === undefined ? {} : { disableSecretDeletion: dto.disableSecretDeletion })
+        ...(dto.disableSecretDeletion === undefined ? {} : { disableSecretDeletion: dto.disableSecretDeletion }),
+        ...(dto.recursive === undefined ? {} : { recursive: dto.recursive })
       },
       destinationConfig: { region: dto.region, path: dto.destinationPath }
     }

--- a/backend/src/ee/services/secret-sync/chef/chef-sync-fns.ts
+++ b/backend/src/ee/services/secret-sync/chef/chef-sync-fns.ts
@@ -2,6 +2,7 @@ import { getChefDataBagItem, updateChefDataBagItem } from "@app/ee/services/app-
 import { TGatewayPoolServiceFactory } from "@app/ee/services/gateway-pool/gateway-pool-service";
 import { TGatewayV2ServiceFactory } from "@app/ee/services/gateway-v2/gateway-v2-service";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import {
@@ -127,10 +128,11 @@ const updateChefSecrets = async (
 export const ChefSyncFns = {
   async syncSecrets(
     secretSync: TChefSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     gatewayV2Service: TChefSyncGatewayV2Service,
     gatewayPoolService: TChefSyncGatewayPoolService
   ) {
+    const secretMap = payload.flatten();
     const {
       environment,
       syncOptions: { disableSecretDeletion, keySchema }
@@ -179,10 +181,11 @@ export const ChefSyncFns = {
 
   async removeSecrets(
     secretSync: TChefSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     gatewayV2Service: TChefSyncGatewayV2Service,
     gatewayPoolService: TChefSyncGatewayPoolService
   ) {
+    const secretMap = payload.flatten();
     const gatewayId = await resolveGatewayId(secretSync, gatewayPoolService);
 
     const { id, secrets: existingSecrets } = await getChefSecrets(secretSync, gatewayId, gatewayV2Service);

--- a/backend/src/ee/services/secret-sync/oci-vault/oci-vault-sync-fns.ts
+++ b/backend/src/ee/services/secret-sync/oci-vault/oci-vault-sync-fns.ts
@@ -13,7 +13,7 @@ import {
 import { delay } from "@app/lib/delay";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
-import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 
 const listOCIVaultVariables = async ({ provider, compartmentId, vaultId, onlyActive }: TOCIVaultListVariables) => {
   const vaultsClient = new vault.VaultsClient({ authenticationDetailsProvider: provider });
@@ -115,7 +115,8 @@ const unmarkOCIVaultVariableFromDeletion = async ({ provider, secretId }: TUnmar
 };
 
 export const OCIVaultSyncFns = {
-  syncSecrets: async (secretSync: TOCIVaultSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TOCIVaultSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -254,7 +255,8 @@ export const OCIVaultSyncFns = {
       }
     }
   },
-  removeSecrets: async (secretSync: TOCIVaultSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TOCIVaultSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { compartmentOcid, vaultOcid }

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -3101,7 +3101,8 @@ export const SecretSyncs = {
     return {
       initialSyncBehavior: `Specify how Infisical should resolve the initial sync to the ${destinationName} destination.`,
       keySchema: `Specify the format to use for structuring secret keys in the ${destinationName} destination.`,
-      disableSecretDeletion: `Enable this flag to prevent removal of secrets from the ${destinationName} destination when syncing.`
+      disableSecretDeletion: `Enable this flag to prevent removal of secrets from the ${destinationName} destination when syncing.`,
+      recursive: `Whether to sync secrets from folders beneath the source path as well.`
     };
   },
   ADDITIONAL_SYNC_OPTIONS: {

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -3169,6 +3169,8 @@ export const registerRoutes = async (
     orgDAL,
     folderDAL,
     projectEnvDAL,
+    projectDAL,
+    projectFolderGrantDAL,
     secretSyncQueue,
     projectBotService,
     keyStore,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -2132,6 +2132,7 @@ export const registerRoutes = async (
     cronJob,
     secretSyncDAL,
     folderDAL,
+    projectEnvDAL,
     secretImportDAL,
     secretV2BridgeDAL,
     kmsService,

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -3168,6 +3168,7 @@ export const registerRoutes = async (
     permissionService,
     orgDAL,
     folderDAL,
+    projectEnvDAL,
     secretSyncQueue,
     projectBotService,
     keyStore,

--- a/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
+++ b/backend/src/server/routes/v1/secret-sync-routers/secret-sync-endpoints.ts
@@ -2,8 +2,9 @@ import { z } from "zod";
 
 import { EventType } from "@app/ee/services/audit-log/audit-log-types";
 import { ApiDocsTags, SecretSyncs } from "@app/lib/api-docs";
-import { startsWithVowel } from "@app/lib/fn";
+import { removeTrailingSlash, startsWithVowel } from "@app/lib/fn";
 import { readLimit, writeLimit } from "@app/server/config/rateLimiter";
+import { slugSchema } from "@app/server/lib/schemas";
 import { getTelemetryDistinctId } from "@app/server/lib/telemetry";
 import { verifyAuth } from "@app/server/plugins/auth/verify-auth";
 import { AuthMode } from "@app/services/auth/auth-type";
@@ -535,6 +536,47 @@ export const registerSyncSecretsEndpoints = <T extends TSecretSync, I extends TS
           excludeSyncId,
           projectId
         },
+        req.permission
+      );
+
+      return result;
+    }
+  });
+
+  // Destination-agnostic: flatten() never uses the destination or source folder path to build a
+  // key, so this is safe to call from the Source step before a destination is even chosen.
+  server.route({
+    method: "POST",
+    url: "/recursive-conflicts",
+    config: {
+      rateLimit: readLimit
+    },
+    schema: {
+      operationId: `check${destinationNameForOpId}SecretSyncRecursiveConflicts`,
+      tags: [ApiDocsTags.SecretSyncs],
+      body: z.object({
+        projectId: z.string().uuid(),
+        environment: slugSchema({ field: "environment", max: 64 }),
+        secretPath: z.string().trim().min(1, "Secret path required").transform(removeTrailingSlash),
+        keySchema: z.string().trim().max(255).optional()
+      }),
+      response: {
+        200: z.object({
+          conflicts: z.array(
+            z.object({
+              key: z.string(),
+              paths: z.array(z.string())
+            })
+          )
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT, AuthMode.IDENTITY_ACCESS_TOKEN, AuthMode.OAUTH]),
+    handler: async (req) => {
+      const { projectId, environment, secretPath, keySchema } = req.body;
+
+      const result = await server.services.secretSync.findRecursiveConflicts(
+        { projectId, environment, secretPath, keySchema },
         req.permission
       );
 

--- a/backend/src/services/secret-sync/1password/1password-sync-fns.ts
+++ b/backend/src/services/secret-sync/1password/1password-sync-fns.ts
@@ -11,7 +11,7 @@ import {
 } from "@app/services/secret-sync/1password/1password-sync-types";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
-import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 
 // This should not be changed or it may break existing logic
 const VALUE_LABEL_DEFAULT = "value";
@@ -142,7 +142,8 @@ const deleteOnePassItem = async ({ instanceUrl, apiToken, vaultId, itemId }: TDe
 };
 
 export const OnePassSyncFns = {
-  syncSecrets: async (secretSync: TOnePassSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TOnePassSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -237,7 +238,8 @@ export const OnePassSyncFns = {
       }
     }
   },
-  removeSecrets: async (secretSync: TOnePassSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TOnePassSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { vaultId, valueLabel }

--- a/backend/src/services/secret-sync/aws-parameter-store/aws-parameter-store-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-parameter-store/aws-parameter-store-sync-fns.ts
@@ -25,6 +25,7 @@ import { isAwsError } from "@app/lib/aws/error";
 import { getAwsConnectionConfig } from "@app/services/app-connection/aws/aws-connection-fns";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TAwsParameterStoreSyncWithCredentials } from "./aws-parameter-store-sync-types";
@@ -353,7 +354,8 @@ const deleteParametersBatch = async (
 };
 
 export const AwsParameterStoreSyncFns = {
-  syncSecrets: async (secretSync: TAwsParameterStoreSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TAwsParameterStoreSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { destinationConfig, syncOptions, environment } = secretSync;
 
     const ssm = await getSSM(secretSync);
@@ -494,7 +496,8 @@ export const AwsParameterStoreSyncFns = {
       Object.entries(awsParameterStoreSecretsRecord).map(([key, value]) => [key, { value: value.Value ?? "" }])
     );
   },
-  removeSecrets: async (secretSync: TAwsParameterStoreSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TAwsParameterStoreSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { destinationConfig, syncOptions, environment } = secretSync;
 
     const ssm = await getSSM(secretSync);

--- a/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
@@ -356,12 +356,14 @@ const getSingleSecretValue = async (
 };
 
 export const AwsSecretsManagerSyncFns = {
-  syncSecrets: async (
-    secretSync: TAwsSecretsManagerSyncWithCredentials,
-    secretMap: TSecretMap,
-    unmodifiedSecretMap: TSecretMap // ie not schematized
-  ) => {
+  syncSecrets: async (secretSync: TAwsSecretsManagerSyncWithCredentials, payload: TSecretSyncPayload) => {
     const { destinationConfig, syncOptions, environment } = secretSync;
+
+    // The many-to-one mapping combines every secret into one AWS secret's JSON body under its
+    // own (unprefixed) key, so this destination needs both views: the schema-applied map for
+    // the one-to-one path below, and the raw-key map for that JSON body.
+    const secretMap = payload.flatten();
+    const unmodifiedSecretMap = payload.flatten({ applySchema: false });
 
     const client = await getSecretsManagerClient(secretSync);
 

--- a/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
@@ -29,7 +29,7 @@ import { getAwsConnectionConfig } from "@app/services/app-connection/aws/aws-con
 import { AwsSecretsManagerSyncMappingBehavior } from "@app/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-enums";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
-import { getKeyWithSchema } from "@app/services/secret-sync/secret-sync-payload";
+import { getKeyWithSchema, TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TAwsSecretsManagerSyncWithCredentials } from "./aws-secrets-manager-sync-types";
@@ -591,7 +591,8 @@ export const AwsSecretsManagerSyncFns = {
       });
     }
   },
-  removeSecrets: async (secretSync: TAwsSecretsManagerSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TAwsSecretsManagerSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { destinationConfig, syncOptions, environment } = secretSync;
 
     const client = await getSecretsManagerClient(secretSync);

--- a/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
+++ b/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-fns.ts
@@ -28,7 +28,8 @@ import { crypto } from "@app/lib/crypto";
 import { getAwsConnectionConfig } from "@app/services/app-connection/aws/aws-connection-fns";
 import { AwsSecretsManagerSyncMappingBehavior } from "@app/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-enums";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
-import { getKeyWithSchema, matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { getKeyWithSchema } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TAwsSecretsManagerSyncWithCredentials } from "./aws-secrets-manager-sync-types";

--- a/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-schemas.ts
+++ b/backend/src/services/secret-sync/aws-secrets-manager/aws-secrets-manager-sync-schemas.ts
@@ -159,7 +159,7 @@ export const UpdateAwsSecretsManagerSyncSchema = GenericUpdateSecretSyncFieldsSc
   .superRefine((sync, ctx) => {
     if (
       sync.destinationConfig?.mappingBehavior === AwsSecretsManagerSyncMappingBehavior.ManyToOne &&
-      sync.syncOptions.syncSecretMetadataAsTags
+      sync.syncOptions?.syncSecretMetadataAsTags
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/backend/src/services/secret-sync/azure-app-configuration/azure-app-configuration-sync-fns.ts
+++ b/backend/src/services/secret-sync/azure-app-configuration/azure-app-configuration-sync-fns.ts
@@ -8,6 +8,7 @@ import { getAzureConnectionAccessToken } from "@app/services/app-connection/azur
 import { isAzureKeyVaultReference } from "@app/services/integration-auth/integration-sync-secret-fns";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TAzureAppConfigurationSyncWithCredentials } from "./azure-app-configuration-sync-types";
@@ -67,7 +68,8 @@ export const azureAppConfigurationSyncFactory = ({
     });
   };
 
-  const syncSecrets = async (secretSync: TAzureAppConfigurationSyncWithCredentials, secretMap: TSecretMap) => {
+  const syncSecrets = async (secretSync: TAzureAppConfigurationSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     if (!secretSync.destinationConfig.configurationUrl.endsWith(".azconfig.io")) {
       throw new BadRequestError({
         message: "Invalid Azure App Configuration URL provided."
@@ -155,7 +157,8 @@ export const azureAppConfigurationSyncFactory = ({
     }
   };
 
-  const removeSecrets = async (secretSync: TAzureAppConfigurationSyncWithCredentials, secretMap: TSecretMap) => {
+  const removeSecrets = async (secretSync: TAzureAppConfigurationSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { accessToken } = await getAzureConnectionAccessToken(secretSync.connectionId, appConnectionDAL, kmsService);
 
     const azureAppConfigValuesUrl = `/kv?api-version=2023-11-01${

--- a/backend/src/services/secret-sync/azure-devops/azure-devops-sync-fns.ts
+++ b/backend/src/services/secret-sync/azure-devops/azure-devops-sync-fns.ts
@@ -5,6 +5,7 @@ import { AzureDevOpsConnectionMethod } from "@app/services/app-connection/azure-
 import { getAzureDevopsConnection } from "@app/services/app-connection/azure-devops/azure-devops-fns";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TAzureDevOpsSyncWithCredentials } from "./azure-devops-sync-types";
@@ -79,7 +80,8 @@ export const azureDevOpsSyncFactory = ({ kmsService, appConnectionDAL }: TAzureD
     return { groupId: "", groupName: "" };
   };
 
-  const syncSecrets = async (secretSync: TAzureDevOpsSyncWithCredentials, secretMap: TSecretMap) => {
+  const syncSecrets = async (secretSync: TAzureDevOpsSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     if (!secretSync.destinationConfig.devopsProjectId) {
       throw new BadRequestError({
         message: "Azure DevOps: project ID is required"

--- a/backend/src/services/secret-sync/azure-entra-id-scim/azure-entra-id-scim-sync-fns.ts
+++ b/backend/src/services/secret-sync/azure-entra-id-scim/azure-entra-id-scim-sync-fns.ts
@@ -1,6 +1,7 @@
 import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import {
   TPreSaveTransformDestinationConfigFn,
   TPreSaveTransformSyncOptionsFn,
@@ -20,9 +21,10 @@ type TAzureEntraIdScimSyncFactoryDeps = {
 export const AzureEntraIdScimSyncFns = {
   syncSecrets: async (
     secretSync: TAzureEntraIdScimSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     { appConnectionDAL, kmsService }: TAzureEntraIdScimSyncFactoryDeps
   ): Promise<void> => {
+    const secretMap = payload.flatten();
     const { servicePrincipalId } = secretSync.destinationConfig;
     const { secretId } = secretSync.syncOptions;
 

--- a/backend/src/services/secret-sync/azure-key-vault/azure-key-vault-sync-fns.ts
+++ b/backend/src/services/secret-sync/azure-key-vault/azure-key-vault-sync-fns.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/services/app-connection/azure-key-vault/azure-key-vault-connection-fns";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SecretSyncError } from "../secret-sync-errors";
@@ -128,7 +129,8 @@ export const azureKeyVaultSyncFactory = ({
     };
   };
 
-  const syncSecrets = async (secretSync: TAzureKeyVaultSyncWithCredentials, secretMap: TSecretMap) => {
+  const syncSecrets = async (secretSync: TAzureKeyVaultSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { connection } = secretSync;
 
     const effectiveGatewayId = await gatewayPoolService.resolveEffectiveGatewayId({
@@ -258,7 +260,8 @@ export const azureKeyVaultSyncFactory = ({
     }
   };
 
-  const removeSecrets = async (secretSync: TAzureKeyVaultSyncWithCredentials, secretMap: TSecretMap) => {
+  const removeSecrets = async (secretSync: TAzureKeyVaultSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { connection } = secretSync;
 
     const effectiveGatewayId = await gatewayPoolService.resolveEffectiveGatewayId({

--- a/backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts
+++ b/backend/src/services/secret-sync/bitbucket/bitbucket-sync-fns.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/services/secret-sync/bitbucket/bitbucket-sync-types";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
@@ -130,7 +131,8 @@ const deleteVariables = async ({
 };
 
 export const BitbucketSyncFns = {
-  syncSecrets: async (secretSync: TBitbucketSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TBitbucketSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -183,7 +185,8 @@ export const BitbucketSyncFns = {
     }
   },
 
-  removeSecrets: async (secretSync: TBitbucketSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TBitbucketSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { workspaceSlug, repositorySlug, environmentId }

--- a/backend/src/services/secret-sync/camunda/camunda-sync-fns.ts
+++ b/backend/src/services/secret-sync/camunda/camunda-sync-fns.ts
@@ -14,7 +14,7 @@ import {
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
-import { TSecretMap } from "../secret-sync-types";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 
 type TCamundaSecretSyncFactoryDeps = {
   appConnectionDAL: Pick<TAppConnectionDALFactory, "updateById">;
@@ -73,7 +73,8 @@ const updateCamundaSecret = async ({ accessToken, clusterUUID, key, value }: TCa
   );
 
 export const camundaSyncFactory = ({ kmsService, appConnectionDAL }: TCamundaSecretSyncFactoryDeps) => {
-  const syncSecrets = async (secretSync: TCamundaSyncWithCredentials, secretMap: TSecretMap) => {
+  const syncSecrets = async (secretSync: TCamundaSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       destinationConfig: { clusterUUID },
       connection
@@ -137,7 +138,8 @@ export const camundaSyncFactory = ({ kmsService, appConnectionDAL }: TCamundaSec
     }
   };
 
-  const removeSecrets = async (secretSync: TCamundaSyncWithCredentials, secretMap: TSecretMap) => {
+  const removeSecrets = async (secretSync: TCamundaSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       destinationConfig: { clusterUUID },
       connection

--- a/backend/src/services/secret-sync/checkly/checkly-sync-fns.ts
+++ b/backend/src/services/secret-sync/checkly/checkly-sync-fns.ts
@@ -7,7 +7,7 @@ import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
 import { SecretSyncError } from "../secret-sync-errors";
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
-import { TSecretMap } from "../secret-sync-types";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 import { TChecklySyncWithCredentials } from "./checkly-sync-types";
 
 export const ChecklySyncFns = {
@@ -15,7 +15,8 @@ export const ChecklySyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  async syncSecrets(secretSync: TChecklySyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TChecklySyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       environment,
       syncOptions: { disableSecretDeletion, keySchema }
@@ -141,7 +142,8 @@ export const ChecklySyncFns = {
     }
   },
 
-  async removeSecrets(secretSync: TChecklySyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TChecklySyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const config = secretSync.destinationConfig;
 
     if (config.groupId) {

--- a/backend/src/services/secret-sync/circleci/circleci-sync-fns.ts
+++ b/backend/src/services/secret-sync/circleci/circleci-sync-fns.ts
@@ -7,6 +7,7 @@ import { getCircleCIApiUrl } from "@app/services/app-connection/circleci";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import {
@@ -129,7 +130,8 @@ const deleteEnvVar = async (projectId: string, apiToken: string, name: string, a
 };
 
 export const CircleCISyncFns = {
-  syncSecrets: async (secretSync: TCircleCISyncWithCredentials, secretMap: TSecretMap): Promise<void> => {
+  syncSecrets: async (secretSync: TCircleCISyncWithCredentials, payload: TSecretSyncPayload): Promise<void> => {
+    const secretMap = payload.flatten();
     const { destinationConfig, connection } = secretSync;
     const { projectId, projectName, orgName } = destinationConfig;
     const { apiToken } = connection.credentials;
@@ -189,7 +191,8 @@ export const CircleCISyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  removeSecrets: async (secretSync: TCircleCISyncWithCredentials, secretMap: TSecretMap): Promise<void> => {
+  removeSecrets: async (secretSync: TCircleCISyncWithCredentials, payload: TSecretSyncPayload): Promise<void> => {
+    const secretMap = payload.flatten();
     const { destinationConfig, connection } = secretSync;
     const { projectId, projectName, orgName } = destinationConfig;
     const { apiToken } = connection.credentials;

--- a/backend/src/services/secret-sync/cloud66/cloud66-sync-fns.ts
+++ b/backend/src/services/secret-sync/cloud66/cloud66-sync-fns.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/services/app-connection/cloud-66/cloud-66-connection-fns";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TCloud66EnvVar, TCloud66SyncWithCredentials } from "./cloud66-sync-types";
@@ -39,7 +40,8 @@ const deleteCloud66EnvVar = (accessToken: string, stackId: string, key: string) 
   );
 
 export const Cloud66SyncFns = {
-  async syncSecrets(secretSync: TCloud66SyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TCloud66SyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -113,7 +115,8 @@ export const Cloud66SyncFns = {
     return Object.fromEntries(existingEnvVars.map((envVar) => [envVar.key, { value: envVar.value }]));
   },
 
-  async removeSecrets(secretSync: TCloud66SyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TCloud66SyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { stackId }

--- a/backend/src/services/secret-sync/cloudflare-pages/cloudflare-pages-fns.ts
+++ b/backend/src/services/secret-sync/cloudflare-pages/cloudflare-pages-fns.ts
@@ -1,6 +1,7 @@
 import { request } from "@app/lib/config/request";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
@@ -42,7 +43,8 @@ const getProjectEnvironmentSecrets = async (secretSync: TCloudflarePagesSyncWith
 };
 
 export const CloudflarePagesSyncFns = {
-  syncSecrets: async (secretSync: TCloudflarePagesSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TCloudflarePagesSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       destinationConfig,
       connection: {
@@ -95,7 +97,8 @@ export const CloudflarePagesSyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  removeSecrets: async (secretSync: TCloudflarePagesSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TCloudflarePagesSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       destinationConfig,
       connection: {

--- a/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
+++ b/backend/src/services/secret-sync/cloudflare-workers/cloudflare-workers-fns.ts
@@ -6,6 +6,7 @@ import { chunkArray } from "@app/lib/fn";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
@@ -148,7 +149,8 @@ const getCloudflareBindings = async (
 };
 
 export const CloudflareWorkersSyncFns = {
-  syncSecrets: async (secretSync: TCloudflareWorkersSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TCloudflareWorkersSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection: {
         credentials: { apiToken, accountId }
@@ -348,7 +350,8 @@ export const CloudflareWorkersSyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  removeSecrets: async (secretSync: TCloudflareWorkersSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TCloudflareWorkersSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection: {
         credentials: { apiToken, accountId }

--- a/backend/src/services/secret-sync/databricks/databricks-sync-fns.ts
+++ b/backend/src/services/secret-sync/databricks/databricks-sync-fns.ts
@@ -14,7 +14,7 @@ import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
 
-import { TSecretMap } from "../secret-sync-types";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 
 type TDatabricksSecretSyncFactoryDeps = {
   appConnectionDAL: Pick<TAppConnectionDALFactory, "updateById">;
@@ -72,7 +72,8 @@ const deleteDatabricksSecrets = async ({ workspaceUrl, scope, key, accessToken }
   );
 
 export const databricksSyncFactory = ({ kmsService, appConnectionDAL }: TDatabricksSecretSyncFactoryDeps) => {
-  const syncSecrets = async (secretSync: TDatabricksSyncWithCredentials, secretMap: TSecretMap) => {
+  const syncSecrets = async (secretSync: TDatabricksSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     if (Object.keys(secretSync).length > DATABRICKS_SCOPE_SECRET_LIMIT) {
       throw new Error(
         `Databricks does not support storing more than ${DATABRICKS_SCOPE_SECRET_LIMIT} secrets per scope.`
@@ -130,7 +131,8 @@ export const databricksSyncFactory = ({ kmsService, appConnectionDAL }: TDatabri
     }
   };
 
-  const removeSecrets = async (secretSync: TDatabricksSyncWithCredentials, secretMap: TSecretMap) => {
+  const removeSecrets = async (secretSync: TDatabricksSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       destinationConfig: { scope },
       connection

--- a/backend/src/services/secret-sync/daytona/daytona-sync-fns.ts
+++ b/backend/src/services/secret-sync/daytona/daytona-sync-fns.ts
@@ -6,6 +6,7 @@ import { getDaytonaAuthHeaders } from "@app/services/app-connection/daytona";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { DAYTONA_SECRET_NAME_PATTERN, DAYTONA_SECRET_NAME_RULE } from "./daytona-sync-schemas";
@@ -62,7 +63,8 @@ const deleteDaytonaSecret = (apiKey: string, secretId: string) =>
   });
 
 export const DaytonaSyncFns = {
-  async syncSecrets(secretSync: TDaytonaSyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TDaytonaSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -139,7 +141,8 @@ export const DaytonaSyncFns = {
     throw new Error("Daytona does not support importing secrets.");
   },
 
-  async removeSecrets(secretSync: TDaytonaSyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TDaytonaSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const { apiKey } = secretSync.connection.credentials;
 
     const existingSecrets = await listDaytonaSecrets(apiKey);

--- a/backend/src/services/secret-sync/devin/devin-sync-fns.ts
+++ b/backend/src/services/secret-sync/devin/devin-sync-fns.ts
@@ -6,6 +6,7 @@ import { IntegrationUrls } from "@app/services/integration-auth/integration-list
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TDevinListSecretsResponse, TDevinSecret, TDevinSyncWithCredentials } from "./devin-sync-types";
@@ -118,7 +119,8 @@ const buildSyncNote = (secretSync: TDevinSyncWithCredentials) => {
 };
 
 export const DevinSyncFns = {
-  syncSecrets: async (secretSync: TDevinSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TDevinSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection: {
         credentials: { apiKey }
@@ -157,7 +159,8 @@ export const DevinSyncFns = {
       }
     }
   },
-  removeSecrets: async (secretSync: TDevinSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TDevinSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection: {
         credentials: { apiKey }

--- a/backend/src/services/secret-sync/digital-ocean-app-platform/digital-ocean-app-platform-sync-fns.ts
+++ b/backend/src/services/secret-sync/digital-ocean-app-platform/digital-ocean-app-platform-sync-fns.ts
@@ -8,7 +8,7 @@ import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
 import { SecretSyncError } from "../secret-sync-errors";
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
-import { TSecretMap } from "../secret-sync-types";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 import { TDigitalOceanAppPlatformSyncWithCredentials } from "./digital-ocean-app-platform-sync-types";
 
 export const DigitalOceanAppPlatformSyncFns = {
@@ -16,7 +16,8 @@ export const DigitalOceanAppPlatformSyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  async syncSecrets(secretSync: TDigitalOceanAppPlatformSyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TDigitalOceanAppPlatformSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       environment,
       syncOptions: { disableSecretDeletion, keySchema }
@@ -55,7 +56,8 @@ export const DigitalOceanAppPlatformSyncFns = {
     }
   },
 
-  async removeSecrets(secretSync: TDigitalOceanAppPlatformSyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TDigitalOceanAppPlatformSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const config = secretSync.destinationConfig;
 
     try {

--- a/backend/src/services/secret-sync/external-infisical/external-infisical-sync-fns.ts
+++ b/backend/src/services/secret-sync/external-infisical/external-infisical-sync-fns.ts
@@ -6,6 +6,7 @@ import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 import { getExternalInfisicalAccessToken } from "@app/services/app-connection/external-infisical";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TExternalInfisicalSyncWithCredentials } from "./external-infisical-sync-types";
@@ -143,8 +144,11 @@ const batchDeleteSecrets = async (
 };
 
 export const ExternalInfisicalSyncFns = {
-  syncSecrets: async (secretSync: TExternalInfisicalSyncWithCredentials, secretMap: TSecretMap) =>
+  syncSecrets: async (secretSync: TExternalInfisicalSyncWithCredentials, payload: TSecretSyncPayload) =>
     withExternalInfisicalErrorHandling(async () => {
+      // Key schema must never be applied for Infisical-to-Infisical syncs, or the prefixed key
+      // triggers another sync cycle on the remote project.
+      const secretMap = payload.flatten({ applySchema: false });
       const ctx = await getRemoteContext(secretSync);
       const remoteSecrets = await fetchRemoteSecrets(secretSync, ctx);
       const environmentSlug = secretSync.environment?.slug || "";
@@ -189,8 +193,9 @@ export const ExternalInfisicalSyncFns = {
       return Object.fromEntries(remoteSecrets.map((s) => [s.secretKey, { value: s.secretValue ?? "" }]));
     }),
 
-  removeSecrets: async (secretSync: TExternalInfisicalSyncWithCredentials, secretMap: TSecretMap) =>
+  removeSecrets: async (secretSync: TExternalInfisicalSyncWithCredentials, payload: TSecretSyncPayload) =>
     withExternalInfisicalErrorHandling(async () => {
+      const secretMap = payload.flatten({ applySchema: false });
       const ctx = await getRemoteContext(secretSync);
       const secretsToDelete = Object.keys(secretMap);
       await batchDeleteSecrets(secretSync, secretsToDelete, ctx);

--- a/backend/src/services/secret-sync/flyio/flyio-sync-fns.ts
+++ b/backend/src/services/secret-sync/flyio/flyio-sync-fns.ts
@@ -11,7 +11,7 @@ import {
 } from "@app/services/secret-sync/flyio/flyio-sync-types";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
-import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
 
@@ -204,7 +204,8 @@ const deleteFlyioSecrets = async ({ accessToken, appId, keys }: TDeleteFlyioVari
 };
 
 export const FlyioSyncFns = {
-  syncSecrets: async (secretSync: TFlyioSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TFlyioSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -243,7 +244,8 @@ export const FlyioSyncFns = {
       await deployAppMachines(secretSync, releaseVersion);
     }
   },
-  removeSecrets: async (secretSync: TFlyioSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TFlyioSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { appId }

--- a/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
+++ b/backend/src/services/secret-sync/gcp/gcp-sync-fns.ts
@@ -8,6 +8,7 @@ import { GcpSyncScope } from "@app/services/secret-sync/gcp/gcp-sync-enums";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
 import { SecretSyncError } from "../secret-sync-errors";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 import { TPreSaveTransformDestinationConfigFn, TSecretMap } from "../secret-sync-types";
 import {
   GCPLatestSecretVersionAccess,
@@ -123,7 +124,8 @@ const getGcpSecrets = async (accessToken: string, secretSync: TGcpSyncWithCreden
 };
 
 export const GcpSyncFns = {
-  syncSecrets: async (secretSync: TGcpSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TGcpSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { destinationConfig, connection } = secretSync;
     const accessToken = await getGcpConnectionAuthToken(connection);
 
@@ -236,7 +238,8 @@ export const GcpSyncFns = {
     return Object.fromEntries(Object.entries(gcpSecrets).map(([key, value]) => [key, { value: value ?? "" }]));
   },
 
-  removeSecrets: async (secretSync: TGcpSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TGcpSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { connection } = secretSync;
     const accessToken = await getGcpConnectionAuthToken(connection);
 

--- a/backend/src/services/secret-sync/github/github-sync-fns.ts
+++ b/backend/src/services/secret-sync/github/github-sync-fns.ts
@@ -16,7 +16,7 @@ import { GitHubSyncScope, GitHubSyncVisibility } from "@app/services/secret-sync
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
-import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 
 import { TGitHubPublicKey, TGitHubSecret, TGitHubSecretPayload, TGitHubSyncWithCredentials } from "./github-sync-types";
 
@@ -233,12 +233,13 @@ const putSecret = async (
 export const GithubSyncFns = {
   syncSecrets: async (
     secretSync: TGitHubSyncWithCredentials,
-    ogSecretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
     gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">,
     gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">,
     gitHubAppDeps: TGitHubAppCredentialResolverDeps
   ) => {
+    const ogSecretMap = payload.flatten();
     const secretMap = Object.fromEntries(Object.entries(ogSecretMap).map(([i, v]) => [i.toUpperCase(), v]));
 
     switch (secretSync.destinationConfig.scope) {
@@ -342,12 +343,13 @@ export const GithubSyncFns = {
   },
   removeSecrets: async (
     secretSync: TGitHubSyncWithCredentials,
-    ogSecretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
     gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">,
     gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">,
     gitHubAppDeps: TGitHubAppCredentialResolverDeps
   ) => {
+    const ogSecretMap = payload.flatten();
     const secretMap = Object.fromEntries(Object.entries(ogSecretMap).map(([i, v]) => [i.toUpperCase(), v]));
 
     const { connection: rawConnection } = secretSync;

--- a/backend/src/services/secret-sync/gitlab/gitlab-sync-fns.ts
+++ b/backend/src/services/secret-sync/gitlab/gitlab-sync-fns.ts
@@ -8,6 +8,7 @@ import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { TGitLabSyncWithCredentials, TGitLabVariable } from "@app/services/secret-sync/gitlab/gitlab-sync-types";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
@@ -289,9 +290,10 @@ const deleteGitLabVariable = async ({
 export const GitLabSyncFns = {
   syncSecrets: async (
     secretSync: TGitLabSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     { appConnectionDAL, kmsService }: TGitLabSyncFactoryDeps
   ): Promise<void> => {
+    const secretMap = payload.flatten();
     const { connection, environment, destinationConfig } = secretSync;
     const { scope, targetEnvironment } = destinationConfig;
 
@@ -405,9 +407,10 @@ export const GitLabSyncFns = {
 
   removeSecrets: async (
     secretSync: TGitLabSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     { appConnectionDAL, kmsService }: TGitLabSyncFactoryDeps
   ): Promise<void> => {
+    const secretMap = payload.flatten();
     const { connection, destinationConfig } = secretSync;
     const { scope, targetEnvironment } = destinationConfig;
 

--- a/backend/src/services/secret-sync/hasura-cloud/hasura-cloud-sync-fns.ts
+++ b/backend/src/services/secret-sync/hasura-cloud/hasura-cloud-sync-fns.ts
@@ -8,6 +8,7 @@ import {
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
 import { SecretSyncError } from "../secret-sync-errors";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 import { TSecretMap } from "../secret-sync-types";
 import { THasuraCloudSyncWithCredentials } from "./hasura-cloud-sync-types";
 
@@ -138,7 +139,8 @@ export const HasuraCloudSyncFns = {
     }
   },
 
-  async syncSecrets(secretSync: THasuraCloudSyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: THasuraCloudSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       destinationConfig,
       connection,
@@ -185,7 +187,8 @@ export const HasuraCloudSyncFns = {
     }
   },
 
-  async removeSecrets(secretSync: THasuraCloudSyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: THasuraCloudSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const { destinationConfig, connection } = secretSync;
     const { accessToken } = connection.credentials;
     const { projectId } = destinationConfig;

--- a/backend/src/services/secret-sync/hc-vault/hc-vault-sync-fns.ts
+++ b/backend/src/services/secret-sync/hc-vault/hc-vault-sync-fns.ts
@@ -20,7 +20,7 @@ import {
 } from "@app/services/secret-sync/hc-vault/hc-vault-sync-types";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
-import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 
 const getKvMountVersion = async ({
   instanceUrl,
@@ -161,11 +161,12 @@ const updateHCVaultVariables = async (
 export const HCVaultSyncFns = {
   syncSecrets: async (
     secretSync: THCVaultSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
     gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">,
     gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">
   ) => {
+    const secretMap = payload.flatten();
     const {
       connection: rawConnection,
       environment,
@@ -264,11 +265,12 @@ export const HCVaultSyncFns = {
   },
   removeSecrets: async (
     secretSync: THCVaultSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     gatewayService: Pick<TGatewayServiceFactory, "fnGetGatewayClientTlsByGatewayId">,
     gatewayV2Service: Pick<TGatewayV2ServiceFactory, "getPlatformConnectionDetailsByGatewayId">,
     gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">
   ) => {
+    const secretMap = payload.flatten();
     const {
       connection: rawConnection,
       destinationConfig: { mount, path }

--- a/backend/src/services/secret-sync/heroku/heroku-sync-fns.ts
+++ b/backend/src/services/secret-sync/heroku/heroku-sync-fns.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/services/secret-sync/heroku/heroku-sync-types";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 type THerokuSyncFactoryDeps = {
@@ -69,9 +70,10 @@ const updateHerokuConfigVars = async ({ authToken, app, configVars }: THerokuUpd
 export const HerokuSyncFns = {
   syncSecrets: async (
     secretSync: THerokuSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     { appConnectionDAL, kmsService }: THerokuSyncFactoryDeps
   ) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -112,9 +114,10 @@ export const HerokuSyncFns = {
 
   removeSecrets: async (
     secretSync: THerokuSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     { appConnectionDAL, kmsService }: THerokuSyncFactoryDeps
   ) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { app }

--- a/backend/src/services/secret-sync/humanitec/humanitec-sync-fns.ts
+++ b/backend/src/services/secret-sync/humanitec/humanitec-sync-fns.ts
@@ -4,6 +4,7 @@ import { IntegrationUrls } from "@app/services/integration-auth/integration-list
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { HumanitecSyncScope } from "./humanitec-sync-enums";
@@ -183,7 +184,8 @@ const updateSecret = async (
 };
 
 export const HumanitecSyncFns = {
-  syncSecrets: async (secretSync: THumanitecSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: THumanitecSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const humanitecSecrets = await getHumanitecSecrets(secretSync);
     const humanitecSecretsKeys = new Map(humanitecSecrets.map((s) => [s.key, s]));
 
@@ -213,7 +215,8 @@ export const HumanitecSyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  removeSecrets: async (secretSync: THumanitecSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: THumanitecSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const encryptedSecrets = await getHumanitecSecrets(secretSync);
 
     for await (const encryptedSecret of encryptedSecrets) {

--- a/backend/src/services/secret-sync/laravel-forge/laravel-forge-sync-fns.ts
+++ b/backend/src/services/secret-sync/laravel-forge/laravel-forge-sync-fns.ts
@@ -1,6 +1,7 @@
 import { request } from "@app/lib/config/request";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import {
@@ -153,7 +154,8 @@ const updateLaravelForgeSecrets = async (secretSync: TLaravelForgeSyncWithCreden
 };
 
 export const LaravelForgeSyncFns = {
-  async syncSecrets(secretSync: TLaravelForgeSyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TLaravelForgeSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       environment,
       syncOptions: { disableSecretDeletion, keySchema }
@@ -191,7 +193,8 @@ export const LaravelForgeSyncFns = {
     return Object.fromEntries(secrets.map((secret) => [secret.key, { value: secret.value }]));
   },
 
-  async removeSecrets(secretSync: TLaravelForgeSyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TLaravelForgeSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const existingSecrets = await getLaravelForgeSecrets(secretSync);
 
     const newSecrets = existingSecrets.filter((secret) => !Object.hasOwn(secretMap, secret.key));

--- a/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
+++ b/backend/src/services/secret-sync/netlify/netlify-sync-fns.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-continue */
 import { NetlifyPublicAPI } from "@app/services/app-connection/netlify/netlify-connection-public-client";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SecretSyncError } from "../secret-sync-errors";
@@ -33,7 +34,8 @@ export const NetlifySyncFns = {
     return map;
   },
 
-  async syncSecrets(secretSync: TNetlifySyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TNetlifySyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       environment,
       syncOptions: { disableSecretDeletion, keySchema }
@@ -113,7 +115,8 @@ export const NetlifySyncFns = {
     }
   },
 
-  async removeSecrets(secretSync: TNetlifySyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TNetlifySyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const config = secretSync.destinationConfig;
 
     const baseParams = {

--- a/backend/src/services/secret-sync/northflank/northflank-sync-fns.ts
+++ b/backend/src/services/secret-sync/northflank/northflank-sync-fns.ts
@@ -2,6 +2,7 @@ import { AxiosError } from "axios";
 
 import { request } from "@app/lib/config/request";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SecretSyncError } from "../secret-sync-errors";
@@ -121,7 +122,8 @@ const updateNorthflankSecrets = async (
 };
 
 export const NorthflankSyncFns = {
-  syncSecrets: async (secretSync: TNorthflankSyncWithCredentials, secretMap: TSecretMap): Promise<void> => {
+  syncSecrets: async (secretSync: TNorthflankSyncWithCredentials, payload: TSecretSyncPayload): Promise<void> => {
+    const secretMap = payload.flatten();
     const northflankSecrets = await getNorthflankSecrets(secretSync);
 
     const updatedVariables: Record<string, string> = {};
@@ -149,7 +151,8 @@ export const NorthflankSyncFns = {
     return Object.fromEntries(Object.entries(northflankSecrets).map(([key, value]) => [key, { value }]));
   },
 
-  removeSecrets: async (secretSync: TNorthflankSyncWithCredentials, secretMap: TSecretMap): Promise<void> => {
+  removeSecrets: async (secretSync: TNorthflankSyncWithCredentials, payload: TSecretSyncPayload): Promise<void> => {
+    const secretMap = payload.flatten();
     const northflankSecrets = await getNorthflankSecrets(secretSync);
 
     const updatedVariables: Record<string, string> = {};

--- a/backend/src/services/secret-sync/octopus-deploy/octopus-deploy-sync-fns.ts
+++ b/backend/src/services/secret-sync/octopus-deploy/octopus-deploy-sync-fns.ts
@@ -2,6 +2,7 @@ import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 import { getOctopusDeployInstanceUrl } from "@app/services/app-connection/octopus-deploy";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
@@ -32,7 +33,8 @@ export const OctopusDeploySyncFns = {
     }
   },
 
-  async syncSecrets(secretSync: TOctopusDeploySyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TOctopusDeploySyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -112,7 +114,8 @@ export const OctopusDeploySyncFns = {
       }
     );
   },
-  async removeSecrets(secretSync: TOctopusDeploySyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TOctopusDeploySyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { spaceId, projectId, scope }

--- a/backend/src/services/secret-sync/ona/ona-sync-fns.ts
+++ b/backend/src/services/secret-sync/ona/ona-sync-fns.ts
@@ -3,6 +3,7 @@ import { AxiosError } from "axios";
 import { request } from "@app/lib/config/request";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { ONA_PAGE_SIZE } from "./ona-sync-enums";
@@ -115,7 +116,8 @@ const deleteSecret = async (secretSync: TOnaSyncWithCredentials, secretId: strin
 };
 
 export const OnaSyncFns = {
-  syncSecrets: async (secretSync: TOnaSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TOnaSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const existingSecrets = await listEnvVarSecrets(secretSync);
     const existingByName = new Map(existingSecrets.map((s) => [s.name, s]));
 
@@ -163,7 +165,8 @@ export const OnaSyncFns = {
     throw new Error("Ona does not support importing secrets.");
   },
 
-  removeSecrets: async (secretSync: TOnaSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TOnaSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const existingSecrets = await listEnvVarSecrets(secretSync);
 
     for (const existing of existingSecrets) {

--- a/backend/src/services/secret-sync/ovh/ovh-sync-fns.ts
+++ b/backend/src/services/secret-sync/ovh/ovh-sync-fns.ts
@@ -7,6 +7,7 @@ import { validateSsrfUrl } from "@app/lib/validator";
 import { getOvhHttpsAgent } from "@app/services/app-connection/ovh";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TOvhSyncWithCredentials } from "./ovh-sync-types";
@@ -163,7 +164,8 @@ const writeSecretBundle = async (
 };
 
 export const OvhSyncFns = {
-  syncSecrets: async (secretSync: TOvhSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TOvhSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       syncOptions: { disableSecretDeletion, keySchema }
     } = secretSync;
@@ -202,7 +204,8 @@ export const OvhSyncFns = {
     }
   },
 
-  removeSecrets: async (secretSync: TOvhSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TOvhSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     await writeSecretBundle(secretSync, (existing) => {
       const desired = { ...existing };
       for (const key of Object.keys(secretMap)) delete desired[key];

--- a/backend/src/services/secret-sync/qovery/qovery-sync-fns.ts
+++ b/backend/src/services/secret-sync/qovery/qovery-sync-fns.ts
@@ -8,6 +8,7 @@ import {
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { QoverySyncScope, QoveryVariableType } from "./qovery-sync-enums";
@@ -113,7 +114,8 @@ const deleteQoveryVariable = async (
 };
 
 export const QoverySyncFns = {
-  syncSecrets: async (secretSync: TQoverySyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TQoverySyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { connection, destinationConfig, environment, syncOptions } = secretSync;
     const { accessToken } = connection.credentials;
     const instanceUrl = QOVERY_DEFAULT_API_URL;
@@ -166,7 +168,8 @@ export const QoverySyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  removeSecrets: async (secretSync: TQoverySyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TQoverySyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { connection, destinationConfig } = secretSync;
     const { accessToken } = connection.credentials;
     const instanceUrl = QOVERY_DEFAULT_API_URL;

--- a/backend/src/services/secret-sync/railway/railway-sync-fns.ts
+++ b/backend/src/services/secret-sync/railway/railway-sync-fns.ts
@@ -7,6 +7,7 @@ import { RailwayPublicAPI } from "@app/services/app-connection/railway/railway-c
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
 import { SecretSyncError } from "../secret-sync-errors";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 import { TSecretMap } from "../secret-sync-types";
 import { TRailwaySyncWithCredentials } from "./railway-sync-types";
 
@@ -62,7 +63,8 @@ export const RailwaySyncFns = {
    * deletion is enabled, drift is removed explicitly via per-key deletes that skip sealed variables.
    * If there's a service, triggers a redeploy to pick up the changes.
    */
-  async syncSecrets(secretSync: TRailwaySyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TRailwaySyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     try {
       const {
         syncOptions: { disableSecretDeletion, keySchema }
@@ -160,7 +162,8 @@ export const RailwaySyncFns = {
     }
   },
 
-  async removeSecrets(secretSync: TRailwaySyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TRailwaySyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const config = secretSync.destinationConfig;
 
     try {

--- a/backend/src/services/secret-sync/render/render-sync-fns.ts
+++ b/backend/src/services/secret-sync/render/render-sync-fns.ts
@@ -5,6 +5,7 @@ import { request } from "@app/lib/config/request";
 import { BadRequestError } from "@app/lib/errors";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { RenderSyncScope } from "./render-sync-enums";
@@ -273,7 +274,8 @@ const redeployService = async (secretSync: TRenderSyncWithCredentials) => {
 };
 
 export const RenderSyncFns = {
-  syncSecrets: async (secretSync: TRenderSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TRenderSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const renderSecrets = await getRenderEnvironmentSecrets(secretSync);
     const environmentSlug = secretSync.environment?.slug || "";
     const { disableSecretDeletion, keySchema } = secretSync.syncOptions;
@@ -334,7 +336,8 @@ export const RenderSyncFns = {
     return Object.fromEntries(renderSecrets.map((secret) => [secret.key, { value: secret.value ?? "" }]));
   },
 
-  removeSecrets: async (secretSync: TRenderSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TRenderSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const renderSecrets = await getRenderEnvironmentSecrets(secretSync);
     const finalEnvVars: Array<{ key: string; value: string }> = [];
 

--- a/backend/src/services/secret-sync/rundeck/rundeck-sync-fns.ts
+++ b/backend/src/services/secret-sync/rundeck/rundeck-sync-fns.ts
@@ -9,6 +9,7 @@ import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
 import { SecretSyncError } from "../secret-sync-errors";
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 import { TSecretMap } from "../secret-sync-types";
 import { TRundeckSyncWithCredentials } from "./rundeck-sync-types";
 
@@ -77,7 +78,8 @@ export const RundeckSyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  async syncSecrets(secretSync: TRundeckSyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TRundeckSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       environment,
       syncOptions: { disableSecretDeletion, keySchema }
@@ -117,7 +119,8 @@ export const RundeckSyncFns = {
     }
   },
 
-  async removeSecrets(secretSync: TRundeckSyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TRundeckSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const { baseUrl, headers } = getRundeckClientDetails(secretSync);
 
     const existingSecretKeys = await listRundeckSecretKeys(baseUrl, headers);

--- a/backend/src/services/secret-sync/secret-sync-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-fns.ts
@@ -84,7 +84,7 @@ import { RailwaySyncFns } from "./railway/railway-sync-fns";
 import { RENDER_SYNC_LIST_OPTION, RenderSyncFns } from "./render";
 import { RUNDECK_SYNC_LIST_OPTION, RundeckSyncFns } from "./rundeck";
 import { SECRET_SYNC_PLAN_MAP } from "./secret-sync-maps";
-import { createSecretSyncPayload, TSecretSyncPayload } from "./secret-sync-payload";
+import { TSecretSyncPayload } from "./secret-sync-payload";
 import { SNOWFLAKE_SYNC_LIST_OPTION, SnowflakeSyncFns } from "./snowflake";
 import { SPACELIFT_SYNC_LIST_OPTION, SpaceliftSyncFns } from "./spacelift";
 import { SUPABASE_SYNC_LIST_OPTION, SupabaseSyncFns } from "./supabase";
@@ -290,16 +290,8 @@ export const SecretSyncFns = {
     switch (secretSync.destination) {
       case SecretSync.AWSParameterStore:
         return AwsParameterStoreSyncFns.syncSecrets(secretSync, payload);
-      case SecretSync.AWSSecretsManager: {
-        // The many-to-one mapping combines every secret into one AWS secret's JSON body under
-        // its own (unprefixed) key, so this destination genuinely needs both views: the
-        // schema-applied map for the one-to-one path, and a schema-free one for that JSON body.
-        // Re-flatten with no schema to keep this view's duplicate-name detection.
-        const unmodifiedPayload = createSecretSyncPayload(payload.all(), {
-          environment: secretSync.environment?.slug || ""
-        });
-        return AwsSecretsManagerSyncFns.syncSecrets(secretSync, payload.flatten(), unmodifiedPayload.flatten());
-      }
+      case SecretSync.AWSSecretsManager:
+        return AwsSecretsManagerSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.GitHub:
         return GithubSyncFns.syncSecrets(secretSync, payload, gatewayService, gatewayV2Service, gatewayPoolService, {
           gitHubAppDAL,
@@ -395,16 +387,8 @@ export const SecretSyncFns = {
         return CircleCISyncFns.syncSecrets(secretSync, payload);
       case SecretSync.AzureEntraIdScim:
         return AzureEntraIdScimSyncFns.syncSecrets(secretSync, payload, { appConnectionDAL, kmsService });
-      case SecretSync.ExternalInfisical: {
-        // Key schema must never be applied for Infisical-to-Infisical syncs, or the prefixed
-        // key triggers another sync cycle. Re-flatten with no schema rather than passing the
-        // payload through, since payload.flatten() would apply the schema this destination
-        // carries for every other provider.
-        const unschematizedPayload = createSecretSyncPayload(payload.all(), {
-          environment: secretSync.environment?.slug || ""
-        });
-        return ExternalInfisicalSyncFns.syncSecrets(secretSync, unschematizedPayload.flatten());
-      }
+      case SecretSync.ExternalInfisical:
+        return ExternalInfisicalSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.OVH:
         return OvhSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Devin:
@@ -724,14 +708,8 @@ export const SecretSyncFns = {
         return CircleCISyncFns.removeSecrets(secretSync, payload);
       case SecretSync.AzureEntraIdScim:
         return AzureEntraIdScimSyncFns.removeSecrets();
-      case SecretSync.ExternalInfisical: {
-        // See the matching case in syncSecrets: this destination always gets the raw,
-        // unschematized view, never payload.flatten().
-        const unschematizedPayload = createSecretSyncPayload(payload.all(), {
-          environment: secretSync.environment?.slug || ""
-        });
-        return ExternalInfisicalSyncFns.removeSecrets(secretSync, unschematizedPayload.flatten());
-      }
+      case SecretSync.ExternalInfisical:
+        return ExternalInfisicalSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.OVH:
         return OvhSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Devin:

--- a/backend/src/services/secret-sync/secret-sync-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-fns.ts
@@ -189,23 +189,6 @@ type TSyncSecretDeps = {
   gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
 };
 
-export const getKeyWithSchema = ({
-  key,
-  environment,
-  schema
-}: {
-  key: string;
-  environment: string;
-  schema?: string;
-}) => {
-  if (!schema) return key;
-
-  return handlebars.compile(schema)({
-    secretKey: key,
-    environment
-  });
-};
-
 // Add schema to secret keys
 const addSchema = (unprocessedSecretMap: TSecretMap, environment: string, schema?: string): TSecretMap => {
   if (!schema) return unprocessedSecretMap;

--- a/backend/src/services/secret-sync/secret-sync-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-fns.ts
@@ -84,6 +84,7 @@ import { RailwaySyncFns } from "./railway/railway-sync-fns";
 import { RENDER_SYNC_LIST_OPTION, RenderSyncFns } from "./render";
 import { RUNDECK_SYNC_LIST_OPTION, RundeckSyncFns } from "./rundeck";
 import { SECRET_SYNC_PLAN_MAP } from "./secret-sync-maps";
+import { TSecretSyncPayload } from "./secret-sync-payload";
 import { SNOWFLAKE_SYNC_LIST_OPTION, SnowflakeSyncFns } from "./snowflake";
 import { SPACELIFT_SYNC_LIST_OPTION, SpaceliftSyncFns } from "./spacelift";
 import { SUPABASE_SYNC_LIST_OPTION, SupabaseSyncFns } from "./supabase";
@@ -189,24 +190,6 @@ type TSyncSecretDeps = {
   gatewayPoolService: Pick<TGatewayPoolServiceFactory, "resolveEffectiveGatewayId">;
 };
 
-// Add schema to secret keys
-const addSchema = (unprocessedSecretMap: TSecretMap, environment: string, schema?: string): TSecretMap => {
-  if (!schema) return unprocessedSecretMap;
-
-  const processedSecretMap: TSecretMap = {};
-
-  for (const [key, value] of Object.entries(unprocessedSecretMap)) {
-    const newKey = handlebars.compile(schema)({
-      secretKey: key,
-      environment
-    });
-
-    processedSecretMap[newKey] = value;
-  }
-
-  return processedSecretMap;
-};
-
 // Strip schema from secret keys
 const stripSchema = (unprocessedSecretMap: TSecretMap, environment: string, schema?: string): TSecretMap => {
   if (!schema) return unprocessedSecretMap;
@@ -294,7 +277,7 @@ const filterForSchema = (secretMap: TSecretMap, environment: string, schema?: st
 export const SecretSyncFns = {
   syncSecrets: (
     secretSync: TSecretSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     {
       kmsService,
       appConnectionDAL,
@@ -304,24 +287,18 @@ export const SecretSyncFns = {
       gatewayPoolService
     }: TSyncSecretDeps
   ): Promise<TSyncSecretsResult | void> => {
-    const schemaSecretMap = addSchema(secretMap, secretSync.environment?.slug || "", secretSync.syncOptions.keySchema);
-
     switch (secretSync.destination) {
       case SecretSync.AWSParameterStore:
-        return AwsParameterStoreSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return AwsParameterStoreSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.AWSSecretsManager:
-        return AwsSecretsManagerSyncFns.syncSecrets(secretSync, schemaSecretMap, secretMap);
+        return AwsSecretsManagerSyncFns.syncSecrets(secretSync, payload, payload);
       case SecretSync.GitHub:
-        return GithubSyncFns.syncSecrets(
-          secretSync,
-          schemaSecretMap,
-          gatewayService,
-          gatewayV2Service,
-          gatewayPoolService,
-          { gitHubAppDAL, kmsService }
-        );
+        return GithubSyncFns.syncSecrets(secretSync, payload, gatewayService, gatewayV2Service, gatewayPoolService, {
+          gitHubAppDAL,
+          kmsService
+        });
       case SecretSync.GCPSecretManager:
-        return GcpSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return GcpSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.AzureKeyVault:
         return azureKeyVaultSyncFactory({
           appConnectionDAL,
@@ -329,115 +306,109 @@ export const SecretSyncFns = {
           gatewayService,
           gatewayV2Service,
           gatewayPoolService
-        }).syncSecrets(secretSync, schemaSecretMap);
+        }).syncSecrets(secretSync, payload);
       case SecretSync.AzureAppConfiguration:
         return azureAppConfigurationSyncFactory({
           appConnectionDAL,
           kmsService
-        }).syncSecrets(secretSync, schemaSecretMap);
+        }).syncSecrets(secretSync, payload);
       case SecretSync.AzureDevOps:
         return azureDevOpsSyncFactory({
           appConnectionDAL,
           kmsService
-        }).syncSecrets(secretSync, schemaSecretMap);
+        }).syncSecrets(secretSync, payload);
       case SecretSync.Databricks:
         return databricksSyncFactory({
           appConnectionDAL,
           kmsService
-        }).syncSecrets(secretSync, schemaSecretMap);
+        }).syncSecrets(secretSync, payload);
       case SecretSync.Humanitec:
-        return HumanitecSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return HumanitecSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.TerraformCloud:
-        return TerraformCloudSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return TerraformCloudSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Camunda:
         return camundaSyncFactory({
           appConnectionDAL,
           kmsService
-        }).syncSecrets(secretSync, schemaSecretMap);
+        }).syncSecrets(secretSync, payload);
       case SecretSync.Heroku:
-        return HerokuSyncFns.syncSecrets(secretSync, schemaSecretMap, { appConnectionDAL, kmsService });
+        return HerokuSyncFns.syncSecrets(secretSync, payload, { appConnectionDAL, kmsService });
       case SecretSync.Vercel:
-        return VercelSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return VercelSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Windmill:
-        return WindmillSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return WindmillSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.HCVault:
-        return HCVaultSyncFns.syncSecrets(
-          secretSync,
-          schemaSecretMap,
-          gatewayService,
-          gatewayV2Service,
-          gatewayPoolService
-        );
+        return HCVaultSyncFns.syncSecrets(secretSync, payload, gatewayService, gatewayV2Service, gatewayPoolService);
       case SecretSync.TeamCity:
-        return TeamCitySyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return TeamCitySyncFns.syncSecrets(secretSync, payload);
       case SecretSync.OCIVault:
-        return OCIVaultSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return OCIVaultSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.OnePass:
-        return OnePassSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return OnePassSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Render:
-        return RenderSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return RenderSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Flyio:
-        return FlyioSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return FlyioSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.TriggerDev:
-        return TriggerDevSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return TriggerDevSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.GitLab:
-        return GitLabSyncFns.syncSecrets(secretSync, schemaSecretMap, { appConnectionDAL, kmsService });
+        return GitLabSyncFns.syncSecrets(secretSync, payload, { appConnectionDAL, kmsService });
       case SecretSync.CloudflarePages:
-        return CloudflarePagesSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return CloudflarePagesSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.CloudflareWorkers:
-        return CloudflareWorkersSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return CloudflareWorkersSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Zabbix:
-        return ZabbixSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return ZabbixSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Railway:
-        return RailwaySyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return RailwaySyncFns.syncSecrets(secretSync, payload);
       case SecretSync.HasuraCloud:
-        return HasuraCloudSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return HasuraCloudSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Checkly:
-        return ChecklySyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return ChecklySyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Supabase:
-        return SupabaseSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return SupabaseSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Rundeck:
-        return RundeckSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return RundeckSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.DigitalOceanAppPlatform:
-        return DigitalOceanAppPlatformSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return DigitalOceanAppPlatformSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Netlify:
-        return NetlifySyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return NetlifySyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Northflank:
-        return NorthflankSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return NorthflankSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Bitbucket:
-        return BitbucketSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return BitbucketSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.LaravelForge:
-        return LaravelForgeSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return LaravelForgeSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Chef:
-        return ChefSyncFns.syncSecrets(secretSync, schemaSecretMap, gatewayV2Service, gatewayPoolService);
+        return ChefSyncFns.syncSecrets(secretSync, payload, gatewayV2Service, gatewayPoolService);
       case SecretSync.OctopusDeploy:
-        return OctopusDeploySyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return OctopusDeploySyncFns.syncSecrets(secretSync, payload);
       case SecretSync.CircleCI:
-        return CircleCISyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return CircleCISyncFns.syncSecrets(secretSync, payload);
       case SecretSync.AzureEntraIdScim:
-        return AzureEntraIdScimSyncFns.syncSecrets(secretSync, schemaSecretMap, { appConnectionDAL, kmsService });
+        return AzureEntraIdScimSyncFns.syncSecrets(secretSync, payload, { appConnectionDAL, kmsService });
       case SecretSync.ExternalInfisical:
         // Key schema is intentionally not applied for Infisical-to-Infisical syncs to prevent
         // infinite sync loops where the prefixed key triggers another sync cycle.
-        return ExternalInfisicalSyncFns.syncSecrets(secretSync, secretMap);
+        return ExternalInfisicalSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.OVH:
-        return OvhSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return OvhSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Devin:
-        return DevinSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return DevinSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Ona:
-        return OnaSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return OnaSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.TravisCI:
-        return TravisCISyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return TravisCISyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Snowflake:
-        return SnowflakeSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return SnowflakeSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Qovery:
-        return QoverySyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return QoverySyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Cloud66:
-        return Cloud66SyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return Cloud66SyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Spacelift:
-        return SpaceliftSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return SpaceliftSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Daytona:
-        return DaytonaSyncFns.syncSecrets(secretSync, schemaSecretMap);
+        return DaytonaSyncFns.syncSecrets(secretSync, payload);
       default:
         throw new Error(
           `Unhandled sync destination for sync secrets fns: ${(secretSync as TSecretSyncWithCredentials).destination}`
@@ -629,7 +600,7 @@ export const SecretSyncFns = {
   },
   removeSecrets: (
     secretSync: TSecretSyncWithCredentials,
-    secretMap: TSecretMap,
+    payload: TSecretSyncPayload,
     {
       kmsService,
       appConnectionDAL,
@@ -639,24 +610,18 @@ export const SecretSyncFns = {
       gatewayPoolService
     }: TSyncSecretDeps
   ): Promise<void> => {
-    const schemaSecretMap = addSchema(secretMap, secretSync.environment?.slug || "", secretSync.syncOptions.keySchema);
-
     switch (secretSync.destination) {
       case SecretSync.AWSParameterStore:
-        return AwsParameterStoreSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return AwsParameterStoreSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.AWSSecretsManager:
-        return AwsSecretsManagerSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return AwsSecretsManagerSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.GitHub:
-        return GithubSyncFns.removeSecrets(
-          secretSync,
-          schemaSecretMap,
-          gatewayService,
-          gatewayV2Service,
-          gatewayPoolService,
-          { gitHubAppDAL, kmsService }
-        );
+        return GithubSyncFns.removeSecrets(secretSync, payload, gatewayService, gatewayV2Service, gatewayPoolService, {
+          gitHubAppDAL,
+          kmsService
+        });
       case SecretSync.GCPSecretManager:
-        return GcpSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return GcpSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.AzureKeyVault:
         return azureKeyVaultSyncFactory({
           appConnectionDAL,
@@ -664,12 +629,12 @@ export const SecretSyncFns = {
           gatewayService,
           gatewayV2Service,
           gatewayPoolService
-        }).removeSecrets(secretSync, schemaSecretMap);
+        }).removeSecrets(secretSync, payload);
       case SecretSync.AzureAppConfiguration:
         return azureAppConfigurationSyncFactory({
           appConnectionDAL,
           kmsService
-        }).removeSecrets(secretSync, schemaSecretMap);
+        }).removeSecrets(secretSync, payload);
       case SecretSync.AzureDevOps:
         return azureDevOpsSyncFactory({
           appConnectionDAL,
@@ -679,100 +644,94 @@ export const SecretSyncFns = {
         return databricksSyncFactory({
           appConnectionDAL,
           kmsService
-        }).removeSecrets(secretSync, schemaSecretMap);
+        }).removeSecrets(secretSync, payload);
       case SecretSync.Humanitec:
-        return HumanitecSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return HumanitecSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.TerraformCloud:
-        return TerraformCloudSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return TerraformCloudSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Camunda:
         return camundaSyncFactory({
           appConnectionDAL,
           kmsService
-        }).removeSecrets(secretSync, schemaSecretMap);
+        }).removeSecrets(secretSync, payload);
       case SecretSync.Vercel:
-        return VercelSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return VercelSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Windmill:
-        return WindmillSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return WindmillSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.HCVault:
-        return HCVaultSyncFns.removeSecrets(
-          secretSync,
-          schemaSecretMap,
-          gatewayService,
-          gatewayV2Service,
-          gatewayPoolService
-        );
+        return HCVaultSyncFns.removeSecrets(secretSync, payload, gatewayService, gatewayV2Service, gatewayPoolService);
       case SecretSync.TeamCity:
-        return TeamCitySyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return TeamCitySyncFns.removeSecrets(secretSync, payload);
       case SecretSync.OCIVault:
-        return OCIVaultSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return OCIVaultSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.OnePass:
-        return OnePassSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return OnePassSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Heroku:
-        return HerokuSyncFns.removeSecrets(secretSync, schemaSecretMap, { appConnectionDAL, kmsService });
+        return HerokuSyncFns.removeSecrets(secretSync, payload, { appConnectionDAL, kmsService });
       case SecretSync.Render:
-        return RenderSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return RenderSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Flyio:
-        return FlyioSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return FlyioSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.TriggerDev:
-        return TriggerDevSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return TriggerDevSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.GitLab:
-        return GitLabSyncFns.removeSecrets(secretSync, schemaSecretMap, { appConnectionDAL, kmsService });
+        return GitLabSyncFns.removeSecrets(secretSync, payload, { appConnectionDAL, kmsService });
       case SecretSync.CloudflarePages:
-        return CloudflarePagesSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return CloudflarePagesSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.CloudflareWorkers:
-        return CloudflareWorkersSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return CloudflareWorkersSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Zabbix:
-        return ZabbixSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return ZabbixSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Railway:
-        return RailwaySyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return RailwaySyncFns.removeSecrets(secretSync, payload);
       case SecretSync.HasuraCloud:
-        return HasuraCloudSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return HasuraCloudSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Checkly:
-        return ChecklySyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return ChecklySyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Supabase:
-        return SupabaseSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return SupabaseSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Rundeck:
-        return RundeckSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return RundeckSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.DigitalOceanAppPlatform:
-        return DigitalOceanAppPlatformSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return DigitalOceanAppPlatformSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Netlify:
-        return NetlifySyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return NetlifySyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Northflank:
-        return NorthflankSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return NorthflankSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Bitbucket:
-        return BitbucketSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return BitbucketSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.LaravelForge:
-        return LaravelForgeSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return LaravelForgeSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Chef:
-        return ChefSyncFns.removeSecrets(secretSync, schemaSecretMap, gatewayV2Service, gatewayPoolService);
+        return ChefSyncFns.removeSecrets(secretSync, payload, gatewayV2Service, gatewayPoolService);
       case SecretSync.OctopusDeploy:
-        return OctopusDeploySyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return OctopusDeploySyncFns.removeSecrets(secretSync, payload);
       case SecretSync.CircleCI:
-        return CircleCISyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return CircleCISyncFns.removeSecrets(secretSync, payload);
       case SecretSync.AzureEntraIdScim:
         return AzureEntraIdScimSyncFns.removeSecrets();
       case SecretSync.ExternalInfisical:
         // Key schema is intentionally not applied for Infisical-to-Infisical syncs to prevent
         // infinite sync loops where the prefixed key triggers another sync cycle.
-        return ExternalInfisicalSyncFns.removeSecrets(secretSync, secretMap);
+        return ExternalInfisicalSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.OVH:
-        return OvhSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return OvhSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Devin:
-        return DevinSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return DevinSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Ona:
-        return OnaSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return OnaSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.TravisCI:
-        return TravisCISyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return TravisCISyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Snowflake:
-        return SnowflakeSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return SnowflakeSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Qovery:
-        return QoverySyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return QoverySyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Cloud66:
-        return Cloud66SyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return Cloud66SyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Spacelift:
-        return SpaceliftSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return SpaceliftSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Daytona:
-        return DaytonaSyncFns.removeSecrets(secretSync, schemaSecretMap);
+        return DaytonaSyncFns.removeSecrets(secretSync, payload);
       default:
         throw new Error(
           `Unhandled sync destination for remove secrets fns: ${(secretSync as TSecretSyncWithCredentials).destination}`

--- a/backend/src/services/secret-sync/secret-sync-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-fns.ts
@@ -84,7 +84,7 @@ import { RailwaySyncFns } from "./railway/railway-sync-fns";
 import { RENDER_SYNC_LIST_OPTION, RenderSyncFns } from "./render";
 import { RUNDECK_SYNC_LIST_OPTION, RundeckSyncFns } from "./rundeck";
 import { SECRET_SYNC_PLAN_MAP } from "./secret-sync-maps";
-import { TSecretSyncPayload } from "./secret-sync-payload";
+import { createSecretSyncPayload, TSecretSyncPayload } from "./secret-sync-payload";
 import { SNOWFLAKE_SYNC_LIST_OPTION, SnowflakeSyncFns } from "./snowflake";
 import { SPACELIFT_SYNC_LIST_OPTION, SpaceliftSyncFns } from "./spacelift";
 import { SUPABASE_SYNC_LIST_OPTION, SupabaseSyncFns } from "./supabase";
@@ -290,8 +290,16 @@ export const SecretSyncFns = {
     switch (secretSync.destination) {
       case SecretSync.AWSParameterStore:
         return AwsParameterStoreSyncFns.syncSecrets(secretSync, payload);
-      case SecretSync.AWSSecretsManager:
-        return AwsSecretsManagerSyncFns.syncSecrets(secretSync, payload, payload);
+      case SecretSync.AWSSecretsManager: {
+        // The many-to-one mapping combines every secret into one AWS secret's JSON body under
+        // its own (unprefixed) key, so this destination genuinely needs both views: the
+        // schema-applied map for the one-to-one path, and a schema-free one for that JSON body.
+        // Re-flatten with no schema to keep this view's duplicate-name detection.
+        const unmodifiedPayload = createSecretSyncPayload(payload.all(), {
+          environment: secretSync.environment?.slug || ""
+        });
+        return AwsSecretsManagerSyncFns.syncSecrets(secretSync, payload.flatten(), unmodifiedPayload.flatten());
+      }
       case SecretSync.GitHub:
         return GithubSyncFns.syncSecrets(secretSync, payload, gatewayService, gatewayV2Service, gatewayPoolService, {
           gitHubAppDAL,
@@ -387,10 +395,16 @@ export const SecretSyncFns = {
         return CircleCISyncFns.syncSecrets(secretSync, payload);
       case SecretSync.AzureEntraIdScim:
         return AzureEntraIdScimSyncFns.syncSecrets(secretSync, payload, { appConnectionDAL, kmsService });
-      case SecretSync.ExternalInfisical:
-        // Key schema is intentionally not applied for Infisical-to-Infisical syncs to prevent
-        // infinite sync loops where the prefixed key triggers another sync cycle.
-        return ExternalInfisicalSyncFns.syncSecrets(secretSync, payload);
+      case SecretSync.ExternalInfisical: {
+        // Key schema must never be applied for Infisical-to-Infisical syncs, or the prefixed
+        // key triggers another sync cycle. Re-flatten with no schema rather than passing the
+        // payload through, since payload.flatten() would apply the schema this destination
+        // carries for every other provider.
+        const unschematizedPayload = createSecretSyncPayload(payload.all(), {
+          environment: secretSync.environment?.slug || ""
+        });
+        return ExternalInfisicalSyncFns.syncSecrets(secretSync, unschematizedPayload.flatten());
+      }
       case SecretSync.OVH:
         return OvhSyncFns.syncSecrets(secretSync, payload);
       case SecretSync.Devin:
@@ -710,10 +724,14 @@ export const SecretSyncFns = {
         return CircleCISyncFns.removeSecrets(secretSync, payload);
       case SecretSync.AzureEntraIdScim:
         return AzureEntraIdScimSyncFns.removeSecrets();
-      case SecretSync.ExternalInfisical:
-        // Key schema is intentionally not applied for Infisical-to-Infisical syncs to prevent
-        // infinite sync loops where the prefixed key triggers another sync cycle.
-        return ExternalInfisicalSyncFns.removeSecrets(secretSync, payload);
+      case SecretSync.ExternalInfisical: {
+        // See the matching case in syncSecrets: this destination always gets the raw,
+        // unschematized view, never payload.flatten().
+        const unschematizedPayload = createSecretSyncPayload(payload.all(), {
+          environment: secretSync.environment?.slug || ""
+        });
+        return ExternalInfisicalSyncFns.removeSecrets(secretSync, unschematizedPayload.flatten());
+      }
       case SecretSync.OVH:
         return OvhSyncFns.removeSecrets(secretSync, payload);
       case SecretSync.Devin:

--- a/backend/src/services/secret-sync/secret-sync-payload.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.test.ts
@@ -1,4 +1,9 @@
-import { createSecretSyncPayload, dedupeEntriesByDestinationKey, TSecretPayload } from "./secret-sync-payload";
+import {
+  createSecretSyncPayload,
+  dedupeEntriesByDestinationKey,
+  findFlattenConflicts,
+  TSecretPayload
+} from "./secret-sync-payload";
 
 const secret = (key: string, path: string, value = "v"): TSecretPayload => ({ key, path, value });
 
@@ -81,6 +86,43 @@ describe("createSecretSyncPayload", () => {
     });
 
     expect(() => payload.flatten()).not.toThrow();
+  });
+});
+
+describe("findFlattenConflicts", () => {
+  test("returns every conflict, uncapped, unlike flatten()'s thrown message", () => {
+    const secrets = Array.from({ length: 7 }, (_, i) => [secret(`K${i}`, "/"), secret(`K${i}`, "/api")]).flat();
+
+    const conflicts = findFlattenConflicts({ secrets, environment: "dev" });
+
+    expect(conflicts).toHaveLength(7);
+    expect(conflicts.map((c) => c.key).sort()).toEqual(["K0", "K1", "K2", "K3", "K4", "K5", "K6"]);
+  });
+
+  test("reports the destination key and every path it appears in", () => {
+    const conflicts = findFlattenConflicts({
+      secrets: [secret("DB_URL", "/backend"), secret("DB_URL", "/backend/api")],
+      environment: "dev"
+    });
+
+    expect(conflicts).toEqual([{ key: "DB_URL", paths: ["/backend", "/backend/api"] }]);
+  });
+
+  test("returns an empty array when there are no conflicts", () => {
+    expect(findFlattenConflicts({ secrets: [secret("DB_URL", "/")], environment: "dev" })).toEqual([]);
+  });
+
+  test("applySchema: false reports raw-key collisions instead of schema-applied ones", () => {
+    const conflicts = findFlattenConflicts(
+      {
+        secrets: [secret("DB_URL", "/backend"), secret("DB_URL", "/backend/api")],
+        environment: "dev",
+        keySchema: "{{environment}}_{{secretKey}}"
+      },
+      { applySchema: false }
+    );
+
+    expect(conflicts).toEqual([{ key: "DB_URL", paths: ["/backend", "/backend/api"] }]);
   });
 });
 

--- a/backend/src/services/secret-sync/secret-sync-payload.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.test.ts
@@ -1,4 +1,4 @@
-import { createSecretSyncPayload, TSecretPayload } from "./secret-sync-payload";
+import { createSecretSyncPayload, dedupeEntriesByDestinationKey, TSecretPayload } from "./secret-sync-payload";
 
 const secret = (key: string, path: string, value = "v"): TSecretPayload => ({ key, path, value });
 
@@ -61,6 +61,41 @@ describe("createSecretSyncPayload", () => {
       environment: "dev",
       keySchema: "{{secretKey}}"
     });
+
+    expect(() => payload.flatten()).not.toThrow();
+  });
+});
+
+describe("dedupeEntriesByDestinationKey", () => {
+  test("keeps one entry per destination key when two folders share a name", () => {
+    const deduped = dedupeEntriesByDestinationKey([secret("DB_URL", "/backend"), secret("DB_URL", "/backend/api")], {
+      environment: "dev"
+    });
+
+    expect(deduped).toHaveLength(1);
+  });
+
+  test("leaves distinct names untouched", () => {
+    const deduped = dedupeEntriesByDestinationKey([secret("DB_URL", "/"), secret("API_KEY", "/api")], {
+      environment: "dev"
+    });
+
+    expect(deduped.map((entry) => entry.key).sort()).toEqual(["API_KEY", "DB_URL"]);
+  });
+
+  test("dedupes by the schema-applied destination key, not the raw name", () => {
+    const deduped = dedupeEntriesByDestinationKey([secret("DB_URL", "/"), secret("dev_DB_URL", "/api")], {
+      environment: "dev",
+      keySchema: "{{secretKey}}"
+    });
+
+    expect(deduped).toHaveLength(2);
+  });
+
+  test("the deduped result never conflicts when flattened", () => {
+    const entries = [secret("DB_URL", "/backend", "one"), secret("DB_URL", "/backend/api", "two")];
+    const deduped = dedupeEntriesByDestinationKey(entries, { environment: "dev" });
+    const payload = createSecretSyncPayload(deduped, { environment: "dev" });
 
     expect(() => payload.flatten()).not.toThrow();
   });

--- a/backend/src/services/secret-sync/secret-sync-payload.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.test.ts
@@ -1,0 +1,67 @@
+import { createSecretSyncPayload, TSecretPayload } from "./secret-sync-payload";
+
+const secret = (key: string, path: string, value = "v"): TSecretPayload => ({ key, path, value });
+
+describe("createSecretSyncPayload", () => {
+  test("all() returns every secret, including ones that share a name", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/"), secret("DB_URL", "/api")], {
+      environment: "dev"
+    });
+
+    expect(payload.all()).toHaveLength(2);
+  });
+
+  test("flatten() returns one entry per secret when names are unique", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/", "one"), secret("API_KEY", "/api", "two")], {
+      environment: "dev"
+    });
+
+    expect(payload.flatten()).toEqual({
+      DB_URL: { value: "one", id: undefined, comment: undefined, secretMetadata: undefined },
+      API_KEY: { value: "two", id: undefined, comment: undefined, secretMetadata: undefined }
+    });
+  });
+
+  test("flatten() throws naming both folders when a name appears twice", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/backend"), secret("DB_URL", "/backend/api")], {
+      environment: "dev"
+    });
+
+    expect(() => payload.flatten()).toThrow(/"DB_URL" in \/backend and \/backend\/api/);
+  });
+
+  test("flatten() reports every conflict in one throw, capped at five with a remainder count", () => {
+    const secrets = Array.from({ length: 7 }, (_, i) => [secret(`K${i}`, "/"), secret(`K${i}`, "/api")]).flat();
+    const payload = createSecretSyncPayload(secrets, { environment: "dev" });
+
+    let message = "";
+    try {
+      payload.flatten();
+    } catch (err) {
+      message = (err as Error).message;
+    }
+
+    expect(message).toContain("K0");
+    expect(message).toContain("K4");
+    expect(message).not.toContain("K5");
+    expect(message).toContain("and 2 more");
+  });
+
+  test("flatten() applies the key schema to destination keys", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/")], {
+      environment: "dev",
+      keySchema: "{{environment}}_{{secretKey}}"
+    });
+
+    expect(Object.keys(payload.flatten())).toEqual(["dev_DB_URL"]);
+  });
+
+  test("flatten() does not treat a name that only resembles a schema-prefixed one as a conflict", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/"), secret("dev_DB_URL", "/api")], {
+      environment: "dev",
+      keySchema: "{{secretKey}}"
+    });
+
+    expect(() => payload.flatten()).not.toThrow();
+  });
+});

--- a/backend/src/services/secret-sync/secret-sync-payload.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.test.ts
@@ -3,12 +3,12 @@ import { createSecretSyncPayload, dedupeEntriesByDestinationKey, TSecretPayload 
 const secret = (key: string, path: string, value = "v"): TSecretPayload => ({ key, path, value });
 
 describe("createSecretSyncPayload", () => {
-  test("all() returns every secret, including ones that share a name", () => {
+  test("secrets includes every secret, including ones that share a name", () => {
     const payload = createSecretSyncPayload([secret("DB_URL", "/"), secret("DB_URL", "/api")], {
       environment: "dev"
     });
 
-    expect(payload.all()).toHaveLength(2);
+    expect(payload.secrets).toHaveLength(2);
   });
 
   test("flatten() returns one entry per secret when names are unique", () => {
@@ -54,6 +54,24 @@ describe("createSecretSyncPayload", () => {
     });
 
     expect(Object.keys(payload.flatten())).toEqual(["dev_DB_URL"]);
+  });
+
+  test("flatten({ applySchema: false }) ignores the key schema", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/")], {
+      environment: "dev",
+      keySchema: "{{environment}}_{{secretKey}}"
+    });
+
+    expect(Object.keys(payload.flatten({ applySchema: false }))).toEqual(["DB_URL"]);
+  });
+
+  test("flatten({ applySchema: false }) still rejects a raw-key collision", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/backend"), secret("DB_URL", "/backend/api")], {
+      environment: "dev",
+      keySchema: "{{environment}}_{{secretKey}}"
+    });
+
+    expect(() => payload.flatten({ applySchema: false })).toThrow(/"DB_URL" in \/backend and \/backend\/api/);
   });
 
   test("flatten() does not treat a name that only resembles a schema-prefixed one as a conflict", () => {

--- a/backend/src/services/secret-sync/secret-sync-payload.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.test.ts
@@ -87,6 +87,31 @@ describe("createSecretSyncPayload", () => {
 
     expect(() => payload.flatten()).not.toThrow();
   });
+
+  test("findConflicts() reports the same collisions as flatten() throws, without throwing", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/backend"), secret("DB_URL", "/backend/api")], {
+      environment: "dev"
+    });
+
+    expect(payload.findConflicts()).toEqual([{ key: "DB_URL", paths: ["/backend", "/backend/api"] }]);
+  });
+
+  test("findConflicts() returns an empty array when there are no conflicts", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/")], { environment: "dev" });
+
+    expect(payload.findConflicts()).toEqual([]);
+  });
+
+  test("findConflicts({ applySchema: false }) reports raw-key collisions instead of schema-applied ones", () => {
+    const payload = createSecretSyncPayload([secret("DB_URL", "/backend"), secret("DB_URL", "/backend/api")], {
+      environment: "dev",
+      keySchema: "{{environment}}_{{secretKey}}"
+    });
+
+    expect(payload.findConflicts({ applySchema: false })).toEqual([
+      { key: "DB_URL", paths: ["/backend", "/backend/api"] }
+    ]);
+  });
 });
 
 describe("findFlattenConflicts", () => {

--- a/backend/src/services/secret-sync/secret-sync-payload.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.ts
@@ -15,8 +15,9 @@ export type TSecretPayload = {
 };
 
 export type TSecretSyncPayload = {
-  all: () => TSecretPayload[];
-  flatten: () => TSecretMap;
+  secrets: TSecretPayload[];
+  environment: string;
+  flatten: (opts?: { applySchema?: boolean }) => TSecretMap;
 };
 
 export const getKeyWithSchema = ({
@@ -87,41 +88,42 @@ export const dedupeEntriesByDestinationKey = (
 export const createSecretSyncPayload = (
   secrets: TSecretPayload[],
   { environment, keySchema }: { environment: string; keySchema?: string }
-): TSecretSyncPayload => {
-  let flattened: TSecretMap | undefined;
+): TSecretSyncPayload => ({
+  secrets,
+  environment,
+  // A destination whose sync targets can't carry the configured key schema (eg a many-to-one
+  // JSON body whose fields are app-facing variable names, or an Infisical-to-Infisical sync,
+  // where a schema-renamed key would look like a new secret and retrigger a sync cycle) calls
+  // flatten({ applySchema: false }) to get the raw-key view instead. Either way flatten() still
+  // groups by the resulting destination key and rejects collisions, so duplicate-name detection
+  // never depends on whether the schema was applied.
+  flatten: ({ applySchema = true }: { applySchema?: boolean } = {}) => {
+    const schema = applySchema ? keySchema : undefined;
+    const grouped = new Map<string, TSecretPayload[]>();
 
-  return {
-    all: () => secrets,
-    flatten: () => {
-      if (flattened) return flattened;
+    for (const entry of secrets) {
+      const destinationKey = getKeyWithSchema({ key: entry.key, environment, schema });
+      const group = grouped.get(destinationKey);
 
-      const grouped = new Map<string, TSecretPayload[]>();
-
-      for (const entry of secrets) {
-        const destinationKey = getKeyWithSchema({ key: entry.key, environment, schema: keySchema });
-        const group = grouped.get(destinationKey);
-
-        if (group) group.push(entry);
-        else grouped.set(destinationKey, [entry]);
-      }
-
-      const conflicts = [...grouped.entries()].filter(([, group]) => group.length > 1);
-
-      if (conflicts.length) throw buildConflictError(conflicts);
-
-      const map: TSecretMap = {};
-
-      for (const [destinationKey, [entry]] of grouped) {
-        map[destinationKey] = {
-          value: entry.value,
-          id: entry.id,
-          comment: entry.comment,
-          secretMetadata: entry.secretMetadata
-        };
-      }
-
-      flattened = map;
-      return map;
+      if (group) group.push(entry);
+      else grouped.set(destinationKey, [entry]);
     }
-  };
-};
+
+    const conflicts = [...grouped.entries()].filter(([, group]) => group.length > 1);
+
+    if (conflicts.length) throw buildConflictError(conflicts);
+
+    const map: TSecretMap = {};
+
+    for (const [destinationKey, [entry]] of grouped) {
+      map[destinationKey] = {
+        value: entry.value,
+        id: entry.id,
+        comment: entry.comment,
+        secretMetadata: entry.secretMetadata
+      };
+    }
+
+    return map;
+  }
+});

--- a/backend/src/services/secret-sync/secret-sync-payload.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.ts
@@ -58,6 +58,32 @@ const buildConflictError = (conflicts: [string, TSecretPayload[]][]) => {
   });
 };
 
+// The remove path deletes by destination key and does not care which duplicate wins, so it
+// dedupes before the payload is built. That keeps flatten() itself unconditional: a sync that
+// has drifted into a duplicate-name state must still be removable, since deleteSyncOnComplete
+// only drops the sync row after a successful remove.
+export const dedupeEntriesByDestinationKey = (
+  entries: TSecretPayload[],
+  { environment, keySchema }: { environment: string; keySchema?: string }
+): TSecretPayload[] => {
+  const seenDestinationKeys = new Set<string>();
+  const deduped: TSecretPayload[] = [];
+
+  for (const entry of entries) {
+    const destinationKey = getKeyWithSchema({ key: entry.key, environment, schema: keySchema });
+
+    if (seenDestinationKeys.has(destinationKey)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    seenDestinationKeys.add(destinationKey);
+    deduped.push(entry);
+  }
+
+  return deduped;
+};
+
 export const createSecretSyncPayload = (
   secrets: TSecretPayload[],
   { environment, keySchema }: { environment: string; keySchema?: string }

--- a/backend/src/services/secret-sync/secret-sync-payload.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.ts
@@ -17,7 +17,13 @@ export type TSecretPayload = {
 export type TSecretSyncPayload = {
   secrets: TSecretPayload[];
   environment: string;
+  keySchema?: string;
   flatten: (opts?: { applySchema?: boolean }) => TSecretMap;
+};
+
+export type TSecretSyncConflict = {
+  key: string;
+  paths: string[];
 };
 
 export const getKeyWithSchema = ({
@@ -37,19 +43,43 @@ export const getKeyWithSchema = ({
   });
 };
 
-const buildConflictError = (conflicts: [string, TSecretPayload[]][]) => {
+const groupByDestinationKey = (
+  { secrets, environment }: Pick<TSecretSyncPayload, "secrets" | "environment">,
+  schema?: string
+): Map<string, TSecretPayload[]> => {
+  const grouped = new Map<string, TSecretPayload[]>();
+
+  for (const entry of secrets) {
+    const destinationKey = getKeyWithSchema({ key: entry.key, environment, schema });
+    const group = grouped.get(destinationKey);
+
+    if (group) group.push(entry);
+    else grouped.set(destinationKey, [entry]);
+  }
+
+  return grouped;
+};
+
+// Returns every destination-key collision, unordered and untruncated: the caller decides how much
+// of this to show. The recursive-conflicts preview endpoint sends the full list so the UI can
+// paginate/truncate it; flatten() below caps what it puts in a thrown error message.
+export const findFlattenConflicts = (
+  payload: Pick<TSecretSyncPayload, "secrets" | "environment" | "keySchema">,
+  { applySchema = true }: { applySchema?: boolean } = {}
+): TSecretSyncConflict[] => {
+  const schema = applySchema ? payload.keySchema : undefined;
+  const grouped = groupByDestinationKey(payload, schema);
+
+  return [...grouped.entries()]
+    .filter(([, group]) => group.length > 1)
+    .map(([key, group]) => ({ key, paths: group.map((entry) => entry.path).sort() }));
+};
+
+const buildConflictError = (conflicts: TSecretSyncConflict[]) => {
   const shown = conflicts.slice(0, MAX_REPORTED_KEY_CONFLICTS);
   const remainder = conflicts.length - shown.length;
 
-  const detail = shown
-    .map(
-      ([key, group]) =>
-        `"${key}" in ${group
-          .map((entry) => entry.path)
-          .sort()
-          .join(" and ")}`
-    )
-    .join("; ");
+  const detail = shown.map(({ key, paths }) => `"${key}" in ${paths.join(" and ")}`).join("; ");
 
   return new SecretSyncError({
     message: `This destination stores secrets in a single flat list, so each name can be used only once. These names are used in more than one folder: ${detail}${
@@ -91,6 +121,7 @@ export const createSecretSyncPayload = (
 ): TSecretSyncPayload => ({
   secrets,
   environment,
+  keySchema,
   // A destination whose sync targets can't carry the configured key schema (eg a many-to-one
   // JSON body whose fields are app-facing variable names, or an Infisical-to-Infisical sync,
   // where a schema-renamed key would look like a new secret and retrigger a sync cycle) calls
@@ -98,21 +129,12 @@ export const createSecretSyncPayload = (
   // groups by the resulting destination key and rejects collisions, so duplicate-name detection
   // never depends on whether the schema was applied.
   flatten: ({ applySchema = true }: { applySchema?: boolean } = {}) => {
-    const schema = applySchema ? keySchema : undefined;
-    const grouped = new Map<string, TSecretPayload[]>();
-
-    for (const entry of secrets) {
-      const destinationKey = getKeyWithSchema({ key: entry.key, environment, schema });
-      const group = grouped.get(destinationKey);
-
-      if (group) group.push(entry);
-      else grouped.set(destinationKey, [entry]);
-    }
-
-    const conflicts = [...grouped.entries()].filter(([, group]) => group.length > 1);
+    const conflicts = findFlattenConflicts({ secrets, environment, keySchema }, { applySchema });
 
     if (conflicts.length) throw buildConflictError(conflicts);
 
+    const schema = applySchema ? keySchema : undefined;
+    const grouped = groupByDestinationKey({ secrets, environment }, schema);
     const map: TSecretMap = {};
 
     for (const [destinationKey, [entry]] of grouped) {

--- a/backend/src/services/secret-sync/secret-sync-payload.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.ts
@@ -1,0 +1,101 @@
+import handlebars from "handlebars";
+
+import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
+import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
+
+export const MAX_REPORTED_KEY_CONFLICTS = 5;
+
+export type TSecretPayload = {
+  key: string;
+  path: string;
+  value: string;
+  id?: string;
+  comment?: string;
+  secretMetadata?: TSecretMap[string]["secretMetadata"];
+};
+
+export type TSecretSyncPayload = {
+  all: () => TSecretPayload[];
+  flatten: () => TSecretMap;
+};
+
+export const getKeyWithSchema = ({
+  key,
+  environment,
+  schema
+}: {
+  key: string;
+  environment: string;
+  schema?: string;
+}) => {
+  if (!schema) return key;
+
+  return handlebars.compile(schema)({
+    secretKey: key,
+    environment
+  });
+};
+
+const buildConflictError = (conflicts: [string, TSecretPayload[]][]) => {
+  const shown = conflicts.slice(0, MAX_REPORTED_KEY_CONFLICTS);
+  const remainder = conflicts.length - shown.length;
+
+  const detail = shown
+    .map(
+      ([key, group]) =>
+        `"${key}" in ${group
+          .map((entry) => entry.path)
+          .sort()
+          .join(" and ")}`
+    )
+    .join("; ");
+
+  return new SecretSyncError({
+    message: `This destination stores secrets in a single flat list, so each name can be used only once. These names are used in more than one folder: ${detail}${
+      remainder > 0 ? `, and ${remainder} more` : ""
+    }. Rename or move one secret in each pair, or point the sync at a narrower secret path.`,
+    shouldRetry: false
+  });
+};
+
+export const createSecretSyncPayload = (
+  secrets: TSecretPayload[],
+  { environment, keySchema }: { environment: string; keySchema?: string }
+): TSecretSyncPayload => {
+  let flattened: TSecretMap | undefined;
+
+  return {
+    all: () => secrets,
+    flatten: () => {
+      if (flattened) return flattened;
+
+      const grouped = new Map<string, TSecretPayload[]>();
+
+      for (const entry of secrets) {
+        const destinationKey = getKeyWithSchema({ key: entry.key, environment, schema: keySchema });
+        const group = grouped.get(destinationKey);
+
+        if (group) group.push(entry);
+        else grouped.set(destinationKey, [entry]);
+      }
+
+      const conflicts = [...grouped.entries()].filter(([, group]) => group.length > 1);
+
+      if (conflicts.length) throw buildConflictError(conflicts);
+
+      const map: TSecretMap = {};
+
+      for (const [destinationKey, [entry]] of grouped) {
+        map[destinationKey] = {
+          value: entry.value,
+          id: entry.id,
+          comment: entry.comment,
+          secretMetadata: entry.secretMetadata
+        };
+      }
+
+      flattened = map;
+      return map;
+    }
+  };
+};

--- a/backend/src/services/secret-sync/secret-sync-payload.ts
+++ b/backend/src/services/secret-sync/secret-sync-payload.ts
@@ -17,8 +17,8 @@ export type TSecretPayload = {
 export type TSecretSyncPayload = {
   secrets: TSecretPayload[];
   environment: string;
-  keySchema?: string;
   flatten: (opts?: { applySchema?: boolean }) => TSecretMap;
+  findConflicts: (opts?: { applySchema?: boolean }) => TSecretSyncConflict[];
 };
 
 export type TSecretSyncConflict = {
@@ -61,10 +61,11 @@ const groupByDestinationKey = (
 };
 
 // Returns every destination-key collision, unordered and untruncated: the caller decides how much
-// of this to show. The recursive-conflicts preview endpoint sends the full list so the UI can
-// paginate/truncate it; flatten() below caps what it puts in a thrown error message.
+// of this to show. findConflicts() below is the public way to reach this on a built payload; the
+// recursive-conflicts preview endpoint calls that method, not this function directly, so
+// keySchema never has to be a field the payload object exposes to its own callers.
 export const findFlattenConflicts = (
-  payload: Pick<TSecretSyncPayload, "secrets" | "environment" | "keySchema">,
+  payload: { secrets: TSecretPayload[]; environment: string; keySchema?: string },
   { applySchema = true }: { applySchema?: boolean } = {}
 ): TSecretSyncConflict[] => {
   const schema = applySchema ? payload.keySchema : undefined;
@@ -121,7 +122,6 @@ export const createSecretSyncPayload = (
 ): TSecretSyncPayload => ({
   secrets,
   environment,
-  keySchema,
   // A destination whose sync targets can't carry the configured key schema (eg a many-to-one
   // JSON body whose fields are app-facing variable names, or an Infisical-to-Infisical sync,
   // where a schema-renamed key would look like a new secret and retrigger a sync cycle) calls
@@ -147,5 +147,9 @@ export const createSecretSyncPayload = (
     }
 
     return map;
-  }
+  },
+  // keySchema itself is deliberately not a field on this object: nothing outside this module
+  // needs to read it directly, and findConflicts() is how an external caller (the
+  // recursive-conflicts preview endpoint) reaches the same check flatten() runs, without it.
+  findConflicts: (opts) => findFlattenConflicts({ secrets, environment, keySchema }, opts)
 });

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -44,7 +44,7 @@ import {
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { enterpriseSyncCheck, parseSyncErrorMessage, SecretSyncFns } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_DAILY_RETRY_DESTINATIONS, SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
-import { buildSyncPayload } from "@app/services/secret-sync/secret-sync-recursive-fns";
+import { buildSyncPayload, getAncestorPaths } from "@app/services/secret-sync/secret-sync-recursive-fns";
 import {
   SecretSyncAction,
   SecretSyncStatus,
@@ -1061,7 +1061,23 @@ export const secretSyncQueueFactory = ({
         `Could not find folder at path "${secretPath}" for environment with slug "${environmentSlug}" in project with ID "${projectId}"`
       );
 
-    const secretSyncs = await secretSyncDAL.find({ folderId: folder.id, isAutoSyncEnabled: true });
+    const ancestorPaths = getAncestorPaths(secretPath);
+
+    const ancestorFolders = (
+      await folderDAL.findByManySecretPath(ancestorPaths.map((path) => ({ envId: folder.envId, secretPath: path })))
+    ).filter((entry): entry is NonNullable<typeof entry> => Boolean(entry));
+
+    const candidateSyncs = await secretSyncDAL.find({
+      $in: { folderId: [...ancestorFolders.map((entry) => entry.id), folder.id] },
+      isAutoSyncEnabled: true
+    });
+
+    // A sync on the changed folder itself always matches, recursive or not. A sync on an
+    // ancestor folder only matches when it is recursive, so a non-recursive sync rooted above
+    // this path is never triggered by a write it was never configured to cover.
+    const secretSyncs = candidateSyncs.filter(
+      (sync) => sync.folderId === folder.id || Boolean((sync.syncOptions as { recursive?: boolean } | null)?.recursive)
+    );
 
     await secretSyncDAL.update(
       {

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -435,8 +435,8 @@ export const secretSyncQueueFactory = ({
 
     const importedSecretMap: TSecretMap = {};
 
-    // Task 5 blocks combining import behavior with a recursive sync, so this payload always
-    // covers exactly one folder. Comparison is against raw keys as returned by the destination
+    // Import behavior is never combined with a recursive sync, so this payload always covers
+    // exactly one folder. Comparison is against raw keys as returned by the destination
     // (already schema-stripped), so entries come from all() rather than the schema-applying flatten().
     const payload = await $getInfisicalSecrets(secretSync, false);
     const secretMap: TSecretMap = Object.fromEntries(

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -267,7 +267,8 @@ export const secretSyncQueueFactory = ({
 
   const $getInfisicalSecrets = async (
     secretSync: TSecretSyncRaw | TSecretSyncWithCredentials,
-    includeImports = true
+    includeImports = true,
+    dedupeForRemoval = false
   ) => {
     const { projectId, folderId, environment, folder } = secretSync;
 
@@ -325,7 +326,8 @@ export const secretSyncQueueFactory = ({
         sourceFolderId: folderId,
         recursive: Boolean(syncOptions?.recursive),
         keySchema: syncOptions?.keySchema,
-        includeImports
+        includeImports,
+        dedupeForRemoval
       }
     );
   };
@@ -833,7 +835,9 @@ export const secretSyncQueueFactory = ({
         projectId
       });
 
-      const payload = await $getInfisicalSecrets(secretSync);
+      // Duplicates across folders are deduped before the payload is built, so flatten() cannot
+      // throw here: a sync that has drifted into a duplicate-name state must still be removable.
+      const payload = await $getInfisicalSecrets(secretSync, true, true);
 
       await SecretSyncFns.removeSecrets(
         {

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -24,6 +24,7 @@ import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TProjectBotDALFactory } from "@app/services/project-bot/project-bot-dal";
+import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
 import { TProjectFolderGrantDALFactory } from "@app/services/project-folder-grant/project-folder-grant-dal";
 import { TProjectMembershipDALFactory } from "@app/services/project-membership/project-membership-dal";
 import { TResourceMetadataDALFactory } from "@app/services/resource-metadata/resource-metadata-dal";
@@ -34,7 +35,6 @@ import { TSecretVersionTagDALFactory } from "@app/services/secret/secret-version
 import { TSecretBlindIndexDALFactory } from "@app/services/secret-blind-index/secret-blind-index-dal";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
 import { TSecretImportDALFactory } from "@app/services/secret-import/secret-import-dal";
-import { fnSecretsV2FromImports } from "@app/services/secret-import/secret-import-fns";
 import { TSecretSyncDALFactory } from "@app/services/secret-sync/secret-sync-dal";
 import {
   SecretSync,
@@ -44,6 +44,7 @@ import {
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { enterpriseSyncCheck, parseSyncErrorMessage, SecretSyncFns } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_DAILY_RETRY_DESTINATIONS, SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
+import { buildSyncPayload } from "@app/services/secret-sync/secret-sync-recursive-fns";
 import {
   SecretSyncAction,
   SecretSyncStatus,
@@ -94,6 +95,7 @@ type TSecretSyncQueueFactoryDep = {
   keyStore: Pick<TKeyStoreFactory, "acquireLock" | "incrementByAndRefreshExpiryIfUnderLimit" | "decrementByOrDelete">;
   gitHubAppDAL: Pick<TGitHubAppDALFactory, "findOne">;
   folderDAL: TSecretFolderDALFactory;
+  projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne">;
   secretV2BridgeDAL: Pick<
     TSecretV2BridgeDALFactory,
     | "findByFolderId"
@@ -106,7 +108,7 @@ type TSecretSyncQueueFactoryDep = {
     | "deleteMany"
     | "invalidateSecretCacheByProjectId"
   >;
-  secretImportDAL: Pick<TSecretImportDALFactory, "find" | "findByFolderIds" | "findByIds">;
+  secretImportDAL: Pick<TSecretImportDALFactory, "findByFolderIds" | "findByIds">;
   secretSyncDAL: Pick<
     TSecretSyncDALFactory,
     "findById" | "find" | "updateById" | "deleteById" | "update" | "updateAndReturnIds"
@@ -162,6 +164,7 @@ export const secretSyncQueueFactory = ({
   gitHubAppDAL,
   keyStore,
   folderDAL,
+  projectEnvDAL,
   secretV2BridgeDAL,
   secretImportDAL,
   secretSyncDAL,
@@ -275,13 +278,12 @@ export const secretSyncQueueFactory = ({
         shouldRetry: false
       });
 
-    const secretMap: TSecretMap = {};
-
     const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
       type: KmsDataKey.SecretManager,
       projectId
     });
     const actorOrgId = secretSync.connection.orgId;
+    const syncOptions = secretSync.syncOptions as { recursive?: boolean; keySchema?: string } | undefined;
 
     const decryptSecretValue = (value?: Buffer | undefined | null) =>
       value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : "";
@@ -300,74 +302,32 @@ export const secretSyncQueueFactory = ({
       kmsService
     });
 
-    const secrets = await secretV2BridgeDAL.findByFolderId({ folderId });
-
-    await Promise.allSettled(
-      secrets.map(async (secret) => {
-        const secretKey = secret.key;
-        const secretValue = decryptSecretValue(secret.encryptedValue);
-        const expandedSecretValue = await expandSecretReferences({
-          environment: environment.slug,
-          secretPath: folder.path,
-          skipMultilineEncoding: secret.skipMultilineEncoding,
-          value: secretValue,
-          secretKey
-        });
-        secretMap[secretKey] = { value: expandedSecretValue || "", id: secret.id };
-
-        if (secret.encryptedComment) {
-          const commentValue = decryptSecretValue(secret.encryptedComment);
-          secretMap[secretKey].comment = commentValue;
-        }
-
-        secretMap[secretKey].skipMultilineEncoding = Boolean(secret.skipMultilineEncoding);
-        secretMap[secretKey].secretMetadata = secret.secretMetadata.map((el) => ({
-          isEncrypted: Boolean(el.encryptedValue),
-          key: el.key,
-          value: el.encryptedValue ? decryptSecretValue(el.encryptedValue) : el.value || ""
-        }));
-      })
-    );
-
-    if (!includeImports) return secretMap;
-
-    const secretImports = await secretImportDAL.find({ folderId, isReplication: false });
-
-    if (secretImports.length) {
-      const importedSecrets = await fnSecretsV2FromImports({
-        decryptor: decryptSecretValue,
+    return buildSyncPayload(
+      {
         folderDAL,
-        secretDAL: secretV2BridgeDAL,
-        expandSecretReferences,
+        projectEnvDAL,
+        secretV2BridgeDAL,
         secretImportDAL,
-        secretImports,
-        hasSecretAccess: () => true,
-        viewSecretValue: true,
-        projectId,
-        projectFolderGrantDAL,
-        actorOrgId,
-        orgDAL,
-        licenseService,
-        kmsService
-      });
-
-      for (let i = importedSecrets.length - 1; i >= 0; i -= 1) {
-        for (let j = 0; j < importedSecrets[i].secrets.length; j += 1) {
-          const importedSecret = importedSecrets[i].secrets[j];
-          if (!secretMap[importedSecret.key]) {
-            secretMap[importedSecret.key] = {
-              skipMultilineEncoding: importedSecret.skipMultilineEncoding,
-              comment: importedSecret.secretComment,
-              value: importedSecret.secretValue || "",
-              id: importedSecret.id,
-              secretMetadata: importedSecret.secretMetadata
-            };
-          }
+        expandSecretReferences,
+        decryptSecretValue,
+        fnSecretsV2FromImportsDeps: {
+          projectFolderGrantDAL,
+          actorOrgId,
+          orgDAL,
+          licenseService,
+          kmsService
         }
+      },
+      {
+        projectId,
+        environment: environment.slug,
+        sourcePath: folder.path,
+        sourceFolderId: folderId,
+        recursive: Boolean(syncOptions?.recursive),
+        keySchema: syncOptions?.keySchema,
+        includeImports
       }
-    }
-
-    return secretMap;
+    );
   };
 
   const queueSecretSyncSyncSecretsById = async (payload: TQueueSecretSyncSyncSecretsByIdDTO) => {
@@ -475,7 +435,18 @@ export const secretSyncQueueFactory = ({
 
     const importedSecretMap: TSecretMap = {};
 
-    const secretMap = await $getInfisicalSecrets(secretSync, false);
+    // Task 5 blocks combining import behavior with a recursive sync, so this payload always
+    // covers exactly one folder. Comparison is against raw keys as returned by the destination
+    // (already schema-stripped), so entries come from all() rather than the schema-applying flatten().
+    const payload = await $getInfisicalSecrets(secretSync, false);
+    const secretMap: TSecretMap = Object.fromEntries(
+      payload
+        .all()
+        .map((entry) => [
+          entry.key,
+          { value: entry.value, id: entry.id, comment: entry.comment, secretMetadata: entry.secretMetadata }
+        ])
+    );
 
     const secretsToCreate: Parameters<typeof $createManySecretsRawFn>[0]["secrets"] = [];
     const secretsToUpdate: Parameters<typeof $updateManySecretsRawFn>[0]["secrets"] = [];
@@ -577,22 +548,22 @@ export const secretSyncQueueFactory = ({
         syncOptions: { initialSyncBehavior }
       } = secretSyncWithCredentials;
 
-      const secretMap = await $getInfisicalSecrets(secretSync);
+      let payload = await $getInfisicalSecrets(secretSync);
 
       if (!lastSyncedAt && initialSyncBehavior !== SecretSyncInitialSyncBehavior.OverwriteDestination) {
-        const importedSecretMap = await $importSecrets(
+        await $importSecrets(
           secretSyncWithCredentials,
           initialSyncBehavior === SecretSyncInitialSyncBehavior.ImportPrioritizeSource
             ? SecretSyncImportBehavior.PrioritizeSource
             : SecretSyncImportBehavior.PrioritizeDestination
         );
 
-        Object.entries(importedSecretMap).forEach(([key, secretData]) => {
-          secretMap[key] = secretData;
-        });
+        // $importSecrets writes directly to the source folder, so the payload built above is
+        // stale. Re-read rather than merge in memory, since the payload is no longer a plain map.
+        payload = await $getInfisicalSecrets(secretSync);
       }
 
-      const result = await SecretSyncFns.syncSecrets(secretSyncWithCredentials, secretMap, {
+      const result = await SecretSyncFns.syncSecrets(secretSyncWithCredentials, payload, {
         appConnectionDAL,
         gitHubAppDAL,
         kmsService,
@@ -862,7 +833,7 @@ export const secretSyncQueueFactory = ({
         projectId
       });
 
-      const secretMap = await $getInfisicalSecrets(secretSync);
+      const payload = await $getInfisicalSecrets(secretSync);
 
       await SecretSyncFns.removeSecrets(
         {
@@ -872,7 +843,7 @@ export const secretSyncQueueFactory = ({
             credentials
           }
         } as TSecretSyncWithCredentials,
-        secretMap,
+        payload,
         {
           appConnectionDAL,
           gitHubAppDAL,

--- a/backend/src/services/secret-sync/secret-sync-queue.ts
+++ b/backend/src/services/secret-sync/secret-sync-queue.ts
@@ -439,15 +439,13 @@ export const secretSyncQueueFactory = ({
 
     // Import behavior is never combined with a recursive sync, so this payload always covers
     // exactly one folder. Comparison is against raw keys as returned by the destination
-    // (already schema-stripped), so entries come from all() rather than the schema-applying flatten().
+    // (already schema-stripped), so entries come from `secrets` rather than the schema-applying flatten().
     const payload = await $getInfisicalSecrets(secretSync, false);
     const secretMap: TSecretMap = Object.fromEntries(
-      payload
-        .all()
-        .map((entry) => [
-          entry.key,
-          { value: entry.value, id: entry.id, comment: entry.comment, secretMetadata: entry.secretMetadata }
-        ])
+      payload.secrets.map((entry) => [
+        entry.key,
+        { value: entry.value, id: entry.id, comment: entry.comment, secretMetadata: entry.secretMetadata }
+      ])
     );
 
     const secretsToCreate: Parameters<typeof $createManySecretsRawFn>[0]["secrets"] = [];

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
@@ -1,4 +1,10 @@
-import { assertWithinSecretLimit, mergeImportedSecrets, resolveSyncFolders, SECRET_SYNC_MAX_SECRETS } from "./secret-sync-recursive-fns";
+import {
+  assertWithinSecretLimit,
+  buildSyncPayload,
+  mergeImportedSecrets,
+  resolveSyncFolders,
+  SECRET_SYNC_MAX_SECRETS
+} from "./secret-sync-recursive-fns";
 
 const deps = {
   folderDAL: {
@@ -86,5 +92,98 @@ describe("mergeImportedSecrets", () => {
 
     expect(merged).toHaveLength(1);
     expect(merged[0].value).toBe("second");
+  });
+});
+
+describe("buildSyncPayload", () => {
+  test("two folders importing the same source both receive its secrets", async () => {
+    const sharedSecret = {
+      id: "secret-1",
+      key: "DB_URL",
+      folderId: "shared-folder",
+      encryptedValue: Buffer.from("shared-value"),
+      encryptedComment: null,
+      skipMultilineEncoding: false,
+      tags: [],
+      secretMetadata: []
+    };
+
+    const rootImport = {
+      id: "import-root",
+      folderId: "root",
+      importPath: "/shared",
+      importEnv: { id: "env-1", slug: "dev", name: "dev", projectId: "proj-1" },
+      isReplication: false,
+      isReserved: false,
+      position: 1
+    };
+
+    const apiImport = {
+      id: "import-api",
+      folderId: "api",
+      importPath: "/shared",
+      importEnv: { id: "env-1", slug: "dev", name: "dev", projectId: "proj-1" },
+      isReplication: false,
+      isReserved: false,
+      position: 1
+    };
+
+    const buildDeps = {
+      folderDAL: {
+        find: async () => [
+          { id: "root", name: "root", parentId: null, envId: "env-1", isReserved: false },
+          { id: "api", name: "api", parentId: "root", envId: "env-1", isReserved: false }
+        ],
+        findByManySecretPath: async (query: { envId: string; secretPath: string }[]) =>
+          query.map(() => ({
+            id: "shared-folder",
+            envId: "env-1",
+            path: "/shared",
+            name: "shared",
+            parentId: null,
+            isReserved: false
+          }))
+      },
+      projectEnvDAL: { findOne: async () => ({ id: "env-1", slug: "dev", projectId: "proj-1" }) },
+      secretV2BridgeDAL: {
+        findByFolderIds: async () => [],
+        find: async () => [sharedSecret]
+      },
+      secretImportDAL: {
+        findByFolderIds: async (folderIds: string[]) =>
+          [rootImport, apiImport].filter((row) => folderIds.includes(row.folderId)),
+        findByIds: async () => []
+      },
+      expandSecretReferences: async ({ value }: { value?: string }) => value,
+      decryptSecretValue: (value?: Buffer | null) => (value ? value.toString() : ""),
+      fnSecretsV2FromImportsDeps: {
+        projectFolderGrantDAL: { find: async () => [] },
+        actorOrgId: "org-1",
+        orgDAL: { findOrgById: async () => ({ allowCrossProjectSecretSharing: false }) },
+        licenseService: { getPlan: async () => ({ crossProjectSecretSharing: false }) },
+        kmsService: {
+          createCipherPairWithDataKey: async () => ({
+            decryptor: () => "",
+            encryptor: () => ({ cipherTextBlob: Buffer.from("") })
+          })
+        }
+      }
+    } as unknown as Parameters<typeof buildSyncPayload>[0];
+
+    const payload = await buildSyncPayload(buildDeps, {
+      projectId: "proj-1",
+      environment: "dev",
+      sourcePath: "/",
+      sourceFolderId: "root",
+      recursive: true,
+      includeImports: true
+    });
+
+    const paths = payload
+      .all()
+      .map((entry) => entry.path)
+      .sort();
+
+    expect(paths).toEqual(["/", "/api"]);
   });
 });

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
@@ -1,0 +1,51 @@
+import { assertWithinSecretLimit, resolveSyncFolders, SECRET_SYNC_MAX_SECRETS } from "./secret-sync-recursive-fns";
+
+const deps = {
+  folderDAL: {
+    find: async () => [
+      { id: "root", name: "root", parentId: null, envId: "env-1", isReserved: false },
+      { id: "api", name: "api", parentId: "root", envId: "env-1", isReserved: false }
+    ]
+  },
+  projectEnvDAL: { findOne: async () => ({ id: "env-1", slug: "dev", projectId: "proj-1" }) }
+} as unknown as Pick<Parameters<typeof resolveSyncFolders>[0], "folderDAL" | "projectEnvDAL">;
+
+describe("resolveSyncFolders", () => {
+  test("returns only the source folder when recursive is off", async () => {
+    const folders = await resolveSyncFolders({
+      ...deps,
+      projectId: "proj-1",
+      environment: "dev",
+      sourcePath: "/",
+      sourceFolderId: "root",
+      recursive: false
+    });
+
+    expect(folders).toEqual([{ folderId: "root", path: "/" }]);
+  });
+
+  test("returns the source folder and its descendants when recursive is on", async () => {
+    const folders = await resolveSyncFolders({
+      ...deps,
+      projectId: "proj-1",
+      environment: "dev",
+      sourcePath: "/",
+      sourceFolderId: "root",
+      recursive: true
+    });
+
+    expect(folders.map((folder) => folder.path).sort()).toEqual(["/", "/api"]);
+  });
+});
+
+describe("assertWithinSecretLimit", () => {
+  test("accepts a count at the limit", () => {
+    expect(() => assertWithinSecretLimit(SECRET_SYNC_MAX_SECRETS)).not.toThrow();
+  });
+
+  test("rejects a count above the limit with a message naming both numbers", () => {
+    expect(() => assertWithinSecretLimit(SECRET_SYNC_MAX_SECRETS + 1)).toThrow(
+      new RegExp(`${SECRET_SYNC_MAX_SECRETS + 1}.*${SECRET_SYNC_MAX_SECRETS}`)
+    );
+  });
+});

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
@@ -1,6 +1,7 @@
 import {
   assertWithinSecretLimit,
   buildSyncPayload,
+  getAncestorPaths,
   mergeImportedSecrets,
   resolveSyncFolders,
   SECRET_SYNC_MAX_SECRETS
@@ -41,6 +42,20 @@ describe("resolveSyncFolders", () => {
     });
 
     expect(folders.map((folder) => folder.path).sort()).toEqual(["/", "/api"]);
+  });
+});
+
+describe("getAncestorPaths", () => {
+  test("returns the root for a top-level path", () => {
+    expect(getAncestorPaths("/")).toEqual([]);
+  });
+
+  test("returns every ancestor, closest last", () => {
+    expect(getAncestorPaths("/backend/api/v2")).toEqual(["/", "/backend", "/backend/api"]);
+  });
+
+  test("returns the root for a single-segment path", () => {
+    expect(getAncestorPaths("/backend")).toEqual(["/"]);
   });
 });
 

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
@@ -54,6 +54,47 @@ describe("getAncestorPaths", () => {
     expect(getAncestorPaths("/backend/api/v2")).toEqual(["/", "/backend", "/backend/api"]);
   });
 
+  test("never includes the path itself", () => {
+    for (const path of ["/", "/backend", "/backend/api", "/backend/api/v2"]) {
+      expect(getAncestorPaths(path)).not.toContain(path);
+    }
+  });
+
+  test("returns one fewer entry than the path has segments", () => {
+    expect(getAncestorPaths("/a")).toHaveLength(1);
+    expect(getAncestorPaths("/a/b")).toHaveLength(2);
+    expect(getAncestorPaths("/a/b/c")).toHaveLength(3);
+    expect(getAncestorPaths("/a/b/c/d")).toHaveLength(4);
+  });
+
+  test("treats a trailing slash as the same path", () => {
+    expect(getAncestorPaths("/backend/api/")).toEqual(getAncestorPaths("/backend/api"));
+  });
+
+  test("tolerates repeated separators", () => {
+    expect(getAncestorPaths("/backend//api")).toEqual(getAncestorPaths("/backend/api"));
+  });
+
+  test("returns an empty list for inputs that name no folder", () => {
+    // The queue passes whatever path the write carried. An empty result must mean
+    // "no ancestors to consider", never a lookup for a folder that cannot exist.
+    expect(getAncestorPaths("")).toEqual([]);
+    expect(getAncestorPaths("//")).toEqual([]);
+  });
+
+  test("every returned path is absolute and free of a trailing slash", () => {
+    for (const ancestor of getAncestorPaths("/a/b/c/d")) {
+      expect(ancestor.startsWith("/")).toBe(true);
+      if (ancestor !== "/") expect(ancestor.endsWith("/")).toBe(false);
+    }
+  });
+
+  test("returns the root exactly once, and only as the first entry", () => {
+    const ancestors = getAncestorPaths("/a/b/c");
+    expect(ancestors.filter((entry) => entry === "/")).toHaveLength(1);
+    expect(ancestors[0]).toBe("/");
+  });
+
   test("returns the root for a single-segment path", () => {
     expect(getAncestorPaths("/backend")).toEqual(["/"]);
   });

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
@@ -187,3 +187,73 @@ describe("buildSyncPayload", () => {
     expect(paths).toEqual(["/", "/api"]);
   });
 });
+
+describe("buildSyncPayload dedupeForRemoval", () => {
+  const duplicateNameSecret = (folderId: string, value: string) => ({
+    id: `secret-${folderId}`,
+    key: "DB_URL",
+    folderId,
+    encryptedValue: Buffer.from(value),
+    encryptedComment: null,
+    skipMultilineEncoding: false,
+    tags: [],
+    secretMetadata: []
+  });
+
+  const dedupeDeps = {
+    folderDAL: {
+      find: async () => [
+        { id: "root", name: "root", parentId: null, envId: "env-1", isReserved: false },
+        { id: "api", name: "api", parentId: "root", envId: "env-1", isReserved: false }
+      ]
+    },
+    projectEnvDAL: { findOne: async () => ({ id: "env-1", slug: "dev", projectId: "proj-1" }) },
+    secretV2BridgeDAL: {
+      findByFolderIds: async () => [duplicateNameSecret("root", "root-value"), duplicateNameSecret("api", "api-value")]
+    },
+    secretImportDAL: {
+      findByFolderIds: async () => [],
+      findByIds: async () => []
+    },
+    expandSecretReferences: async ({ value }: { value?: string }) => value,
+    decryptSecretValue: (value?: Buffer | null) => (value ? value.toString() : ""),
+    fnSecretsV2FromImportsDeps: {
+      projectFolderGrantDAL: { find: async () => [] },
+      actorOrgId: "org-1",
+      orgDAL: { findOrgById: async () => ({ allowCrossProjectSecretSharing: false }) },
+      licenseService: { getPlan: async () => ({ crossProjectSecretSharing: false }) },
+      kmsService: {
+        createCipherPairWithDataKey: async () => ({
+          decryptor: () => "",
+          encryptor: () => ({ cipherTextBlob: Buffer.from("") })
+        })
+      }
+    }
+  } as unknown as Parameters<typeof buildSyncPayload>[0];
+
+  const args = {
+    projectId: "proj-1",
+    environment: "dev",
+    sourcePath: "/",
+    sourceFolderId: "root",
+    recursive: true,
+    includeImports: true
+  };
+
+  // Pins the sync-path requirement from the same bug: a name used in two folders must still
+  // fail loudly on this path, since only the remove path may look past it.
+  test("a cross-folder duplicate name still throws when dedupeForRemoval is not set", async () => {
+    const payload = await buildSyncPayload(dedupeDeps, args);
+
+    expect(() => payload.flatten()).toThrow(/DB_URL/);
+  });
+
+  // A sync whose secrets collide across folders would otherwise be stuck: it fails to sync,
+  // and until this test, it also failed to remove, which is the only way to delete it.
+  test("dedupeForRemoval lets the remove path complete despite the same duplicate", async () => {
+    const payload = await buildSyncPayload(dedupeDeps, { ...args, dedupeForRemoval: true });
+
+    expect(() => payload.flatten()).not.toThrow();
+    expect(Object.keys(payload.flatten())).toEqual(["DB_URL"]);
+  });
+});

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
@@ -1,4 +1,4 @@
-import { assertWithinSecretLimit, resolveSyncFolders, SECRET_SYNC_MAX_SECRETS } from "./secret-sync-recursive-fns";
+import { assertWithinSecretLimit, mergeImportedSecrets, resolveSyncFolders, SECRET_SYNC_MAX_SECRETS } from "./secret-sync-recursive-fns";
 
 const deps = {
   folderDAL: {
@@ -47,5 +47,44 @@ describe("assertWithinSecretLimit", () => {
     expect(() => assertWithinSecretLimit(SECRET_SYNC_MAX_SECRETS + 1)).toThrow(
       new RegExp(`${SECRET_SYNC_MAX_SECRETS + 1}.*${SECRET_SYNC_MAX_SECRETS}`)
     );
+  });
+});
+
+describe("mergeImportedSecrets", () => {
+  const imported = (key: string, secretValue: string) => ({ key, secretValue }) as never;
+
+  test("a folder's own secret beats one it imported", () => {
+    const merged = mergeImportedSecrets(
+      [{ key: "DB_URL", path: "/backend", value: "local" }],
+      [{ path: "/backend", secrets: [imported("DB_URL", "remote")] }]
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].value).toBe("local");
+  });
+
+  test("the same name imported into two folders yields two entries", () => {
+    const merged = mergeImportedSecrets(
+      [],
+      [
+        { path: "/backend", secrets: [imported("DB_URL", "one")] },
+        { path: "/backend/api", secrets: [imported("DB_URL", "two")] }
+      ]
+    );
+
+    expect(merged.map((entry) => entry.path).sort()).toEqual(["/backend", "/backend/api"]);
+  });
+
+  test("a later import wins over an earlier one in the same folder, as today", () => {
+    const merged = mergeImportedSecrets(
+      [],
+      [
+        { path: "/backend", secrets: [imported("DB_URL", "first")] },
+        { path: "/backend", secrets: [imported("DB_URL", "second")] }
+      ]
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].value).toBe("second");
   });
 });

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
@@ -106,9 +106,19 @@ describe("assertWithinSecretLimit", () => {
   });
 
   test("rejects a count above the limit with a message naming both numbers", () => {
-    expect(() => assertWithinSecretLimit(SECRET_SYNC_MAX_SECRETS + 1)).toThrow(
-      new RegExp(`${SECRET_SYNC_MAX_SECRETS + 1}.*${SECRET_SYNC_MAX_SECRETS}`)
-    );
+    let error: unknown;
+    try {
+      assertWithinSecretLimit(SECRET_SYNC_MAX_SECRETS + 1);
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    const message = (error as Error).message;
+    const overIndex = message.indexOf(String(SECRET_SYNC_MAX_SECRETS + 1));
+    const limitIndex = message.indexOf(String(SECRET_SYNC_MAX_SECRETS), overIndex + 1);
+    expect(overIndex).toBeGreaterThanOrEqual(0);
+    expect(limitIndex).toBeGreaterThan(overIndex);
   });
 });
 

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.test.ts
@@ -114,7 +114,7 @@ describe("assertWithinSecretLimit", () => {
     }
 
     expect(error).toBeInstanceOf(Error);
-    const message = (error as Error).message;
+    const { message } = error as Error;
     const overIndex = message.indexOf(String(SECRET_SYNC_MAX_SECRETS + 1));
     const limitIndex = message.indexOf(String(SECRET_SYNC_MAX_SECRETS), overIndex + 1);
     expect(overIndex).toBeGreaterThanOrEqual(0);
@@ -245,10 +245,7 @@ describe("buildSyncPayload", () => {
       includeImports: true
     });
 
-    const paths = payload
-      .all()
-      .map((entry) => entry.path)
-      .sort();
+    const paths = payload.secrets.map((entry) => entry.path).sort();
 
     expect(paths).toEqual(["/", "/api"]);
   });

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
@@ -30,6 +30,12 @@ export type TFnSecretsV2FromImportsDeps = {
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
 };
 
+export const getAncestorPaths = (path: string): string[] => {
+  const segments = path.split("/").filter(Boolean);
+
+  return segments.map((_, index) => (index === 0 ? "/" : `/${segments.slice(0, index).join("/")}`));
+};
+
 export const SECRET_SYNC_MAX_SECRETS = 10_000;
 
 export const assertWithinSecretLimit = (count: number) => {

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
@@ -1,4 +1,5 @@
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { groupBy } from "@app/lib/fn";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
@@ -108,7 +109,7 @@ export const buildSyncPayload = async (
   deps: {
     folderDAL: Pick<TSecretFolderDALFactory, "find" | "findByManySecretPath">;
     projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne">;
-    secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "findByFolderIds" | "find">;
+    secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "findByFolderId" | "findByFolderIds" | "find">;
     secretImportDAL: Pick<TSecretImportDALFactory, "findByFolderIds" | "findByIds">;
     expandSecretReferences: TExpandSecretReferences;
     decryptSecretValue: (value?: Buffer | null) => string;
@@ -140,7 +141,14 @@ export const buildSyncPayload = async (
 
   const pathByFolderId = new Map(folders.map(({ folderId, path }) => [folderId, path]));
 
-  const secrets = await secretV2BridgeDAL.findByFolderIds({ folderIds: folders.map(({ folderId }) => folderId) });
+  // findByFolderIds joins tags, metadata, rotation, honey token, reminder, recipients and users
+  // plus a DENSE_RANK window, so it costs far more than the three narrow queries findByFolderId
+  // runs. Every non-recursive sync (the vast majority today) hits this path, so it keeps using
+  // the cheaper single-folder read; only a genuinely multi-folder subtree pays for the join.
+  const secrets =
+    folders.length === 1
+      ? await secretV2BridgeDAL.findByFolderId({ folderId: folders[0].folderId })
+      : await secretV2BridgeDAL.findByFolderIds({ folderIds: folders.map(({ folderId }) => folderId) });
 
   assertWithinSecretLimit(secrets.length);
 
@@ -182,18 +190,31 @@ export const buildSyncPayload = async (
   let allEntries = entries;
 
   if (secretImports.length) {
-    const importedSecrets = await fnSecretsV2FromImports({
-      decryptor: decryptSecretValue,
-      folderDAL,
-      secretDAL: secretV2BridgeDAL,
-      expandSecretReferences,
-      secretImportDAL,
-      secretImports,
-      hasSecretAccess: () => true,
-      viewSecretValue: true,
-      projectId,
-      ...deps.fnSecretsV2FromImportsDeps
-    });
+    // fnSecretsV2FromImports dedupes by (importEnv, importPath) across the whole batch it is
+    // given, keeping one result row per source. Two folders importing the same source in one
+    // batched call would collapse to a single importFolderId, silently dropping the other
+    // folder's copy from the payload. Calling it once per declaring folder keeps each call's
+    // dedup scoped to that folder's own imports, so every declaring folder gets its own result.
+    const importsByDeclaringFolder = groupBy(secretImports, (secretImport) => secretImport.folderId);
+
+    const importedSecrets = (
+      await Promise.all(
+        Object.values(importsByDeclaringFolder).map((declaringFolderImports) =>
+          fnSecretsV2FromImports({
+            decryptor: decryptSecretValue,
+            folderDAL,
+            secretDAL: secretV2BridgeDAL,
+            expandSecretReferences,
+            secretImportDAL,
+            secretImports: declaringFolderImports,
+            hasSecretAccess: () => true,
+            viewSecretValue: true,
+            projectId,
+            ...deps.fnSecretsV2FromImportsDeps
+          })
+        )
+      )
+    ).flat();
 
     allEntries = mergeImportedSecrets(
       entries,

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
@@ -1,7 +1,11 @@
 import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
+import { fnSecretsV2FromImports } from "@app/services/secret-import/secret-import-fns";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
+import { TSecretPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { recursivelyGetSecretPaths } from "@app/services/secret-v2-bridge/secret-v2-bridge-fns";
+
+type TImportedSecret = Awaited<ReturnType<typeof fnSecretsV2FromImports>>[number]["secrets"][number];
 
 export const SECRET_SYNC_MAX_SECRETS = 10_000;
 
@@ -49,4 +53,32 @@ export const resolveSyncFolders = async ({
   }
 
   return paths.map(({ folderId, path }) => ({ folderId, path }));
+};
+
+export const mergeImportedSecrets = (
+  localEntries: TSecretPayload[],
+  importsByFolder: { path: string; secrets: TImportedSecret[] }[]
+): TSecretPayload[] => {
+  const merged = [...localEntries];
+
+  for (let i = importsByFolder.length - 1; i >= 0; i -= 1) {
+    const { path, secrets } = importsByFolder[i];
+    const claimedInFolder = new Set(merged.filter((entry) => entry.path === path).map((entry) => entry.key));
+
+    for (const imported of secrets) {
+      if (claimedInFolder.has(imported.key)) continue;
+
+      claimedInFolder.add(imported.key);
+      merged.push({
+        key: imported.key,
+        path,
+        value: imported.secretValue || "",
+        id: imported.id,
+        comment: imported.secretComment,
+        secretMetadata: imported.secretMetadata
+      });
+    }
+  }
+
+  return merged;
 };

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
@@ -10,6 +10,7 @@ import { fnSecretsV2FromImports } from "@app/services/secret-import/secret-impor
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import {
   createSecretSyncPayload,
+  dedupeEntriesByDestinationKey,
   TSecretPayload,
   TSecretSyncPayload
 } from "@app/services/secret-sync/secret-sync-payload";
@@ -123,11 +124,15 @@ export const buildSyncPayload = async (
     recursive: boolean;
     keySchema?: string;
     includeImports: boolean;
+    // The remove path passes true so a duplicate name across folders cannot leave the sync
+    // undeletable; every other caller must keep the duplicate-name check intact.
+    dedupeForRemoval?: boolean;
   }
 ): Promise<TSecretSyncPayload> => {
   const { folderDAL, projectEnvDAL, secretV2BridgeDAL, secretImportDAL, expandSecretReferences, decryptSecretValue } =
     deps;
-  const { projectId, environment, sourcePath, sourceFolderId, recursive, keySchema, includeImports } = args;
+  const { projectId, environment, sourcePath, sourceFolderId, recursive, keySchema, includeImports, dedupeForRemoval } =
+    args;
 
   const folders = await resolveSyncFolders({
     folderDAL,
@@ -182,7 +187,10 @@ export const buildSyncPayload = async (
   );
 
   if (!includeImports) {
-    return createSecretSyncPayload(entries, { environment, keySchema });
+    return createSecretSyncPayload(
+      dedupeForRemoval ? dedupeEntriesByDestinationKey(entries, { environment, keySchema }) : entries,
+      { environment, keySchema }
+    );
   }
 
   const secretImports = await secretImportDAL.findByFolderIds(folders.map(({ folderId }) => folderId));
@@ -227,5 +235,8 @@ export const buildSyncPayload = async (
     assertWithinSecretLimit(allEntries.length);
   }
 
-  return createSecretSyncPayload(allEntries, { environment, keySchema });
+  return createSecretSyncPayload(
+    dedupeForRemoval ? dedupeEntriesByDestinationKey(allEntries, { environment, keySchema }) : allEntries,
+    { environment, keySchema }
+  );
 };

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
@@ -36,7 +36,10 @@ export const getAncestorPaths = (path: string): string[] => {
   return segments.map((_, index) => (index === 0 ? "/" : `/${segments.slice(0, index).join("/")}`));
 };
 
-export const SECRET_SYNC_MAX_SECRETS = 10_000;
+// buildSyncPayload expands secret references for every secret concurrently
+// (Promise.allSettled below), and expansion can hit the DB per secret. Kept low against a
+// 10-connection pool; raise it if customers need more room and the concurrency is bounded first.
+export const SECRET_SYNC_MAX_SECRETS = 100;
 
 export const assertWithinSecretLimit = (count: number) => {
   if (count <= SECRET_SYNC_MAX_SECRETS) return;

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
@@ -1,0 +1,52 @@
+import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
+import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
+import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
+import { recursivelyGetSecretPaths } from "@app/services/secret-v2-bridge/secret-v2-bridge-fns";
+
+export const SECRET_SYNC_MAX_SECRETS = 10_000;
+
+export const assertWithinSecretLimit = (count: number) => {
+  if (count <= SECRET_SYNC_MAX_SECRETS) return;
+
+  throw new SecretSyncError({
+    message: `This sync covers ${count} secrets, which is above the limit of ${SECRET_SYNC_MAX_SECRETS} for a single sync. Point the sync at a narrower secret path, or split it into several syncs.`,
+    shouldRetry: false
+  });
+};
+
+export const resolveSyncFolders = async ({
+  folderDAL,
+  projectEnvDAL,
+  projectId,
+  environment,
+  sourcePath,
+  sourceFolderId,
+  recursive
+}: {
+  folderDAL: Pick<TSecretFolderDALFactory, "find">;
+  projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne">;
+  projectId: string;
+  environment: string;
+  sourcePath: string;
+  sourceFolderId: string;
+  recursive: boolean;
+}): Promise<{ folderId: string; path: string }[]> => {
+  if (!recursive) return [{ folderId: sourceFolderId, path: sourcePath }];
+
+  const paths = await recursivelyGetSecretPaths({
+    folderDAL,
+    projectEnvDAL,
+    projectId,
+    environment,
+    currentPath: sourcePath
+  });
+
+  if (!paths.length) {
+    throw new SecretSyncError({
+      message: `Could not find the folder "${sourcePath}" in environment "${environment}". Update the sync's source environment and secret path.`,
+      shouldRetry: false
+    });
+  }
+
+  return paths.map(({ folderId, path }) => ({ folderId, path }));
+};

--- a/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
+++ b/backend/src/services/secret-sync/secret-sync-recursive-fns.ts
@@ -1,11 +1,32 @@
+import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
+import { TKmsServiceFactory } from "@app/services/kms/kms-service";
+import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
-import { fnSecretsV2FromImports } from "@app/services/secret-import/secret-import-fns";
+import { TProjectFolderGrantDALFactory } from "@app/services/project-folder-grant/project-folder-grant-dal";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
+import { TSecretImportDALFactory } from "@app/services/secret-import/secret-import-dal";
+import { fnSecretsV2FromImports } from "@app/services/secret-import/secret-import-fns";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
-import { TSecretPayload } from "@app/services/secret-sync/secret-sync-payload";
+import {
+  createSecretSyncPayload,
+  TSecretPayload,
+  TSecretSyncPayload
+} from "@app/services/secret-sync/secret-sync-payload";
+import { expandSecretReferencesFactory } from "@app/services/secret-v2-bridge/secret-reference-fns";
+import { TSecretV2BridgeDALFactory } from "@app/services/secret-v2-bridge/secret-v2-bridge-dal";
 import { recursivelyGetSecretPaths } from "@app/services/secret-v2-bridge/secret-v2-bridge-fns";
 
 type TImportedSecret = Awaited<ReturnType<typeof fnSecretsV2FromImports>>[number]["secrets"][number];
+
+type TExpandSecretReferences = ReturnType<typeof expandSecretReferencesFactory>["expandSecretReferences"];
+
+export type TFnSecretsV2FromImportsDeps = {
+  projectFolderGrantDAL: Pick<TProjectFolderGrantDALFactory, "find">;
+  actorOrgId: string;
+  orgDAL: Pick<TOrgDALFactory, "findOrgById">;
+  licenseService: Pick<TLicenseServiceFactory, "getPlan">;
+  kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
+};
 
 export const SECRET_SYNC_MAX_SECRETS = 10_000;
 
@@ -81,4 +102,109 @@ export const mergeImportedSecrets = (
   }
 
   return merged;
+};
+
+export const buildSyncPayload = async (
+  deps: {
+    folderDAL: Pick<TSecretFolderDALFactory, "find" | "findByManySecretPath">;
+    projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne">;
+    secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "findByFolderIds" | "find">;
+    secretImportDAL: Pick<TSecretImportDALFactory, "findByFolderIds" | "findByIds">;
+    expandSecretReferences: TExpandSecretReferences;
+    decryptSecretValue: (value?: Buffer | null) => string;
+    fnSecretsV2FromImportsDeps: TFnSecretsV2FromImportsDeps;
+  },
+  args: {
+    projectId: string;
+    environment: string;
+    sourcePath: string;
+    sourceFolderId: string;
+    recursive: boolean;
+    keySchema?: string;
+    includeImports: boolean;
+  }
+): Promise<TSecretSyncPayload> => {
+  const { folderDAL, projectEnvDAL, secretV2BridgeDAL, secretImportDAL, expandSecretReferences, decryptSecretValue } =
+    deps;
+  const { projectId, environment, sourcePath, sourceFolderId, recursive, keySchema, includeImports } = args;
+
+  const folders = await resolveSyncFolders({
+    folderDAL,
+    projectEnvDAL,
+    projectId,
+    environment,
+    sourcePath,
+    sourceFolderId,
+    recursive
+  });
+
+  const pathByFolderId = new Map(folders.map(({ folderId, path }) => [folderId, path]));
+
+  const secrets = await secretV2BridgeDAL.findByFolderIds({ folderIds: folders.map(({ folderId }) => folderId) });
+
+  assertWithinSecretLimit(secrets.length);
+
+  const entries: TSecretPayload[] = [];
+
+  await Promise.allSettled(
+    secrets.map(async (secret) => {
+      const secretPath = pathByFolderId.get(secret.folderId) ?? sourcePath;
+      const secretValue = decryptSecretValue(secret.encryptedValue);
+      const expandedSecretValue = await expandSecretReferences({
+        environment,
+        secretPath,
+        skipMultilineEncoding: secret.skipMultilineEncoding,
+        value: secretValue,
+        secretKey: secret.key
+      });
+
+      entries.push({
+        key: secret.key,
+        path: secretPath,
+        value: expandedSecretValue || "",
+        id: secret.id,
+        comment: secret.encryptedComment ? decryptSecretValue(secret.encryptedComment) : undefined,
+        secretMetadata: secret.secretMetadata.map((el) => ({
+          isEncrypted: Boolean(el.encryptedValue),
+          key: el.key,
+          value: el.encryptedValue ? decryptSecretValue(el.encryptedValue) : el.value || ""
+        }))
+      });
+    })
+  );
+
+  if (!includeImports) {
+    return createSecretSyncPayload(entries, { environment, keySchema });
+  }
+
+  const secretImports = await secretImportDAL.findByFolderIds(folders.map(({ folderId }) => folderId));
+
+  let allEntries = entries;
+
+  if (secretImports.length) {
+    const importedSecrets = await fnSecretsV2FromImports({
+      decryptor: decryptSecretValue,
+      folderDAL,
+      secretDAL: secretV2BridgeDAL,
+      expandSecretReferences,
+      secretImportDAL,
+      secretImports,
+      hasSecretAccess: () => true,
+      viewSecretValue: true,
+      projectId,
+      ...deps.fnSecretsV2FromImportsDeps
+    });
+
+    allEntries = mergeImportedSecrets(
+      entries,
+      importedSecrets.map((group) => ({
+        path: pathByFolderId.get(group.importFolderId) ?? sourcePath,
+        secrets: group.secrets
+      }))
+    );
+
+    assertWithinSecretLimit(allEntries.length);
+  }
+
+  return createSecretSyncPayload(allEntries, { environment, keySchema });
 };

--- a/backend/src/services/secret-sync/secret-sync-schemas.test.ts
+++ b/backend/src/services/secret-sync/secret-sync-schemas.test.ts
@@ -1,0 +1,31 @@
+import { SecretSync, SecretSyncInitialSyncBehavior } from "./secret-sync-enums";
+import { BaseSecretSyncSchema } from "./secret-sync-schemas";
+
+const schema = BaseSecretSyncSchema(SecretSync.Render, { canImportSecrets: true }).shape.syncOptions;
+
+describe("BaseSyncOptionsSchema recursive", () => {
+  test("defaults to absent, which means non-recursive", () => {
+    const result = schema.safeParse({ initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination });
+
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.recursive).toBeUndefined();
+  });
+
+  test("accepts recursive with the overwrite behavior", () => {
+    const result = schema.safeParse({
+      initialSyncBehavior: SecretSyncInitialSyncBehavior.OverwriteDestination,
+      recursive: true
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects recursive combined with importing from the destination", () => {
+    const result = schema.safeParse({
+      initialSyncBehavior: SecretSyncInitialSyncBehavior.ImportPrioritizeSource,
+      recursive: true
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/backend/src/services/secret-sync/secret-sync-schemas.ts
+++ b/backend/src/services/secret-sync/secret-sync-schemas.ts
@@ -63,16 +63,29 @@ const BaseSyncOptionsSchema = <T extends AnyZodObject | undefined = undefined>({
           .describe(`Not supported for ${syncName} syncs.`),
     disableSecretDeletion: supportsDisableSecretDeletion
       ? z.boolean().optional().describe(SecretSyncs.SYNC_OPTIONS(destination).disableSecretDeletion)
-      : z.literal(false).or(z.undefined()).describe(`Not supported for ${syncName} syncs.`)
+      : z.literal(false).or(z.undefined()).describe(`Not supported for ${syncName} syncs.`),
+    recursive: z.boolean().optional().describe(SecretSyncs.SYNC_OPTIONS(destination).recursive)
   });
 
   const schema = merge ? baseSchema.merge(merge) : baseSchema;
 
+  const refinedSchema = (schema as AnyZodObject).refine(
+    (options) =>
+      !options.recursive || options.initialSyncBehavior === SecretSyncInitialSyncBehavior.OverwriteDestination,
+    {
+      path: ["recursive"],
+      message:
+        "A sync that includes subfolders cannot also import existing secrets from the destination, because there is no single folder to import them into. Turn off subfolders, or set the first sync to overwrite the destination."
+    }
+  );
+
   return (
     isUpdateSchema
-      ? schema.describe(SecretSyncs.UPDATE(destination).syncOptions).optional()
-      : schema.describe(SecretSyncs.CREATE(destination).syncOptions)
-  ) as T extends AnyZodObject ? z.ZodObject<z.objectUtil.MergeShapes<typeof schema.shape, T["shape"]>> : typeof schema;
+      ? refinedSchema.describe(SecretSyncs.UPDATE(destination).syncOptions).optional()
+      : refinedSchema.describe(SecretSyncs.CREATE(destination).syncOptions)
+  ) as unknown as T extends AnyZodObject
+    ? z.ZodObject<z.objectUtil.MergeShapes<typeof schema.shape, T["shape"]>>
+    : typeof schema;
 };
 
 export const BaseSecretSyncSchema = <T extends AnyZodObject | undefined = undefined>(

--- a/backend/src/services/secret-sync/secret-sync-schemas.ts
+++ b/backend/src/services/secret-sync/secret-sync-schemas.ts
@@ -9,6 +9,15 @@ import { SecretSync, SecretSyncInitialSyncBehavior } from "@app/services/secret-
 import { SECRET_SYNC_CONNECTION_MAP, SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
 import { TSyncOptionsConfig } from "@app/services/secret-sync/secret-sync-types";
 
+const RECURSIVE_SYNC_REFINEMENT = {
+  path: ["recursive"],
+  message:
+    "A sync that includes subfolders cannot also import existing secrets from the destination, because there is no single folder to import them into. Turn off subfolders, or set the first sync to overwrite the destination."
+};
+
+const isRecursiveCombinationAllowed = (options: { recursive?: unknown; initialSyncBehavior?: unknown }) =>
+  !options.recursive || options.initialSyncBehavior === SecretSyncInitialSyncBehavior.OverwriteDestination;
+
 const BaseSyncOptionsSchema = <T extends AnyZodObject | undefined = undefined>({
   destination,
   syncOptionsConfig: { canImportSecrets, supportsKeySchema = true, supportsDisableSecretDeletion = true },
@@ -67,25 +76,24 @@ const BaseSyncOptionsSchema = <T extends AnyZodObject | undefined = undefined>({
     recursive: z.boolean().optional().describe(SecretSyncs.SYNC_OPTIONS(destination).recursive)
   });
 
-  const schema = merge ? baseSchema.merge(merge) : baseSchema;
+  type TRefinedSchema = z.ZodEffects<
+    T extends AnyZodObject
+      ? z.ZodObject<z.objectUtil.MergeShapes<typeof baseSchema.shape, T["shape"]>>
+      : typeof baseSchema
+  >;
 
-  const refinedSchema = (schema as AnyZodObject).refine(
-    (options) =>
-      !options.recursive || options.initialSyncBehavior === SecretSyncInitialSyncBehavior.OverwriteDestination,
-    {
-      path: ["recursive"],
-      message:
-        "A sync that includes subfolders cannot also import existing secrets from the destination, because there is no single folder to import them into. Turn off subfolders, or set the first sync to overwrite the destination."
-    }
+  // `merge` is supplied exactly when `T` is a ZodObject, which is the condition this type branches
+  // on, and the compiler cannot correlate a runtime ternary with a type parameter. Passing an
+  // explicit type argument that disagrees with the `merge` argument would make the assertion false.
+  const refinedSchema = (
+    merge
+      ? baseSchema.merge(merge).refine(isRecursiveCombinationAllowed, RECURSIVE_SYNC_REFINEMENT)
+      : baseSchema.refine(isRecursiveCombinationAllowed, RECURSIVE_SYNC_REFINEMENT)
+  ) as TRefinedSchema;
+
+  return refinedSchema.describe(
+    isUpdateSchema ? SecretSyncs.UPDATE(destination).syncOptions : SecretSyncs.CREATE(destination).syncOptions
   );
-
-  return (
-    isUpdateSchema
-      ? refinedSchema.describe(SecretSyncs.UPDATE(destination).syncOptions).optional()
-      : refinedSchema.describe(SecretSyncs.CREATE(destination).syncOptions)
-  ) as unknown as T extends AnyZodObject
-    ? z.ZodObject<z.objectUtil.MergeShapes<typeof schema.shape, T["shape"]>>
-    : typeof schema;
 };
 
 export const BaseSecretSyncSchema = <T extends AnyZodObject | undefined = undefined>(
@@ -162,5 +170,5 @@ export const GenericUpdateSecretSyncFieldsSchema = <T extends AnyZodObject | und
       .optional()
       .describe(SecretSyncs.UPDATE(destination).secretPath),
     isAutoSyncEnabled: z.boolean().optional().describe(SecretSyncs.UPDATE(destination).isAutoSyncEnabled),
-    syncOptions: BaseSyncOptionsSchema({ destination, syncOptionsConfig, merge, isUpdateSchema: true })
+    syncOptions: BaseSyncOptionsSchema({ destination, syncOptionsConfig, merge, isUpdateSchema: true }).optional()
   });

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -11,7 +11,7 @@ import {
 } from "@app/ee/services/permission/project-permission";
 import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { DatabaseErrorCode } from "@app/lib/error-codes";
-import { BadRequestError, DatabaseError, NotFoundError } from "@app/lib/errors";
+import { BadRequestError, DatabaseError, ForbiddenRequestError, NotFoundError } from "@app/lib/errors";
 import { deepEqualSkipFields } from "@app/lib/fn/object";
 import { logger } from "@app/lib/logger";
 import { requestMemoKeys } from "@app/lib/request-context/memo-keys";
@@ -22,6 +22,7 @@ import { TAppConnectionServiceFactory } from "@app/services/app-connection/app-c
 import { TAppConnection } from "@app/services/app-connection/app-connection-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectBotServiceFactory } from "@app/services/project-bot/project-bot-service";
+import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
 import { SecretSync } from "@app/services/secret-sync/secret-sync-enums";
 import {
@@ -30,6 +31,7 @@ import {
   preSaveTransformDestinationConfig,
   preSaveTransformSyncOptions
 } from "@app/services/secret-sync/secret-sync-fns";
+import { resolveSyncFolders } from "@app/services/secret-sync/secret-sync-recursive-fns";
 import {
   SecretSyncStatus,
   TCheckDuplicateDestinationDTO,
@@ -69,7 +71,8 @@ type TSecretSyncServiceFactoryDep = {
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getOrgPermission">;
   orgDAL: Pick<TOrgDALFactory, "findById">;
   projectBotService: Pick<TProjectBotServiceFactory, "getBotKey">;
-  folderDAL: Pick<TSecretFolderDALFactory, "findByProjectId" | "findById" | "findBySecretPath">;
+  folderDAL: Pick<TSecretFolderDALFactory, "findByProjectId" | "findById" | "findBySecretPath" | "find">;
+  projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne">;
   keyStore: Pick<TKeyStoreFactory, "getItem">;
   secretSyncQueue: Pick<
     TSecretSyncQueueFactory,
@@ -83,6 +86,7 @@ export type TSecretSyncServiceFactory = ReturnType<typeof secretSyncServiceFacto
 export const secretSyncServiceFactory = ({
   secretSyncDAL,
   folderDAL,
+  projectEnvDAL,
   secretImportDAL,
   secretV2BridgeDAL,
   appConnectionDAL,
@@ -120,6 +124,56 @@ export const secretSyncServiceFactory = ({
   };
 
   const preSaveTransformDeps = { secretV2BridgeDAL, appConnectionDAL, kmsService };
+
+  // The sync worker reads its folders with every access check disabled, so this is the only place
+  // the actor's read access to them is established. A recursive sync reads the whole subtree, and
+  // folder grants let an actor hold read on a parent while being denied on a child.
+  const $assertCanReadSyncedFolders = async (
+    projectPermission: Awaited<ReturnType<TPermissionServiceFactory["getProjectPermission"]>>["permission"],
+    {
+      projectId,
+      environment,
+      sourcePath,
+      sourceFolderId,
+      recursive
+    }: {
+      projectId: string;
+      environment: string;
+      sourcePath: string;
+      sourceFolderId: string;
+      recursive: boolean;
+    }
+  ) => {
+    const folders = await resolveSyncFolders({
+      folderDAL,
+      projectEnvDAL,
+      projectId,
+      environment,
+      sourcePath,
+      sourceFolderId,
+      recursive
+    });
+
+    for (const { path } of folders) {
+      try {
+        throwIfMissingSecretReadValueOrDescribePermission(
+          projectPermission,
+          ProjectPermissionSecretActions.DescribeSecret,
+          {
+            environment,
+            secretPath: path
+          }
+        );
+      } catch {
+        throw new ForbiddenRequestError({
+          message:
+            path === sourcePath
+              ? `You do not have permission to read secrets at path "${path}" in environment "${environment}".`
+              : `You do not have permission to read secrets at path "${path}" in environment "${environment}". This sync includes subfolders, so it reads every folder beneath "${sourcePath}".`
+        });
+      }
+    }
+  };
 
   const listSecretSyncsByProjectId = async (
     { projectId, destination }: TListSecretSyncsByProjectId,
@@ -414,21 +468,20 @@ export const secretSyncServiceFactory = ({
       })
     );
 
-    throwIfMissingSecretReadValueOrDescribePermission(
-      projectPermission,
-      ProjectPermissionSecretActions.DescribeSecret,
-      {
-        environment,
-        secretPath
-      }
-    );
-
     const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
 
     if (!folder)
       throw new BadRequestError({
         message: `Could not find folder with path "${secretPath}" in environment "${environment}" for project with ID "${projectId}"`
       });
+
+    await $assertCanReadSyncedFolders(projectPermission, {
+      projectId,
+      environment,
+      sourcePath: secretPath,
+      sourceFolderId: folder.id,
+      recursive: Boolean((params.syncOptions as { recursive?: boolean } | undefined)?.recursive)
+    });
 
     // getProjectPermission above throws NotFoundError if the project doesn't exist and
     // guarantees actor.orgId === project.orgId — no separate project lookup needed.
@@ -612,29 +665,43 @@ export const secretSyncServiceFactory = ({
       }
     }
 
-    if (
-      (secretPath && secretPath !== secretSync.folder?.path) ||
-      (environment && environment !== secretSync.environment?.slug)
-    ) {
+    const isSourceChanged =
+      (Boolean(secretPath) && secretPath !== secretSync.folder?.path) ||
+      (Boolean(environment) && environment !== secretSync.environment?.slug);
+
+    const wasRecursive = Boolean((secretSync.syncOptions as { recursive?: boolean } | undefined)?.recursive);
+    const isRecursive = Boolean((params.syncOptions as { recursive?: boolean } | undefined)?.recursive ?? wasRecursive);
+
+    if (isSourceChanged || (isRecursive && !wasRecursive)) {
       const updatedEnvironment = environment ?? secretSync.environment?.slug;
       const updatedSecretPath = secretPath ?? secretSync.folder?.path;
 
       if (!updatedEnvironment || !updatedSecretPath)
         throw new BadRequestError({ message: "Must specify both source environment and secret path" });
 
-      throwIfMissingSecretReadValueOrDescribePermission(permission, ProjectPermissionSecretActions.DescribeSecret, {
-        environment: updatedEnvironment,
-        secretPath: updatedSecretPath
-      });
+      if (isSourceChanged) {
+        const newFolder = await folderDAL.findBySecretPath(secretSync.projectId, updatedEnvironment, updatedSecretPath);
 
-      const newFolder = await folderDAL.findBySecretPath(secretSync.projectId, updatedEnvironment, updatedSecretPath);
+        if (!newFolder)
+          throw new BadRequestError({
+            message: `Could not find folder with path "${updatedSecretPath}" in environment "${updatedEnvironment}" for project with ID "${secretSync.projectId}"`
+          });
 
-      if (!newFolder)
+        folderId = newFolder.id;
+      }
+
+      if (!folderId)
         throw new BadRequestError({
-          message: `Could not find folder with path "${secretPath}" in environment "${environment}" for project with ID "${secretSync.projectId}"`
+          message: `Could not find folder with path "${updatedSecretPath}" in environment "${updatedEnvironment}" for project with ID "${secretSync.projectId}"`
         });
 
-      folderId = newFolder.id;
+      await $assertCanReadSyncedFolders(permission, {
+        projectId: secretSync.projectId,
+        environment: updatedEnvironment,
+        sourcePath: updatedSecretPath,
+        sourceFolderId: folderId,
+        recursive: isRecursive
+      });
     }
 
     const isAutoSyncEnabled = params.isAutoSyncEnabled ?? secretSync.isAutoSyncEnabled;

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -35,7 +35,6 @@ import {
   preSaveTransformDestinationConfig,
   preSaveTransformSyncOptions
 } from "@app/services/secret-sync/secret-sync-fns";
-import { findFlattenConflicts } from "@app/services/secret-sync/secret-sync-payload";
 import { buildSyncPayload, resolveSyncFolders } from "@app/services/secret-sync/secret-sync-recursive-fns";
 import {
   SecretSyncStatus,
@@ -191,6 +190,88 @@ export const secretSyncServiceFactory = ({
     }
   };
 
+  // A SecretSyncError is written for the end user already (see secret-sync-payload.ts); every
+  // caller that can surface one directly just needs it translated to the house error envelope.
+  const $rethrowSecretSyncErrorsAsBadRequest = async <T>(fn: () => T | Promise<T>): Promise<T> => {
+    try {
+      return await fn();
+    } catch (error) {
+      if (error instanceof SecretSyncError) throw new BadRequestError({ message: error.message });
+
+      throw error;
+    }
+  };
+
+  // Shared by $assertSyncableAtDestination and findRecursiveConflicts: both need the same
+  // decrypt-and-expand payload for the full recursive subtree, and differ only in what they do
+  // with it once built (throw on the first conflict vs. report every conflict back).
+  const $buildRecursiveSyncPayload = ({
+    projectId,
+    actorOrgId,
+    environment,
+    sourcePath,
+    sourceFolderId,
+    keySchema
+  }: {
+    projectId: string;
+    actorOrgId: string;
+    environment: string;
+    sourcePath: string;
+    sourceFolderId: string;
+    keySchema?: string;
+  }) =>
+    $rethrowSecretSyncErrorsAsBadRequest(async () => {
+      const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
+        type: KmsDataKey.SecretManager,
+        projectId
+      });
+
+      const decryptSecretValue = (value?: Buffer | null) =>
+        value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : "";
+
+      const { expandSecretReferences } = expandSecretReferencesFactory({
+        decryptSecretValue,
+        secretDAL: secretV2BridgeDAL,
+        folderDAL,
+        projectId,
+        canExpandValue: () => true,
+        actorOrgId,
+        orgDAL,
+        licenseService,
+        projectFolderGrantDAL,
+        projectDAL,
+        kmsService
+      });
+
+      return buildSyncPayload(
+        {
+          folderDAL,
+          projectEnvDAL,
+          secretV2BridgeDAL,
+          secretImportDAL,
+          expandSecretReferences,
+          decryptSecretValue,
+          fnSecretsV2FromImportsDeps: {
+            projectFolderGrantDAL,
+            actorOrgId,
+            orgDAL,
+            licenseService,
+            kmsService
+          }
+        },
+        {
+          projectId,
+          environment,
+          sourcePath,
+          sourceFolderId,
+          recursive: true,
+          keySchema,
+          includeImports: true,
+          dedupeForRemoval: false
+        }
+      );
+    });
+
   // Flattening a subtree onto a destination that holds one flat list can produce two secrets with
   // the same destination key. flatten() is what detects that, and the job runs it on every sync, so
   // calling it here means a user reads the same sentence at save time and when the sync later drifts
@@ -214,63 +295,16 @@ export const secretSyncServiceFactory = ({
   }) => {
     if (!recursive) return;
 
-    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
-      type: KmsDataKey.SecretManager,
-      projectId
-    });
-
-    const decryptSecretValue = (value?: Buffer | null) =>
-      value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : "";
-
-    const { expandSecretReferences } = expandSecretReferencesFactory({
-      decryptSecretValue,
-      secretDAL: secretV2BridgeDAL,
-      folderDAL,
+    const payload = await $buildRecursiveSyncPayload({
       projectId,
-      canExpandValue: () => true,
       actorOrgId,
-      orgDAL,
-      licenseService,
-      projectFolderGrantDAL,
-      projectDAL,
-      kmsService
+      environment,
+      sourcePath,
+      sourceFolderId,
+      keySchema
     });
 
-    try {
-      const payload = await buildSyncPayload(
-        {
-          folderDAL,
-          projectEnvDAL,
-          secretV2BridgeDAL,
-          secretImportDAL,
-          expandSecretReferences,
-          decryptSecretValue,
-          fnSecretsV2FromImportsDeps: {
-            projectFolderGrantDAL,
-            actorOrgId,
-            orgDAL,
-            licenseService,
-            kmsService
-          }
-        },
-        {
-          projectId,
-          environment,
-          sourcePath,
-          sourceFolderId,
-          recursive,
-          keySchema,
-          includeImports: true,
-          dedupeForRemoval: false
-        }
-      );
-
-      payload.flatten();
-    } catch (error) {
-      if (error instanceof SecretSyncError) throw new BadRequestError({ message: error.message });
-
-      throw error;
-    }
+    await $rethrowSecretSyncErrorsAsBadRequest(() => payload.flatten());
   };
 
   // Lets the frontend check for duplicate-name conflicts while the user is still on the Source
@@ -311,63 +345,16 @@ export const secretSyncServiceFactory = ({
       recursive: true
     });
 
-    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
-      type: KmsDataKey.SecretManager,
-      projectId
-    });
-
-    const decryptSecretValue = (value?: Buffer | null) =>
-      value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : "";
-
-    const { expandSecretReferences } = expandSecretReferencesFactory({
-      decryptSecretValue,
-      secretDAL: secretV2BridgeDAL,
-      folderDAL,
+    const payload = await $buildRecursiveSyncPayload({
       projectId,
-      canExpandValue: () => true,
       actorOrgId: actor.orgId,
-      orgDAL,
-      licenseService,
-      projectFolderGrantDAL,
-      projectDAL,
-      kmsService
+      environment,
+      sourcePath: secretPath,
+      sourceFolderId: folder.id,
+      keySchema
     });
 
-    try {
-      const payload = await buildSyncPayload(
-        {
-          folderDAL,
-          projectEnvDAL,
-          secretV2BridgeDAL,
-          secretImportDAL,
-          expandSecretReferences,
-          decryptSecretValue,
-          fnSecretsV2FromImportsDeps: {
-            projectFolderGrantDAL,
-            actorOrgId: actor.orgId,
-            orgDAL,
-            licenseService,
-            kmsService
-          }
-        },
-        {
-          projectId,
-          environment,
-          sourcePath: secretPath,
-          sourceFolderId: folder.id,
-          recursive: true,
-          keySchema,
-          includeImports: true,
-          dedupeForRemoval: false
-        }
-      );
-
-      return { conflicts: findFlattenConflicts(payload) };
-    } catch (error) {
-      if (error instanceof SecretSyncError) throw new BadRequestError({ message: error.message });
-
-      throw error;
-    }
+    return { conflicts: payload.findConflicts() };
   };
 
   const listSecretSyncsByProjectId = async (

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -35,12 +35,14 @@ import {
   preSaveTransformDestinationConfig,
   preSaveTransformSyncOptions
 } from "@app/services/secret-sync/secret-sync-fns";
+import { findFlattenConflicts } from "@app/services/secret-sync/secret-sync-payload";
 import { buildSyncPayload, resolveSyncFolders } from "@app/services/secret-sync/secret-sync-recursive-fns";
 import {
   SecretSyncStatus,
   TCheckDuplicateDestinationDTO,
   TCreateSecretSyncDTO,
   TDeleteSecretSyncDTO,
+  TFindRecursiveSyncConflictsDTO,
   TFindSecretSyncByIdDTO,
   TFindSecretSyncByNameDTO,
   TListSecretSyncsByFolderId,
@@ -264,6 +266,103 @@ export const secretSyncServiceFactory = ({
       );
 
       payload.flatten();
+    } catch (error) {
+      if (error instanceof SecretSyncError) throw new BadRequestError({ message: error.message });
+
+      throw error;
+    }
+  };
+
+  // Lets the frontend check for duplicate-name conflicts while the user is still on the Source
+  // step, before a provider or destination is even chosen: the check is destination-agnostic
+  // (flatten() never uses the destination or the source folder path to build a key), so nothing
+  // downstream can change the answer. Returns every conflict, untruncated, unlike the
+  // BadRequestError $assertSyncableAtDestination throws at create/update time.
+  const findRecursiveConflicts = async (
+    { projectId, environment, secretPath, keySchema }: TFindRecursiveSyncConflictsDTO,
+    actor: OrgServiceActor
+  ) => {
+    const { permission: projectPermission } = await permissionService.getProjectPermission({
+      actor: actor.type,
+      actorId: actor.id,
+      actorAuthMethod: actor.authMethod,
+      actorOrgId: actor.orgId,
+      actionProjectType: ActionProjectType.SecretManager,
+      projectId
+    });
+
+    ForbiddenError.from(projectPermission).throwUnlessCan(
+      ProjectPermissionSecretSyncActions.Read,
+      ProjectPermissionSub.SecretSyncs
+    );
+
+    const folder = await folderDAL.findBySecretPath(projectId, environment, secretPath);
+
+    if (!folder)
+      throw new BadRequestError({
+        message: `Could not find folder with path "${secretPath}" in environment "${environment}" for project with ID "${projectId}"`
+      });
+
+    await $assertCanReadSyncedFolders(projectPermission, {
+      projectId,
+      environment,
+      sourcePath: secretPath,
+      sourceFolderId: folder.id,
+      recursive: true
+    });
+
+    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
+      type: KmsDataKey.SecretManager,
+      projectId
+    });
+
+    const decryptSecretValue = (value?: Buffer | null) =>
+      value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : "";
+
+    const { expandSecretReferences } = expandSecretReferencesFactory({
+      decryptSecretValue,
+      secretDAL: secretV2BridgeDAL,
+      folderDAL,
+      projectId,
+      canExpandValue: () => true,
+      actorOrgId: actor.orgId,
+      orgDAL,
+      licenseService,
+      projectFolderGrantDAL,
+      projectDAL,
+      kmsService
+    });
+
+    try {
+      const payload = await buildSyncPayload(
+        {
+          folderDAL,
+          projectEnvDAL,
+          secretV2BridgeDAL,
+          secretImportDAL,
+          expandSecretReferences,
+          decryptSecretValue,
+          fnSecretsV2FromImportsDeps: {
+            projectFolderGrantDAL,
+            actorOrgId: actor.orgId,
+            orgDAL,
+            licenseService,
+            kmsService
+          }
+        },
+        {
+          projectId,
+          environment,
+          sourcePath: secretPath,
+          sourceFolderId: folder.id,
+          recursive: true,
+          keySchema,
+          includeImports: true,
+          dedupeForRemoval: false
+        }
+      );
+
+      return { conflicts: findFlattenConflicts(payload) };
     } catch (error) {
       if (error instanceof SecretSyncError) throw new BadRequestError({ message: error.message });
 
@@ -1130,6 +1229,7 @@ export const secretSyncServiceFactory = ({
     triggerSecretSyncSyncSecretsById,
     triggerSecretSyncImportSecretsById,
     triggerSecretSyncRemoveSecretsById,
-    checkDuplicateDestination
+    checkDuplicateDestination,
+    findRecursiveConflicts
   };
 };

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -67,6 +67,10 @@ import {
 } from "./secret-sync-maps";
 import { TSecretSyncQueueFactory } from "./secret-sync-queue";
 
+// secretSyncDAL rows carry syncOptions as an untyped jsonb column, not the destination-specific
+// shape TSecretSync narrows it to elsewhere, so reading a field back out needs a cast.
+type TRawSyncOptions = { recursive?: boolean; keySchema?: string };
+
 type TSecretSyncServiceFactoryDep = {
   secretSyncDAL: TSecretSyncDALFactory;
   secretImportDAL: TSecretImportDALFactory;
@@ -140,7 +144,8 @@ export const secretSyncServiceFactory = ({
 
   // The sync worker reads its folders with every access check disabled, so this is the only place
   // the actor's read access to them is established. A recursive sync reads the whole subtree, and
-  // folder grants let an actor hold read on a parent while being denied on a child.
+  // folder grants are per-folder rather than inherited, so checking only the root wouldn't catch a
+  // child folder the actor is denied on.
   const $assertCanReadSyncedFolders = async (
     projectPermission: Awaited<ReturnType<TPermissionServiceFactory["getProjectPermission"]>>["permission"],
     {
@@ -202,7 +207,7 @@ export const secretSyncServiceFactory = ({
     }
   };
 
-  // Shared by $assertSyncableAtDestination and findRecursiveConflicts: both need the same
+  // Shared by $assertSyncedSecretsAreFlattenable and findRecursiveConflicts: both need the same
   // decrypt-and-expand payload for the full recursive subtree, and differ only in what they do
   // with it once built (throw on the first conflict vs. report every conflict back).
   const $buildRecursiveSyncPayload = ({
@@ -275,14 +280,14 @@ export const secretSyncServiceFactory = ({
   // Flattening a subtree onto a destination that holds one flat list can produce two secrets with
   // the same destination key. flatten() is what detects that, and the job runs it on every sync, so
   // calling it here means a user reads the same sentence at save time and when the sync later drifts
-  // into the same state.
-  const $assertSyncableAtDestination = async ({
+  // into the same state. Callers only call this for a recursive sync — a non-recursive one covers a
+  // single folder, where flatten() can never find a conflict.
+  const $assertSyncedSecretsAreFlattenable = async ({
     projectId,
     actorOrgId,
     environment,
     sourcePath,
     sourceFolderId,
-    recursive,
     keySchema
   }: {
     projectId: string;
@@ -290,11 +295,8 @@ export const secretSyncServiceFactory = ({
     environment: string;
     sourcePath: string;
     sourceFolderId: string;
-    recursive: boolean;
     keySchema?: string;
   }) => {
-    if (!recursive) return;
-
     const payload = await $buildRecursiveSyncPayload({
       projectId,
       actorOrgId,
@@ -311,7 +313,7 @@ export const secretSyncServiceFactory = ({
   // step, before a provider or destination is even chosen: the check is destination-agnostic
   // (flatten() never uses the destination or the source folder path to build a key), so nothing
   // downstream can change the answer. Returns every conflict, untruncated, unlike the
-  // BadRequestError $assertSyncableAtDestination throws at create/update time.
+  // BadRequestError $assertSyncedSecretsAreFlattenable throws at create/update time.
   const findRecursiveConflicts = async (
     { projectId, environment, secretPath, keySchema }: TFindRecursiveSyncConflictsDTO,
     actor: OrgServiceActor
@@ -657,7 +659,7 @@ export const secretSyncServiceFactory = ({
         message: `Could not find folder with path "${secretPath}" in environment "${environment}" for project with ID "${projectId}"`
       });
 
-    const requestedSyncOptions = params.syncOptions as { recursive?: boolean; keySchema?: string } | undefined;
+    const requestedSyncOptions = params.syncOptions as TRawSyncOptions | undefined;
     const isRecursive = Boolean(requestedSyncOptions?.recursive);
 
     await $assertCanReadSyncedFolders(projectPermission, {
@@ -668,17 +670,19 @@ export const secretSyncServiceFactory = ({
       recursive: isRecursive
     });
 
-    // Runs after the permission check above: the conflict it raises names every folder beneath the
-    // source, including ones this actor is denied on.
-    await $assertSyncableAtDestination({
-      projectId,
-      actorOrgId: actor.orgId,
-      environment,
-      sourcePath: secretPath,
-      sourceFolderId: folder.id,
-      recursive: isRecursive,
-      keySchema: requestedSyncOptions?.keySchema
-    });
+    // Some destinations store secrets in a single flat list rather than a folder hierarchy, so a
+    // recursive sync must flatten its whole subtree to one namespace. Check that it can here, so
+    // the sync doesn't get created only to fail immediately on its first run.
+    if (isRecursive) {
+      await $assertSyncedSecretsAreFlattenable({
+        projectId,
+        actorOrgId: actor.orgId,
+        environment,
+        sourcePath: secretPath,
+        sourceFolderId: folder.id,
+        keySchema: requestedSyncOptions?.keySchema
+      });
+    }
 
     // getProjectPermission above throws NotFoundError if the project doesn't exist and
     // guarantees actor.orgId === project.orgId — no separate project lookup needed.
@@ -866,8 +870,11 @@ export const secretSyncServiceFactory = ({
       (Boolean(secretPath) && secretPath !== secretSync.folder?.path) ||
       (Boolean(environment) && environment !== secretSync.environment?.slug);
 
-    const wasRecursive = Boolean((secretSync.syncOptions as { recursive?: boolean } | undefined)?.recursive);
-    const isRecursive = Boolean((params.syncOptions as { recursive?: boolean } | undefined)?.recursive ?? wasRecursive);
+    const existingSyncOptions = secretSync.syncOptions as TRawSyncOptions | undefined;
+    const requestedSyncOptions = params.syncOptions as TRawSyncOptions | undefined;
+
+    const wasRecursive = Boolean(existingSyncOptions?.recursive);
+    const isRecursive = Boolean(requestedSyncOptions?.recursive ?? wasRecursive);
 
     // Every update to a recursive sync re-authorizes the whole subtree, because an actor holding
     // Edit on the source folder can otherwise repoint an existing recursive sync at a destination
@@ -904,17 +911,16 @@ export const secretSyncServiceFactory = ({
         recursive: isRecursive
       });
 
-      await $assertSyncableAtDestination({
-        projectId: secretSync.projectId,
-        actorOrgId: actor.orgId,
-        environment: updatedEnvironment,
-        sourcePath: updatedSecretPath,
-        sourceFolderId: folderId,
-        recursive: isRecursive,
-        keySchema:
-          (params.syncOptions as { keySchema?: string } | undefined)?.keySchema ??
-          (secretSync.syncOptions as { keySchema?: string } | undefined)?.keySchema
-      });
+      if (isRecursive) {
+        await $assertSyncedSecretsAreFlattenable({
+          projectId: secretSync.projectId,
+          actorOrgId: actor.orgId,
+          environment: updatedEnvironment,
+          sourcePath: updatedSecretPath,
+          sourceFolderId: folderId,
+          keySchema: requestedSyncOptions?.keySchema ?? existingSyncOptions?.keySchema
+        });
+      }
     }
 
     const isAutoSyncEnabled = params.isAutoSyncEnabled ?? secretSync.isAutoSyncEnabled;

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -164,7 +164,9 @@ export const secretSyncServiceFactory = ({
             secretPath: path
           }
         );
-      } catch {
+      } catch (error) {
+        if (!(error instanceof ForbiddenError)) throw error;
+
         throw new ForbiddenRequestError({
           message:
             path === sourcePath
@@ -672,7 +674,11 @@ export const secretSyncServiceFactory = ({
     const wasRecursive = Boolean((secretSync.syncOptions as { recursive?: boolean } | undefined)?.recursive);
     const isRecursive = Boolean((params.syncOptions as { recursive?: boolean } | undefined)?.recursive ?? wasRecursive);
 
-    if (isSourceChanged || (isRecursive && !wasRecursive)) {
+    // Every update to a recursive sync re-authorizes the whole subtree, because an actor holding
+    // Edit on the source folder can otherwise repoint an existing recursive sync at a destination
+    // they control and read descendants they were never granted. A non-recursive sync covers only
+    // its source folder, so it re-authorizes when that source actually changes.
+    if (isSourceChanged || isRecursive) {
       const updatedEnvironment = environment ?? secretSync.environment?.slug;
       const updatedSecretPath = secretPath ?? secretSync.folder?.path;
 

--- a/backend/src/services/secret-sync/secret-sync-service.ts
+++ b/backend/src/services/secret-sync/secret-sync-service.ts
@@ -20,18 +20,22 @@ import { OrgServiceActor } from "@app/lib/types";
 import { decryptAppConnectionCredentials } from "@app/services/app-connection/app-connection-fns";
 import { TAppConnectionServiceFactory } from "@app/services/app-connection/app-connection-service";
 import { TAppConnection } from "@app/services/app-connection/app-connection-types";
+import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
+import { TProjectDALFactory } from "@app/services/project/project-dal";
 import { TProjectBotServiceFactory } from "@app/services/project-bot/project-bot-service";
 import { TProjectEnvDALFactory } from "@app/services/project-env/project-env-dal";
+import { TProjectFolderGrantDALFactory } from "@app/services/project-folder-grant/project-folder-grant-dal";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
 import { SecretSync } from "@app/services/secret-sync/secret-sync-enums";
+import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import {
   enterpriseSyncCheck,
   listSecretSyncOptions,
   preSaveTransformDestinationConfig,
   preSaveTransformSyncOptions
 } from "@app/services/secret-sync/secret-sync-fns";
-import { resolveSyncFolders } from "@app/services/secret-sync/secret-sync-recursive-fns";
+import { buildSyncPayload, resolveSyncFolders } from "@app/services/secret-sync/secret-sync-recursive-fns";
 import {
   SecretSyncStatus,
   TCheckDuplicateDestinationDTO,
@@ -47,6 +51,7 @@ import {
   TTriggerSecretSyncSyncSecretsByIdDTO,
   TUpdateSecretSyncDTO
 } from "@app/services/secret-sync/secret-sync-types";
+import { expandSecretReferencesFactory } from "@app/services/secret-v2-bridge/secret-reference-fns";
 
 import { TAppConnectionDALFactory } from "../app-connection/app-connection-dal";
 import { TKmsServiceFactory } from "../kms/kms-service";
@@ -64,15 +69,20 @@ import { TSecretSyncQueueFactory } from "./secret-sync-queue";
 type TSecretSyncServiceFactoryDep = {
   secretSyncDAL: TSecretSyncDALFactory;
   secretImportDAL: TSecretImportDALFactory;
-  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "findOne">;
+  secretV2BridgeDAL: Pick<TSecretV2BridgeDALFactory, "findOne" | "find" | "findByFolderId" | "findByFolderIds">;
   appConnectionDAL: Pick<TAppConnectionDALFactory, "findById" | "updateById">;
   appConnectionService: Pick<TAppConnectionServiceFactory, "validateAppConnectionUsageById">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   permissionService: Pick<TPermissionServiceFactory, "getProjectPermission" | "getOrgPermission">;
-  orgDAL: Pick<TOrgDALFactory, "findById">;
+  orgDAL: Pick<TOrgDALFactory, "findById" | "findOrgById">;
   projectBotService: Pick<TProjectBotServiceFactory, "getBotKey">;
-  folderDAL: Pick<TSecretFolderDALFactory, "findByProjectId" | "findById" | "findBySecretPath" | "find">;
+  folderDAL: Pick<
+    TSecretFolderDALFactory,
+    "findByProjectId" | "findById" | "findBySecretPath" | "find" | "findByManySecretPath"
+  >;
   projectEnvDAL: Pick<TProjectEnvDALFactory, "findOne">;
+  projectDAL: Pick<TProjectDALFactory, "find">;
+  projectFolderGrantDAL: Pick<TProjectFolderGrantDALFactory, "find">;
   keyStore: Pick<TKeyStoreFactory, "getItem">;
   secretSyncQueue: Pick<
     TSecretSyncQueueFactory,
@@ -87,6 +97,8 @@ export const secretSyncServiceFactory = ({
   secretSyncDAL,
   folderDAL,
   projectEnvDAL,
+  projectDAL,
+  projectFolderGrantDAL,
   secretImportDAL,
   secretV2BridgeDAL,
   appConnectionDAL,
@@ -174,6 +186,88 @@ export const secretSyncServiceFactory = ({
               : `You do not have permission to read secrets at path "${path}" in environment "${environment}". This sync includes subfolders, so it reads every folder beneath "${sourcePath}".`
         });
       }
+    }
+  };
+
+  // Flattening a subtree onto a destination that holds one flat list can produce two secrets with
+  // the same destination key. flatten() is what detects that, and the job runs it on every sync, so
+  // calling it here means a user reads the same sentence at save time and when the sync later drifts
+  // into the same state.
+  const $assertSyncableAtDestination = async ({
+    projectId,
+    actorOrgId,
+    environment,
+    sourcePath,
+    sourceFolderId,
+    recursive,
+    keySchema
+  }: {
+    projectId: string;
+    actorOrgId: string;
+    environment: string;
+    sourcePath: string;
+    sourceFolderId: string;
+    recursive: boolean;
+    keySchema?: string;
+  }) => {
+    if (!recursive) return;
+
+    const { decryptor: secretManagerDecryptor } = await kmsService.createCipherPairWithDataKey({
+      type: KmsDataKey.SecretManager,
+      projectId
+    });
+
+    const decryptSecretValue = (value?: Buffer | null) =>
+      value ? secretManagerDecryptor({ cipherTextBlob: value }).toString() : "";
+
+    const { expandSecretReferences } = expandSecretReferencesFactory({
+      decryptSecretValue,
+      secretDAL: secretV2BridgeDAL,
+      folderDAL,
+      projectId,
+      canExpandValue: () => true,
+      actorOrgId,
+      orgDAL,
+      licenseService,
+      projectFolderGrantDAL,
+      projectDAL,
+      kmsService
+    });
+
+    try {
+      const payload = await buildSyncPayload(
+        {
+          folderDAL,
+          projectEnvDAL,
+          secretV2BridgeDAL,
+          secretImportDAL,
+          expandSecretReferences,
+          decryptSecretValue,
+          fnSecretsV2FromImportsDeps: {
+            projectFolderGrantDAL,
+            actorOrgId,
+            orgDAL,
+            licenseService,
+            kmsService
+          }
+        },
+        {
+          projectId,
+          environment,
+          sourcePath,
+          sourceFolderId,
+          recursive,
+          keySchema,
+          includeImports: true,
+          dedupeForRemoval: false
+        }
+      );
+
+      payload.flatten();
+    } catch (error) {
+      if (error instanceof SecretSyncError) throw new BadRequestError({ message: error.message });
+
+      throw error;
     }
   };
 
@@ -477,12 +571,27 @@ export const secretSyncServiceFactory = ({
         message: `Could not find folder with path "${secretPath}" in environment "${environment}" for project with ID "${projectId}"`
       });
 
+    const requestedSyncOptions = params.syncOptions as { recursive?: boolean; keySchema?: string } | undefined;
+    const isRecursive = Boolean(requestedSyncOptions?.recursive);
+
     await $assertCanReadSyncedFolders(projectPermission, {
       projectId,
       environment,
       sourcePath: secretPath,
       sourceFolderId: folder.id,
-      recursive: Boolean((params.syncOptions as { recursive?: boolean } | undefined)?.recursive)
+      recursive: isRecursive
+    });
+
+    // Runs after the permission check above: the conflict it raises names every folder beneath the
+    // source, including ones this actor is denied on.
+    await $assertSyncableAtDestination({
+      projectId,
+      actorOrgId: actor.orgId,
+      environment,
+      sourcePath: secretPath,
+      sourceFolderId: folder.id,
+      recursive: isRecursive,
+      keySchema: requestedSyncOptions?.keySchema
     });
 
     // getProjectPermission above throws NotFoundError if the project doesn't exist and
@@ -707,6 +816,18 @@ export const secretSyncServiceFactory = ({
         sourcePath: updatedSecretPath,
         sourceFolderId: folderId,
         recursive: isRecursive
+      });
+
+      await $assertSyncableAtDestination({
+        projectId: secretSync.projectId,
+        actorOrgId: actor.orgId,
+        environment: updatedEnvironment,
+        sourcePath: updatedSecretPath,
+        sourceFolderId: folderId,
+        recursive: isRecursive,
+        keySchema:
+          (params.syncOptions as { keySchema?: string } | undefined)?.keySchema ??
+          (secretSync.syncOptions as { keySchema?: string } | undefined)?.keySchema
       });
     }
 

--- a/backend/src/services/secret-sync/secret-sync-types.ts
+++ b/backend/src/services/secret-sync/secret-sync-types.ts
@@ -499,6 +499,13 @@ export type TCheckDuplicateDestinationDTO = {
   projectId: string;
 };
 
+export type TFindRecursiveSyncConflictsDTO = {
+  projectId: string;
+  environment: string;
+  secretPath: string;
+  keySchema?: string;
+};
+
 export enum SecretSyncStatus {
   Pending = "pending",
   Running = "running",

--- a/backend/src/services/secret-sync/snowflake/snowflake-sync-fns.ts
+++ b/backend/src/services/secret-sync/snowflake/snowflake-sync-fns.ts
@@ -10,6 +10,7 @@ import {
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 import { SECRET_SYNC_NAME_MAP } from "@app/services/secret-sync/secret-sync-maps";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { TSnowflakeSyncWithCredentials } from "./snowflake-sync-types";
@@ -78,7 +79,8 @@ const wrapSnowflakeError = (err: unknown, credentials: TSnowflakeConnection["cre
 };
 
 export const SnowflakeSyncFns = {
-  syncSecrets: async (secretSync: TSnowflakeSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TSnowflakeSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       destinationConfig: { database, schema },
       connection
@@ -133,7 +135,8 @@ export const SnowflakeSyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  removeSecrets: async (secretSync: TSnowflakeSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TSnowflakeSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       destinationConfig: { database, schema },
       connection

--- a/backend/src/services/secret-sync/spacelift/spacelift-sync-fns.ts
+++ b/backend/src/services/secret-sync/spacelift/spacelift-sync-fns.ts
@@ -3,6 +3,7 @@ import { parseEnvFile, serializeEnvFile } from "@app/lib/dotenv";
 import { removeTrailingSlash } from "@app/lib/fn";
 import { safeRequest } from "@app/lib/validator";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SpaceliftConfigType, SpaceliftFileMountFormat } from "./spacelift-sync-constants";
@@ -319,7 +320,8 @@ const removeDotEnvFile = async (
 };
 
 export const SpaceliftSyncFns = {
-  syncSecrets: async (secretSync: TSpaceliftSyncWithCredentials, secretMap: TSecretMap): Promise<void> => {
+  syncSecrets: async (secretSync: TSpaceliftSyncWithCredentials, payload: TSecretSyncPayload): Promise<void> => {
+    const secretMap = payload.flatten();
     const instanceUrl = removeTrailingSlash(secretSync.connection.credentials.apiUrl);
     const { apiKeyId, apiKeySecret } = secretSync.connection.credentials;
     const { contextId, configType, mountPath, fileMountFormat } = secretSync.destinationConfig;
@@ -398,7 +400,8 @@ export const SpaceliftSyncFns = {
     return secretMap;
   },
 
-  removeSecrets: async (secretSync: TSpaceliftSyncWithCredentials, secretMap: TSecretMap): Promise<void> => {
+  removeSecrets: async (secretSync: TSpaceliftSyncWithCredentials, payload: TSecretSyncPayload): Promise<void> => {
+    const secretMap = payload.flatten();
     const instanceUrl = removeTrailingSlash(secretSync.connection.credentials.apiUrl);
     const { apiKeyId, apiKeySecret } = secretSync.connection.credentials;
     const { contextId, configType, mountPath, fileMountFormat } = secretSync.destinationConfig;

--- a/backend/src/services/secret-sync/supabase/supabase-sync-fns.ts
+++ b/backend/src/services/secret-sync/supabase/supabase-sync-fns.ts
@@ -9,7 +9,7 @@ import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
 
 import { SecretSyncError } from "../secret-sync-errors";
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
-import { TSecretMap } from "../secret-sync-types";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 import { TSupabaseSyncWithCredentials } from "./supabase-sync-types";
 
 const SUPABASE_INTERNAL_SECRETS = ["SUPABASE_URL", "SUPABASE_ANON_KEY", "SUPABASE_SERVICE_ROLE_KEY", "SUPABASE_DB_URL"];
@@ -19,7 +19,8 @@ export const SupabaseSyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  async syncSecrets(secretSync: TSupabaseSyncWithCredentials, secretMap: TSecretMap) {
+  async syncSecrets(secretSync: TSupabaseSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const {
       environment,
       syncOptions: { disableSecretDeletion, keySchema }
@@ -73,7 +74,8 @@ export const SupabaseSyncFns = {
     }
   },
 
-  async removeSecrets(secretSync: TSupabaseSyncWithCredentials, secretMap: TSecretMap) {
+  async removeSecrets(secretSync: TSupabaseSyncWithCredentials, payload: TSecretSyncPayload) {
+    const secretMap = payload.flatten();
     const config = secretSync.destinationConfig;
 
     const variables = await SupabasePublicAPI.getVariables(secretSync.connection, config.projectId);

--- a/backend/src/services/secret-sync/teamcity/teamcity-sync-fns.ts
+++ b/backend/src/services/secret-sync/teamcity/teamcity-sync-fns.ts
@@ -2,7 +2,7 @@ import { request } from "@app/lib/config/request";
 import { getTeamCityInstanceUrl } from "@app/services/app-connection/teamcity";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
-import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import {
   TDeleteTeamCityVariable,
   TPostTeamCityVariable,
@@ -88,7 +88,8 @@ const deleteTeamCityVariable = async ({
 };
 
 export const TeamCitySyncFns = {
-  syncSecrets: async (secretSync: TTeamCitySyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TTeamCitySyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { project, buildConfig }
@@ -100,7 +101,7 @@ export const TeamCitySyncFns = {
     for await (const entry of Object.entries(secretMap)) {
       const [key, { value }] = entry;
 
-      const payload = {
+      const requestPayload = {
         instanceUrl,
         accessToken,
         project,
@@ -112,7 +113,7 @@ export const TeamCitySyncFns = {
       try {
         // Replace every secret since TeamCity does not return secret values that we can cross-check
         // No need to differenciate create / update because TeamCity uses the same method for both
-        await updateTeamCityVariable(payload);
+        await updateTeamCityVariable(requestPayload);
       } catch (error) {
         throw new SecretSyncError({
           error,
@@ -147,7 +148,8 @@ export const TeamCitySyncFns = {
       }
     }
   },
-  removeSecrets: async (secretSync: TTeamCitySyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TTeamCitySyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { project, buildConfig }

--- a/backend/src/services/secret-sync/terraform-cloud/terraform-cloud-sync-fns.ts
+++ b/backend/src/services/secret-sync/terraform-cloud/terraform-cloud-sync-fns.ts
@@ -5,6 +5,7 @@ import { request } from "@app/lib/config/request";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
@@ -214,7 +215,8 @@ const updateVariable = async (
 };
 
 export const TerraformCloudSyncFns = {
-  syncSecrets: async (secretSync: TTerraformCloudSyncWithCredentials, secretMap: TSecretMap): Promise<void> => {
+  syncSecrets: async (secretSync: TTerraformCloudSyncWithCredentials, payload: TSecretSyncPayload): Promise<void> => {
+    const secretMap = payload.flatten();
     const terraformCloudVariables = await getTerraformCloudVariables(secretSync);
     const terraformCloudVariablesMap = new Map<string, TerraformCloudVariable>(
       terraformCloudVariables.map((v) => [v.key, v])
@@ -250,7 +252,8 @@ export const TerraformCloudSyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  removeSecrets: async (secretSync: TTerraformCloudSyncWithCredentials, secretMap: TSecretMap): Promise<void> => {
+  removeSecrets: async (secretSync: TTerraformCloudSyncWithCredentials, payload: TSecretSyncPayload): Promise<void> => {
+    const secretMap = payload.flatten();
     const terraformCloudVariables = await getTerraformCloudVariables(secretSync);
 
     for (const variable of terraformCloudVariables) {

--- a/backend/src/services/secret-sync/travis-ci/travis-ci-sync-fns.ts
+++ b/backend/src/services/secret-sync/travis-ci/travis-ci-sync-fns.ts
@@ -6,6 +6,7 @@ import { request } from "@app/lib/config/request";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
@@ -124,7 +125,8 @@ export const TravisCISyncFns = {
     throw new Error(`${SECRET_SYNC_NAME_MAP[secretSync.destination]} does not support importing secrets.`);
   },
 
-  async syncSecrets(secretSync: TTravisCISyncWithCredentials, secretMap: TSecretMap): Promise<void> {
+  async syncSecrets(secretSync: TTravisCISyncWithCredentials, payload: TSecretSyncPayload): Promise<void> {
+    const secretMap = payload.flatten();
     const {
       connection: {
         credentials: { apiToken }
@@ -189,7 +191,8 @@ export const TravisCISyncFns = {
     }
   },
 
-  async removeSecrets(secretSync: TTravisCISyncWithCredentials, secretMap: TSecretMap): Promise<void> {
+  async removeSecrets(secretSync: TTravisCISyncWithCredentials, payload: TSecretSyncPayload): Promise<void> {
+    const secretMap = payload.flatten();
     const {
       connection: {
         credentials: { apiToken }

--- a/backend/src/services/secret-sync/trigger-dev/trigger-dev-sync-fns.ts
+++ b/backend/src/services/secret-sync/trigger-dev/trigger-dev-sync-fns.ts
@@ -2,6 +2,7 @@ import { request } from "@app/lib/config/request";
 import { getTriggerDevInstanceUrl } from "@app/services/app-connection/trigger-dev";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { SECRET_SYNC_NAME_MAP } from "../secret-sync-maps";
@@ -109,7 +110,8 @@ const deleteTriggerDevEnvVar = async (
 };
 
 export const TriggerDevSyncFns = {
-  syncSecrets: async (secretSync: TTriggerDevSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TTriggerDevSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { environment, syncOptions } = secretSync;
 
     const variables: Record<string, string> = Object.fromEntries(
@@ -149,7 +151,8 @@ export const TriggerDevSyncFns = {
     }
   },
 
-  removeSecrets: async (secretSync: TTriggerDevSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TTriggerDevSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const existing = await listTriggerDevEnvVars(secretSync);
 
     const keysToDelete = existing.map((envVar) => envVar.name).filter((key) => key in secretMap);

--- a/backend/src/services/secret-sync/vercel/vercel-sync-fns.ts
+++ b/backend/src/services/secret-sync/vercel/vercel-sync-fns.ts
@@ -3,6 +3,7 @@ import { request } from "@app/lib/config/request";
 import { IntegrationUrls } from "@app/services/integration-auth/integration-list";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 
 import { VercelEnvironmentType, VercelSyncScope } from "./vercel-sync-enums";
@@ -870,7 +871,8 @@ const detachTeamSharedEnvVar = async (
 };
 
 export const VercelSyncFns = {
-  syncSecrets: async (secretSync: TVercelSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TVercelSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     if (secretSync.destinationConfig.scope === VercelSyncScope.Team) {
       const teamDestinationConfig = secretSync.destinationConfig;
       const allSharedEnvVars = await getTeamSharedEnvVars(secretSync);
@@ -1031,7 +1033,8 @@ export const VercelSyncFns = {
     return Object.fromEntries(vercelSecrets.map((s) => [s.key, { value: s.value ?? "" }]));
   },
 
-  removeSecrets: async (secretSync: TVercelSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TVercelSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     if (secretSync.destinationConfig.scope === VercelSyncScope.Team) {
       const sharedEnvVars = await getOwnedTeamSharedEnvVars(secretSync);
 

--- a/backend/src/services/secret-sync/windmill/windmill-sync-fns.ts
+++ b/backend/src/services/secret-sync/windmill/windmill-sync-fns.ts
@@ -11,7 +11,7 @@ import {
   TWindmillVariable
 } from "@app/services/secret-sync/windmill/windmill-sync-types";
 
-import { TSecretMap } from "../secret-sync-types";
+import { TSecretSyncPayload } from "../secret-sync-payload";
 
 const PAGE_LIMIT = 100;
 
@@ -125,7 +125,8 @@ const deleteWindmillVariable = async ({ path, instanceUrl, accessToken, workspac
   });
 
 export const WindmillSyncFns = {
-  syncSecrets: async (secretSync: TWindmillSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TWindmillSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       environment,
@@ -146,7 +147,7 @@ export const WindmillSyncFns = {
       const [key, { value, comment = "" }] = entry;
 
       try {
-        const payload = {
+        const requestPayload = {
           instanceUrl,
           workspace,
           path: path + key,
@@ -156,9 +157,9 @@ export const WindmillSyncFns = {
         };
         if (key in variables) {
           if (variables[key].value !== value || variables[key].description !== comment)
-            await updateWindmillVariable(payload);
+            await updateWindmillVariable(requestPayload);
         } else {
-          await createWindmillVariable(payload);
+          await createWindmillVariable(requestPayload);
         }
       } catch (error) {
         throw new SecretSyncError({
@@ -191,7 +192,8 @@ export const WindmillSyncFns = {
       }
     }
   },
-  removeSecrets: async (secretSync: TWindmillSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TWindmillSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const {
       connection,
       destinationConfig: { path }

--- a/backend/src/services/secret-sync/zabbix/zabbix-sync-fns.ts
+++ b/backend/src/services/secret-sync/zabbix/zabbix-sync-fns.ts
@@ -4,6 +4,7 @@ import { request } from "@app/lib/config/request";
 import { blockLocalAndPrivateIpAddresses } from "@app/lib/validator";
 import { SecretSyncError } from "@app/services/secret-sync/secret-sync-errors";
 import { matchesSchema } from "@app/services/secret-sync/secret-sync-fns";
+import { TSecretSyncPayload } from "@app/services/secret-sync/secret-sync-payload";
 import { TSecretMap } from "@app/services/secret-sync/secret-sync-types";
 import {
   TZabbixSecret,
@@ -195,7 +196,8 @@ const deleteZabbixSecrets = async (
 };
 
 export const ZabbixSyncFns = {
-  syncSecrets: async (secretSync: TZabbixSyncWithCredentials, secretMap: TSecretMap) => {
+  syncSecrets: async (secretSync: TZabbixSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { connection, environment, destinationConfig } = secretSync;
     const { apiToken, instanceUrl } = connection.credentials;
     await blockLocalAndPrivateIpAddresses(instanceUrl);
@@ -239,7 +241,8 @@ export const ZabbixSyncFns = {
     }
   },
 
-  removeSecrets: async (secretSync: TZabbixSyncWithCredentials, secretMap: TSecretMap) => {
+  removeSecrets: async (secretSync: TZabbixSyncWithCredentials, payload: TSecretSyncPayload) => {
+    const secretMap = payload.flatten();
     const { connection, destinationConfig } = secretSync;
     const { apiToken, instanceUrl } = connection.credentials;
     await blockLocalAndPrivateIpAddresses(instanceUrl);

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -69,6 +69,9 @@ services:
       AUTH_SECRET: something-random
       ENCRYPTION_KEY: p5e5k2j3+HIErjm02dzSrlhXc1xhdgoWvC6pox410rE=
       NODE_ENV: test
+      # Defaults to info. Overridable so a run being debugged can see the queue lifecycle lines
+      # without editing this file.
+      PINO_LOG_LEVEL: ${PINO_LOG_LEVEL:-info}
       # The heap is set explicitly because Node derives its default from available memory, so
       # without this the suite's budget depends on the host: a 16GB CI runner gets about 4GB
       # and boots fine, while an 8GB Docker Desktop VM gets ~2GB and dies during environment

--- a/frontend/src/components/secret-syncs/forms/CreateSecretSyncForm.tsx
+++ b/frontend/src/components/secret-syncs/forms/CreateSecretSyncForm.tsx
@@ -34,6 +34,7 @@ import {
   TSecretSync,
   useCreateSecretSync,
   useDuplicateDestinationCheck,
+  useRecursiveConflictsCheck,
   useSecretSyncOption
 } from "@app/hooks/api/secretSyncs";
 
@@ -226,18 +227,34 @@ export const CreateSecretSyncForm = ({
     initialSyncBehavior === SecretSyncInitialSyncBehavior.OverwriteDestination &&
     !disableSecretDeletion &&
     !keySchema;
+  const importsFromDestination =
+    initialSyncBehavior === SecretSyncInitialSyncBehavior.ImportPrioritizeSource ||
+    initialSyncBehavior === SecretSyncInitialSyncBehavior.ImportPrioritizeDestination;
+
+  const { conflicts: recursiveConflicts } = useRecursiveConflictsCheck({
+    destination,
+    projectId: currentProject?.id || "",
+    environment: watch("environment")?.slug,
+    secretPath: watch("secretPath"),
+    keySchema,
+    recursive: Boolean(watch("syncOptions.recursive")) && !importsFromDestination
+  });
 
   const isStepValid = async (index: number) => trigger(formTabs[index].fields);
 
   const isFinalStep = selectedTabIndex === formTabs.length - 1;
-  const isCreateButtonDisabled =
-    isFinalStep && hasDuplicate && currentOrg?.blockDuplicateSecretSyncDestinations;
+  const isSourceStep = selectedTabIndex === 0;
+  const isNextButtonDisabled =
+    (isFinalStep && hasDuplicate && currentOrg?.blockDuplicateSecretSyncDestinations) ||
+    (isSourceStep && recursiveConflicts.length > 0);
 
   const handleNext = async () => {
     if (isFinalStep) {
       setShowConfirmation(true);
       return;
     }
+
+    if (isSourceStep && recursiveConflicts.length > 0) return;
 
     const isValid = await isStepValid(selectedTabIndex);
 
@@ -266,6 +283,10 @@ export const CreateSecretSyncForm = ({
       setSelectedTabIndex(targetTab);
       return;
     }
+
+    // The Source step (index 0) is always behind a forward jump, since targetTab > selectedTabIndex
+    // here, so a conflict there must block the jump the same way it blocks handleNext.
+    if (recursiveConflicts.length > 0) return;
 
     let canJump = true;
     for (let i = selectedTabIndex; i < targetTab; i += 1) {
@@ -390,7 +411,7 @@ export const CreateSecretSyncForm = ({
             <Button variant="outline" onClick={handlePrev}>
               Back
             </Button>
-            <Button variant="project" onClick={handleNext} isDisabled={isCreateButtonDisabled}>
+            <Button variant="project" onClick={handleNext} isDisabled={isNextButtonDisabled}>
               {isFinalStep ? "Create Sync" : "Continue"}
             </Button>
           </div>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncReviewFields/SecretSyncReviewFields.tsx
@@ -96,7 +96,7 @@ export const SecretSyncReviewFields = () => {
     connection,
     environment,
     secretPath,
-    syncOptions: { disableSecretDeletion, initialSyncBehavior, keySchema },
+    syncOptions: { disableSecretDeletion, initialSyncBehavior, keySchema, recursive },
     destination,
     isAutoSyncEnabled
   } = watch();
@@ -357,6 +357,14 @@ export const SecretSyncReviewFields = () => {
             )}
           </Detail>
           {AdditionalSyncOptionsFieldsComponent}
+          <Detail>
+            <DetailLabel>Include Subfolders</DetailLabel>
+            <DetailValue>
+              <Badge variant={recursive ? "success" : "neutral"}>
+                {recursive ? "Enabled" : "Disabled"}
+              </Badge>
+            </DetailValue>
+          </Detail>
           <Detail>
             <DetailLabel>Secret Deletion Protection</DetailLabel>
             <DetailValue>

--- a/frontend/src/components/secret-syncs/forms/SecretSyncSourceFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncSourceFields.tsx
@@ -1,8 +1,12 @@
 import { useEffect } from "react";
 import { Controller, useFormContext, useWatch } from "react-hook-form";
 import { subject } from "@casl/ability";
+import { CheckCircle2, TriangleAlert } from "lucide-react";
 
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Field,
   FieldContent,
   FieldDescription,
@@ -19,10 +23,18 @@ import {
   ProjectPermissionSecretSyncActions,
   ProjectPermissionSub
 } from "@app/context/ProjectPermissionContext/types";
-import { SecretSync, SecretSyncInitialSyncBehavior } from "@app/hooks/api/secretSyncs";
+import {
+  SecretSync,
+  SecretSyncInitialSyncBehavior,
+  useRecursiveConflictsCheck
+} from "@app/hooks/api/secretSyncs";
 
 import { AzureEntraIdScimSyncSourceFields } from "./AzureEntraIdScimSyncSourceFields";
 import { TSecretSyncForm } from "./schemas";
+
+// Mirrors SECRET_SYNC_MAX_SECRETS in backend/src/services/secret-sync/secret-sync-recursive-fns.ts.
+const SECRET_SYNC_MAX_SECRETS = 100;
+const MAX_DISPLAYED_CONFLICTS = 5;
 
 const DefaultSecretSyncSourceFields = () => {
   const { control, watch, setValue, setError, clearErrors } = useFormContext<TSecretSyncForm>();
@@ -30,14 +42,25 @@ const DefaultSecretSyncSourceFields = () => {
   const { permission } = useProjectPermission();
   const { currentProject } = useProject();
 
+  const destination = watch("destination");
   const selectedEnvironment = watch("environment");
   const selectedSecretPath = watch("secretPath");
   const initialSyncBehavior = watch("syncOptions.initialSyncBehavior");
   const recursive = watch("syncOptions.recursive");
+  const keySchema = watch("syncOptions.keySchema");
 
   const importsFromDestination =
     initialSyncBehavior === SecretSyncInitialSyncBehavior.ImportPrioritizeSource ||
     initialSyncBehavior === SecretSyncInitialSyncBehavior.ImportPrioritizeDestination;
+
+  const { conflicts, isChecking, isClear } = useRecursiveConflictsCheck({
+    destination,
+    projectId: currentProject.id,
+    environment: selectedEnvironment?.slug,
+    secretPath: selectedSecretPath,
+    keySchema,
+    recursive: Boolean(recursive) && !importsFromDestination
+  });
 
   useEffect(() => {
     if (!selectedEnvironment) {
@@ -118,11 +141,11 @@ const DefaultSecretSyncSourceFields = () => {
           <Field>
             <Field orientation="horizontal">
               <FieldContent>
-                <Label htmlFor="recursive">Include subfolders</Label>
+                <Label htmlFor="recursive">Recursively sync secrets</Label>
                 <FieldDescription>
                   {importsFromDestination
                     ? "Not available when the initial sync imports secrets from the destination. There is no single folder to import them back into."
-                    : "Also sync secrets from every folder beneath this path. Secret names must be unique across those folders."}
+                    : `Also sync secrets from every folder beneath this path, however deep. Secret names must be unique across all of them, and the combined total can't exceed ${SECRET_SYNC_MAX_SECRETS} secrets.`}
                 </FieldDescription>
               </FieldContent>
               <Switch
@@ -134,6 +157,50 @@ const DefaultSecretSyncSourceFields = () => {
               />
             </Field>
             <FieldError errors={[error]} />
+            {isChecking && (
+              <p className="text-sm text-muted">Checking for naming conflicts across folders...</p>
+            )}
+            {isClear && (
+              <p className="flex items-center gap-1.5 text-sm text-success">
+                <CheckCircle2 className="size-4" />
+                No naming collisions detected
+              </p>
+            )}
+            {!isChecking && conflicts.length > 0 && (
+              <Alert variant="danger">
+                <TriangleAlert />
+                <AlertTitle>
+                  {conflicts.length === 1
+                    ? "1 secret name conflicts across folders"
+                    : `${conflicts.length} secret names conflict across folders`}
+                </AlertTitle>
+                <AlertDescription>
+                  <p>
+                    This destination stores secrets in a single flat list, so each name can be used
+                    only once. Rename or move one secret in each pair, or point the sync at a
+                    narrower secret path.
+                  </p>
+                  <ul className="mt-1 space-y-2">
+                    {conflicts.slice(0, MAX_DISPLAYED_CONFLICTS).map((conflict) => (
+                      <li key={conflict.key}>
+                        <span className="font-mono font-semibold">&quot;{conflict.key}&quot;</span>{" "}
+                        is used in {conflict.paths.length} folders:
+                        <ul className="mt-0.5 list-inside list-disc">
+                          {conflict.paths.map((path) => (
+                            <li key={path} className="font-mono">
+                              {path}
+                            </li>
+                          ))}
+                        </ul>
+                      </li>
+                    ))}
+                  </ul>
+                  {conflicts.length > MAX_DISPLAYED_CONFLICTS && (
+                    <p>and {conflicts.length - MAX_DISPLAYED_CONFLICTS} more</p>
+                  )}
+                </AlertDescription>
+              </Alert>
+            )}
           </Field>
         )}
       />

--- a/frontend/src/components/secret-syncs/forms/SecretSyncSourceFields.tsx
+++ b/frontend/src/components/secret-syncs/forms/SecretSyncSourceFields.tsx
@@ -5,30 +5,39 @@ import { subject } from "@casl/ability";
 import {
   Field,
   FieldContent,
+  FieldDescription,
   FieldError,
   FieldGroup,
   FieldLabel,
   FilterableSelect,
-  SecretPathInput
+  Label,
+  SecretPathInput,
+  Switch
 } from "@app/components/v3";
 import { useProject, useProjectPermission } from "@app/context";
 import {
   ProjectPermissionSecretSyncActions,
   ProjectPermissionSub
 } from "@app/context/ProjectPermissionContext/types";
-import { SecretSync } from "@app/hooks/api/secretSyncs";
+import { SecretSync, SecretSyncInitialSyncBehavior } from "@app/hooks/api/secretSyncs";
 
 import { AzureEntraIdScimSyncSourceFields } from "./AzureEntraIdScimSyncSourceFields";
 import { TSecretSyncForm } from "./schemas";
 
 const DefaultSecretSyncSourceFields = () => {
-  const { control, watch, setError, clearErrors } = useFormContext<TSecretSyncForm>();
+  const { control, watch, setValue, setError, clearErrors } = useFormContext<TSecretSyncForm>();
 
   const { permission } = useProjectPermission();
   const { currentProject } = useProject();
 
   const selectedEnvironment = watch("environment");
   const selectedSecretPath = watch("secretPath");
+  const initialSyncBehavior = watch("syncOptions.initialSyncBehavior");
+  const recursive = watch("syncOptions.recursive");
+
+  const importsFromDestination =
+    initialSyncBehavior === SecretSyncInitialSyncBehavior.ImportPrioritizeSource ||
+    initialSyncBehavior === SecretSyncInitialSyncBehavior.ImportPrioritizeDestination;
 
   useEffect(() => {
     if (!selectedEnvironment) {
@@ -52,6 +61,12 @@ const DefaultSecretSyncSourceFields = () => {
       clearErrors("secretPath");
     }
   }, [selectedEnvironment, selectedSecretPath]);
+
+  useEffect(() => {
+    if (importsFromDestination && recursive) {
+      setValue("syncOptions.recursive", false);
+    }
+  }, [importsFromDestination, recursive, setValue]);
 
   return (
     <FieldGroup>
@@ -93,6 +108,32 @@ const DefaultSecretSyncSourceFields = () => {
               />
               <FieldError errors={[error]} />
             </FieldContent>
+          </Field>
+        )}
+      />
+      <Controller
+        control={control}
+        name="syncOptions.recursive"
+        render={({ field: { value, onChange }, fieldState: { error } }) => (
+          <Field>
+            <Field orientation="horizontal">
+              <FieldContent>
+                <Label htmlFor="recursive">Include subfolders</Label>
+                <FieldDescription>
+                  {importsFromDestination
+                    ? "Not available when the initial sync imports secrets from the destination. There is no single folder to import them back into."
+                    : "Also sync secrets from every folder beneath this path. Secret names must be unique across those folders."}
+                </FieldDescription>
+              </FieldContent>
+              <Switch
+                id="recursive"
+                variant="project"
+                checked={Boolean(value) && !importsFromDestination}
+                disabled={importsFromDestination}
+                onCheckedChange={onChange}
+              />
+            </Field>
+            <FieldError errors={[error]} />
           </Field>
         )}
       />

--- a/frontend/src/components/secret-syncs/forms/schemas/base-secret-sync-schema.ts
+++ b/frontend/src/components/secret-syncs/forms/schemas/base-secret-sync-schema.ts
@@ -9,6 +9,7 @@ export const BaseSecretSyncSchema = <T extends AnyZodObject | undefined = undefi
   const baseSyncOptionsSchema = z.object({
     initialSyncBehavior: z.nativeEnum(SecretSyncInitialSyncBehavior),
     disableSecretDeletion: z.boolean().optional().default(false),
+    recursive: z.boolean().optional(),
     keySchema: z
       .string()
       .optional()

--- a/frontend/src/hooks/api/secretSyncs/index.ts
+++ b/frontend/src/hooks/api/secretSyncs/index.ts
@@ -3,3 +3,4 @@ export * from "./mutations";
 export * from "./queries";
 export * from "./types";
 export * from "./useDuplicateDestinationCheck";
+export * from "./useRecursiveConflictsCheck";

--- a/frontend/src/hooks/api/secretSyncs/queries.tsx
+++ b/frontend/src/hooks/api/secretSyncs/queries.tsx
@@ -28,7 +28,28 @@ export const secretSyncKeys = {
       destinationConfig,
       connectionId,
       excludeSyncId
+    ] as const,
+  recursiveConflicts: (
+    destination: SecretSync,
+    projectId: string,
+    environment?: string,
+    secretPath?: string,
+    keySchema?: string
+  ) =>
+    [
+      ...secretSyncKeys.all,
+      destination,
+      "recursive-conflicts",
+      projectId,
+      environment,
+      secretPath,
+      keySchema
     ] as const
+};
+
+export type TSecretSyncRecursiveConflict = {
+  key: string;
+  paths: string[];
 };
 
 export const useSecretSyncOptions = (
@@ -140,6 +161,43 @@ export const useCheckDuplicateDestination = (
       return data;
     },
     enabled: Boolean(destinationConfig) && Object.keys(destinationConfig || {}).length > 0,
+    ...options
+  });
+};
+
+export const useCheckRecursiveConflicts = (
+  destination: SecretSync,
+  projectId: string,
+  environment?: string,
+  secretPath?: string,
+  keySchema?: string,
+  options?: Omit<
+    UseQueryOptions<
+      { conflicts: TSecretSyncRecursiveConflict[] },
+      unknown,
+      { conflicts: TSecretSyncRecursiveConflict[] },
+      ReturnType<typeof secretSyncKeys.recursiveConflicts>
+    >,
+    "queryKey" | "queryFn"
+  >
+) => {
+  return useQuery({
+    queryKey: secretSyncKeys.recursiveConflicts(
+      destination,
+      projectId,
+      environment,
+      secretPath,
+      keySchema
+    ),
+    queryFn: async () => {
+      const { data } = await apiRequest.post<{ conflicts: TSecretSyncRecursiveConflict[] }>(
+        `/api/v1/secret-syncs/${destination}/recursive-conflicts`,
+        { projectId, environment, secretPath, keySchema }
+      );
+
+      return data;
+    },
+    enabled: Boolean(environment) && Boolean(secretPath),
     ...options
   });
 };

--- a/frontend/src/hooks/api/secretSyncs/types/root-sync.ts
+++ b/frontend/src/hooks/api/secretSyncs/types/root-sync.ts
@@ -5,6 +5,7 @@ export type RootSyncOptions = {
   initialSyncBehavior: SecretSyncInitialSyncBehavior;
   disableSecretDeletion?: boolean;
   keySchema?: string;
+  recursive?: boolean;
 };
 
 export type TRootSecretSync = {

--- a/frontend/src/hooks/api/secretSyncs/useRecursiveConflictsCheck.ts
+++ b/frontend/src/hooks/api/secretSyncs/useRecursiveConflictsCheck.ts
@@ -1,0 +1,45 @@
+import { SecretSync, useCheckRecursiveConflicts } from "@app/hooks/api/secretSyncs";
+
+type UseRecursiveConflictsCheckProps = {
+  destination: SecretSync;
+  projectId: string;
+  environment?: string;
+  secretPath?: string;
+  keySchema?: string;
+  recursive: boolean;
+};
+
+export const useRecursiveConflictsCheck = ({
+  destination,
+  projectId,
+  environment,
+  secretPath,
+  keySchema,
+  recursive
+}: UseRecursiveConflictsCheckProps) => {
+  const shouldCheck = recursive && Boolean(environment) && Boolean(secretPath);
+
+  const { data, isLoading, isSuccess, error } = useCheckRecursiveConflicts(
+    destination,
+    projectId,
+    shouldCheck ? environment : undefined,
+    shouldCheck ? secretPath : undefined,
+    keySchema,
+    {
+      enabled: shouldCheck,
+      staleTime: 0,
+      gcTime: 0
+    }
+  );
+
+  const conflicts = shouldCheck ? (data?.conflicts ?? []) : [];
+
+  return {
+    conflicts,
+    isChecking: shouldCheck && isLoading,
+    // True once a check has actually completed and found nothing, so the caller can render a
+    // "no conflicts" success state distinct from "no check has run yet".
+    isClear: shouldCheck && isSuccess && conflicts.length === 0,
+    hasError: Boolean(error)
+  };
+};


### PR DESCRIPTION
## Context

Stage one of recursive secret syncs ([SECRETS-525](https://linear.app/infisical/issue/SECRETS-525/recursive-secret-syncs)). Adds a `recursive` sync option: when it is on, a sync pushes every secret in its source folder and in all folders beneath it.

Infisical does not decide where those secrets land at the destination. Each provider does. Today every provider lands them in one flat list. Providers whose destination has its own folder structure, such as AWS Parameter Store, can later keep the paths. That is separate work.

**Stacked on #<e2e-harness-pr> (`calvin/secret-sync-e2e-tests`), which must merge first.**

### The contract

Providers receive a payload object with two views:

```ts
all()       // every secret, each with its name, folder path, id and value
flatten()   // the same secrets as a single flat list, keyed by name
```

`flatten()` is where duplicate names are caught. Two secrets in different folders can share a name and a flat destination has room for only one, so calling `flatten()` reports every clash, naming both folders, and the sync fails. A provider that keeps the folder structure calls `all()` instead and never meets the problem, because it does not have one.

Obtaining the flat view is what runs the check, so there is no separate call to forget. The payload is an object rather than a record for the same reason: every provider previously destructured a `Record` with `Object.entries` and reconciled deletions with `key in secretMap`, and both of those compile against an array or a path-keyed record, so an unconverted provider would have typechecked and silently either named secrets `0`, `1`, `2` or deleted the whole destination.

### Who does what

| Part | Responsibility |
| --- | --- |
| Infisical | Collect every secret below the source folder and hand it over. Knows folders, permissions and imports. Knows nothing about destinations. |
| The payload | Offer two ways to read the same secrets. Decides nothing. |
| Provider | Choose one, and place the secrets at the destination. Knows what its own destination supports. |

### Permissions

The sync worker performs no authorization of its own, so create and update time is the only gate. Folder grants let someone read `/backend` while being denied `/backend/api`, so without a check a recursive sync would have read the denied folder on their behalf and delivered it to a destination they control. Every folder a sync will read is now authorized, on create and on every update that leaves the sync recursive.

### Secret imports

Inside one folder a secret that lives there still beats one pulled in, which is existing behaviour and unchanged. Across folders, two folders offering the same name is a clash and the sync fails.

## Screenshots

Not added yet. The `Include subfolders` toggle sits on the source step, disabled with a stated reason when an import initial-sync behavior is selected.

## Steps to verify the change

```
make test-api-unit SPEC=secret-sync     # 37 tests
make test-api-e2e  SPEC=secret-sync     # 29 tests, 4 files
cd backend && npm run type:check        # zero errors
```

Note: the end-to-end harness does not reset state between runs, so a docker stack left up across many runs accumulates enough data to start timing out. If you see intermittent "Timed out waiting for a sync run to reach the destination", tear it down first:

```
docker compose -f docker-compose.test.yml --profile runner down -v
```

Five consecutive runs pass on a freshly rebuilt stack, with no degradation across them.

## Other things worth a look

- **A pre-existing hole, not introduced here.** An actor with `SecretSyncs.Edit` on a **non-recursive** sync's source path, but no read permission on those secrets, can still repoint that sync at a destination they control. The update gate only fires when the source changes. This is on `main` today. Fixing it would re-check permissions on every edit of every existing sync and could refuse edits that work now, so it is left for a separate decision.
- **A bug this work uncovered and fixed.** `UpdateAwsSecretsManagerSyncSchema` dereferenced `sync.syncOptions.syncSecretMetadataAsTags` without a guard while `syncOptions` is optional on the update schema, so a `PATCH` omitting it threw. Fixed in `f16d30e65a`.
- Authorization happens at create and update time while the folder set resolves at run time, so a subfolder created under the source after authorization is read with no further check.
- **Two unrelated fixes rode along, both found while debugging the suite.** Queue job failures were logged nowhere, only counted, so an uncaught handler exception was invisible (`cee9aca2cc`). And `PINO_LOG_LEVEL=debug` was a no-op product-wide, because the pino transport target was pinned to `info` while the logger read the variable (`f123037698`). Both are small and separable if you would rather they went in on their own.
- Import-from-destination is rejected while `recursive` is on, because there is no single folder to import into.

## Type

- [x] Feature

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally (37 unit, 29 e2e, type check clean)
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
