### PR TITLE
fix(ui): render project access errors during route loading

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 import { setWasmUrl } from "@lottiefiles/dotlottie-react";
 import lottieWasmUrl from "@lottiefiles/dotlottie-web/dist/dotlottie-player.wasm?url";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import NProgress from "nprogress";
 
@@ -103,7 +104,9 @@ if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement);
   root.render(
     <StrictMode>
-      <RouterProvider router={router} />
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
     </StrictMode>
   );
 }

--- a/frontend/src/pages/root.tsx
+++ b/frontend/src/pages/root.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import { createRootRouteWithContext, Outlet, useRouterState } from "@tanstack/react-router";
 
 import { NotificationContainer } from "@app/components/notifications";
@@ -12,7 +12,6 @@ import { TServerConfig } from "@app/hooks/api/admin/types";
 import { authKeys } from "@app/hooks/api/auth/queries";
 import { fetchAuthToken, shouldRetryAuthTokenFetch } from "@app/hooks/api/auth/refresh";
 import { ProjectType } from "@app/hooks/api/projects/types";
-import { queryClient } from "@app/hooks/api/reactQuery";
 
 type TRouterContext = {
   serverConfig: TServerConfig | null;
@@ -48,13 +47,11 @@ const RootCommandMenuMount = () => {
 
 const RootPage = () => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <Outlet />
-        <RootCommandMenuMount />
-        <NotificationContainer />
-      </TooltipProvider>
-    </QueryClientProvider>
+    <TooltipProvider>
+      <Outlet />
+      <RootCommandMenuMount />
+      <NotificationContainer />
+    </TooltipProvider>
   );
 };
 


### PR DESCRIPTION
## Context

Fixes [SECRETS-642](https://linear.app/infisical/issue/SECRETS-642/show-access-error-for-non-member-project-views).

Opening a project without membership returns the expected `ProjectMembershipNotFound` response during the route's `beforeLoad` phase. The dedicated project access error page uses React Query, but its `QueryClientProvider` was mounted inside the root route component. Because route loaders run before that component mounts, rendering the error page threw `No QueryClient set` and fell back to TanStack Router's bare “Something went wrong!” screen.

This moves `QueryClientProvider` above `RouterProvider`, making the query client available to route error boundaries during initial loading. The existing access-restricted experience can now render for non-members without changing normal route behavior.

## Screenshots

![Project access restricted page](https://api-nightly.capy.ai/pr-assets/OPU8KqXAErjS92sTwOMpR9eTsoKcw8RV2lcCR3ejW1I)

## Steps to verify the change

1. Sign in as an organization member who is not a member of a project.
2. Open a direct URL to that project's Secret Manager view.
3. Confirm the access-restricted page renders with the membership status and appropriate action instead of the generic TanStack Router fallback.
4. Confirm normal authenticated routes continue to load.

Local verification:

- `make reviewable-ui`
- `cd frontend && npm test`
- `cd frontend && npm run build`
- Browser smoke test with a mocked 403 `ProjectMembershipNotFound` response

## Type

- [x] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [ ] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`).
- [x] Tested locally
- [x] Updated docs (not needed)
- [x] Updated CLAUDE.md files (not needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)

<!-- capy-badge:start -->
<a href="https://nightly.capy.ai/thread/jam_01M29H80266VKR23PRGAD9AJRA"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/badge/accent-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/badge/accent-light.svg"><img alt="Open in Capy" src="https://capy.ai/badge/accent-light.svg"></picture></a>
<!-- capy-badge:end -->