### PR TITLE
feat(blind-index): allow orgs to enable blind index for all projects

### DIFF
--- a/backend/e2e-test/secret-blind-index-migration.spec.ts
+++ b/backend/e2e-test/secret-blind-index-migration.spec.ts
@@ -1,0 +1,269 @@
+import { randomUUID } from "node:crypto";
+
+import { afterEach, describe, expect, test } from "vitest";
+
+import { TableName } from "@app/db/schemas";
+import { seedData1 } from "@app/db/seed-data";
+import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
+import { getConfig } from "@app/lib/config/env";
+import { crypto } from "@app/lib/crypto/cryptography";
+import { QueueName, TQueueServiceFactory } from "@app/queue";
+import { AuthMethod, AuthTokenType } from "@app/services/auth/auth-type";
+import {
+  releaseSecretBlindIndexMigrationOrgSlot,
+  SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT,
+  SECRET_BLIND_INDEX_MIGRATION_WORKER_CONCURRENCY,
+  tryAdmitSecretBlindIndexMigrationOrgSlot
+} from "@app/services/project/project-fns";
+
+import { createSecretV2 } from "./testUtils/secrets";
+
+declare const testKeyStore: TKeyStoreFactory;
+declare const testQueue: TQueueServiceFactory;
+
+const ORG_AT_CAP_MESSAGE = "too many migrations are already running for this organization";
+const DEFAULT_ENV_SLUG = "dev";
+const MIGRATION_JOB_PREFIX = "enable-blind-index-project-";
+
+const createdOrgIds: string[] = [];
+const createdProjectIds: string[] = [];
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+const waitUntil = async (probe: () => Promise<boolean>, timeoutMs: number, intervalMs = 150) => {
+  const deadline = Date.now() + timeoutMs;
+  // eslint-disable-next-line no-await-in-loop
+  while (!(await probe())) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms`);
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(intervalMs);
+  }
+};
+
+const mintOrgJwt = (orgId: string) => {
+  const cfg = getConfig();
+  return crypto.jwt().sign(
+    {
+      authTokenType: AuthTokenType.ACCESS_TOKEN,
+      userId: seedData1.id,
+      tokenVersionId: seedData1.token.id,
+      authMethod: AuthMethod.EMAIL,
+      organizationId: orgId,
+      accessVersion: 1
+    },
+    cfg.AUTH_SECRET,
+    { expiresIn: cfg.JWT_AUTH_LIFETIME }
+  );
+};
+
+const createOrg = async () => {
+  const suffix = randomUUID().slice(0, 8);
+  const res = await testServer.inject({
+    method: "POST",
+    url: "/api/v2/organizations",
+    headers: { authorization: `Bearer ${jwtAuthToken}` },
+    body: { name: `sbi-org-${suffix}` }
+  });
+  expect(res.statusCode).toBe(200);
+  const { organization } = JSON.parse(res.payload) as { organization: { id: string } };
+  createdOrgIds.push(organization.id);
+  return { orgId: organization.id, authToken: mintOrgJwt(organization.id) };
+};
+
+const createProject = async (authToken: string, name: string) => {
+  const res = await testServer.inject({
+    method: "POST",
+    url: "/api/v1/projects",
+    headers: { authorization: `Bearer ${authToken}` },
+    body: { projectName: name }
+  });
+  expect(res.statusCode).toBe(200);
+  const { project } = JSON.parse(res.payload) as { project: { id: string } };
+  createdProjectIds.push(project.id);
+  return project.id;
+};
+
+const createDisabledProjects = async (authToken: string, count: number) => {
+  const suffix = randomUUID().slice(0, 8);
+  const projectIds: string[] = [];
+  for (let i = 0; i < count; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const projectId = await createProject(authToken, `sbi-${suffix}-${i}`);
+    projectIds.push(projectId);
+  }
+  await testDb(TableName.Project).whereIn("id", projectIds).update({ secretBlindIndexEnabled: false });
+  return projectIds;
+};
+
+const orgSlotKey = (orgId: string) => KeyStorePrefixes.SecretBlindIndexMigrationOrgSlot(orgId);
+
+const getOrgSlotCount = async (orgId: string) => {
+  const raw = await testKeyStore.getItem(orgSlotKey(orgId));
+  return raw === null ? 0 : Number(raw);
+};
+
+const occupyOrgSeats = async (orgId: string, count: number) => {
+  for (let i = 0; i < count; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const admitted = await tryAdmitSecretBlindIndexMigrationOrgSlot(testKeyStore, orgId);
+    expect(admitted).toBe(true);
+  }
+};
+
+const releaseOrgSeats = async (orgId: string, count: number) => {
+  for (let i = 0; i < count; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await releaseSecretBlindIndexMigrationOrgSlot(testKeyStore, orgId);
+  }
+};
+
+const migrationJobId = (projectId: string) => `${MIGRATION_JOB_PREFIX}${projectId}`;
+
+const getMigrationJob = (projectId: string) =>
+  testQueue.getJob(QueueName.SecretBlindIndexMigration, migrationJobId(projectId));
+
+const waitForOverflowJobs = async (projectIds: string[], timeoutMs = 20_000) => {
+  await waitUntil(async () => {
+    const jobs = await Promise.all(projectIds.map((projectId) => getMigrationJob(projectId)));
+    if (jobs.some((job) => !job)) return false;
+    const present = jobs.filter((job): job is NonNullable<typeof job> => Boolean(job));
+    const states = await Promise.all(present.map((job) => job.getState()));
+    return present.every((job, index) => {
+      const state = states[index];
+      return (job.attemptsMade ?? 0) >= 1 && (state === "delayed" || state === "failed");
+    });
+  }, timeoutMs);
+};
+
+const expectOverflowJobs = async (projectIds: string[]) => {
+  for (const projectId of projectIds) {
+    // eslint-disable-next-line no-await-in-loop
+    const job = await getMigrationJob(projectId);
+    expect(job).toBeDefined();
+    if (!job) return;
+    // eslint-disable-next-line no-await-in-loop
+    const state = await job.getState();
+    expect(["delayed", "failed"]).toContain(state);
+    expect(job.failedReason).toContain(ORG_AT_CAP_MESSAGE);
+    expect(job.opts.attempts).toBe(5);
+    expect(job.attemptsMade).toBeGreaterThanOrEqual(1);
+  }
+};
+
+const waitForProjectsEnabled = async (projectIds: string[], timeoutMs: number) => {
+  await waitUntil(async () => {
+    const projects = await testDb(TableName.Project).whereIn("id", projectIds).select("secretBlindIndexEnabled");
+    return projects.length === projectIds.length && projects.every((project) => project.secretBlindIndexEnabled);
+  }, timeoutMs);
+};
+
+const countActiveJobs = async (projectIds: string[]) => {
+  const jobs = await Promise.all(projectIds.map((projectId) => getMigrationJob(projectId)));
+  const states = await Promise.all(jobs.map((job) => job?.getState()));
+  return states.filter((state) => state === "active").length;
+};
+
+const waitForProjectsEnabledAndPeakInFlight = async (projectIds: string[], orgIds: string[], timeoutMs: number) => {
+  let peak = 0;
+  await waitUntil(
+    async () => {
+      const [active, slots] = await Promise.all([
+        countActiveJobs(projectIds),
+        Promise.all(orgIds.map((orgId) => getOrgSlotCount(orgId))).then((counts) =>
+          counts.reduce((sum, count) => sum + count, 0)
+        )
+      ]);
+      peak = Math.max(peak, active, slots);
+      const projects = await testDb(TableName.Project).whereIn("id", projectIds).select("secretBlindIndexEnabled");
+      return projects.length === projectIds.length && projects.every((project) => project.secretBlindIndexEnabled);
+    },
+    timeoutMs,
+    50
+  );
+  return peak;
+};
+
+const removeMigrationJobs = async (projectIds: string[]) => {
+  await Promise.all(
+    projectIds.map((projectId) => testQueue.stopJobById(QueueName.SecretBlindIndexMigration, migrationJobId(projectId)))
+  );
+};
+
+afterEach(async () => {
+  await Promise.all(
+    createdProjectIds.map((projectId) =>
+      testQueue.stopJobById(QueueName.SecretBlindIndexMigration, migrationJobId(projectId))
+    )
+  );
+  if (createdOrgIds.length > 0) {
+    await testKeyStore.deleteItemsByKeyIn(createdOrgIds.map(orgSlotKey));
+  }
+  createdOrgIds.length = 0;
+  createdProjectIds.length = 0;
+});
+
+describe("secret blind index migration concurrency", () => {
+  test("enables secretBlindIndexEnabled for every project in an org", async () => {
+    const { orgId, authToken } = await createOrg();
+    const projectIds = await createDisabledProjects(authToken, 3);
+    const secretKey = `SBI_${randomUUID().slice(0, 8)}`;
+
+    await createSecretV2({
+      workspaceId: projectIds[0],
+      environmentSlug: DEFAULT_ENV_SLUG,
+      secretPath: "/",
+      key: secretKey,
+      value: "blind-index-source",
+      authToken
+    });
+    await testDb(TableName.SecretV2).where({ key: secretKey }).update({ secretValueBlindIndex: null });
+
+    await testServer.services.project.startSecretBlindIndexMigrationPerOrg(orgId, 3);
+    await waitForProjectsEnabled(projectIds, 15_000);
+
+    const secret = await testDb(TableName.SecretV2).where({ key: secretKey }).first();
+    expect(secret?.secretValueBlindIndex).toBeTruthy();
+    expect(await getOrgSlotCount(orgId)).toBe(0);
+  });
+
+  test("respects the per-org in-flight cap and retries overflow jobs", async () => {
+    const { orgId, authToken } = await createOrg();
+    const projectIds = await createDisabledProjects(authToken, 3);
+
+    await occupyOrgSeats(orgId, SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT);
+    await testServer.services.project.startSecretBlindIndexMigrationPerOrg(orgId, 3);
+
+    await waitForOverflowJobs(projectIds);
+    expect(await getOrgSlotCount(orgId)).toBe(SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT);
+    await expectOverflowJobs(projectIds);
+
+    await removeMigrationJobs(projectIds);
+    await releaseOrgSeats(orgId, SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT);
+    await testServer.services.project.startSecretBlindIndexMigrationPerOrg(orgId, 3);
+    await waitForProjectsEnabled(projectIds, 15_000);
+    expect(await getOrgSlotCount(orgId)).toBe(0);
+  });
+
+  test("a single pod runs only one migration at a time across orgs", async () => {
+    const orgA = await createOrg();
+    const orgB = await createOrg();
+    const projectIdsA = await createDisabledProjects(orgA.authToken, 1);
+    const projectIdsB = await createDisabledProjects(orgB.authToken, 1);
+    const projectIds = [...projectIdsA, ...projectIdsB];
+
+    await Promise.all([
+      testServer.services.project.startSecretBlindIndexMigrationPerOrg(orgA.orgId, 1),
+      testServer.services.project.startSecretBlindIndexMigrationPerOrg(orgB.orgId, 1)
+    ]);
+
+    const peakInFlight = await waitForProjectsEnabledAndPeakInFlight(projectIds, [orgA.orgId, orgB.orgId], 20_000);
+    expect(peakInFlight).toBeLessThanOrEqual(SECRET_BLIND_INDEX_MIGRATION_WORKER_CONCURRENCY);
+    expect(await getOrgSlotCount(orgA.orgId)).toBe(0);
+    expect(await getOrgSlotCount(orgB.orgId)).toBe(0);
+  });
+});

--- a/backend/e2e-test/testUtils/insights.ts
+++ b/backend/e2e-test/testUtils/insights.ts
@@ -83,7 +83,8 @@ export const projectScopedInsightsDepStubs: Pick<
     createCipherPairWithDataKey: unreachable("kmsService.createCipherPairWithDataKey")
   },
   projectQueue: {
-    startSecretBlindIndexMigrationForOrg: unreachable("projectQueue.startSecretBlindIndexMigrationForOrg")
+    startSecretBlindIndexMigrationForOrg: unreachable("projectQueue.startSecretBlindIndexMigrationForOrg"),
+    isSecretBlindIndexMigrationRunningForOrg: unreachable("projectQueue.isSecretBlindIndexMigrationRunningForOrg")
   }
 };
 

--- a/backend/e2e-test/testUtils/insights.ts
+++ b/backend/e2e-test/testUtils/insights.ts
@@ -22,10 +22,7 @@ const unreachable = (method: string) => (): never => {
 };
 
 // Specs supply their own getOrgPermission; this fills the other half of the permissionService contract.
-const unreachableGetProjectPermission: Pick<
-  TInsightsServiceFactoryDep["permissionService"],
-  "getProjectPermission"
-> = {
+const unreachableGetProjectPermission: Pick<TInsightsServiceFactoryDep["permissionService"], "getProjectPermission"> = {
   getProjectPermission: unreachable("permissionService.getProjectPermission")
 };
 
@@ -42,6 +39,7 @@ export const projectScopedInsightsDepStubs: Pick<
   | "projectDAL"
   | "userDAL"
   | "kmsService"
+  | "projectQueue"
 > = {
   auditLogDAL: {
     countByDateAndActor: unreachable("auditLogDAL.countByDateAndActor"),
@@ -75,13 +73,17 @@ export const projectScopedInsightsDepStubs: Pick<
     getBotKey: unreachable("projectBotService.getBotKey")
   },
   projectDAL: {
-    findById: unreachable("projectDAL.findById")
+    findById: unreachable("projectDAL.findById"),
+    countOrgProjectsPendingSecretBlindIndex: unreachable("projectDAL.countOrgProjectsPendingSecretBlindIndex")
   },
   userDAL: {
     find: unreachable("userDAL.find")
   },
   kmsService: {
     createCipherPairWithDataKey: unreachable("kmsService.createCipherPairWithDataKey")
+  },
+  projectQueue: {
+    startSecretBlindIndexMigrationForOrg: unreachable("projectQueue.startSecretBlindIndexMigrationForOrg")
   }
 };
 

--- a/backend/src/ee/routes/v1/insights-router.ts
+++ b/backend/src/ee/routes/v1/insights-router.ts
@@ -357,6 +357,42 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
 
   server.route({
     method: "GET",
+    url: "/secrets/blind-index/status",
+    config: { rateLimit: readLimit },
+    schema: {
+      hide: true,
+      operationId: "getOrgSecretBlindIndexMigrationStatus",
+      description:
+        "Get whether a secret blind index migration is running for the organization, and how many of its secret management projects still need one.",
+      security: [{ bearerAuth: [] }],
+      response: {
+        200: z.object({
+          secretBlindIndexMigration: z.object({
+            pendingProjectCount: z
+              .number()
+              .int()
+              .describe(INSIGHTS.GET_SECRET_BLIND_INDEX_MIGRATION_STATUS.pendingProjectCount),
+            isRunning: z.boolean().describe(INSIGHTS.GET_SECRET_BLIND_INDEX_MIGRATION_STATUS.isRunning)
+          })
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const secretBlindIndexMigration = await server.services.insights.getSecretBlindIndexMigrationStatus({
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        orgId: req.permission.orgId
+      });
+
+      return { secretBlindIndexMigration };
+    }
+  });
+
+  server.route({
+    method: "GET",
     url: "/secrets/reports",
     config: { rateLimit: readLimit },
     schema: {

--- a/backend/src/ee/routes/v1/insights-router.ts
+++ b/backend/src/ee/routes/v1/insights-router.ts
@@ -312,6 +312,50 @@ export const registerInsightsRouter = async (server: FastifyZodProvider) => {
   });
 
   server.route({
+    method: "POST",
+    url: "/secrets/enable-blind-index",
+    config: { rateLimit: writeLimit },
+    schema: {
+      hide: true,
+      operationId: "startOrgSecretBlindIndexMigration",
+      description:
+        "Start the secret blind index migration for every one of the organization's secret management projects that still needs it.",
+      security: [{ bearerAuth: [] }],
+      response: {
+        200: z.object({
+          secretBlindIndexMigration: z.object({
+            pendingProjectCount: z
+              .number()
+              .int()
+              .describe(INSIGHTS.START_SECRET_BLIND_INDEX_MIGRATION.pendingProjectCount)
+          })
+        })
+      }
+    },
+    onRequest: verifyAuth([AuthMode.JWT]),
+    handler: async (req) => {
+      const secretBlindIndexMigration = await server.services.insights.startSecretBlindIndexMigration({
+        actor: req.permission.type,
+        actorId: req.permission.id,
+        actorAuthMethod: req.permission.authMethod,
+        actorOrgId: req.permission.orgId,
+        orgId: req.permission.orgId
+      });
+
+      await server.services.auditLog.createAuditLog({
+        ...req.auditLogInfo,
+        orgId: req.permission.orgId,
+        event: {
+          type: EventType.START_ORG_SECRET_BLIND_INDEX_MIGRATION,
+          metadata: { pendingProjectCount: secretBlindIndexMigration.pendingProjectCount }
+        }
+      });
+
+      return { secretBlindIndexMigration };
+    }
+  });
+
+  server.route({
     method: "GET",
     url: "/secrets/reports",
     config: { rateLimit: readLimit },

--- a/backend/src/ee/services/audit-log/audit-log-types.ts
+++ b/backend/src/ee/services/audit-log/audit-log-types.ts
@@ -697,6 +697,7 @@ export enum EventType {
   VIEW_INSIGHTS_SECRETS_MANAGEMENT_COUNTS = "view-insights-secrets-management-counts",
   VIEW_INSIGHTS_SECRETS_MANAGEMENT_USAGE = "view-insights-secrets-management-usage",
   VIEW_INSIGHTS_SECRETS_MANAGEMENT_PROJECT_WARNINGS = "view-insights-secrets-management-project-warnings",
+  START_ORG_SECRET_BLIND_INDEX_MIGRATION = "start-org-secret-blind-index-migration",
 
   CREATE_AUDIT_REPORT = "create-audit-report",
   GET_AUDIT_REPORTS = "get-audit-reports",
@@ -5726,6 +5727,13 @@ interface ViewSecretManagementInsightsProjectWarningsEvent {
   };
 }
 
+interface StartOrgSecretBlindIndexMigrationEvent {
+  type: EventType.START_ORG_SECRET_BLIND_INDEX_MIGRATION;
+  metadata: {
+    pendingProjectCount: number;
+  };
+}
+
 interface CreateAuditReportEvent {
   type: EventType.CREATE_AUDIT_REPORT;
   metadata: {
@@ -7825,6 +7833,7 @@ export type Event =
   | ViewSecretManagementInsightsCountsEvent
   | ViewSecretManagementInsightsUsageEvent
   | ViewSecretManagementInsightsProjectWarningsEvent
+  | StartOrgSecretBlindIndexMigrationEvent
   | CreateAuditReportEvent
   | GetAuditReportsEvent
   | GetAuditReportEvent

--- a/backend/src/ee/services/insights/insights-service.test.ts
+++ b/backend/src/ee/services/insights/insights-service.test.ts
@@ -65,7 +65,8 @@ const projectScopedDepStubs: Pick<
     getBotKey: unreachable("projectBotService.getBotKey")
   },
   projectDAL: {
-    findById: unreachable("projectDAL.findById")
+    findById: unreachable("projectDAL.findById"),
+    countOrgProjectsPendingSecretBlindIndex: unreachable("projectDAL.countOrgProjectsPendingSecretBlindIndex")
   },
   userDAL: {
     find: unreachable("userDAL.find")
@@ -120,6 +121,9 @@ const buildService = (catalog: TSecretsProjectWarning[]) => {
       getItem: async () => null,
       setItemWithExpiry: async () => "OK",
       ttl: async () => -2
+    },
+    projectQueue: {
+      startSecretBlindIndexMigrationForOrg: unreachable("projectQueue.startSecretBlindIndexMigrationForOrg")
     },
     orgDAL: { countSecretManagerProjectMembers: unreachable("orgDAL.countSecretManagerProjectMembers") },
     identityOrgMembershipDAL: {

--- a/backend/src/ee/services/insights/insights-service.test.ts
+++ b/backend/src/ee/services/insights/insights-service.test.ts
@@ -123,7 +123,8 @@ const buildService = (catalog: TSecretsProjectWarning[]) => {
       ttl: async () => -2
     },
     projectQueue: {
-      startSecretBlindIndexMigrationForOrg: unreachable("projectQueue.startSecretBlindIndexMigrationForOrg")
+      startSecretBlindIndexMigrationForOrg: unreachable("projectQueue.startSecretBlindIndexMigrationForOrg"),
+      isSecretBlindIndexMigrationRunningForOrg: unreachable("projectQueue.isSecretBlindIndexMigrationRunningForOrg")
     },
     orgDAL: { countSecretManagerProjectMembers: unreachable("orgDAL.countSecretManagerProjectMembers") },
     identityOrgMembershipDAL: {

--- a/backend/src/ee/services/insights/insights-service.ts
+++ b/backend/src/ee/services/insights/insights-service.ts
@@ -90,7 +90,10 @@ export type TInsightsServiceFactoryDep = {
   userDAL: Pick<TUserDALFactory, "find">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "ttl">;
-  projectQueue: Pick<TProjectQueueFactory, "startSecretBlindIndexMigrationForOrg">;
+  projectQueue: Pick<
+    TProjectQueueFactory,
+    "startSecretBlindIndexMigrationForOrg" | "isSecretBlindIndexMigrationRunningForOrg"
+  >;
   orgDAL: Pick<TOrgDALFactory, "countSecretManagerProjectMembers">;
   identityOrgMembershipDAL: Pick<TIdentityOrgDALFactory, "countSecretManagerProjectIdentities">;
   dynamicSecretLeaseDAL: Pick<TDynamicSecretLeaseDALFactory, "countLeasesForOrg">;
@@ -769,6 +772,17 @@ export const insightsServiceFactory = ({
     };
   };
 
+  const getSecretBlindIndexMigrationStatus = async (dto: TOrgInsightsDTO) => {
+    await assertOrgInsightsRead(dto);
+
+    const [pendingProjectCount, isRunning] = await Promise.all([
+      projectDAL.countOrgProjectsPendingSecretBlindIndex(dto.orgId),
+      projectQueue.isSecretBlindIndexMigrationRunningForOrg(dto.orgId)
+    ]);
+
+    return { pendingProjectCount, isRunning };
+  };
+
   const startSecretBlindIndexMigration = async ({
     actor,
     actorId,
@@ -815,6 +829,7 @@ export const insightsServiceFactory = ({
     getSecretsUsageInsights,
     getSecretsProjects,
     getStaticSecretsUsage,
-    startSecretBlindIndexMigration
+    startSecretBlindIndexMigration,
+    getSecretBlindIndexMigrationStatus
   };
 };

--- a/backend/src/ee/services/insights/insights-service.ts
+++ b/backend/src/ee/services/insights/insights-service.ts
@@ -9,6 +9,7 @@ import { TDynamicSecretLeaseDALFactory } from "@app/ee/services/dynamic-secret-l
 import { THoneyTokenDALFactory } from "@app/ee/services/honey-token/honey-token-dal";
 import { TLicenseServiceFactory } from "@app/ee/services/license/license-service";
 import {
+  OrgPermissionActions,
   OrgPermissionSecretsManagementInsightsActions,
   OrgPermissionSubjects
 } from "@app/ee/services/permission/org-permission";
@@ -22,7 +23,7 @@ import { TSecretRotationV2DALFactory } from "@app/ee/services/secret-rotation-v2
 import { KeyStorePrefixes, KeyStoreTtls, TKeyStoreFactory } from "@app/keystore/keystore";
 import { getCacheTtl, withCache } from "@app/lib/cache/with-cache";
 import { getConfig } from "@app/lib/config/env";
-import { BadRequestError } from "@app/lib/errors";
+import { BadRequestError, ConflictError } from "@app/lib/errors";
 import { OrgServiceActor } from "@app/lib/types";
 import { ActorType } from "@app/services/auth/auth-type";
 import { TIdentityOrgDALFactory } from "@app/services/identity/identity-org-dal";
@@ -30,6 +31,7 @@ import { TKmsServiceFactory } from "@app/services/kms/kms-service";
 import { KmsDataKey } from "@app/services/kms/kms-types";
 import { TOrgDALFactory } from "@app/services/org/org-dal";
 import { TProjectDALFactory } from "@app/services/project/project-dal";
+import { TProjectQueueFactory } from "@app/services/project/project-queue";
 import { TProjectBotServiceFactory } from "@app/services/project-bot/project-bot-service";
 import { TReminderDALFactory } from "@app/services/reminder/reminder-dal";
 import { TSecretFolderDALFactory } from "@app/services/secret-folder/secret-folder-dal";
@@ -84,10 +86,11 @@ export type TInsightsServiceFactoryDep = {
   dynamicSecretDAL: Pick<TDynamicSecretDALFactory, "countByProject">;
   honeyTokenDAL: Pick<THoneyTokenDALFactory, "countByProjectId">;
   projectBotService: Pick<TProjectBotServiceFactory, "getBotKey">;
-  projectDAL: Pick<TProjectDALFactory, "findById">;
+  projectDAL: Pick<TProjectDALFactory, "findById" | "countOrgProjectsPendingSecretBlindIndex">;
   userDAL: Pick<TUserDALFactory, "find">;
   kmsService: Pick<TKmsServiceFactory, "createCipherPairWithDataKey">;
   keyStore: Pick<TKeyStoreFactory, "setItemWithExpiry" | "getItem" | "ttl">;
+  projectQueue: Pick<TProjectQueueFactory, "startSecretBlindIndexMigrationForOrg">;
   orgDAL: Pick<TOrgDALFactory, "countSecretManagerProjectMembers">;
   identityOrgMembershipDAL: Pick<TIdentityOrgDALFactory, "countSecretManagerProjectIdentities">;
   dynamicSecretLeaseDAL: Pick<TDynamicSecretLeaseDALFactory, "countLeasesForOrg">;
@@ -156,7 +159,8 @@ export const insightsServiceFactory = ({
   orgDAL,
   identityOrgMembershipDAL,
   dynamicSecretLeaseDAL,
-  insightsDAL
+  insightsDAL,
+  projectQueue
 }: TInsightsServiceFactoryDep) => {
   // Gate for every org-wide aggregate: the org-level read permission plus the insights entitlement.
   const assertOrgInsightsRead = async ({ actor, actorId, orgId, actorAuthMethod, actorOrgId }: TOrgInsightsDTO) => {
@@ -765,6 +769,40 @@ export const insightsServiceFactory = ({
     };
   };
 
+  const startSecretBlindIndexMigration = async ({
+    actor,
+    actorId,
+    orgId,
+    actorAuthMethod,
+    actorOrgId
+  }: TOrgInsightsDTO) => {
+    const { permission } = await permissionService.getOrgPermission({
+      scope: OrganizationActionScope.Any,
+      actor,
+      actorId,
+      orgId,
+      actorAuthMethod,
+      actorOrgId
+    });
+    ForbiddenError.from(permission).throwUnlessCan(OrgPermissionActions.Edit, OrgPermissionSubjects.Settings);
+    await assertInsightsPlanEnabled(licenseService, orgId);
+
+    const pendingProjectCount = await projectDAL.countOrgProjectsPendingSecretBlindIndex(orgId);
+    if (!pendingProjectCount) {
+      return { pendingProjectCount: 0 };
+    }
+
+    const dispatched = await projectQueue.startSecretBlindIndexMigrationForOrg(orgId);
+    if (!dispatched) {
+      throw new ConflictError({
+        message:
+          "A secret blind index migration is already running for this organization. Wait for it to finish before starting another."
+      });
+    }
+
+    return { pendingProjectCount };
+  };
+
   return {
     getCalendar,
     getAccessVolume,
@@ -776,6 +814,7 @@ export const insightsServiceFactory = ({
     getCounts,
     getSecretsUsageInsights,
     getSecretsProjects,
-    getStaticSecretsUsage
+    getStaticSecretsUsage,
+    startSecretBlindIndexMigration
   };
 };

--- a/backend/src/keystore/keystore.ts
+++ b/backend/src/keystore/keystore.ts
@@ -60,6 +60,7 @@ export const KeyStorePrefixes = {
   PkiSyncLock: (syncId: string) => `pki-sync-mutex-${syncId}` as const,
   AppConnectionConcurrentJobs: (connectionId: string, targetHost?: string) =>
     `app-connection-concurrency-${connectionId}${targetHost ? `-${targetHost.toLowerCase()}` : ""}` as const,
+  SecretBlindIndexMigrationOrgSlot: (orgId: string) => `secret-blind-index-migration-org:${orgId}` as const,
   AppConnectionCommandLock: (connectionId: string, targetHost?: string) =>
     `app-connection-command-mutex-${connectionId}${targetHost ? `-${targetHost.toLowerCase()}` : ""}` as const,
   LdapHostLogin: (fingerprint: string) => `ldap-host-login-${fingerprint}` as const,

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -936,6 +936,11 @@ export const INSIGHTS = {
     pendingProjectCount:
       "The number of the organization's secret management projects that were scheduled for a secret blind index migration. The migrations run in the background."
   },
+  GET_SECRET_BLIND_INDEX_MIGRATION_STATUS: {
+    pendingProjectCount:
+      "The number of the organization's secret management projects that still need a secret blind index migration.",
+    isRunning: "Whether a secret blind index migration is currently running for the organization."
+  },
   GET_SECRETS_ACCESS_VOLUME: {
     days: "One entry for each of the last seven days, oldest first. Days with no secret access are included with a total of zero.",
     date: "The day the accesses happened on, in UTC, as YYYY-MM-DD.",

--- a/backend/src/lib/api-docs/constants.ts
+++ b/backend/src/lib/api-docs/constants.ts
@@ -932,6 +932,10 @@ export const INSIGHTS = {
     totalProjects: "The total number of secret management projects in the organization.",
     projectsWithIssues: "The number of secret management projects in the organization with at least one issue."
   },
+  START_SECRET_BLIND_INDEX_MIGRATION: {
+    pendingProjectCount:
+      "The number of the organization's secret management projects that were scheduled for a secret blind index migration. The migrations run in the background."
+  },
   GET_SECRETS_ACCESS_VOLUME: {
     days: "One entry for each of the last seven days, oldest first. Days with no secret access are included with a total of zero.",
     date: "The day the accesses happened on, in UTC, as YYYY-MM-DD.",

--- a/backend/src/queue/queue-service.ts
+++ b/backend/src/queue/queue-service.ts
@@ -126,6 +126,7 @@ export enum QueueName {
   ProjectEnvHardDelete = "project-env-hard-delete",
   SignerAutoRenewal = "signer-auto-renewal",
   SecretBlindIndexMigration = "secret-blind-index-migration",
+  SecretBlindIndexMigrationDispatch = "secret-blind-index-migration-dispatch",
   UsageEvent = "usage-event",
   IntegrationDeprecationNotice = "integration-deprecation-notice"
 }
@@ -213,6 +214,7 @@ export enum QueueJobs {
   ProjectEnvHardDelete = "project-env-hard-delete-job",
   SignerDailyAutoRenewal = "signer-daily-auto-renewal",
   SecretBlindIndexMigration = "secret-blind-index-migration",
+  SecretBlindIndexMigrationDispatch = "secret-blind-index-migration-dispatch",
   UsageEvent = "usage-event-job",
   SendIntegrationDeprecationNotice = "send-integration-deprecation-notice"
 }
@@ -605,6 +607,10 @@ export type TQueueJobTypes = {
   [QueueName.SecretBlindIndexMigration]: {
     name: QueueJobs.SecretBlindIndexMigration;
     payload: { projectId: string };
+  };
+  [QueueName.SecretBlindIndexMigrationDispatch]: {
+    name: QueueJobs.SecretBlindIndexMigrationDispatch;
+    payload: { orgId: string };
   };
   [QueueName.UsageEvent]: {
     name: QueueJobs.UsageEvent;

--- a/backend/src/server/routes/index.ts
+++ b/backend/src/server/routes/index.ts
@@ -3255,7 +3255,8 @@ export const registerRoutes = async (
     orgDAL,
     identityOrgMembershipDAL,
     dynamicSecretLeaseDAL,
-    insightsDAL
+    insightsDAL,
+    projectQueue: projectQueueService
   });
 
   const auditReportDAL = auditReportDALFactory(db);

--- a/backend/src/services/project/project-dal.ts
+++ b/backend/src/services/project/project-dal.ts
@@ -1011,6 +1011,23 @@ export const projectDALFactory = (db: TDbClient) => {
     }
   };
 
+  const countOrgProjectsPendingSecretBlindIndex = async (orgId: string, tx?: Knex) => {
+    try {
+      const doc = await (tx || db.replicaNode())(TableName.Project)
+        .where({
+          orgId,
+          secretBlindIndexEnabled: false,
+          type: ProjectType.SecretManager,
+          version: ProjectVersion.V3
+        })
+        .whereNull("deleteAfter")
+        .count();
+      return Number(doc?.[0]?.count ?? 0);
+    } catch (error) {
+      throw new DatabaseError({ error, name: "Count org projects pending secret blind index" });
+    }
+  };
+
   const countOfBillableOrgProjects = async (orgId: string | null, tx?: Knex) => {
     try {
       const subOrgProjects = db.replicaNode()(TableName.Organization).where({ rootOrgId: orgId }).select("id");
@@ -1036,6 +1053,7 @@ export const projectDALFactory = (db: TDbClient) => {
 
   return {
     ...projectOrm,
+    countOrgProjectsPendingSecretBlindIndex,
     findById,
     findOne,
     find,

--- a/backend/src/services/project/project-fns.ts
+++ b/backend/src/services/project/project-fns.ts
@@ -107,6 +107,10 @@ export const getProjectKmsCertificateKeyId = async ({
 export const SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT = 4;
 export const SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_TTL_SECONDS = 60 * 60;
 export const SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_RETRY_DELAY_MS = 30_000;
+export const SECRET_BLIND_INDEX_MIGRATION_MAX_ATTEMPTS = 5;
+export const SECRET_BLIND_INDEX_MIGRATION_WORKER_CONCURRENCY = 2;
+
+export const SECRET_BLIND_INDEX_MIGRATION_DISPATCH_MAX_STALLED_ITERATIONS = 60;
 
 type TOrgSlotKeyStore = Pick<TKeyStoreFactory, "incrementByAndRefreshExpiryIfUnderLimit" | "decrementByOrDelete">;
 

--- a/backend/src/services/project/project-fns.ts
+++ b/backend/src/services/project/project-fns.ts
@@ -1,4 +1,5 @@
 import { ProjectVersion, TProjects } from "@app/db/schemas";
+import { KeyStorePrefixes, TKeyStoreFactory } from "@app/keystore/keystore";
 import { crypto } from "@app/lib/crypto/cryptography";
 import { NotFoundError } from "@app/lib/errors";
 import { TKmsServiceFactory } from "@app/services/kms/kms-service";
@@ -101,4 +102,23 @@ export const getProjectKmsCertificateKeyId = async ({
   });
 
   return keyId;
+};
+
+export const SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT = 4;
+export const SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_TTL_SECONDS = 60 * 60;
+export const SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_RETRY_DELAY_MS = 30_000;
+
+type TOrgSlotKeyStore = Pick<TKeyStoreFactory, "incrementByAndRefreshExpiryIfUnderLimit" | "decrementByOrDelete">;
+
+export const tryAdmitSecretBlindIndexMigrationOrgSlot = async (keyStore: TOrgSlotKeyStore, orgId: string) => {
+  const count = await keyStore.incrementByAndRefreshExpiryIfUnderLimit(
+    KeyStorePrefixes.SecretBlindIndexMigrationOrgSlot(orgId),
+    SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT,
+    SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_TTL_SECONDS
+  );
+  return count !== -1;
+};
+
+export const releaseSecretBlindIndexMigrationOrgSlot = async (keyStore: TOrgSlotKeyStore, orgId: string) => {
+  await keyStore.decrementByOrDelete(KeyStorePrefixes.SecretBlindIndexMigrationOrgSlot(orgId));
 };

--- a/backend/src/services/project/project-queue.ts
+++ b/backend/src/services/project/project-queue.ts
@@ -683,65 +683,69 @@ export const projectQueueFactory = ({
     );
   };
 
-  queueService.start(QueueName.SecretBlindIndexMigration, async (job) => {
-    const { projectId } = job.data;
-    const BATCH_SIZE = 1000;
+  queueService.start(
+    QueueName.SecretBlindIndexMigration,
+    async (job) => {
+      const { projectId } = job.data;
+      const BATCH_SIZE = 1000;
 
-    logger.info(`SecretBlindIndexMigration: starting migration [projectId=${projectId}]`);
+      logger.info(`SecretBlindIndexMigration: starting migration [projectId=${projectId}]`);
 
-    const { decryptor, generateSecretBlindIndex } = await kmsService.createCipherPairWithDataKey({
-      type: KmsDataKey.SecretManager,
-      projectId
-    });
-
-    let totalProcessed = 0;
-
-    // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
-    while (true) {
-      const secrets = await secretV2BridgeDAL.findProjectSecretsWithNullBlindIndex(projectId, BATCH_SIZE);
-
-      if (secrets.length === 0) break;
-
-      const updates: { id: string; secretValueBlindIndex: string }[] = [];
-      for (const secret of secrets) {
-        if (secret.encryptedValue) {
-          const decryptedValue = decryptor({ cipherTextBlob: secret.encryptedValue });
-          const blindIndex = await generateSecretBlindIndex(decryptedValue);
-          updates.push({ id: secret.id, secretValueBlindIndex: blindIndex });
-        }
-      }
-
-      if (updates.length > 0) {
-        await secretV2BridgeDAL.batchSetBlindIndexes(updates);
-      }
-
-      totalProcessed += updates.length;
-      logger.info(
-        `SecretBlindIndexMigration: processed batch [projectId=${projectId}] [batchSize=${updates.length}] [totalProcessed=${totalProcessed}]`
-      );
-
-      // Prevents job from being marked as stalled
-      await job.updateProgress(totalProcessed);
-
-      if (secrets.length < BATCH_SIZE) break;
-
-      // pause between batches to avoid saturating the CPU
-      const jitter = 100 + Math.floor(Math.random() * 100);
-      await new Promise((resolve) => {
-        setTimeout(resolve, jitter);
+      const { decryptor, generateSecretBlindIndex } = await kmsService.createCipherPairWithDataKey({
+        type: KmsDataKey.SecretManager,
+        projectId
       });
-    }
 
-    await projectDAL.updateById(projectId, { secretBlindIndexEnabled: true });
+      let totalProcessed = 0;
 
-    await keyStore.deleteItems({
-      pattern: `${KeyStorePrefixes.InsightsCache(projectId, "secrets-duplication")}*`
-    });
+      // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
+      while (true) {
+        const secrets = await secretV2BridgeDAL.findProjectSecretsWithNullBlindIndex(projectId, BATCH_SIZE);
 
-    logger.info(
-      `SecretBlindIndexMigration: migration complete [projectId=${projectId}] [totalProcessed=${totalProcessed}]`
-    );
-  });
+        if (secrets.length === 0) break;
+
+        const updates: { id: string; secretValueBlindIndex: string }[] = [];
+        for (const secret of secrets) {
+          if (secret.encryptedValue) {
+            const decryptedValue = decryptor({ cipherTextBlob: secret.encryptedValue });
+            const blindIndex = await generateSecretBlindIndex(decryptedValue);
+            updates.push({ id: secret.id, secretValueBlindIndex: blindIndex });
+          }
+        }
+
+        if (updates.length > 0) {
+          await secretV2BridgeDAL.batchSetBlindIndexes(updates);
+        }
+
+        totalProcessed += updates.length;
+        logger.info(
+          `SecretBlindIndexMigration: processed batch [projectId=${projectId}] [batchSize=${updates.length}] [totalProcessed=${totalProcessed}]`
+        );
+
+        // Prevents job from being marked as stalled
+        await job.updateProgress(totalProcessed);
+
+        if (secrets.length < BATCH_SIZE) break;
+
+        // pause between batches to avoid saturating the CPU
+        const jitter = 100 + Math.floor(Math.random() * 100);
+        await new Promise((resolve) => {
+          setTimeout(resolve, jitter);
+        });
+      }
+
+      await projectDAL.updateById(projectId, { secretBlindIndexEnabled: true });
+
+      await keyStore.deleteItems({
+        pattern: `${KeyStorePrefixes.InsightsCache(projectId, "secrets-duplication")}*`
+      });
+
+      logger.info(
+        `SecretBlindIndexMigration: migration complete [projectId=${projectId}] [totalProcessed=${totalProcessed}]`
+      );
+    },
+    { limiter: { max: 8, duration: 10_000 } }
+  );
 
   queueService.listen(QueueName.SecretBlindIndexMigration, "failed", (job, err) => {
     logger.error(err, `SecretBlindIndexMigration: failed [projectId=${job?.data.projectId}]`);

--- a/backend/src/services/project/project-queue.ts
+++ b/backend/src/services/project/project-queue.ts
@@ -785,7 +785,7 @@ export const projectQueueFactory = ({
         await releaseSecretBlindIndexMigrationOrgSlot(keyStore, orgId);
       }
     },
-    { limiter: { max: 10, duration: 60_000 } }
+    { concurrency: 2, limiter: { max: 20, duration: 60_000 } }
   );
 
   queueService.listen(QueueName.SecretBlindIndexMigration, "failed", (job, err) => {

--- a/backend/src/services/project/project-queue.ts
+++ b/backend/src/services/project/project-queue.ts
@@ -50,13 +50,19 @@ import { TSecretFolderDALFactory } from "../secret-folder/secret-folder-dal";
 import { TSecretV2BridgeDALFactory } from "../secret-v2-bridge/secret-v2-bridge-dal";
 import { TUserDALFactory } from "../user/user-dal";
 import { TProjectDALFactory } from "./project-dal";
-import { assignWorkspaceKeysToMembers, createProjectKey } from "./project-fns";
+import {
+  assignWorkspaceKeysToMembers,
+  createProjectKey,
+  releaseSecretBlindIndexMigrationOrgSlot,
+  SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_RETRY_DELAY_MS,
+  tryAdmitSecretBlindIndexMigrationOrgSlot
+} from "./project-fns";
 
 export type TProjectQueueFactory = ReturnType<typeof projectQueueFactory>;
 
 type TProjectQueueFactoryDep = {
   queueService: TQueueServiceFactory;
-  keyStore: Pick<TKeyStoreFactory, "deleteItems">;
+  keyStore: Pick<TKeyStoreFactory, "deleteItems" | "incrementByAndRefreshExpiryIfUnderLimit" | "decrementByOrDelete">;
   secretVersionDAL: Pick<TSecretVersionDALFactory, "find" | "bulkUpdateNoVersionIncrement" | "delete">;
   folderDAL: Pick<TSecretFolderDALFactory, "find">;
   secretDAL: Pick<TSecretDALFactory, "find" | "bulkUpdateNoVersionIncrement">;
@@ -678,9 +684,18 @@ export const projectQueueFactory = ({
         removeOnComplete: { age: 60 },
         // 1 day, this gives us time to display the error to the customer
         removeOnFail: { age: 24 * 3600 },
+        attempts: 5,
+        backoff: { type: "fixed", delay: SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_RETRY_DELAY_MS },
         jobId
       }
     );
+  };
+
+  const startSecretBlindIndexMigrationPerOrg = async (orgId: string, limit: number) => {
+    const projects = await projectDAL.find({ orgId, secretBlindIndexEnabled: false }, { limit, sort: [["id", "asc"]] });
+    for (const project of projects) {
+      await startSecretBlindIndexMigration(project.id);
+    }
   };
 
   queueService.start(
@@ -689,62 +704,88 @@ export const projectQueueFactory = ({
       const { projectId } = job.data;
       const BATCH_SIZE = 1000;
 
-      logger.info(`SecretBlindIndexMigration: starting migration [projectId=${projectId}]`);
-
-      const { decryptor, generateSecretBlindIndex } = await kmsService.createCipherPairWithDataKey({
-        type: KmsDataKey.SecretManager,
-        projectId
-      });
-
-      let totalProcessed = 0;
-
-      // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
-      while (true) {
-        const secrets = await secretV2BridgeDAL.findProjectSecretsWithNullBlindIndex(projectId, BATCH_SIZE);
-
-        if (secrets.length === 0) break;
-
-        const updates: { id: string; secretValueBlindIndex: string }[] = [];
-        for (const secret of secrets) {
-          if (secret.encryptedValue) {
-            const decryptedValue = decryptor({ cipherTextBlob: secret.encryptedValue });
-            const blindIndex = await generateSecretBlindIndex(decryptedValue);
-            updates.push({ id: secret.id, secretValueBlindIndex: blindIndex });
-          }
-        }
-
-        if (updates.length > 0) {
-          await secretV2BridgeDAL.batchSetBlindIndexes(updates);
-        }
-
-        totalProcessed += updates.length;
-        logger.info(
-          `SecretBlindIndexMigration: processed batch [projectId=${projectId}] [batchSize=${updates.length}] [totalProcessed=${totalProcessed}]`
-        );
-
-        // Prevents job from being marked as stalled
-        await job.updateProgress(totalProcessed);
-
-        if (secrets.length < BATCH_SIZE) break;
-
-        // pause between batches to avoid saturating the CPU
-        const jitter = 100 + Math.floor(Math.random() * 100);
-        await new Promise((resolve) => {
-          setTimeout(resolve, jitter);
-        });
+      const project = await projectDAL.findOne({ id: projectId });
+      if (!project) {
+        logger.info(`SecretBlindIndexMigration: project not found, skipping [projectId=${projectId}]`);
+        return;
+      }
+      if (project.secretBlindIndexEnabled) {
+        logger.info(`SecretBlindIndexMigration: already enabled, skipping [projectId=${projectId}]`);
+        return;
       }
 
-      await projectDAL.updateById(projectId, { secretBlindIndexEnabled: true });
+      const { orgId } = project;
+      const admitted = await tryAdmitSecretBlindIndexMigrationOrgSlot(keyStore, orgId);
+      if (!admitted) {
+        const attempt = (job.attemptsMade ?? 0) + 1;
+        logger.info(
+          `SecretBlindIndexMigration: org at cap [projectId=${projectId}] [orgId=${orgId}] [attempt=${attempt}/5]`
+        );
+        throw new Error(
+          "Secret blind index migration could not start because too many migrations are already running for this organization. Try again later."
+        );
+      }
 
-      await keyStore.deleteItems({
-        pattern: `${KeyStorePrefixes.InsightsCache(projectId, "secrets-duplication")}*`
-      });
+      try {
+        logger.info(`SecretBlindIndexMigration: starting migration [projectId=${projectId}]`);
 
-      logger.info(
-        `SecretBlindIndexMigration: migration complete [projectId=${projectId}] [totalProcessed=${totalProcessed}]`
-      );
+        const { decryptor, generateSecretBlindIndex } = await kmsService.createCipherPairWithDataKey({
+          type: KmsDataKey.SecretManager,
+          projectId
+        });
+
+        let totalProcessed = 0;
+
+        // eslint-disable-next-line no-constant-condition, @typescript-eslint/no-unnecessary-condition
+        while (true) {
+          const secrets = await secretV2BridgeDAL.findProjectSecretsWithNullBlindIndex(projectId, BATCH_SIZE);
+
+          if (secrets.length === 0) break;
+
+          const updates: { id: string; secretValueBlindIndex: string }[] = [];
+          for (const secret of secrets) {
+            if (secret.encryptedValue) {
+              const decryptedValue = decryptor({ cipherTextBlob: secret.encryptedValue });
+              const blindIndex = await generateSecretBlindIndex(decryptedValue);
+              updates.push({ id: secret.id, secretValueBlindIndex: blindIndex });
+            }
+          }
+
+          if (updates.length > 0) {
+            await secretV2BridgeDAL.batchSetBlindIndexes(updates);
+          }
+
+          totalProcessed += updates.length;
+          logger.info(
+            `SecretBlindIndexMigration: processed batch [projectId=${projectId}] [batchSize=${updates.length}] [totalProcessed=${totalProcessed}]`
+          );
+
+          // Prevents job from being marked as stalled
+          await job.updateProgress(totalProcessed);
+
+          if (secrets.length < BATCH_SIZE) break;
+
+          // pause between batches to avoid saturating the CPU
+          const jitter = 100 + Math.floor(Math.random() * 100);
+          await new Promise((resolve) => {
+            setTimeout(resolve, jitter);
+          });
+        }
+
+        await projectDAL.updateById(projectId, { secretBlindIndexEnabled: true });
+
+        await keyStore.deleteItems({
+          pattern: `${KeyStorePrefixes.InsightsCache(projectId, "secrets-duplication")}*`
+        });
+
+        logger.info(
+          `SecretBlindIndexMigration: migration complete [projectId=${projectId}] [totalProcessed=${totalProcessed}]`
+        );
+      } finally {
+        await releaseSecretBlindIndexMigrationOrgSlot(keyStore, orgId);
+      }
     },
-    { limiter: { max: 8, duration: 10_000 } }
+    { limiter: { max: 10, duration: 60_000 } }
   );
 
   queueService.listen(QueueName.SecretBlindIndexMigration, "failed", (job, err) => {
@@ -775,6 +816,7 @@ export const projectQueueFactory = ({
   return {
     upgradeProject,
     startSecretBlindIndexMigration,
+    startSecretBlindIndexMigrationPerOrg,
     getJobState
   };
 };

--- a/backend/src/services/project/project-queue.ts
+++ b/backend/src/services/project/project-queue.ts
@@ -5,6 +5,7 @@ import {
   AccessScope,
   IntegrationAuthsSchema,
   ProjectMembershipRole,
+  ProjectType,
   ProjectUpgradeStatus,
   ProjectVersion,
   SecretApprovalRequestsSecretsSchema,
@@ -54,7 +55,11 @@ import {
   assignWorkspaceKeysToMembers,
   createProjectKey,
   releaseSecretBlindIndexMigrationOrgSlot,
+  SECRET_BLIND_INDEX_MIGRATION_DISPATCH_MAX_STALLED_ITERATIONS,
+  SECRET_BLIND_INDEX_MIGRATION_MAX_ATTEMPTS,
+  SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT,
   SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_RETRY_DELAY_MS,
+  SECRET_BLIND_INDEX_MIGRATION_WORKER_CONCURRENCY,
   tryAdmitSecretBlindIndexMigrationOrgSlot
 } from "./project-fns";
 
@@ -671,7 +676,7 @@ export const projectQueueFactory = ({
         await existingJob.remove();
       } else {
         logger.info(`Job for project ${projectId} already exists, skipping`);
-        return;
+        return false;
       }
     }
 
@@ -684,19 +689,113 @@ export const projectQueueFactory = ({
         removeOnComplete: { age: 60 },
         // 1 day, this gives us time to display the error to the customer
         removeOnFail: { age: 24 * 3600 },
-        attempts: 5,
+        attempts: SECRET_BLIND_INDEX_MIGRATION_MAX_ATTEMPTS,
         backoff: { type: "fixed", delay: SECRET_BLIND_INDEX_MIGRATION_ORG_SLOT_RETRY_DELAY_MS },
         jobId
       }
     );
+
+    return true;
   };
 
   const startSecretBlindIndexMigrationPerOrg = async (orgId: string, limit: number) => {
-    const projects = await projectDAL.find({ orgId, secretBlindIndexEnabled: false }, { limit, sort: [["id", "asc"]] });
+    const projects = await projectDAL.find(
+      {
+        orgId,
+        secretBlindIndexEnabled: false,
+        type: ProjectType.SecretManager,
+        version: ProjectVersion.V3
+      },
+      { limit, sort: [["id", "asc"]], count: true }
+    );
+    const pendingProjectCount = projects.length ? Number((projects[0] as unknown as { count: string }).count) : 0;
+
+    const enqueuedProjectIds: string[] = [];
     for (const project of projects) {
-      await startSecretBlindIndexMigration(project.id);
+      if (await startSecretBlindIndexMigration(project.id)) enqueuedProjectIds.push(project.id);
     }
+
+    return { enqueuedProjectIds, pendingProjectCount };
   };
+
+  const startSecretBlindIndexMigrationForOrg = async (orgId: string) => {
+    const jobId = `enable-blind-index-org-${orgId}`;
+
+    const existingJob = await queueService.getJob(QueueName.SecretBlindIndexMigrationDispatch, jobId);
+    if (existingJob) {
+      const state = await existingJob.getState();
+      if (state === "completed" || state === "failed") {
+        await existingJob.remove();
+      } else {
+        logger.info(`SecretBlindIndexMigrationDispatch: already running, skipping [orgId=${orgId}]`);
+        return false;
+      }
+    }
+
+    await queueService.queue(
+      QueueName.SecretBlindIndexMigrationDispatch,
+      QueueJobs.SecretBlindIndexMigrationDispatch,
+      { orgId },
+      {
+        removeOnComplete: { age: 60 },
+        removeOnFail: { age: 24 * 3600 },
+        attempts: 1,
+        jobId
+      }
+    );
+
+    return true;
+  };
+
+  queueService.start(
+    QueueName.SecretBlindIndexMigrationDispatch,
+    async (job) => {
+      const { orgId } = job.data;
+
+      let totalEnqueued = 0;
+      let stalledIterations = 0;
+      let lastPendingProjectCount = Infinity;
+
+      for (;;) {
+        const { enqueuedProjectIds, pendingProjectCount } = await startSecretBlindIndexMigrationPerOrg(
+          orgId,
+          SECRET_BLIND_INDEX_MIGRATION_ORG_IN_FLIGHT_LIMIT
+        );
+
+        if (!pendingProjectCount) {
+          logger.info(`SecretBlindIndexMigrationDispatch: complete [orgId=${orgId}] [totalEnqueued=${totalEnqueued}]`);
+          return;
+        }
+
+        totalEnqueued += enqueuedProjectIds.length;
+        await job.updateProgress(totalEnqueued);
+
+        const backlogDrained = pendingProjectCount < lastPendingProjectCount;
+        if (backlogDrained) {
+          stalledIterations = 0;
+        } else {
+          stalledIterations += 1;
+        }
+        lastPendingProjectCount = pendingProjectCount;
+
+        if (stalledIterations >= SECRET_BLIND_INDEX_MIGRATION_DISPATCH_MAX_STALLED_ITERATIONS) {
+          logger.error(
+            `SecretBlindIndexMigrationDispatch: giving up, backlog is not draining [orgId=${orgId}] [pendingProjectCount=${pendingProjectCount}] [totalEnqueued=${totalEnqueued}]`
+          );
+          return;
+        }
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 30_000);
+        });
+      }
+    },
+    { concurrency: 5 }
+  );
+
+  queueService.listen(QueueName.SecretBlindIndexMigrationDispatch, "failed", (job, err) => {
+    logger.error(err, `SecretBlindIndexMigrationDispatch: failed [orgId=${job?.data.orgId}]`);
+  });
 
   queueService.start(
     QueueName.SecretBlindIndexMigration,
@@ -785,7 +884,10 @@ export const projectQueueFactory = ({
         await releaseSecretBlindIndexMigrationOrgSlot(keyStore, orgId);
       }
     },
-    { concurrency: 2, limiter: { max: 20, duration: 60_000 } }
+    {
+      concurrency: SECRET_BLIND_INDEX_MIGRATION_WORKER_CONCURRENCY,
+      limiter: { max: 20, duration: 60_000 }
+    }
   );
 
   queueService.listen(QueueName.SecretBlindIndexMigration, "failed", (job, err) => {
@@ -816,6 +918,7 @@ export const projectQueueFactory = ({
   return {
     upgradeProject,
     startSecretBlindIndexMigration,
+    startSecretBlindIndexMigrationForOrg,
     startSecretBlindIndexMigrationPerOrg,
     getJobState
   };

--- a/backend/src/services/project/project-queue.ts
+++ b/backend/src/services/project/project-queue.ts
@@ -718,8 +718,10 @@ export const projectQueueFactory = ({
     return { enqueuedProjectIds, pendingProjectCount };
   };
 
+  const getSecretBlindIndexMigrationOrgJobId = (orgId: string) => `enable-blind-index-org-${orgId}`;
+
   const startSecretBlindIndexMigrationForOrg = async (orgId: string) => {
-    const jobId = `enable-blind-index-org-${orgId}`;
+    const jobId = getSecretBlindIndexMigrationOrgJobId(orgId);
 
     const existingJob = await queueService.getJob(QueueName.SecretBlindIndexMigrationDispatch, jobId);
     if (existingJob) {
@@ -915,11 +917,23 @@ export const projectQueueFactory = ({
     return { status: JobState.Pending };
   };
 
+  const isSecretBlindIndexMigrationRunningForOrg = async (orgId: string) => {
+    const job = await queueService.getJob(
+      QueueName.SecretBlindIndexMigrationDispatch,
+      getSecretBlindIndexMigrationOrgJobId(orgId)
+    );
+    if (!job) return false;
+
+    const state = await job.getState();
+    return state !== JobState.Completed && state !== JobState.Failed;
+  };
+
   return {
     upgradeProject,
     startSecretBlindIndexMigration,
     startSecretBlindIndexMigrationForOrg,
     startSecretBlindIndexMigrationPerOrg,
+    isSecretBlindIndexMigrationRunningForOrg,
     getJobState
   };
 };

--- a/backend/src/services/project/project-service.ts
+++ b/backend/src/services/project/project-service.ts
@@ -2415,6 +2415,7 @@ export const projectServiceFactory = ({
     searchProjects,
     extractProjectIdFromSlug,
     enableSecretBlindIndex,
-    getSecretBlindIndexMigrationStatus
+    getSecretBlindIndexMigrationStatus,
+    startSecretBlindIndexMigrationPerOrg: projectQueue.startSecretBlindIndexMigrationPerOrg
   };
 };

--- a/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
+++ b/backend/src/services/secret-v2-bridge/secret-v2-bridge-dal.ts
@@ -1200,7 +1200,7 @@ export const secretV2BridgeDALFactory = ({ db, keyStore }: TSecretV2DalArg) => {
 
   const findProjectSecretsWithNullBlindIndex = async (projectId: string, limit: number, tx?: Knex) => {
     try {
-      const docs = await (tx || db.replicaNode())(TableName.SecretV2)
+      const docs = await (tx || db)(TableName.SecretV2)
         .join(TableName.SecretFolder, `${TableName.SecretV2}.folderId`, `${TableName.SecretFolder}.id`)
         .join(TableName.Environment, `${TableName.SecretFolder}.envId`, `${TableName.Environment}.id`)
         .where(`${TableName.Environment}.projectId`, projectId)

--- a/frontend/src/hooks/api/auditLogs/constants.tsx
+++ b/frontend/src/hooks/api/auditLogs/constants.tsx
@@ -304,6 +304,8 @@ export const eventToNameMap: { [K in EventType]: string } = {
   [EventType.VIEW_INSIGHTS_SECRETS_MANAGEMENT_USAGE]: "View Secrets Management Usage Insights",
   [EventType.VIEW_INSIGHTS_SECRETS_MANAGEMENT_PROJECT_WARNINGS]:
     "View Secrets Management Project Warnings Insights",
+  [EventType.START_ORG_SECRET_BLIND_INDEX_MIGRATION]:
+    "Start Organization Secret Blind Index Migration",
 
   [EventType.CREATE_ORG_AUDIT_REPORT]: "Create Organization Audit Report",
   [EventType.GET_ORG_AUDIT_REPORTS]: "List Organization Audit Reports",

--- a/frontend/src/hooks/api/auditLogs/enums.tsx
+++ b/frontend/src/hooks/api/auditLogs/enums.tsx
@@ -292,6 +292,7 @@ export enum EventType {
   VIEW_INSIGHTS_SECRETS_MANAGEMENT_COUNTS = "view-insights-secrets-management-counts",
   VIEW_INSIGHTS_SECRETS_MANAGEMENT_USAGE = "view-insights-secrets-management-usage",
   VIEW_INSIGHTS_SECRETS_MANAGEMENT_PROJECT_WARNINGS = "view-insights-secrets-management-project-warnings",
+  START_ORG_SECRET_BLIND_INDEX_MIGRATION = "start-org-secret-blind-index-migration",
 
   CREATE_ORG_AUDIT_REPORT = "create-org-audit-report",
   GET_ORG_AUDIT_REPORTS = "get-org-audit-reports",

--- a/frontend/src/hooks/api/secretInsights/index.ts
+++ b/frontend/src/hooks/api/secretInsights/index.ts
@@ -1,9 +1,11 @@
+export { useStartOrgBlindIndexMigration } from "./mutations";
 export {
   secretInsightsKeys,
   useGetAuthMethodDistribution,
   useGetCalendarInsights,
   useGetInsightsSummary,
   useGetOrgAuthMethodDistribution,
+  useGetOrgBlindIndexMigrationStatus,
   useGetOrgSecretsAccessVolume,
   useGetOrgSecretsProjects,
   useGetOrgSecretsSummary,
@@ -32,6 +34,7 @@ export type {
   TGetSecretsDuplicationDTO,
   TGetSecretsDuplicationResponse,
   TOrgAuthMethodUsage,
+  TOrgBlindIndexMigrationStatus,
   TOrgProjectInsight,
   TOrgProjectInsightWarnings,
   TOrgProjectsInsights,
@@ -39,5 +42,6 @@ export type {
   TOrgSecretsSummary,
   TOrgStaticSecretUsage,
   TSecretAccessVolumeActor,
-  TSecretAccessVolumeDay
+  TSecretAccessVolumeDay,
+  TStartOrgBlindIndexMigrationResponse
 } from "./types";

--- a/frontend/src/hooks/api/secretInsights/mutations.tsx
+++ b/frontend/src/hooks/api/secretInsights/mutations.tsx
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { apiRequest } from "@app/config/request";
+
+import { secretInsightsKeys } from "./queries";
+import { TStartOrgBlindIndexMigrationResponse } from "./types";
+
+export const useStartOrgBlindIndexMigration = () => {
+  const queryClient = useQueryClient();
+  // The endpoint resolves the org from the auth token and takes no body; orgId is carried only so
+  // the success handler can key the invalidation.
+  return useMutation<TStartOrgBlindIndexMigrationResponse, object, { orgId: string }>({
+    mutationFn: async () => {
+      const { data } = await apiRequest.post<{
+        secretBlindIndexMigration: TStartOrgBlindIndexMigrationResponse;
+      }>("/api/v1/insights/secrets/enable-blind-index");
+      return data.secretBlindIndexMigration;
+    },
+    onSuccess: (_, { orgId }) =>
+      queryClient.invalidateQueries({
+        queryKey: secretInsightsKeys.orgBlindIndexMigration(orgId)
+      })
+  });
+};

--- a/frontend/src/hooks/api/secretInsights/queries.tsx
+++ b/frontend/src/hooks/api/secretInsights/queries.tsx
@@ -21,6 +21,7 @@ import {
   TGetSecretsDuplicationDTO,
   TGetSecretsDuplicationResponse,
   TOrgAuthMethodUsage,
+  TOrgBlindIndexMigrationStatus,
   TOrgProjectsInsights,
   TOrgSecretAccessVolume,
   TOrgSecretsSummary,
@@ -56,7 +57,9 @@ export const secretInsightsKeys = {
   orgStaticSecretsUsage: (orgId: string) =>
     [...secretInsightsKeys.all(), "org-static-secrets-usage", { orgId }] as const,
   orgAccessVolume: (orgId: string) =>
-    [...secretInsightsKeys.all(), "org-access-volume", { orgId }] as const
+    [...secretInsightsKeys.all(), "org-access-volume", { orgId }] as const,
+  orgBlindIndexMigration: (orgId: string) =>
+    [...secretInsightsKeys.all(), "org-blind-index-migration", { orgId }] as const
 };
 
 const INSIGHTS_STALE_TIME = 5 * 60 * 1000; // 5 minutes
@@ -324,5 +327,28 @@ export const useGetOrgSecretsAccessVolume = (orgId: string, options?: { enabled?
     },
     enabled: Boolean(orgId) && (options?.enabled ?? true),
     staleTime: INSIGHTS_STALE_TIME
+  });
+};
+
+// Unlike the other org hooks this one drives live progress, so it takes no stale time and lets the
+// caller poll while a migration runs.
+export const useGetOrgBlindIndexMigrationStatus = (
+  orgId: string,
+  options?: {
+    enabled?: boolean;
+    refetchInterval?: UseQueryOptions<TOrgBlindIndexMigrationStatus>["refetchInterval"];
+  }
+) => {
+  return useQuery({
+    queryKey: secretInsightsKeys.orgBlindIndexMigration(orgId),
+    queryFn: async () => {
+      const { data } = await apiRequest.get<{
+        secretBlindIndexMigration: TOrgBlindIndexMigrationStatus;
+      }>("/api/v1/insights/secrets/blind-index/status");
+      return data.secretBlindIndexMigration;
+    },
+    enabled: Boolean(orgId) && (options?.enabled ?? true),
+    staleTime: 0,
+    refetchInterval: options?.refetchInterval
   });
 };

--- a/frontend/src/hooks/api/secretInsights/types.ts
+++ b/frontend/src/hooks/api/secretInsights/types.ts
@@ -220,3 +220,12 @@ export type TOrgStaticSecretUsage = {
 export type TOrgSecretAccessVolume = {
   days: { date: string; total: number }[];
 };
+
+export type TOrgBlindIndexMigrationStatus = {
+  pendingProjectCount: number;
+  isRunning: boolean;
+};
+
+export type TStartOrgBlindIndexMigrationResponse = {
+  pendingProjectCount: number;
+};

--- a/frontend/src/pages/organization/SecretInsightsPage/SecretInsightsPage.tsx
+++ b/frontend/src/pages/organization/SecretInsightsPage/SecretInsightsPage.tsx
@@ -45,6 +45,7 @@ import { ProjectType } from "@app/hooks/api/projects/types";
 
 import {
   AuthMethodsCard,
+  BlindIndexCard,
   InsightsCard,
   RequestOrgAuditReportModal,
   SecretAccessVolumeCard,
@@ -234,6 +235,7 @@ export const SecretInsightsPage = withPermission(
                   </AlertDescription>
                 </Alert>
               )}
+              {hasInsightsPlan && <BlindIndexCard />}
               {isSummaryLoading && (
                 <div className="grid gap-4 md:grid-cols-3">
                   <Skeleton className="h-[150px]" />

--- a/frontend/src/pages/organization/SecretInsightsPage/components/BlindIndexCard.tsx
+++ b/frontend/src/pages/organization/SecretInsightsPage/components/BlindIndexCard.tsx
@@ -1,0 +1,72 @@
+import { createNotification } from "@app/components/notifications";
+import { OrgPermissionCan } from "@app/components/permissions";
+import { Alert, AlertAction, AlertDescription, AlertTitle, Button } from "@app/components/v3";
+import { OrgPermissionActions, OrgPermissionSubjects, useOrganization } from "@app/context";
+import {
+  useGetOrgBlindIndexMigrationStatus,
+  useStartOrgBlindIndexMigration
+} from "@app/hooks/api/secretInsights";
+
+const POLL_INTERVAL_MS = 5000;
+
+const pluralizeProjects = (count: number) => (count === 1 ? "Project" : "Projects");
+
+export const BlindIndexCard = () => {
+  const { currentOrg } = useOrganization();
+
+  const { data: status, isPending } = useGetOrgBlindIndexMigrationStatus(currentOrg.id, {
+    refetchInterval: (query) => (query.state.data?.isRunning ? POLL_INTERVAL_MS : false)
+  });
+
+  const startMigration = useStartOrgBlindIndexMigration();
+
+  if (isPending || !status) return null;
+
+  const { pendingProjectCount, isRunning } = status;
+  if (!pendingProjectCount && !isRunning) return null;
+
+  const handleEnable = () => {
+    startMigration.mutate(
+      { orgId: currentOrg.id },
+      {
+        onSuccess: ({ pendingProjectCount: scheduledProjectCount }) =>
+          createNotification({
+            text: `Blind index migration started for ${scheduledProjectCount} ${pluralizeProjects(
+              scheduledProjectCount
+            ).toLowerCase()}`,
+            type: "success"
+          })
+      }
+    );
+  };
+
+  return (
+    <Alert variant="info">
+      <AlertTitle>
+        Blind index not enabled on {pendingProjectCount} {pluralizeProjects(pendingProjectCount)}
+      </AlertTitle>
+      <AlertDescription>
+        <p>
+          {isRunning
+            ? "Indexing secrets across the remaining projects. This may take a few minutes."
+            : "Without blind index, duplicated secrets in those projects can't be detected, so their counts below may be incomplete."}
+        </p>
+        <AlertAction>
+          <OrgPermissionCan I={OrgPermissionActions.Edit} an={OrgPermissionSubjects.Settings}>
+            {(isAllowed) => (
+              <Button
+                variant="info"
+                size="xs"
+                isDisabled={!isAllowed || isRunning}
+                isPending={isRunning || startMigration.isPending}
+                onClick={handleEnable}
+              >
+                Enable on {pendingProjectCount} {pluralizeProjects(pendingProjectCount)}
+              </Button>
+            )}
+          </OrgPermissionCan>
+        </AlertAction>
+      </AlertDescription>
+    </Alert>
+  );
+};

--- a/frontend/src/pages/organization/SecretInsightsPage/components/index.ts
+++ b/frontend/src/pages/organization/SecretInsightsPage/components/index.ts
@@ -1,4 +1,5 @@
 export { AuthMethodsCard } from "./AuthMethodsCard";
+export { BlindIndexCard } from "./BlindIndexCard";
 export { InsightsCard } from "./InsightsCard";
 export { RequestOrgAuditReportModal } from "./RequestOrgAuditReportModal";
 export { SecretAccessVolumeCard } from "./SecretAccessVolumeCard";


### PR DESCRIPTION
## Context

This will allow users to enable blind index for projects that were created before the addition of this new feature. 

## Screenshots

<img width="1208" height="759" alt="image" src="https://github.com/user-attachments/assets/72ae2637-e4e1-40b3-a61d-4c2083928c22" />



## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [x] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [x] Tested locally
- [ ] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [ ] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)