### PR TITLE
chore(auth): revert grouped input autofill styling and signup form restructure

### DIFF
--- a/frontend/src/components/auth/UserInfoStep.tsx
+++ b/frontend/src/components/auth/UserInfoStep.tsx
@@ -162,11 +162,7 @@ export default function UserInfoStep({
   };
 
   return (
-    <form
-      className="mx-auto flex w-full flex-col items-center justify-center"
-      onSubmit={handleSubmit(onSubmit)}
-      noValidate
-    >
+    <div className="mx-auto flex w-full flex-col items-center justify-center">
       <AuthPagePanel>
         <CardHeader className={isInvite ? "mb-6 gap-2" : "mb-4 gap-2"}>
           <CardTitle
@@ -199,6 +195,14 @@ export default function UserInfoStep({
           ) : null}
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
+          <input
+            className="hidden"
+            type="text"
+            name="username"
+            autoComplete="username"
+            value={email}
+            readOnly
+          />
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <Field data-invalid={showDangerState && Boolean(errors.firstName)}>
               <FieldLabel className="sr-only" htmlFor="signup-first-name">
@@ -233,6 +237,14 @@ export default function UserInfoStep({
               ) : null}
             </Field>
           </div>
+          {isInvite && (
+            <Field>
+              <FieldLabel className="sr-only" htmlFor="signup-email">
+                Email
+              </FieldLabel>
+              <Input variant="outlined" id="signup-email" type="email" value={email} disabled />
+            </Field>
+          )}
           {!isInvite && (
             <Field data-invalid={showOrganizationNameError}>
               <FieldLabel className="sr-only" htmlFor="signup-organization-name">
@@ -268,20 +280,6 @@ export default function UserInfoStep({
               />
             </Field>
           )}
-          <Field className={isInvite ? undefined : "hidden"}>
-            <FieldLabel className="sr-only" htmlFor="signup-email">
-              Email
-            </FieldLabel>
-            <Input
-              variant="outlined"
-              id="signup-email"
-              name="email"
-              type="email"
-              autoComplete="username"
-              value={email}
-              readOnly
-            />
-          </Field>
           <PasswordField
             variant="outlined"
             id="new-password"
@@ -340,6 +338,7 @@ export default function UserInfoStep({
           </AnimatedCollapse>
           <Button
             type="submit"
+            onClick={handleSubmit(onSubmit)}
             variant="project"
             size="lg"
             isFullWidth
@@ -350,6 +349,6 @@ export default function UserInfoStep({
           </Button>
         </CardContent>
       </AuthPagePanel>
-    </form>
+    </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -46,12 +46,6 @@
     box-shadow: 0 0 0 1000px var(--autofill-background, var(--color-background)) inset !important;
   }
 
-  input[data-slot="input-group-control"]:-webkit-autofill {
-    background-clip: text;
-    -webkit-text-fill-color: currentColor;
-    box-shadow: none !important;
-  }
-
   [data-slot="dialog-content"],
   [data-slot="sheet-content"] {
     --autofill-background: var(--color-popover);


### PR DESCRIPTION
## Context

Reverts Infisical/infisical#8084.

That PR made two changes:

- `frontend/src/index.css` gained an autofill override for grouped inputs (`input[data-slot="input-group-control"]:-webkit-autofill`) that clipped the native autofill background to the text and dropped the inset shadow, so the opaque rectangle no longer covered the input group's border.
- `UserInfoStep` wrapped the signup credential fields in a native `<form>` with `onSubmit`, and folded the hidden username input and the invite email display into a single `autocomplete="username"` field.

This reverts both. Grouped inputs fall back to the global autofill rule again, and the signup step submits through the button's `onClick={handleSubmit(onSubmit)}` rather than a native form, so Enter-to-submit from the credential fields goes away with it. The hidden username input and the disabled invite email field are separate elements again.

`frontend/src/components/auth/UserInfoStep.tsx` and `frontend/src/index.css` return to their state on main before #8084. No other files change.

## Steps to verify the change

1. Sign up with a new email and complete verification to reach the password step.
2. Enter a name, organization name, and password, then submit. Confirm validation runs and the account is created once.
3. Repeat through an invite link. Confirm the email appears in a disabled field and the organization field is absent.
4. Autofill a saved password in the field. Confirm the styling matches the pre-#8084 behavior, with the global inset-shadow autofill background back.

## Type

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [x] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [ ] Tested locally
- [x] Updated docs (if needed): not needed, the reverted change had no docs.
- [x] Updated CLAUDE.md files (if needed): not needed.
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
