### PR TITLE
fix(queue): log job failures and make PINO_LOG_LEVEL work

### DIFF
--- a/backend/src/lib/logger/logger.ts
+++ b/backend/src/lib/logger/logger.ts
@@ -106,13 +106,15 @@ const extractOrgId = () => {
   }
 };
 
+// A transport target filters independently of the logger instance, so both have to be set from
+// the same place. Pinning the target to info while the instance read the variable is what made
+// PINO_LOG_LEVEL=debug do nothing.
+const getLogLevel = () => process.env.PINO_LOG_LEVEL || "info";
+
 export const initLogger = () => {
   const targets: pino.TransportMultiOptions["targets"][number][] = [
     {
-      // Follows the same env var as the logger instance below. A transport target filters
-      // independently of the logger, so pinning this to info silently discarded every debug
-      // record no matter what PINO_LOG_LEVEL said.
-      level: process.env.PINO_LOG_LEVEL || "info",
+      level: getLogLevel(),
       target: "pino/file",
       options: {
         destination: 1,
@@ -154,7 +156,7 @@ export const initLogger = () => {
       mixin(_context, level) {
         return { severity: logLevelToSeverityLookup[level] || logLevelToSeverityLookup["30"] };
       },
-      level: process.env.PINO_LOG_LEVEL || "info",
+      level: getLogLevel(),
       formatters: {
         bindings: (bindings) => ({
           pid: bindings.pid,

--- a/backend/src/lib/logger/logger.ts
+++ b/backend/src/lib/logger/logger.ts
@@ -106,9 +106,6 @@ const extractOrgId = () => {
   }
 };
 
-// A transport target filters independently of the logger instance, so both have to be set from
-// the same place. Pinning the target to info while the instance read the variable is what made
-// PINO_LOG_LEVEL=debug do nothing.
 const getLogLevel = () => process.env.PINO_LOG_LEVEL || "info";
 
 export const initLogger = () => {

--- a/backend/src/lib/logger/logger.ts
+++ b/backend/src/lib/logger/logger.ts
@@ -109,7 +109,10 @@ const extractOrgId = () => {
 export const initLogger = () => {
   const targets: pino.TransportMultiOptions["targets"][number][] = [
     {
-      level: "info",
+      // Follows the same env var as the logger instance below. A transport target filters
+      // independently of the logger, so pinning this to info silently discarded every debug
+      // record no matter what PINO_LOG_LEVEL said.
+      level: process.env.PINO_LOG_LEVEL || "info",
       target: "pino/file",
       options: {
         destination: 1,

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -871,7 +871,7 @@ export const queueServiceFactory = (redisCfg: TRedisConfigKeys): TQueueServiceFa
       }
 
       const errorType = classifyError(err);
-      const attemptsExhausted = !!(job?.opts.attempts && job.attemptsMade && job.attemptsMade >= job.opts.attempts);
+      const attemptsExhausted = !!job && job.attemptsMade >= (job.opts.attempts || 1);
       queueJobFailureCounter.add(1, {
         ...baseAttrs,
         "error.type": errorType,

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -842,6 +842,8 @@ export const queueServiceFactory = (redisCfg: TRedisConfigKeys): TQueueServiceFa
       const baseAttrs = { "queue.name": name, "job.name": job.name } as Record<string, string>;
       queueJobCounter.add(1, { ...baseAttrs, outcome: "completed" });
 
+      logger.debug({ queue: name, job: job.name, jobId: job.id }, "Queue job completed");
+
       if (typeof job.processedOn === "number" && typeof job.timestamp === "number") {
         const durationMs = Date.now() - job.processedOn;
         queueJobDurationHistogram.record(durationMs / 1000, { ...baseAttrs, outcome: "completed" });
@@ -875,10 +877,26 @@ export const queueServiceFactory = (redisCfg: TRedisConfigKeys): TQueueServiceFa
         "error.type": errorType,
         "attempts.exhausted": attemptsExhausted ? "true" : "false"
       });
+
+      // A handler that throws without catching leaves no other trace: the metrics above carry no
+      // message and no stack, so without this the only evidence is a counter moving.
+      logger.error(
+        err,
+        `Queue job failed [queue=${name}] [job=${job?.name ?? "unknown"}] [jobId=${job?.id ?? "unknown"}] [attempt=${
+          job?.attemptsMade ?? 0
+        }] [attemptsExhausted=${attemptsExhausted}]`
+      );
     });
 
-    worker.on("stalled", () => {
+    // Stalling means the worker stopped heartbeating and BullMQ handed the job to someone else, so
+    // it is both rare and always worth seeing. It stays at warn rather than debug for that reason.
+    worker.on("stalled", (jobId) => {
       queueStalledCounter.add(1, { "queue.name": name });
+      logger.warn({ queue: name, jobId }, `Queue job stalled and was requeued [queue=${name}] [jobId=${jobId}]`);
+    });
+
+    worker.on("active", (job) => {
+      logger.debug({ queue: name, job: job.name, jobId: job.id }, "Queue job picked up by a worker");
     });
 
     workerContainer[name] = worker;
@@ -907,6 +925,11 @@ export const queueServiceFactory = (redisCfg: TRedisConfigKeys): TQueueServiceFa
     };
 
     await q?.add(job, data, finalOptions);
+
+    // Only when the job really exists. `q` is undefined only where QUEUE_WORKERS_ENABLED is false,
+    // and a pod in that mode neither produces nor consumes, so a no-op there is expected rather
+    // than a dropped job worth reporting.
+    if (q) logger.debug({ queue: name, job, jobId }, "Queue job enqueued");
   };
 
   const stopRepeatableJob: TQueueServiceFactory["stopRepeatableJob"] = async (name, job, repeatOpt, jobId) => {

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -922,12 +922,12 @@ export const queueServiceFactory = (redisCfg: TRedisConfigKeys): TQueueServiceFa
       jobId
     };
 
-    await q?.add(job, data, finalOptions);
+    const addedJob = await q?.add(job, data, finalOptions);
 
     // Only when the job really exists. `q` is undefined only where QUEUE_WORKERS_ENABLED is false,
     // and a pod in that mode neither produces nor consumes, so a no-op there is expected rather
     // than a dropped job worth reporting.
-    if (q) logger.debug({ queue: name, job, jobId }, "Queue job enqueued");
+    if (addedJob) logger.debug({ queue: name, job, jobId: addedJob.id }, "Queue job enqueued");
   };
 
   const stopRepeatableJob: TQueueServiceFactory["stopRepeatableJob"] = async (name, job, repeatOpt, jobId) => {

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -878,8 +878,6 @@ export const queueServiceFactory = (redisCfg: TRedisConfigKeys): TQueueServiceFa
         "attempts.exhausted": attemptsExhausted ? "true" : "false"
       });
 
-      // A handler that throws without catching leaves no other trace: the metrics above carry no
-      // message and no stack, so without this the only evidence is a counter moving.
       logger.error(
         err,
         `Queue job failed [queue=${name}] [job=${job?.name ?? "unknown"}] [jobId=${job?.id ?? "unknown"}] [attempt=${


### PR DESCRIPTION
## Context

Two logging gaps found while debugging a flaky test suite. Neither is specific to that suite, and both hide failures in production.

### Queue job failures were counted, never logged

`worker.on("failed")` recorded OpenTelemetry counters and nothing else. A counter carries no message, no stack and no job identity, so an uncaught exception in a queue handler left no usable trace. Several handlers await work with no `try`/`catch` (eg the `SecretSync` handler in `secret-queue.ts`), so this is reachable rather than theoretical.

It was hiding real volume. A single run of the secret sync end-to-end suite logs around 150 job failures that nobody could see, mostly background jobs firing against projects a finished test had already deleted. One of them is a genuine null dereference in `secret-integration-pull` (`Cannot read properties of undefined (reading 'orgId')`) that is worth chasing separately.

### PINO_LOG_LEVEL below info did nothing, anywhere

`initLogger` built its transport target with a hardcoded `level: "info"` while the logger instance read `PINO_LOG_LEVEL`. A pino transport filters independently of the logger, so debug records were discarded at the transport no matter what the variable said. Setting `PINO_LOG_LEVEL=debug` has been a no-op product-wide.

## What changed

- Job failures log at `error`, with queue, job name, job id, attempt and whether attempts are exhausted.
- Enqueued, picked up and completed log at `debug`, so a run being debugged can tell "never queued" from "queued but never ran" from "ran and hung".
- Stalling logs at `warn`. A worker that stopped heartbeating is rare and always worth seeing, so it does not belong behind debug.
- The transport target now follows `PINO_LOG_LEVEL`.

Two details worth a reviewer's eye:

- All four calls pass structured fields with a static message rather than an interpolated string. Pino swaps a disabled level for a noop, but JavaScript still evaluates the arguments at the call site, so building a string per job completion would cost work in production for output nobody reads.
- The enqueue line is guarded on the queue existing. `q` is undefined only where `QUEUE_WORKERS_ENABLED` is false, and a pod in that mode neither produces nor consumes, so a no-op there is expected rather than a dropped job worth reporting.

## Screenshots

Not applicable.

## Steps to verify the change

```
cd backend && npm run type:check
```

Then, on a branch that has the end-to-end harness, `PINO_LOG_LEVEL=debug make test-api-e2e SPEC=secret-sync` shows the lifecycle lines and the previously invisible failures.

## Type

- [x] Fix
- [x] Improvement

## Checklist

- [x] Title follows the conventional commit format
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the contributing guide
