### PR TITLE
docs(agent-vault): the session token can come from the environment

### DIFF
--- a/docs/cli/commands/agent-vault.mdx
+++ b/docs/cli/commands/agent-vault.mdx
@@ -121,7 +121,7 @@ export INFISICAL_DOMAIN=https://eu.infisical.com
 Launch an agent through an Agent Vault proxy. Everything after `--` is the agent's own command. On each run, the CLI:
 
 - Fetches the proxy's certificate authority from the proxy, checks it against `--ca-fingerprint` if you passed one, and writes it to `--ca-file`.
-- Gets a session: the one you pass with `--session-token`, or one created now with the access bundle named by `--access-bundle`. Exactly one of the two is required.
+- Gets a session: the one you pass with `--session-token` (or `INFISICAL_AGENT_VAULT_SESSION_TOKEN`), or one created now with the access bundle named by `--access-bundle`. Exactly one of the two is required.
 - Starts the agent with `HTTPS_PROXY` and `HTTP_PROXY` pointing at the proxy, `NO_PROXY` set to `localhost,127.0.0.1` merged with your own `NO_PROXY` and `--no-proxy`, and the certificate trusted through `SSL_CERT_FILE`, `NODE_EXTRA_CA_CERTS`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, and `DENO_CERT`.
 
 The CLI prints the proxy's name and fingerprint and, for a session it created, when it expires, then hands the terminal to the agent. When the agent exits, a session created with `--access-bundle` is revoked unless `--keep-session` was set. A session passed with `--session-token` is left alone.
@@ -140,7 +140,7 @@ infisical agent-vault run --access-bundle on-call-infrastructure --proxy 10.0.1.
 
 #### `--session-token`
 
-Run with a session token created in the dashboard. No login is needed, and the CLI never revokes the session. Can't be combined with `--access-bundle`.
+Run with a session token created in the dashboard. No login is needed, and the CLI never revokes the session. Can't be combined with `--access-bundle`. Can also be set through `INFISICAL_AGENT_VAULT_SESSION_TOKEN`, which keeps the token out of your shell history and out of process listings.
 
 ```bash
 # Example
@@ -237,6 +237,18 @@ infisical agent-vault run --access-bundle code-review --client-id <client-id> --
 ```
 
 ### Environment variables
+
+#### `INFISICAL_AGENT_VAULT_SESSION_TOKEN`
+
+A session token created in the dashboard. Alternative to `--session-token`, and the way to keep the token off the command line, where it lands in your shell history and in process listings.
+
+`--session-token` wins if you pass both. Passing `--access-bundle` while this is set creates a new session and ignores the variable, with a warning: the flag was typed for this run, and an exported variable may be left over from another one.
+
+```bash
+# Example
+export INFISICAL_AGENT_VAULT_SESSION_TOKEN=<session-token>
+infisical agent-vault run --proxy 10.0.1.5:17323 -- claude
+```
 
 #### `INFISICAL_AGENT_VAULT_PROXY_ADDRESS`
 

--- a/docs/documentation/platform/agent-vault/sessions.mdx
+++ b/docs/documentation/platform/agent-vault/sessions.mdx
@@ -28,6 +28,13 @@ Anyone granted at least one access bundle can create a session. Admins can creat
     </Frame>
 
     This is the way to start an agent on a machine that has no Infisical login. The token is the only thing you hand over.
+
+    To keep the token out of your shell history and out of process listings, pass it in the environment instead:
+
+    ```bash
+    export INFISICAL_AGENT_VAULT_SESSION_TOKEN=<session-token>
+    infisical agent-vault run --proxy <proxy-address> -- claude
+    ```
   </Tab>
   <Tab title="CLI">
     `infisical agent-vault run` creates a session for you when you name the access bundle:


### PR DESCRIPTION
## Context

`--session-token` was the only Agent Vault flag with no environment fallback, so the docs only ever showed the token pasted onto a command line, where it lands in shell history and in process listings. The CLI now reads `INFISICAL_AGENT_VAULT_SESSION_TOKEN`, so the docs cover it.

- CLI reference: the variable gets its own entry under `infisical agent-vault run`, next to `INFISICAL_AGENT_VAULT_PROXY_ADDRESS`, with the precedence rules. `--session-token` wins if both are given, and `--access-bundle` creates a new session and ignores the variable, with a warning.
- The `--session-token` flag entry and the "Gets a session" bullet point at the variable.
- Sessions page: the same note on the Dashboard tab, where the token is handed over and an operator decides whether to paste it onto a command line.

CLI PR: https://github.com/Infisical/cli/pull/395

## Screenshots

<!-- If UI/UX changes, add screenshots or videos. Delete if not applicable. -->

## Steps to verify the change

## Type

<!-- Tick at least one. CI fails if none are ticked. -->

- [ ] Fix
- [ ] Feature
- [ ] Improvement
- [ ] Breaking
- [x] Docs
- [ ] Chore

## Checklist

- [x] Title follows the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: `type(scope): short description` (scope is optional, e.g., `fix: prevent crash on sync` or `fix(api): handle null response`). 
- [ ] Tested locally
- [x] Updated docs (if needed)
- [ ] Updated CLAUDE.md files (if needed)
- [x] Read the [contributing guide](https://infisical.com/docs/contributing/getting-started/overview)
